### PR TITLE
fix(content-switcher): fix code syntax in readme

### DIFF
--- a/src/components/content-switcher/README.md
+++ b/src/components/content-switcher/README.md
@@ -110,14 +110,14 @@ const instance = ContentSwitcher.init();
 instance.setActive(button);
 ```
 
-> The `setActive` method also takes an optional `callback` function parameter. The most typical example of using this is acting on a newly selected content-switcher button. 
-> ```js
-> contentSwitcher.setActive(button, function (error, item) {
->  if (!error) {
->    // Having no error means that content switching is not canceled, so go on…
->    item.ownerDocument.querySelector(item.dataset.target).querySelector('input').focus(); // `item` is the newly selected button
->  }
->});
+ The `setActive` method also takes an optional `callback` function parameter. The most typical example of using this is acting on a newly selected content-switcher button. 
+ ```js
+ contentSwitcher.setActive(button, function (error, item) {
+  if (!error) {
+    // Having no error means that content switching is not canceled, so go on…
+    item.ownerDocument.querySelector(item.dataset.target).querySelector('input').focus(); // `item` is the newly selected button
+  }
+});
 ```
 
 #### Using buttons or anchor elements are both fine


### PR DESCRIPTION
## Overview

Wasn't rendering correctly on website

![image](https://cloud.githubusercontent.com/assets/4185382/25141919/c89784c0-242a-11e7-8ada-d90eaaf43bbc.png)

Since it doesn't look like the site uses asides, I removed the syntax for asides to ensure correct rendering on site. 
