### PR TITLE
fix(accordion): fixed the focus outline on the arrow in safari

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -23,6 +23,8 @@
 
       .bx--accordion__arrow {
         @include focus-outline('border');
+        overflow: visible; // safari fix
+        outline-offset: -.5px; // safari fix
       }
     }
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,6 +1,7 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
-import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import initComponentBySearch
+  from '../../globals/js/mixins/init-component-by-search';
 import eventMatches from '../../globals/js/misc/event-matches';
 
 class Accordion extends mixin(createComponent, initComponentBySearch) {
@@ -12,14 +13,14 @@ class Accordion extends mixin(createComponent, initComponentBySearch) {
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', event => {
+    this.element.addEventListener('click', (event) => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         item.classList.toggle(this.options.classActive);
       }
     });
 
-    this.element.addEventListener('keypress', event => {
+    this.element.addEventListener('keypress', (event) => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         this._handleKeypress(event);

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,7 +1,6 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
-import initComponentBySearch
-  from '../../globals/js/mixins/init-component-by-search';
+import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventMatches from '../../globals/js/misc/event-matches';
 
 class Accordion extends mixin(createComponent, initComponentBySearch) {
@@ -13,14 +12,14 @@ class Accordion extends mixin(createComponent, initComponentBySearch) {
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', (event) => {
+    this.element.addEventListener('click', event => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         item.classList.toggle(this.options.classActive);
       }
     });
 
-    this.element.addEventListener('keypress', (event) => {
+    this.element.addEventListener('keypress', event => {
       const item = eventMatches(event, this.options.selectorAccordionItem);
       if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
         this._handleKeypress(event);


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/218

Fixed an issue in Safari where the outline around the arrow did not render properly on focus.
