### PR TITLE
fix(components): fixed accessibility issues

### DIFF
--- a/src/components/card/card--with-status.html
+++ b/src/components/card/card--with-status.html
@@ -1,4 +1,4 @@
-<article class="bx--card" tabindex="0" aria-labelledby="#card-title">
+<article class="bx--card" tabindex="0" aria-labelledby="card-title-1">
   <div class="bx--card__card-overview">
     <!-- OverflowMenu -->
     <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">
@@ -28,7 +28,7 @@
         <img src="/globals/assets/images/placeholder-icon-32x32.svg" alt="" class="bx--about__icon--img"/>
       </figure>
       <header class="bx--about__title">
-        <h3 id="card-title" class="bx--about__title--name">Card Name</h3>
+        <h3 id="card-title-1" class="bx--about__title--name">Card Name</h3>
         <a href="" class="bx--link bx--about__title--link">Secondary Information</a>
       </header>
     </div>

--- a/src/components/card/card.html
+++ b/src/components/card/card.html
@@ -1,4 +1,4 @@
-<article class="bx--card" tabindex="0" aria-labelledby="#card-title">
+<article class="bx--card" tabindex="0" aria-labelledby="card-title-2">
   <div class="bx--card__card-overview">
     <!-- OverflowMenu -->
     <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">
@@ -28,7 +28,7 @@
         <img src="/globals/assets/images/placeholder-icon-32x32.svg" alt="" class="bx--about__icon--img"/>
       </figure>
       <header class="bx--about__title">
-        <h3 id="card-title" class="bx--about__title--name">Card Name</h3>
+        <h3 id="card-title-2" class="bx--about__title--name">Card Name</h3>
         <h4 class="bx--about__title--additional-info">Secondary Information</h4>
       </header>
     </div>

--- a/src/components/code-snippet/code-snippet--code.html
+++ b/src/components/code-snippet/code-snippet--code.html
@@ -22,7 +22,7 @@
       </pre>
     </code>
   </div>
-  <button data-copy-btn class="bx--snippet-button">
+  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code">
     <svg class="bx--snippet__icon">
       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--copy"></use>
     </svg>

--- a/src/components/code-snippet/code-snippet--terminal.html
+++ b/src/components/code-snippet/code-snippet--terminal.html
@@ -2,7 +2,7 @@
   <div class="bx--snippet-container">
     <pre><code>node -v Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis, veritatis voluptate id incidunt molestiae officia possimus, quasi itaque alias, architecto hic, dicta fugit? Debitis delectus quidem explicabo vitae fuga laboriosam!</code></pre>
   </div>
-  <button data-copy-btn class="bx--snippet-button">
+  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code">
     <svg class="bx--snippet__icon">
       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--copy"></use>
     </svg>

--- a/src/components/detail-page-header/detail-page-header--with-tabs.html
+++ b/src/components/detail-page-header/detail-page-header--with-tabs.html
@@ -33,19 +33,19 @@
       </div>
       <ul class="bx--tabs__nav bx--tabs__nav--hidden" role="tablist">
         <li class="bx--tabs__nav-item bx--tabs__nav-item--selected" data-target=".tab-1" role="presentation">
-          <a id="tab-link-1" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="tab-panel-1" aria-selected="true">Tab Label 1</a>
+          <a id="tab-link-1" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-selected="true">Tab Label 1</a>
         </li>
         <li class="bx--tabs__nav-item" data-target=".tab-2" role="presentation">
-          <a id="tab-link-2" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="tab-panel-2" aria-selected="false">Tab Label 2</a>
+          <a id="tab-link-2" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-selected="false">Tab Label 2</a>
         </li>
         <li class="bx--tabs__nav-item" data-target=".tab-3" role="presentation">
-          <a id="tab-link-3" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="tab-panel-3" aria-selected="false">Tab Label 3</a>
+          <a id="tab-link-3" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-selected="false">Tab Label 3</a>
         </li>
         <li class="bx--tabs__nav-item" data-target=".tab-4" role="presentation">
-          <a id="tab-link-4" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="tab-panel-4" aria-selected="false">Tab Label 4</a>
+          <a id="tab-link-4" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-selected="false">Tab Label 4</a>
         </li>
         <li class="bx--tabs__nav-item" data-target=".tab-5" role="presentation">
-          <a id="tab-link-5" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="tab-panel-5" aria-selected="false">Tab Label 5</a>
+          <a id="tab-link-5" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-selected="false">Tab Label 5</a>
         </li>
       </ul>
     </nav>

--- a/src/components/pagination/pagination.html
+++ b/src/components/pagination/pagination.html
@@ -18,14 +18,14 @@
   </div>
   <div class="bx--pagination__right">
     <span class="bx--pagination__text"><span data-displayed-page-number>1</span> of <span data-total-pages>4</span> pages</span>
-    <button class="bx--pagination__button bx--pagination__button--backward" data-page-backward>
+    <button class="bx--pagination__button bx--pagination__button--backward" data-page-backward aria-label="Backward button">
       <svg class="bx--pagination__button-icon">
         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--left"></use>
       </svg>
     </button>
     <label for="page-number-input" class="bx--visually-hidden">Page number input</label>
     <input id="page-number-input" type="text" class="bx--text-input" placeholder="0" value="1" data-page-number-input>
-    <button class="bx--pagination__button bx--pagination__button--forward" data-page-forward>
+    <button class="bx--pagination__button bx--pagination__button--forward" data-page-forward aria-label="Forward button">
       <svg class="bx--pagination__button-icon">
         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--right"></use>
       </svg>

--- a/src/components/search/search-large.html
+++ b/src/components/search/search-large.html
@@ -3,7 +3,7 @@
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--search--glyph"/>
   </svg>
   <label class="bx--label" id="search-input-label-2" for="search__input-1">Search</label>
