### PR TITLE
fix(tooltip): Fixed visual styles and structure for tooltip

### DIFF
--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -6,32 +6,43 @@
 
 @include exports('tooltip') {
 
+  .bx--tooltip--simple {
+    display: flex;
+    align-items: center;
+  }
+
   .bx--tooltip__trigger {
     @include font-size('18');
-    font-weight: 700;
-    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
     color: $text-01;
+    font-weight: 700;
 
     svg {
       fill: $brand-01;
+      margin-left: .625rem;
+      cursor: pointer;
     }
   }
 
   .bx--tooltip {
-    @include helvetica;
-    @include font-size('14');
     @include layer('overlay');
+    @include reset;
     position: absolute;
     display: none;
-    max-width: rem(244px);
+    max-width: rem(240px);
     background: $ui-01;
-    padding: 1rem;
+    padding: 1.5rem;
     border: 1px solid $ui-04;
-    color: $text-01;
-    text-decoration: none;
 
-    svg {
-      fill: $brand-01;
+    p {
+      @include helvetica;
+      @include font-size('14');
+    }
+
+    .bx--tooltip__label {
+      font-weight: 700;
+      margin-bottom: .5rem;
     }
 
     &:before {
@@ -86,14 +97,18 @@
 
   // Simple CSS only tooltip
   .bx--tooltip--simple__top, .bx--tooltip--simple__bottom {
-    // Element: when hovered or focused will show tooltip
     @include helvetica;
     @include reset;
     @include font-size('18');
-    font-weight: 700;
     position: relative;
     display: inline-flex;
     align-items: center;
+    cursor: pointer;
+
+    svg {
+      fill: $brand-01;
+      margin-left: .625rem;
+    }
 
     // Tooltip - renders as a combo of :before and :after elements
     &:before,
@@ -107,7 +122,8 @@
     &:before {
       @include font-size('14');
       @include layer('overlay');
-      padding: 1rem;
+      max-width: rem(240px);
+      padding: 1.5rem;
       border: 1px solid $ui-04;
       margin-left: 50%;
       color: $text-01;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -6,6 +6,17 @@
 
 @include exports('tooltip') {
 
+  .bx--tooltip__trigger {
+    @include font-size('18');
+    font-weight: 700;
+    text-decoration: none;
+    color: $text-01;
+
+    svg {
+      fill: $brand-01;
+    }
+  }
+
   .bx--tooltip {
     @include helvetica;
     @include font-size('14');
@@ -17,6 +28,11 @@
     padding: 1rem;
     border: 1px solid $ui-04;
     color: $text-01;
+    text-decoration: none;
+
+    svg {
+      fill: $brand-01;
+    }
 
     &:before {
       position: absolute;
@@ -73,7 +89,8 @@
     // Element: when hovered or focused will show tooltip
     @include helvetica;
     @include reset;
-    @include font-size('16');
+    @include font-size('18');
+    font-weight: 700;
     position: relative;
     display: inline-flex;
     align-items: center;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -12,7 +12,7 @@
   }
 
   .bx--tooltip__trigger {
-    @include font-size('18');
+    @include font-size('16');
     display: inline-flex;
     align-items: center;
     color: $text-01;
@@ -22,6 +22,17 @@
       fill: $brand-01;
       margin-left: .625rem;
       cursor: pointer;
+
+      &:focus {
+        fill: $brand-02;
+      }
+    }
+
+    &:hover,
+    &:focus {
+      svg {
+        fill: $brand-02;
+      }
     }
   }
 
@@ -146,6 +157,11 @@
 
     &:hover,
     &:focus {
+
+      svg {
+        fill: $brand-02;
+      }
+
       &:before,
       &:after {
         position: absolute;

--- a/src/components/tooltip/tooltip--simple.html
+++ b/src/components/tooltip/tooltip--simple.html
@@ -1,6 +1,8 @@
-<div class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">
-  Tooltip
-  <svg width="16" height="16">
-    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
-  </svg>
+<div class="bx--tooltip--simple">
+  <p class="bx--tooltip__trigger">CSS Tooltip</p>
+  <div class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">
+    <svg width="16" height="16">
+      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
+    </svg>
+  </div>
 </div>

--- a/src/components/tooltip/tooltip--simple.html
+++ b/src/components/tooltip/tooltip--simple.html
@@ -1,1 +1,6 @@
-<div class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">Tooltip - no js, single line only</div>
+<div class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">
+  Tooltip
+  <svg width="16" height="16">
+    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
+  </svg>
+</div>

--- a/src/components/tooltip/tooltip--simple.html
+++ b/src/components/tooltip/tooltip--simple.html
@@ -1,6 +1,6 @@
 <div class="bx--tooltip--simple">
   <p class="bx--tooltip__trigger">CSS Tooltip</p>
-  <div class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">
+  <div tabindex="0" class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">
     <svg width="16" height="16">
       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
     </svg>

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -1,12 +1,11 @@
-<a href="#" data-tooltip-trigger data-tooltip-target="#unique-tooltip" class="bx--tooltip__trigger">
-  Tooltip
-  <svg width="16" height="16">
+<a class="bx--tooltip__trigger">
+  JavaScript Tooltip
+  <svg data-tooltip-trigger data-tooltip-target="#unique-tooltip" width="16" height="16">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
   </svg>
 </a>
 <div id="unique-tooltip" data-floating-menu-direction="bottom" class="bx--tooltip">
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-  dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-  non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  <p class="bx--tooltip__label">Tooltip label</p>
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 </div>

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -6,6 +6,6 @@
 </a>
 <div id="unique-tooltip" data-floating-menu-direction="bottom" class="bx--tooltip">
   <p class="bx--tooltip__label">Tooltip label</p>
-  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, seed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 </div>

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -1,2 +1,12 @@
-<a href="#" data-tooltip-trigger data-tooltip-target="#unique-tooltip">Tooltip - with js, multi line content supported</a>
-<div id="unique-tooltip" data-floating-menu-direction="bottom" class="bx--tooltip">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+<a href="#" data-tooltip-trigger data-tooltip-target="#unique-tooltip" class="bx--tooltip__trigger">
+  Tooltip
+  <svg width="16" height="16">
+    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
+  </svg>
+</a>
+<div id="unique-tooltip" data-floating-menu-direction="bottom" class="bx--tooltip">
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+  dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+  non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</div>

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -1,6 +1,6 @@
 <a class="bx--tooltip__trigger">
   JavaScript Tooltip
-  <svg data-tooltip-trigger data-tooltip-target="#unique-tooltip" width="16" height="16">
+  <svg tabindex="0" data-tooltip-trigger data-tooltip-target="#unique-tooltip" width="16" height="16">
     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
   </svg>
 </a>


### PR DESCRIPTION
## Overview

**Visual review:** http://tooltip-fix.stage1.mybluemix.net/components/tooltip/

Closes https://github.ibm.com/Bluemix/carbon-issues/issues/95

This PR fixes some visual bugs and structure problems for tooltips. More specifically: 

- The tooltip is supposed to be an icon and not a link/text
- The text inside the tooltip needs to be styled the same way as the rest of our paragraphs
- The padding inside the tooltip was too small
- The tooltip is supposed to be centered under the icon and not under the text
- The icon needs to be selectable by tabbing, not the link/text

**Before:** 

<img width="434" alt="screen shot 2017-04-26 at 10 58 31 am" src="https://cloud.githubusercontent.com/assets/5447411/25444319/4a24000e-2a70-11e7-8e26-f58823dcdd26.png">

**After:**

![screen shot 2017-04-26 at 11 05 57 am](https://cloud.githubusercontent.com/assets/5447411/25444334/5a4bfd6a-2a70-11e7-87cc-0ddb2bebcc46.png)

### Changed

I had to make some structural changes in order to get the desirable result, so this might be considered breaking changes - however, I think these changes are highly important as the tooltips we are showing on the website now are not aligning up with the design kit and what we're displaying on the Style tab (http://carbondesignsystem.com/components/tooltip/style).
