### PR TITLE
fix(interior-left-nav): fixed background color bug on the left nav

### DIFF
--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -219,7 +219,7 @@
 
     .left-nav-list__item--active > .left-nav-list__item-link {
       position: relative;
-      background-color: #fff;
+      background-color: transparent;
 
       &:before {
         top: 0;


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/180

Changed the active menu item's background to white so it doesn't show up as white when the left nav is collapsed.
