### PR TITLE
fix(tooltip): add touch listeners to tooltip

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -120,9 +120,9 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
       }
       if (type === 'mousemove' || type === 'click') {
         if (type === 'click') {
-          document.querySelector(this.options.selectorThumb).classList.add('bx--slider__thumb--clicked');
+          this.element.querySelector(this.options.selectorThumb).classList.add('bx--slider__thumb--clicked');
         } else {
-          document.querySelector(this.options.selectorThumb).classList.remove('bx--slider__thumb--clicked');
+          this.element.querySelector(this.options.selectorThumb).classList.remove('bx--slider__thumb--clicked');
         }
 
         const track = this.track.getBoundingClientRect();

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -13,7 +13,7 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
    */
   constructor(element, options) {
     super(element, options);
-    ['mouseover', 'mouseout', 'focus', 'blur'].forEach(name => {
+    ['mouseover', 'mouseout', 'focus', 'blur', 'touchleave', 'touchcancel'].forEach(name => {
       this.element.addEventListener(name, event => {
         this._handleHover(event);
       });
@@ -66,6 +66,8 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
       mouseout: 'hidden',
       focus: 'shown',
       blur: 'hidden',
+      touchleave: 'hidden',
+      touchcancel: 'hidden',
     }[event.type];
     this.changeState(state, getLaunchingDetails(event));
   }


### PR DESCRIPTION
Resolves: https://github.com/carbon-design-system/carbon-components/issues/381

Adds in specific touch listeners so that `tooltip` is closed on blur on mobile