### PR TITLE
fix(interior-left-nav): replace svg with inline svg

### DIFF
--- a/src/components/interior-left-nav/interior-left-nav.html
+++ b/src/components/interior-left-nav/interior-left-nav.html
@@ -15,8 +15,8 @@
       <a class="left-nav-list__item-link">
         Example Item 3
         <div class="left-nav-list__item-icon">
-          <svg class="bx--interior-left-nav__icon">
-            <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
+          <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+            <path d="M10 0L5 5 0 0z"></path>
           </svg>
         </div>
       </a>
@@ -40,8 +40,8 @@
       <a class="left-nav-list__item-link">
         Example Item 4
         <div class="left-nav-list__item-icon">
-          <svg class="bx--interior-left-nav__icon">
-            <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
+          <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+            <path d="M10 0L5 5 0 0z"></path>
           </svg>
         </div>
       </a>
@@ -64,8 +64,8 @@
 
   <div class="bx--interior-left-nav-collapse" data-interior-left-nav-collapse>
     <a class="bx--interior-left-nav-collapse__link" href="#">
-      <svg class="bx--interior-left-nav-collapse__arrow">
-        <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--left"></use>
+      <svg class="bx--interior-left-nav-collapse__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+        <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
       </svg>
     </a>
   </div>


### PR DESCRIPTION
## Replace Interior Left Nav SVG with Inline SVG

### Changed
- Updated Interior Left Nav

Closes https://github.com/carbon-design-system/carbon-components/issues/109