### PR TITLE
fix(toolbar): resolve toolbar icon size issue

### DIFF
--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -13,7 +13,6 @@ $css--helpers: true;
 @import '../search/search';
 
 @include exports('toolbar') {
-
   .bx--toolbar {
     @include helvetica;
     display: flex;
@@ -100,7 +99,8 @@ $css--helpers: true;
   }
 
   .bx--toolbar-filter-icon {
-    width: 1.2rem;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .bx--toolbar-menu__title {


### PR DESCRIPTION
## Overview

Ideal scenario would be tag the parent with a new class and expand the width, but that would require any consumers to update that and I guess that'd be a breaking change.