-  <input class="bx--search-input" type="text" id="search__input-1" placeholder="Search" aria-labelledby="search-input-label-2">
+  <input class="bx--search-input" type="text" role="search" id="search__input-1" placeholder="Search" aria-labelledby="search-input-label-2">
   <svg class="bx--search-close bx--search-close--hidden">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph"/>
   </svg>

--- a/src/components/search/search-large.html
+++ b/src/components/search/search-large.html
@@ -2,17 +2,17 @@
   <svg class="bx--search-magnifier">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--search--glyph"/>
   </svg>
-  <label class="bx--label" for="search__input">Search</label>
-  <input class="bx--search-input" type="text" id="search__input" placeholder="Search">
+  <label class="bx--label" id="search-input-label-2" for="search__input-1">Search</label>
+  <input class="bx--search-input" type="text" id="search__input-1" placeholder="Search" aria-labelledby="search-input-label-2">
   <svg class="bx--search-close bx--search-close--hidden">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph"/>
   </svg>
-  <button class="bx--search-button" type="button">
+  <button class="bx--search-button" type="button" aria-label="Filter button">
     <svg class="bx--search-filter">
       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--filter--glyph"/>
     </svg>
   </button>
-  <button class="bx--search-button" type="button" data-search-toggle>
+  <button class="bx--search-button" type="button" data-search-toggle aria-label="Grid and list toggle button">
     <div data-search-view="grid">
       <svg class="bx--search-view">
         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--grid"/>

--- a/src/components/search/search-small.html
+++ b/src/components/search/search-small.html
@@ -2,8 +2,8 @@
   <svg class="bx--search-magnifier">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--search--glyph"/>
   </svg>
-  <label class="bx--label" for="search__input">Search</label>
-  <input class="bx--search-input" type="text" id="search__input" placeholder="Search">
+  <label id="search-input-label-1" class="bx--label" for="search__input-2">Search</label>
+  <input class="bx--search-input" type="text" id="search__input-2" placeholder="Search" aria-labelledby="search-input-label-1">
   <svg class="bx--search-close bx--search-close--hidden">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph"/>
   </svg>

--- a/src/components/search/search-small.html
+++ b/src/components/search/search-small.html
@@ -3,7 +3,7 @@
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--search--glyph"/>
   </svg>
   <label id="search-input-label-1" class="bx--label" for="search__input-2">Search</label>
-  <input class="bx--search-input" type="text" id="search__input-2" placeholder="Search" aria-labelledby="search-input-label-1">
+  <input class="bx--search-input" type="text" id="search__input-2" role="search" placeholder="Search" aria-labelledby="search-input-label-1">
   <svg class="bx--search-close bx--search-close--hidden">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph"/>
   </svg>

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -115,4 +115,8 @@ $css--helpers: true;
     border: 0;
     border-top: 1px solid $ui-04;
   }
+
+  .bx--radio-button-group {
+    border: none;
+  }
 }

--- a/src/components/toolbar/toolbar.html
+++ b/src/components/toolbar/toolbar.html
@@ -2,7 +2,7 @@
   <div class="bx--search bx--search--sm bx--toolbar-search" role="search" data-search data-toolbar-search>
     <label for="search__input" class="bx--label">Search</label>
     <input type="search" class="bx--search-input" id="search__input" placeholder="Search">
-    <button class="bx--toolbar-search__btn">
+    <button class="bx--toolbar-search__btn" aria-label="Toolbar search">
       <svg class="bx--search-magnifier">
         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--search--glyph"/>
       </svg>
@@ -18,7 +18,7 @@
     <ul class="bx--overflow-menu-options">
       <li class="bx--toolbar-menu__title">FILTER BY</li>
       <li class="bx--toolbar-menu__option">
-        <input id="filter-option-1" class="bx--checkbox" type="checkbox" value="green" name="checkbox">
+        <input id="filter-option-1" class="bx--checkbox" type="checkbox" value="filter-option-1" name="checkbox">
         <label for="filter-option-1" class="bx--checkbox-label">
           <span class="bx--checkbox-appearance">
             <svg class="bx--checkbox-checkmark">
@@ -29,7 +29,7 @@
         </label>
       </li>
       <li class="bx--toolbar-menu__option">
-        <input id="filter-option-2" class="bx--checkbox" type="checkbox" value="green" name="checkbox">
+        <input id="filter-option-2" class="bx--checkbox" type="checkbox" value="filter-option-2" name="checkbox">
         <label for="filter-option-2" class="bx--checkbox-label">
           <span class="bx--checkbox-appearance">
             <svg class="bx--checkbox-checkmark">
@@ -40,7 +40,7 @@
         </label>
       </li>
       <li class="bx--toolbar-menu__option">
-        <input id="filter-option-3" class="bx--checkbox" type="checkbox" value="green" name="checkbox">
+        <input id="filter-option-3" class="bx--checkbox" type="checkbox" value="filter-option-3" name="checkbox">
         <label for="filter-option-3" class="bx--checkbox-label">
           <span class="bx--checkbox-appearance">
             <svg class="bx--checkbox-checkmark">


### PR DESCRIPTION
## Overview

Resolves https://github.ibm.com/Bluemix/bluemix-components/issues/2470

This PR fixes some accessibility issues that surfaced during my accessibility audit of the website. 

### Changed

- Card had the wrong `aria-labelledby` value
- The copy button in the code snippet needed an `aria-label`
- The buttons in Toolbar needed labels
- The DPH had `aria-controls` on the tabs without tab content present
- Pagination buttons needed labels
- Search button needed labels
- The inputs in Search needed labels

I've been testing this using the [Axe Chrome extension](https://www.deque.com/products/axe/).
