### PR TITLE
style(card): hide scroll bar in title

### DIFF
--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -90,6 +90,7 @@
       font-weight: 400;
       margin: 0;
       line-height: 1.2;
+      overflow: hidden;
     }
 
     .bx--about__title--link {


### PR DESCRIPTION
## Overview

There's a visible scroll bar on the card title
<img width="211" alt="screen shot 2017-12-12 at 2 06 47 pm" src="https://user-images.githubusercontent.com/11317322/33903312-034b4e22-df46-11e7-898b-f88b14197191.png">


### Added

- hide overflow on `.bx--about__title--name`
<img width="224" alt="screen shot 2017-12-12 at 2 06 36 pm" src="https://user-images.githubusercontent.com/11317322/33903355-24139b00-df46-11e7-84bd-5f0ce9ef9714.png">

