### PR TITLE
fix(checkbox): ensures checkbox minimum width

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -39,6 +39,7 @@
     margin-right: 0.5rem;
     background-color: $ui-01;
     border: $checkbox-border-width solid $ui-05;
+    min-width: 18px;
   }
 
   .bx--checkbox:checked + .bx--checkbox-appearance,


### PR DESCRIPTION
Did not fix Radio button bug because this was due to browser being zoomed. Adding a min-width to the radio button causes weird rendering when not  zoomed. If this becomes a bigger issue we can reopen.

Fixes https://github.com/carbon-design-system/carbon-components/issues/260