### PR TITLE
Remove outlines on elements

### DIFF
--- a/src/globals/scss/_css--reset.scss
+++ b/src/globals/scss/_css--reset.scss
@@ -73,6 +73,9 @@
 
     * {
       box-sizing: border-box;
+      
+      // Remove outlines on elements
+      outline: none;
     }
   }
 }


### PR DESCRIPTION
## Overview
Many elements in Carbon, onClick get an outline that's by default shown by W3C standards, but really need to and are removed by any reputable design framework using:
```
* {
   outline: none;
}
```

![image](https://cloud.githubusercontent.com/assets/14989804/26256604/84b9511a-3c8b-11e7-9d54-ddbda13e51d1.png)
That's a title, not at all necessary.

![image](https://cloud.githubusercontent.com/assets/14989804/26256621/97bc605e-3c8b-11e7-824d-3b33d0ec37cf.png)
That checkbox is already highlighted, so really no justification as to why that outline is needed.

![image](https://cloud.githubusercontent.com/assets/14989804/26256684/c09f5c9c-3c8b-11e7-90a4-05451b4ecfe5.png)
On an input, somewhat makes sense, but still is not really helpful since the blinking typing indicator already indicates that your focus right now is on that input.

![image](https://cloud.githubusercontent.com/assets/14989804/26256738/e8de251c-3c8b-11e7-9bed-b03e4fcd3b81.png)
Even onFocus, we're seeing this behaviour, which is actually very confusing since the focus of the app is really on the other highlighted tab, but the focus of the DOM is on the outlined tab.