### PR TITLE
fix(scss): re-add eyeglass support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "patterns",
     "sass",
     "scss",
-    "style guide"
+    "style guide",
+    "eyeglass-module"
   ],
   "dependencies": {
     "carbon-icons": "^6.0.4",
@@ -178,5 +179,11 @@
       "name": "Chris Dhanaraj",
       "email": "chrisdhanaraj@us.ibm.com"
     }
-  ]
+  ],
+  "eyeglass": {
+    "sassDir": "scss",
+    "exports": false,
+    "name": "carbon-components",
+    "needs": "^1.2.1"
+  }
 }


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/286

Looks like eyeglass support was added when we were still on GitHub Enterprise but went missing when we migrated to public.