### PR TITLE
feat(v6): add modifier for V6 header size

### DIFF
--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -22,6 +22,10 @@
     background-color: $color__white;
     border-right: 1px solid $color__gray-1;
 
+    &--v6 {
+      top: rem(50px);
+    }
+
     .left-nav-list {
       list-style: none;
       display: flex;
@@ -255,6 +259,10 @@
       margin-top: auto;
       margin-bottom: rem(90px);
       padding: rem(14px) rem(16px);
+
+      &--v6 {
+        margin-bottom: rem(50px);
+      }
 
       &:hover,
       &:focus {


### PR DESCRIPTION
## Overview

Bluemix is rolling out a new header (V6) that changes its height. This adds a new modifier class to the interior left nav to adjust for that.

<img width="1440" alt="screencap-by-jlengstorf 36" src="https://user-images.githubusercontent.com/163561/30942496-2bac9888-a3b1-11e7-974e-0ecd5fb9b991.png">

### Added

Added `.bx--interior-left-nav--v6` and `.bx--interior-left-nav-collapse--v6` adjusting the 90px height to 50px.

## Testing / Reviewing

Check the interior left nav with the new V6 header.

Sample markup:

```html
<nav role="navigation" aria-label="Interior Left Navigation" data-interior-left-nav class="bx--interior-left-nav bx--interior-left-nav--v6 bx--interior-left-nav--collapseable">
  <ul role="menubar" class="left-nav-list" data-interior-left-nav-list aria-hidden="false">
    <li role="menuitem" tabindex="0" class="left-nav-list__item" data-interior-left-nav-item>
      <a class="left-nav-list__item-link">
        Example Item 1
      </a>
    </li>
    <li role="menuitem" tabindex="0" class="left-nav-list__item" data-interior-left-nav-item>
      <a class="left-nav-list__item-link">
        Example Item 2
      </a>
    </li>
  </ul>

  <div class="bx--interior-left-nav-collapse bx--interior-left-nav-collapse--v6" data-interior-left-nav-collapse>
    <a class="bx--interior-left-nav-collapse__link" href="#">
      <svg class="bx--interior-left-nav-collapse__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
        <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
      </svg>
    </a>
  </div>
</nav>
```
