### PR TITLE
fix(text-input): fix letters being cut off

### DIFF
--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -18,7 +18,7 @@
     width: 100%;
     height: rem(40px);
     min-width: 10rem;
-    padding: .825rem 1rem;
+    padding: 0 1rem;
     color: $text-01;
     background-color: $field-01;
     border: 1px solid transparent;


### PR DESCRIPTION
## Fix letters being cut off in text-input

### Changed
- Removed vertical padding, as the specified height takes care of this. Was leading to weird rendering issues in Firefox where letters like `q`,`j`, and `y` were cut off at the bottom.


