### PR TITLE
fix(table): 1px border instead of 2px

### DIFF
--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -22,7 +22,7 @@
     min-width: 500px;
     border-collapse: collapse;
     border-spacing: 0;
-    border: 2px solid $ui-04;
+    border: 1px double $ui-04;
 
     td {
       @include reset;
@@ -66,7 +66,7 @@
       @include reset;
       border-collapse: collapse;
       width: auto;
-      border: 2px solid $ui-04;
+      border: 1px double $ui-04;
 
       tr td:first-child, tr th:first-child {
         padding-left: 1.5rem;
@@ -125,13 +125,11 @@
     border: 1px solid transparent;
 
     &:first-child:hover, &:first-child:focus {
-      border-left: 2px solid $brand-02;
-      outline: 1px solid $brand-02;
+      border: 1px double $brand-02;
     }
 
     &:not(:first-child):hover, &:not(:first-child):focus {
-      border-left: 2px solid $brand-02;
-      outline: 1px solid $brand-02;
+      border: 1px double $brand-02;
     }
   }
 


### PR DESCRIPTION
## Overview

Resolves #158 

uses a 1px double instead of 2px solid

![image](https://user-images.githubusercontent.com/4836277/28891775-41efe70e-7791-11e7-8895-0ee9c7d95428.png)

### Changed

scss


## Testing / Reviewing

check the table component....?
