### PR TITLE
fix(slider): update animation, increase input width

### DIFF
--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -84,10 +84,13 @@
     border-radius: 50%;
     top: 0;
     transform: translate(-50%, -50%);
-    transition: transform 100ms $bx--standard-easing, background 100ms $bx--standard-easing,
-      left $transition--base $bx--standard-easing;
+    transition: transform 100ms $bx--standard-easing, background 100ms $bx--standard-easing;
     cursor: pointer;
     outline: none;
+
+    &--clicked {
+      transition: left $transition--base $bx--standard-easing;
+    }
 
     &:hover {
       transform: translate(-50%, -50%) scale(1.05);
@@ -107,7 +110,7 @@
 
   .bx--slider-text-input,
   .bx-slider-text-input {
-    width: rem(44px);
+    width: rem(60px);
     min-width: 0;
     height: 2rem;
     padding: 0;

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -119,6 +119,12 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
         }
       }
       if (type === 'mousemove' || type === 'click') {
+        if (type === 'click') {
+          document.querySelector(this.options.selectorThumb).classList.add('bx--slider__thumb--clicked');
+        } else {
+          document.querySelector(this.options.selectorThumb).classList.remove('bx--slider__thumb--clicked');
+        }
+
         const track = this.track.getBoundingClientRect();
         const unrounded = (evt.clientX - track.left) / track.width;
         const rounded = Math.round(range * unrounded / step) * step;


### PR DESCRIPTION
Resolves https://github.com/carbon-design-system/carbon-components/issues/320

Ensures a smooth animation when dragging, while maintaining the original easing curve when clicked. Also increased the input width to accommodate numbers up to 4 digits (can be overridden as needed)