### PR TITLE
fix(vars): Add colors import to vars

### DIFF
--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -1,3 +1,5 @@
+@import 'colors';
+
 $bx--ease-in: cubic-bezier(0.25, 0, 1, 1); // Used primarily for removing elements from the screen.
 $bx--ease-out: cubic-bezier(
   0,


### PR DESCRIPTION
## Overview
Added the `colors` partial to `_vars.scss`. This prevents webpack errors when trying to import `_modal.scss` in a component that's trying to use the `Modal` component. The following is an error that was being returned:

```bash
ERROR in ./~/css-loader!./~/sass-loader!./~/carbon-components/scss/components/modal/_modal.scss
Module build failed:
$brand-01: $color__blue-51 !default;
          ^
      Undefined variable: "$color--blue-51".
      in /path/to/node_modules/carbon-components/scss/globals/scss/_vars.scss (line 12, column 12)
 @ ./~/carbon-components/scss/components/modal/_modal.scss 4:14-105
```

This PR fixes the dependency errors.