### PR TITLE
fix(loading): ensure loading overlay stays above components

### DIFF
--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -49,6 +49,7 @@ $loading__size: 10.5rem;
     justify-content: center;
     align-items: center;
     transition: background-color 2000ms $bx--standard-easing;
+    z-index: z('overlay');
   }
 
   .bx--loading-overlay--stop {


### PR DESCRIPTION
Fixes https://github.com/carbon-design-system/carbon-components/issues/403