### PR TITLE
style(modal): adds the danger style to modals

### DIFF
--- a/src/components/modal/_mixins.scss
+++ b/src/components/modal/_mixins.scss
@@ -1,0 +1,9 @@
+//----------------------------------------------
+// Modal
+// ---------------------------------------------
+
+@mixin modal--color($color) {
+  .#{$prefix}--modal-container {
+    border-top-color: $color;
+  }
+}

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -42,6 +42,10 @@
     }
   }
 
+  .#{$prefix}--modal--danger {
+    @include modal--color($support-01);
+  }
+
   .#{$prefix}--modal-container {
     @include reset;
     @include layer('pop-out');

--- a/src/components/modal/modal--nofooter.html
+++ b/src/components/modal/modal--nofooter.html
@@ -19,3 +19,25 @@
     </div>
   </div>
 </div>
+
+<button class="bx--btn bx--btn--danger" type="button" data-modal-target="#nofooter--danger">Passive Danger</button>
+
+<div data-modal id="nofooter--danger" class="bx--modal bx--modal--danger" tabindex="-1">
+  <div class="bx--modal-container">
+    <div class="bx--modal-header">
+      <p class="bx--modal-header__label bx--type-delta">Optional label</p>
+      <p class="bx--modal-header__heading bx--type-beta">Modal heading</p>
+      <button class="bx--modal-close" type="button" data-modal-close data-modal-primary-focus aria-label="close modal">
+        <svg class="bx--modal-close__icon" width="10" height="10" viewBox="0 0 10 10" fill-rule="evenodd">
+          <title>Close Modal</title>
+          <path d="M9.8 8.6L8.4 10 5 6.4 1.4 10 0 8.6 3.6 5 .1 1.4 1.5 0 5 3.6 8.6 0 10 1.4 6.4 5z"></path>
+        </svg>
+      </button>
+    </div>
+
+    <div class="bx--modal-content">
+      <p>Passive modal notifications should only appear if there is an action the user needs to address immediately. Passive
+        modal notifications are persistent on the screen.</p>
+    </div>
+  </div>
+</div>

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<button class="bx--btn bx--btn--danger" type="button" data-modal-target="#modal--danger">Transactional Danger</button>
+<button class="bx--btn bx--btn--danger--primary" type="button" data-modal-target="#modal--danger">Transactional Danger</button>
 
 <div data-modal id="modal--danger" class="bx--modal bx--modal--danger" tabindex="-1">
   <div class="bx--modal-container">
@@ -44,8 +44,8 @@
     </div>
 
     <div class="bx--modal-footer">
-      <button class="bx--btn bx--btn--secondary" type="button" data-modal-close>Secondary button</button>
-      <button class="bx--btn bx--btn--danger" type="button" data-modal-primary-focus>Danger button</button>
+      <button class="bx--btn bx--btn--tertiary" type="button" data-modal-close>Tertiary button</button>
+      <button class="bx--btn bx--btn--danger--primary" type="button" data-modal-primary-focus>Danger button</button>
     </div>
   </div>
 </div>

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -23,3 +23,29 @@
     </div>
   </div>
 </div>
+
+<button class="bx--btn bx--btn--danger" type="button" data-modal-target="#modal--danger">Transactional Danger</button>
+
+<div data-modal id="modal--danger" class="bx--modal bx--modal--danger" tabindex="-1">
+  <div class="bx--modal-container">
+    <div class="bx--modal-header">
+      <p class="bx--modal-header__label bx--type-delta">Optional label</p>
+      <p class="bx--modal-header__heading bx--type-beta">Modal heading</p>
+      <button class="bx--modal-close" type="button" data-modal-close aria-label="close modal">
+        <svg class="bx--modal-close__icon" width="10" height="10" viewBox="0 0 10 10" fill-rule="evenodd">
+           <title>Close Modal</title>
+          <path d="M9.8 8.6L8.4 10 5 6.4 1.4 10 0 8.6 3.6 5 .1 1.4 1.5 0 5 3.6 8.6 0 10 1.4 6.4 5z"></path>
+        </svg>
+      </button>
+    </div>
+
+    <div class="bx--modal-content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae tellus tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla facilisi. Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>
+    </div>
+
+    <div class="bx--modal-footer">
+      <button class="bx--btn bx--btn--secondary" type="button" data-modal-close>Secondary button</button>
+      <button class="bx--btn bx--btn--danger" type="button" data-modal-primary-focus>Danger button</button>
+    </div>
+  </div>
+</div>

--- a/src/globals/scss/_mixins.scss
+++ b/src/globals/scss/_mixins.scss
@@ -7,3 +7,4 @@
 @import '../../components/tag/mixins';
 @import '../../components/unified-header/mixins';
 @import '../../components/structured-list/mixins';
+@import '../../components/modal/mixins';


### PR DESCRIPTION
## Overview

Adds the danger style to modals
<img width="775" alt="screen shot 2018-02-13 at 10 22 27 am" src="https://user-images.githubusercontent.com/6370760/36160913-06646f2e-10a8-11e8-90ba-32635ebee959.png">

<img width="791" alt="screen shot 2018-02-13 at 10 22 45 am" src="https://user-images.githubusercontent.com/6370760/36160924-0b70ae1a-10a8-11e8-81be-5ce97eddd4c0.png">

Based on other current implementations I think we would like to see new styles of button to be paired with the danger modal. This is a currently implemented danger modal in Bluemix-
![screen shot 2018-02-12 at 2 28 03 pm](https://user-images.githubusercontent.com/6370760/36161079-668bf1b0-10a8-11e8-8d1c-c918c6601432.png)

Notice the primary button is a solid red and the secondary is the grey outline. It's somewhat unrelated to this PR, but I think we would like to open this up to discussion.