### PR TITLE
feat(DataTable): adjust expandable row striping

### DIFF
--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -103,11 +103,19 @@
 
   // zebra stripes
   .bx--table-body {
-    > .bx--parent-row, > .bx--parent-row + .bx--expandable-row {
+    > .bx--parent-row, > .bx--parent-row {
       background-color: $ui-01;
+
+      & + .bx--expandable-row {
+        background-color: $ui-01;
+      }
 
       &--even {
         background-color: $ui-03;
+
+        & + .bx--expandable-row {
+          background-color: $ui-03;
+        }
       }
     }
   }


### PR DESCRIPTION
## Overview

This fix is related to carbon-design-system/carbon-components-react#66 and is required to allow that fix to work properly.

Expandable rows will now always match the stripe state of the row that toggles them.

### Changed

Adjusted sibling element selector for table rows and expanded table rows so that an expanded table row will always match the background color of the preceding table row.


## Testing / Reviewing

Create a data table with expandable rows and verify that the expandable row inherits the background color of the preceding table row without any added classes.
