### PR TITLE
chore(demo): make demo navigable with left nav

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,4 @@
 dist
 demo/demo.js
 node_modules
-server.js
 gulpfile.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "root": true,
   "parserOptions" : {
     "ecmaVersion": 6,
-    "sourceType": "script",
+    "sourceType": "script"
   },
   "env": {
     "node": true,

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,10 +2,52 @@ import './polyfills/index';
 
 import DemoSwitcher from './js/demo-switcher';
 
+import eventMatches from '../src/globals/js/misc/event-matches';
+
 export * from '../src/index';
+
+function switchTo(name) {
+  const selectedLeftNavItem = document.querySelector(`[data-demo-name=${name}].left-nav-list__item`);
+  [...document.querySelectorAll('[data-demo-name].left-nav-list__item')].forEach((item) => {
+    item.classList.toggle('left-nav-list__item--active', item.dataset.demoName === name);
+  });
+  [...document.querySelectorAll('[data-interior-left-nav-with-children]')].forEach((item) => {
+    if (item.contains(selectedLeftNavItem)) {
+      item.classList.add('left-nav-list__item--expanded');
+    }
+  });
+  [...document.querySelectorAll('[data-demo-name].demo--container__panel')].forEach((panel) => {
+    if (panel.dataset.demoName === name) {
+      panel.removeAttribute('hidden');
+    } else {
+      panel.setAttribute('hidden', '');
+    }
+  });
+}
 
 const init = () => {
   DemoSwitcher.init();
+
+  document.body.addEventListener('left-nav-toggled', (evt) => {
+    document.body.classList.toggle('demo--collapsed', evt.detail.collapsed);
+  });
+
+  document.body.addEventListener('click', (evt) => {
+    const link = eventMatches(evt, '.left-nav-list__item-link');
+    if (link) {
+      evt.preventDefault();
+    }
+    const leafLink = eventMatches(evt, '[data-interior-left-nav-leaf-item-link]');
+    if (leafLink) {
+      const name = leafLink.textContent;
+      window.history.pushState({ name }, name, `/demo/${name}`);
+      switchTo(name);
+    }
+  });
+
+  window.addEventListener('popstate', (evt) => {
+    switchTo(evt.state.name);
+  });
 };
 
 if (document.readyState === 'loading') {

--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -1,17 +1,33 @@
 @import '../../src/globals/scss/styles';
 
 .demo--container {
-  @include grid-container;
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  padding: 1rem;
-  margin-top: 5rem;
+  padding-top: 1em;
   transition: .2s;
   background-color: $ui-02;
 
-  &.flex-col {
+  .demo--collapsed & {
+    padding-left: 3rem;
+  }
+
+  .demo--standalone & {
+    padding-left: 0;
+  }
+}
+
+.demo--container__panel {
+  @include grid-container;
+  width: 100%;
+  max-width: 960px;
+  height: 100%;
+  // min-height: 2000px;
+  padding: 1em;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  .demo--container.flex-col & {
     flex-direction: column;
     margin: 0 auto;
 
@@ -20,7 +36,7 @@
     }
   }
 
-  &.flex-row {
+  .demo--container.flex-row & {
     flex-direction: row;
     flex-wrap: wrap;
     margin: 0 auto;
@@ -33,49 +49,81 @@
   &.mobile {
     max-width: 600px;
   }
+
+  &[hidden] {
+    display: none;
+  }
 }
 
-.demo--panels {
-  width: 100%;
-  height: 15rem;
-}
-
-.demo--panel {
-  width: 100%;
-  max-width: 960px;
-  height: 100%;
-  padding: 3em 1em 1em;
+.bx--global-header--demo {
+  top: 0;
+  height: 5.375em;
+  display: flex;
+  align-items: center;
+  padding: 1em;
+  z-index: 0;
 }
 
 .demo-switcher {
   &__container {
     display: flex;
-    position: fixed;
-    top: 1.5rem;
-    left: 1rem;
+    align-items: center;
 
     label {
+      color: #fff;
       margin-right: 1rem;
     }
   }
 }
 
-.test-header {
-  position: fixed;
-  background-color: $ui-05;
-  width: 100%;
-  top: 0;
-  left: 0;
-  height: 86px;
-  z-index: 8000;
+.demo--standalone {
+  .test-header {
+    position: fixed;
+    background-color: $ui-05;
+    width: 100%;
+    top: 0;
+    left: 0;
+    height: 86px;
+    z-index: 8000;
+  }
+
+  .test-nav {
+    position: fixed;
+    background-color: $ui-04;
+    width: 200px;
+    height: calc(100vh - 86px);
+    bottom: 0;
+    left: 0;
+    z-index: 8000;
+  }
 }
 
-.test-nav {
-  position: fixed;
-  background-color: $ui-04;
-  width: 200px;
-  height: calc(100vh - 86px);
-  bottom: 0;
-  left: 0;
-  z-index: 8000;
+.demo--navigated {
+  .test-header {
+    display: none;
+  }
+
+  .test-nav {
+    display: none;
+  }
+
+  .demo--container {
+    padding-left: 12.5rem;
+  }
+
+  .bx--detail-page-header--with-tabs {
+    margin-left: 12.5em;
+  }
+
+  &.demo--collapsed .bx--detail-page-header--with-tabs {
+    margin-left: 3rem;
+  }
+}
+
+// carbon-components no longer owns alternate theme, hiding the theme switcher for now
+.theme-switcher {
+  .demo--navigated &,
+  .demo--standalone & {
+    display: none;
+  }
 }

--- a/demo/views/demo-all.dust
+++ b/demo/views/demo-all.dust
@@ -1,8 +1,8 @@
-
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
+  <base href="/">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
   <title>Carbon Components</title>
@@ -23,23 +23,83 @@
   </style>
 </head>
 
-<body class="bx--body">
-  <div data-demo-switcher class="demo-switcher__container">
-    <input id="flex-col" data-demo-col class="bx--radio" type="radio" value="col" name="radio">
-    <label for="flex-col" data-demo-col class="bx--radio__label">
-      <span data-demo-col class="bx--radio__appearance"></span>
-      Flex - Column
-    </label>
-    <br>
-    <input id="flex-row" data-demo-row class="bx--radio" type="radio" value="row" name="radio">
-    <label for="flex-row" data-demo-row class="bx--radio__label">
-      <span data-demo-row class="bx--radio__appearance"></span>
-      Flex - Row
-    </label>
-  </div>
+<body class="bx--body{?links} demo--navigated{:else} demo--standalone{/links}">
+  <header role="banner" class="bx--global-header bx--global-header--demo">
+    <div data-demo-switcher class="demo-switcher__container bx--radio-button-group">
+      <input id="flex-col" data-demo-col class="bx--radio-button" type="radio" value="col" name="radio">
+      <label for="flex-col" data-demo-col class="bx--radio-button__label">
+        <span data-demo-col class="bx--radio-button__appearance"></span>
+        Flex - Column
+      </label>
+      <br>
+      <input id="flex-row" data-demo-row class="bx--radio-button" type="radio" value="row" name="radio">
+      <label for="flex-row" data-demo-row class="bx--radio-button__label">
+        <span data-demo-row class="bx--radio-button__appearance"></span>
+        Flex - Row
+      </label>
+    </div>
+    <button class="bx--btn bx--btn--primary theme-switcher" data-theme-switcher>Theme Switcher</button>
+  </header>
+  {?links}
+    <nav role="navigation" aria-label="Interior Left Navigation" data-interior-left-nav class="bx--interior-left-nav bx--interior-left-nav--collapseable">
+      <ul role="menubar" class="left-nav-list" data-interior-left-nav-list aria-hidden="false">
+        {#links}
+          {?items}
+            <li role="menuitem" tabindex="0" class="left-nav-list__item left-nav-list__item--has-children{?selected} left-nav-list__item--expanded{/selected}" data-interior-left-nav-item data-interior-left-nav-with-children>
+              <a class="left-nav-list__item-link">
+                {name}
+                <div class="left-nav-list__item-icon">
+                  <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+                    <path d="M10 0L5 5 0 0z"></path>
+                  </svg>
+                </div>
+              </a>
+              <ul role="menu" aria-hidden="true" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
+                {#items}
+                  <li class="left-nav-list__item{?selected} left-nav-list__item--active{/selected}" data-interior-left-nav-nested-item data-demo-name="{name}" role="menuitem" tabindex="-1">
+                    <a class="left-nav-list__item-link" data-interior-left-nav-item-link data-interior-left-nav-leaf-item-link tabindex="-1">{name}</a>
+                  </li>
+                {/items}
+              </ul>
+            </li>
+          {:else}
+            <li role="menuitem" tabindex="0" class="left-nav-list__item{?selected} left-nav-list__item--active{/selected}" data-interior-left-nav-item data-demo-name="{name}">
+              <a class="left-nav-list__item-link" data-interior-left-nav-leaf-item-link>{name}</a>
+            </li>
+          {/items}
+        {/links}
+      </ul>
+      <div class="bx--interior-left-nav-collapse" data-interior-left-nav-collapse>
+        <a class="bx--interior-left-nav-collapse__link" href="#">
+          <svg class="bx--interior-left-nav-collapse__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+            <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
+          </svg>
+        </a>
+      </div>
+    </nav>
+  {/links}
 
-  <div class="demo--container" data-card-list>
-    {html|s}
+  <div class="demo--container">
+    {?links}
+      {#links}
+        {?items}
+          {#items}
+            <div class="demo--container__panel" data-card-list data-demo-name="{name}"{^selected} hidden{/selected}>
+              {content|s}
+            </div>
+          {/items}
+        {:else}
+          <div class="demo--container__panel" data-card-list data-demo-name="{name}"{^selected} hidden{/selected}>
+            {content|s}
+          </div>
+        {/items}
+      {/links}
+    {/links}
+    {?content}
+      <div class="demo--container__panel" data-card-list data-demo-name="{name}">
+        {content|s}
+      </div>
+    {/content}
   </div>
 
   <!-- Pseudo element to demonstrate focus-wrap behavior (focus trap) -->

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -310,6 +310,7 @@ gulp.task('test:a11y', ['sass:compiled'], done => {
 gulp.task('watch', () => {
   gulp.watch('src/**/**/*.html').on('change', browserSync.reload);
   gulp.watch(['src/**/**/*.js'], ['scripts:dev', 'scripts:compiled']);
+  gulp.watch(['demo/**/**/*.js', '!demo/demo.js'], ['scripts:dev']);
   gulp.watch(['src/**/**/*.scss', 'demo/**/*.scss'], ['sass:dev']);
 });
 


### PR DESCRIPTION
## Overview

This PR introduces new version of the demo for all components (hitting localhost:3000 without specifying component with `npm run dev` running), with each component browsable with interior left nav - Instead of showing all components at once.

### Added

1. Left nav for browsing components
2. localhost:3000/demo/:component route to support browser history (Note: localhost:3000/components/:component is almost kept intact so that a single component can be tested without worrying about side effects from other components)

### Removed

* Theme switcher (Anybody - Please kindly let me know if alternate theme that demo can access is still available)

## Testing / Reviewing

Testing should make sure no demo environment is broken.