### PR TITLE
chore(build): apply babel-plugin-external-helpers to non-demo bundle

### DIFF
--- a/demo/.babelrc
+++ b/demo/.babelrc
@@ -9,5 +9,5 @@
         }
     }]
   ],
-  "plugins": ["transform-class-properties", "babel-plugin-external-helpers"],
+  "plugins": ["transform-class-properties", "external-helpers"],
 }

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -9,5 +9,5 @@
         }
     }]
   ],
-  "plugins": ["transform-class-properties"],
+  "plugins": ["transform-class-properties", "external-helpers"],
 }


### PR DESCRIPTION
### Added

`babel-plugin-external-helpers` usage to non-demo bundle.

## Testing / Reviewing

Testing should make sure build/demo is not broken.