### PR TITLE
fix(overflow-menu): firefox bug with focus outline

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -19,7 +19,8 @@
     cursor: pointer;
 
     &:focus {
-      @include focus-outline('border');
+      outline: 1px solid transparent;
+      box-shadow: 0 0 0 1px $brand-01;
     }
   }
 


### PR DESCRIPTION
Closes #475

Firefox includes absolutely positioned children in the focus style of a containing element, as a result OverflowMenu would have a larger focus outline in Firefox than it would in other browsers.

This PR adjusts the focus styles to be based on `box-shadow` instead of `outline` to resolve this behavior for `carbon-components-react`

#### Changelog

**New**

**Changed**

- Update OverflowMenu to use `box-shadow` for focus states

**Removed**
