### PR TITLE
Allow font weights and styles to be overidden

### DIFF
--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -32,7 +32,7 @@ $weights: (
     font-style: normal,
     font-weight: 600,
   )
-);
+) !default;
 
 @mixin plex-font-face {
   @each $family, $name in $families {


### PR DESCRIPTION
Add !default to allow variations on plex.

## Overview

Allow weights var to be overridden 

### Added

!default 

 Please review @asudoh 