### PR TITLE
fix(number-input): add number input disabled styles back in

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -98,3 +98,12 @@
     }
   }
 }
+
+.bx--number[data-invalid] {
+  input[type='number'] {
+    box-shadow: 0 2px 0px 0px $support-01;
+  }
+  ~ .bx--form-requirement {
+    max-height: rem(200px);
+  }
+}

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -30,6 +30,17 @@
     &:focus {
       @include focus-outline('border');
     }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:disabled ~ .bx--number__controls {
+      opacity: 0.5;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
   }
 
   .bx--number input[type='number'] {

--- a/src/components/number-input/number-input.html
+++ b/src/components/number-input/number-input.html
@@ -16,3 +16,25 @@
     </div>
   </div>
 </div>
+
+<div class="bx--form-item">
+  <label for="number-input" class="bx--label">Number Input label</label>
+  <div data-invalid data-numberinput class="bx--number">
+    <input id="number-input" type="number" min="0" max="100" value="1">
+    <div class="bx--number__controls">
+      <button class="bx--number__control-btn up-icon">
+        <svg viewBox="0 2 10 5" width="10" height="5" fill-rule="evenodd">
+          <path d="M10 5L5 0 0 5z"></path>
+        </svg>
+      </button>
+      <button class="bx--number__control-btn down-icon">
+        <svg viewBox="0 2 10 5" width="10" height="5" fill-rule="evenodd">
+          <path d="M10 0L5 5 0 0z"></path>
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div class="bx--form-requirement">
+    Test
+  </div>
+</div>

--- a/src/components/number-input/number-input.html
+++ b/src/components/number-input/number-input.html
@@ -35,6 +35,6 @@
     </div>
   </div>
   <div class="bx--form-requirement">
-    Test
+    Invalid number
   </div>
 </div>


### PR DESCRIPTION
Number input was missing the disabled styles. This adds them back in. May also affect https://github.com/carbon-design-system/carbon-components-react/pull/360