### PR TITLE
fix(dropdown): clean up dropdown animation to avoid ghosting over con…

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -68,13 +68,21 @@
   .#{$prefix}--dropdown-list {
     @include reset;
     @include layer('overlay');
+    @include typescale('zeta');
+    background-color: $ui-01;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     list-style: none;
     position: absolute;
     z-index: z('dropdown');
     max-height: 0;
+    transition: max-height $transition--expansion $carbon--ease-out;
     overflow: hidden;
-    transition: $transition--expansion $carbon--ease-out;
+  }
+
+  .#{$prefix}--dropdown-item {
+    transition: opacity $transition--expansion $carbon--ease-out;
     opacity: 0;
   }
 
@@ -108,20 +116,18 @@
     }
 
     .#{$prefix}--dropdown-list {
-      @include typescale('zeta');
-      display: flex;
-      flex-direction: column;
-      background-color: $ui-01;
       max-height: 15rem;
       overflow: auto;
-      transition: $transition--expansion $carbon--ease-in;
-      opacity: 1;
     }
 
     &:focus {
       .#{$prefix}--dropdown-list {
         box-shadow: 0 1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
       }
+    }
+
+    .#{$prefix}--dropdown-item {
+      opacity: 1;
     }
   }
 

--- a/src/components/dropdown/dropdown.html
+++ b/src/components/dropdown/dropdown.html
@@ -5,11 +5,21 @@
   </svg>
   <li>
     <ul class="bx--dropdown-list">
-      <li data-option data-value="all" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">Option 1</a></li>
-      <li data-option data-value="cloudFoundry" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">Option 2</a></li>
-      <li data-option data-value="staging" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">Option 3</a></li>
-      <li data-option data-value="dea" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">Option 4</a></li>
-      <li data-option data-value="router" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">Option 5</a></li>
+      <li data-option data-value="all" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 1</a>
+      </li>
+      <li data-option data-value="cloudFoundry" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 2</a>
+      </li>
+      <li data-option data-value="staging" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 3</a>
+      </li>
+      <li data-option data-value="dea" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 4</a>
+      </li>
+      <li data-option data-value="router" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 5</a>
+      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
## Update Dropdown Animation

When the old `Dropdown` was toggled, the opacity change produced a 'ghosting' effect on elements below it, most notably on the `Order Summary` component. This should eliminate any ghosting effects. 

### Old
![dropdown-old](https://user-images.githubusercontent.com/11928039/35299311-838a7a0c-004a-11e8-8f05-474f8078e3ff.gif)

### New
![dropdown-new](https://user-images.githubusercontent.com/11928039/35299338-98052306-004a-11e8-8de5-811d135d8605.gif)

