### PR TITLE
fix(scss): scss config vars, missing imports and hotfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Hide package manager
 node_modules
 bower_components
@@ -28,13 +27,13 @@ tests/a11y-results
 tests/coverage
 
 # built files
-es
-umd
-scripts
-css
-scss
-html
-docs/js
+/es
+/umd
+/scripts
+/css/**
+/scss
+/html
+/docs/js
 
 # a11y testing
 .aat.yml

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,7 +1,8 @@
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
 
 @include exports('accordion') {
 
@@ -38,8 +39,8 @@
 
   .bx--accordion__arrow {
     transition: all $transition--base $bx--standard-easing;
-    height: .75rem;
-    width: .75rem;
+    height: 1.25rem;
+    width: 1.25rem;
     padding: .25rem .125rem .25rem .25rem;
     margin-left: .075rem;
     fill: $ui-05;

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -3,9 +3,9 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('accordion') {
-
   .bx--accordion {
     @include reset;
     @include helvetica;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -2,6 +2,7 @@
 @import '../../globals/scss/mixins';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--typography';
 @import '../link/link';
 
 @include exports('breadcrumb') {
@@ -42,8 +43,7 @@
     text-decoration: none;
     border-bottom: 1px solid transparent;
 
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       outline: none;
       color: $brand-01;
       border-bottom: 1px solid $brand-01;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1,9 +1,8 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/css--reset';
-@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import 'mixins';
+@import '../../globals/scss/css--reset';
 
 @include exports('button') {
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -1,17 +1,17 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../overflow-menu/overflow-menu';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 @import '../button/button';
 @import '../link/link';
 @import 'mixins';
 
 @include exports('card') {
-
   .bx--card {
     @include reset;
     @include helvetica;
@@ -117,7 +117,6 @@
     border: 1px solid $ui-04;
     border-radius: 100%;
 
-
     .bx--about__icon--img {
       width: rem(32px);
       height: rem(32px);
@@ -163,8 +162,7 @@
     background: none;
     border: none;
 
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       .bx--app-actions__button--icon {
         fill: $brand-01;
       }

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -1,7 +1,3 @@
-//-----------------------------
-// Card
-//-----------------------------
-
 @import '../../globals/scss/colors';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
@@ -85,17 +81,21 @@
     @include text-overflow(rem(180px));
     font-weight: 400;
     margin: 0;
+    line-height: 1.2;
   }
 
   .bx--about__title--link {
     @include font-size('12');
     @include text-overflow(rem(180px));
+    display: inline;
     font-weight: 400;
+    text-align: center;
   }
 
   .bx--about__title--additional-info {
     @include font-size('12');
     @include text-overflow(rem(180px));
+    display: inline;
     font-weight: 400;
     padding: 0;
     margin: 0;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -1,12 +1,9 @@
-//-----------------------------
-// Checkbox
-//-----------------------------
-
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../form/form';
+@import '../../globals/scss/css--reset';
 
 @include exports('checkbox') {
   .bx--form-item.bx--checkbox-wrapper {

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -1,7 +1,8 @@
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/css--reset';
 @import 'mixins';
 
 @include exports('snippet') {

--- a/src/components/copy-button/_copy-button.scss
+++ b/src/components/copy-button/_copy-button.scss
@@ -1,9 +1,9 @@
-@import '../../globals/scss/import-once';
-@import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
+@import '../../globals/scss/typography';
+@import '../../globals/scss/layer';
+@import '../../globals/scss/import-once';
 @import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/css--reset';
 @import '../button/button';
 
 @include exports('copy-button') {

--- a/src/components/copy-button/copy-button.html
+++ b/src/components/copy-button/copy-button.html
@@ -1,7 +1,7 @@
 <button data-copy-btn class="bx--btn bx--btn--primary bx--btn--copy bx--btn--sm">
   Copy button
-  <svg class="bx--btn__icon">
-    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--add--glyph"></use>
+  <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+    <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
   </svg>
   <div class="bx--btn--copy__feedback" data-feedback="Copied!"></div>
 </button>

--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -1,6 +1,7 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/layout';
+@import '../../globals/scss/css--typography';
 @import '../checkbox/checkbox';
 @import '../../globals/scss/import-once';
 @import '../../components/overflow-menu/overflow-menu';
@@ -67,8 +68,7 @@
       width: auto;
       border: 2px solid $ui-04;
 
-      tr td:first-child,
-      tr th:first-child {
+      tr td:first-child, tr th:first-child {
         padding-left: 1.5rem;
       }
     }
@@ -103,8 +103,7 @@
 
   // zebra stripes
   .bx--table-body {
-    > .bx--parent-row,
-    > .bx--parent-row + .bx--expandable-row {
+    > .bx--parent-row, > .bx--parent-row + .bx--expandable-row {
       background-color: $ui-01;
 
       &--even {
@@ -116,14 +115,12 @@
   .bx--table-body .bx--table-row {
     border: 1px solid transparent;
 
-    &:first-child:hover,
-    &:first-child:focus {
+    &:first-child:hover, &:first-child:focus {
       border-left: 2px solid $brand-02;
       outline: 1px solid $brand-02;
     }
 
-    &:not(:first-child):hover,
-    &:not(:first-child):focus {
+    &:not(:first-child):hover, &:not(:first-child):focus {
       border-left: 2px solid $brand-02;
       outline: 1px solid $brand-02;
     }
@@ -167,9 +164,9 @@
     margin-left: rem(7px);
     margin-right: rem(2px);
 
-    @media all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm) {
-        margin-top: 2px;
-      }
+    @media all and (min--moz-device-pixel-ratio: 0) and (min-resolution: 3e1dpcm) {
+      margin-top: 2px;
+    }
   }
 
   .bx--table-expand[data-previous-value='collapsed'] .bx--table-expand__svg {
@@ -205,7 +202,7 @@
       display: inline-flex;
       margin: 0;
 
-      @media all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm) {
+      @media all and (min--moz-device-pixel-ratio: 0) and (min-resolution: 3e1dpcm) {
         margin-top: 2px;
       }
     }

--- a/src/components/detail-page-header/_detail-page-header.scss
+++ b/src/components/detail-page-header/_detail-page-header.scss
@@ -1,11 +1,12 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 @import '../tabs/tabs';
 @import '../overflow-menu/overflow-menu';
 @import '../breadcrumb/breadcrumb';
@@ -45,8 +46,8 @@
   .bx--detail-page-header .bx--breadcrumb {
     display: none;
     transition: opacity $transition--base $bx--standard-easing $transition-time / 2,
-    visibility $transition--base $bx--standard-easing $transition-time / 2,
-    transform $transition--base $bx--standard-easing 0s;
+      visibility $transition--base $bx--standard-easing $transition-time / 2,
+      transform $transition--base $bx--standard-easing 0s;
     will-change: opacity, visibility, transform;
 
     @include breakpoint(bp--sm--major) {
@@ -136,7 +137,7 @@
     display: flex;
     align-items: flex-start;
     transition: top $transition--base $bx--standard-easing 0s,
-    transform $transition--base $bx--standard-easing 0s;
+      transform $transition--base $bx--standard-easing 0s;
     will-change: transform, top;
 
     @include breakpoint(bp--sm--major) {
@@ -148,7 +149,7 @@
 
   .bx--detail-page-header .bx--tabs {
     transition: opacity $transition--base $bx--standard-easing $transition-time / 2,
-    visibility $transition--base $bx--standard-easing $transition-time / 2;
+      visibility $transition--base $bx--standard-easing $transition-time / 2;
     will-change: opacity, visibility, transform;
   }
 
@@ -173,8 +174,7 @@
 
   // Scroll
   .bx--detail-page-header--scroll {
-    .bx--breadcrumb,
-    .bx--tabs {
+    .bx--breadcrumb, .bx--tabs {
       transition-delay: 0s;
 
       @include breakpoint(bp--sm--major) {

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -4,11 +4,12 @@
 
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('dropdown') {
   .bx--dropdown {
@@ -76,8 +77,7 @@
     padding-left: 1rem;
     padding-right: 1.5rem;
 
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       background-color: $brand-01;
       color: $inverse-01;
       outline: 1px solid transparent;

--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -1,7 +1,3 @@
-//-----------------------------
-// File Uploader
-//-----------------------------
-
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/css--reset';
@@ -9,6 +5,7 @@
 @import '../../globals/scss/import-once';
 @import '../button/button';
 @import '../form/form';
+@import '../loading/loading';
 
 @include exports('file-uploader') {
 
@@ -58,20 +55,19 @@
   .bx--file-filename {
     @include font-size('12');
     @include text-overflow(100%);
+    display: inline-flex;
+    align-items: center;
     color: $text-01;
     margin-right: 1rem;
+    height: 1.875rem;
   }
 
 
   .bx--file__state-container {
     display: flex;
     align-items: center;
-  }
 
-  .bx--file__state-container {
     .bx--loading {
-      // width: 2rem;
-      // height: 2rem;
       width: 1.125rem;
       height: 1.125rem;
       margin-right: -7px;

--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -3,12 +3,12 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--typography';
 @import '../button/button';
 @import '../form/form';
 @import '../loading/loading';
 
 @include exports('file-uploader') {
-
   .bx--file {
     width: 100%;
   }
@@ -62,7 +62,6 @@
     height: 1.875rem;
   }
 
-
   .bx--file__state-container {
     display: flex;
     align-items: center;
@@ -78,8 +77,7 @@
     }
   }
 
-  .bx--file__state-container .bx--file-close,
-  .bx--file__state-container .bx--file-complete {
+  .bx--file__state-container .bx--file-close, .bx--file__state-container .bx--file-complete {
     width: 1rem;
     height: 1rem;
     fill: $text-01;

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -4,8 +4,9 @@
 
 @import '../../globals/scss/colors';
 @import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 @import '../button/button';
 @import '../link/link';
 
@@ -63,5 +64,3 @@
 .bx--footer-cta {
   margin-left: auto;
 }
-
-

--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -3,12 +3,13 @@
 //-----------------------------
 
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/mixins';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('interior-left-nav') {
   .bx--interior-left-nav {
@@ -180,16 +181,13 @@
     flex-direction: column;
     width: rem(200px);
     padding-top: rem(20px);
-    transition: background-color 300ms $bx--standard-easing,
-                width 300ms $bx--standard-easing;
+    transition: background-color 300ms $bx--standard-easing, width 300ms $bx--standard-easing;
 
-    ul, li, hr,
-    .bx--interior-left-nav-collapse__target {
+    ul, li, hr, .bx--interior-left-nav-collapse__target {
       opacity: 1;
     }
 
-    .left-nav-list,
-    .left-nav-list__item-link {
+    .left-nav-list, .left-nav-list__item-link {
       background-color: inherit;
     }
 
@@ -234,8 +232,7 @@
       margin-bottom: rem(5px);
     }
 
-    .left-nav-list__item-link,
-    .left-nav-list--nested .left-nav-list__item-link {
+    .left-nav-list__item-link, .left-nav-list--nested .left-nav-list__item-link {
       padding: rem(9px) rem(20px);
     }
 
@@ -254,8 +251,7 @@
       margin-bottom: rem(90px);
       padding: rem(14px) rem(16px);
 
-      &:hover,
-      &:focus {
+      &:hover, &:focus {
         background-color: rgba($color__blue-51, .30);
       }
     }
@@ -285,21 +281,17 @@
     }
   }
 
-  .bx--interior-left-nav--collapsing,
-  .bx--interior-left-nav--collapsed {
+  .bx--interior-left-nav--collapsing, .bx--interior-left-nav--collapsed {
     width: rem(48px);
-    transition: background-color 300ms $bx--standard-easing,
-                width 300ms $bx--standard-easing;
+    transition: background-color 300ms $bx--standard-easing, width 300ms $bx--standard-easing;
     cursor: pointer;
     background-color: rgba($color__blue-51, .10);
 
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       background-color: rgba($color__blue-51, .30);
     }
 
-    ul, li, hr,
-    .bx--interior-left-nav-collapse__target {
+    ul, li, hr, .bx--interior-left-nav-collapse__target {
       opacity: 0;
       transition: opacity 300ms $bx--standard-easing;
       overflow: hidden;
@@ -321,8 +313,7 @@
   }
 
   .bx--interior-left-nav--collapsed {
-    ul, li, hr,
-    .bx--interior-left-nav-collapse__target {
+    ul, li, hr, .bx--interior-left-nav-collapse__target {
       display: none;
     }
 
@@ -338,8 +329,7 @@
     transition: width 300ms $bx--standard-easing;
     background-color: #fff;
 
-    ul, li, hr,
-    .bx--interior-left-nav-collapse__target {
+    ul, li, hr, .bx--interior-left-nav-collapse__target {
       opacity: 1;
       transition: opacity 300ms $bx--standard-easing;
       overflow: hidden;

--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -13,6 +13,7 @@
 @include exports('interior-left-nav') {
   .bx--interior-left-nav {
     @include reset;
+    @include helvetica;
     width: rem(250px);
     position: fixed;
     top: rem(90px);
@@ -21,7 +22,6 @@
     border-right: 1px solid $color__gray-1;
 
     .left-nav-list {
-      @include reset;
       list-style: none;
       display: flex;
       flex-direction: column;
@@ -30,7 +30,6 @@
       overflow: auto;
 
       &__item {
-        @include reset;
         cursor: pointer;
         width: 100%;
         padding: 0;
@@ -62,7 +61,6 @@
         }
 
         &-link {
-          @include reset;
           @include font-size('14');
           color: $color__blue-90;
           font-weight: 400;
@@ -76,7 +74,6 @@
         }
 
         &-icon {
-          @include reset;
           display: flex;
 
           .bx--interior-left-nav__icon {

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -4,10 +4,11 @@
 
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
 
 
 @include exports('link') {

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -91,7 +91,6 @@
 
   .bx--modal-content {
     margin-bottom: rem(48px);
-    overflow-y: auto;
 
     > * {
       @include reset;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -6,9 +6,10 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @import '../button/button';
 
@@ -28,9 +29,7 @@
     content: '';
     opacity: 0;
     background-color: rgba($ui-03, .5);
-    transition: opacity 200ms,
-                z-index 0s 200ms,
-                visibility 0s 200ms;
+    transition: opacity 200ms, z-index 0s 200ms, visibility 0s 200ms;
     visibility: hidden;
 
     &.is-visible {
@@ -135,4 +134,3 @@
     height: rem(12px);
   }
 }
-

--- a/src/components/module/_module.scss
+++ b/src/components/module/_module.scss
@@ -3,10 +3,11 @@
 //-----------------------------
 
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('modules') {
   .bx--module {

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -17,6 +17,7 @@
     @include font-smoothing;
     @include font-size('14');
     display: flex;
+    justify-content: space-between;
     background-color: transparent;
     padding: .75rem 1rem;
     min-height: rem(40px);

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -3,12 +3,12 @@
 //-----------------------------
 
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/mixins';
-
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('inline-notifications') {
   .bx--inline-notification {

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -3,15 +3,14 @@
 //-----------------------------
 
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/mixins';
-
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('toast-notifications') {
-
   .bx--toast-notification {
     @include reset;
     @include helvetica;
@@ -79,7 +78,7 @@
     font-weight: 700;
     letter-spacing: 0;
     line-height: 1;
-    padding-bottom: .125rem
+    padding-bottom: .125rem;
   }
 
   .bx--toast-notification__subtitle {

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -1,11 +1,9 @@
-//-----------------------------
-// Number Input
-//-----------------------------
-
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/css--reset';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../form/form';
 
 @include exports('number-input') {
   .bx--number {

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -25,7 +25,7 @@
   .bx--progress-line {
     position: absolute;
     top: .625rem;
-    right: 99.5%;
+    right: 100%;
     height: 1px;
     width: calc(100% - 24px);
     border: 1px inset transparent;

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -5,8 +5,9 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/import-once';
+@import '../form/form';
+@import '../../globals/scss/css--reset';
 
 @include exports('radio-button') {
 

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -101,6 +101,7 @@
     fill: $brand-01;
     height: 1rem;
     width: 1rem;
+    vertical-align: middle;
   }
 
   .bx--search-button:hover,

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -94,14 +94,18 @@
     margin-left: .25rem;
     background-color: $ui-01;
     position: relative;
+    padding: 0;
   }
 
   .bx--search-button svg {
+    position: relative;
+    top: -1px;
+    box-sizing: border-box;
+    vertical-align: middle;
     transition: $transition--base;
     fill: $brand-01;
     height: 1rem;
     width: 1rem;
-    vertical-align: middle;
   }
 
   .bx--search-button:hover,

--- a/src/components/select/inline-select.html
+++ b/src/components/select/inline-select.html
@@ -13,8 +13,8 @@
         <option class="bx--select-option" value="option2">Option 2</option>
       </optgroup>
     </select>
-    <svg class="bx--select__arrow">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
+    <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+      <path d="M10 0L5 5 0 0z"></path>
     </svg>
   </div>
 </div>

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -8,6 +8,7 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--typography';
 
 @include exports('tabs') {
   .bx--tabs {
@@ -97,8 +98,7 @@
     background-color: $ui-01;
     padding: 0;
 
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       background-color: $brand-01;
 
       @include breakpoint(bp--sm--major) {
@@ -111,7 +111,7 @@
       background: transparent;
       padding: .725rem 0 rem(10px);
 
-      &+& {
+      & + & {
         margin-left: rem(48px);
       }
     }
@@ -140,7 +140,6 @@
       color: $brand-01;
     }
   }
-
 
   .bx--tabs__nav-link {
     display: inline-block;

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -7,6 +7,7 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../form/form';
 
 @include exports('toggle') {
   .bx--toggle {

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -93,6 +93,10 @@ $css--helpers: true;
     border: 0;
     height: rem(32px);
     width: rem(32px);
+
+    &:focus {
+      @include focus-outline;
+    }
   }
 
   .bx--toolbar-filter-icon {

--- a/src/components/toolbar/toolbar.html
+++ b/src/components/toolbar/toolbar.html
@@ -3,17 +3,18 @@
     <label for="search__input" class="bx--label">Search</label>
     <input type="search" class="bx--search-input" id="search__input" placeholder="Search">
     <button class="bx--toolbar-search__btn" aria-label="Toolbar search">
-      <svg class="bx--search-magnifier">
-        <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--search--glyph"/>
+      <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+        <path d="M6 2c2.2 0 4 1.8 4 4s-1.8 4-4 4-4-1.8-4-4 1.8-4 4-4zm0-2C2.7 0 0 2.7 0 6s2.7 6 6 6 6-2.7 6-6-2.7-6-6-6zM16 13.8L13.8 16l-3.6-3.6 2.2-2.2z"></path>
+        <path d="M16 13.8L13.8 16l-3.6-3.6 2.2-2.2z"></path>
       </svg>
     </button>
-    <svg class="bx--search-close bx--search-close--hidden">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--close--glyph" />
+    <svg class="bx--search-close bx--search-close--hidden" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+      <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm3.5 10.1l-1.4 1.4L8 9.4l-2.1 2.1-1.4-1.4L6.6 8 4.5 5.9l1.4-1.4L8 6.6l2.1-2.1 1.4 1.4L9.4 8l2.1 2.1z"></path>
     </svg>
   </div>
   <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">
-    <svg class="bx--overflow-menu__icon bx--toolbar-filter-icon">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--filter"></use>
+    <svg class="bx--overflow-menu__icon bx--toolbar-filter-icon" width="24" height="24" viewBox="0 0 24 24" fill-rule="evenodd">
+      <path d="M10.9 3c-.4-1.7-2-3-3.9-3S3.6 1.3 3.1 3H0v2h3.1c.4 1.7 2 3 3.9 3s3.4-1.3 3.9-3H24V3H10.9zM7 5c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1zM17 8c-1.9 0-3.4 1.3-3.9 3H0v2h13.1c.4 1.7 2 3 3.9 3s3.4-1.3 3.9-3H24v-2h-3.1c-.5-1.7-2-3-3.9-3zm0 5c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1zM7 16c-1.9 0-3.4 1.3-3.9 3H0v2h3.1c.4 1.7 2 3 3.9 3s3.4-1.3 3.9-3H24v-2H10.9c-.5-1.7-2-3-3.9-3zm0 5c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"></path>
     </svg>
     <ul class="bx--overflow-menu-options">
       <li class="bx--toolbar-menu__title">FILTER BY</li>
@@ -21,8 +22,8 @@
         <input id="filter-option-1" class="bx--checkbox" type="checkbox" value="filter-option-1" name="checkbox">
         <label for="filter-option-1" class="bx--checkbox-label">
           <span class="bx--checkbox-appearance">
-            <svg class="bx--checkbox-checkmark">
-              <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--checkmark"></use>
+            <svg class="bx--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
+              <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
             </svg>
           </span>
           Filter option 1
@@ -32,8 +33,8 @@
         <input id="filter-option-2" class="bx--checkbox" type="checkbox" value="filter-option-2" name="checkbox">
         <label for="filter-option-2" class="bx--checkbox-label">
           <span class="bx--checkbox-appearance">
-            <svg class="bx--checkbox-checkmark">
-              <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--checkmark"></use>
+            <svg class="bx--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
+              <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
             </svg>
           </span>
           Filter option 2
@@ -43,8 +44,8 @@
         <input id="filter-option-3" class="bx--checkbox" type="checkbox" value="filter-option-3" name="checkbox">
         <label for="filter-option-3" class="bx--checkbox-label">
           <span class="bx--checkbox-appearance">
-            <svg class="bx--checkbox-checkmark">
-              <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--checkmark"></use>
+            <svg class="bx--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
+              <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
             </svg>
           </span>
           Filter option 3
@@ -53,8 +54,10 @@
     </ul>
   </div>
   <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">
-    <svg class="bx--overflow-menu__icon">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--overflow-menu"></use>
+    <svg class="bx--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
+      <circle cx="2" cy="2" r="2"></circle>
+      <circle cx="2" cy="10" r="2"></circle>
+      <circle cx="2" cy="18" r="2"></circle>
     </svg>
     <ul class="bx--overflow-menu-options">
       <li class="bx--overflow-menu-options__option">

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -4,9 +4,9 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 
 @include exports('tooltip') {
-
   .bx--tooltip--simple {
     display: flex;
     align-items: center;
@@ -31,8 +31,7 @@
       }
     }
 
-    &:hover,
-    &:focus {
+    &:hover, &:focus {
       svg {
         fill: $brand-02;
       }
@@ -125,8 +124,7 @@
     }
 
     // Tooltip - renders as a combo of :before and :after elements
-    &:before,
-    &:after {
+    &:before, &:after {
       @include helvetica;
       position: absolute;
       display: none;
@@ -158,15 +156,12 @@
       content: '';
     }
 
-    &:hover,
-    &:focus {
-
+    &:hover, &:focus {
       svg {
         fill: $brand-02;
       }
 
-      &:before,
-      &:after {
+      &:before, &:after {
         position: absolute;
         display: block;
       }
@@ -187,10 +182,9 @@
       bottom: 1.8rem;
     }
 
-
     &:after {
       bottom: 1.5rem;
-      transform:rotate(45deg);
+      transform: rotate(45deg);
     }
   }
 
@@ -202,7 +196,7 @@
 
     &:after {
       top: 1.5rem;
-      transform:rotate(-135deg);
+      transform: rotate(-135deg);
     }
   }
 }

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -1,8 +1,9 @@
 @import '../../globals/scss/colors';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
 
 @include exports('tooltip') {
 
@@ -12,6 +13,7 @@
   }
 
   .bx--tooltip__trigger {
+    @include helvetica;
     @include font-size('16');
     display: inline-flex;
     align-items: center;

--- a/src/components/tooltip/tooltip--simple.html
+++ b/src/components/tooltip/tooltip--simple.html
@@ -1,8 +1,8 @@
 <div class="bx--tooltip--simple">
   <p class="bx--tooltip__trigger">CSS Tooltip</p>
   <div tabindex="0" class="bx--tooltip--simple__top" data-tooltip-text="This is some tooltip text">
-    <svg width="16" height="16">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
+    <svg width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+      <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 4c.6 0 1 .4 1 1s-.4 1-1 1-1-.4-1-1 .4-1 1-1zm2 8H6v-1h1V8H6V7h3v4h1v1z"></path>
     </svg>
   </div>
 </div>

--- a/src/components/tooltip/tooltip.html
+++ b/src/components/tooltip/tooltip.html
@@ -1,7 +1,7 @@
 <a class="bx--tooltip__trigger">
   JavaScript Tooltip
-  <svg tabindex="0" data-tooltip-trigger data-tooltip-target="#unique-tooltip" width="16" height="16">
-    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--info--glyph"></use>
+  <svg tabindex="0" data-tooltip-trigger data-tooltip-target="#unique-tooltip" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+    <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 4c.6 0 1 .4 1 1s-.4 1-1 1-1-.4-1-1 .4-1 1-1zm2 8H6v-1h1V8H6V7h3v4h1v1z"></path>
   </svg>
 </a>
 <div id="unique-tooltip" data-floating-menu-direction="bottom" class="bx--tooltip">

--- a/src/components/unified-header/_unified-header.scss
+++ b/src/components/unified-header/_unified-header.scss
@@ -1,11 +1,12 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/css--reset';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/css--reset';
+@import '../../globals/scss/css--typography';
 @import 'mixins';
 @import 'left-nav-trigger';
 @import 'global-header';

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -16,7 +16,7 @@
 }
 
 @include exports('css--body') {
-  @if global-variable-exists('css--body') and $css--body == true {
+  @if global-variable-exists('css--body') == false or $css--body == true {
     @include css-body;
   }
 }

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -2,6 +2,7 @@
 @import 'vars';
 @import 'mixins';
 @import 'typography';
+@import 'reset';
 @import 'import-once';
 
 @mixin css-body {

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -2,7 +2,7 @@
 @import 'vars';
 @import 'mixins';
 @import 'typography';
-@import 'reset';
+@import 'css--reset';
 @import 'import-once';
 
 @mixin css-body {

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -4,70 +4,6 @@
 @import 'typography';
 @import 'import-once';
 
-@mixin typography {
-  h1 {
-    @include reset;
-    @include font-size('32');
-    @include line-height('heading');
-    @include letter-spacing;
-  }
-
-  h2 {
-    @include reset;
-    @include font-size('26');
-    @include line-height('heading');
-    @include letter-spacing;
-  }
-
-  h3 {
-    @include reset;
-    @include font-size('20');
-    @include line-height('heading');
-    @include letter-spacing;
-  }
-
-  h4 {
-    @include reset;
-    @include font-size('18');
-    @include line-height('heading');
-  }
-
-  h5 {
-    @include reset;
-    @include font-size('16');
-    @include line-height('heading');
-  }
-
-  h6 {
-    @include reset;
-    @include font-size('14');
-    @include line-height('heading');
-  }
-
-  p {
-    @include reset;
-    @include font-size('16');
-    @include line-height('body');
-  }
-
-  strong {
-    @include reset;
-    @include font-smoothing;
-    @include letter-spacing;
-    font-weight: 700;
-  }
-
-  em {
-    @include reset;
-    font-style: italic;
-  }
-
-  a {
-    @include reset;
-    color: $brand-01;
-  }
-}
-
 @mixin css-body {
   body {
     @include reset;
@@ -81,6 +17,5 @@
 @include exports('css--body') {
   @if global-variable-exists('css--body') and $css--body == true {
     @include css-body;
-    @include typography;
   }
 }

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -1,4 +1,4 @@
-@import 'reset';
+@import 'css--reset';
 @import 'typography';
 @import 'import-once';
 

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -1,3 +1,5 @@
+@import 'reset';
+@import 'typography';
 @import 'import-once';
 
 @mixin css-helpers {

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -26,7 +26,7 @@
 }
 
 @include exports('css--helpers') {
-  @if global-variable-exists('css--helpers') and $css--helpers == true {
+  @if global-variable-exists('css--helpers') == false or $css--helpers == true {
     @include css-helpers;
   }
 }

--- a/src/globals/scss/_css--reset.scss
+++ b/src/globals/scss/_css--reset.scss
@@ -19,7 +19,7 @@
 }
 
 @include exports('css--reset') {
-  @if global-variable-exists(css--reset) == true and $css--reset == true {
+  @if global-variable-exists(css--reset) == false or $css--reset == true {
     // http://cssreset.com/scripts/eric-meyer-reset-css/
     html, body, div, span, applet, object, iframe,
     h1, h2, h3, h4, h5, h6, p, blockquote, pre,

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -1,0 +1,75 @@
+@import 'colors';
+@import 'vars';
+@import 'mixins';
+@import 'typography';
+@import 'import-once';
+
+@mixin typography {
+  h1 {
+    @include reset;
+    @include font-size('32');
+    @include line-height('heading');
+    @include letter-spacing;
+  }
+
+  h2 {
+    @include reset;
+    @include font-size('26');
+    @include line-height('heading');
+    @include letter-spacing;
+  }
+
+  h3 {
+    @include reset;
+    @include font-size('20');
+    @include line-height('heading');
+    @include letter-spacing;
+  }
+
+  h4 {
+    @include reset;
+    @include font-size('18');
+    @include line-height('heading');
+  }
+
+  h5 {
+    @include reset;
+    @include font-size('16');
+    @include line-height('heading');
+  }
+
+  h6 {
+    @include reset;
+    @include font-size('14');
+    @include line-height('heading');
+  }
+
+  p {
+    @include reset;
+    @include font-size('16');
+    @include line-height('body');
+  }
+
+  strong {
+    @include reset;
+    @include font-smoothing;
+    @include letter-spacing;
+    font-weight: 700;
+  }
+
+  em {
+    @include reset;
+    font-style: italic;
+  }
+
+  a {
+    @include reset;
+    color: $brand-01;
+  }
+}
+
+@include exports('css--typography') {
+  @if global-variable-exists('css--typography') and $css--typography == true {
+    @include typography;
+  }
+}

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -70,7 +70,7 @@
 }
 
 @include exports('css--typography') {
-  @if global-variable-exists('css--typography') and $css--typography == true {
+  @if global-variable-exists('css--typography') == false or $css--typography == true {
     @include typography;
   }
 }

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -2,7 +2,7 @@
 @import 'vars';
 @import 'mixins';
 @import 'typography';
-@import 'reset';
+@import 'css--reset';
 @import 'import-once';
 
 @mixin typography {

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -2,6 +2,7 @@
 @import 'vars';
 @import 'mixins';
 @import 'typography';
+@import 'reset';
 @import 'import-once';
 
 @mixin typography {

--- a/src/globals/scss/_mixins.scss
+++ b/src/globals/scss/_mixins.scss
@@ -1,5 +1,4 @@
 @import 'helper-mixins';
-
 @import '../../components/button/mixins';
 @import '../../components/card/mixins';
 @import '../../components/detail-page-header/mixins';

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -5,8 +5,8 @@
 $css--font-face: false !default;
 $css--helpers: true !default;
 $css--body: true !default;
-$css--reset: false !default;
 $css--use-layer: true !default;
+$css--reset: true !default;
 $css--typography: true !default;
 
 @import 'colors';

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -7,6 +7,7 @@ $css--helpers: true !default;
 $css--body: true !default;
 $css--reset: false !default;
 $css--use-layer: true !default;
+$css--typography: true !default;
 
 @import 'colors';
 @import 'vars';
@@ -19,6 +20,7 @@ $css--use-layer: true !default;
 @import 'css--font-face';
 @import 'css--helpers';
 @import 'css--body';
+@import 'css--typography';
 
 //-------------------------
 // 🍕 Components


### PR DESCRIPTION
## Overview

resubmission of #72 
related https://github.com/carbon-design-system/carbon-components/issues/71
resolves https://github.ibm.com/Bluemix/bluemix-components-react/issues/610

### Add `_css--typography.scss`

This is all of our `h1`, `h2`, `h3` etc styles that used to be part of `_css--body.scss`.
This new SCSS file is controlled by a **new variable**: `$css--typography: true !default;`

### New defaults for global SCSS variables

```scss
$css--font-face: false !default;
$css--helpers: true !default;
$css--body: true !default;
$css--reset: true !default;
$css--typography: true !default;
```

All variables default to `true` except for `$css--font-face: false !default;`.

### New global SCSS variable conditionals

```scss
@if global-variable-exists('css--body') == false or $css--body == true {
  @include css-body;
}
```
Conditionals have changed.

CSS output occurs when:
- if the `$var` **does not** exist, then output CSS.
- if the `$var` equals `true`, then output CSS

The user can opt out of CSS output by setting the variable to `false`.
- `$css--body: false;` will prevent CSS output. 

### 🔥 Fixes Fixes Fixes (so many fixes, 🙏 🇨🇦)

- Add missing `@import` statements (tested for importing single components w/o vars).
- Remove `<use>` and inline SVG icons in HTML files
- Change SCSS for various visual fixes, see comments for details.