### PR TITLE
chore(travis): make one-component-by-one test optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ cache:
   directories:
   - node_modules
 
+env:
+  - TEST_SUITE=misc
+  - TEST_SUITE=unit
+  - TEST_SUITE=unit-each
+  - TEST_SUITE=a11y
+
 node_js:
   - "6"
 
@@ -14,6 +20,13 @@ addons:
     packages:
       - google-chrome-stable
   firefox: "latest-esr"
+
+matrix:
+  exclude:
+  - env: TEST_SUITE=unit-each
+  allow_failures:
+  - env: TEST_SUITE=unit-each
+  - env: TEST_SUITE=a11y
 
 before_install:
   - if [[ -n "${AAT_TOKEN}" ]]; then sed -e "s|\${AAT_TOKEN}|$AAT_TOKEN|g" < .aat.yml.src > .aat.yml; fi
@@ -29,11 +42,11 @@ install:
   - npm i https://aat.mybluemix.net/dist/karma-ibma.tgz
 
 script:
-  - npm run build
-  - npm run test:unit -- -b PhantomJS -b Chrome -b Firefox
-  - find tests/spec -name "*.js" ! -name left-nav_spec.js -print0 | xargs -0 -n 1 -P 1 npm run test:unit -- -d -f
-  - if [[ -n "${AAT_TOKEN}" ]]; then (npm run test:a11y || true); fi
-  - npm run lint
+  - if [[ "$TEST_SUITE" == "misc" ]]; then npm run build; fi
+  - if [[ "$TEST_SUITE" == "unit" ]]; then npm run test:unit -- -b PhantomJS -b Chrome -b Firefox; fi
+  - if [[ "$TEST_SUITE" == "unit-each" ]]; then find tests/spec -name "*.js" ! -name left-nav_spec.js -print0 | xargs -0 -n 1 -P 1 npm run test:unit -- -d -f; fi
+  - if [[ -n "${AAT_TOKEN}" && "$TEST_SUITE" == "a11y" ]]; then npm run test:a11y; fi
+  - if [[ "$TEST_SUITE" == "misc" ]]; then npm run lint; fi
 
 after_success:
   - npm run semantic-release


### PR DESCRIPTION
## Overview

This PR makes the test run faster, by making one-component-by-one test optional.

### Added

* Travis test matrix for testing multiple categories of tests in parallel
* Put one-component-by-one test in the “excluded” bucket

## Testing / Reviewing

Should make sure our Travis test is not broken.