### PR TITLE
test(sauce): introduce Sauce Labs testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 env:
   - TEST_SUITE=misc
   - TEST_SUITE=unit
+  - TEST_SUITE=unit-sauce
   - TEST_SUITE=unit-each
   - TEST_SUITE=a11y
 
@@ -42,11 +43,11 @@ install:
   - npm i https://aat.mybluemix.net/dist/karma-ibma.tgz
 
 script:
-  - if [[ "$TEST_SUITE" == "misc" ]]; then npm run build; fi
+  - if [[ "$TEST_SUITE" == "misc" ]]; then npm run lint; npm run build; fi
   - if [[ "$TEST_SUITE" == "unit" ]]; then npm run test:unit -- -b PhantomJS -b Chrome -b Firefox; fi
+  - if [[ "$TEST_SUITE" == "unit-sauce" && -n "${SAUCE_ACCESS_KEY}" ]]; then npm run test:unit -- -s -d -b Chrome -b Firefox -b Safari -b MicrosoftEdge -b IE; fi
   - if [[ "$TEST_SUITE" == "unit-each" ]]; then find tests/spec -name "*.js" ! -name left-nav_spec.js -print0 | xargs -0 -n 1 -P 1 npm run test:unit -- -d -f; fi
   - if [[ -n "${AAT_TOKEN}" && "$TEST_SUITE" == "a11y" ]]; then npm run test:a11y; fi
-  - if [[ "$TEST_SUITE" == "misc" ]]; then npm run lint; fi
 
 after_success:
   - npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-rollup-plugin": "^0.2.0",
     "karma-safari-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.1.0",
     "karma-sinon-chai": "^1.1.0",
     "karma-sourcemap-loader": "~0.3.7",
     "lolex": "1.4.0",

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -12,17 +12,128 @@ function ensureArray(as) {
   return !as || Array.isArray(as) ? as : [as];
 }
 
+function flatten(a) {
+  return a.reduce((result, item) => {
+    if (Array.isArray(item)) {
+      result.push.apply(result, flatten(item)); // eslint-disable-line prefer-spread
+    } else {
+      result.push(item);
+    }
+    return result;
+  }, []);
+}
+
 const cloptions = require('minimist')(process.argv.slice(2), {
   alias: {
     b: 'browsers',
     f: 'files',
     d: 'debug',
+    s: 'sauce',
     v: 'verbose',
   },
   boolean: ['debug', 'verbose'],
 });
 
+const customLaunchers = {
+  sl_chrome_sierra: {
+    base: 'SauceLabs',
+    platform: 'OS X 10.12',
+    browserName: 'chrome',
+  },
+  sl_chrome_linux: {
+    base: 'SauceLabs',
+    platform: 'Linux',
+    browserName: 'chrome',
+  },
+  sl_chrome_win7: {
+    base: 'SauceLabs',
+    platform: 'Windows 7',
+    browserName: 'chrome',
+  },
+  sl_chrome_android: {
+    base: 'SauceLabs',
+    platform: 'Android',
+    browserName: 'chrome',
+  },
+  sl_firefox_sierra: {
+    base: 'SauceLabs',
+    platform: 'OS X 10.12',
+    browserName: 'firefox',
+    version: '45',
+  },
+  sl_firefox_linux: {
+    base: 'SauceLabs',
+    platform: 'Linux',
+    browserName: 'firefox',
+    version: '45',
+  },
+  sl_firefox_win7: {
+    base: 'SauceLabs',
+    platform: 'Windows 7',
+    browserName: 'firefox',
+    version: '45',
+  },
+  sl_safari_sierra: {
+    base: 'SauceLabs',
+    platform: 'OS X 10.12',
+    browserName: 'safari',
+    version: '10',
+  },
+  sl_safari_elcapitan: {
+    base: 'SauceLabs',
+    platform: 'OS X 10.11',
+    browserName: 'safari',
+    version: '10',
+  },
+  sl_microsoftedge_win10: {
+    base: 'SauceLabs',
+    version: 14,
+    platform: 'Windows 10',
+    browserName: 'microsoftedge',
+  },
+  sl_ie_win10: {
+    base: 'SauceLabs',
+    version: 11,
+    platform: 'Windows 10',
+    browserName: 'internet explorer',
+  },
+  sl_ie_win7: {
+    base: 'SauceLabs',
+    version: 11,
+    platform: 'Windows 7',
+    browserName: 'internet explorer',
+  },
+  Chrome_Travis: {
+    base: 'Chrome',
+    flags: ['--no-sandbox'],
+  },
+};
+
+const sauceLaunchers = {
+  chrome: ['sl_chrome_sierra', 'sl_chrome_linux', 'sl_chrome_win7', 'sl_chrome_android'],
+  firefox: ['sl_firefox_sierra', 'sl_firefox_linux', 'sl_firefox_win7'],
+  safari: ['sl_safari_sierra', 'sl_safari_elcapitan'],
+  microsoftedge: ['sl_microsoftedge_win10'],
+  ie: ['sl_ie_win10', 'sl_ie_win7'],
+};
+
+const travisLaunchers = {
+  chrome: 'Chrome_Travis',
+};
+
 module.exports = function (config) {
+  if (cloptions.sauce) {
+    if (!process.env.TRAVIS) {
+      throw new Error([
+        'You need extra caution when you run Sauce testing locally.',
+        'You can comment out lines here if you know what you are doing.',
+      ].join(' '));
+    }
+    if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+      throw new Error('Missing SAUCE_USERNAME or SAUCE_ACCESS_KEY environment variables.');
+    }
+  }
+
   config.set({
     basePath: '..',
 
@@ -104,11 +215,13 @@ module.exports = function (config) {
       sourceMap: 'inline',
     },
 
-    customLaunchers: {
-      Chrome_Travis: {
-        base: 'Chrome',
-        flags: ['--no-sandbox'],
-      },
+    customLaunchers,
+
+    sauceLabs: {
+      testName: `carbon-components #${process.env.TRAVIS_BUILD_NUMBER} (${process.env.TRAVIS_BUILD_ID})`,
+      buildLabel: `TRAVIS #${process.env.TRAVIS_BUILD_NUMBER} (${process.env.TRAVIS_BUILD_ID})`,
+      recordScreenshots: true,
+      tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
     },
 
     plugins: [
@@ -123,7 +236,7 @@ module.exports = function (config) {
       require('karma-firefox-launcher'),
       require('karma-safari-launcher'),
       require('karma-ie-launcher'),
-    ],
+    ].concat(cloptions.sauce ? [require('karma-sauce-launcher')] : []),
 
     reporters: (() => {
       const reporters = ['mocha'];
@@ -175,8 +288,13 @@ module.exports = function (config) {
     autoWatch: true,
     autoWatchBatchDelay: 400,
 
-    browsers: (Array.isArray(cloptions.browsers) ? cloptions.browsers : [cloptions.browsers || 'PhantomJS'])
-      .map(browser => browser + (browser === 'Chrome' && process.env.TRAVIS ? '_Travis' : '')),
+    browsers: flatten(ensureArray(cloptions.browsers || 'PhantomJS')
+      .map((browser) => {
+        const browserLower = browser.toLowerCase();
+        return (cloptions.sauce && sauceLaunchers[browserLower])
+          || (process.env.TRAVIS && travisLaunchers[browserLower])
+          || browser;
+      })),
 
     singleRun: false,
 


### PR DESCRIPTION
## Overview

This PR introduces Sauce Labs testing on Travis.

### Added

`karma-sauce-launcher` and the configuration for that module.

## Testing / Reviewing

Testing should make sure no unit tests in local/Travis is broken.