### PR TITLE
fix(loading): hide the overlay for stopped state

### DIFF
--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -53,6 +53,6 @@ $loading__size: 10.5rem;
   }
 
   .bx--loading-overlay--stop {
-    background-color: transparent;
+    display: none;
   }
 }


### PR DESCRIPTION
## Overview

Fixes #144.

This PR makes the overlay for stopped state hidden, instead of just making the overlay transparent. Doing so prevents the overlay from covering up the rest of the contents.

### Changed

The style of spinner overlay, from transparent to hidden.

## Testing / Reviewing

Testing should make sure the spinner component is not broken.