### PR TITLE
fix(overflow-menu): make trigger button toggle overflow menu

### DIFF
--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -27,11 +27,17 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     this.manage(
       on(this.element.ownerDocument, 'click', event => {
         this._handleDocumentClick(event);
+        this.wasOpenBeforeClick = undefined;
       })
     );
     this.manage(
       on(this.element.ownerDocument, 'keypress', event => {
         this._handleKeyPress(event);
+      })
+    );
+    this.manage(
+      on(this.element, 'mousedown', () => {
+        this.wasOpenBeforeClick = element.classList.contains(this.options.classShown);
       })
     );
   }
@@ -75,7 +81,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
   _handleDocumentClick(event) {
     const element = this.element;
     const isOfSelf = element.contains(event.target);
-    const shouldBeOpen = isOfSelf && !element.classList.contains(this.options.classShown);
+    const shouldBeOpen = isOfSelf && !this.wasOpenBeforeClick;
     const state = shouldBeOpen ? 'shown' : 'hidden';
 
     if (isOfSelf) {

--- a/tests/spec/overflow-menu_spec.js
+++ b/tests/spec/overflow-menu_spec.js
@@ -35,6 +35,7 @@ describe('Test Overflow menu', function() {
       expect(element.classList.contains('bx--overflow-menu--open')).to.be.true;
 
       // Secondary click to close overflow-menu:
+      element.dispatchEvent(new CustomEvent('mousedown', { bubbles: true }));
       element.dispatchEvent(new CustomEvent('click', { bubbles: true }));
       expect(element.classList.contains('bx--overflow-menu--open')).to.be.false;
     });
@@ -97,6 +98,7 @@ describe('Test Overflow menu', function() {
       const spyOverflowEvent = sinon.spy();
       events.on(document, 'floating-menu-hidden', spyOverflowEvent);
       element.classList.add('bx--overflow-menu--open');
+      element.dispatchEvent(new CustomEvent('mousedown', { bubbles: true }));
       element.dispatchEvent(new CustomEvent('click', { bubbles: true }));
       expect(spyOverflowEvent).to.have.been.called;
     });


### PR DESCRIPTION
**NOTE**: This PR includes https://github.com/carbon-design-system/carbon-components/pull/273, because this PR depends on https://github.com/carbon-design-system/carbon-components/pull/273. The change for this PR itself can be seen in: https://github.com/carbon-design-system/carbon-components/pull/426/commits/deca2107ba9d24a782730aa77e40ebac7a1752af

## Overview

Resolves #423.

This PR looks at the state of overflow menu's open/close state right before the trigger button is clicked to determine if such clicking action should open or close the overflow menu. Older code looks at such state after the the menu, which is a separate element from trigger button, gets out of focus upon clicking on trigger button and thus closed, which caused #423.

## Testing / Reviewing

Testing should make sure overflow menu is not broken.