### PR TITLE
fix(components): support moving components in watch mode

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,23 +1,28 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 
-class Accordion extends mixin(createComponent, initComponentBySearch) {
+class Accordion extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Accordion.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as an accordion.
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', event => {
-      const item = eventMatches(event, this.options.selectorAccordionItem);
-      if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
-        this._toggle(item);
-      }
-    });
+    this.manage(
+      on(this.element, 'click', event => {
+        const item = eventMatches(event, this.options.selectorAccordionItem);
+        if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
+          this._toggle(item);
+        }
+      })
+    );
 
     /**
      *
@@ -30,13 +35,15 @@ class Accordion extends mixin(createComponent, initComponentBySearch) {
      */
 
     if (!this._checkIfButton()) {
-      this.element.addEventListener('keypress', event => {
-        const item = eventMatches(event, this.options.selectorAccordionItem);
+      this.manage(
+        on(this.element, 'keypress', event => {
+          const item = eventMatches(event, this.options.selectorAccordionItem);
 
-        if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
-          this._handleKeypress(event);
-        }
-      });
+          if (item && !eventMatches(event, this.options.selectorAccordionContent)) {
+            this._handleKeypress(event);
+          }
+        })
+      );
     }
   }
 

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -2,24 +2,29 @@ import warning from 'warning';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 
 let didWarnAboutDeprecation = false;
 
