### PR TITLE
feat(theming): add global theming overrides

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -54,6 +54,7 @@
     padding-bottom: rem(13px);
     padding-left: 1rem;
     font-weight: 700;
+    border: $input-border;
   }
 
   .bx--dropdown-list {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -25,7 +25,7 @@
     @include reset;
     @include helvetica;
     @include font-size('14');
-    font-weight: 700;
+    font-weight: $input-label-weight;
     display: inline-block;
     vertical-align: baseline;
     margin-bottom: rem(10px);

--- a/src/components/form/form.html
+++ b/src/components/form/form.html
@@ -1,13 +1,13 @@
 <div class="bx--form-item">
   <label for="text1" class="bx--label">Username</label>
-  <input data-invalid id="text1" type="text" class="bx--text-input" placeholder="Enter username here" />
+  <input id="text1" type="text" class="bx--text-input" placeholder="Enter username here" />
   <div class="bx--form-requirement">
     Username is taken.
   </div>
 </div>
 <div class="bx--form-item">
   <label for="text-area-1" class="bx--label">Text area label</label>
-  <textarea data-invalid id="text-area-1" class="bx--text-area" rows="4" cols="50" placeholder="Placeholder text"></textarea>
+  <textarea id="text-area-1" class="bx--text-area" rows="4" cols="50" placeholder="Placeholder text"></textarea>
   <div class="bx--form-requirement">
     Please do not leave blank.
   </div>
@@ -15,7 +15,7 @@
 <div class="bx--form-item">
   <label for="select-id" class="bx--label">Select</label>
   <div class="bx--select">
-    <select data-invalid id="select-id" class="bx--select-input">
+    <select id="select-id" class="bx--select-input">
       <option class="bx--select-option" disabled selected hidden>Pick an option</option>
       <option class="bx--select-option" value="solong">A much longer option that is worth having around to check how text flows</option>
       <optgroup class="bx--select-optgroup" label="Category 1">
@@ -30,8 +30,8 @@
     <div class="bx--form-requirement">
       Please choose an option.
     </div>
-    <svg class="bx--select__arrow">
-      <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
+    <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+      <path d="M10 0L5 5 0 0z"></path>
     </svg>
   </div>
 </div>

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -25,7 +25,7 @@
     height: rem(40px);
     color: $text-01;
     background-color: $field-01;
-    border: none;
+    border: $input-border;
     border-radius: 0;
 
     &:focus {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -25,7 +25,7 @@
     padding: .75rem 2.75rem .75rem 1rem;
     color: $text-01;
     background-color: $field-01;
-    border: none;
+    border: $input-border;
     border-radius: 0;
     cursor: pointer;
 

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -20,7 +20,7 @@
     padding: 1rem;
     color: $text-01;
     background-color: $field-01;
-    border: 1px solid transparent;
+    border: $input-border;
 
     &:focus {
       @include focus-outline('border');
@@ -36,7 +36,7 @@
     }
 
     &:disabled:hover {
-      border: 1px solid transparent;
+      border: $input-border;
     }
   }
 }

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -21,7 +21,7 @@
     padding: 0 1rem;
     color: $text-01;
     background-color: $field-01;
-    border: 1px solid transparent;
+    border: $input-border;
 
     &::-webkit-input-placeholder {
       @include placeholder-colors;
@@ -37,7 +37,7 @@
     }
 
     &:disabled:hover {
-      border: 1px solid transparent;
+      border: $input-border;
     }
   }
 }

--- a/src/globals/scss/_layer.scss
+++ b/src/globals/scss/_layer.scss
@@ -35,10 +35,12 @@ $layer-shadows: (
 
 // Layer mixin
 @mixin layer($layer) {
-  @if map-has-key($layer-shadows, $layer) {
-    box-shadow: #{map-get($layer-shadows, $layer)};
-  }
-  @else {
-    @warn '#{$layer} is not a valid layer.';
+  @if ($css--use-layer) {
+    @if map-has-key($layer-shadows, $layer) {
+      box-shadow: #{map-get($layer-shadows, $layer)};
+    }
+    @else {
+      @warn '#{$layer} is not a valid layer.';
+    }
   }
 }

--- a/src/globals/scss/_layer.scss
+++ b/src/globals/scss/_layer.scss
@@ -35,7 +35,7 @@ $layer-shadows: (
 
 // Layer mixin
 @mixin layer($layer) {
-  @if ($css--use-layer) {
+  @if global-variable-exists('css--use-layer') == false or $css--use-layer == true  {
     @if map-has-key($layer-shadows, $layer) {
       box-shadow: #{map-get($layer-shadows, $layer)};
     }

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -31,6 +31,10 @@ $nav-06: $color__teal-50 !default;
 $nav-07: $color__blue-30 !default;
 $nav-08: $color__blue-51 !default;
 
+// Global
+$input-border: 1px solid transparent !default;
+$input-label-weight: 700 !default;
+
 // Button Theme Variables
 $button-font-weight: 700 !default;
 $button-font-size: .875rem !default;

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -6,6 +6,7 @@ $css--font-face: false !default;
 $css--helpers: true !default;
 $css--body: true !default;
 $css--reset: false !default;
+$css--use-layer: true !default;
 
 @import 'colors';
 @import 'vars';


### PR DESCRIPTION
## Theming - Global Overrides

### Added
3 new variables
- `$input-border`: this controls the border on input elements (`dropdown`, `select`, `number-input`, `text-input`, `textarea`). It is `1px solid transparent` by default.
- `$input-label-weight`: controls the font-weight of the `.bx--label` class. It is set to 700 by default. 
- `$css--use-layer`: A global flag to control whether or not layer is applied to all elements. It is set to `true` by default.

### Changed
- Layer mixin has been updated to check if the global `$css--use-layer` flag has been to set to false. If it has, it does not generate any box-shadow.
- Above mentioned input elements to use `$input-border` instead of the hard coded value.
- `bx--label` now uses `$input-label-weight` to set it's font-weight