### PR TITLE
fix(global-left-nav): refactor for a11y in v6

### DIFF
--- a/consumables/html/components/unified-header/unified-header.html
+++ b/consumables/html/components/unified-header/unified-header.html
@@ -218,12 +218,12 @@
   <!-- Global Header -->
   <header role="banner" class="bx--global-header">
     <div class="bx--global-header__left-container">
-      <div class="bx--left-nav__trigger bx--left-nav__trigger--apps" data-left-nav-toggle="open" tabindex="0">
+      <button class="bx--left-nav__trigger" data-left-nav-toggle="open" aria-haspopup="true" aria-label="Navigation" aria-expanded="false">
         <div class="bx--left-nav__trigger--btn">
           <span></span>
         </div>
-      </div>
-      <div class="bx--global-header__left-nav" data-left-nav-container aria-expanded="false" tabindex="-1">
+      </button>
+      <div class="bx--global-header__left-nav" data-left-nav-container aria-expanded="false" tabindex="-1" role="menu">
         <div class="bx--left-nav__close-row"></div>
         <nav class="bx--left-nav" data-left-nav role="navigation" aria-label="Left Navigation">
           <label class='bx--left-nav__section-label'>Something title</label>

--- a/consumables/js/es2015/left-nav.js
+++ b/consumables/js/es2015/left-nav.js
@@ -56,40 +56,49 @@ class LeftNav extends mixin(createCoponent, initComponent) {
     if (leftNavContainer.getAttribute('aria-expanded') === 'false') {
       leftNavContainer.setAttribute('aria-expanded', 'true');
       toggleOpenNode.setAttribute('aria-expanded', 'true');
-      // commenting out because translation of this label needs to happen, will do in Common
-      // toggleOpenNode.setAttribute('aria-label', 'Close Navigation'); 
       this.focusIndex = 0;
     } else {
       leftNavContainer.setAttribute('aria-expanded', 'false');
       toggleOpenNode.removeAttribute('aria-expanded');
-      // toggleOpenNode.setAttribute('aria-label', 'Navigation');
     }
   }
 
