### PR TITLE
feat: css to support parent element of ExpandedLeftNavList

### DIFF
--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -69,6 +69,11 @@
             }
           }
 
+          &__item-label {
+            @include typescale('zeta');
+            cursor: default;
+          }
+
           &-link {
             @include typescale('zeta');
             color: $color__blue-90;
@@ -245,7 +250,8 @@
       }
 
       .left-nav-list__item-link,
-      .left-nav-list--nested .left-nav-list__item-link {
+      .left-nav-list--nested .left-nav-list__item-link,
+      .left-nav-list__item-label {
         padding: rem(9px) rem(20px);
       }
 


### PR DESCRIPTION
ExpandedLeftNavList would be a new component in carbon-components-react that would support the lists to be expanded all the time

## Overview

Our watson console wants to support the LeftNav to have the nested child elements to be expanded all the time

### Added

css for the parent item as we dont want it to be a link
