### PR TITLE
fix(search): hide x icon on IE

### DIFF
--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -41,6 +41,10 @@
       @include placeholder-colors;
       font-weight: 400;
     }
+
+    &::-ms-clear {
+      display: none;
+    }
   }
 
   .bx--search--sm .bx--search-input {

--- a/src/globals/scss/_css--reset.scss
+++ b/src/globals/scss/_css--reset.scss
@@ -119,6 +119,10 @@
       border-radius: 0;
     }
 
+    input[type="text"]::-ms-clear {
+      display: none;
+    }
+
     /* HTML5 display-role reset for older browsers */
     article,
     aside,


### PR DESCRIPTION
Hides the X icon added on IE11 search inputs.

Closes https://github.com/carbon-design-system/carbon-components/issues/412