### PR TITLE
refactor(structured-list): remove <p> and content class

### DIFF
--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -87,14 +87,12 @@
   }
 
   .bx--structured-list-td {
+    @include reset;
+    @include font-size('14');
+    @include line-height('body');
     @include padding-td;
     position: relative;
     display: table-cell;
-    font-size: rem(14px);
-  }
-
-  .bx--structured-list-content {
-    font-size: rem(14px);
   }
 
   .bx--structured-list-content--nowrap {

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -95,6 +95,7 @@
     display: table-cell;
   }
 
+  // Deprecated class
   .bx--structured-list-content {
     @include font-size('14');
   }

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -95,6 +95,10 @@
     display: table-cell;
   }
 
+  .bx--structured-list-content {
+    @include font-size('14');
+  }
+
   .bx--structured-list-content--nowrap {
     white-space: nowrap;
   }

--- a/src/components/structured-list/structured-list--selection.html
+++ b/src/components/structured-list/structured-list--selection.html
@@ -20,7 +20,7 @@
       <div class="bx--structured-list-td bx--structured-list-content--nowrap">Apache Spark</div>
       <div class="bx--structured-list-td">IBM</div>
       <div class="bx--structured-list-td">
-        <p class="bx--structured-list-content">Apache Spark is an open source cluster computing framework optimized for extremely fast and large scale data processing, which you can access via the newly integrated notebook interface IBM Analytics for Apache Spark.</p>
+        Apache Spark is an open source cluster computing framework optimized for extremely fast and large scale data processing, which you can access via the newly integrated notebook interface IBM Analytics for Apache Spark.
       </div>
     </label>
     <input tabindex="-1" id="cloudant-id" class="bx--structured-list-input" value="Cloudant" type="radio" name="services" title="Cloudant"
@@ -33,8 +33,8 @@
         </svg>
       </div>
       <div class="bx--structured-list-td bx--structured-list-content--nowrap">Cloudant</div>
-      <div class="bx--structured-list-td"><p class="bx--structured-list-content">IBM</p></div>
-      <div class="bx--structured-list-td"><p class="bx--structured-list-content">Cloudant NoSQL DB is a fully managed data layer designed for modern web and mobile applications that leverages a flexible JSON schema.</p></div>
+      <div class="bx--structured-list-td">IBM</div>
+      <div class="bx--structured-list-td">Cloudant NoSQL DB is a fully managed data layer designed for modern web and mobile applications that leverages a flexible JSON schema.</div>
     </label>
     <input tabindex="-1" id="block-storate-id" class="bx--structured-list-input" value="block-storage" type="radio" name="services"
       title="block-storage" />
@@ -46,8 +46,8 @@
         </svg>
       </div>
       <div class="bx--structured-list-td bx--structured-list-content--nowrap">Block Storage</div>
-      <div class="bx--structured-list-td"><p class="bx--structured-list-content">IBM</p></div>
-      <div class="bx--structured-list-td"><p class="bx--structured-list-content">Get local disk performance with SAN persistence and durability. Increase storage capacity available to your Bluemix Virtual and Bare Metal Servers with a maximum of 48k IOPs.*</p></div>
+      <div class="bx--structured-list-td">IBM</div>
+      <div class="bx--structured-list-td">Get local disk performance with SAN persistence and durability. Increase storage capacity available to your Bluemix Virtual and Bare Metal Servers with a maximum of 48k IOPs.*</div>
     </label>
     <input tabindex="-1" id="open-whisk-id" class="bx--structured-list-input" value="open-whisk" type="radio" name="services"
       title="open-whisk" />
@@ -59,8 +59,8 @@
         </svg>
       </div>
       <div class="bx--structured-list-td bx--structured-list-content--nowrap">Open Whisk</div>
-      <div class="bx--structured-list-td"><p class="bx--structured-list-content">IBM</p></div>
-      <div class="bx--structured-list-td"><p class="bx--structured-list-content">OpenWhisk is an open-source server less compute platform. It executes your functions (actions) in response to events from triggers. It costs nothing when not in use.</p></div>
+      <div class="bx--structured-list-td">IBM</div>
+      <div class="bx--structured-list-td">OpenWhisk is an open-source server less compute platform. It executes your functions (actions) in response to events from triggers. It costs nothing when not in use.</div>
     </label>
   </div>
 </section>

--- a/src/components/structured-list/structured-list.html
+++ b/src/components/structured-list/structured-list.html
@@ -11,18 +11,18 @@
       <div class="bx--structured-list-td bx--structured-list-content--nowrap">Apache Spark</div>
       <div class="bx--structured-list-td">IBM</div>
       <div class="bx--structured-list-td">
-        <p class="bx--structured-list-content">Apache Spark is an open source cluster computing framework optimized for extremely fast and large scale data processing,
-          which you can access via the newly integrated notebook interface IBM Analytics for Apache Spark.</p>
+        Apache Spark is an open source cluster computing framework optimized for extremely fast and large scale data processing,
+        which you can access via the newly integrated notebook interface IBM Analytics for Apache Spark.
       </div>
     </div>
     <div class="bx--structured-list-row">
       <div class="bx--structured-list-td bx--structured-list-content--nowrap">Cloudant</div>
       <div class="bx--structured-list-td">
-        <p class="bx--structured-list-content">IBM</p>
+        IBM
       </div>
       <div class="bx--structured-list-td">
-        <p class="bx--structured-list-content">Cloudant NoSQL DB is a fully managed data layer designed for modern web and mobile applications that leverages a
-          flexible JSON schema.</p>
+        Cloudant NoSQL DB is a fully managed data layer designed for modern web and mobile applications that leverages a flexible
+        JSON schema.
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Overview

While porting Structured List to React, realized that I didn't need to use `<p>` or `.bx--structured-list-content` class. 