### PR TITLE
fix(interior-left-nav): make scrollable when in short viewport

### DIFF
--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -27,6 +27,7 @@
       flex-direction: column;
       background-color: $color__white;
       padding-top: 1.5rem;
+      overflow: auto;
 
       &__item {
         @include reset;


### PR DESCRIPTION
## Overview

Fixes https://github.com/carbon-design-system/carbon-components/issues/65

<img width="231" alt="screen shot 2017-05-19 at 5 32 08 pm" src="https://cloud.githubusercontent.com/assets/4185382/26269276/2070342a-3cb9-11e7-8849-c775a04f093b.png">
