### PR TITLE
fix(a11y): accordion a11y fixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -136,7 +136,12 @@ gulp.task('scripts:compiled', ['scripts:rollup'], cb => {
   const srcFile = './scripts/carbon-components.js';
 
   pump(
-    [gulp.src(srcFile), uglify(), rename('carbon-components.min.js'), gulp.dest('scripts')],
+    [
+      gulp.src(srcFile),
+      uglify(),
+      rename('carbon-components.min.js'),
+      gulp.dest('scripts'),
+    ],
     cb
   );
 });
@@ -221,7 +226,13 @@ gulp.task('html:source', () => {
 
 gulp.task('lint', () =>
   gulp
-    .src(['gulpfile.js', 'server.js', 'src/**/*.js', 'tests/**/*.js', 'demo/**/*.js'])
+    .src([
+      'gulpfile.js',
+      'server.js',
+      'src/**/*.js',
+      'tests/**/*.js',
+      'demo/**/*.js',
+    ])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError())
@@ -305,13 +316,16 @@ gulp.task('test:a11y', ['sass:compiled'], done => {
     showOnlyViolations: true,
     exclude: '.offleft, #flex-col, #flex-row',
     tags: ['wcag2aa', 'wcag2a'],
-    folderOutputReport: componentName === undefined ? 'tests/axe/allHtml' : 'tests/axe',
-    saveOutputIn: componentName === undefined
-      ? `a11y-html.json`
-      : `a11y-${componentName}.json`,
-    urls: componentName === undefined
-      ? ['http://localhost:3000']
-      : [`http://localhost:3000/components/${componentName}/`],
+    folderOutputReport:
+      componentName === undefined ? 'tests/axe/allHtml' : 'tests/axe',
+    saveOutputIn:
+      componentName === undefined
+        ? `a11y-html.json`
+        : `a11y-${componentName}.json`,
+    urls:
+      componentName === undefined
+        ? ['http://localhost:3000']
+        : [`http://localhost:3000/components/${componentName}/`],
   };
 
   return axe(options, done);

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -34,12 +34,26 @@
   }
 
   .bx--accordion__heading {
+    @include button-reset;
+
     display: flex;
     align-items: center;
     justify-content: $accordion-justify-content;
     flex-direction: $accordion-flex-direction;
     cursor: pointer;
     padding: .5rem 0;
+
+    // new version of markup uses focus on the heading,
+    // not the list element itself
+    &:focus {
+      outline: none;
+
+      .bx--accordion__arrow {
+        @include focus-outline('border');
+        overflow: visible; // safari fix
+        outline-offset: -.5px; // safari fix
+      }
+    }
   }
 
   .bx--accordion__arrow {

--- a/src/components/accordion/accordion.html
+++ b/src/components/accordion/accordion.html
@@ -1,48 +1,48 @@
 <ul data-accordion class="bx--accordion">
-  <li tabindex="0" data-accordion-item class="bx--accordion__item">
-    <div class="bx--accordion__heading">
+  <li data-accordion-item class="bx--accordion__item">
+    <button class="bx--accordion__heading" aria-expanded="false" aria-controls="pane1">
       <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
         <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
       </svg>
       <p class="bx--accordion__title">Label</p>
-    </div>
-    <div class="bx--accordion__content">
+    </button>
+    <div id="pane1" class="bx--accordion__content">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </li>
-  <li tabindex="0" data-accordion-item class="bx--accordion__item">
-    <div class="bx--accordion__heading">
+  <li data-accordion-item class="bx--accordion__item">
+    <button class="bx--accordion__heading" aria-expanded="false" aria-controls="pane2">
       <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
         <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
       </svg>
       <p class="bx--accordion__title">Label with multiple words</p>
-    </div>
-    <div class="bx--accordion__content">
+    </button>
+    <div id="pane2" class="bx--accordion__content">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </li>
-  <li tabindex="0" data-accordion-item class="bx--accordion__item">
-    <div class="bx--accordion__heading">
+  <li data-accordion-item class="bx--accordion__item">
+    <button class="bx--accordion__heading" aria-expanded="false" aria-controls="pane3">
       <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
         <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
       </svg>
       <p class="bx--accordion__title">Label</p>
-    </div>
-    <div class="bx--accordion__content">
+    </button>
+    <div id="pane3" class="bx--accordion__content">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </li>
-  <li tabindex="0" data-accordion-item class="bx--accordion__item">
-    <div class="bx--accordion__heading">
+  <li data-accordion-item class="bx--accordion__item">
+    <button class="bx--accordion__heading" aria-expanded="false" aria-controls="pane4">
       <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
         <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
       </svg>
       <p class="bx--accordion__title">Label</p>
-    </div>
-    <div class="bx--accordion__content">
+    </button>
+    <div id="pane4" class="bx--accordion__content">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>

--- a/src/components/accordion/legacyaccordion.html
+++ b/src/components/accordion/legacyaccordion.html
@@ -1,0 +1,50 @@
+<ul data-accordion class="bx--accordion">
+  <li tabindex="0" data-accordion-item class="bx--accordion__item">
+    <div class="bx--accordion__heading">
+      <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+        <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
+      </svg>
+      <p class="bx--accordion__title">Label</p>
+    </div>
+    <div class="bx--accordion__content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
+  </li>
+  <li tabindex="0" data-accordion-item class="bx--accordion__item">
+    <div class="bx--accordion__heading">
+      <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+        <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
+      </svg>
+      <p class="bx--accordion__title">Label with multiple words</p>
+    </div>
+    <div class="bx--accordion__content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
+  </li>
+  <li tabindex="0" data-accordion-item class="bx--accordion__item">
+    <div class="bx--accordion__heading">
+      <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+        <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
+      </svg>
+      <p class="bx--accordion__title">Label</p>
+    </div>
+    <div class="bx--accordion__content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
+  </li>
+  <li tabindex="0" data-accordion-item class="bx--accordion__item">
+    <div class="bx--accordion__heading">
+      <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+        <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
+      </svg>
+      <p class="bx--accordion__title">Label</p>
+    </div>
+    <div class="bx--accordion__content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
+  </li>
+</ul>

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -4,14 +4,14 @@
 
 @mixin css-helpers {
   .bx--visually-hidden {
-    position:absolute;
-    width:1px;
-    height:1px;
-    padding:0;
-    margin:-1px;
-    overflow:hidden;
-    clip:rect(0, 0, 0, 0);
-    border:0;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
     visibility: visible;
     white-space: nowrap;
   }

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -12,6 +12,9 @@
 // Misc
 // ---------------------------------------------
 
+@import 'css--reset';
+@import 'typography';
+
 @mixin text-overflow($width) {
   display: block;
   width: $width;
@@ -66,6 +69,10 @@
 }
 
 @mixin button-reset($width: true) {
+  @include reset;
+  @include helvetica;
+  @include font-smoothing;
+  @include letter-spacing;
   background: none;
   appearance: none;
   border: 0;

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -8,7 +8,6 @@
 //   Deprecated           ||  Not used anymore
 //   ===========================================
 
-
 //----------------------------------------------
 // Misc
 // ---------------------------------------------
@@ -64,6 +63,16 @@
   border: 0;
   visibility: visible;
   white-space: nowrap;
+}
+
+@mixin button-reset($width: true) {
+  background: none;
+  appearance: none;
+  border: 0;
+
+  @if ($width == true) {
+    width: 100%;
+  }
 }
 
 //----------------------------------------------

--- a/tests/spec/accordion_spec.js
+++ b/tests/spec/accordion_spec.js
@@ -1,94 +1,123 @@
 import 'core-js/modules/es6.weak-map'; // For PhantomJS
 import Accordion from '../../src/components/accordion/accordion';
 import HTML from '../../src/components/accordion/accordion.html';
+import LegacyHTML from '../../src/components/accordion/legacyaccordion.html';
 
-describe('Test accordion', function () {
-  describe('Constructor', function () {
-    it('Should throw if root element is not given', function () {
+describe('Test accordion', function() {
+  describe('Constructor', function() {
+    let instance;
+    const container = document.createElement('div');
+    container.innerHTML = HTML;
+
+    before(function() {
+      document.body.appendChild(container);
+      instance = new Accordion(document.querySelector('[data-accordion]'));
+    });
+
+    it('Should throw if root element is not given', function() {
       expect(() => {
         new Accordion();
       }).to.throw(Error);
     });
 
-    it('Should throw if root element is not a DOM element', function () {
+    it('Should throw if root element is not a DOM element', function() {
       expect(() => {
         new Accordion(document.createTextNode(''));
       }).to.throw(Error);
     });
 
-    it('Should set default options', function () {
-      const instance = new Accordion(document.createElement('div'));
+    it('Should set default options', function() {
       expect(instance.options).to.deep.equal({
         selectorInit: '[data-accordion]',
         selectorAccordionItem: '.bx--accordion__item',
+        selectorAccordionItemHeading: '.bx--accordion__heading',
         selectorAccordionContent: '.bx--accordion__content',
         classActive: 'bx--accordion__item--active',
       });
     });
-  });
 
-  describe('Clicking list item', function () {
-    let listItem;
-    const container = document.createElement('div');
-    container.innerHTML = HTML;
-
-    before(function () {
-      document.body.appendChild(container);
-      new Accordion(document.querySelector('[data-accordion]'));
-      listItem = document.querySelector('[data-accordion-item]');
-    });
-
-    it('Should set active state on click', function () {
-      listItem.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(listItem.classList.contains('bx--accordion__item--active')).to.be.true;
-    });
-
-    it('Should remove active state on second click', function () {
-      listItem.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(listItem.classList.contains('bx--accordion__item--active')).to.be.false;
-    });
-
-    after(function () {
+    after(function() {
       if (document.body.contains(container)) {
         document.body.removeChild(container);
       }
     });
   });
 
-  describe('Keypress list item', function () {
-    let accordion; //eslint-disable-line
+  // Why no keyboard tests on the current markup? onClick actually
+  // maps to the default action of an element - for interactive elements like
+  // button, that's also enter + space. Keydown/keypress won't
+  // trigger the event listener, as it's a different event
+
+  describe('Clicking list item', function() {
     let listItem;
+    let buttonItem;
     const container = document.createElement('div');
     container.innerHTML = HTML;
 
-    before(function () {
+    before(function() {
+      document.body.appendChild(container);
+      new Accordion(document.querySelector('[data-accordion]'));
+      listItem = document.querySelector('[data-accordion-item]');
+      buttonItem = listItem.querySelector('.bx--accordion__heading');
+    });
+
+    it('Should set active state on click', function() {
+      buttonItem.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      expect(listItem.classList.contains('bx--accordion__item--active')).to.be
+        .true;
+    });
+
+    it('Should remove active state on second click', function() {
+      buttonItem.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      expect(listItem.classList.contains('bx--accordion__item--active')).to.be
+        .false;
+    });
+
+    after(function() {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+
+  // Only to ensure old markup still works as normal
+  describe('Keypress legacy list item', function() {
+    let accordion; //eslint-disable-line
+    let listItem;
+    const container = document.createElement('div');
+    container.innerHTML = LegacyHTML;
+
+    before(function() {
       document.body.appendChild(container);
       accordion = new Accordion(document.querySelector('[data-accordion]'));
       listItem = document.querySelector('[data-accordion-item]');
     });
 
-    it('Should not set active state on other keypress', function () {
+    it('Should not set active state on other keypress', function() {
       const event = new CustomEvent('keypress', { bubbles: true });
       event.which = 86;
       listItem.dispatchEvent(event);
-      expect(listItem.classList.contains('bx--accordion__item--active')).to.be.false;
+      expect(listItem.classList.contains('bx--accordion__item--active')).to.be
+        .false;
     });
 
-    it('Should set active state on enter or spacebar press', function () {
+    it('Should set active state on enter or spacebar press', function() {
       const event = new CustomEvent('keypress', { bubbles: true });
       event.which = 13;
       listItem.dispatchEvent(event);
-      expect(listItem.classList.contains('bx--accordion__item--active')).to.be.true;
+      expect(listItem.classList.contains('bx--accordion__item--active')).to.be
+        .true;
     });
 
-    it('Should remove active state on second enter or spacebar press', function () {
+    it('Should remove active state on second enter or spacebar press', function() {
       const event = new CustomEvent('keypress', { bubbles: true });
       event.which = 13;
       listItem.dispatchEvent(event);
-      expect(listItem.classList.contains('bx--accordion__item--active')).to.be.false;
+      expect(listItem.classList.contains('bx--accordion__item--active')).to.be
+        .false;
     });
 
-    after(function () {
+    after(function() {
       accordion.release();
       document.body.removeChild(container);
     });


### PR DESCRIPTION
## Overview

Part of a11y fixes

Notable changes

- HTML markup for the heading control swapped to a button
- `aria-expanded` and `aria-controls` attributes added to button heading
- `id` given to each accordion pane to correspond to aria-controls
- Keyboard event handler only added if using the old markup - button's naturally map click events to space and enter
- New mixin created to reset button styles specifically