### PR TITLE
chore(package.json): update to carbon-icons@5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "adaro": "1.0.4",
     "bluebird": "~3.1.1",
-    "carbon-icons": "5.0.1",
+    "carbon-icons": "5.1.2",
     "eslint": "^3.0.0",
     "express": "4.13.4",
     "globby": "4.0.0",


### PR DESCRIPTION
## Overview

Update to the latest carbon-icons

This comes with the removal of `"engines"` in package.json to allow `yarn install` and avoid other restrictions