### PR TITLE
Slider use number input

### DIFF
--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -105,12 +105,17 @@
     display: none;
   }
 
-  .bx-slider-text-input {
-    width: rem(32px);
+  .bx--slider-text-input {
+    width: rem(44px);
     min-width: 0;
     height: 2rem;
     padding: 0;
     text-align: center;
     font-weight: 600;
+    -moz-appearance: textfield;
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      display: none;
+    }
   }
 }

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -105,7 +105,8 @@
     display: none;
   }
 
-  .bx--slider-text-input {
+  .bx--slider-text-input,
+  .bx-slider-text-input {
     width: rem(44px);
     min-width: 0;
     height: 2rem;

--- a/src/components/slider/slider.html
+++ b/src/components/slider/slider.html
@@ -10,7 +10,7 @@
       <input id="slider" class="bx--slider__input" type="range" step="1" min="0" max="100" value="50">
     </div>
     <span class="bx--slider__range-label">100</span>
-    <input id="slider-input-box" type="text" class="bx--text-input bx-slider-text-input" placeholder="0">
+    <input id="slider-input-box" type="number" class="bx--text-input bx--slider-text-input" placeholder="0">
   </div>
 </div>
 </div>

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -28,6 +28,13 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
       this.boundInput.addEventListener('change', evt => {
         this.setValue(evt.target.value);
       });
+      this.boundInput.addEventListener('focus', evt => {
+        evt.target.select();
+      });
+      // workaround for safari
+      this.boundInput.addEventListener('mouseup', evt => {
+        evt.preventDefault();
+      });
     }
 
     this._updatePosition();


### PR DESCRIPTION
## Overview

Helps resolve [#278](https://github.com/carbon-design-system/carbon-components-react/issues/278) from the react repo.

Changes the input on the slider to be a number input, and selects it on focus. Added some webkit styles to remove the increment / decrement arrows. 

## Testing / Reviewing

Verified in Chrome, Firefox, Safari. Input type=number isn't supported in Edge 
