### PR TITLE
fix(dropdown): update dropdown so that it no longer pushes elements down

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -54,8 +54,12 @@
 
   .bx--dropdown-list {
     @include reset;
+    @include layer('overlay');
+    width: 100%;
     display: none;
     list-style: none;
+    position: absolute;
+    z-index: z('dropdown');
   }
 
   .bx--dropdown-link {
@@ -85,7 +89,6 @@
 
     .bx--dropdown-list {
       @include font-size('14');
-      @include layer('overlay');
       display: flex;
       flex-direction: column;
       background-color: $ui-01;


### PR DESCRIPTION
## Prevent Dropdown from pushing elements down

Dropdown was pushing other elements in the DOM down since the menu was not positioned absolutely. Changed this so that the dropdown no longer pushes other elements down. 

### Testing
- Add another element below the dropdown and ensure the element is not pushed down when the menu is toggled. 