### PR TITLE
fix(pagination): fix render issue in IE11

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -19,6 +19,10 @@ $css--helpers: true;
     display: flex;
     align-items: center;
     border: 1px solid $ui-04;
+
+    .bx--form-item {
+      flex: auto;
+    }
   }
 
   .bx--pagination__left {


### PR DESCRIPTION
### Pagination fix

IE has a tough time with `flex: 1`; Setting to `flex: auto` fixes this issue.

Closes https://github.com/carbon-design-system/carbon-components/issues/210