### PR TITLE
fix(dropdown): prevent changing dropdown item style for navigation mode

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -153,8 +153,6 @@ class Dropdown extends mixin(createComponent, initComponentBySearch) {
         }
       });
 
-      itemToSelect.classList.add(this.options.classSelected);
-
       this.element.dispatchEvent(new CustomEvent(this.options.eventAfterSelected, {
         bubbles: true,
         cancelable: true,

--- a/tests/spec/dropdown_spec.js
+++ b/tests/spec/dropdown_spec.js
@@ -205,6 +205,13 @@ describe('Dropdown', function () {
       expect(textNode.textContent).to.equal('0');
     });
 
+    it('Should not add "selected" modifier class if dropdown type is navigation', function () {
+      element.setAttribute('data-dropdown-type', 'navigation');
+      itemNodes[1].dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      expect(itemNodes[0].classList.contains('bx--dropdown--selected'), 'Unselected item').to.be.false;
+      expect(itemNodes[1].classList.contains('bx--dropdown--selected'), 'Selected item').to.be.false;
+    });
+
     it('Should not cause an error if text does not exist', function () {
       textNode.parentNode.removeChild(textNode);
       expect(() => {


### PR DESCRIPTION
## Overview

Fixes #48.

### Removed

The duplicated code to set style of selected dropdown item.

## Testing / Reviewing

Testing should make sure dropdown item style is right for navigation mode as well as non-navigation mode.