### PR TITLE
feat(Dropdown): add disabled state to dropdown component

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -113,14 +113,7 @@
   }
 
   .bx--dropdown--disabled {
-    background-color: rgba($field-01, 0.05);
-
-    &:first-child .bx--dropdown-text {
-      color: rgba($text-03, 0.5);
-    }
-
-    .bx--dropdown__arrow {
-      fill: rgba($brand-01, 0.5);
-    }
+    opacity: .5;
+    cursor: not-allowed;
   }
 }

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -111,4 +111,16 @@
       }
     }
   }
+
+  .bx--dropdown--disabled {
+    background-color: rgba($field-01, 0.05);
+
+    &:first-child .bx--dropdown-text {
+      color: rgba($text-03, 0.5);
+    }
+
+    .bx--dropdown__arrow {
+      fill: rgba($brand-01, 0.5);
+    }
+  }
 }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -74,8 +74,14 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @param {Event} [event] The event triggering this method.
    */
   _toggle(event) {
-    if (([13, 32, 40].indexOf(event.which) >= 0 && !event.target.matches(this.options.selectorItem))
-    || event.which === 27 || event.type === 'click') {
+    const isDisabled = this.element.classList.contains('bx--dropdown--disabled');
+
+    if (isDisabled) {
+      return;
+    }
+
+    if (([13, 32, 40].indexOf(event.which) >= 0 && !event.target.matches(this.options.selectorItem)) ||
+    event.which === 27 || event.type === 'click') {
       const isOpen = this.element.classList.contains('bx--dropdown--open');
       const isOfSelf = this.element.contains(event.target);
       const actions = {

--- a/tests/spec/dropdown_spec.js
+++ b/tests/spec/dropdown_spec.js
@@ -138,6 +138,12 @@ describe('Dropdown', function () {
       expect(stubFocus, 'Focus requested').not.to.have.been.called;
     });
 
+    it('Should not open when the disabled class is applied', function () {
+      element.classList.add('bx--dropdown--disabled');
+      element.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      expect(element.classList.contains('bx--dropdown--open'), 'Open state').to.be.false;
+    });
+
     afterEach(function () {
       if (stubFocus) {
         stubFocus.restore();


### PR DESCRIPTION
## Overview

Adds an optional 'disabled' class that can be applied to the dropdown component.

<img width="395" alt="screen shot 2017-08-12 at 4 18 48 pm" src="https://user-images.githubusercontent.com/17710824/29244288-06518fb8-7f7a-11e7-990a-f2e50e8653b1.png">

### Added

Added a `--disabled` class to the dropdown scss, as well as an appropriate test.

### Removed

N/A

### Changed

The `_toggle()` method will return if the `bx--dropdown--disabled` class is found on the element.

## Testing / Reviewing

To inspect, add a class of `bx--dropdown--disabled` to the html.