### PR TITLE
fix(dropdown): Elements overflowing should be hidden but allow scrolling

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -112,8 +112,8 @@
       display: flex;
       flex-direction: column;
       background-color: $ui-01;
-      max-height: 50rem;
-      overflow: visible;
+      max-height: 15rem;
+      overflow: auto;
       transition: $transition--expansion $bx--ease-in;
       opacity: 1;
     }


### PR DESCRIPTION
## Overview

Resolves #469

Allow dropdown to scale with many items.

OLD:
<img width="341" alt="screen shot 2017-12-19 at 10 56 45 am" src="https://user-images.githubusercontent.com/11449728/34166800-e381d882-e4ad-11e7-88be-0d839f3f175f.png">

NEW:
<img width="370" alt="screen shot 2017-12-19 at 11 03 31 am" src="https://user-images.githubusercontent.com/11449728/34166805-e9b99e7e-e4ad-11e7-8705-d5fc9fbe7269.png">

### Changed

Adjusted styles to a smaller maximum (50rem was far too long). Up for design discussion. Allowed auto overflow to show scrollbar if content is longer than max-height.
