### PR TITLE
fix(card-with-status.html): update to use new launch--glyph icon

### DIFF
--- a/src/components/card/card--with-status.html
+++ b/src/components/card/card--with-status.html
@@ -25,7 +25,7 @@
     </div>
     <div class="bx--card-overview__about">
       <figure class="bx--about__icon">
-        <img src="/globals/assets/images/placeholder-icon-32x32.svg" alt="" class="bx--about__icon--img"/>
+        <img src="/globals/assets/images/placeholder-icon-32x32.svg" alt="" class="bx--about__icon--img" />
       </figure>
       <header class="bx--about__title">
         <h3 id="card-title-1" class="bx--about__title--name">Card Name</h3>
@@ -52,8 +52,9 @@
         </svg>
       </button>
       <button class="bx--app-actions__button" id="load-app" aria-label="load-app">
-        <svg class="bx--app-actions__button--icon">
-          <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--launch--glyph"></use>
+        <svg class="bx--app-actions__button--icon" width="16" height="16" viewBox="-3 5 16 16" fill-rule="evenodd">
+          <path d="M7.5 12l3.6-3.6V11H13V5H7.1v2h2.5l-3.5 3.5z"></path>
+          <path d="M11 19H-1V9h5V5h-7v16h16v-7h-2z"></path>
         </svg>
       </button>
     </div>


### PR DESCRIPTION
## Overview

closes https://github.ibm.com/Bluemix/carbon-issues/issues/97

Inlining the SVG instead of using the sprite because the new icon is only in the next major version (v6). 