### PR TITLE
feat(components): introduce watch mode

### DIFF
--- a/src/globals/js/mixins/init-component-by-event.js
+++ b/src/globals/js/mixins/init-component-by-event.js
@@ -8,6 +8,12 @@ export default function (ToMix) {
    */
   class InitComponentByEvent extends ToMix {
     /**
+     * `true` suggests that this component is lazily initialized upon an action/event, etc.
+     * @type {boolean}
+     */
+    static forLazyInit = true;
+
+    /**
      * Instantiates this component in the given element.
      * If the given element indicates that it's an component of this class, instantiates it.
      * Otherwise, instantiates this component by clicking on this component in the given node.
@@ -30,6 +36,7 @@ export default function (ToMix) {
           const eventName = name === 'focus' && hasFocusin ? 'focusin' : name;
           return on(target, eventName, (event) => {
             const element = eventMatches(event, effectiveOptions.selectorInit);
+            // Instantiated components handles events by themselves
             if (element && !this.components.has(element)) {
               const component = this.create(element, options);
               if (typeof component.createdByEvent === 'function') {

--- a/src/globals/js/mixins/init-component-by-launcher.js
+++ b/src/globals/js/mixins/init-component-by-launcher.js
@@ -8,6 +8,12 @@ export default function (ToMix) {
    */
   class InitComponentByLauncher extends ToMix {
     /**
+     * `true` suggests that this component is lazily initialized upon an action/event, etc.
+     * @type {boolean}
+     */
+    static forLazyInit = true;
+
+    /**
      * Instantiates this component in the given element.
      * If the given element indicates that it's an component of this class, instantiates it.
      * Otherwise, instantiates this component by clicking on launcher buttons

--- a/src/globals/js/watch.js
+++ b/src/globals/js/watch.js
@@ -1,0 +1,66 @@
+import initCheckbox from '../../components/checkbox/checkbox';
+import { componentClasses } from '../../index';
+
+const forEach = Array.prototype.forEach;
+
+/**
+ * Automatically instantiates/destroys components in the given element, by watching for DOM additions/removals.
+ * @param {Node} target The DOM node to instantiate components in. Should be a document or an element.
+ * @param {Object} [options] The component options.
+ * @returns {Handle} The handle to stop watching.
+ */
+export default function (target = document, options = {}) {
+  if (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE) {
+    throw new TypeError('DOM document or DOM element should be given to watch for DOM node to create/release components.');
+  }
+
+  const handles = componentClasses.map(Clz => Clz.init(target, options)).filter(Boolean);
+  handles.push(initCheckbox());
+
+  const componentClassesForWatchInit = componentClasses.filter(Clz => !Clz.forLazyInit);
+  let observer = new MutationObserver((records) => {
+    records.forEach((record) => {
+      forEach.call(record.addedNodes, (node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          componentClassesForWatchInit.forEach((Clz) => {
+            Clz.init(node, options);
+          });
+        }
+      });
+      forEach.call(record.removedNodes, (node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          componentClasses.forEach((Clz) => {
+            if (node.matches(Clz.options.selectorInit)) {
+              const instance = Clz.components.get(node);
+              if (instance) {
+                instance.release();
+              }
+            } else {
+              forEach.call(node.querySelectorAll(Clz.options.selectorInit), (element) => {
+                const instance = Clz.components.get(element);
+                if (instance) {
+                  instance.release();
+                }
+              });
+            }
+          });
+        }
+      });
+    });
+  });
+  observer.observe(target, {
+    childList: true,
+    subtree: true,
+  });
+  return {
+    release() {
+      for (let handle = handles.pop(); handle; handle = handles.pop()) {
+        handle.release();
+      }
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+    },
+  };
+}

--- a/src/globals/js/watch.js
+++ b/src/globals/js/watch.js
@@ -3,6 +3,37 @@ import { componentClasses } from '../../index';
 
 const forEach = Array.prototype.forEach;
 
+const createAndReleaseComponentsUponDOMMutation = (records, componentClassesForWatchInit, options) => {
+  records.forEach((record) => {
+    forEach.call(record.addedNodes, (node) => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        componentClassesForWatchInit.forEach((Clz) => {
+          Clz.init(node, options);
+        });
+      }
+    });
+    forEach.call(record.removedNodes, (node) => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        componentClasses.forEach((Clz) => {
+          if (node.matches(Clz.options.selectorInit)) {
+            const instance = Clz.components.get(node);
+            if (instance) {
+              instance.release();
+            }
+          } else {
+            forEach.call(node.querySelectorAll(Clz.options.selectorInit), (element) => {
+              const instance = Clz.components.get(element);
+              if (instance) {
+                instance.release();
+              }
+            });
+          }
+        });
+      }
+    });
+  });
+};
+
 /**
  * Automatically instantiates/destroys components in the given element, by watching for DOM additions/removals.
  * @param {Node} target The DOM node to instantiate components in. Should be a document or an element.
@@ -18,35 +49,9 @@ export default function (target = document, options = {}) {
   handles.push(initCheckbox());
 
   const componentClassesForWatchInit = componentClasses.filter(Clz => !Clz.forLazyInit);
+
   let observer = new MutationObserver((records) => {
-    records.forEach((record) => {
-      forEach.call(record.addedNodes, (node) => {
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          componentClassesForWatchInit.forEach((Clz) => {
-            Clz.init(node, options);
-          });
-        }
-      });
-      forEach.call(record.removedNodes, (node) => {
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          componentClasses.forEach((Clz) => {
-            if (node.matches(Clz.options.selectorInit)) {
-              const instance = Clz.components.get(node);
-              if (instance) {
-                instance.release();
-              }
-            } else {
-              forEach.call(node.querySelectorAll(Clz.options.selectorInit), (element) => {
-                const instance = Clz.components.get(element);
-                if (instance) {
-                  instance.release();
-                }
-              });
-            }
-          });
-        }
-      });
-    });
+    createAndReleaseComponentsUponDOMMutation(records, componentClassesForWatchInit, options);
   });
   observer.observe(target, {
     childList: true,

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,8 @@ import FloatingMenu from './components/floating-menu/floating-menu';
 import StructuredList from './components/structured-list/structured-list';
 import Slider from './components/slider/slider';
 
+export { default as watch } from './globals/js/watch';
+
 const settings = {};
 
 /**
@@ -204,45 +206,52 @@ export {
 };
 
 /**
+ * List of component classes to be auto-instantiated.
+ * @private
+ */
+export const componentClasses = [
+  FabButton,
+  FileUploader,
+  ContentSwitcher,
+  Tab,
+  OverflowMenu,
+  Modal,
+  Loading,
+  Dropdown,
+  Card,
+  NumberInput,
+  DataTable,
+  DetailPageHeader,
+  LeftNav,
+  InteriorLeftNav,
+  ProfileSwitcher,
+  Pagination,
+  Search,
+  Accordion,
+  CopyButton,
+  Notification,
+  Toolbar,
+  Tooltip,
+  ProgressIndicator,
+  StructuredList,
+  DatePicker,
+  Slider,
+  // Floating menu instances are created by Tooltip, etc. and thus not for automatic instantiation
+];
+
+/**
  * Instantiates components automatically
  * by searching for elements with `data-component-name` (e.g. `data-loading`) attribute
  * or upon DOM events (e.g. clicking) on such elements.
  * See each components' static `.init()` methods for details.
- *
- *
  * @private
  */
