### PR TITLE
fix(date-picker): let Flatpickr parse date instead of doing it with new Date()

### DIFF
--- a/src/components/date-picker/date-picker.js
+++ b/src/components/date-picker/date-picker.js
@@ -128,7 +128,7 @@ class DatePicker extends mixin(createComponent, initComponentBySearch) {
   _addInputLogic = input => {
     const inputField = input;
     inputField.addEventListener('change', () => {
-      const inputDate = this.calendar.parseDate(new Date(inputField.value));
+      const inputDate = this.calendar.parseDate(inputField.value);
       if (!isNaN(inputDate.valueOf())) {
         this.calendar.setDate(inputDate);
       }


### PR DESCRIPTION
## Overview

Fixes #396.

JavaScript Date constructor does not have proper i18n support when a string is given.
You'll see a very ambiguous spec at: https://www.ecma-international.org/ecma-262/6.0/#sec-date.parse
In the particular case of #396, `new Date()` seems to think `Y-m-d` format as an ISO8601 UTC-based string, whereas `Y/m/d` seems to be treated as a locale-specific, local-timezone-based string.
It ends up with producing a date object for the former case, that is of six hours before the clock for users in Austin, and thus one day off for the date part.

### Removed

The logic parsing date string in `<input>` by `new Date()`.

## Testing / Reviewing

Testing should make sure date picker is not broken.