### PR TITLE
feat(typescale): update typescale and mixin

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -77,7 +77,7 @@
     opacity: 0;
 
     p {
-      @include font-size('14');
+      @include typescale('zeta');
     }
   }
 }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -7,7 +7,7 @@
 
 @include exports('breadcrumb') {
   .bx--breadcrumb {
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-family;
     display: none;
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -59,7 +59,7 @@
   }
 
   .bx--card-footer__link {
-    @include font-size('14');
+    @include typescale('zeta');
 
     &:focus {
       @include focus-outline('border');
@@ -81,7 +81,7 @@
   }
 
   .bx--about__title--name {
-    @include font-size('18');
+    @include typescale('delta');
     @include text-overflow(rem(180px));
     font-weight: 400;
     margin: 0;
@@ -89,7 +89,7 @@
   }
 
   .bx--about__title--link {
-    @include font-size('12');
+    @include typescale('omega');
     @include text-overflow(rem(180px));
     display: inline;
     font-weight: 400;
@@ -97,7 +97,7 @@
   }
 
   .bx--about__title--additional-info {
-    @include font-size('12');
+    @include typescale('omega');
     @include text-overflow(rem(180px));
     display: inline;
     font-weight: 400;
@@ -158,7 +158,7 @@
   }
 
   .bx--app-actions__button {
-    @include font-size('16');
+    @include typescale('epsilon');
     display: inline-block;
     padding: 0.125rem 0 0;
     margin: 0 0.175rem;

--- a/src/components/card/_mixins.scss
+++ b/src/components/card/_mixins.scss
@@ -1,6 +1,6 @@
 @mixin app-status($status) {
   @include reset;
-  @include font-size('12');
+  @include typescale('omega');
   display: none;
   align-items: center;
 

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -26,7 +26,7 @@
     @include reset;
     @include font-family;
     @include font-smoothing;
-    @include font-size('14');
+    @include typescale('zeta');
     display: flex;
     align-items: center;
     cursor: pointer;

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -13,7 +13,7 @@
   }
 
   .bx--snippet code {
-    @include font-size('16');
+    @include typescale('epsilon');
   }
 
   .bx--snippet--code .bx--snippet-container {

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -14,7 +14,7 @@
   .bx--content-switcher-btn {
     @include reset;
     @include font-smoothing;
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-family;
     background-color: transparent;
     display: flex;

--- a/src/components/copy-button/_copy-button.scss
+++ b/src/components/copy-button/_copy-button.scss
@@ -24,7 +24,7 @@
 
     &:before {
       @include layer('overlay');
-      @include font-size('12');
+      @include typescale('omega');
       top: 1.1rem;
       padding: 0.5rem 1rem;
       border: 1px solid $ui-04;

--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -26,18 +26,18 @@
 
     td {
       @include reset;
-      font-size: rem(14px);
+      @include typescale('zeta');
       padding: 0 rem(6px);
       vertical-align: middle;
     }
 
     td p {
-      @include font-size('14');
+      @include typescale('zeta');
     }
 
     th {
       @include reset;
-      font-size: rem(12px);
+      @include typescale('omega');
       padding: rem(9px) rem(6px);
       vertical-align: middle;
       font-weight: 700;
@@ -97,8 +97,8 @@
 
   .bx--table-header {
     @include reset;
+    @include typescale('omega');
     font-weight: 700;
-    font-size: rem(12px);
     letter-spacing: 1px;
     text-align: left;
     text-transform: $data-table-heading-transform;

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -38,7 +38,7 @@
   .bx--date-picker__input {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     display: block;
     position: relative;
     height: rem(40px);
@@ -143,7 +143,7 @@
 
   .bx--date-picker__month .flatpickr-current-month,
   .flatpickr-month .flatpickr-current-month {
-    @include font-size('12');
+    @include typescale('omega');
     text-transform: uppercase;
     padding: 0;
   }
@@ -207,14 +207,14 @@
 
   span.bx--date-picker__weekday,
   span.flatpickr-weekday {
-    @include font-size('12');
+    @include typescale('omega');
     font-weight: 700;
     color: $text-01;
   }
 
   .bx--date-picker__day,
   .flatpickr-day {
-    @include font-size('12');
+    @include typescale('omega');
     height: rem(25px);
     width: 1.8rem;
     line-height: rem(25px);

--- a/src/components/detail-page-header/_detail-page-header.scss
+++ b/src/components/detail-page-header/_detail-page-header.scss
@@ -107,9 +107,13 @@
   }
 
   .bx--detail-page-header-title {
-    @include font-size('29');
+    @include typescale('gamma');
     font-weight: 300;
     color: $text-02;
+
+    @include breakpoint(bp--sm--major) {
+      @include typescale('beta');
+    }
   }
 
   .bx--detail-page-header-status-container {

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -16,7 +16,7 @@
   .bx--dropdown {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     position: relative;
     list-style: none;
     display: block;
@@ -104,7 +104,7 @@
     }
 
     .bx--dropdown-list {
-      @include font-size('14');
+      @include typescale('zeta');
       display: flex;
       flex-direction: column;
       background-color: $ui-01;

--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -24,7 +24,7 @@
 
   .bx--label-description {
     @include reset;
-    @include font-size('14');
+    @include typescale('zeta');
     @include line-height('body');
     color: $text-02;
     margin-top: 0.25rem;
@@ -53,7 +53,7 @@
   }
 
   .bx--file-filename {
-    @include font-size('12');
+    @include typescale('omega');
     @include text-overflow(100%);
     display: inline-flex;
     align-items: center;

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -39,7 +39,7 @@
 }
 
 .bx--footer-info__item {
-  @include font-size('18');
+  @include typescale('delta');
   @include line-height('body');
   display: flex;
   flex-direction: column;
@@ -52,7 +52,7 @@
 }
 
 .bx--footer-info__item > .bx--footer-label {
-  @include font-size('14');
+  @include typescale('zeta');
   @include line-height('body');
   margin: 0;
 

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -24,7 +24,7 @@
   .bx--label {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     font-weight: $input-label-weight;
     display: inline-block;
     vertical-align: baseline;
@@ -47,7 +47,7 @@
 
   .bx--form-requirement {
     @include reset;
-    @include font-size('11');
+    @include typescale('omega');
     margin: 0.75rem 0 0;
     max-height: 0;
     overflow: hidden;

--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -66,7 +66,7 @@
         }
 
         &-link {
-          @include font-size('14');
+          @include typescale('zeta');
           color: $color__blue-90;
           font-weight: 400;
           position: relative;
@@ -146,7 +146,7 @@
         opacity: 0;
 
         &-link {
-          @include font-size('14');
+          @include typescale('zeta');
           color: $color__blue-90;
           padding: 0.75rem 1.35rem 0.75rem 4.5rem;
           font-weight: 400;
@@ -246,7 +246,7 @@
     }
 
     .left-nav-list--nested .left-nav-list__item-link {
-      font-size: rem(12px);
+      @include typescale('omega');
       padding-left: rem(40px);
     }
 
@@ -276,10 +276,10 @@
     }
 
     .bx--interior-left-nav-collapse__link {
+      @include typescale('zeta');
       display: flex;
       align-items: center;
       text-decoration: none;
-      font-size: rem(14px);
       padding: 0.25rem;
 
       &:focus {

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -14,7 +14,7 @@
   .bx--link {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-smoothing;
     font-weight: 700;
     color: $brand-01;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -13,7 +13,7 @@
   .bx--list--ordered {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-smoothing;
     margin-left: 2rem;
     line-height: 1.5;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -73,17 +73,15 @@
 
   .bx--modal-header__label {
     @include reset;
-    @include font-size('12');
+    @include typescale('zeta');
     color: $text-01;
     font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
     margin-bottom: rem(8px);
   }
 
   .bx--modal-header__heading {
     @include reset;
-    @include font-size('26');
+    @include typescale('beta');
     font-weight: 300;
     color: $text-02;
   }

--- a/src/components/module/_module.scss
+++ b/src/components/module/_module.scss
@@ -33,7 +33,7 @@
     }
 
     .bx--module__title {
-      @include font-size('14');
+      @include typescale('zeta');
       @include font-smoothing;
       letter-spacing: 0;
       font-weight: 700;
@@ -47,7 +47,7 @@
       padding: 1.5rem;
 
       p {
-        @include font-size('14');
+        @include typescale('zeta');
       }
     }
 

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -15,7 +15,7 @@
     @include reset;
     @include font-family;
     @include font-smoothing;
-    @include font-size('14');
+    @include typescale('zeta');
     display: flex;
     justify-content: space-between;
     background-color: transparent;
@@ -65,14 +65,14 @@
   }
 
   .bx--inline-notification__title {
-    @include font-size('14');
+    @include typescale('zeta');
     font-weight: 700;
     margin-right: 0.25rem;
     line-height: 1.125;
   }
 
   .bx--inline-notification__subtitle {
-    @include font-size('14');
+    @include typescale('zeta');
     line-height: 1.125;
   }
 

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -74,7 +74,7 @@
   }
 
   .bx--toast-notification__title {
-    @include font-size('14');
+    @include typescale('zeta');
     font-weight: 700;
     letter-spacing: 0;
     line-height: 1;
@@ -82,7 +82,7 @@
   }
 
   .bx--toast-notification__subtitle {
-    @include font-size('12');
+    @include typescale('omega');
     color: $text-03;
     margin-top: 0;
     margin-bottom: 1rem;
@@ -90,7 +90,7 @@
   }
 
   .bx--toast-notification__caption {
-    @include font-size('12');
+    @include typescale('omega');
     color: $text-03;
     line-height: 1;
   }

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -12,7 +12,7 @@
   }
 
   .bx--number input[type='number'] {
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-family;
     box-sizing: border-box;
     display: inline-flex;

--- a/src/components/order-summary/_order-summary.scss
+++ b/src/components/order-summary/_order-summary.scss
@@ -7,7 +7,7 @@
 @import '../dropdown/_dropdown.scss';
 
 .bx--order-summary {
-  @include font-size('14');
+  @include typescale('zeta');
   background-color: $ui-01;
   padding-bottom: 1.25rem;
   width: 18rem;
@@ -45,7 +45,7 @@
 }
 
 .bx--order-header-title {
-  @include font-size('14');
+  @include typescale('zeta');
   font-weight: 700;
   flex: 2;
 }
@@ -67,14 +67,14 @@
 }
 
 .bx--order-detail {
-  @include font-size('14');
+  @include typescale('zeta');
   color: $text-02;
   padding-right: 1.25rem;
   line-height: 1.25;
 }
 
 .bx--order-price {
-  @include font-size('12');
+  @include typescale('omega');
   font-weight: 700;
   white-space: nowrap;
 }
@@ -113,14 +113,14 @@
   font-weight: 700;
 
   span {
-    @include font-size('12');
+    @include typescale('omega');
     color: $text-02;
     font-weight: 400;
   }
 }
 
 .bx--order-total-subtitle {
-  @include font-size('11');
+  @include typescale('legal');
   color: $text-02;
   font-style: italic;
 }
@@ -134,7 +134,7 @@
 }
 
 .bx--order-footer-text {
-  @include font-size('14');
+  @include typescale('zeta');
   color: $text-02;
   line-height: 1;
 }
@@ -148,7 +148,7 @@
 }
 
 .bx--order-category-title {
-  @include font-size('12');
+  @include typescale('omega');
   font-weight: 700;
   margin-bottom: rem(4px);
   text-transform: uppercase;

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -86,7 +86,7 @@
 
   .bx--overflow-menu-options__btn {
     @include reset;
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-family;
     font-weight: 400;
     width: 100%;

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -36,7 +36,7 @@ $css--helpers: true;
   }
 
   .bx--pagination__text {
-    @include font-size('12');
+    @include typescale('omega');
     color: $text-02;
     display: none;
 

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -21,7 +21,7 @@
   }
 
   .bx--radio-button__label {
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-family;
     display: flex;
     align-items: center;

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -44,12 +44,12 @@
   }
 
   .bx--search--sm .bx--search-input {
-    @include font-size('14');
+    @include typescale('zeta');
     height: rem(32px);
   }
 
   .bx--search--lg .bx--search-input {
-    @include font-size('14');
+    @include typescale('zeta');
     height: rem(40px);
   }
 

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -18,7 +18,7 @@
 
   .bx--select-input {
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     appearance: none;
     display: block;
     width: 100%;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -49,7 +49,7 @@
   }
 
   .bx--slider__range-label {
-    @include font-size('14');
+    @include typescale('zeta');
     color: $text-02;
 
     &:last-of-type {

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -83,11 +83,10 @@
   .bx--structured-list-th {
     @include reset;
     @include padding-th;
+    @include typescale('zeta');
     display: table-cell;
-    font-size: rem(12px);
     font-weight: 700;
     height: rem(40px);
-    letter-spacing: 1px;
     text-align: left;
     text-transform: $structured-list-text-transform;
     vertical-align: middle;
@@ -100,7 +99,7 @@
 
   .bx--structured-list-td {
     @include reset;
-    @include font-size('14');
+    @include typescale('zeta');
     @include line-height('body');
     @include padding-td;
     position: relative;
@@ -129,6 +128,6 @@
 
   // Deprecated class
   .bx--structured-list-content {
-    @include font-size('14');
+    @include typescale('zeta');
   }
 }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -12,7 +12,7 @@
 
 @include exports('tabs') {
   .bx--tabs {
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-smoothing;
     @include font-family;
     color: $text-01;
@@ -72,7 +72,7 @@
     flex-direction: column;
 
     @include breakpoint(bp--sm--major) {
-      @include font-size('16');
+      @include typescale('epsilon');
       flex-direction: row;
       margin-right: rem(16px);
       margin-left: rem(16px);
@@ -94,7 +94,7 @@
   }
 
   .bx--tabs__nav-item {
-    @include font-size('14');
+    @include typescale('zeta');
     background-color: $ui-01;
     padding: 0;
 

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -6,7 +6,7 @@
 @include exports('tags') {
   .bx--tag {
     @include font-family;
-    @include font-size('12');
+    @include typescale('omega');
     display: inline-flex;
     align-items: center;
     padding: 0 0.625rem;

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -13,7 +13,7 @@
   .bx--text-area {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     width: 100%;
     min-width: 10rem;
     padding: 1rem;

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -13,7 +13,7 @@
   .bx--text-input {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     display: block;
     width: 100%;
     height: rem(40px);

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -24,7 +24,7 @@
   .bx--time-picker__input-field {
     @include reset;
     @include font-family;
-    @include font-size('14');
+    @include typescale('zeta');
     display: flex;
     align-items: center;
     background-color: $field-01;

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -58,7 +58,7 @@
 
   .bx--toggle__text--left,
   .bx--toggle__text--right {
-    @include font-size('14');
+    @include typescale('zeta');
     position: relative;
   }
 

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -104,7 +104,7 @@ $css--helpers: true;
   }
 
   .bx--toolbar-menu__title {
-    @include font-size('12');
+    @include typescale('omega');
     @include letter-spacing;
     font-weight: 700;
     padding: 0.5rem 1.25rem;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -14,7 +14,7 @@
 
   .bx--tooltip__trigger {
     @include font-family;
-    @include font-size('16');
+    @include typescale('epsilon');
     display: inline-flex;
     align-items: center;
     color: $text-01;
@@ -51,7 +51,7 @@
 
     p {
       @include font-family;
-      @include font-size('14');
+      @include typescale('zeta');
     }
 
     .bx--tooltip__label {
@@ -114,7 +114,7 @@
   .bx--tooltip--simple__bottom {
     @include font-family;
     @include reset;
-    @include font-size('18');
+    @include typescale('delta');
     position: relative;
     display: inline-flex;
     align-items: center;
@@ -135,7 +135,7 @@
     }
 
     &:before {
-      @include font-size('14');
+      @include typescale('zeta');
       @include layer('overlay');
       max-width: rem(240px);
       padding: 1.5rem;

--- a/src/components/unified-header/_account-switcher.scss
+++ b/src/components/unified-header/_account-switcher.scss
@@ -53,7 +53,7 @@
   }
 
   .bx--account-switcher__toggle--text {
-    @include font-size('11');
+    @include typescale('legal');
     letter-spacing: 0.5px;
     overflow: hidden;
     display: inline-flex;
@@ -151,7 +151,7 @@
       padding: 0.75rem 0 1rem 1.5rem;
 
       a {
-        @include font-size('11');
+        @include typescale('legal');
         padding-right: 1rem;
         color: $color__blue-30; // anna
 
@@ -167,9 +167,9 @@
   }
 
   .bx--account-switcher__menu__item--title {
-    @include font-size('14');
+    @include typescale('zeta');
     @include font-smoothing;
-    font-weight: 700;
+    font-weight: 600;
     height: 44px;
     min-width: 100px;
     display: flex;
@@ -178,7 +178,7 @@
   }
 
   .bx--account-switcher__menu__item .bx--dropdown {
-    @include font-size('14');
+    @include typescale('zeta');
     flex: 3;
     background-color: $color__navy-gray-5; // anna
     display: block;

--- a/src/components/unified-header/_global-header.scss
+++ b/src/components/unified-header/_global-header.scss
@@ -66,7 +66,7 @@
   }
 
   .bx--global-header .bx--logo__text {
-    @include font-size('18');
+    @include typescale('delta');
     @include font-smoothing;
     font-weight: 400;
     cursor: pointer;
@@ -119,8 +119,8 @@
   .bx--global-header__menu__item--link {
     @include reset;
     @include font-smoothing;
-    @include font-size('14');
-    font-weight: 700;
+    @include typescale('zeta');
+    font-weight: 600;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/unified-header/_left-nav.scss
+++ b/src/components/unified-header/_left-nav.scss
@@ -68,10 +68,10 @@
   }
 
   .bx--left-nav__header--title {
-    @include font-size('16');
+    @include typescale('epsilon');
     @include font-smoothing;
     color: $inverse-01;
-    font-weight: 700;
+    font-weight: 600;
     margin-right: auto;
   }
 
@@ -123,7 +123,7 @@
 
       .bx--left-nav__section--link {
         @include font-smoothing;
-        font-weight: 700;
+        font-weight: 600;
         color: $inverse-01;
       }
 
@@ -199,7 +199,7 @@
 
   .bx--left-nav__section--link {
     @include reset;
-    @include font-size('16');
+    @include typescale('epsilon');
     display: flex;
     align-items: center;
     color: $text-01;
@@ -254,7 +254,7 @@
 
   .bx--parent-item__link {
     @include reset;
-    @include font-size('14');
+    @include typescale('zeta');
     font-weight: 400;
     display: flex;
     align-items: center;
@@ -405,7 +405,7 @@
   }
 
   .bx--nested-list__item--link {
-    @include font-size('14');
+    @include typescale('zeta');
     color: $text-01;
     padding: 0.5rem 1.35rem 0.5rem 2rem;
     font-weight: 400;
@@ -523,7 +523,7 @@
   }
 
   .bx--flyout-menu__item--link {
-    @include font-size('14');
+    @include typescale('zeta');
     padding: 0 1.75rem 0 1rem;
     color: $text-01;
     text-decoration: none;

--- a/src/components/unified-header/_topnav.scss
+++ b/src/components/unified-header/_topnav.scss
@@ -28,7 +28,7 @@
   .bx--top-nav__left-container,
   .bx--top-nav__right-container {
     .bx--dropdown {
-      @include font-size('12');
+      @include typescale('omega');
       list-style: none;
       background-color: $nav-01;
       color: $inverse-01;
@@ -50,7 +50,7 @@
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      font-weight: 700;
+      font-weight: 600;
     }
 
     .bx--dropdown-list {
@@ -108,7 +108,7 @@
   }
 
   .bx--top-nav__left-container__link {
-    @include font-size('11');
+    @include typescale('legal');
     @include font-smoothing;
     display: flex;
     justify-content: flex-start;
@@ -116,7 +116,7 @@
     align-items: flex-start;
     text-decoration: none;
     color: $inverse-01;
-    font-weight: 700;
+    font-weight: 600;
     margin-right: 1rem;
 
     &:hover,
@@ -256,25 +256,25 @@
 
     .bx--dropdown__trial-content .bx--link,
     .bx--dropdown__credit-content .bx--link {
-      @include font-size('11');
+      @include typescale('legal');
       color: $color__blue-30; // anna
       margin-top: 1rem;
       text-align: center;
     }
 
     .bx--dropdown__trial-content--desc {
-      @include font-size('12');
+      @include typescale('omega');
     }
 
     .bx--dropdown__credit-content div {
       .bx--dropdown__credit-content--heading {
         @include font-smoothing;
-        @include font-size('12');
+        @include typescale('omega');
         font-weight: 600;
       }
 
       .bx--dropdown__credit-content--desc {
-        @include font-size('14');
+        @include typescale('zeta');
       }
 
       &:last-child {
@@ -368,8 +368,8 @@
 
     p {
       @include font-smoothing;
-      @include font-size('14');
-      font-weight: 700;
+      @include typescale('zeta');
+      font-weight: 600;
     }
   }
 
@@ -379,7 +379,7 @@
     align-items: center;
 
     a {
-      @include font-size('12');
+      @include typescale('omega');
       color: $color__blue-30; // anna
 
       &:hover {

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -8,13 +8,14 @@
 @mixin typography {
   // really big
   .bx--type-giga {
-    @include font-size('74');
+    @include typescale('giga');
     @include reset;
     @include line-height('heading');
     font-weight: 300;
   }
+
   .bx--type-mega {
-    @include font-size('52');
+    @include typescale('mega');
     @include reset;
     @include line-height('heading');
     font-weight: 300;
@@ -22,22 +23,25 @@
 
   // really small
   .bx--type-omega {
-    @include font-size('12');
+    @include typescale('omega');
     @include reset;
     @include line-height('heading');
     @include letter-spacing;
-    font-weight: 700;
-    text-transform: uppercase;
+    font-weight: 600;
   }
+
   .bx--type-caption {
-    @include font-size('12');
+    @include typescale('caption');
     @include reset;
     @include line-height('body');
+    font-weight: 400;
   }
+
   .bx--type-legal {
-    @include font-size('11');
+    @include typescale('legal');
     @include reset;
     @include line-height('body');
+    font-weight: 400;
   }
 
   .bx--type-caps {
@@ -52,8 +56,9 @@
 
   p {
     @include reset;
-    @include font-size('16');
+    @include typescale('p');
     @include line-height('body');
+    font-weight: 400;
   }
 
   em {
@@ -69,46 +74,52 @@
   h1,
   .bx--type-alpha {
     @include reset;
-    @include font-size('32');
+    @include typescale('alpha');
     @include line-height('heading');
     @include letter-spacing;
+    font-weight: 300;
   }
 
   h2,
   .bx--type-beta {
     @include reset;
-    @include font-size('26');
+    @include typescale('beta');
     @include line-height('heading');
     @include letter-spacing;
+    font-weight: 300;
   }
 
   h3,
   .bx--type-gamma {
     @include reset;
-    @include font-size('20');
+    @include typescale('gamma');
     @include line-height('heading');
     @include letter-spacing;
+    font-weight: 300;
   }
 
   h4,
   .bx--type-delta {
     @include reset;
-    @include font-size('18');
+    @include typescale('delta');
     @include line-height('heading');
+    font-weight: 600;
   }
 
   h5,
   .bx--type-epsilon {
     @include reset;
-    @include font-size('16');
+    @include typescale('epsilon');
     @include line-height('heading');
+    font-weight: 600;
   }
 
   h6,
   .bx--type-zeta {
     @include reset;
-    @include font-size('14');
+    @include typescale('zeta');
     @include line-height('heading');
+    font-weight: 600;
   }
 }
 

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -2,27 +2,28 @@
 
 $base-font-size: 16px !default; // Default, Use with em() and rem() functions
 
-$major-second-typescale-map: (
-  '11' : 0.6875rem,
-  '12' : 0.75rem,
-  '14' : 0.875rem,
-  '16' : 1rem,
-  '18' : 1.125rem,
-  '20' : 1.25rem,
-  '23' : 1.4375rem,
-  '26' : 1.625rem,
-  '29' : 1.8125rem,
-  '32' : 2rem,
-  '36' : 2.25rem,
-  '41' : 2.5625rem,
-  '46' : 2.875rem,
-  '52' : 3.25rem,
-  '58' : 3.625rem,
-  '66' : 4.125rem,
-  '74' : 4.625rem,
-  '83' : 5.1875rem,
-  '94' : 5.875rem
+$typescale-map: (
+  'giga'    : 4.75rem,
+  'mega'    : 3.375rem,
+  'alpha'   : 2.25rem,
+  'beta'    : 1.75rem,
+  'gamma'   : 1.25rem,
+  'delta'   : 1.125rem,
+  'epsilon' : 1rem,
+  'zeta'    : 0.875rem,
+  'omega'   : 0.75rem,
+  'caption' : 0.75rem,
+  'legal'   : 0.6875rem,
+  'p'       : 1rem,
 );
+
+@mixin typescale($size) {
+  @if map-has-key($typescale-map, $size) {
+    font-size: map-get($typescale-map, $size);
+  } @else {
+    @warn 'This is not a step of the Carbon Type Scale!';
+  }
+}
 
 @function rem($px) {
   @return ($px / $base-font-size) * 1rem;
@@ -37,14 +38,6 @@ $major-second-typescale-map: (
     font-family: 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif;
   } @else {
     font-family: 'IBM Helvetica', Helvetica Neue, HelveticaNeue, Helvetica, sans-serif;
-  }
-}
-
-@mixin font-size($size) {
-  @if map-has-key($major-second-typescale-map, $size) {
-    font-size: map-get($major-second-typescale-map, $size);
-  } @else {
-    @warn 'This is not a step of the Bluemix Type Scale!';
   }
 }
 
@@ -68,4 +61,37 @@ $major-second-typescale-map: (
 // Only applied to h1, h2, h3, bold weights and always to All Caps.
 @mixin letter-spacing {
   letter-spacing: 0.5px;
+}
+
+// ☠️ Deprecated ☠️
+$major-second-typescale-map: (
+  '11' : 0.6875rem,
+  '12' : 0.75rem,
+  '14' : 0.875rem,
+  '16' : 1rem,
+  '18' : 1.125rem,
+  '20' : 1.25rem,
+  '23' : 1.4375rem,
+  '26' : 1.625rem,
+  '29' : 1.8125rem,
+  '32' : 2rem,
+  '36' : 2.25rem,
+  '41' : 2.5625rem,
+  '46' : 2.875rem,
+  '52' : 3.25rem,
+  '58' : 3.625rem,
+  '66' : 4.125rem,
+  '74' : 4.625rem,
+  '83' : 5.1875rem,
+  '94' : 5.875rem
+);
+
+// ☠️ Deprecated ☠️
+@mixin font-size($size) {
+  @if map-has-key($major-second-typescale-map, $size) {
+    font-size: map-get($major-second-typescale-map, $size);
+    @warn 'This mixin will be deprecated in V9';
+  } @else {
+    @warn 'This is not a step of the Carbon Type Scale!';
+  }
 }

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -40,10 +40,10 @@ $nav-08: $color__blue-51 !default;
 
 // Global
 $input-border: 1px solid transparent !default;
-$input-label-weight: 700 !default;
+$input-label-weight: 600 !default;
 
 // Button Theme Variables
-$button-font-weight: 700 !default;
+$button-font-weight: 600 !default;
 $button-font-size: 0.875rem !default;
 $button-border-radius: 0 !default;
 $button-height: 40px !default;
@@ -91,4 +91,4 @@ $radio-border-width: 2px !default;
 
 // Structured Theme Variables
 $structured-list-padding: 2rem !default;
-$structured-list-text-transform: uppercase !default;
+$structured-list-text-transform: none !default;

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -8,7 +8,7 @@ $css--body: true !default;
 $css--use-layer: true !default;
 $css--reset: true !default;
 $css--typography: true !default;
-$css--plex: true !default;
+$css--plex: false !default;
 
 @import 'colors';
 @import 'vars';


### PR DESCRIPTION
## Overview

Update Carbon Components to new typescale

Closes https://github.ibm.com/Bluemix/carbon-issues/issues/348

### Added

A new typescale, based on [this](https://media.github.ibm.com/user/380/files/8ac73bcc-ad14-11e7-9215-570774223778).
A new `typescale` mixin: `@include typescale('zeta');`

![screen shot 2017-10-11 at 4 17 37 pm](https://user-images.githubusercontent.com/11928039/31467483-bb2e36e4-ae9f-11e7-9ee2-a597a168221b.png)

### Removed
 
Marked the old `font-size` mixin as deprecated. Will be removed in V9.

### Changed

Removed all references to `@include font-size` and replaced with `@include typescale`

## Testing / Reviewing

Make sure no type look wacky? 🙃