-class Card extends mixin(createComponent, initComponentBySearch) {
+class Card extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * The container for cards.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a container.
    * @param {Object} [options] The component options.
    * @param {string} [options.selectorCard] The CSS selector to find cards.
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('keydown', event => {
-      this._cardKeyPress(event);
-    });
+    this.manage(
+      on(this.element, 'keydown', event => {
+        this._cardKeyPress(event);
+      })
+    );
     if (__DEV__) {
       warning(
         didWarnAboutDeprecation,

--- a/src/components/content-switcher/content-switcher.js
+++ b/src/components/content-switcher/content-switcher.js
@@ -2,14 +2,17 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedState from '../../globals/js/mixins/evented-state';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 
-class ContentSwitcher extends mixin(createComponent, initComponentBySearch, eventedState) {
+class ContentSwitcher extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * Set of content switcher buttons.
    * @extends CreateComponent
    * @extends InitComponentBySearch
    * @extends EventedState
+   * @extends Handles
    * @param {HTMLElement} element The element working as a set of content switcher buttons.
    * @param {Object} [options] The component options.
    * @param {string} [options.selectorButton] The CSS selector to find switcher buttons.
@@ -22,9 +25,11 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', event => {
-      this._handleClick(event);
-    });
+    this.manage(
+      on(this.element, 'click', event => {
+        this._handleClick(event);
+      })
+    );
   }
 
   /**

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -1,17 +1,20 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import InitComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
 
-class CopyButton extends mixin(createComponent, InitComponentBySearch) {
+class CopyButton extends mixin(createComponent, InitComponentBySearch, handles) {
   /**
    * CopyBtn UI.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a copy button UI.
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('click', () => this.handleClick());
+    this.manage(on(this.element, 'click', () => this.handleClick()));
   }
 
   /**

--- a/src/components/data-table/data-table.js
+++ b/src/components/data-table/data-table.js
@@ -2,14 +2,17 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedState from '../../globals/js/mixins/evented-state';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 
-class DataTable extends mixin(createComponent, initComponentBySearch, eventedState) {
+class DataTable extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * Data Table
    * @extends CreateComponent
    * @extends InitComponentBySearch
    * @extends EventedState
+   * @extends Handles
    * @param {HTMLElement} element The root element of tables
    * @param {Object} [options] the... options
    * @param {string} [options.selectorInit] selector initialization
@@ -32,21 +35,25 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
 
     this.refreshRows();
 
-    this.element.addEventListener('click', evt => {
-      const eventElement = eventMatches(evt, this.options.eventTrigger);
-      if (eventElement) {
-        this._toggleState(eventElement, evt);
-      }
-    });
-
-    this.element.addEventListener('keydown', evt => {
-      if (evt.which === 13) {
+    this.manage(
+      on(this.element, 'click', evt => {
         const eventElement = eventMatches(evt, this.options.eventTrigger);
         if (eventElement) {
           this._toggleState(eventElement, evt);
         }
-      }
-    });
+      })
+    );
+
+    this.manage(
+      on(this.element, 'keydown', evt => {
+        if (evt.which === 13) {
+          const eventElement = eventMatches(evt, this.options.eventTrigger);
+          if (eventElement) {
+            this._toggleState(eventElement, evt);
+          }
+        }
+      })
+    );
   }
 
   /**

--- a/src/components/detail-page-header/detail-page-header.js
+++ b/src/components/detail-page-header/detail-page-header.js
@@ -3,15 +3,17 @@ import debounce from 'lodash.debounce';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import on from '../../globals/js/misc/on';
 
 let didWarnAboutDeprecation = false;
 
-class DetailPageHeader extends mixin(createComponent, initComponentBySearch) {
+class DetailPageHeader extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * The Detail Page Header.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a page header.
    * @param {Object} [options] The component options.
    */
@@ -21,7 +23,7 @@ class DetailPageHeader extends mixin(createComponent, initComponentBySearch) {
     this.previousScrollY = 0;
     // Debounce scroll event calls to handleScroll (default: 50)
     const debouncedScroll = debounce(this._handleScroll.bind(this), 25);
-    this.hScroll = on(this.element.ownerDocument.defaultView, 'scroll', debouncedScroll);
+    this.manage(on(this.element.ownerDocument.defaultView, 'scroll', debouncedScroll));
     if (__DEV__) {
       warning(
         didWarnAboutDeprecation,
@@ -57,14 +59,6 @@ class DetailPageHeader extends mixin(createComponent, initComponentBySearch) {
     }
 
     this.previousScrollY = scrollPosition;
-  }
-
-  /**
-   * Cleans up stuffs specific to this widget.
-   */
-  release() {
-    this.hScroll.release();
-    super.release();
   }
 
   /**

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -10,6 +10,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * A selector with drop downs.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends TrackBlur
    * @param {HTMLElement} element The element working as a selector.
    * @param {Object} [options] The component options.
    * @param {string} [options.selectorItem] The CSS selector to find clickable areas in dropdown items.
@@ -23,36 +24,24 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
   constructor(element, options) {
     super(element, options);
 
-    /**
-     * The handle to release click event listener on document object.
-     * @member {Handle}
-     */
-    this.hDocumentClick = on(this.element.ownerDocument, 'click', event => {
-      this._toggle(event);
-    });
-
-    this.element.addEventListener('keydown', event => {
-      this._handleKeyDown(event);
-    });
-    this.element.addEventListener('click', event => {
-      const item = eventMatches(event, this.options.selectorItem);
-      if (item) {
-        this.select(item);
-      }
-    });
-  }
-
-  /**
-   * Cleans up stuffs specific to this widget.
-   */
-  release() {
-    if (this.hFocusIn) {
-      this.hFocusIn = this.hFocusIn.release();
-    }
-    if (this.hDocumentClick) {
-      this.hDocumentClick = this.hDocumentClick.release();
-    }
-    super.release();
+    this.manage(
+      on(this.element.ownerDocument, 'click', event => {
+        this._toggle(event);
+      })
+    );
+    this.manage(
+      on(this.element, 'keydown', event => {
+        this._handleKeyDown(event);
+      })
+    );
+    this.manage(
+      on(this.element, 'click', event => {
+        const item = eventMatches(event, this.options.selectorItem);
+        if (item) {
+          this.select(item);
+        }
+      })
+    );
   }
 
   /**

--- a/src/components/fab/fab.js
+++ b/src/components/fab/fab.js
@@ -1,19 +1,24 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentByEvent from '../../globals/js/mixins/init-component-by-event';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
 
-class FabButton extends mixin(createComponent, initComponentByEvent) {
+class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
   /**
    * Floating action button.
    * @extends CreateComponent
    * @extends InitComponentByEvent
+   * @extends Handles
    * @param {HTMLElement} element The element working as a floting action button.
    */
   constructor(element) {
     super(element);
-    element.addEventListener('click', event => {
-      this.toggle(event);
-    });
+    this.manage(
+      on(element, 'click', event => {
+        this.toggle(event);
+      })
+    );
   }
 
   /**

--- a/src/components/interior-left-nav/interior-left-nav.js
+++ b/src/components/interior-left-nav/interior-left-nav.js
@@ -2,16 +2,19 @@ import warning from 'warning';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 import toggleClass from '../../globals/js/misc/svg-toggle-class';
 
 let didWarnAboutDeprecation = false;
 
-class InteriorLeftNav extends mixin(createComponent, initComponentBySearch) {
+class InteriorLeftNav extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Interior left nav.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as an interior left nav.
    * @param {Object} options The component options.
    */
@@ -34,39 +37,43 @@ class InteriorLeftNav extends mixin(createComponent, initComponentBySearch) {
   }
 
   hookListItemsEvents = () => {
-    this.element.addEventListener('click', evt => {
-      const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
-      const collapseEl = eventMatches(evt, this.options.selectorLeftNavCollapse);
-      const collapsedBar = eventMatches(evt, `.${this.options.classLeftNavCollapsed}`);
+    this.manage(
+      on(this.element, 'click', evt => {
+        const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
+        const collapseEl = eventMatches(evt, this.options.selectorLeftNavCollapse);
+        const collapsedBar = eventMatches(evt, `.${this.options.classLeftNavCollapsed}`);
 
-      if (leftNavItem) {
-        const childItem = eventMatches(evt, this.options.selectorLeftNavNestedListItem);
-        const hasChildren = leftNavItem.classList.contains('left-nav-list__item--has-children');
-        if (childItem) {
-          this.addActiveListItem(childItem);
-        } else if (hasChildren) {
-          this.handleNestedListClick(leftNavItem, evt);
-        } else {
+        if (leftNavItem) {
+          const childItem = eventMatches(evt, this.options.selectorLeftNavNestedListItem);
+          const hasChildren = leftNavItem.classList.contains('left-nav-list__item--has-children');
+          if (childItem) {
+            this.addActiveListItem(childItem);
+          } else if (hasChildren) {
+            this.handleNestedListClick(leftNavItem, evt);
+          } else {
+            this.addActiveListItem(leftNavItem);
+          }
+        }
+
+        if (collapseEl || collapsedBar) {
+          evt.preventDefault();
+          this.toggleLeftNav();
+        }
+      })
+    );
+
+    this.manage(
+      on(this.element, 'keydown', evt => {
+        const leftNavItemWithChildren = eventMatches(evt, this.options.selectorLeftNavListItemHasChildren);
+        const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
+
+        if (leftNavItemWithChildren && evt.which === 13) {
+          this.handleNestedListClick(leftNavItemWithChildren, evt);
+        } else if (leftNavItem && evt.which === 13) {
           this.addActiveListItem(leftNavItem);
         }
-      }
-
-      if (collapseEl || collapsedBar) {
-        evt.preventDefault();
-        this.toggleLeftNav();
-      }
-    });
-
-    this.element.addEventListener('keydown', evt => {
-      const leftNavItemWithChildren = eventMatches(evt, this.options.selectorLeftNavListItemHasChildren);
-      const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
-
-      if (leftNavItemWithChildren && evt.which === 13) {
-        this.handleNestedListClick(leftNavItemWithChildren, evt);
-      } else if (leftNavItem && evt.which === 13) {
-        this.addActiveListItem(leftNavItem);
-      }
-    });
+      })
+    );
   };
 
   addActiveListItem(item) {

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -1,12 +1,15 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
 
-class Loading extends mixin(createComponent, initComponentBySearch) {
+class Loading extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Spinner indicating loading state.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a spinner.
    * @param {Object} [options] The component options.
    * @param {boolean} [options.active] `true` if this spinner should roll.
@@ -64,11 +67,16 @@ class Loading extends mixin(createComponent, initComponentBySearch) {
    */
   end() {
     this.set(false);
-    this.element.addEventListener('animationend', evt => {
-      if (evt.animationName === 'rotate-end-p2') {
-        this._deleteElement();
-      }
-    });
+    let handleAnimationEnd = this.manage(
+      on(this.element, 'animationend', evt => {
+        if (handleAnimationEnd) {
+          handleAnimationEnd = this.unmanage(handleAnimationEnd).release();
+        }
+        if (evt.animationName === 'rotate-end-p2') {
+          this._deleteElement();
+        }
+      })
+    );
   }
 
   /**

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -2,23 +2,28 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedState from '../../globals/js/mixins/evented-state';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
 
-class Notification extends mixin(createComponent, initComponentBySearch, eventedState) {
+class Notification extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * InlineNotification.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a InlineNotification.
    */
   constructor(element, options) {
     super(element, options);
     this.button = element.querySelector(this.options.selectorButton);
     if (this.button) {
-      this.button.addEventListener('click', evt => {
-        if (evt.currentTarget === this.button) {
-          this.remove();
-        }
-      });
+      this.manage(
+        on(this.button, 'click', evt => {
+          if (evt.currentTarget === this.button) {
+            this.remove();
+          }
+        })
+      );
     }
   }
 

--- a/src/components/number-input/number-input.js
+++ b/src/components/number-input/number-input.js
@@ -1,24 +1,31 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
 
-class NumberInput extends mixin(createComponent, initComponentBySearch) {
+class NumberInput extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Number input UI.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a number input UI.
    */
   constructor(element, options) {
     super(element, options);
     // Broken DOM tree is seen with up/down arrows <svg> in IE, which breaks event delegation.
     // <svg> does not have `Element.classList` in IE11
-    this.element.querySelector('.up-icon').addEventListener('click', event => {
-      this._handleClick(event);
-    });
-    this.element.querySelector('.down-icon').addEventListener('click', event => {
-      this._handleClick(event);
-    });
+    this.manage(
+      on(this.element.querySelector('.up-icon'), 'click', event => {
+        this._handleClick(event);
+      })
+    );
+    this.manage(
+      on(this.element.querySelector('.down-icon'), 'click', event => {
+        this._handleClick(event);
+      })
+    );
   }
 
   /**

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -2,15 +2,17 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedShowHideState from '../../globals/js/mixins/evented-show-hide-state';
+import handles from '../../globals/js/mixins/handles';
 import FloatingMenu from '../floating-menu/floating-menu';
 import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
 import on from '../../globals/js/misc/on';
 
-class OverflowMenu extends mixin(createComponent, initComponentBySearch, eventedShowHideState) {
+class OverflowMenu extends mixin(createComponent, initComponentBySearch, eventedShowHideState, handles) {
   /**
    * Overflow menu.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a modal dialog.
    * @param {Object} [options] The component options.
    * @param {string} [options.selectorOptionMenu] The CSS selector to find the menu.
@@ -22,22 +24,16 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
    */
   constructor(element, options) {
     super(element, options);
-
-    /**
-     * The handle to release click event listener on document object.
-     * @member {Handle}
-     */
-    this.hDocumentClick = on(this.element.ownerDocument, 'click', event => {
-      this._handleDocumentClick(event);
-    });
-
-    /**
-     * The handle to release keypress event listener on document object.
-     * @member {Handle}
-     */
-    this.hDocumentKeyPress = on(this.element.ownerDocument, 'keypress', event => {
-      this._handleKeyPress(event);
-    });
+    this.manage(
+      on(this.element.ownerDocument, 'click', event => {
+        this._handleDocumentClick(event);
+      })
+    );
+    this.manage(
+      on(this.element.ownerDocument, 'keypress', event => {
+        this._handleKeyPress(event);
+      })
+    );
   }
 
   /**
@@ -114,16 +110,6 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
 
       this.changeState(state, getLaunchingDetails(event));
     }
-  }
-
-  release() {
-    if (this.hDocumentClick) {
-      this.hDocumentClick = this.hDocumentClick.release();
-    }
-    if (this.hDocumentKeyPress) {
-      this.hDocumentKeyPress = this.hDocumentKeyPress.release();
-    }
-    super.release();
   }
 
   static components = new WeakMap();

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -1,8 +1,10 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
 
-class Pagination extends mixin(createComponent, initComponentBySearch) {
+class Pagination extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Pagination component.
    * @extends CreateComponent
@@ -28,41 +30,45 @@ class Pagination extends mixin(createComponent, initComponentBySearch) {
   constructor(element, options) {
     super(element, options);
 
-    this.element.addEventListener('click', evt => {
-      if (evt.target.matches(this.options.selectorPageBackward)) {
-        const detail = {
-          initialEvt: evt,
-          element: evt.target,
-          direction: 'backward',
-        };
-        this._emitEvent(this.options.eventPageChange, detail);
-      } else if (evt.target.matches(this.options.selectorPageForward)) {
-        const detail = {
-          initialEvt: evt,
-          element: evt.target,
-          direction: 'forward',
-        };
-        this._emitEvent(this.options.eventPageChange, detail);
-      }
-    });
+    this.manage(
+      on(this.element, 'click', evt => {
+        if (evt.target.matches(this.options.selectorPageBackward)) {
+          const detail = {
+            initialEvt: evt,
+            element: evt.target,
+            direction: 'backward',
+          };
+          this._emitEvent(this.options.eventPageChange, detail);
+        } else if (evt.target.matches(this.options.selectorPageForward)) {
+          const detail = {
+            initialEvt: evt,
+            element: evt.target,
+            direction: 'forward',
+          };
+          this._emitEvent(this.options.eventPageChange, detail);
+        }
+      })
+    );
 
-    this.element.addEventListener('input', evt => {
-      if (evt.target.matches(this.options.selectorItemsPerPageInput)) {
-        const detail = {
-          initialEvt: evt,
-          element: evt.target,
-          value: evt.target.value,
-        };
-        this._emitEvent(this.options.eventItemsPerPage, detail);
-      } else if (evt.target.matches(this.options.selectorPageNumberInput)) {
-        const detail = {
-          initialEvt: evt,
-          element: evt.target,
-          value: evt.target.value,
-        };
-        this._emitEvent(this.options.eventPageNumber, detail);
-      }
-    });
+    this.manage(
+      on(this.element, 'input', evt => {
+        if (evt.target.matches(this.options.selectorItemsPerPageInput)) {
+          const detail = {
+            initialEvt: evt,
+            element: evt.target,
+            value: evt.target.value,
+          };
+          this._emitEvent(this.options.eventItemsPerPage, detail);
+        } else if (evt.target.matches(this.options.selectorPageNumberInput)) {
+          const detail = {
+            initialEvt: evt,
+            element: evt.target,
+            value: evt.target.value,
+          };
+          this._emitEvent(this.options.eventPageNumber, detail);
+        }
+      })
+    );
   }
 
   /**

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -1,14 +1,17 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 import svgToggleClass from '../../globals/js/misc/svg-toggle-class';
 
-class Search extends mixin(createComponent, initComponentBySearch) {
+class Search extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Search with Options.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as the search component.
    * @param {Object} [options] The component options
    * @property {string} [options.selectorInit]
@@ -32,21 +35,27 @@ class Search extends mixin(createComponent, initComponentBySearch) {
     }
 
     if (closeIcon) {
-      closeIcon.addEventListener('click', () => {
-        svgToggleClass(closeIcon, this.options.classClearHidden, true);
-        input.value = '';
-        input.focus();
-      });
+      this.manage(
+        on(closeIcon, 'click', () => {
+          svgToggleClass(closeIcon, this.options.classClearHidden, true);
+          input.value = '';
+          input.focus();
+        })
+      );
     }
 
-    this.element.addEventListener('click', evt => {
-      const toggleItem = eventMatches(evt, this.options.selectorIconContainer);
-      if (toggleItem) this.toggleLayout(toggleItem);
-    });
+    this.manage(
+      on(this.element, 'click', evt => {
+        const toggleItem = eventMatches(evt, this.options.selectorIconContainer);
+        if (toggleItem) this.toggleLayout(toggleItem);
+      })
+    );
 
-    input.addEventListener('input', evt => {
-      if (closeIcon) this.showClear(evt.target.value, closeIcon);
-    });
+    this.manage(
+      on(input, 'input', evt => {
+        if (closeIcon) this.showClear(evt.target.value, closeIcon);
+      })
+    );
   }
 
   /**

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -2,13 +2,15 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedState from '../../globals/js/mixins/evented-state';
+import handles from '../../globals/js/mixins/handles';
 import on from '../../globals/js/misc/on';
 
-class Slider extends mixin(createComponent, initComponentBySearch, eventedState) {
+class Slider extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * Slider.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as an slider.
    */
   constructor(element, options) {
@@ -25,44 +27,60 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
     if (this.element.dataset.sliderInputBox) {
       this.boundInput = this.element.ownerDocument.querySelector(this.element.dataset.sliderInputBox);
       this._updateInput();
-      this.boundInput.addEventListener('change', evt => {
-        this.setValue(evt.target.value);
-      });
-      this.boundInput.addEventListener('focus', evt => {
-        evt.target.select();
-      });
+      this.manage(
+        on(this.boundInput, 'change', evt => {
+          this.setValue(evt.target.value);
+        })
+      );
+      this.manage(
+        on(this.boundInput, 'focus', evt => {
+          evt.target.select();
+        })
+      );
       // workaround for safari
-      this.boundInput.addEventListener('mouseup', evt => {
-        evt.preventDefault();
-      });
+      this.manage(
+        on(this.boundInput, 'mouseup', evt => {
+          evt.preventDefault();
+        })
+      );
     }
 
     this._updatePosition();
 
-    this.thumb.addEventListener('mousedown', () => {
-      this.sliderActive = true;
-    });
-    this.hDocumentMouseUp = on(this.element.ownerDocument, 'mouseup', () => {
-      this.sliderActive = false;
-    });
-    this.hDocumentMouseMove = on(this.element.ownerDocument, 'mousemove', evt => {
-      const disabled = this.element.classList.contains('bx--slider--disabled');
-      if (this.sliderActive === true && !disabled) {
-        this._updatePosition(evt);
-      }
-    });
-    this.thumb.addEventListener('keydown', evt => {
-      const disabled = this.element.classList.contains('bx--slider--disabled');
-      if (!disabled) {
-        this._updatePosition(evt);
-      }
-    });
-    this.track.addEventListener('click', evt => {
-      const disabled = this.element.classList.contains('bx--slider--disabled');
-      if (!disabled) {
-        this._updatePosition(evt);
-      }
-    });
+    this.manage(
+      on(this.thumb, 'mousedown', () => {
+        this.sliderActive = true;
+      })
+    );
+    this.manage(
+      on(this.element.ownerDocument, 'mouseup', () => {
+        this.sliderActive = false;
+      })
+    );
+    this.manage(
+      on(this.element.ownerDocument, 'mousemove', evt => {
+        const disabled = this.element.classList.contains('bx--slider--disabled');
+        if (this.sliderActive === true && !disabled) {
+          this._updatePosition(evt);
+        }
+      })
+    );
+    this.manage(
+      on(this.thumb, 'keydown', evt => {
+        const disabled = this.element.classList.contains('bx--slider--disabled');
+        if (!disabled) {
+          this._updatePosition(evt);
+        }
+      })
+    );
+    this.manage(
+      on(this.track, 'click', evt => {
+        const disabled = this.element.classList.contains('bx--slider--disabled');
+        if (!disabled) {
+          this._updatePosition(evt);
+        }
+      })
+    );
   }
 
   _changeState = (state, detail, callback) => {
@@ -174,16 +192,6 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
   stepDown() {
     this.input.stepDown();
     this._updatePosition();
-  }
-
-  release() {
-    if (this.hDocumentMouseUp) {
-      this.hDocumentMouseUp = this.hDocumentMouseUp.release();
-    }
-    if (this.hDocumentMouseMove) {
-      this.hDocumentMouseMove = this.hDocumentMouseMove.release();
-    }
-    super.release();
   }
 
   /**

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -1,13 +1,16 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
+import on from '../../globals/js/misc/on';
 
-class StructuredList extends mixin(createComponent, initComponentBySearch) {
+class StructuredList extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * StructuredList
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The root element of tables
    * @param {Object} [options] the... options
    * @param {string} [options.selectorInit] selector initialization
@@ -15,17 +18,21 @@ class StructuredList extends mixin(createComponent, initComponentBySearch) {
    */
   constructor(element, options) {
     super(element, options);
-    this.element.addEventListener('keydown', evt => {
-      if (evt.which === 38 || evt.which === 40) {
-        this._handleKeydownArrow(evt);
-      }
-      if (evt.which === 13 || evt.which === 32) {
-        this._handleKeydownChecked(evt);
-      }
-    });
-    this.element.addEventListener('click', evt => {
-      this._handleClick(evt);
-    });
+    this.manage(
+      on(this.element, 'keydown', evt => {
+        if (evt.which === 38 || evt.which === 40) {
+          this._handleKeydownArrow(evt);
+        }
+        if (evt.which === 13 || evt.which === 32) {
+          this._handleKeydownChecked(evt);
+        }
+      })
+    );
+    this.manage(
+      on(this.element, 'click', evt => {
+        this._handleClick(evt);
+      })
+    );
   }
 
   _direction(evt) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -1,5 +1,6 @@
 import eventMatches from '../../globals/js/misc/event-matches';
 import ContentSwitcher from '../content-switcher/content-switcher';
+import on from '../../globals/js/misc/on';
 
 class Tab extends ContentSwitcher {
   /**
@@ -24,9 +25,11 @@ class Tab extends ContentSwitcher {
   constructor(element, options) {
     super(element, options);
 
-    this.element.addEventListener('keydown', event => {
-      this._handleKeyDown(event);
-    });
+    this.manage(
+      on(this.element, 'keydown', event => {
+        this._handleKeyDown(event);
+      })
+    );
 
     const selected = this.element.querySelector(this.options.selectorButtonSelected);
     if (selected) {

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -1,14 +1,16 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
-class Toolbar extends mixin(createComponent, initComponentBySearch) {
+class Toolbar extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Toolbar.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as an toolbar.
    */
   constructor(element, options) {
@@ -20,22 +22,27 @@ class Toolbar extends mixin(createComponent, initComponentBySearch) {
       const boundTable = this.element.ownerDocument.querySelector(this.element.dataset.tableTarget);
       const rowHeightBtns = this.element.querySelector(this.options.selectorRowHeight);
       if (rowHeightBtns) {
-        rowHeightBtns.addEventListener('click', event => {
-          this._handleRowHeightChange(event, boundTable);
-        });
+        this.manage(
+          on(rowHeightBtns, 'click', event => {
+            this._handleRowHeightChange(event, boundTable);
+          })
+        );
         // [...this.element.querySelectorAll(this.options.selectorRowHeight)].forEach((item) => {
         //   item.addEventListener('click', (event) => { this._handleRowHeightChange(event, boundTable); });
         // });
       }
     }
 
-    this.hDocumentKeyDown = on(this.element.ownerDocument, 'keydown', evt => {
-      this._handleKeyDown(evt);
-    });
-
-    this.hDocumentClick = on(this.element.ownerDocument, 'click', evt => {
-      this._handleDocumentClick(evt);
-    });
+    this.manage(
+      on(this.element.ownerDocument, 'keydown', evt => {
+        this._handleKeyDown(evt);
+      })
+    );
+    this.manage(
+      on(this.element.ownerDocument, 'click', evt => {
+        this._handleDocumentClick(evt);
+      })
+    );
   }
 
   /**
@@ -95,16 +102,6 @@ class Toolbar extends mixin(createComponent, initComponentBySearch) {
     } else {
       boundTable.classList.remove(this.options.classTallRows);
     }
-  }
-
-  release() {
-    if (this.hDocumentClick) {
-      this.hDocumentClick = this.hDocumentClick.release();
-    }
-    if (this.hDocumentKeyPress) {
-      this.hDocumentKeyPress = this.hDocumentKeyPress.release();
-    }
-    super.release();
   }
 
   /**

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -2,21 +2,26 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentByEvent from '../../globals/js/mixins/init-component-by-event';
 import eventedShowHideState from '../../globals/js/mixins/evented-show-hide-state';
+import handles from '../../globals/js/mixins/handles';
 import FloatingMenu from '../floating-menu/floating-menu';
 import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
+import on from '../../globals/js/misc/on';
 
-class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHideState) {
+class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHideState, handles) {
   /**
    * Tooltip.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    */
   constructor(element, options) {
     super(element, options);
     ['mouseover', 'mouseout', 'focus', 'blur', 'touchleave', 'touchcancel'].forEach(name => {
-      this.element.addEventListener(name, event => {
-        this._handleHover(event);
-      });
+      this.manage(
+        on(this.element, name, event => {
+          this._handleHover(event);
+        })
+      );
     });
   }
 

--- a/src/components/unified-header/left-nav.js
+++ b/src/components/unified-header/left-nav.js
@@ -1,14 +1,16 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
-class LeftNav extends mixin(createComponent, initComponentBySearch) {
+class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Left Navigation.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a left navigation.
    * @param {Object} [options] The component options
    * @param {string} [options.selectorLeftNav] The data attribute selector for the nav element in the left nav container.
@@ -39,9 +41,11 @@ class LeftNav extends mixin(createComponent, initComponentBySearch) {
     this.hookOpenActions();
     this.hookListSectionEvents();
     this.hookListItemsEvents();
-    this.hDocumentClick = on(this.element.ownerDocument, 'click', evt => {
-      this.handleDocumentClick(evt);
-    });
+    this.manage(
+      on(this.element.ownerDocument, 'click', evt => {
+        this.handleDocumentClick(evt);
+      })
+    );
   }
 
   /**
@@ -140,37 +144,47 @@ class LeftNav extends mixin(createComponent, initComponentBySearch) {
     const openBtn = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleOpen);
     const closeBtn = this.element.ownerDocument.querySelector(this.options.selectorLeftNavToggleClose);
 
-    openBtn.addEventListener('click', () => {
-      this.element.tabIndex = '0';
-      this.toggleMenu();
-    });
-
-    openBtn.addEventListener('keydown', evt => {
-      if (evt.which === 13) {
+    this.manage(
+      on(openBtn, 'click', () => {
         this.element.tabIndex = '0';
         this.toggleMenu();
-      }
-    });
+      })
+    );
+
+    this.manage(
+      on(openBtn, 'keydown', evt => {
+        if (evt.which === 13) {
+          this.element.tabIndex = '0';
+          this.toggleMenu();
+        }
+      })
+    );
 
     if (closeBtn) {
-      closeBtn.addEventListener('click', () => {
-        this.element.tabIndex = '-1';
-        this.closeMenu();
-      });
-
-      closeBtn.addEventListener('keydown', evt => {
-        if (evt.which === 13) {
+      this.manage(
+        on(closeBtn, 'click', () => {
           this.element.tabIndex = '-1';
           this.closeMenu();
-        }
-      });
+        })
+      );
+
+      this.manage(
+        on(closeBtn, 'keydown', evt => {
+          if (evt.which === 13) {
+            this.element.tabIndex = '-1';
+            this.closeMenu();
+          }
+        })
+      );
     }
 
-    this.element.ownerDocument.addEventListener('keydown', evt => {
-      if (evt.which === 27 && this.element.classList.contains(this.options.classActiveLeftNav)) {
-        this.closeMenu();
-      }
-    });
+    this.manage(
+      on(this.element.ownerDocument, 'keydown', evt => {
+        if (evt.which === 27 && this.element.classList.contains(this.options.classActiveLeftNav)) {
+          this.closeMenu();
+        }
+      })
+    );
   }
 
   /**
@@ -178,16 +192,20 @@ class LeftNav extends mixin(createComponent, initComponentBySearch) {
    */
   hookListSectionEvents() {
     const leftNavSections = this.element.querySelector(this.options.selectorLeftNavSections);
-    leftNavSections.addEventListener('click', evt => {
-      this.handleSectionItemClick(evt, leftNavSections);
-    });
-
-    leftNavSections.addEventListener('keydown', evt => {
-      if (evt.which === 13) {
+    this.manage(
+      on(leftNavSections, 'click', evt => {
         this.handleSectionItemClick(evt, leftNavSections);
-        this.element.querySelector(this.options.selectorLeftNavCurrentSectionTitle).focus();
-      }
-    });
+      })
+    );
+
+    this.manage(
+      on(leftNavSections, 'keydown', evt => {
+        if (evt.which === 13) {
+          this.handleSectionItemClick(evt, leftNavSections);
+          this.element.querySelector(this.options.selectorLeftNavCurrentSectionTitle).focus();
+        }
+      })
+    );
   }
 
   /**
@@ -196,76 +214,84 @@ class LeftNav extends mixin(createComponent, initComponentBySearch) {
   hookListItemsEvents() {
     const leftNavList = [...this.element.querySelectorAll(this.options.selectorLeftNavList)];
     leftNavList.forEach(list => {
-      list.addEventListener('click', evt => {
-        const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
-        if (leftNavItem) {
-          const childItem = eventMatches(evt, this.options.selectorLeftNavNestedListItem);
-          const hasChildren = eventMatches(evt, this.options.selectorLeftNavListItemHasChildren);
-          const flyoutItem = eventMatches(evt, this.options.selectorLeftNavFlyoutItem);
-          if (flyoutItem) {
-            this.addActiveListItem(flyoutItem);
-          } else if (childItem) {
-            if (childItem.querySelector(this.options.selectorLeftNavFlyoutMenu)) {
-              const flyoutMenu = childItem.querySelector(this.options.selectorLeftNavFlyoutMenu);
-              flyoutMenu.classList.toggle(this.options.classFlyoutDisplayed);
-            } else {
-              this.addActiveListItem(childItem);
-            }
-          } else if (hasChildren) {
-            this.handleNestedListClick(leftNavItem);
-          } else {
-            this.addActiveListItem(leftNavItem);
-          }
-        }
-      });
-      list.addEventListener('keydown', evt => {
-        if (evt.which === 13) {
+      this.manage(
+        on(list, 'click', evt => {
           const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
           if (leftNavItem) {
             const childItem = eventMatches(evt, this.options.selectorLeftNavNestedListItem);
             const hasChildren = eventMatches(evt, this.options.selectorLeftNavListItemHasChildren);
             const flyoutItem = eventMatches(evt, this.options.selectorLeftNavFlyoutItem);
-            const hasLinkItem = !(leftNavItem.querySelector(this.options.selectorLeftNavListItemLink) === undefined);
             if (flyoutItem) {
               this.addActiveListItem(flyoutItem);
             } else if (childItem) {
-              if (!childItem.querySelector(this.options.selectorLeftNavFlyoutMenu)) {
-                this.addActiveListItem(childItem);
+              if (childItem.querySelector(this.options.selectorLeftNavFlyoutMenu)) {
+                const flyoutMenu = childItem.querySelector(this.options.selectorLeftNavFlyoutMenu);
+                flyoutMenu.classList.toggle(this.options.classFlyoutDisplayed);
               } else {
-                childItem.querySelector(this.options.selectorLeftNavFlyoutMenu).setAttribute('aria-hidden', 'false');
-                childItem.querySelector(this.options.selectorLeftNavFlyoutMenu).style.top = `${childItem.offsetTop -
-                  this.element.querySelector(this.options.selectorLeftNav).scrollTop}px`;
-                childItem.querySelector(this.options.selectorLeftNavFlyoutMenu).style.left = `${childItem.offsetLeft +
-                  Math.round(childItem.offsetWidth)}px`;
+                this.addActiveListItem(childItem);
               }
             } else if (hasChildren) {
               this.handleNestedListClick(leftNavItem);
-            } else if (hasLinkItem) {
-              const link = leftNavItem.querySelector(this.options.selectorLeftNavListItemLink);
-              link.click();
             } else {
               this.addActiveListItem(leftNavItem);
             }
           }
-        }
-      });
+        })
+      );
+      this.manage(
+        on(list, 'keydown', evt => {
+          if (evt.which === 13) {
+            const leftNavItem = eventMatches(evt, this.options.selectorLeftNavListItem);
+            if (leftNavItem) {
+              const childItem = eventMatches(evt, this.options.selectorLeftNavNestedListItem);
+              const hasChildren = eventMatches(evt, this.options.selectorLeftNavListItemHasChildren);
+              const flyoutItem = eventMatches(evt, this.options.selectorLeftNavFlyoutItem);
+              const hasLinkItem = !(leftNavItem.querySelector(this.options.selectorLeftNavListItemLink) === undefined);
+              if (flyoutItem) {
+                this.addActiveListItem(flyoutItem);
+              } else if (childItem) {
+                if (!childItem.querySelector(this.options.selectorLeftNavFlyoutMenu)) {
+                  this.addActiveListItem(childItem);
+                } else {
+                  childItem.querySelector(this.options.selectorLeftNavFlyoutMenu).setAttribute('aria-hidden', 'false');
+                  childItem.querySelector(this.options.selectorLeftNavFlyoutMenu).style.top = `${childItem.offsetTop -
+                    this.element.querySelector(this.options.selectorLeftNav).scrollTop}px`;
+                  childItem.querySelector(this.options.selectorLeftNavFlyoutMenu).style.left = `${childItem.offsetLeft +
+                    Math.round(childItem.offsetWidth)}px`;
+                }
+              } else if (hasChildren) {
+                this.handleNestedListClick(leftNavItem);
+              } else if (hasLinkItem) {
+                const link = leftNavItem.querySelector(this.options.selectorLeftNavListItemLink);
+                link.click();
+              } else {
+                this.addActiveListItem(leftNavItem);
+              }
+            }
+          }
+        })
+      );
     });
     const flyouts = [...this.element.ownerDocument.querySelectorAll(this.options.selectorLeftNavListItemHasFlyout)];
     flyouts.forEach(flyout => {
-      flyout.addEventListener('mouseenter', () => {
-        flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).setAttribute('aria-hidden', 'false');
-        // eslint-disable-next-line no-param-reassign
-        flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).style.top = `${flyout.offsetTop -
-          this.element.querySelector(this.options.selectorLeftNav).scrollTop}px`;
-        // eslint-disable-next-line no-param-reassign
-        flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).style.left = `${flyout.offsetLeft +
-          Math.round(flyout.offsetWidth)}px`;
-        flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).classList.toggle(this.options.classFlyoutDisplayed);
-      });
-      flyout.addEventListener('mouseleave', () => {
-        flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).setAttribute('aria-hidden', 'true');
-        flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).classList.remove(this.options.classFlyoutDisplayed);
-      });
+      this.manage(
+        on(flyout, 'mouseenter', () => {
+          flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).setAttribute('aria-hidden', 'false');
+          // eslint-disable-next-line no-param-reassign
+          flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).style.top = `${flyout.offsetTop -
+            this.element.querySelector(this.options.selectorLeftNav).scrollTop}px`;
+          // eslint-disable-next-line no-param-reassign
+          flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).style.left = `${flyout.offsetLeft +
+            Math.round(flyout.offsetWidth)}px`;
+          flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).classList.toggle(this.options.classFlyoutDisplayed);
+        })
+      );
+      this.manage(
+        on(flyout, 'mouseleave', () => {
+          flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).setAttribute('aria-hidden', 'true');
+          flyout.querySelector(this.options.selectorLeftNavFlyoutMenu).classList.remove(this.options.classFlyoutDisplayed);
+        })
+      );
     });
   }
 
@@ -422,13 +448,6 @@ class LeftNav extends mixin(createComponent, initComponentBySearch) {
         this.leftNavSectionActive = false;
       }, 450); // Wait for nav items to animate
     }
-  }
-
-  release() {
-    if (this.hDocumentClick) {
-      this.hDocumentClick = this.hDocumentClick.release();
-    }
-    super.release();
   }
 
   /**

--- a/src/components/unified-header/profile-switcher.js
+++ b/src/components/unified-header/profile-switcher.js
@@ -1,14 +1,16 @@
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
-class ProfileSwitcher extends mixin(createComponent, initComponentBySearch) {
+class ProfileSwitcher extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Profile Switcher.
    * @extends CreateComponent
    * @extends InitComponentBySearch
+   * @extends Handles
    * @param {HTMLElement} element The element working as a profile switcher.
    * @param {Object} [options] The component options
    * @param {string} [options.selectorProfileSwitcher] The data attribute selector for the profile switcher.
@@ -28,38 +30,48 @@ class ProfileSwitcher extends mixin(createComponent, initComponentBySearch) {
   constructor(element, options) {
     super(element, options);
 
-    this.hDocumentClick = on(this.element.ownerDocument, 'click', evt => {
-      this.handleDocumentClick(evt);
-    });
+    this.manage(
+      on(this.element.ownerDocument, 'click', evt => {
+        this.handleDocumentClick(evt);
+      })
+    );
 
-    this.element.addEventListener('dropdown-beingselected', event => {
-      if (event.target.querySelector(this.options.selectorAccountDropdown) !== null) {
-        const linkedIconNode = event.detail.item.querySelector(this.options.classLinkedIcon);
-        this.element.isLinked = !!linkedIconNode;
-        this.element.linkedIcon = linkedIconNode && linkedIconNode.cloneNode(true);
-        const linkedAccountNode = event.detail.item.querySelector(this.options.selectorAccountSlLinked);
-        this.element.linkedAccount = linkedAccountNode && linkedAccountNode.cloneNode(true);
-      }
-    });
+    this.manage(
+      on(this.element, 'dropdown-beingselected', event => {
+        if (event.target.querySelector(this.options.selectorAccountDropdown) !== null) {
+          const linkedIconNode = event.detail.item.querySelector(this.options.classLinkedIcon);
+          this.element.isLinked = !!linkedIconNode;
+          this.element.linkedIcon = linkedIconNode && linkedIconNode.cloneNode(true);
+          const linkedAccountNode = event.detail.item.querySelector(this.options.selectorAccountSlLinked);
+          this.element.linkedAccount = linkedAccountNode && linkedAccountNode.cloneNode(true);
+        }
+      })
+    );
 
     const toggleNode = this.element.querySelector(this.options.selectorToggle);
     if (toggleNode) {
-      toggleNode.addEventListener('keydown', event => {
-        this.toggle(event);
-      });
+      this.manage(
+        on(toggleNode, 'keydown', event => {
+          this.toggle(event);
+        })
+      );
 
-      toggleNode.addEventListener('mouseenter', event => {
-        this.getLinkedData(event);
-        this.determineSwitcherValues(true);
-      });
+      this.manage(
+        on(toggleNode, 'mouseenter', event => {
+          this.getLinkedData(event);
+          this.determineSwitcherValues(true);
+        })
+      );
 
-      toggleNode.addEventListener('mouseleave', event => {
-        this.getLinkedData(event);
-        this.determineSwitcherValues(false);
-      });
+      this.manage(
+        on(toggleNode, 'mouseleave', event => {
+          this.getLinkedData(event);
+          this.determineSwitcherValues(false);
+        })
+      );
     }
 
-    this.element.ownerDocument.addEventListener('keyup', () => this.handleBlur());
+    this.manage(on(this.element.ownerDocument, 'keyup', () => this.handleBlur()));
   }
 
   /**
@@ -233,13 +245,6 @@ class ProfileSwitcher extends mixin(createComponent, initComponentBySearch) {
         menuElement.style.width = `${this.element.getBoundingClientRect().width}px`;
       }
     }
-  }
-
-  release() {
-    if (this.hDocumentClick) {
-      this.hDocumentClick = this.hDocumentClick.release();
-    }
-    super.release();
   }
 
   /**

--- a/src/globals/js/mixins/create-component.js
+++ b/src/globals/js/mixins/create-component.js
@@ -1,6 +1,13 @@
 export default function(ToMix) {
   class CreateComponent extends ToMix {
     /**
+     * The component instances managed by this component.
+     * Releasing this component also releases the components in `this.children`.
+     * @type {Component[]}
+     */
+    children = [];
+
+    /**
      * Mix-in class to manage lifecycle of component.
      * The constructor sets up this component's effective options,
      * and registers this component't instance associated to an element.
@@ -20,13 +27,6 @@ export default function(ToMix) {
        * @type {Element}
        */
       this.element = element;
-
-      /**
-       * The component instances managed by this component.
-       * Releasing this component also releases the components in `this.children`.
-       * @type {Component[]}
-       */
-      this.children = [];
 
       /**
        * The component options.

--- a/src/globals/js/mixins/handles.js
+++ b/src/globals/js/mixins/handles.js
@@ -1,0 +1,45 @@
+export default function(ToMix) {
+  /**
+   * Mix-in class to manage handles in component.
+   * Managed handles are automatically released when the component with this class mixed in is released.
+   * @class Handles
+   * @implements Handle
+   */
+  class Handles extends ToMix {
+    /**
+     * The handled managed by this component.
+     * Releasing this component releases the handles.
+     * @type {Set<Handle>}
+     */
+    handles = new Set();
+
+    /**
+     * Manages the given handle.
+     * @param {Handle} handle The handle to manage.
+     * @returns {Handle} The given handle.
+     */
+    manage(handle) {
+      this.handles.add(handle);
+      return handle;
+    }
+
+    /**
+     * Stop managing the given handle.
+     * @param {Handle} handle The handle to stop managing.
+     * @returns {Handle} The given handle.
+     */
+    unmanage(handle) {
+      this.handles.delete(handle);
+      return handle;
+    }
+
+    release() {
+      this.handles.forEach(handle => {
+        handle.release();
+        this.handles.delete(handle);
+      });
+      return super.release();
+    }
+  }
+  return Handles;
+}

--- a/src/globals/js/mixins/track-blur.js
+++ b/src/globals/js/mixins/track-blur.js
@@ -1,9 +1,11 @@
 import on from '../misc/on';
+import handles from './handles';
 
-export default function(ToMix) {
+function trackBlur(ToMix) {
   class TrackBlur extends ToMix {
     /**
      * Mix-in class to add an handler for losing focus.
+     * @extends Handles
      * @param {HTMLElement} element The element working as this component.
      * @param {Object} [options] The component options.
      */
@@ -11,15 +13,17 @@ export default function(ToMix) {
       super(element, options);
       const hasFocusin = 'onfocusin' in window;
       const focusinEventName = hasFocusin ? 'focusin' : 'focus';
-      this.hFocusIn = on(
-        this.element.ownerDocument,
-        focusinEventName,
-        event => {
-          if (!this.element.contains(event.target)) {
-            this.handleBlur(event);
-          }
-        },
-        !hasFocusin
+      this.manage(
+        on(
+          this.element.ownerDocument,
+          focusinEventName,
+          event => {
+            if (!this.element.contains(event.target)) {
+              this.handleBlur(event);
+            }
+          },
+          !hasFocusin
+        )
       );
     }
 
@@ -30,14 +34,10 @@ export default function(ToMix) {
     handleBlur() {
       throw new Error('Components inheriting TrackBlur mix-in must implement handleBlur() method.');
     }
-
-    release() {
-      if (this.hFocusIn) {
-        this.hFocusIn = this.hFocusIn.release();
-      }
-      super.release();
-    }
   }
 
   return TrackBlur;
 }
+
+const exports = [handles, trackBlur];
+export default exports;


### PR DESCRIPTION
## Overview

This change makes sure all associated event handlers are released when component instance is released.

Fixes #272.

### Added

A mix-in class with `manage(handle)` method, for automatic release of `handle` when the component is released.

### Changed

"X” button handler in file uploader, with event delegation technique, for easier management of event handles.

## Testing / Reviewing

Testing should make sure no component is broken. Automation should cover most of this, and I ran some manuals against all components.