### PR TITLE
fix(slider): fix logic to calculate new left position and new value

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -128,8 +128,8 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
         const track = this.track.getBoundingClientRect();
         const unrounded = (evt.clientX - track.left) / track.width;
         const rounded = Math.round(range * unrounded / step) * step;
-        left = (rounded - min) / range * 100;
-        newValue = rounded;
+        left = rounded / range * 100;
+        newValue = rounded + min;
       }
     }
 
@@ -153,10 +153,10 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState)
 
   getInputProps() {
     const values = {
-      value: this.input.value,
-      min: this.input.min,
-      max: this.input.max,
-      step: this.input.step ? this.input.step : 1,
+      value: Number(this.input.value),
+      min: Number(this.input.min),
+      max: Number(this.input.max),
+      step: this.input.step ? Number(this.input.step) : 1,
     };
     return values;
   }

--- a/tests/spec/slider_spec.js
+++ b/tests/spec/slider_spec.js
@@ -53,17 +53,17 @@ describe('Test slider', function() {
     });
     it('Should setValue as expected', function() {
       slider.setValue(100);
-      expect(slider.getInputProps().value).to.equal('100');
+      expect(slider.getInputProps().value).to.equal(100);
     });
     it('Should stepUp as expected', function() {
       slider.setValue(50);
       slider.stepUp();
-      expect(slider.getInputProps().value).to.equal('51');
+      expect(slider.getInputProps().value).to.equal(51);
     });
     it('Should stepDown as expected', function() {
       slider.setValue(50);
       slider.stepDown();
-      expect(slider.getInputProps().value).to.equal('49');
+      expect(slider.getInputProps().value).to.equal(49);
     });
     afterEach(function() {
       if (slider) {
@@ -93,22 +93,22 @@ describe('Test slider', function() {
       event.which = 39;
       thumb.dispatchEvent(event);
       mockRaf.step({ count: 1 });
-      expect(slider.getInputProps().value).to.equal('51');
+      expect(slider.getInputProps().value).to.equal(51);
       event.which = 38;
       thumb.dispatchEvent(event);
       mockRaf.step({ count: 1 });
-      expect(slider.getInputProps().value).to.equal('52');
+      expect(slider.getInputProps().value).to.equal(52);
     });
     it('Should stepDown value on down/left key', function() {
       const event = new CustomEvent('keydown', { bubbles: true });
       event.which = 40;
       thumb.dispatchEvent(event);
       mockRaf.step({ count: 1 });
-      expect(slider.getInputProps().value).to.equal('49');
+      expect(slider.getInputProps().value).to.equal(49);
       event.which = 37;
       thumb.dispatchEvent(event);
       mockRaf.step({ count: 1 });
-      expect(slider.getInputProps().value).to.equal('48');
+      expect(slider.getInputProps().value).to.equal(48);
     });
     afterEach(function() {
       if (mockRaf) {
@@ -142,7 +142,7 @@ describe('Test slider', function() {
       event.clientX = 0;
       track.dispatchEvent(event);
       mockRaf.step({ count: 1 });
-      expect(slider.getInputProps().value).to.equal('0');
+      expect(slider.getInputProps().value).to.equal(0);
     });
     afterEach(function() {
       if (mockRaf) {


### PR DESCRIPTION
## Overview

Fixes #349.

There was an error in logic happening when min value is non-zero. This PR addresses that.

## Testing / Reviewing

Testing should make sure slider is not broken.