### PR TITLE
fix(data-table): add transition to items when toolbar is active

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-action.scss
+++ b/src/components/data-table-v2/_data-table-v2-action.scss
@@ -148,15 +148,19 @@
   @include button-reset(auto);
   @include typescale('zeta');
   -webkit-font-smoothing: auto;
-  font-weight: 400;
   color: $ui-01;
   border-bottom: 1px solid $ui-01;
-  letter-spacing: 1;
+  font-weight: 600;
   cursor: pointer;
+}
 
-  &:hover,
-  &:focus {
-    letter-spacing: 0;
-    font-weight: 700;
-  }
+.bx--batch-actions ~ .bx--toolbar-search-container,
+.bx--batch-actions ~ .bx--toolbar-content {
+  opacity: 1;
+  transition: opacity $transition--base;
+}
+
+.bx--batch-actions--active ~ .bx--toolbar-search-container,
+.bx--batch-actions--active ~ .bx--toolbar-content {
+  opacity: 0;
 }

--- a/src/components/data-table-v2/data-table-v2--pagination.html
+++ b/src/components/data-table-v2/data-table-v2--pagination.html
@@ -1,5 +1,35 @@
 <div class="bx--data-table-v2-container" data-table-v2>
   <section class="bx--table-toolbar">
+
+    <div class="bx--batch-actions" aria-label="Table Action Bar">
+      <div class="bx--action-list">
+        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+          Ghost
+          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
+          </svg>
+        </button>
+
+        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+          Ghost
+          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
+          </svg>
+        </button>
+
+        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+          Ghost
+          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
+          </svg>
+        </button>
+      </div>
+      <div class="bx--batch-summary">
+        <p class="bx--batch-summary__para">
+          <span data-items-selected>3</span> items selected</p>
+        <button data-event="action-bar-cancel" class="bx--batch-summary__cancel">Cancel</button>
+      </div>
+    </div>
     <div class="bx--toolbar-search-container">
       <div data-search class="bx--search bx--search--sm" role="search">
         <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
@@ -38,35 +68,7 @@
       <button class="bx--btn bx--btn--sm bx--btn--primary">Add new</button>
     </div>
 
-    <div class="bx--batch-actions" aria-label="Table Action Bar">
-      <div class="bx--action-list">
-        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
-          Ghost
-          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
-          </svg>
-        </button>
 
-        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
-          Ghost
-          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
-          </svg>
-        </button>
-
-        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
-          Ghost
-          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
-          </svg>
-        </button>
-      </div>
-      <div class="bx--batch-summary">
-        <p class="bx--batch-summary__para">
-          <span data-items-selected>3</span> items selected</p>
-        <button data-event="action-bar-cancel" class="bx--batch-summary__cancel">Cancel</button>
-      </div>
-    </div>
   </section>
 
   <table class="bx--data-table-v2">

--- a/src/components/data-table-v2/data-table-v2.html
+++ b/src/components/data-table-v2/data-table-v2.html
@@ -1,5 +1,35 @@
 <div class="bx--data-table-v2-container" data-table-v2>
   <section class="bx--table-toolbar">
+    <div class="bx--batch-actions" aria-label="Table Action Bar">
+      <div class="bx--action-list">
+        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+          Ghost
+          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
+          </svg>
+        </button>
+
+        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+          Ghost
+          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
+          </svg>
+        </button>
+
+        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+          Ghost
+          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
+          </svg>
+        </button>
+      </div>
+      <div class="bx--batch-summary">
+        <p class="bx--batch-summary__para">
+          <span data-items-selected>3</span> items selected</p>
+        <button data-event="action-bar-cancel" class="bx--batch-summary__cancel">Cancel</button>
+      </div>
+    </div>
+
     <div class="bx--toolbar-search-container">
       <div data-search class="bx--search bx--search--sm" role="search">
         <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
@@ -36,36 +66,6 @@
       </button>
 
       <button class="bx--btn bx--btn--sm bx--btn--primary">Add new</button>
-    </div>
-
-    <div class="bx--batch-actions" aria-label="Table Action Bar">
-      <div class="bx--action-list">
-        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
-          Ghost
-          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
-          </svg>
-        </button>
-
-        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
-          Ghost
-          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
-          </svg>
-        </button>
-
-        <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
-          Ghost
-          <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-            <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
-          </svg>
-        </button>
-      </div>
-      <div class="bx--batch-summary">
-        <p class="bx--batch-summary__para">
-          <span data-items-selected>3</span> items selected</p>
-        <button data-event="action-bar-cancel" class="bx--batch-summary__cancel">Cancel</button>
-      </div>
     </div>
   </section>
 

--- a/src/globals/scss/_css--reset.scss
+++ b/src/globals/scss/_css--reset.scss
@@ -110,6 +110,15 @@
       vertical-align: baseline;
     }
 
+    // Chrome 62 fix
+    button,
+    input[type="button"],
+    input[type="submit"],
+    input[type="reset"],
+    input[type="file"] {
+      border-radius: 0;
+    }
+
     /* HTML5 display-role reset for older browsers */
     article,
     aside,


### PR DESCRIPTION
- Reordered `data-table-v2` so that the search bar is hidden when toolbar is active to avoid rendering issues when the toolbar is hidden
- Added `border-radius: 0` to reset buttons on Chrome v62