### PR TITLE
fix(readme): update migration guides to differentiate between old / new

### DIFF
--- a/src/components/accordion/migrate-to-7.x.md
+++ b/src/components/accordion/migrate-to-7.x.md
@@ -16,6 +16,12 @@ For more details on installing and using bluemix-icons, see install and usage gu
 
 The `_accordion.scss` file is now located at __src/components/accordion/_accordion.scss__. You'll need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/accordion/accordion';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/accordion/accordion';
 ```

--- a/src/components/accordion/migrate-to-7.x.md
+++ b/src/components/accordion/migrate-to-7.x.md
@@ -14,7 +14,7 @@ For more details on installing and using bluemix-icons, see install and usage gu
 
 ### SCSS
 
-The `_accordion.scss` file is now located at __src/components/accordion/_accordion.scss__. You'll need to update any `@import` statements for this file to reflect this change.
+The `_accordion.scss` file is now located at `src/components/accordion/_accordion.scss`. You'll need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/breadcrumb/migrate-to-7.x.md
+++ b/src/components/breadcrumb/migrate-to-7.x.md
@@ -6,8 +6,12 @@ The `bx--breadcrumb--lg` modifier class has been removed in `7.x` and is no long
 
 The `_breadcrumb.scss` file is now located at __src/components/breadcrumb/_breadcrumb.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/breadcrumb/breadcrumb';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/breadcrumb/breadcrumb';
 ```
-
-

--- a/src/components/breadcrumb/migrate-to-7.x.md
+++ b/src/components/breadcrumb/migrate-to-7.x.md
@@ -4,7 +4,7 @@ The `bx--breadcrumb--lg` modifier class has been removed in `7.x` and is no long
 
 ### SCSS
 
-The `_breadcrumb.scss` file is now located at __src/components/breadcrumb/_breadcrumb.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_breadcrumb.scss` file is now located at `src/components/breadcrumb/_breadcrumb.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/button/migrate-to-7.x.md
+++ b/src/components/button/migrate-to-7.x.md
@@ -2,6 +2,12 @@
 
 The `_button.scss` file is now located at __src/components/button/_button.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/button/button';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/button/button';
 ```

--- a/src/components/button/migrate-to-7.x.md
+++ b/src/components/button/migrate-to-7.x.md
@@ -1,6 +1,6 @@
 ### SCSS
 
-The `_button.scss` file is now located at __src/components/button/_button.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_button.scss` file is now located at `src/components/button/_button.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/card/migrate-to-7.x.md
+++ b/src/components/card/migrate-to-7.x.md
@@ -6,6 +6,12 @@ The various card HTML variations of previous versions are now replaced by two si
 
 The `_card.scss` file is now located at __src/components/card/card.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/card/card';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/card/card';
 ```

--- a/src/components/card/migrate-to-7.x.md
+++ b/src/components/card/migrate-to-7.x.md
@@ -4,7 +4,7 @@ The various card HTML variations of previous versions are now replaced by two si
 
 ### SCSS
 
-The `_card.scss` file is now located at __src/components/card/card.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_card.scss` file is now located at `src/components/card/_card.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/checkbox/migrate-to-7.x.md
+++ b/src/components/checkbox/migrate-to-7.x.md
@@ -7,6 +7,12 @@ All checkboxes must use SVG icons to ensure browser compatibility.
 
 The `_checkbox.scss` file is now located in __src/components/checkbox__. You'll need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/checkbox/checkbox';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/checkbox/checkbox';
 ```

--- a/src/components/checkbox/migrate-to-7.x.md
+++ b/src/components/checkbox/migrate-to-7.x.md
@@ -5,7 +5,7 @@ All checkboxes must use SVG icons to ensure browser compatibility.
 
 ### SCSS
 
-The `_checkbox.scss` file is now located in __src/components/checkbox__. You'll need to update any `@import` statements for this file to reflect this change.
+The `_checkbox.scss` file is now located in `src/components/checkbox/_checkbox.scss`. You'll need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/code-snippet/migrate-to-7.x.md
+++ b/src/components/code-snippet/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No changes.
 
 ### SCSS
 
-The `_code-snippet.scss` file is now located at __src/components/code-snippet/_code-snippet.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_code-snippet.scss` file is now located at `src/components/code-snippet/_code-snippet.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/code-snippet/migrate-to-7.x.md
+++ b/src/components/code-snippet/migrate-to-7.x.md
@@ -6,6 +6,12 @@ No changes.
 
 The `_code-snippet.scss` file is now located at __src/components/code-snippet/_code-snippet.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/code-snippet/code-snippet';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/code-snippet/code-snippet';
 ```