-  onKeyDown (evt) {
+  onKeyDown(evt) {
     const leftNavContainer = document.querySelector('[data-left-nav]');
-    var navItems = [...leftNavContainer.getElementsByClassName('bx--parent-item__link')];
-    var button = [...document.getElementsByClassName('bx--left-nav__trigger')];
+    const navItems = [...leftNavContainer.getElementsByClassName('bx--parent-item__link')];
+    const button = [...document.getElementsByClassName('bx--left-nav__trigger')];
     navItems.unshift(button[0]);
 
     switch (evt.which) {
       case 9: // tab
-        if (evt.shiftKey) { 
-          if ( this.focusIndex > 0 ) { this.focusIndex--; }
-          else { this.closeMenu(); }
-        } else { 
-          if ( this.focusIndex < navItems.length-1 ) { this.focusIndex++; }
-          else { this.closeMenu(); }
+        if (evt.shiftKey) {
+          if (this.focusIndex > 0) {
+            this.focusIndex--;
+          } else {
+            this.closeMenu();
+          }
+        }
+
+        if (!evt.shiftKey) {
+          if (this.focusIndex < navItems.length - 1) {
+            this.focusIndex++;
+          } else {
+            this.closeMenu();
+          }
         }
         break;
 
       case 38: // arrow up
-        if ( this.focusIndex > 0 ) { this.focusIndex--; }
+        if (this.focusIndex > 0) {
+          this.focusIndex--;
+        }
         navItems[this.focusIndex].focus();
         break;
 
       case 40: // arrow down
-        if ( this.focusIndex < navItems.length-1 ) { this.focusIndex++; }
+        if (this.focusIndex < navItems.length - 1) {
+          this.focusIndex++;
+        }
         navItems[this.focusIndex].focus();
         break;
 
@@ -99,8 +108,11 @@ class LeftNav extends mixin(createCoponent, initComponent) {
         break;
 
       case 35: // end
-        this.focusIndex = navItems.length-1;
+        this.focusIndex = navItems.length - 1;
         navItems[this.focusIndex].focus();
+        break;
+
+      default:
         break;
     }
   }
@@ -116,10 +128,9 @@ class LeftNav extends mixin(createCoponent, initComponent) {
     this.element.ownerDocument.addEventListener('keydown', (evt) => {
       if ((evt.which === 27) && this.element.classList.contains(this.options.classActiveLeftNav)) {
         this.closeMenu();
-      }
-      else {
+      } else {
         const toggleOpen = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
-        if(toggleOpen.classList.contains(this.options.classActiveTrigger)) {
+        if (toggleOpen.classList.contains(this.options.classActiveTrigger)) {
           this.onKeyDown = this.onKeyDown.bind(this);
           this.onKeyDown(evt);
         }

--- a/consumables/js/es2015/left-nav.js
+++ b/consumables/js/es2015/left-nav.js
@@ -29,7 +29,7 @@ class LeftNav extends mixin(createCoponent, initComponent) {
   constructor(element, options) {
     super(element, options);
     this.leftNavSectionActive = false;
-    this.focusIndex = -1;
+    this.focusIndex = 0;
     this.hookOpenActions();
     this.hookListItemsEvents();
     this.hDocumentClick = on(this.element.ownerDocument, 'click', (evt) => { this.handleDocumentClick(evt); });
@@ -56,45 +56,53 @@ class LeftNav extends mixin(createCoponent, initComponent) {
     if (leftNavContainer.getAttribute('aria-expanded') === 'false') {
       leftNavContainer.setAttribute('aria-expanded', 'true');
       toggleOpenNode.setAttribute('aria-expanded', 'true');
-      toggleOpenNode.setAttribute('aria-label', 'Close Navigation');
-      // this.element.ownerDocument.addEventListener('keydown', this.onKeyDown);
+      // commenting out because translation of this label needs to happen, will do in Common
+      // toggleOpenNode.setAttribute('aria-label', 'Close Navigation'); 
+      this.focusIndex = 0;
     } else {
       leftNavContainer.setAttribute('aria-expanded', 'false');
       toggleOpenNode.removeAttribute('aria-expanded');
-      toggleOpenNode.setAttribute('aria-label', 'Navigation');
-      // this.element.ownerDocument.removeEventListener('keydown', this.onKeyDown);
+      // toggleOpenNode.setAttribute('aria-label', 'Navigation');
     }
   }
 
-  onKeyDown (evt, newThis) {
-    console.log('========== hitting start of on key down function ========');
-    var activeElement = document.activeElement;
+  onKeyDown (evt) {
     const leftNavContainer = document.querySelector('[data-left-nav]');
-    var navItems = leftNavContainer.getElementsByClassName('bx--parent-item__link');
-    // const hasFocus = document.querySelector(':focus');
-    // hasFocus.classList.add('focus');
-    console.log (navItems);
-    console.log('2 '+navItems[2]);
+    var navItems = [...leftNavContainer.getElementsByClassName('bx--parent-item__link')];
+    var button = [...document.getElementsByClassName('bx--left-nav__trigger')];
+    navItems.unshift(button[0]);
 
-      switch (evt.which) {
-        case 38: // arrow up
-          newThis.focusIndex--;
-          navItems[newThis.focusIndex].focus();
-          break;
+    switch (evt.which) {
+      case 9: // tab
+        if (evt.shiftKey) { 
+          if ( this.focusIndex > 0 ) { this.focusIndex--; }
+          else { this.closeMenu(); }
+        } else { 
+          if ( this.focusIndex < navItems.length-1 ) { this.focusIndex++; }
+          else { this.closeMenu(); }
+        }
+        break;
 
-        case 40: // arrow down
-          newThis.focusIndex++;
-          navItems[newThis.focusIndex].focus();
-          break;
+      case 38: // arrow up
+        if ( this.focusIndex > 0 ) { this.focusIndex--; }
+        navItems[this.focusIndex].focus();
+        break;
 
-        case 36: // home
-          navItems[0].focus();
-          break;
+      case 40: // arrow down
+        if ( this.focusIndex < navItems.length-1 ) { this.focusIndex++; }
+        navItems[this.focusIndex].focus();
+        break;
 
-        case 35: // end
-          navItems[navItems.length-1].focus();
-          break;
-      }
+      case 36: // home
+        this.focusIndex = 1;
+        navItems[this.focusIndex].focus();
+        break;
+
+      case 35: // end
+        this.focusIndex = navItems.length-1;
+        navItems[this.focusIndex].focus();
+        break;
+    }
   }
 
   hookOpenActions() {
@@ -110,31 +118,13 @@ class LeftNav extends mixin(createCoponent, initComponent) {
         this.closeMenu();
       }
       else {
-        console.log('keypress');
         const toggleOpen = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
         if(toggleOpen.classList.contains(this.options.classActiveTrigger)) {
-          console.log('>>>>>>> toggle is open <<<<<<<<');
-          this.onKeyDown(evt, this);
+          this.onKeyDown = this.onKeyDown.bind(this);
+          this.onKeyDown(evt);
         }
       }
     });
-
-    //up and down keys
-    // console.log("what is options selector Left Nav: ", this.options.selectorLeftNav);
-    // console.log("left nav container?: ", this.options.selectorInit);
-    //
-    // const navContainer = this.element.ownerDocument.querySelector(this.options.selectorInit);
-    // console.log('what is nav container? ', navContainer);
-    // this.element.ownerDocument.addEventListener('keydown', (evt) => {
-    //   //check if toggle is open
-    //   console.log('keeeeey is dooooown');
-    //   // const toggleOpen = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
-    //   // if(toggleOpen) {
-    //   //   console.log('>>>>>>> toggle is open <<<<<<<<');
-    //   //   this.onKeyDown(evt);
-    //   // }
-    // });
-
   }
 
   /**

--- a/consumables/js/es2015/left-nav.js
+++ b/consumables/js/es2015/left-nav.js
@@ -29,6 +29,7 @@ class LeftNav extends mixin(createCoponent, initComponent) {
   constructor(element, options) {
     super(element, options);
     this.leftNavSectionActive = false;
+    this.focusIndex = -1;
     this.hookOpenActions();
     this.hookListItemsEvents();
     this.hDocumentClick = on(this.element.ownerDocument, 'click', (evt) => { this.handleDocumentClick(evt); });
@@ -56,16 +57,17 @@ class LeftNav extends mixin(createCoponent, initComponent) {
       leftNavContainer.setAttribute('aria-expanded', 'true');
       toggleOpenNode.setAttribute('aria-expanded', 'true');
       toggleOpenNode.setAttribute('aria-label', 'Close Navigation');
-      this.element.ownerDocument.addEventListener('keydown', this.onKeyDown);
+      // this.element.ownerDocument.addEventListener('keydown', this.onKeyDown);
     } else {
       leftNavContainer.setAttribute('aria-expanded', 'false');
       toggleOpenNode.removeAttribute('aria-expanded');
       toggleOpenNode.setAttribute('aria-label', 'Navigation');
-      this.element.ownerDocument.removeEventListener('keydown', this.onKeyDown);
+      // this.element.ownerDocument.removeEventListener('keydown', this.onKeyDown);
     }
   }
 
-  onKeyDown (evt) {
+  onKeyDown (evt, newThis) {
+    console.log('========== hitting start of on key down function ========');
     var activeElement = document.activeElement;
     const leftNavContainer = document.querySelector('[data-left-nav]');
     var navItems = leftNavContainer.getElementsByClassName('bx--parent-item__link');
@@ -74,20 +76,15 @@ class LeftNav extends mixin(createCoponent, initComponent) {
     console.log (navItems);
     console.log('2 '+navItems[2]);
 
-    // var focusIndex;
-    // for (var i=0; i < navItems.length; i++) {
-    //   console.log('i: '+i+' nav[i] '+navItems[i]);
-    //   if (navItems[i].hasClass('focus')) {
-    //     focusIndex = i;
-    //   }
-    // }
       switch (evt.which) {
         case 38: // arrow up
-          // navItems[i-1].focus();
+          newThis.focusIndex--;
+          navItems[newThis.focusIndex].focus();
           break;
 
         case 40: // arrow down
-          // navItems[i+1].focus();
+          newThis.focusIndex++;
+          navItems[newThis.focusIndex].focus();
           break;
 
         case 36: // home
@@ -112,7 +109,32 @@ class LeftNav extends mixin(createCoponent, initComponent) {
       if ((evt.which === 27) && this.element.classList.contains(this.options.classActiveLeftNav)) {
         this.closeMenu();
       }
+      else {
+        console.log('keypress');
+        const toggleOpen = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
+        if(toggleOpen.classList.contains(this.options.classActiveTrigger)) {
+          console.log('>>>>>>> toggle is open <<<<<<<<');
+          this.onKeyDown(evt, this);
+        }
+      }
     });
+
+    //up and down keys
+    // console.log("what is options selector Left Nav: ", this.options.selectorLeftNav);
+    // console.log("left nav container?: ", this.options.selectorInit);
+    //
+    // const navContainer = this.element.ownerDocument.querySelector(this.options.selectorInit);
+    // console.log('what is nav container? ', navContainer);
+    // this.element.ownerDocument.addEventListener('keydown', (evt) => {
+    //   //check if toggle is open
+    //   console.log('keeeeey is dooooown');
+    //   // const toggleOpen = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
+    //   // if(toggleOpen) {
+    //   //   console.log('>>>>>>> toggle is open <<<<<<<<');
+    //   //   this.onKeyDown(evt);
+    //   // }
+    // });
+
   }
 
   /**

--- a/consumables/js/es2015/left-nav.js
+++ b/consumables/js/es2015/left-nav.js
@@ -52,23 +52,62 @@ class LeftNav extends mixin(createCoponent, initComponent) {
     this.element.classList.toggle(this.options.classActiveLeftNav);
     const toggleOpenNode = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
     toggleOpenNode.classList.toggle(this.options.classActiveTrigger);
-    if (leftNavContainer.getAttribute('aria-expanded') === 'false') leftNavContainer.setAttribute('aria-expanded', 'true');
-    else leftNavContainer.setAttribute('aria-expanded', 'false');
+    if (leftNavContainer.getAttribute('aria-expanded') === 'false') {
+      leftNavContainer.setAttribute('aria-expanded', 'true');
+      toggleOpenNode.setAttribute('aria-expanded', 'true');
+      toggleOpenNode.setAttribute('aria-label', 'Close Navigation');
+      this.element.ownerDocument.addEventListener('keydown', this.onKeyDown);
+    } else {
+      leftNavContainer.setAttribute('aria-expanded', 'false');
+      toggleOpenNode.removeAttribute('aria-expanded');
+      toggleOpenNode.setAttribute('aria-label', 'Navigation');
+      this.element.ownerDocument.removeEventListener('keydown', this.onKeyDown);
+    }
+  }
+
+  onKeyDown (evt) {
+    var activeElement = document.activeElement;
+    const leftNavContainer = document.querySelector('[data-left-nav]');
+    var navItems = leftNavContainer.getElementsByClassName('bx--parent-item__link');
+    // const hasFocus = document.querySelector(':focus');
+    // hasFocus.classList.add('focus');
+    console.log (navItems);
+    console.log('2 '+navItems[2]);
+
+    // var focusIndex;
+    // for (var i=0; i < navItems.length; i++) {
+    //   console.log('i: '+i+' nav[i] '+navItems[i]);
+    //   if (navItems[i].hasClass('focus')) {
+    //     focusIndex = i;
+    //   }
+    // }
+      switch (evt.which) {
+        case 38: // arrow up
+          // navItems[i-1].focus();
+          break;
+
+        case 40: // arrow down
+          // navItems[i+1].focus();
+          break;
+
+        case 36: // home
+          navItems[0].focus();
+          break;
+
+        case 35: // end
+          navItems[navItems.length-1].focus();
+          break;
+      }
   }
 
   hookOpenActions() {
     const openBtn = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
-
+    // on btn click or enter press or space press
     openBtn.addEventListener('click', () => {
       this.toggleMenu();
     });
 
-    openBtn.addEventListener('keydown', (evt) => {
-      if (evt.which === 13) {
-        this.toggleMenu();
-      }
-    });
-
+    // on esc press
     this.element.ownerDocument.addEventListener('keydown', (evt) => {
       if ((evt.which === 27) && this.element.classList.contains(this.options.classActiveLeftNav)) {
         this.closeMenu();
@@ -82,10 +121,12 @@ class LeftNav extends mixin(createCoponent, initComponent) {
   hookListItemsEvents() {
     const leftNavList = [...this.element.querySelectorAll(this.options.selectorLeftNavList)];
     leftNavList.forEach((list) => {
+      // on mouse click
       list.addEventListener('click', (evt) => {
         const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
         if (leftNavItem) this.addActiveListItem(leftNavItem);
       });
+      // on enter press
       list.addEventListener('keydown', (evt) => {
         if (evt.which === 13) {
           const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);

--- a/consumables/js/es2015/left-nav.js
+++ b/consumables/js/es2015/left-nav.js
@@ -127,6 +127,7 @@ class LeftNav extends mixin(createCoponent, initComponent) {
     // on esc press
     this.element.ownerDocument.addEventListener('keydown', (evt) => {
       if ((evt.which === 27) && this.element.classList.contains(this.options.classActiveLeftNav)) {
+        openBtn.focus();
         this.closeMenu();
       } else {
         const toggleOpen = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);

--- a/consumables/scss/components/unified-header/_left-nav-new.scss
+++ b/consumables/scss/components/unified-header/_left-nav-new.scss
@@ -29,7 +29,7 @@
   width: 100%;
   height: 100%;
   background-color: $color__navy-gray-1;
-  padding: 1rem 0 4rem 0;
+  padding: .5rem 0 3rem 0;
   overflow-y: auto;
   overflow-x: hidden;
 
@@ -65,12 +65,12 @@
   list-style: none;
   display: flex;
   flex-direction: column;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.2rem;
   margin-top: 0; // Have to use margin, because setting position to anything other than static breaks the flyouts.
   transition: all 250ms $bx---ease-out;
   background-color: $color__navy-gray-1;
   &:last-child {
-    padding-bottom: 4rem;
+    padding-bottom: 0;
   }
 
   @include light-ui {
@@ -110,7 +110,7 @@
   justify-content: flex-start;
   color: $color__white;
   text-decoration: none;
-  padding: .5rem rem(20px);
+  padding: .4rem rem(20px);
   transition: background-color $transition--base $bx--standard-easing;
 
   @include light-ui {
@@ -119,8 +119,8 @@
 
   &--taxonomy-icon {
     fill: $color__blue-30;
-    width: rem(24px);
-    height: rem(24px);
+    width: rem(18px);
+    height: rem(18px);
     margin-right: 1rem;
 
     @include light-ui {

--- a/consumables/scss/components/unified-header/_left-nav-trigger.scss
+++ b/consumables/scss/components/unified-header/_left-nav-trigger.scss
@@ -10,6 +10,8 @@
   transition: $transition--base $bx--standard-easing;
   cursor: pointer;
   z-index: 9999;
+  border: 0;
+  background: none;
 
   &:focus {
     @include focus-outline;
@@ -17,6 +19,8 @@
 
   &:hover,
   &:focus {
+    background: transparent;
+    
     span,
     span:before,
     span:after {


### PR DESCRIPTION
## Overview

Resolves 
https://github.ibm.com/Bluemix/core-dev/issues/3881

Best keyboard accessible navigation ever, for the global left nav.

### Added

Some javascript to handle more keypresses.

### Removed

...nothing?

### Changed

Menu trigger is now a `<button>` element.
Nav items are closer together, icons are smaller. (these design tweaks are already in staging, will be cleaned up in Common after this PR is merged)


## Testing / Reviewing

Tab to hamburger, use space/enter to open, use tab OR arrows to navigate! Home and end keys select first and last item. Menu closes automatically when you tab out of menu.
