### PR TITLE
feat(components): start using Element.closest()

### DIFF
--- a/demo/polyfills/element-closest.js
+++ b/demo/polyfills/element-closest.js
@@ -1,0 +1,11 @@
+if (typeof Element.prototype.closest !== 'function') {
+  Element.prototype.closest = function closestElement(selector) {
+    const doc = this.ownerDocument;
+    for (let traverse = this; traverse && traverse !== doc; traverse = traverse.parentNode) {
+      if (traverse.matches(selector)) {
+        return traverse;
+      }
+    }
+    return null;
+  };
+}

--- a/demo/polyfills/index.js
+++ b/demo/polyfills/index.js
@@ -5,5 +5,6 @@ import 'core-js/modules/es6.object.assign';
 /* eslint-enable import/no-extraneous-dependencies */
 
 import './custom-event';
+import './element-closest';
 import './element-matches';
 import './toggle-class';

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -46,17 +46,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState) {
    * @returns {Element} The element that this menu should be placed to.
    */
   _getContainer() {
-    const element = this.element;
-    const body = element.ownerDocument.body;
-    if (typeof element.closest === 'function') {
-      return element.closest(this.options.selectorContainer) || body;
-    }
-    for (let traverse = element; traverse && traverse !== body; traverse = traverse.parentNode) {
-      if (traverse.matches(this.options.selectorContainer)) {
-        return traverse;
-      }
-    }
-    return body;
+    return this.element.closest(this.options.selectorContainer) || this.element.ownerDocument.body;
   }
 
   /**

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -48,6 +48,9 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState) {
   _getContainer() {
     const element = this.element;
     const body = element.ownerDocument.body;
+    if (typeof element.closest === 'function') {
+      return element.closest(this.options.selectorContainer) || body;
+    }
     for (let traverse = element; traverse && traverse !== body; traverse = traverse.parentNode) {
       if (traverse.matches(this.options.selectorContainer)) {
         return traverse;

--- a/src/globals/js/misc/event-matches.js
+++ b/src/globals/js/misc/event-matches.js
@@ -8,19 +8,14 @@ export default function eventMatches(event, selector) {
   // <svg> in IE does not have `Element#msMatchesSelector()` (that should be copied to `Element#matches()` by a polyfill).
   // Also a weird behavior is seen in IE where DOM tree seems broken when `event.target` is on <svg>.
   // Therefore this function simply returns `undefined` when `event.target` is on <svg>.
-  if (typeof event.target.closest === 'function') {
-    return event.target.closest(selector);
-  } else if (typeof event.target.matches === 'function') {
+  if (typeof event.target.matches === 'function') {
     if (event.target.matches(selector)) {
       // If event target itself matches the given selector, return it
       return event.target;
     } else if (event.target.matches(`${selector} *`)) {
-      // If event target is a child node of a DOM element that matches the given selector,
-      // find the DOM element by going up the DOM tree
-      for (let traverse = event.target; traverse && traverse !== event.currentTarget; traverse = traverse.parentNode) {
-        if (traverse.matches(selector)) {
-          return traverse;
-        }
+      const closest = event.target.closest(selector);
+      if (event.currentTarget.contains(closest)) {
+        return closest;
       }
     }
   }

--- a/src/globals/js/misc/event-matches.js
+++ b/src/globals/js/misc/event-matches.js
@@ -1,8 +1,16 @@
+/**
+ * @param {Event} event The event.
+ * @param {string} selector The selector.
+ * @returns {Element}
+ *   The closest ancestor of the event target (or the event target itself) which matches the selectors given in parameter.
+ */
 export default function eventMatches(event, selector) {
   // <svg> in IE does not have `Element#msMatchesSelector()` (that should be copied to `Element#matches()` by a polyfill).
   // Also a weird behavior is seen in IE where DOM tree seems broken when `event.target` is on <svg>.
   // Therefore this function simply returns `undefined` when `event.target` is on <svg>.
-  if (typeof event.target.matches === 'function') {
+  if (typeof event.target.closest === 'function') {
+    return event.target.closest(selector);
+  } else if (typeof event.target.matches === 'function') {
     if (event.target.matches(selector)) {
       // If event target itself matches the given selector, return it
       return event.target;


### PR DESCRIPTION
## Overview

This PR introduces [`Element.closest()` DOM API](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest), which is supported by all non-IE browsers we support, to carbon-components.

### Changed

Floating menu and [event-matches internal API](https://github.com/carbon-design-system/carbon-components/blob/9fe93fc/src/globals/js/misc/event-matches.js) to use `Element.closest()`.

## Testing / Reviewing

Testing should make sure no component is broken, especially tooltip and overflow menu.