--- a/src/components/content-switcher/migrate-to-7.x.md
+++ b/src/components/content-switcher/migrate-to-7.x.md
@@ -13,7 +13,7 @@ Use the smaller, simpler HTML for content-switcher from now on:
 
 ### SCSS
 
-The `_content-switcher.scss` file is now located at __src/components/content-switcher/_content-switcher.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_content-switcher.scss` file is now located at `src/components/content-switcher/_content-switcher.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/content-switcher/migrate-to-7.x.md
+++ b/src/components/content-switcher/migrate-to-7.x.md
@@ -15,6 +15,12 @@ Use the smaller, simpler HTML for content-switcher from now on:
 
 The `_content-switcher.scss` file is now located at __src/components/content-switcher/_content-switcher.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/content-switcher/content-switcher';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/content-switcher/content-switcher';
 ```

--- a/src/components/data-table/migrate-to-7.x.md
+++ b/src/components/data-table/migrate-to-7.x.md
@@ -4,7 +4,7 @@ Main changes to HTML are for changes to Overflow Menu, Checkbox and icons that a
 
 ### SCSS
 
-The `_data-table.scss` file is now located at __src/components/data-table/_data-table.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_data-table.scss` file is now located at `src/components/data-table/_data-table.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/data-table/migrate-to-7.x.md
+++ b/src/components/data-table/migrate-to-7.x.md
@@ -6,6 +6,12 @@ Main changes to HTML are for changes to Overflow Menu, Checkbox and icons that a
 
 The `_data-table.scss` file is now located at __src/components/data-table/_data-table.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/data-table/data-table';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/data-table/data-table';
 ```

--- a/src/components/detail-page-header/migrate-to-7.x.md
+++ b/src/components/detail-page-header/migrate-to-7.x.md
@@ -7,6 +7,12 @@ A lot of classes have been removed, see SCSS for more details.
 
 The `_detail-page-header.scss` file is now located at __src/components/detail-page-header/_detail-page-header.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/detail-page-header/detail-page-header';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/detail-page-header/detail-page-header';
 ```

--- a/src/components/detail-page-header/migrate-to-7.x.md
+++ b/src/components/detail-page-header/migrate-to-7.x.md
@@ -5,7 +5,7 @@ A lot of classes have been removed, see SCSS for more details.
 
 ### SCSS
 
-The `_detail-page-header.scss` file is now located at __src/components/detail-page-header/_detail-page-header.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_detail-page-header.scss` file is now located at `src/components/detail-page-header/_detail-page-header.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/dropdown/migrate-to-7.x.md
+++ b/src/components/dropdown/migrate-to-7.x.md
@@ -6,9 +6,16 @@ No structural changes. However, class names have been changed.
 
 The `_dropdown.scss` file is now located at __src/components/.dropdown/dropdown.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/dropdown/dropdown';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/dropdown/dropdown';
 ```
+
 Quite a few class names have changed. See table below.
 
 | Old Class               | New Class         |

--- a/src/components/dropdown/migrate-to-7.x.md
+++ b/src/components/dropdown/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No structural changes. However, class names have been changed.
 
 ### SCSS
 
-The `_dropdown.scss` file is now located at __src/components/.dropdown/dropdown.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_dropdown.scss` file is now located at `src/components/dropdown/_dropdown.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/file-uploader/migrate-to-7.x.md
+++ b/src/components/file-uploader/migrate-to-7.x.md
@@ -8,7 +8,7 @@ There's also a new `.bx--file-container` element that is used to display filenam
 
 ### SCSS
 
