### PR TITLE
fix(number-input): use button for keyboard a11y

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -76,5 +76,11 @@
     fill: $brand-01;
     width: rem(9px);
     height: rem(20px);
+
+    // Hover styles for use with old HTML w/o button
+    &:hover {
+      cursor: pointer;
+      fill: $brand-02;
+    }
   }
 }

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -56,8 +56,10 @@
 
   .bx--number__control-btn {
     @include button-reset;
+    position: relative;
+    bottom: 0;
     width: rem(20px);
-    height: rem(20px);
+    height: rem(10px);
 
     &:focus {
       @include focus-outline;
@@ -75,7 +77,7 @@
   .bx--number__controls svg {
     fill: $brand-01;
     width: rem(9px);
-    height: rem(20px);
+    height: rem(9px);
 
     // Hover styles for use with old HTML w/o button
     &:hover {

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -54,16 +54,27 @@
     align-items: center;
   }
 
-  .bx--number__controls .up-icon,
-  .bx--number__controls .down-icon {
-    fill: $brand-01;
-    width: rem(9px);
+  .bx--number__control-btn {
+    @include button-reset;
+    width: rem(20px);
     height: rem(20px);
-    position: relative;
+
+    &:focus {
+      @include focus-outline;
+    }
 
     &:hover {
       cursor: pointer;
+    }
+
+    &:hover svg {
       fill: $brand-02;
     }
+  }
+
+  .bx--number__controls svg {
+    fill: $brand-01;
+    width: rem(9px);
+    height: rem(20px);
   }
 }

--- a/src/components/number-input/number-input.html
+++ b/src/components/number-input/number-input.html
@@ -4,15 +4,15 @@
     <input id="number-input" type="number" min="0" max="100" value="1">
     <div class="bx--number__controls">
       <button class="bx--number__control-btn up-icon">
-        <svg viewBox="0 -6 10 5" width="10" height="5" fill-rule="evenodd">
+        <svg viewBox="0 2 10 5" width="10" height="5" fill-rule="evenodd">
           <path d="M10 5L5 0 0 5z"></path>
         </svg>
       </button>
       <button class="bx--number__control-btn down-icon">
-        <svg viewBox="0 6 10 5" width="10" height="5" fill-rule="evenodd">
+        <svg viewBox="0 2 10 5" width="10" height="5" fill-rule="evenodd">
           <path d="M10 0L5 5 0 0z"></path>
         </svg>
-    </button>
+      </button>
     </div>
   </div>
 </div>

--- a/src/components/number-input/number-input.html
+++ b/src/components/number-input/number-input.html
@@ -3,12 +3,16 @@
   <div data-numberinput class="bx--number">
     <input id="number-input" type="number" min="0" max="100" value="1">
     <div class="bx--number__controls">
-      <svg class="up-icon" viewBox="0 -6 10 5" width="10" height="5" fill-rule="evenodd">
-        <path d="M10 5L5 0 0 5z"></path>
-      </svg>
-      <svg class="down-icon" viewBox="0 6 10 5" width="10" height="5" fill-rule="evenodd">
-        <path d="M10 0L5 5 0 0z"></path>
-      </svg>
+      <button class="bx--number__control-btn up-icon">
+        <svg viewBox="0 -6 10 5" width="10" height="5" fill-rule="evenodd">
+          <path d="M10 5L5 0 0 5z"></path>
+        </svg>
+      </button>
+      <button class="bx--number__control-btn down-icon">
+        <svg viewBox="0 6 10 5" width="10" height="5" fill-rule="evenodd">
+          <path d="M10 0L5 5 0 0z"></path>
+        </svg>
+    </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Overview

Resolves https://github.ibm.com/Bluemix/carbon-issues/issues/256

- copy `@mixin button-reset` from https://github.com/carbon-design-system/carbon-components/pull/262
- wrap up and down arrows with `<button>` for keyboard a11y