### PR TITLE
chore(a11y-test): use latest policy from a11y team

### DIFF
--- a/.aat.yml.src
+++ b/.aat.yml.src
@@ -7,7 +7,7 @@ rulePack: https://cc-rules.w3ibm.mybluemix.net/js/latest/
 # i.e. Multiple policies: CI162_5_2_DCP080115,CI162_5_2_DCP070116 or refer to below as a list
 # Default: CI162_5_2_DCP070116
 policies:
-    - CI162_5_2_DCP080115
+    - IBM_Accessibility_2017_02
 
 # optional - Specify one or many violation levels on which to fail the test
 #            i.e. If specified violation then the testcase will only fail if

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 install:
   - npm prune
   - npm install || (cat npm-debug.log; false)
-  - npm i https://aat.mybluemix.net/dist/karma-ibma.tgz
+  - if [[ -n "${AAT_TOKEN}" && "$TEST_SUITE" == "a11y" ]]; then npm i https://aat.mybluemix.net/dist/karma-ibma.tgz; fi
 
 script:
   - if [[ "$TEST_SUITE" == "misc" ]]; then npm run build; fi


### PR DESCRIPTION
## Overview

This PR is for using the latest policy from a11y team.
This PR also avoids installing karma-ibma for non-a11y Travis tests.

## Testing / Reviewing

Travis test shouldn’t be broken.