-The `_file-uploader.scss` file is now located at __src/components/file-uploader/_file-uploader.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_file-uploader.scss` file is now located at `src/components/file-uploader/_file-uploader.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/file-uploader/migrate-to-7.x.md
+++ b/src/components/file-uploader/migrate-to-7.x.md
@@ -10,6 +10,12 @@ There's also a new `.bx--file-container` element that is used to display filenam
 
 The `_file-uploader.scss` file is now located at __src/components/file-uploader/_file-uploader.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/file-uploader/file-uploader';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/file-uploader/file-uploader';
 ```

--- a/src/components/footer/migrate-to-7.x.md
+++ b/src/components/footer/migrate-to-7.x.md
@@ -5,7 +5,7 @@ Now there's only one variant of HTML for Footer that more closely resembles what
 
 ### SCSS
 
-The `_footer.scss` file is now located at __src/components/footer/_footer.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_footer.scss` file is now located at `src/components/footer/_footer.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/footer/migrate-to-7.x.md
+++ b/src/components/footer/migrate-to-7.x.md
@@ -7,6 +7,12 @@ Now there's only one variant of HTML for Footer that more closely resembles what
 
 The `_footer.scss` file is now located at __src/components/footer/_footer.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/footer/footer';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/footer/footer';
 ```

--- a/src/components/form/migrate-to-7.x.md
+++ b/src/components/form/migrate-to-7.x.md
@@ -16,9 +16,16 @@ For full usage guidelines of the new HTML see the component README file.
 
 The `_form.scss` file is now located at __src/components/form/form.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/form/form';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/form/form';
 ```
+
 Quite a few class names have changed. See table below.
 
 | Old Class              | New Class            | Note    |

--- a/src/components/form/migrate-to-7.x.md
+++ b/src/components/form/migrate-to-7.x.md
@@ -14,7 +14,7 @@ For full usage guidelines of the new HTML see the component README file.
 
 ### SCSS
 
-The `_form.scss` file is now located at __src/components/form/form.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_form.scss` file is now located at `src/components/form/_form.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/interior-left-nav/migrate-to-7.x.md
+++ b/src/components/interior-left-nav/migrate-to-7.x.md
@@ -17,6 +17,12 @@ All data-attributes containing the words `inline-left-nav` have been changed to 
 
 The `_interior-left-nav.scss` file is now located at __src/components/interior-left-nav/_interior-left-nav.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/interior-left-nav/interior-left-nav';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/interior-left-nav/interior-left-nav';
 ```

--- a/src/components/interior-left-nav/migrate-to-7.x.md
+++ b/src/components/interior-left-nav/migrate-to-7.x.md
@@ -15,7 +15,7 @@ All data-attributes containing the words `inline-left-nav` have been changed to 
 
 ### SCSS
 
-The `_interior-left-nav.scss` file is now located at __src/components/interior-left-nav/_interior-left-nav.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_interior-left-nav.scss` file is now located at `src/components/interior-left-nav/_interior-left-nav.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/link/migrate-to-7.x.md
+++ b/src/components/link/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No changes.
 
 ### SCSS
 
-The `_link.scss` file is now located at __src/components/link/link.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_link.scss` file is now located at `src/components/link/_link.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/link/migrate-to-7.x.md
+++ b/src/components/link/migrate-to-7.x.md
@@ -6,6 +6,12 @@ No changes.
 
 The `_link.scss` file is now located at __src/components/link/link.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/link/link';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/link/link';
 ```

--- a/src/components/list/migrate-to-7.x.md
+++ b/src/components/list/migrate-to-7.x.md
@@ -6,6 +6,12 @@ No changes.
 
 The `_list.scss` file is now located at __src/components/list/list.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/list/list';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/list/list';
 ```

--- a/src/components/list/migrate-to-7.x.md
+++ b/src/components/list/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No changes.
 
 ### SCSS
 
-The `_list.scss` file is now located at __src/components/list/list.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_list.scss` file is now located at `src/components/list/_list.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/loading/migrate-to-7.x.md
+++ b/src/components/loading/migrate-to-7.x.md
@@ -5,7 +5,7 @@ No class names have changed.
 
 ### SCSS
 
-The `_loading.scss` file is now located at __src/components/loading/loading.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_loading.scss` file is now located at `src/components/loading/_loading.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/loading/migrate-to-7.x.md
+++ b/src/components/loading/migrate-to-7.x.md
@@ -7,6 +7,12 @@ No class names have changed.
 
 The `_loading.scss` file is now located at __src/components/loading/loading.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/loading/loading';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/loading/loading';
 ```

--- a/src/components/modal/migrate-to-7.x.md
+++ b/src/components/modal/migrate-to-7.x.md
@@ -19,6 +19,12 @@ With that said, it will be best to copy and paste the new HTML for Modal to capt
 
 The `_modal.scss` file is now located at __src/components/modal/_modal.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/modal/modal';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/modal/modal';
 ```

