### PR TITLE
fix(dropdown): fix the API to get focused dropdown item for IE

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -98,7 +98,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch) {
    */
   getCurrentNavigation() {
     const focused = this.element.ownerDocument.activeElement;
-    return focused.matches(this.options.selectorItem) ? focused : null;
+    return focused.nodeType === Node.ELEMENT_NODE && focused.matches(this.options.selectorItem) ? focused : null;
   }
 
   /**

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -285,6 +285,8 @@ module.exports = function (config) {
 
     logLevel: config.LOG_INFO,
 
+    browserNoActivityTimeout: 60000,
+
     autoWatch: true,
     autoWatchBatchDelay: 400,
 


### PR DESCRIPTION
## Overview

This PR fixes error in automated test against IE, complaining missing `document.activeElement.matches`.

Also increase browserNoActivityTimeout for Sauce.

### Added

`ELEMENT_NODE` check before running `matches()`, in `Dropdown#getCurrentNavigation()`.

## Testing / Reviewing

Tests should make sure dropdown is not broken, should be covered by automation.