### PR TITLE
chore(build): remove old sauce lab integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "karma-mocha-reporter": "~1.1.5",
     "karma-rollup-preprocessor": "^5.0.0",
     "karma-safari-launcher": "^1.0.0",
-    "karma-sauce-launcher": "^1.1.0",
     "karma-sinon-chai": "^1.1.0",
     "karma-sourcemap-loader": "~0.3.7",
     "lolex": "1.4.0",
@@ -113,15 +112,7 @@
     "validate-commit-msg": "^2.8.2",
     "vinyl-named": "^1.1.0"
   },
-  "files": [
-    "css/**/*",
-    "es/**/*",
-    "html/**/*",
-    "scripts/**/*",
-    "scss/**/*",
-    "src/**/*",
-    "umd/**/*"
-  ],
+  "files": ["css/**/*", "es/**/*", "html/**/*", "scripts/**/*", "scss/**/*", "src/**/*", "umd/**/*"],
   "scripts": {
     "build": "gulp build",
     "build-dev": "gulp build:dev",
@@ -146,17 +137,7 @@
       "maxSubjectLength": 100,
       "subjectPattern": ".+",
       "subjectPatternErrorMsg": "Subject does not match subject pattern!",
-      "types": [
-        "chore",
-        "docs",
-        "feat",
-        "fix",
-        "perf",
-        "refactor",
-        "revert",
-        "style",
-        "test"
-      ],
+      "types": ["chore", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"],
       "warnOnFail": false
     }
   },

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -28,81 +28,12 @@ const cloptions = require('minimist')(process.argv.slice(2), {
     b: 'browsers',
     f: 'files',
     d: 'debug',
-    s: 'sauce',
     v: 'verbose',
   },
   boolean: ['debug', 'verbose'],
 });
 
 const customLaunchers = {
-  sl_chrome_sierra: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.12',
-    browserName: 'chrome',
-  },
-  sl_chrome_linux: {
-    base: 'SauceLabs',
-    platform: 'Linux',
-    browserName: 'chrome',
-  },
-  sl_chrome_win7: {
-    base: 'SauceLabs',
-    platform: 'Windows 7',
-    browserName: 'chrome',
-  },
-  sl_chrome_android: {
-    base: 'SauceLabs',
-    platform: 'Android',
-    browserName: 'chrome',
-  },
-  sl_firefox_sierra: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.12',
-    browserName: 'firefox',
-    version: '45',
-  },
-  sl_firefox_linux: {
-    base: 'SauceLabs',
-    platform: 'Linux',
-    browserName: 'firefox',
-    version: '45',
-  },
-  sl_firefox_win7: {
-    base: 'SauceLabs',
-    platform: 'Windows 7',
-    browserName: 'firefox',
-    version: '45',
-  },
-  sl_safari_sierra: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.12',
-    browserName: 'safari',
-    version: '10',
-  },
-  sl_safari_elcapitan: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.11',
-    browserName: 'safari',
-    version: '10',
-  },
-  sl_microsoftedge_win10: {
-    base: 'SauceLabs',
-    version: 14,
-    platform: 'Windows 10',
-    browserName: 'microsoftedge',
-  },
-  sl_ie_win10: {
-    base: 'SauceLabs',
-    version: 11,
-    platform: 'Windows 10',
-    browserName: 'internet explorer',
-  },
-  sl_ie_win7: {
-    base: 'SauceLabs',
-    version: 11,
-    platform: 'Windows 7',
-    browserName: 'internet explorer',
-  },
   Chrome_Travis: {
     base: 'Chrome',
     flags: ['--no-sandbox'],
@@ -113,34 +44,12 @@ const customLaunchers = {
   },
 };
 
-const sauceLaunchers = {
-  chrome: ['sl_chrome_sierra', 'sl_chrome_linux', 'sl_chrome_win7', 'sl_chrome_android'],
-  firefox: ['sl_firefox_sierra', 'sl_firefox_linux', 'sl_firefox_win7'],
-  safari: ['sl_safari_sierra', 'sl_safari_elcapitan'],
-  microsoftedge: ['sl_microsoftedge_win10'],
-  ie: ['sl_ie_win10', 'sl_ie_win7'],
-};
-
 const travisLaunchers = {
   chrome: 'Chrome_Travis',
 };
 
 module.exports = function(config) {
   const objectToStringPolyfillPath = require.resolve('core-js/library/modules/es6.object.to-string.js');
-
-  if (cloptions.sauce) {
-    if (!process.env.TRAVIS) {
-      throw new Error(
-        [
-          'You need extra caution when you run Sauce testing locally.',
-          'You can comment out lines here if you know what you are doing.',
-        ].join(' ')
-      );
-    }
-    if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
-      throw new Error('Missing SAUCE_USERNAME or SAUCE_ACCESS_KEY environment variables.');
-    }
-  }
 
   config.set({
     basePath: '..',
@@ -236,14 +145,6 @@ module.exports = function(config) {
     },
 
     customLaunchers,
-
-    sauceLabs: {
-      testName: `carbon-components #${process.env.TRAVIS_BUILD_NUMBER} (${process.env.TRAVIS_BUILD_ID})`,
-      buildLabel: `TRAVIS #${process.env.TRAVIS_BUILD_NUMBER} (${process.env.TRAVIS_BUILD_ID})`,
-      recordScreenshots: true,
-      tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
-    },
-
     plugins: [
       require('karma-mocha'),
       require('karma-sinon-chai'),
@@ -255,7 +156,7 @@ module.exports = function(config) {
       require('karma-firefox-launcher'),
       require('karma-safari-launcher'),
       require('karma-ie-launcher'),
-    ].concat(cloptions.sauce ? [require('karma-sauce-launcher')] : []),
+    ],
 
     reporters: (() => {
       const reporters = ['mocha'];
@@ -314,9 +215,7 @@ module.exports = function(config) {
     browsers: flatten(
       ensureArray(cloptions.browsers || 'ChromeHeadless').map(browser => {
         const browserLower = browser.toLowerCase();
-        return (
-          (cloptions.sauce && sauceLaunchers[browserLower]) || (process.env.TRAVIS && travisLaunchers[browserLower]) || browser
-        );
+        return (process.env.TRAVIS && travisLaunchers[browserLower]) || browser;
       })
     ),
 


### PR DESCRIPTION
As it is currently, none of the Carbon dev's have access to the Sauce Labs integration / have worked with it. Removing it for now.