### PR TITLE
chore(test): replace es6-weak-map with core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "custom-event": "^1.0.0",
     "cz-conventional-changelog": "^1.2.0",
     "del": "~2.0.2",
-    "es6-weak-map": "^2.0.1",
     "eslint": "^3.0.0",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/tests/remainders.js
+++ b/tests/remainders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('./utils/es6-weak-map-global'); // For PhantomJS
+require('core-js/modules/es6.weak-map'); // For PhantomJS
 
 // Ref: https://github.com/karma-runner/karma-coverage/issues/125#issuecomment-241229152
 [

--- a/tests/spec/accordion_spec.js
+++ b/tests/spec/accordion_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Accordion from '../../src/components/accordion/accordion';
 import HTML from '../../src/components/accordion/accordion.html';
 

--- a/tests/spec/card_spec.js
+++ b/tests/spec/card_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Card from '../../src/components/card/card';
 
 describe('Test card', function () {

--- a/tests/spec/checkbox_spec.js
+++ b/tests/spec/checkbox_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import initCheckbox from '../../src/components/checkbox/checkbox';
 
 describe('Test checkbox', function () {

--- a/tests/spec/content-switcher_spec.js
+++ b/tests/spec/content-switcher_spec.js
@@ -1,5 +1,5 @@
 import Promise, { promisify } from 'bluebird'; // For testing on browsers not supporting Promise
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import ContentSwitcher from '../../src/components/content-switcher/content-switcher';
 import HTML from '../../src/components/content-switcher/content-switcher.html';

--- a/tests/spec/copy-button_spec.js
+++ b/tests/spec/copy-button_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import CopyButton from '../../src/components/copy-button/copy-button';
 
 const HTML = `

--- a/tests/spec/data-table_spec.js
+++ b/tests/spec/data-table_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import ResponsiveTable from '../../src/components/data-table/data-table';
 import HTML from '../../src/components/data-table/data-table.html';

--- a/tests/spec/detail-page-header_spec.js
+++ b/tests/spec/detail-page-header_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import DetailPageHeader from '../../src/components/detail-page-header/detail-page-header';
 
 describe('Test detail page header', function () {

--- a/tests/spec/dropdown_spec.js
+++ b/tests/spec/dropdown_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import Dropdown from '../../src/components/dropdown/dropdown';
 

--- a/tests/spec/fab_spec.js
+++ b/tests/spec/fab_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import FabButton from '../../src/components/fab/fab';
 
 describe('Test floating action button', function () {

--- a/tests/spec/file-uploader_spec.js
+++ b/tests/spec/file-uploader_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import FileUploader from '../../src/components/file-uploader/file-uploader';
 import HTML from '../../src/components/file-uploader/file-uploader.html';
 

--- a/tests/spec/floating-menu_spec.js
+++ b/tests/spec/floating-menu_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import FloatingMenu from '../../src/components/floating-menu/floating-menu';
 import HTML from '../../src/components/overflow-menu/overflow-menu.html'; // Use ul.bx--overflow-menu-options for testing

--- a/tests/spec/interior-left-nav_spec.js
+++ b/tests/spec/interior-left-nav_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import InteriorLeftNav from '../../src/components/interior-left-nav/interior-left-nav';
 import InteriorLeftNavHtml from '../../src/components/interior-left-nav/interior-left-nav.html';
 

--- a/tests/spec/left-nav_spec.js
+++ b/tests/spec/left-nav_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import LeftNav from '../../src/components/unified-header/left-nav';
 
 describe('Test Left Navigation', function () {

--- a/tests/spec/loading_spec.js
+++ b/tests/spec/loading_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Loading from '../../src/components/loading/loading';
 import LoadingHTML from '../../src/components/loading/loading.html';
 

--- a/tests/spec/mixins/init-component-by-launcher_spec.js
+++ b/tests/spec/mixins/init-component-by-launcher_spec.js
@@ -1,4 +1,4 @@
-import '../../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import mixin from '../../../src/globals/js/misc/mixin';
 import initComponentByLauncher from '../../../src/globals/js/mixins/init-component-by-launcher';
 import EventManager from '../../utils/event-manager';

--- a/tests/spec/mixins/init-component-by-search_spec.js
+++ b/tests/spec/mixins/init-component-by-search_spec.js
@@ -1,4 +1,4 @@
-import '../../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import mixin from '../../../src/globals/js/misc/mixin';
 import initComponentBySearch from '../../../src/globals/js/mixins/init-component-by-search';
 

--- a/tests/spec/modal_spec.js
+++ b/tests/spec/modal_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Modal from '../../src/components/modal/modal';
 import ModalHtml from '../../src/components/modal/modal.html';
 import EventManager from '../utils/event-manager';

--- a/tests/spec/notification_spec.js
+++ b/tests/spec/notification_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import Notification from '../../src/components/notification/notification';
 import HTML from '../../src/components/notification/toast-notification.html';

--- a/tests/spec/number-input_spec.js
+++ b/tests/spec/number-input_spec.js
@@ -1,5 +1,5 @@
 import Promise from 'bluebird'; // For testing on browsers not supporting Promise
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import NumberInput from '../../src/components/number-input/number-input';
 import HTML from '../../src/components/number-input/number-input.html';

--- a/tests/spec/overflow-menu_spec.js
+++ b/tests/spec/overflow-menu_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import EventManager from '../utils/event-manager';
 import OverflowMenu from '../../src/components/overflow-menu/overflow-menu';
 import HTML from '../../src/components/overflow-menu/overflow-menu.html';

--- a/tests/spec/pagination_spec.js
+++ b/tests/spec/pagination_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Pagination from '../../src/components/pagination/pagination';
 
 describe('Test pagination', function () {

--- a/tests/spec/profile-switcher_spec.js
+++ b/tests/spec/profile-switcher_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import ProfileSwitcher from '../../src/components/unified-header/profile-switcher';
 import unifiedHeaderHtml from '../../src/components/unified-header/unified-header.html';
 

--- a/tests/spec/progress-indicator_spec.js
+++ b/tests/spec/progress-indicator_spec.js
@@ -1,5 +1,5 @@
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import '../../demo/polyfills/custom-event';
-import '../utils/es6-weak-map-global'; // For PhantomJS
 import ProgressIndicator from '../../src/components/progress-indicator/progress-indicator';
 import HTML from '../../src/components/progress-indicator/progress-indicator.html';
 

--- a/tests/spec/search_spec.js
+++ b/tests/spec/search_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Search from '../../src/components/search/search';
 import searchHTML from '../../src/components/search/search-large.html';
 

--- a/tests/spec/tabs_spec.js
+++ b/tests/spec/tabs_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Tab from '../../src/components/tabs/tabs';
 
 describe('Test tabs', function () {

--- a/tests/spec/toolbar_spec.js
+++ b/tests/spec/toolbar_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import '../../demo/polyfills/custom-event';
 import Toolbar from '../../src/components/toolbar/toolbar';
 import ToolbarHTML from '../../src/components/toolbar/toolbar.html';

--- a/tests/spec/tooltip_spec.js
+++ b/tests/spec/tooltip_spec.js
@@ -1,4 +1,4 @@
-import '../utils/es6-weak-map-global'; // For PhantomJS
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Tooltip from '../../src/components/tooltip/tooltip';
 import HTML from '../../src/components/tooltip/tooltip.html';
 

--- a/tests/utils/es6-weak-map-global.js
+++ b/tests/utils/es6-weak-map-global.js
@@ -1,5 +1,0 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
-import WeakMap from 'es6-weak-map';
-
-window.WeakMap = WeakMap; // For PhantomJS


### PR DESCRIPTION
### Changed

Usage of es6-weak-map (used for tests to support PhantomJS) with core-js/modules/es6.weak-map.

## Testing / Reviewing

Testing should make sure no test is broken.