### PR TITLE
fix(modal): support floating menus in modal

### DIFF
--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -47,7 +47,7 @@
         position: absolute;
         top: 1rem;
         right: 1rem;
-        z-index: z('overflowOptions');
+        z-index: z('floating');
         margin: 0;
       }
     }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -117,7 +117,11 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
    * @private
    */
   _handleFocusin = evt => {
-    if (this.element.classList.contains(this.options.classVisible) && !this.element.contains(evt.target)) {
+    if (
+      this.element.classList.contains(this.options.classVisible) &&
+      !this.element.contains(evt.target) &&
+      this.options.selectorsFloatingMenus.every(selector => !eventMatches(evt, selector))
+    ) {
       this.element.focus();
     }
   };
@@ -148,6 +152,9 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
    * @type {Object}
    * @property {string} selectorInit The CSS class to find modal dialogs.
    * @property {string} attribInitTarget The attribute name in the launcher buttons to find target modal dialogs.
+   * @property {string[]} [selectorsFloatingMenu]
+   *   The CSS selectors of floating menus.
+   *   Used for detecting if focus-wrap behavior should be disabled temporarily.
    * @property {string} [classVisible] The CSS class for the visible state.
    * @property {string} [classNoScroll] The CSS class for hiding scroll bar in body element while modal is shown.
    * @property {string} [eventBeforeShown]
@@ -167,6 +174,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
     selectorInit: '[data-modal]',
     selectorModalClose: '[data-modal-close]',
     selectorPrimaryFocus: '[data-modal-primary-focus]',
+    selectorsFloatingMenus: ['.bx--overflow-menu-options', '.bx-tooltip'],
     classVisible: 'is-visible',
     attribInitTarget: 'data-modal-target',
     initEventNames: ['click'],

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -42,7 +42,7 @@
     flex-direction: column;
     align-items: flex-start;
     position: absolute;
-    z-index: 1;
+    z-index: z('floating');
     background-color: $inverse-01;
     border: 1px solid $ui-04;
     width: 11.25rem;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -48,6 +48,7 @@
     background: $ui-01;
     padding: 1.5rem;
     border: 1px solid $ui-04;
+    z-index: z('floating');
 
     p {
       @include font-family;

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -59,7 +59,7 @@ $z-indexes: (
   footer : 5000,
   hidden : - 1,
   overflowHidden: - 1,
-  overflowOptions: 1
+  floating: 10000
 );
 
 //-------------------------------------

--- a/tests/spec/modal_spec.js
+++ b/tests/spec/modal_spec.js
@@ -28,6 +28,7 @@ describe('Test modal', function() {
         selectorInit: '[data-modal]',
         selectorModalClose: '[data-modal-close]',
         selectorPrimaryFocus: '[data-modal-primary-focus]',
+        selectorsFloatingMenus: ['.bx--overflow-menu-options', '.bx-tooltip'],
         classVisible: 'is-visible',
         attribInitTarget: 'data-modal-target',
         initEventNames: ['click'],


### PR DESCRIPTION
## Overview

Fixes #280.

This PR adds support for floating menus in modal.

### Changed

Sass variable for overflow menu `z-index` - Now shared with tooltip one, and the value is changed to be bigger than modal's.

## Testing / Reviewing

Testing should make sure modal, overflow menu, tooltip or card are not broken.