### PR TITLE
Focus states: Accordion and Code Snippet

### DIFF
--- a/results/summary_2017-04-28-10-16-03GMT.json
+++ b/results/summary_2017-04-28-10-16-03GMT.json
@@ -1,0 +1,25 @@
+{
+    "counts": {
+        "violation": 0,
+        "potentialviolation": 0,
+        "recommendation": 0,
+        "potentialrecommendation": 0,
+        "manual": 0
+    },
+    "startReport": 1493392563297,
+    "endReport": 1493392595931,
+    "toolID": "@ibma/karma-ibma-v2.1.0",
+    "reportLevels": [
+        "violation",
+        "potentialviolation",
+        "recommendation",
+        "potentialrecommendation",
+        "manual"
+    ],
+    "failLevels": [
+        "violation",
+        "potentialviolation"
+    ],
+    "scanID": "e65f5bbc-3171-4b19-8c63-d7a9965d5990",
+    "pageScanSummary": []
+}

--- a/results/summary_2017-04-28-10-21-11GMT.json
+++ b/results/summary_2017-04-28-10-21-11GMT.json
@@ -1,0 +1,25 @@
+{
+    "counts": {
+        "violation": 0,
+        "potentialviolation": 0,
+        "recommendation": 0,
+        "potentialrecommendation": 0,
+        "manual": 0
+    },
+    "startReport": 1493392871272,
+    "endReport": 1493392903520,
+    "toolID": "@ibma/karma-ibma-v2.1.0",
+    "reportLevels": [
+        "violation",
+        "potentialviolation",
+        "recommendation",
+        "potentialrecommendation",
+        "manual"
+    ],
+    "failLevels": [
+        "violation",
+        "potentialviolation"
+    ],
+    "scanID": "747b8859-9088-4ce9-9e71-3b3bb0465011",
+    "pageScanSummary": []
+}

--- a/results/summary_2017-05-02-14-36-38GMT.json
+++ b/results/summary_2017-05-02-14-36-38GMT.json
@@ -1,0 +1,25 @@
+{
+    "counts": {
+        "violation": 0,
+        "potentialviolation": 0,
+        "recommendation": 0,
+        "potentialrecommendation": 0,
+        "manual": 0
+    },
+    "startReport": 1493753798116,
+    "endReport": 1493753830299,
+    "toolID": "@ibma/karma-ibma-v2.1.0",
+    "reportLevels": [
+        "violation",
+        "potentialviolation",
+        "recommendation",
+        "potentialrecommendation",
+        "manual"
+    ],
+    "failLevels": [
+        "violation",
+        "potentialviolation"
+    ],
+    "scanID": "41ec5536-fd48-430f-8220-0d20d1e77a18",
+    "pageScanSummary": []
+}

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -16,7 +16,7 @@
     border-top: 1px solid $ui-04;
     overflow: hidden;
 
-    &.focus {
+    &:focus {
       outline: none;
 
       .bx--accordion__arrow {
@@ -40,7 +40,7 @@
     transition: all $transition--base $bx--standard-easing;
     height: .75rem;
     width: .75rem;
-    padding: .25rem;
+    padding: .25rem .125rem .25rem .25rem;
     margin-left: .075rem;
     fill: $ui-05;
   }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -16,6 +16,14 @@
     border-top: 1px solid $ui-04;
     overflow: hidden;
 
+    &.focus {
+      outline: none;
+
+      .bx--accordion__arrow {
+        @include focus-outline('border');
+      }
+    }
+
     &:last-child {
       border-bottom: 1px solid $ui-04;
     }
@@ -32,6 +40,8 @@
     transition: all $transition--base $bx--standard-easing;
     height: .75rem;
     width: .75rem;
+    padding: .25rem;
+    margin-left: .075rem;
     fill: $ui-05;
   }
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -13,14 +13,14 @@ class Accordion extends mixin(createComponent, initComponentBySearch) {
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', event => {
+    this.element.addEventListener('click', (event) => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         item.classList.toggle(this.options.classActive);
       }
     });
 
