### PR TITLE
fix(pagination): Remove hover state and hand cursor for disabled arrow

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -72,6 +72,14 @@ $css--helpers: true;
     &:focus {
       @include focus-outline('border');
     }
+
+    &:disabled:hover {
+      cursor: default;
+      
+      .bx--pagination__button-icon {
+        fill: $ui-05;
+      }
+    }
   }
 
   .bx--pagination__button--backward {


### PR DESCRIPTION
## Overview

Resolves #466 

Updated styling so that disabled arrow buttons don't appear clickable. Removed hover state and cursor change. 