### PR TITLE
feat(inline-select): Add inline-select component

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -23,7 +23,6 @@
     display: block;
     width: 100%;
     padding: .75rem 2.75rem .75rem 1rem;
-    height: rem(40px);
     color: $text-01;
     background-color: $field-01;
     border: none;
@@ -69,6 +68,28 @@
 
     .bx--select-optgroup {
       color: $text-01;
+    }
+  }
+}
+
+.bx--select--inline {
+  display: flex;
+  align-items: center;
+
+  .bx--label {
+    white-space: nowrap;
+    margin: 0 .5rem 0 0;
+    font-weight: 400;
+  }
+
+  .bx--select-input {
+    background-color: transparent;
+    color: $brand-01;
+    font-weight: 600;
+
+    &:disabled ~ * {
+      opacity: .5;
+      cursor: not-allowed;
     }
   }
 }

--- a/src/components/select/inline-select.html
+++ b/src/components/select/inline-select.html
@@ -1,0 +1,20 @@
+<div class="bx--form-item">
+  <div class="bx--select bx--select--inline">
+    <label for="select-id" class="bx--label">Select label</label>
+    <select id="select-id" class="bx--select-input">
+      <option class="bx--select-option" disabled selected hidden>Pick an option</option>
+      <option class="bx--select-option" value="solong">A much longer option that is worth having around to check how text flows</option>
+      <optgroup class="bx--select-optgroup" label="Category 1">
+        <option class="bx--select-option" value="option1">Option 1</option>
+        <option class="bx--select-option" value="option2">Option 2</option>
+      </optgroup>
+      <optgroup class="bx--select-optgroup" label="Category 2">
+        <option class="bx--select-option" value="option1">Option 1</option>
+        <option class="bx--select-option" value="option2">Option 2</option>
+      </optgroup>
+    </select>
+    <svg class="bx--select__arrow">
+      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
+    </svg>
+  </div>
+</div>


### PR DESCRIPTION
## Add Inline Select

### Added 
`html` and `scss` for inline-select


Note: width of the select can be set so that there is not as much whitespace to the left of the arrow, but by default, it will fit the width of its container (`bx--form-item`)
![screen shot 2017-05-23 at 10 53 12 am](https://cloud.githubusercontent.com/assets/11928039/26363279/2ff0da36-3fa6-11e7-8955-2c2391f38f9c.png)
