### PR TITLE
DropdownItem doesn't use ellipsis for text overflow

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -86,6 +86,8 @@
     padding-bottom: 1rem;
     padding-left: 1rem;
     padding-right: 1.5rem;
+    text-overflow: ellipsis;
+    overflow: hidden;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Fixes carbon-design-system/carbon-components#473

## Overview

Resolves carbon-design-system/carbon-components#473

DropdownItem wasn't using ellipsis. As a result, long texts were displaying outside the menu box.
![image](https://user-images.githubusercontent.com/5316797/34011235-60bcb06c-e0dd-11e7-8d58-9e7bbc6a38bf.png)



### Added

Added ellipsis for text overflow


## Testing / Reviewing

Tried the CSS in Chrome dev inspector and fixed the overflow problem.
![image](https://user-images.githubusercontent.com/5316797/34011185-331b1a86-e0dd-11e7-9842-86635ff301aa.png)
