### PR TITLE
chore(build): fix pushing to bluemix cloud

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,2 +1,1 @@
-node_modules
 templates

--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,2 @@
 templates
+.npmrc

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -346,7 +346,7 @@ gulp.task('watch', () => {
 gulp.task('serve', ['browser-sync', 'watch']);
 
 // Build task collection
-gulp.task('build:scripts', ['scripts:umd', 'scripts:es', 'scripts:compiled']);
+gulp.task('build:scripts', ['scripts:umd', 'scripts:es', 'scripts:compiled', 'scripts:dev']);
 gulp.task('build:styles', ['sass:compiled', 'sass:source']);
 
 // Mapped to npm run build

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: carbon-dev-environment
   memory: 64M
-  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.22
   random-route: true
   env:
     NPM_CONFIG_PRODUCTION: false

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,3 @@ applications:
   memory: 64M
   buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.22
   random-route: true
-  env:
-    NPM_CONFIG_PRODUCTION: false

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: carbon-dev-environment
+  memory: 64M
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git
+  random-route: true
+  env:
+    NPM_CONFIG_PRODUCTION: false

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,5 @@ applications:
   memory: 64M
   buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.22
   random-route: true
+  env:
+    NPM_CONFIG_PRODUCTION: false

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
     "express": "4.13.4",
-    "freshy": "^1.0.3",
     "globby": "4.0.0",
     "gulp": "~3.9.0",
     "gulp-autoprefixer": "~3.0.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "test": "gulp test",
     "test:unit": "gulp test:unit",
     "test:a11y": "gulp test:a11y",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release":
+      "semantic-release pre && npm publish && semantic-release post"
   },
   "license": "Apache-2",
   "config": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "eyeglass-module"
   ],
   "engines": {
-    "node": "^6.0.0 || ^8.0.0"
+    "node": "^6.0.0 || ^8.0.0",
+    "npm": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "carbon-icons": "^6.0.4",
@@ -127,7 +128,7 @@
     "dev": "gulp serve & npm run serve",
     "lint": "gulp lint",
     "prebuild": "gulp clean",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "serve": "nodemon -e dust,js server.js",
     "start": "node server.js",
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eyeglass-module"
   ],
   "engines": {
-    "node": "^6.0.0"
+    "node": "^6.0.0 || ^8.0.0"
   },
   "dependencies": {
     "carbon-icons": "^6.0.4",
@@ -59,6 +59,7 @@
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
     "express": "4.13.4",
+    "freshy": "^1.0.3",
     "globby": "4.0.0",
     "gulp": "~3.9.0",
     "gulp-autoprefixer": "~3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "style guide",
     "eyeglass-module"
   ],
+  "engines": {
+    "node": "^6.0.0"
+  },
   "dependencies": {
     "carbon-icons": "^6.0.4",
     "flatpickr": "2.6.3",


### PR DESCRIPTION
- Vendor the node_modules (so to push, do an npm install / yarn before `cf push`), it's a little faster of a push time.
- Add the scripts:dev to our compile step
- Add a base manifest.yml file
- Pin our engines 
- swap prepublish to prepublishOnly