### PR TITLE
fix(letter-spacing): remove letter-spacing from typography files

### DIFF
--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -26,7 +26,6 @@
     @include typescale('omega');
     @include reset;
     @include line-height('heading');
-    @include letter-spacing;
     font-weight: 600;
   }
 
@@ -76,7 +75,6 @@
     @include reset;
     @include typescale('alpha');
     @include line-height('heading');
-    @include letter-spacing;
     font-weight: 300;
   }
 
@@ -85,7 +83,6 @@
     @include reset;
     @include typescale('beta');
     @include line-height('heading');
-    @include letter-spacing;
     font-weight: 300;
   }
 
@@ -94,7 +91,6 @@
     @include reset;
     @include typescale('gamma');
     @include line-height('heading');
-    @include letter-spacing;
     font-weight: 300;
   }
 

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -62,7 +62,6 @@ $typescale-map: (
   -moz-osx-font-smoothing: grayscale;
 }
 
-// Only applied to h1, h2, h3, bold weights and always to All Caps.
 @mixin letter-spacing {
   letter-spacing: 0.5px;
 }


### PR DESCRIPTION
Removed `@include letter-spacing` from base heading styles