### PR TITLE
refactor(css--body): apply styles to body element

### DIFF
--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -69,7 +69,7 @@
 }
 
 @mixin css-body {
-  .bx--body {
+  body {
     @include reset;
     @include helvetica;
     color: $text-01;

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -13,6 +13,14 @@
     visibility: visible;
     white-space: nowrap;
   }
+
+  .bx--body {
+    @include reset;
+    @include helvetica;
+    color: $text-01;
+    background-color: $ui-02;
+    line-height: 1;
+  }
 }
 
 @include exports('css--helpers') {


### PR DESCRIPTION
Relates to: https://github.com/carbon-design-system/carbon-components/issues/71
Setting `$css--body: true` should apply styles directly to `body`, while
`.bx--body` class is now moved to css--helpers

