### PR TITLE
chore(package.json): upgrade freshy package

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,9 @@
     "webpack-dev-middleware": "^2.0.0",
     "webpack-hot-middleware": "^2.21.0"
   },
+  "resolutions": {
+    "freshy": ">= 1.0.3"
+  },
   "files": [
     "css/**/*",
     "es/**/*",


### PR DESCRIPTION
## Overview

This PR ensures `freshy` package installed is `>= 1.0.3` as `1.0.2` has an issue with node.js 8.x.