### PR TITLE
fix(dropdown): remove focus when disabled

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -115,5 +115,9 @@
   .bx--dropdown--disabled {
     opacity: .5;
     cursor: not-allowed;
+
+    &:focus {
+      outline: none;
+    }
   }
 }


### PR DESCRIPTION
Removes the focus outline when a disabled dropdown is focused