### PR TITLE
refactor(fonts): use fonts from unpkg cdn

### DIFF
--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -72,6 +72,6 @@
 
 @include exports('css--font-face') {
   @if global-variable-exists('css--font-face') and $css--font-face == true {
-    @include font-face-css('https://unpkg.com/carbon-components/src/globals/fonts/');
+    @include font-face-css('https://unpkg.com/carbon-components/src/globals/fonts');
   }
 }

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -72,6 +72,6 @@
 
 @include exports('css--font-face') {
   @if global-variable-exists('css--font-face') and $css--font-face == true {
-    @include font-face-css('https://unpkg.com/carbon-components/src/globals/fonts');
+    @include font-face-css('https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/');
   }
 }

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -72,6 +72,6 @@
 
 @include exports('css--font-face') {
   @if global-variable-exists('css--font-face') and $css--font-face == true {
-    @include font-face-css('/assets/fonts');
+    @include font-face-css('https://unpkg.com/carbon-components/src/globals/fonts/');
   }
 }


### PR DESCRIPTION
## Overview

This should make using fonts a lot easier now. 
We can recommend our users pull fonts from from [unpkg cdn](https://unpkg.com/carbon-components/src/globals/fonts/) and our dev env will pull from the same place. 