-
 const init = () => {
   if (!settings.disableAutoInit) {
     initCheckbox();
-    FabButton.init();
-    FileUploader.init();
-    ContentSwitcher.init();
-    Tab.init();
-    OverflowMenu.init();
-    Modal.init();
-    Loading.init();
-    Dropdown.init();
-    Card.init();
-    NumberInput.init();
-    DataTable.init();
-    DetailPageHeader.init();
-    LeftNav.init();
-    InteriorLeftNav.init();
-    ProfileSwitcher.init();
-    Pagination.init();
-    Search.init();
-    Accordion.init();
-    CopyButton.init();
-    Notification.init();
-    Toolbar.init();
-    Tooltip.init();
-    ProgressIndicator.init();
-    StructuredList.init();
-    DatePicker.init();
-    Slider.init();
-    // Floating menu instances are created by Tooltip, etc. and thus not for automatic instantiation
+    componentClasses.forEach((Clz) => {
+      Clz.init();
+    });
   }
 };
 

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -159,7 +159,9 @@ module.exports = function (config) {
       return list;
     })(),
 
-    exclude: [],
+    exclude: [
+      'src/globals/js/watch.js', // watch.js imports index.js, which runs automatic instantiation
+    ],
 
     preprocessors: {
       '**/core-js/**/*.js': ['rollup', 'sourcemap'], // For generatoring coverage report for untested files
@@ -189,7 +191,7 @@ module.exports = function (config) {
         commonjs({
           include: ['node_modules/**'],
           namedExports: {
-            'node_modules/bluebird/js/release/bluebird.js': ['promisify'],
+            'node_modules/bluebird/js/release/bluebird.js': ['delay', 'promisify'],
           },
         }),
         babel({

--- a/tests/spec/watch_spec.js
+++ b/tests/spec/watch_spec.js
@@ -1,0 +1,226 @@
+import { delay } from 'bluebird'; // For testing on browsers not supporting Promise
+import 'core-js/modules/es6.weak-map'; // For PhantomJS
+import { componentClasses, settings } from '../../src/index';
+import mixin from '../../src/globals/js/misc/mixin';
+import createComponent from '../../src/globals/js/mixins/create-component';
+import initComponentBySearch from '../../src/globals/js/mixins/init-component-by-search';
+import initComponentByEvent from '../../src/globals/js/mixins/init-component-by-event';
+import initComponentByLauncher from '../../src/globals/js/mixins/init-component-by-launcher';
+import watch from '../../src/globals/js/watch';
+
+settings.disableAutoInit = true;
+
+describe('Test watch mode', function () {
+  const watchOptions = { foo: 'Foo' };
+  const ClassInitedBySearch = class extends mixin(createComponent, initComponentBySearch) {
+    release = spyReleaseComponentBySearch;
+    static options = {
+      selectorInit: '[data-my-component-inited-by-search]',
+    };
+    static components = new WeakMap();
+  };
+
+  const spyInitComponentBySearch = sinon.spy(ClassInitedBySearch, 'init');
+  const spyReleaseComponentBySearch = sinon.spy(ClassInitedBySearch.prototype, 'release');
+
+  const ClassInitedByEvent = class extends mixin(createComponent, initComponentByEvent) {
+    release = spyReleaseComponentByEvent;
+    static options = {
+      selectorInit: '[data-my-component-inited-by-event]',
+      initEventNames: ['instantiating-event'],
+    };
+    static components = new WeakMap();
+  };
+
+  const spyInitComponentByEvent = sinon.spy(ClassInitedByEvent, 'init');
+  const spyReleaseComponentByEvent = sinon.spy(ClassInitedByEvent.prototype, 'release');
+
+  const ClassInitedByLauncher = class extends mixin(createComponent, initComponentByLauncher) {
+    release = spyReleaseComponentByLauncher;
+    static options = {
+      selectorInit: '[data-my-component-inited-by-launcher]',
+      attribInitTarget: 'data-init-target',
+      initEventNames: ['launching-event'],
+    };
+    static components = new WeakMap();
+  };
+
+  const spyInitComponentByLauncher = sinon.spy(ClassInitedByLauncher, 'init');
+  const spyReleaseComponentByLauncher = sinon.spy(ClassInitedByLauncher.prototype, 'release');
+
+  componentClasses.splice(0, componentClasses.length, ClassInitedBySearch, ClassInitedByEvent, ClassInitedByLauncher);
+
+  describe('Handling regular components', function () {
+    let lastTarget;
+    let stubObserve;
+    let handle;
+    let element;
+
+    before(function () {
+      const origObserve = MutationObserver.prototype.observe;
+      stubObserve = sinon.stub(MutationObserver.prototype, 'observe').callsFake(function stubObserveImpl(target, options) {
+        lastTarget = target;
+        origObserve.call(this, target, options);
+      });
+    });
+
+    it('Should throw if given element is neither a DOM element or a document', function () {
+      expect(() => {
+        handle = watch(document.createTextNode(''));
+      }).to.throw(Error);
+    });
+
+    it('Should look at document if no element is given', function () {
+      handle = watch();
+      expect(lastTarget).to.equal(document);
+    });
+
+    it('Should instantiate the components', async function () {
+      handle = watch(document, watchOptions);
+
+      spyInitComponentBySearch.reset();
+
+      expect(lastTarget, 'Watch target').to.equal(document);
+      expect(spyInitComponentByEvent, 'Call count of ClassInitedByEvent.init()').to.have.been.calledOnce;
+      expect(spyInitComponentByEvent, 'Args of ClassInitedByEvent.init()').to.have.been.calledWith(document, watchOptions);
+      expect(spyInitComponentByLauncher, 'Call count of ClassInitedByLauncher.init()').to.have.been.calledOnce;
+      expect(spyInitComponentByLauncher, 'Args of ClassInitedByLauncher.init()').to.have.been.calledWith(document, watchOptions);
+
+      element = document.createElement('div');
+      element.dataset.myComponentInitedBySearch = '';
+      document.body.appendChild(element);
+
+      await delay(0); // Wait for mutation observer to deliver records
+
+      expect(spyInitComponentBySearch, 'Call count of ClassInitedBySearch.init()').to.have.been.calledOnce;
+      expect(spyInitComponentBySearch.args[0][1], 'Option arg of ClassInitedBySearch.init()').to.deep.equal(watchOptions);
+    });
+
+    it('Should release the components', async function () {
+      handle = watch();
+
+      element = document.createElement('div');
+      document.body.appendChild(element);
+
+      const elementInitedBySearch = document.createElement('div');
+      elementInitedBySearch.dataset.myComponentInitedBySearch = '';
+      element.appendChild(elementInitedBySearch);
+
+      const elementInitedByEvent = document.createElement('div');
+      elementInitedByEvent.dataset.myComponentInitedByEvent = '';
+      element.appendChild(elementInitedByEvent);
+
+      elementInitedByEvent.dispatchEvent(new CustomEvent('instantiating-event', { bubbles: true, cancelable: true }));
+
+      const elementInitedByLauncher = document.createElement('div');
+      elementInitedByLauncher.dataset.myComponentInitedByLauncher = '';
+      element.appendChild(elementInitedByLauncher);
+
+      const launcherButton = document.createElement('button');
+      launcherButton.dataset.initTarget = '[data-my-component-inited-by-launcher]';
+      element.appendChild(launcherButton);
+
+      launcherButton.dispatchEvent(new CustomEvent('launching-event', { bubbles: true, cancelable: true }));
+
+      await delay(0); // Wait for mutation observer to deliver records
+
+      document.body.removeChild(element);
+
+      await delay(0); // Wait for mutation observer to deliver records
+
+      expect(spyReleaseComponentBySearch).to.have.been.calledOnce;
+      expect(spyReleaseComponentByEvent).to.have.been.calledOnce;
+      expect(spyReleaseComponentByLauncher).to.have.been.calledOnce;
+    });
+
+    it('Should release the components even if the removed node is of the component', async function () {
+      handle = watch();
+
+      element = document.createElement('div');
+      element.dataset.myComponentInitedBySearch = '';
+      document.body.appendChild(element);
+
+      await delay(0); // Wait for mutation observer to deliver records
+
+      document.body.removeChild(element);
+
+      await delay(0); // Wait for mutation observer to deliver records
+
+      expect(spyReleaseComponentBySearch).to.have.been.calledOnce;
+    });
+
+    it('Should stop instantiating components once the handle is released', async function () {
+      handle = watch(document, watchOptions);
+
+      spyInitComponentBySearch.reset();
+
+      expect(lastTarget, 'Watch target').to.equal(document);
+      expect(spyInitComponentByEvent, 'Call count of ClassInitedByEvent.init()').to.have.been.calledOnce;
+      expect(spyInitComponentByEvent, 'Args of ClassInitedByEvent.init()').to.have.been.calledWith(document, watchOptions);
+      expect(spyInitComponentByLauncher, 'Call count of ClassInitedByLauncher.init()').to.have.been.calledOnce;
+      expect(spyInitComponentByLauncher, 'Args of ClassInitedByLauncher.init()').to.have.been.calledWith(document, watchOptions);
+
+      element = document.createElement('div');
+      element.dataset.myComponentInitedBySearch = '';
+      document.body.appendChild(element);
+
+      handle = handle.release();
+
+      await delay(0); // Wait for mutation observer to deliver records
+
+      expect(spyInitComponentBySearch, 'Call count of ClassInitedBySearch.init()').not.to.have.been.called;
+    });
+
+    afterEach(function () {
+      if (element && element.parentNode) {
+        element.parentNode.removeChild(element);
+        element = null;
+      }
+      if (handle) {
+        handle = handle.release();
+      }
+    });
+
+    after(function () {
+      stubObserve.restore();
+    });
+  });
+
+  describe('Handling checkbox', function () {
+    let element;
+    let handle;
+
+    before(function () {
+      handle = watch();
+      element = document.createElement('input');
+      element.type = 'checkbox';
+      document.body.appendChild(element);
+    });
+
+    it('Should add checked attribute when it is checked', function () {
+      element.removeAttribute('checked');
+      element.checked = true;
+      element.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+      expect(element.hasAttribute('checked')).to.be.true;
+    });
+
+    after(function () {
+      if (element && element.parentNode) {
+        element.parentNode.removeChild(element);
+        element = null;
+      }
+      if (handle) {
+        handle = handle.release();
+      }
+    });
+  });
+
+  afterEach(function () {
+    spyReleaseComponentByLauncher.reset();
+    spyReleaseComponentByEvent.reset();
+    spyReleaseComponentBySearch.reset();
+    spyInitComponentByLauncher.reset();
+    spyInitComponentByEvent.reset();
+    spyInitComponentBySearch.reset();
+  });
+});


### PR DESCRIPTION
## Overview

The new `CarbonComponents.watch()` API watches for changes in DOM and instantiate/destroy components automatically.
Would be convenient for quickly prototyping applications with dynamic DOM additions/removals, e.g. upon changes in array with JavaScript frameworks.

Without `CarbonComponents.watch()` API (which is what we have today without this PR), as shown in the former half of below movie, components associated with newly added DOM elements are not instantiated (unless application manually instantiates the components). With `CarbonComponents.watch()`, as shown in the latter half of below movie, components associated with newly added DOM elements are instantiated automatically.

![watch-mode](https://user-images.githubusercontent.com/1259051/27845559-569b50bc-616b-11e7-9355-3c05e6382f12.gif)

### Added

`CarbonComponents.watch()` API.

### Changed

A flag for components that are automatically instantiated upon click, etc.

## Testing / Reviewing

Testing should make sure no existing features are broken.