### PR TITLE
feat(contentswitcher): position icons within switch

### DIFF
--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -32,7 +32,7 @@
       fill: currentColor;
     }
 
-    > svg g {
+    > svg * {
       fill: currentColor;
     }
 

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -27,6 +27,15 @@
     border: 1px solid $brand-01;
     color: $brand-01;
 
+    > svg {
+      margin-right: 0.5rem;
+      fill: currentColor;
+    }
+
+    > svg g {
+      fill: currentColor;
+    }
+
     &:focus {
       outline: 1px solid transparent;
       box-shadow: 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -27,15 +27,6 @@
     border: 1px solid $brand-01;
     color: $brand-01;
 
-    > svg {
-      margin-right: 0.5rem;
-      fill: currentColor;
-    }
-
-    > svg * {
-      fill: currentColor;
-    }
-
     &:focus {
       outline: 1px solid transparent;
       box-shadow: 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
@@ -55,6 +46,15 @@
       background-color: $brand-02;
       border-color: $brand-02;
       color: $inverse-01;
+    }
+  }
+
+  .#{$prefix}--content-switcher__icon {
+    margin-right: $spacing-xs;
+    fill: currentColor;
+    // need to color any child path or g
+    * {
+      fill: currentColor;
     }
   }
 


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/547

This feature adds support for putting svgs within the buttons of the content switcher.  It puts space between the icon and the text and changes the color of the svg to match the color of the text.

{{ Include images and gifs when applicable }}
![image](https://user-images.githubusercontent.com/6663002/36032457-b6e1cdc0-0d73-11e8-9855-9234aea5c8b5.png)


### Added

contentswitcher.scss two style rules to position the svgs and text and color them to match the text color.

## Testing / Reviewing
Add svg icons before the text within each of the content switcher switches/buttons and make sure they're positioned correctly and colored correctly
