### PR TITLE
feat(modal): allow specifying primary focus element

### DIFF
--- a/src/components/modal/modal--nofooter.html
+++ b/src/components/modal/modal--nofooter.html
@@ -5,7 +5,7 @@
     <div class="bx--modal-header">
       <h4 class="bx--modal-header__label">Label (Optional)</h4>
       <h2 class="bx--modal-header__heading">Modal Title</h2>
-      <button class="bx--modal-close" type="button" data-modal-close>
+      <button class="bx--modal-close" type="button" data-modal-close data-modal-primary-focus>
         <svg
           class="bx--modal-close__icon"
         >

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -20,7 +20,7 @@
 
     <div class="bx--modal-footer">
       <button class="bx--btn bx--btn--secondary" type="button" data-modal-close>Cancel</button>
-      <button class="bx--btn bx--btn--primary" type="button">Save</button>
+      <button class="bx--btn bx--btn--primary" type="button" data-modal-primary-focus>Save</button>
     </div>
   </div>
 </div>

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -62,7 +62,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
     const transitionEnd = () => {
       this.element.removeEventListener('transitionend', transitionEnd);
       if (state === 'shown' && this.element.offsetWidth > 0 && this.element.offsetHeight > 0) {
-        this.element.focus();
+        (this.element.querySelector(this.options.selectorPrimaryFocus) || this.element).focus();
       }
       callback();
     };
@@ -141,6 +141,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
   static options = {
     selectorInit: '[data-modal]',
     selectorModalClose: '[data-modal-close]',
+    selectorPrimaryFocus: '[data-modal-primary-focus]',
     classVisible: 'is-visible',
     attribInitTarget: 'data-modal-target',
     initEventNames: ['click'],

--- a/tests/spec/modal_spec.js
+++ b/tests/spec/modal_spec.js
@@ -28,6 +28,7 @@ describe('Test modal', function () {
       expect(modal.options).to.deep.equal({
         selectorInit: '[data-modal]',
         selectorModalClose: '[data-modal-close]',
+        selectorPrimaryFocus: '[data-modal-primary-focus]',
         classVisible: 'is-visible',
         attribInitTarget: 'data-modal-target',
         initEventNames: ['click'],
@@ -54,6 +55,8 @@ describe('Test modal', function () {
     before(function () {
       container = document.createElement('div');
       container.innerHTML = ModalHtml;
+      // Reset primary focus eleemnt for testing
+      delete container.querySelector('[data-modal-primary-focus]').dataset.modalPrimaryFocus;
       document.body.appendChild(container);
       element = container.querySelector('[data-modal]');
     });
@@ -101,6 +104,31 @@ describe('Test modal', function () {
       modal.show(spy);
       modal.element.dispatchEvent(new CustomEvent('transitionend', { bubbles: true }));
       expect(spy).have.been.calledOnce;
+    });
+
+    it('Should focus on modal upon showning', function () {
+      const spy = sinon.spy(modal.element, 'focus');
+      try {
+        modal.show();
+        modal.element.dispatchEvent(new CustomEvent('transitionend', { bubbles: true }));
+        expect(spy).to.have.been.calledOnce;
+      } finally {
+        spy.restore();
+      }
+    });
+
+    it('Should support specifying the primary focus element', function () {
+      const primaryButton = modal.element.querySelector('.bx--btn--primary');
+      const spy = sinon.spy(primaryButton, 'focus');
+      primaryButton.dataset.modalPrimaryFocus = '';
+      try {
+        modal.show();
+        modal.element.dispatchEvent(new CustomEvent('transitionend', { bubbles: true }));
+        expect(spy).to.have.been.calledOnce;
+      } finally {
+        delete primaryButton.dataset.modalPrimaryFocus;
+        spy.restore();
+      }
     });
 
     it('Should sanity check hide()\'s arguments', function () {


### PR DESCRIPTION
## Overview

Fixes #2342.

This PR introduces support for `data-modal-primary-focus` attribute. DOM element in modal with that attribute should get focus when modal gets open.

### Added

* Support for `data-modal-primary-focus` attribute
* Option to change above attribute name

## Testing / Reviewing

Testing should make sure no other modal feature is broken.