### PR TITLE
fix(interior-left-nav): fixed a couple of a11y bugs

### DIFF
--- a/src/components/interior-left-nav/interior-left-nav-keep-open.html
+++ b/src/components/interior-left-nav/interior-left-nav-keep-open.html
@@ -1,27 +1,27 @@
-<nav role="navigation" aria-label="Interior Left Navigation" data-interior-left-nav class="bx--interior-left-nav bx--interior-left-nav--collapseable"
+<nav role="navigation" aria-label="Interior Left Navigation Open" data-interior-left-nav class="bx--interior-left-nav bx--interior-left-nav--collapseable"
   data-keep-open="true">
-  <ul role="menubar" class="left-nav-list" data-interior-left-nav-list aria-hidden="false">
+  <ul role="menubar" aria-label="left nav list" class="left-nav-list" data-interior-left-nav-list aria-hidden="false">
     <li role="menuitem" tabindex="0" class="left-nav-list__item" data-interior-left-nav-item>
       <a class="left-nav-list__item-link">
-          Example Item 1
-        </a>
+        Example Item 1
+      </a>
     </li>
     <li role="menuitem" tabindex="0" class="left-nav-list__item" data-interior-left-nav-item>
       <a class="left-nav-list__item-link">
-          Example Item 2
-        </a>
+        Example Item 2
+      </a>
     </li>
     <li role="menuitem" tabindex="0" class="left-nav-list__item left-nav-list__item--has-children" data-interior-left-nav-item
       data-interior-left-nav-with-children>
       <a class="left-nav-list__item-link">
-          Example Item 3
-          <div class="left-nav-list__item-icon">
-            <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
-              <path d="M10 0L5 5 0 0z"></path>
-            </svg>
-          </div>
-        </a>
-      <ul role="menu" aria-hidden="true" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
+        Example Item 3
+        <div class="left-nav-list__item-icon">
+          <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+            <path d="M10 0L5 5 0 0z"></path>
+          </svg>
+        </div>
+      </a>
+      <ul role="menu" aria-hidden="true" aria-label="nested left nav list" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
         <li class="left-nav-list__item" data-interior-left-nav-nested-item role="menuitem" tabindex="-1">
           <a href="#example-item-1A" class="left-nav-list__item-link" data-interior-left-nav-item-link tabindex="-1">Example Item 1A</a>
         </li>
@@ -39,14 +39,14 @@
     <li role="menuitem" tabindex="0" class="left-nav-list__item left-nav-list__item--has-children" data-interior-left-nav-item
       data-interior-left-nav-with-children>
       <a class="left-nav-list__item-link">
-          Example Item 4
-          <div class="left-nav-list__item-icon">
-            <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
-              <path d="M10 0L5 5 0 0z"></path>
-            </svg>
-          </div>
-        </a>
-      <ul role="menu" aria-hidden="true" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
+        Example Item 4
+        <div class="left-nav-list__item-icon">
+          <svg class="bx--interior-left-nav__icon" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+            <path d="M10 0L5 5 0 0z"></path>
+          </svg>
+        </div>
+      </a>
+      <ul role="menu" aria-hidden="true" aria-label="nested left nav list" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
         <li class="left-nav-list__item" data-interior-left-nav-nested-item role="menuitem" tabindex="-1">
           <a href="#example-item-2A" class="left-nav-list__item-link" data-interior-left-nav-item-link tabindex="-1">Example Item 2A</a>
         </li>
@@ -64,7 +64,7 @@
   </ul>
 
   <div class="bx--interior-left-nav-collapse" data-interior-left-nav-collapse>
-    <a class="bx--interior-left-nav-collapse__link" href="#">
+    <a class="bx--interior-left-nav-collapse__link" href="#" aria-label="collapse nav pane">
       <svg class="bx--interior-left-nav-collapse__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd" data-interior-left-nav-arrow>
         <title>Collapse nav pane</title>
         <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>

--- a/src/components/interior-left-nav/interior-left-nav.html
+++ b/src/components/interior-left-nav/interior-left-nav.html
@@ -1,5 +1,5 @@
 <nav role="navigation" aria-label="Interior Left Navigation" data-interior-left-nav class="bx--interior-left-nav bx--interior-left-nav--collapseable">
-  <ul role="menubar" class="left-nav-list" data-interior-left-nav-list aria-hidden="false">
+  <ul role="menubar" class="left-nav-list" data-interior-left-nav-list aria-label="left nav list" aria-hidden="false">
     <li role="menuitem" tabindex="0" class="left-nav-list__item" data-interior-left-nav-item>
       <a class="left-nav-list__item-link">
         Example Item 1
@@ -20,7 +20,7 @@
           </svg>
         </div>
       </a>
-      <ul role="menu" aria-hidden="true" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
+      <ul role="menu" aria-hidden="true" aria-label="nested left nav list" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
         <li class="left-nav-list__item" data-interior-left-nav-nested-item role="menuitem" tabindex="-1">
           <a href="#example-item-1A" class="left-nav-list__item-link" data-interior-left-nav-item-link tabindex="-1">Example Item 1A</a>
         </li>
@@ -45,7 +45,7 @@
           </svg>
         </div>
       </a>
-      <ul role="menu" aria-hidden="true" class="left-nav-list left-nav-list--nested" data-interior-left-nav-nested-list>
+      <ul role="menu" aria-hidden="true" class="left-nav-list left-nav-list--nested" aria-label="nested left nav list" data-interior-left-nav-nested-list>
         <li class="left-nav-list__item" data-interior-left-nav-nested-item role="menuitem" tabindex="-1">
           <a href="#example-item-2A" class="left-nav-list__item-link" data-interior-left-nav-item-link tabindex="-1">Example Item 2A</a>
         </li>
@@ -63,7 +63,7 @@
   </ul>
 
   <div class="bx--interior-left-nav-collapse" data-interior-left-nav-collapse>
-    <a class="bx--interior-left-nav-collapse__link" href="#">
+    <a class="bx--interior-left-nav-collapse__link" href="#" aria-label="collapse nav pane">
       <svg class="bx--interior-left-nav-collapse__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd" data-interior-left-nav-arrow>
         <title>Collapse nav pane</title>
         <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>


### PR DESCRIPTION
## Overview

Closes https://github.com/carbon-design-system/carbon-components/issues/382

Most of the error messages in issue 382 are not related directly to Carbon. I fixed the once that were, such as:
- Adding label to any widget (in this case, all of the `ul's`)
- Added label to the collapse left nav icon

Still getting some violations through the DAP tool saying that the left nav links are not color accessible - however, they are #152935 on white so this is wrong.

![screen shot 2018-01-31 at 3 20 43 pm](https://user-images.githubusercontent.com/5447411/35648138-532a34fa-069a-11e8-85cf-efc37fa5e8de.png)

Will also need to update this component in the add-on repo.
