### PR TITLE
fix(overflow-menu): update hover color

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -29,7 +29,7 @@
     fill: $ui-05;
 
     &:hover {
-      fill: $brand-02;
+      fill: $brand-01;
     }
   }
 


### PR DESCRIPTION
## Overflow Menu - Hover Color Update

The `Overflow Menu` icon was incorrectly using `$brand-02` instead of `$brand-01`. This fixes that.