### PR TITLE
fix(table): remove default browser outline on table row focus

### DIFF
--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -124,12 +124,9 @@
   .bx--table-body .bx--table-row {
     border: 1px solid transparent;
 
-    &:first-child:hover, &:first-child:focus {
+    &:hover, &:focus {
       border: 1px double $brand-02;
-    }
-
-    &:not(:first-child):hover, &:not(:first-child):focus {
-      border: 1px double $brand-02;
+      outline: 0;
     }
   }
 


### PR DESCRIPTION
## Overview

fixing table row focus things

### Added

`outline: 0` for table rows on hover and focus

### Removed

redundant scss block for first-child row hover and focus

