### PR TITLE
fix(overflow-menu): replace svg with inline-svg

### DIFF
--- a/src/components/overflow-menu/overflow-menu.html
+++ b/src/components/overflow-menu/overflow-menu.html
@@ -1,6 +1,8 @@
 <div data-overflow-menu tabindex="0" aria-label="Overflow menu description" class="bx--overflow-menu">
-  <svg class="bx--overflow-menu__icon">
-    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--overflow-menu"></use>
+  <svg class="bx--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
+    <circle cx="2" cy="2" r="2"></circle>
+    <circle cx="2" cy="10" r="2"></circle>
+    <circle cx="2" cy="18" r="2"></circle>
   </svg>
   <ul class="bx--overflow-menu-options">
     <li class="bx--overflow-menu-options__option">
@@ -22,8 +24,10 @@
 </div>
 
 <div data-overflow-menu tabindex="0" aria-label="Overflow menu description" class="bx--overflow-menu">
-  <svg class="bx--overflow-menu__icon">
-    <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--overflow-menu"></use>
+  <svg class="bx--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
+    <circle cx="2" cy="2" r="2"></circle>
+    <circle cx="2" cy="10" r="2"></circle>
+    <circle cx="2" cy="18" r="2"></circle>
   </svg>
   <ul class="bx--overflow-menu-options bx--overflow-menu--flip">
     <li class="bx--overflow-menu-options__option">


### PR DESCRIPTION
## Replace Overflow Menu SVG with Inline SVG

### Changed
- Updated Overflow Menu

https://github.com/carbon-design-system/carbon-components/issues/113