### PR TITLE
fix(build): Revert "apply babel-plugin-external-helpers to non-demo bundle"

### DIFF
--- a/demo/.babelrc
+++ b/demo/.babelrc
@@ -9,5 +9,5 @@
         }
     }]
   ],
-  "plugins": ["transform-class-properties", "external-helpers"],
+  "plugins": ["transform-class-properties", "babel-plugin-external-helpers"],
 }

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -9,5 +9,5 @@
         }
     }]
   ],
-  "plugins": ["transform-class-properties", "external-helpers"],
+  "plugins": ["transform-class-properties"],
 }


### PR DESCRIPTION
Reverts carbon-design-system/carbon-components#52

Introducing `babelHelpers` slims the build down, but then requires users to also include it in their build. Removing this from the build. 