### PR TITLE
fix(overflowmenu): increase icon hit range for react

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -11,11 +11,11 @@
 @import '../../globals/scss/import-once';
 
 @include exports('overflow-menu') {
-
   .bx--overflow-menu {
     @include reset;
     position: relative;
-    padding: .5rem;
+    width: rem(20px);
+    height: rem(38px);
     cursor: pointer;
 
     &:focus {
@@ -24,8 +24,9 @@
   }
 
   .bx--overflow-menu__icon {
-    width: rem(4px);
-    height: rem(20px);
+    width: 100%;
+    height: 100%;
+    padding: 0.5rem;
     fill: $ui-05;
 
     &:hover,


### PR DESCRIPTION
## Overview

Related to: https://github.com/carbon-design-system/carbon-components-react/pull/63

Changing the click trigger on the React side also decreases the hit radius. This transfers the height/width/padding properties around to maintain the same visual style, while increasing the hitbox of the icon itself