### PR TITLE
fix(data-table-v2): fix NodeList.forEach() call not supported by IE

### DIFF
--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -61,7 +61,7 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
   _sortToggle = detail => {
     const { element, previousValue } = detail;
 
-    this.tableHeaders.forEach(header => {
+    [...this.tableHeaders].forEach(header => {
       const sortEl = header.querySelector('.bx--table-sort-v2');
 
       if (sortEl !== null && sortEl !== element) {


### PR DESCRIPTION
## Overview

Fixes #485.

### Changed

Converting `NodeList` to `Array` before calling `.forEach()`.

## Testing / Reviewing

Testing should make sure data table v2 is not broken.