### PR TITLE
fix: remove yarn from engines field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "eyeglass-module"
   ],
   "engines": {
-    "node": ">=6.x",
-    "yarn": "1.3.2"
+    "node": ">=6.x"
   },
   "dependencies": {
     "carbon-icons": "^6.0.4",


### PR DESCRIPTION
## Overview

### Added

### Removed

### Changed

- Removed `yarn` from `engines` field in `package.json`
