### PR TITLE
fix: Add hover background color for inline dropdown

### DIFF
--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -81,6 +81,10 @@ $list-box-menu-width: rem(300px);
     cursor: pointer;
   }
 
+  .#{$prefix}--list-box__field:hover {
+    background: $field-01;
+  }
+
   .#{$prefix}--list-box__field:focus,
   .#{$prefix}--list-box__field[aria-expanded='true'] {
     outline: 1px solid $brand-01;


### PR DESCRIPTION
## Overview

Resolves #534 

Add `$field-01` background color on hover to inline dropdown. 