--- a/src/components/modal/migrate-to-7.x.md
+++ b/src/components/modal/migrate-to-7.x.md
@@ -17,7 +17,7 @@ With that said, it will be best to copy and paste the new HTML for Modal to capt
 
 ### SCSS
 
-The `_modal.scss` file is now located at __src/components/modal/_modal.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_modal.scss` file is now located at `src/components/modal/_modal.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/module/migrate-to-7.x.md
+++ b/src/components/module/migrate-to-7.x.md
@@ -24,6 +24,12 @@ For more examples see the `module.html` file.
 
 The `_module.scss` file is now located at __src/components/modules/module.scss__. You'll need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/module/module';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/module/module';
 ```

--- a/src/components/module/migrate-to-7.x.md
+++ b/src/components/module/migrate-to-7.x.md
@@ -22,7 +22,7 @@ For more examples see the `module.html` file.
 
 ### SCSS
 
-The `_module.scss` file is now located at __src/components/modules/module.scss__. You'll need to update any `@import` statements for this file to reflect this change.
+The `_module.scss` file is now located at `src/components/modules/_module.scss`. You'll need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/notification/migrate-to-7.x.md
+++ b/src/components/notification/migrate-to-7.x.md
@@ -8,11 +8,12 @@ The majority of the class names have changed along with some structural changes.
 
 ### SCSS
 
-The `_notification.scss` file is now located at __src/components/notification/notification.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_notification.scss` is now split in to two files. They are located at `src/components/notification/_inline-notification.scss` and `src/components/notification/_toast-notification.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss
-@import 'path_to_node_modules/carbon-components/src/components/notification/notification';
+@import 'path_to_node_modules/carbon-components/src/components/notification/_toast-notification.scss';
+@import 'path_to_node_modules/carbon-components/src/components/notification/_inline-notification.scss';
 ```
 
 **Old**: 

--- a/src/components/notification/migrate-to-7.x.md
+++ b/src/components/notification/migrate-to-7.x.md
@@ -10,9 +10,16 @@ The majority of the class names have changed along with some structural changes.
 
 The `_notification.scss` file is now located at __src/components/notification/notification.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/notification/notification';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/notification/notification';
 ```
+
 Quite a few class names have changed. See table below.
 
 | Old Class                      | New Class: Inline                     | New Class: Toast                     |

--- a/src/components/number-input/migrate-to-7.x.md
+++ b/src/components/number-input/migrate-to-7.x.md
@@ -7,7 +7,7 @@ In general, it will be easiest to simply copy and paste the new HTML to replace 
 
 ### SCSS
 
-The `_number-input.scss` file is now located at __src/components/number-input/_number-input.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_number-input.scss` file is now located at `src/components/number-input/_number-input.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/number-input/migrate-to-7.x.md
+++ b/src/components/number-input/migrate-to-7.x.md
@@ -9,6 +9,12 @@ In general, it will be easiest to simply copy and paste the new HTML to replace 
 
 The `_number-input.scss` file is now located at __src/components/number-input/_number-input.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/number-input/number-input';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/number-input/number-input';
 ```

--- a/src/components/overflow-menu/migrate-to-7.x.md
+++ b/src/components/overflow-menu/migrate-to-7.x.md
@@ -4,7 +4,7 @@ Structure stays the same but some class names have been changed. See below.
 
 ### SCSS
 
-The `_overflow-menu.scss` file is now located at `__src/components/overflow-menu/_overflow-menu.scss.` You will need to update any `@import` statements for this file to reflect this change.
+The `_overflow-menu.scss` file is now located at `src/components/overflow-menu/_overflow-menu.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/overflow-menu/migrate-to-7.x.md
+++ b/src/components/overflow-menu/migrate-to-7.x.md
@@ -6,8 +6,14 @@ Structure stays the same but some class names have been changed. See below.
 
 The `_overflow-menu.scss` file is now located at `__src/components/overflow-menu/_overflow-menu.scss.` You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
 ```scss
