### PR TITLE
fix: update package.json engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "style guide",
     "eyeglass-module"
   ],
-  "engines": {		
-    "node": "6.x || 7.x || 9.x",		
-    "yarn": "1.3.2"		
+  "engines": {
+    "node": "6.x || 7.x || 9.x",
+    "yarn": "1.3.2"
   },
   "dependencies": {
     "carbon-icons": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
     "style guide",
     "eyeglass-module"
   ],
-  "devEngines": {
-    "node": "8.x || 9.x",
-    "yarn": "1.3.2"
-  },
   "dependencies": {
     "carbon-icons": "^6.0.4",
     "flatpickr": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "style guide",
     "eyeglass-module"
   ],
+  "engines": {		
+    "node": "6.x || 7.x || 9.x",		
+    "yarn": "1.3.2"		
+  },
   "dependencies": {
     "carbon-icons": "^6.0.4",
     "flatpickr": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "style guide",
     "eyeglass-module"
   ],
-  "engines": {
-    "node": "^6.0.0 || ^8.0.0",
-    "npm": "^4.0.0 || ^5.0.0"
+  "devEngines": {
+    "node": "8.x || 9.x",
+    "yarn": "1.3.2"
   },
   "dependencies": {
     "carbon-icons": "^6.0.4",


### PR DESCRIPTION
Replaces `engines` field with the `devEngines` field. Should help with consumers not having a valid node or yarn range, while still allowing the development team to specify specific versions for development-related purposes.
