### PR TITLE
fix(typography): add font-size mixin back in

### DIFF
--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -71,35 +71,23 @@ $typescale-map: (
   letter-spacing: 0.5px;
 }
 
-// ☠️ Deprecated ☠️
-$major-second-typescale-map: (
-  '11' : 0.6875rem,
-  '12' : 0.75rem,
-  '14' : 0.875rem,
-  '16' : 1rem,
-  '18' : 1.125rem,
-  '20' : 1.25rem,
-  '23' : 1.4375rem,
-  '26' : 1.625rem,
-  '29' : 1.8125rem,
-  '32' : 2rem,
+$font-size-map: (
+  '76' : 4.75rem,
+  '54' : 3.375rem,
   '36' : 2.25rem,
-  '41' : 2.5625rem,
-  '46' : 2.875rem,
-  '52' : 3.25rem,
-  '58' : 3.625rem,
-  '66' : 4.125rem,
-  '74' : 4.625rem,
-  '83' : 5.1875rem,
-  '94' : 5.875rem
-);
+  '28' : 1.75rem,
+  '20' : 1.25rem,
+  '18' : 1.125rem,
+  '16' : 1rem,
+  '14' : 0.875rem,
+  '12' : 0.75rem,
+  '11' : 0.6875rem,
+ );
 
-// ☠️ Deprecated ☠️
 @mixin font-size($size) {
-  @if map-has-key($major-second-typescale-map, $size) {
+  @if map-has-key($font-size-map, $size) {
     font-size: map-get($major-second-typescale-map, $size);
-    @warn 'This mixin will be deprecated in V9';
   } @else {
-    @warn 'This is not a step of the Carbon Type Scale!';
+    @warn 'This is not a step of the Carbon Type Scale! Valid sizes are 11, 12, 14, 16, 18, 20, 28, 36, 54, and 76';
   }
 }


### PR DESCRIPTION
### Update font-size mixin

Works exactly like the old one, just with our new typescale. Based on feedback we received in `carbon-components` slack channel

![screen shot 2018-02-15 at 4 12 03 pm](https://user-images.githubusercontent.com/11928039/36283831-5b23317a-126b-11e8-8abc-ef35065932b2.png)

![screen shot 2018-02-15 at 4 15 08 pm](https://user-images.githubusercontent.com/11928039/36283849-6fcc0bb0-126b-11e8-8dd4-dacaa9569408.png)



### Changed
- A new `$font-size-map` which maps to our new typescale
- Removed deprecated warning from `font-size` mixin
- Adds a warning if not using our current scale values, suggests valid ones

<img width="724" alt="screen shot 2018-02-15 at 4 14 06 pm" src="https://user-images.githubusercontent.com/11928039/36283808-45712ed6-126b-11e8-8e4f-41d206e15989.png">