-    this.element.addEventListener('keypress', event => {
+    this.element.addEventListener('keypress', (event) => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         this._handleKeypress(event);

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,6 +1,7 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
-import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import initComponentBySearch
+  from '../../globals/js/mixins/init-component-by-search';
 import eventMatches from '../../globals/js/misc/event-matches';
 
 class Accordion extends mixin(createComponent, initComponentBySearch) {
@@ -12,18 +13,22 @@ class Accordion extends mixin(createComponent, initComponentBySearch) {
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', (event) => {
+    this.element.addEventListener('click', event => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         item.classList.toggle(this.options.classActive);
       }
     });
 
-    this.element.addEventListener('keypress', (event) => {
+    this.element.addEventListener('keypress', event => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         this._handleKeypress(event);
       }
+    });
+
+    this.element.ownerDocument.body.addEventListener('keydown', event => {
+      console.log(document.activeElement);
     });
   }
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -26,10 +26,6 @@ class Accordion extends mixin(createComponent, initComponentBySearch) {
         this._handleKeypress(event);
       }
     });
-
-    this.element.ownerDocument.body.addEventListener('keydown', event => {
-      console.log(document.activeElement);
-    });
   }
 
   /**

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -19,6 +19,7 @@
     max-height: rem(192px);
     overflow-y: scroll;
     margin-right: 1rem;
+    position: relative;
   }
 
   .bx--snippet--code .bx--snippet-container pre {
@@ -39,13 +40,11 @@
     height: 130%;
     white-space: nowrap;
     overflow-x: scroll;
+    position: relative;
   }
 
   .bx--snippet__icon {
     cursor: pointer;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
     fill: $brand-01;
     height: rem(24px);
     width: rem(18px);
@@ -66,9 +65,19 @@
 
   .bx--snippet-button {
     @include reset;
+    position: absolute;
+    top: .5rem;
+    right: .5rem;
     border: none;
+    background-color: transparent;
     outline: none;
     padding: 0;
+    height: rem(32px);
+    width: rem(32px);
+
+    &:focus {
+      @include focus-outline('border');
+    }
   }
 
   .bx--snippet .bx--btn--copy__feedback {
@@ -76,7 +85,7 @@
     z-index: z('overlay');
     font-weight: 700;
     left: inherit;
-    top: 2rem;
-    right: 1.75rem;
+    top: 1rem;
+    right: 1.25rem;
   }
 }

--- a/src/components/code-snippet/code-snippet--code.html
+++ b/src/components/code-snippet/code-snippet--code.html
@@ -22,7 +22,7 @@
       </pre>
     </code>
   </div>
-  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code">
+  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code" tabindex="0">
     <svg class="bx--snippet__icon">
       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--copy"></use>
     </svg>

--- a/src/components/code-snippet/code-snippet--terminal.html
+++ b/src/components/code-snippet/code-snippet--terminal.html
@@ -2,7 +2,7 @@
   <div class="bx--snippet-container">
     <pre><code>node -v Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis, veritatis voluptate id incidunt molestiae officia possimus, quasi itaque alias, architecto hic, dicta fugit? Debitis delectus quidem explicabo vitae fuga laboriosam!</code></pre>
   </div>
-  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code">
+  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code" tabindex="0">
     <svg class="bx--snippet__icon">
       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--copy"></use>
     </svg>

--- a/src/components/toolbar/toolbar.html
+++ b/src/components/toolbar/toolbar.html
@@ -8,7 +8,7 @@
       </svg>
     </button>
     <svg class="bx--search-close bx--search-close--hidden">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph"/>
+      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph" />
     </svg>
   </div>
   <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -41,6 +41,20 @@
   outline: auto 5px -webkit-focus-ring-color; // webkit default
 }
 
+@mixin focus-outline($type: 'border') {
+  @if ($type == 'border') {
+    outline: 1px solid $brand-01;
+  }
+
+  @if ($type == 'underline') {
+
+  }
+
+  @if ($type == 'blurry-border') {
+
+  }
+}
+
 @mixin rotate($deg, $speed, $origin: center) {
   transform: rotate($deg);
   transition: transform $speed;


### PR DESCRIPTION
## Overview

Closes https://github.ibm.com/Bluemix/design-system-website/issues/1053
Closes https://github.ibm.com/Bluemix/design-system-website/issues/1048

Focus states for Accordion and Code Snippet.

![screen shot 2017-05-02 at 2 13 06 pm](https://cloud.githubusercontent.com/assets/5447411/25634850/b2b1740a-2f41-11e7-929f-50c8d2ea1f2f.png)

![screen shot 2017-05-02 at 2 13 13 pm](https://cloud.githubusercontent.com/assets/5447411/25634794/818b2f60-2f41-11e7-870c-bd44ef8226aa.png)

The focus state styles are applied both on click and on tab now, I'm not completely sure how to solve this and if it's considered bad practice to only have it show on tab. That would also require adding javascript to each component who would need this.
