### PR TITLE
chore(version): bump to 7.2, prepare for semantic-release to replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "carbon-components",
   "description": "Carbon Components is a component library for IBM Cloud",
   "homepage": "http://carbondesignsystem.com/",
-  "version": "0.0.0-development",
+  "version": "7.2.0",
   "module": "es/index.js",
   "main": "umd/index.js",
   "repository": {


### PR DESCRIPTION
## Overview

Last time I published was from the v7 branch, semantic-release doesn't like that. One last manual bump