### PR TITLE
fix(structured-list): add modifier class for variant

### DIFF
--- a/src/components/structured-list/README.md
+++ b/src/components/structured-list/README.md
@@ -29,6 +29,7 @@ Use these modifiers with `.bx--structured-list` class.
 | .bx--structured-list--border         | Applies border around structured-list and white background-color                             |
 | .bx--structured-list--condensed      | Applies condensed styles for all body rows                                                   |
 | .bx--structured-list-content--nowrap | Applies `white-space: nowrap;` on content. Prevents titles from wrapping in small viewports. |
+| .bx--structured-list--selection      | Applies styles used for selection variant of structured-list.                                |
 
 
 Use these modifiers with `.bx--structured-list-td` class. 
@@ -67,8 +68,8 @@ Use CSS to add visual styles to text.
 
 **HTML**
 ```html
-<div class="bx--structured-list-td">
-  <p class="bx--structured-list-content bold">Apache Spark</p>
+<div class="bx--structured-list-td bold">
+  Apache Spark
 </div>
 ```
 

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -7,6 +7,8 @@
 @import '../../globals/scss/import-once';
 
 @include exports('structured-list') {
+  .bx--structured-list--selection .bx--structured-list-td,
+  .bx--structured-list--selection .bx--structured-list-th,
   [data-structured-list] .bx--structured-list-td,
   [data-structured-list] .bx--structured-list-th {
     @include padding--data-structured-list;
@@ -44,9 +46,11 @@
     border-bottom: 1px solid $ui-04;
     transition: $transition--base $bx--standard-easing;
 
-    [data-structured-list] &:hover:not(.bx--structured-list-row--header-row) {
-      background-color: rgba($brand-02, .1);
-      cursor: pointer;
+    [data-structured-list], .bx--structured-list--selection {
+      &:hover:not(.bx--structured-list-row--header-row) {
+        background-color: rgba($brand-02, .1);
+        cursor: pointer;
+      }
     }
 
     .bx--structured-list-input:checked + & {

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -8,7 +8,11 @@
 
 @include exports('structured-list') {
   .bx--structured-list--selection .bx--structured-list-td,
-  .bx--structured-list--selection .bx--structured-list-th,
+  .bx--structured-list--selection .bx--structured-list-th {
+    @include padding--data-structured-list;
+  }
+
+  // Deprecated
   [data-structured-list] .bx--structured-list-td,
   [data-structured-list] .bx--structured-list-th {
     @include padding--data-structured-list;
@@ -46,11 +50,15 @@
     border-bottom: 1px solid $ui-04;
     transition: $transition--base $bx--standard-easing;
 
-    [data-structured-list], .bx--structured-list--selection {
-      &:hover:not(.bx--structured-list-row--header-row) {
-        background-color: rgba($brand-02, .1);
-        cursor: pointer;
-      }
+    .bx--structured-list--selection &:hover:not(.bx--structured-list-row--header-row) {
+      background-color: rgba($brand-02, .1);
+      cursor: pointer;
+    }
+
+    // Deprecated
+    [data-structured-list] &:hover:not(.bx--structured-list-row--header-row) {
+      background-color: rgba($brand-02, .1);
+      cursor: pointer;
     }
 
     .bx--structured-list-input:checked + & {

--- a/src/components/structured-list/structured-list--selection.html
+++ b/src/components/structured-list/structured-list--selection.html
@@ -1,4 +1,4 @@
-<section class="bx--structured-list bx--structured-list--border" data-structured-list>
+<section class="bx--structured-list bx--structured-list--border bx--structured-list--selection" data-structured-list>
   <div class="bx--structured-list-thead">
     <div class="bx--structured-list-row bx--structured-list-row--header-row">
       <div class="bx--structured-list-th"></div>


### PR DESCRIPTION
## Overview

I was styling against the `[data-structured-list]` attribute for the variant that uses selections and javascript.
This was not following our convention for our use of `class` and `data-` attributes.

I created a new modifier class called `bx--structured-list--selection` that is used to apply styles for the variant.

Selectors for `data-` attribute are still intact but are now marked as deprecated.

Furthermore, this change is needed to avoid including data attributes in the React version. 