### PR TITLE
chore(devenv): remove JS build from dev server prereq

### DIFF
--- a/demo/views/demo-live.dust
+++ b/demo/views/demo-live.dust
@@ -6,7 +6,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
   <title>Carbon Components</title>
-  <link rel="stylesheet" href="/demo.css">
+  <link rel="stylesheet" href="/demo/demo.css">
   <style>
     .offleft {
       position: absolute;
@@ -29,7 +29,7 @@
 
   <!-- Scripts -->
   <!-- <script src="/carbon-components.min.js"></script> -->
-  <script src="/demo.js"></script>
+  <script src="/demo/demo.js"></script>
   <!-- Disable Auto Init with this flag -->
   <!-- true = JavaScript will not initialize automatically -->
   <!-- false = JavaScript will initialize automatically -->

--- a/demo/views/demo-nav.dust
+++ b/demo/views/demo-nav.dust
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
     <title>Carbon Components</title>
-    <link rel="stylesheet" href="/demo.css">
+    <link rel="stylesheet" href="/demo/demo.css">
     <style>
       .offleft {
         position: absolute;
@@ -24,6 +24,6 @@
       var componentItems = {componentItems|js|s};
       var docItems = {docItems|js|s};
     </script>
-    <script src="/demo.js"></script>
+    <script src="/demo/demo.js"></script>
   </body>
 </html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ const axe = require('gulp-axe-webdriver');
  * BrowserSync
  */
 
-gulp.task('browser-sync', ['build:dev'], cb => {
+gulp.task('browser-sync', ['sass:dev'], cb => {
   let started;
   nodemon({
     script: './server.js',

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ fractal.docs.set('path', path.join(__dirname, 'docs'));
 app.engine('dust', adaro.dust());
 app.set('view engine', 'dust');
 app.set('views', path.resolve(__dirname, 'demo/views'));
-app.use(express.static('demo'));
+app.use('/demo', express.static('demo'));
 app.use(express.static('src'));
 app.use(express.static('scripts'));
 app.use('/docs/js', express.static('docs/js'));


### PR DESCRIPTION
## Overview

This change removes JS build that used to run before our dev server runs, as our dev server code (server.js) itself runs WebPack to build JS code.

## Changed

Changed the route of dev env's static content so that WebPack dev middleware can handle the route.

## Testing / Reviewing

Testing should make sure our dev env is not broken.