### PR TITLE
fix(loading): fix extra space in loading HTML

### DIFF
--- a/src/components/loading/loading--small.html
+++ b/src/components/loading/loading--small.html
@@ -1,6 +1,6 @@
 <div data-loading class="bx--loading bx--loading--small">
   <svg class=" bx--loading__svg " viewBox="-75 -75 150 150 ">
     <title>Loading</title>
-    <circle cx="0 " cy="0 " r="37.5 " />
+    <circle cx="0 " cy="0 " r="37.5" />
   </svg>
 </div>


### PR DESCRIPTION
## Overview

Fixes #356.

### Removed

Extra space in the radius attribute of `<circle>` in loading HTML.

## Testing / Reviewing

Testing should make sure loading spinner component is not broken.