-@import 'path_to_node_modules/@console/bluemix-components/src/components/tooltip/tooltip;
+@import 'path_to_node_modules/carbon-components/src/components/overflow-menu/overflow-menu';
+```
+
+**Old**: 
+```scss
+@import 'path_to_node_modules/@console/bluemix-components/src/components/overflow-menu/overflow-menu;
 ```
 
 `.bx--overflow-menu__options` is now `.bx--overflow-menu-options`

--- a/src/components/pagination/migrate-to-7.x.md
+++ b/src/components/pagination/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No changes.
 
 ### SCSS
 
-The `_pagination.scss` file is now located at __src/components/pagination/_pagination.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_pagination.scss` file is now located at `src/components/pagination/_pagination.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/pagination/migrate-to-7.x.md
+++ b/src/components/pagination/migrate-to-7.x.md
@@ -6,6 +6,12 @@ No changes.
 
 The `_pagination.scss` file is now located at __src/components/pagination/_pagination.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/pagination/pagination';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/pagination/pagination';
 ```

--- a/src/components/progress-indicator/migrate-to-7.x.md
+++ b/src/components/progress-indicator/migrate-to-7.x.md
@@ -8,6 +8,12 @@ SVGs representing incomplete, complete and current steps now rely on inline SVGs
 
 The `_progress-indicator.scss` file is now located at __src/components/progress-indicator/_progress-indicator.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/progress-indicator/progress-indicator';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/progress-indicator/progress-indicator';
 ```

--- a/src/components/progress-indicator/migrate-to-7.x.md
+++ b/src/components/progress-indicator/migrate-to-7.x.md
@@ -6,7 +6,7 @@ SVGs representing incomplete, complete and current steps now rely on inline SVGs
 
 ### SCSS
 
-The `_progress-indicator.scss` file is now located at __src/components/progress-indicator/_progress-indicator.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_progress-indicator.scss` file is now located at `src/components/progress-indicator/_progress-indicator.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/radio-button/migrate-to-7.x.md
+++ b/src/components/radio-button/migrate-to-7.x.md
@@ -6,6 +6,12 @@
 
 The `_radio-button.scss` file is now located in __src/components/radio-button__. You'll need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/radio-button/radio-button';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/radio-button/radio-button';
 ```

--- a/src/components/radio-button/migrate-to-7.x.md
+++ b/src/components/radio-button/migrate-to-7.x.md
@@ -4,7 +4,7 @@
 
 ### SCSS
 
