### PR TITLE
fix(radio-button): Squished on overflow text

### DIFF
--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -34,6 +34,7 @@
     background-color: $inverse-01;
     border-radius: 50%;
     border: $radio-border-width solid $ui-05;
+    flex-shrink: 0;
     height: rem(18px);
     width: rem(18px);
     margin-right: rem(10px);


### PR DESCRIPTION
## Overview

Resolves #322

Adds flex shrink to prevent distorting radio button. Check it out [here](https://codepen.io/jamesvclements/pen/xXEKVv) by removing the commented out style.