### PR TITLE
fix(scss): Add necessary imports to _order-summary.scss

### DIFF
--- a/src/components/order-summary/_order-summary.scss
+++ b/src/components/order-summary/_order-summary.scss
@@ -4,6 +4,7 @@
 
 @import '../../globals/scss/colors';
 @import '../../globals/scss/mixins';
+@import '../dropdown/_dropdown.scss';
 
 .bx--order-summary {
   @include font-size('14');

--- a/src/components/order-summary/_order-summary.scss
+++ b/src/components/order-summary/_order-summary.scss
@@ -1,3 +1,10 @@
+//-----------------------------
+// Order Summary
+//-----------------------------
+
+@import '../../globals/scss/colors';
+@import '../../globals/scss/mixins';
+
 .bx--order-summary {
   @include font-size('14');
   background-color: $ui-01;


### PR DESCRIPTION
## Overview
`import`ing the `_order-summary.scss` with Webpack was producing errors because it couldn't reference dependencies like `font-size()` mixin. I've added the necessary `@import`s that the .scss file relies on, so that there's no more errors in Webpack.