### PR TITLE
feat(floating-menu): add close-on-blur behavior

### DIFF
--- a/demo/views/demo-all.dust
+++ b/demo/views/demo-all.dust
@@ -79,7 +79,7 @@
     </nav>
   {/links}
 
-  <div class="demo--container">
+  <div class="demo--container" data-floating-menu-container>
     {?links}
       {#links}
         {?items}

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1,10 +1,11 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import trackBlur from '../../globals/js/mixins/track-blur';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
-class Dropdown extends mixin(createComponent, initComponentBySearch) {
+class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) {
   /**
    * A selector with drop downs.
    * @extends CreateComponent
@@ -27,8 +28,6 @@ class Dropdown extends mixin(createComponent, initComponentBySearch) {
      * @member {Handle}
      */
     this.hDocumentClick = on(this.element.ownerDocument, 'click', (event) => { this._toggle(event); });
-
-    this._setCloseOnBlur();
 
     this.element.addEventListener('keydown', (event) => { this._handleKeyDown(event); });
     this.element.addEventListener('click', (event) => {
@@ -162,16 +161,10 @@ class Dropdown extends mixin(createComponent, initComponentBySearch) {
   }
 
   /**
-   * Sets an event handler to document for "close on blur" behavior.
+   * Closes the dropdown menu if this component loses focus.
    */
-  _setCloseOnBlur() {
-    const hasFocusin = 'onfocusin' in window;
-    const focusinEventName = hasFocusin ? 'focusin' : 'focus';
-    this.hFocusIn = on(this.element.ownerDocument, focusinEventName, (event) => {
-      if (!this.element.contains(event.target)) {
-        this.element.classList.remove('bx--dropdown--open');
-      }
-    }, !hasFocusin);
+  handleBlur() {
+    this.element.classList.remove('bx--dropdown--open');
   }
 
   /**

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -1,9 +1,11 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import eventedShowHideState from '../../globals/js/mixins/evented-show-hide-state';
+import trackBlur from '../../globals/js/mixins/track-blur';
+import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
 import optimizedResize from '../../globals/js/misc/resize';
 
-class FloatingMenu extends mixin(createComponent, eventedShowHideState) {
+class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlur) {
   /**
    * Floating menu.
    * @extends CreateComponent
@@ -38,6 +40,18 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState) {
     if (!attribDirectionValue) {
       // Update attribute for styling
       this.element.setAttribute(this.options.attribDirection, this.options.direction);
+    }
+  }
+
+  /**
+   * Focuses back on the trigger button if this component loses focus.
+   */
+  handleBlur(event) {
+    if (this.element.classList.contains(this.options.classShown)) {
+      this.changeState('hidden', getLaunchingDetails(event));
+      if (this.element.contains(event.relatedTarget) && event.target !== this.options.refNode) {
+        this.options.refNode.focus();
+      }
     }
   }
 
@@ -169,6 +183,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState) {
       }
       this._getContainer().appendChild(this.element);
       this._place();
+      (this.element.querySelector(this.options.selectorPrimaryFocus) || this.element).focus();
     }
     if (state === 'hidden' && this.hResize) {
       this.hResize.release();
@@ -187,6 +202,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState) {
 
   static options = {
     selectorContainer: '[data-floating-menu-container]',
+    selectorPrimaryFocus: '[data-floating-menu-primary-focus]',
     attribDirection: 'data-floating-menu-direction',
     classShown: '', // Should be provided from options arg in constructor
     classRefShown: '', // Should be provided from options arg in constructor

--- a/src/components/overflow-menu/overflow-menu.html
+++ b/src/components/overflow-menu/overflow-menu.html
@@ -4,7 +4,7 @@
     <circle cx="2" cy="10" r="2"></circle>
     <circle cx="2" cy="18" r="2"></circle>
   </svg>
-  <ul class="bx--overflow-menu-options">
+  <ul class="bx--overflow-menu-options" tabindex="-1">
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Stop app</button>
     </li>
@@ -29,7 +29,7 @@
     <circle cx="2" cy="10" r="2"></circle>
     <circle cx="2" cy="18" r="2"></circle>
   </svg>
-  <ul class="bx--overflow-menu-options bx--overflow-menu--flip">
+  <ul class="bx--overflow-menu-options bx--overflow-menu--flip" tabindex="-1">
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Stop app</button>
     </li>

--- a/src/components/overflow-menu/overflow-menu.html
+++ b/src/components/overflow-menu/overflow-menu.html
@@ -6,7 +6,7 @@
   </svg>
   <ul class="bx--overflow-menu-options">
     <li class="bx--overflow-menu-options__option">
-      <button class="bx--overflow-menu-options__btn">Stop app</button>
+      <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Stop app</button>
     </li>
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn">Restart app</button>
@@ -31,7 +31,7 @@
   </svg>
   <ul class="bx--overflow-menu-options bx--overflow-menu--flip">
     <li class="bx--overflow-menu-options__option">
-      <button class="bx--overflow-menu-options__btn">Stop app</button>
+      <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Stop app</button>
     </li>
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn">Restart app</button>

--- a/src/globals/js/mixins/track-blur.js
+++ b/src/globals/js/mixins/track-blur.js
@@ -1,0 +1,38 @@
+import on from '../misc/on';
+
+export default function (ToMix) {
+  class TrackBlur extends ToMix {
+    /**
+     * Mix-in class to add an handler for losing focus.
+     * @param {HTMLElement} element The element working as this component.
+     * @param {Object} [options] The component options.
+     */
+    constructor(element, options) {
+      super(element, options);
+      const hasFocusin = 'onfocusin' in window;
+      const focusinEventName = hasFocusin ? 'focusin' : 'focus';
+      this.hFocusIn = on(this.element.ownerDocument, focusinEventName, (event) => {
+        if (!this.element.contains(event.target)) {
+          this.handleBlur(event);
+        }
+      }, !hasFocusin);
+    }
+
+    /**
+     * The method called when this component loses focus.
+     * @abstract
+     */
+    handleBlur() {
+      throw new Error('Components inheriting TrackBlur mix-in must implement handleBlur() method.');
+    }
+
+    release() {
+      if (this.hFocusIn) {
+        this.hFocusIn = this.hFocusIn.release();
+      }
+      super.release();
+    }
+  }
+
+  return TrackBlur;
+}

--- a/tests/spec/overflow-menu_spec.js
+++ b/tests/spec/overflow-menu_spec.js
@@ -134,17 +134,17 @@ describe('Test Overflow menu', function () {
 
     it('Should open one menu on a single click event', function () {
       element1.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(element1.classList.contains('bx--overflow-menu--open')).to.be.true;
-      expect(element2.classList.contains('bx--overflow-menu--open')).to.be.false;
-      expect(element3.classList.contains('bx--overflow-menu--open')).to.be.false;
+      expect(element1.classList.contains('bx--overflow-menu--open'), '1st overflow menu').to.be.true;
+      expect(element2.classList.contains('bx--overflow-menu--open'), '2nd overflow menu').to.be.false;
+      expect(element3.classList.contains('bx--overflow-menu--open'), '3rd overflow menu').to.be.false;
     });
 
     it('Should open one menu on multiple click events', function () {
       element1.dispatchEvent(new CustomEvent('click', { bubbles: true }));
       element2.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(element1.classList.contains('bx--overflow-menu--open')).to.be.false;
-      expect(element2.classList.contains('bx--overflow-menu--open')).to.be.true;
-      expect(element3.classList.contains('bx--overflow-menu--open')).to.be.false;
+      expect(element1.classList.contains('bx--overflow-menu--open'), '1st overflow menu').to.be.false;
+      expect(element2.classList.contains('bx--overflow-menu--open'), '2nd overflow menu').to.be.true;
+      expect(element3.classList.contains('bx--overflow-menu--open'), '3rd overflow menu').to.be.false;
     });
 
     afterEach(function () {
@@ -154,6 +154,43 @@ describe('Test Overflow menu', function () {
     });
 
     after(function () {
+      document.body.removeChild(container);
+    });
+  });
+
+  describe('Managing focus', function () {
+    let menu;
+    let element;
+    let firstItemNode;
+    let spyFocusFirstItemNode;
+    const container = document.createElement('div');
+    container.innerHTML = HTML;
+
+    before(function () {
+      document.body.appendChild(container);
+      element = document.querySelector('.bx--overflow-menu');
+      firstItemNode = element.querySelector('[data-floating-menu-primary-focus]');
+      spyFocusFirstItemNode = sinon.spy(firstItemNode, 'focus');
+      menu = new OverflowMenu(element);
+    });
+
+    it('Should focus on the floating menu when the menu is open', function () {
+      element.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      expect(spyFocusFirstItemNode).to.have.been.calledOnce;
+    });
+
+    afterEach(function () {
+      if (spyFocusFirstItemNode) {
+        spyFocusFirstItemNode.reset();
+      }
+    });
+
+    after(function () {
+      if (spyFocusFirstItemNode) {
+        spyFocusFirstItemNode.restore();
+        spyFocusFirstItemNode = null;
+      }
+      menu.release();
       document.body.removeChild(container);
     });
   });


### PR DESCRIPTION
## Overview

With this change, floating menu closes when it loses focus, and sets the focus back to the trigger button.

### Added

* A feature to close floating menu when it loses focus
* track-blur mix-in which calls `handleBlur` method when component's root element loses focus

## Testing / Reviewing

Testing should make sure dropdown, overflow-menu and tooltip are not broken.