### PR TITLE
Focus states: Card, Breadcrumb, Checkbox

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -41,7 +41,9 @@
     text-decoration: none;
     border-bottom: 1px solid transparent;
 
-    &:hover {
+    &:hover,
+    &:focus {
+      outline: none;
       color: $brand-01;
       border-bottom: 1px solid $brand-01;
     }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -48,6 +48,7 @@
       border-bottom: 1px solid $brand-01;
     }
 
+    // Applies to Firefox only
     @-moz-document url-prefix() {
       & {
         border-bottom: none;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -47,5 +47,11 @@
       color: $brand-01;
       border-bottom: 1px solid $brand-01;
     }
+
+    @-moz-document url-prefix() {
+      & {
+        border-bottom: none;
+      }
+    }
   }
 }

--- a/src/components/breadcrumb/breadcrumb.html
+++ b/src/components/breadcrumb/breadcrumb.html
@@ -1,12 +1,12 @@
 <div class="bx--breadcrumb">
   <div class="bx--breadcrumb-item">
-    <a href="#" class="bx--link" tabindex="0">Breadcrumb 1</a>
+    <a href="#" class="bx--link">Breadcrumb 1</a>
   </div>
   <div class="bx--breadcrumb-item">
-    <a href="#" class="bx--link" tabindex="0">Breadcrumb 2</a>
+    <a href="#" class="bx--link">Breadcrumb 2</a>
   </div>
   <div class="bx--breadcrumb-item">
-    <a href="#" class="bx--link" tabindex="0">Breadcrumb 3</a>
+    <a href="#" class="bx--link">Breadcrumb 3</a>
   </div>
 </div>
 

--- a/src/components/breadcrumb/breadcrumb.html
+++ b/src/components/breadcrumb/breadcrumb.html
@@ -1,12 +1,12 @@
 <div class="bx--breadcrumb">
   <div class="bx--breadcrumb-item">
-    <a href="#" class="bx--link">Breadcrumb 1</a>
+    <a href="#" class="bx--link" tabindex="0">Breadcrumb 1</a>
   </div>
   <div class="bx--breadcrumb-item">
-    <a href="#" class="bx--link">Breadcrumb 2</a>
+    <a href="#" class="bx--link" tabindex="0">Breadcrumb 2</a>
   </div>
   <div class="bx--breadcrumb-item">
-    <a href="#" class="bx--link">Breadcrumb 3</a>
+    <a href="#" class="bx--link" tabindex="0">Breadcrumb 3</a>
   </div>
 </div>
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -28,7 +28,6 @@
     border: 1px solid $ui-04;
 
     &:focus {
-      outline: none;
       @include focus-outline('border');
     }
   }

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -26,6 +26,11 @@
     height: rem(240px);
     background-color: $ui-01;
     border: 1px solid $ui-04;
+
+    &:focus {
+      outline: none;
+      @include focus-outline('border');
+    }
   }
 
   .bx--card__card-overview {
@@ -153,23 +158,28 @@
   .bx--app-actions__button {
     @include font-size('16');
     display: inline-block;
-    padding: 0;
-    margin: 0;
+    padding: .125rem 0 0;
+    margin: 0 .175rem;
     cursor: pointer;
     background: none;
     border: none;
 
-    &:hover {
+    &:hover,
+    &:focus {
       .bx--app-actions__button--icon {
         fill: $brand-01;
       }
+    }
+
+    &:focus {
+      @include focus-outline('border');
     }
   }
 
   .bx--app-actions__button--icon {
     width: 1rem;
     height: 1rem;
-    margin: 0 .3rem;
+    margin: 0 .125rem;
     transition: 200ms;
     fill: $ui-05;
     cursor: pointer;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -62,7 +62,7 @@
 
   .bx--checkbox:focus + .bx--checkbox-label .bx--checkbox-appearance,
   .bx--checkbox:focus + .bx--checkbox-appearance {
-    @include focus-outline;
+    @include focus-outline('blurred');
   }
 
   .bx--checkbox-checkmark {

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -75,5 +75,11 @@
   .bx--checkbox:checked + .bx--checkbox-appearance .bx--checkbox-checkmark,
   .bx--checkbox:checked + .bx--checkbox-label .bx--checkbox-appearance .bx--checkbox-checkmark {
     display: block;
+
+    @-moz-document url-prefix() {
+      & {
+        stroke: $brand-01;
+      }
+    }
   }
 }

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -88,8 +88,7 @@
     }
 
     .bx--toggle__appearance:after {
-      box-shadow: 0 0 0 3px $color__blue-20;
-      outline: 1px solid transparent;
+      @include focus-outline('blurred');
     }
   }
 


### PR DESCRIPTION
## Overview

Focus states for Card, Breadcrumb, Checkbox

Added `blurred` focus-outline, and updated Toggle to use the mixin.

Closes https://github.ibm.com/Bluemix/design-system-website/issues/1052
Closes https://github.ibm.com/Bluemix/design-system-website/issues/1051
Closes https://github.ibm.com/Bluemix/design-system-website/issues/1050