### PR TITLE
fix(number-input): make sure numbers do not extend under controls

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -19,6 +19,7 @@
     width: 100%;
     min-width: 9.375rem;
     padding-left: 1rem;
+    padding-right: 2rem;
     font-weight: 300;
     height: rem(40px);
     color: $text-01;

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -20,6 +20,7 @@
     color: $text-01;
     background-color: $field-01;
     border: $input-border;
+    resize: vertical;
 
     &:focus {
       @include focus-outline('border');


### PR DESCRIPTION
- Makes sure numbers never appear under controls.
- Also restricts `TextArea` resizing to only vertical