### PR TITLE
refactor(global-scss-vars): Add new var for typography

### DIFF
--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -5,7 +5,7 @@
 @import 'import-once';
 
 @mixin css-body {
-  .bx--body {
+  body {
     @include reset;
     @include helvetica;
     color: $text-01;

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -4,70 +4,6 @@
 @import 'typography';
 @import 'import-once';
 
-@mixin typography {
-  h1 {
-    @include reset;
-    @include font-size('32');
-    @include line-height('heading');
-    @include letter-spacing;
-  }
-
-  h2 {
-    @include reset;
-    @include font-size('26');
-    @include line-height('heading');
-    @include letter-spacing;
-  }
-
-  h3 {
-    @include reset;
-    @include font-size('20');
-    @include line-height('heading');
-    @include letter-spacing;
-  }
-
-  h4 {
-    @include reset;
-    @include font-size('18');
-    @include line-height('heading');
-  }
-
-  h5 {
-    @include reset;
-    @include font-size('16');
-    @include line-height('heading');
-  }
-
-  h6 {
-    @include reset;
-    @include font-size('14');
-    @include line-height('heading');
-  }
-
-  p {
-    @include reset;
-    @include font-size('16');
-    @include line-height('body');
-  }
-
-  strong {
-    @include reset;
-    @include font-smoothing;
-    @include letter-spacing;
-    font-weight: 700;
-  }
-
-  em {
-    @include reset;
-    font-style: italic;
-  }
-
-  a {
-    @include reset;
-    color: $brand-01;
-  }
-}
-
 @mixin css-body {
   .bx--body {
     @include reset;
@@ -81,6 +17,5 @@
 @include exports('css--body') {
   @if global-variable-exists('css--body') and $css--body == true {
     @include css-body;
-    @include typography;
   }
 }

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -1,3 +1,7 @@
+@import 'colors';
+@import 'vars';
+@import 'mixins';
+@import 'typography';
 @import 'import-once';
 
 @mixin css-helpers {
@@ -12,6 +16,14 @@
     border:0;
     visibility: visible;
     white-space: nowrap;
+  }
+
+  .bx--body {
+    @include reset;
+    @include helvetica;
+    color: $text-01;
+    background-color: $ui-02;
+    line-height: 1;
   }
 }
 

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -5,6 +5,7 @@
 $css--font-face: false !default;
 $css--helpers: true !default;
 $css--body: true !default;
+$css--typography: true !default;
 $css--reset: false !default;
 
 @import 'colors';
@@ -16,6 +17,7 @@ $css--reset: false !default;
 @import 'import-once';
 @import 'css--reset';
 @import 'css--font-face';
+@import 'css--typography';
 @import 'css--helpers';
 @import 'css--body';
 


### PR DESCRIPTION
New global SCSS variable called $css--typography: true !default;
This toggles h1, h2, h3 and similar element selector styles on and off.

Note: I think if someone is only importing SCSS for individual components, they need to declare those global variables at the top of their main SCSS file. Docs coming in another PR today or tomorrow. 