### PR TITLE
feat(components): Add spacing variables

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,6 +1,7 @@
 @import '../../globals/scss/vars';
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
@@ -42,7 +43,7 @@
     justify-content: $accordion-justify-content;
     flex-direction: $accordion-flex-direction;
     cursor: pointer;
-    padding: 0.5rem 0;
+    padding: $spacing-xs 0;
 
     // new version of markup uses focus on the heading,
     // not the list element itself
@@ -61,7 +62,7 @@
     transition: all $transition--base $carbon--standard-easing;
     height: 1.25rem;
     width: 1.25rem;
-    padding: 0.25rem 0.125rem 0.25rem 0.25rem;
+    padding: $spacing-2xs $spacing-3xs $spacing-2xs $spacing-2xs;
     margin: $accordion-arrow-margin;
     fill: $ui-05;
   }
@@ -87,8 +88,8 @@
   overflow: visible;
 
   .#{$prefix}--accordion__content {
-    padding-top: 1rem;
-    padding-bottom: 1.5rem;
+    padding-top: $spacing-md;
+    padding-bottom: $spacing-lg;
     height: auto;
     visibility: visible;
     opacity: 1;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -2,6 +2,7 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/mixins';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/spacing';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--typography';
 @import '../link/link';
@@ -19,14 +20,14 @@
   }
 
   .#{$prefix}--breadcrumb-item {
-    margin-right: rem(20.66px);
+    margin-right: $spacing-md;
     display: flex;
     align-items: center;
   }
 
   .#{$prefix}--breadcrumb-item::after {
     content: '/';
-    margin-left: 1rem;
+    margin-left: $spacing-md;
     color: $text-03;
   }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1,6 +1,7 @@
 @import '../../globals/scss/vars';
 @import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/spacing';
 @import '../../globals/scss/import-once';
 @import 'mixins';
 @import '../../globals/scss/css--reset';
@@ -91,7 +92,7 @@
     }
 
     .#{$prefix}--btn__icon {
-      margin-left: 0.275rem;
+      margin-left: $spacing-xs;
     }
 
     &:hover:disabled,
@@ -141,6 +142,6 @@
   }
 
   .#{$prefix}--btn--secondary + .#{$prefix}--btn--primary {
-    margin-left: 1rem;
+    margin-left: $spacing-md;
   }
 }

--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -15,21 +15,15 @@
 //   3xl  ||  48px
 //   ==========================================
 
-//Should this by default be 16px or $base-font-size  
-$spacing-baseline: $base-font-size !default; 
+$spacing-baseline: 1rem !default;
 
-$spacing-3xs: rem($spacing-baseline * .125) !default; 
-$spacing-2xs: rem($spacing-baseline * .25) !default; 
-$spacing-xs: rem($spacing-baseline * .5) !default; 
-$spacing-sm	: rem($spacing-baseline * .75) !default; 
-$spacing-md: rem($spacing-baseline) !default; 
-$spacing-lg: rem($spacing-baseline * 1.5) !default; 
-$spacing-xl: rem($spacing-baseline * 2) !default; 
-$spacing-2xl: rem($spacing-baseline * 2.5) !default; 
-$spacing-3xl: rem($spacing-baseline * 3) !default; 
-
-//Do we even need these variables?
-$spacing-center: center; 
-$spacing-auto: auto;
-
+$spacing-3xs: $spacing-baseline * .125 !default; 
+$spacing-2xs: $spacing-baseline * .25 !default; 
+$spacing-xs: $spacing-baseline * .5 !default; 
+$spacing-sm: $spacing-baseline * .75 !default; 
+$spacing-md: $spacing-baseline !default; 
+$spacing-lg: $spacing-baseline * 1.5 !default; 
+$spacing-xl: $spacing-baseline * 2 !default; 
+$spacing-2xl: $spacing-baseline * 2.5 !default; 
+$spacing-3xl: $spacing-baseline * 3 !default; 
 

--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -1,0 +1,35 @@
+//-------------------------------------------
+// 🌌 Spacing
+// ------------------------------------------
+//
+//   Size in px based on 16px base
+//   ==========================================
+//   3xs  ||  2px
+//   2xs  ||  4px
+//   xs   ||  8px
+//   sm   ||  12px
+//   md   ||  16px
+//   lg   ||  24px
+//   xl   ||  32px
+//   2xl  ||  40px
+//   3xl  ||  48px
+//   ==========================================
+
+//Should this by default be 16px or $base-font-size  
+$spacing-baseline: $base-font-size !default; 
+
+$spacing-3xs: rem($spacing-baseline * .125) !default; 
+$spacing-2xs: rem($spacing-baseline * .25) !default; 
+$spacing-xs: rem($spacing-baseline * .5) !default; 
+$spacing-sm	: rem($spacing-baseline * .75) !default; 
+$spacing-md: rem($spacing-baseline) !default; 
+$spacing-lg: rem($spacing-baseline * 1.5) !default; 
+$spacing-xl: rem($spacing-baseline * 2) !default; 
+$spacing-2xl: rem($spacing-baseline * 2.5) !default; 
+$spacing-3xl: rem($spacing-baseline * 3) !default; 
+
+//Do we even need these variables?
+$spacing-center: center; 
+$spacing-auto: auto;
+
+

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -1,4 +1,5 @@
 @import 'colors';
+@import 'spacing';
 
 $prefix: 'bx' !default;
 
@@ -55,16 +56,16 @@ $button-font-weight: 600 !default;
 $button-font-size: 0.875rem !default;
 $button-border-radius: 0 !default;
 $button-height: 40px !default;
-$button-padding: 0 1rem !default;
-$button-padding-sm: 0 0.5rem !default;
+$button-padding: 0 $spacing-md !default;
+$button-padding-sm: 0 $spacing-xs !default;
 $button-border-width: 2px !default;
 
 // Accordion (Reverse)
 $accordion-flex-direction: row !default;
 $accordion-justify-content: flex-start !default;
-$accordion-arrow-margin: 0 0 0 0.25rem !default;
-$accordion-title-margin: 0 0 0 1rem !default;
-$accordion-content-padding: 0 1rem 0 1.75rem !default;
+$accordion-arrow-margin: 0 0 0 $spacing-2xs !default;
+$accordion-title-margin: 0 0 0 $spacing-md !default;
+$accordion-content-padding: 0 $spacing-md 0  $spacing-2xl !default;
 
 // Card
 $card-text-align: center !default;

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -15,7 +15,7 @@ $css--plex: true !default;
 @import 'mixins';
 @import 'layout';
 @import 'layer';
-//@import 'spacing';
+@import 'spacing';
 @import 'typography';
 @import 'import-once';
 @import 'css--reset';

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -15,6 +15,7 @@ $css--plex: true !default;
 @import 'mixins';
 @import 'layout';
 @import 'layer';
+//@import 'spacing';
 @import 'typography';
 @import 'import-once';
 @import 'css--reset';


### PR DESCRIPTION
https://github.ibm.com/Bluemix/carbon-issues/issues/410

Added initial spacing variables. Looking for feedback to make sure the way I set up the `_spacing.scss` file makes sense?

### Added
Added new variables to 
accordion
breadcrumb
button

###Questions
Does anyone see a need to have these variables included in the spacing scale? Or is it fine to just keep `center` and `auto`.
```
$spacing-center: center; 
$spacing-auto: auto;
```
Is this something that we will merge in as it gets done, or is it waiting for a v9 release? 
