### PR TITLE
Update to express 4.16.2 to address vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "carbon-components",
   "description": "Carbon Components is a component library for IBM Cloud",
   "homepage": "http://carbondesignsystem.com/",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "module": "es/index.js",
   "main": "umd/index.js",
   "repository": {
@@ -64,7 +64,7 @@
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-prettier": "^2.3.1",
-    "express": "4.13.4",
+    "express": "4.16.2",
     "globby": "4.0.0",
     "gulp": "~3.9.0",
     "gulp-autoprefixer": "~3.0.1",


### PR DESCRIPTION
express 4.13.4 has the following dependencies that have vulnerabilities:
Vulnerable module: fresh
Vulnerable module: negotiator
Vulnerable module: qs
Vulnerable module: mime

## Overview

Resolves {{ issue number(s) here }}

{{ Description about the PR }}

{{ Include images and gifs when applicable }}

### Added

{{ Description of things added }}

### Removed

{{ Description of things removed }}

### Changed

{{ Description of things changed }}


## Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
