### PR TITLE
fix(modal.scss): re-add overflow-y

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -89,6 +89,7 @@
   }
 
   .bx--modal-content {
+    overflow-y: auto;
     margin-bottom: rem(48px);
 
     > * {


### PR DESCRIPTION
fixes #187

Needed for modal's content when the modal's viewport window is drastically short.

