### PR TITLE
chore(build): avoid non-build-artifacts from being removed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,8 +99,10 @@ gulp.task('clean', () =>
     'html',
     'dist',
     'demo/**/*.{js,map}',
+    '!demo/js/components/**/*',
     '!demo/js/demo-switcher.js',
     '!demo/js/theme-switcher.js',
+    '!demo/js/prism.js',
     '!demo/index.js',
     '!demo/polyfills/*.js',
   ])


### PR DESCRIPTION
## Overview

This change avoids several non-build-artifact files from being removed upon our Gulp `clean` task.

### Added

- Ignore list for `clean` task, for `demo/js/components` files and `prism.js`

## Testing / Reviewing

Testing should make sure build is not broken.