### PR TITLE
chore(build): support source map in dev build

### DIFF
--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -16,7 +16,7 @@ module.exports = {
     }),
     commonjs({
       include: 'node_modules/**',
-      sourceMap: false,
+      sourceMap: true,
     }),
     babel({
       exclude: 'node_modules/**',
@@ -27,4 +27,5 @@ module.exports = {
     }),
   ],
   file: 'demo/demo.js',
+  sourcemap: 'inline',
 };


### PR DESCRIPTION
## Overview

The dev build missed source map. This PR fixes that.

### Added

Source map support for demo build.

## Testing / Reviewing

Testing should make sure dev env is not broken.