### PR TITLE
fix(font-path-var): allow font-path default to be overwritten

### DIFF
--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -2,25 +2,9 @@ $font-path: 'https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/' !defa
 
 @import 'import-once';
 
-@mixin font-face-css($font-path) {
+@mixin font-face-css() {
   // Default font directory, `!default` flag allows user override.
   // (font files are configured to be served as static assets from server.js)
-
-  @font-face {
-    font-family: 'IBM Helvetica';
-    font-style: normal;
-    font-weight: 200;
-    src: url('#{$font-path}/helvetica-neue-light.woff2') format('woff2'),
-      url('#{$font-path}/helvetica-neue-light.woff') format('woff');
-  }
-
-  @font-face {
-    font-family: 'IBM Helvetica';
-    font-style: italic;
-    font-weight: 200;
-    src: url('#{$font-path}/helvetica-neue-light-italic.woff2') format('woff2'),
-      url('#{$font-path}/helvetica-neue-light-italic.woff') format('woff');
-  }
 
   @font-face {
     font-family: 'IBM Helvetica';

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -2,7 +2,7 @@ $font-path: 'https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/' !defa
 
 @import 'import-once';
 
-@mixin font-face-css($font-path) {
+@mixin font-face-css {
   // Default font directory, `!default` flag allows user override.
   // (font files are configured to be served as static assets from server.js)
 
@@ -57,6 +57,6 @@ $font-path: 'https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/' !defa
 
 @include exports('css--font-face') {
   @if global-variable-exists('css--font-face') and $css--font-face == true {
-    @include font-face-css($font-path);
+    @include font-face-css;
   }
 }

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -2,7 +2,7 @@ $font-path: 'https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/' !defa
 
 @import 'import-once';
 
-@mixin font-face-css() {
+@mixin font-face-css($font-path) {
   // Default font directory, `!default` flag allows user override.
   // (font files are configured to be served as static assets from server.js)
 

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -1,16 +1,17 @@
+$font-path: 'https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/' !default;
+
 @import 'import-once';
 
-@mixin font-face-css($path) {
+@mixin font-face-css($font-path) {
   // Default font directory, `!default` flag allows user override.
   // (font files are configured to be served as static assets from server.js)
-  $font-path: '#{$path}' !default;
 
   @font-face {
     font-family: 'IBM Helvetica';
     font-style: normal;
     font-weight: 200;
     src: url('#{$font-path}/helvetica-neue-light.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-light.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-light.woff') format('woff');
   }
 
   @font-face {
@@ -18,7 +19,7 @@
     font-style: italic;
     font-weight: 200;
     src: url('#{$font-path}/helvetica-neue-light-italic.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-light-italic.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-light-italic.woff') format('woff');
   }
 
   @font-face {
@@ -26,7 +27,7 @@
     font-style: normal;
     font-weight: 300;
     src: url('#{$font-path}/helvetica-neue-light.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-light.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-light.woff') format('woff');
   }
 
   @font-face {
@@ -34,7 +35,7 @@
     font-style: italic;
     font-weight: 300;
     src: url('#{$font-path}/helvetica-neue-light-italic.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-light-italic.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-light-italic.woff') format('woff');
   }
 
   @font-face {
@@ -42,7 +43,7 @@
     font-style: normal;
     font-weight: 400;
     src: url('#{$font-path}/helvetica-neue-roman.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-roman.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-roman.woff') format('woff');
   }
 
   @font-face {
@@ -50,7 +51,7 @@
     font-style: italic;
     font-weight: 400;
     src: url('#{$font-path}/helvetica-neue-roman-italic.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-roman-italic.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-roman-italic.woff') format('woff');
   }
 
   @font-face {
@@ -58,7 +59,7 @@
     font-style: normal;
     font-weight: 700;
     src: url('#{$font-path}/helvetica-neue-bold.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-bold.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-bold.woff') format('woff');
   }
 
   @font-face {
@@ -66,12 +67,12 @@
     font-style: italic;
     font-weight: 700;
     src: url('#{$font-path}/helvetica-neue-bold-italic.woff2') format('woff2'),
-         url('#{$font-path}/helvetica-neue-bold-italic.woff') format('woff')
+      url('#{$font-path}/helvetica-neue-bold-italic.woff') format('woff');
   }
 }
 
 @include exports('css--font-face') {
   @if global-variable-exists('css--font-face') and $css--font-face == true {
-    @include font-face-css('https://unpkg.com/carbon-components@7.0.0/src/globals/fonts/');
+    @include font-face-css($font-path);
   }
 }


### PR DESCRIPTION
## Overview

`$font-path` previously wasn't able to be overwritten, now it can! 