### PR TITLE
fix(secondary-button): define active text color

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -52,9 +52,14 @@
       $brand-01 // icon-color
     );
 
+
     &:hover,
     &:focus {
       color: $inverse-01;
+    }
+
+    &:active {
+      color: $brand-01;
     }
 
     &:hover > .bx--btn__icon,


### PR DESCRIPTION
## Overview

Resolves #228 

SCSS fix that defines an `:active` button text color for `secondary-button`. 

## Testing / Reviewing

Click and hold on a Secondary Button without releasing. 
Or in Chrome dev tools, select both the `:focus` and `:active` pseudo-classes