-The `_radio-button.scss` file is now located in __src/components/radio-button__. You'll need to update any `@import` statements for this file to reflect this change.
+The `_radio-button.scss` file is now located at `src/components/radio-button/_radio-button.scss`. You'll need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/search/migrate-to-7.x.md
+++ b/src/components/search/migrate-to-7.x.md
@@ -6,6 +6,12 @@ The new HTML is structurally the same. However, we've now added the `[data-searc
 
 The `_search.scss` file is now located at __src/components/search/search.scss__. You'll need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/search/search';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/search/search';
 ```

--- a/src/components/search/migrate-to-7.x.md
+++ b/src/components/search/migrate-to-7.x.md
@@ -4,7 +4,7 @@ The new HTML is structurally the same. However, we've now added the `[data-searc
 
 ### SCSS
 
-The `_search.scss` file is now located at __src/components/search/search.scss__. You'll need to update any `@import` statements for this file to reflect this change.
+The `_search.scss` file is now located at `src/components/search/_search.scss`. You'll need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/select/migrate-to-7.x.md
+++ b/src/components/select/migrate-to-7.x.md
@@ -6,9 +6,16 @@ No changes.
 
 The `_select.scss` file is now located at __src/components/select/select.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/select/select';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/select/select';
 ```
+
 Quite a few class names have changed. See table below.
 
 | Old Class            | New Class           | Note    |

--- a/src/components/select/migrate-to-7.x.md
+++ b/src/components/select/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No changes.
 
 ### SCSS
 
-The `_select.scss` file is now located at __src/components/select/select.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_select.scss` file is now located at `src/components/select/_select.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/tabs/migrate-to-7.x.md
+++ b/src/components/tabs/migrate-to-7.x.md
@@ -6,6 +6,12 @@ No changes.
 
 The `_tabs.scss` file is now located at __src/components/tabs/_tabs.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/tabs/tabs';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/tabs/tabs';
 ```

--- a/src/components/tabs/migrate-to-7.x.md
+++ b/src/components/tabs/migrate-to-7.x.md
@@ -4,7 +4,7 @@ No changes.
 
 ### SCSS
 
-The `_tabs.scss` file is now located at __src/components/tabs/_tabs.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_tabs.scss` file is now located at `src/components/tabs/_tabs.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/tag/migrate-to-7.x.md
+++ b/src/components/tag/migrate-to-7.x.md
@@ -6,6 +6,12 @@ HTML has not changed except for class attributes. See SCSS for more details.
 
 The `_tag.scss` file is now located at __src/components/tag/_tag.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/tag/tag';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/tag/tag';
 ```

--- a/src/components/tag/migrate-to-7.x.md
+++ b/src/components/tag/migrate-to-7.x.md
@@ -4,7 +4,7 @@ HTML has not changed except for class attributes. See SCSS for more details.
 
 ### SCSS
 
-The `_tag.scss` file is now located at __src/components/tag/_tag.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_tag.scss` file is now located at `src/components/tag/_tag.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/text-area/migrate-to-7.x.md
+++ b/src/components/text-area/migrate-to-7.x.md
@@ -4,7 +4,7 @@ Text Area and other form components now make use of common form HTML and CSS. Se
 
 ### SCSS
 
-The `_text-area.scss` file is now located at __src/components/breadcrumb/_text-area.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_text-area.scss` file is now located at `src/components/text-area/_text-area.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/text-area/migrate-to-7.x.md
+++ b/src/components/text-area/migrate-to-7.x.md
@@ -6,6 +6,12 @@ Text Area and other form components now make use of common form HTML and CSS. Se
 
 The `_text-area.scss` file is now located at __src/components/breadcrumb/_text-area.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/text-area/text-area';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/text-area/text-area';
 ```

--- a/src/components/text-input/migrate-to-7.x.md
+++ b/src/components/text-input/migrate-to-7.x.md
@@ -15,6 +15,12 @@ See Forms for more details on using labels and form validation.
 
 The `_text-input.scss` file is now located at __src/components/text-input/_text-input.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/text-input/text-input';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/text-input/text-input';
 ```

--- a/src/components/text-input/migrate-to-7.x.md
+++ b/src/components/text-input/migrate-to-7.x.md
@@ -13,7 +13,7 @@ See Forms for more details on using labels and form validation.
 
 ### SCSS
 
-The `_text-input.scss` file is now located at __src/components/text-input/_text-input.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_text-input.scss` file is now located at `src/components/text-input/_text-input.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/toggle/migrate-to-7.x.md
+++ b/src/components/toggle/migrate-to-7.x.md
@@ -6,6 +6,12 @@ Toggle and other form components are wrapped with the `.bx--form-item` element.
 
 The `_toggle.scss` file is now located at __src/components/toggle/_toggle.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/toggle/toggle';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/toggle/toggle';
 ```

--- a/src/components/toggle/migrate-to-7.x.md
+++ b/src/components/toggle/migrate-to-7.x.md
@@ -4,7 +4,7 @@ Toggle and other form components are wrapped with the `.bx--form-item` element.
 
 ### SCSS
 
-The `_toggle.scss` file is now located at __src/components/toggle/_toggle.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_toggle.scss` file is now located at `src/components/toggle/_toggle.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/tooltip/migrate-to-7.x.md
+++ b/src/components/tooltip/migrate-to-7.x.md
@@ -6,7 +6,7 @@ There are now two major variations of this component. The original tooltip is no
 
 ### SCSS
 
-The `_tooltip.scss` file is now located at __src/components/tooltip/tooltip.scss__. You will need to update any `@import` statements for this file to reflect this change.
+The `_tooltip.scss` file is now located at `src/components/tooltip/_tooltip.scss`. You will need to update any `@import` statements for this file to reflect this change.
 
 **New**: 
 ```scss

--- a/src/components/tooltip/migrate-to-7.x.md
+++ b/src/components/tooltip/migrate-to-7.x.md
@@ -8,6 +8,12 @@ There are now two major variations of this component. The original tooltip is no
 
 The `_tooltip.scss` file is now located at __src/components/tooltip/tooltip.scss__. You will need to update any `@import` statements for this file to reflect this change.
 
+**New**: 
+```scss
+@import 'path_to_node_modules/carbon-components/src/components/tooltip/tooltip';
+```
+
+**Old**: 
 ```scss
 @import 'path_to_node_modules/@console/bluemix-components/src/components/tooltip/tooltip;
 ```


### PR DESCRIPTION
Basically just makes it easier to differentiate between old and new import statements as suggested by @eddiemonge