### PR TITLE
fix(overflow-menu): put focus back on the trigger button upon selection

### DIFF
--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -80,9 +80,10 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
    * @private
    */
   _handleDocumentClick(event) {
-    const element = this.element;
+    const { element, optionMenu, wasOpenBeforeClick } = this;
     const isOfSelf = element.contains(event.target);
-    const shouldBeOpen = isOfSelf && !this.wasOpenBeforeClick;
+    const isOfMenu = optionMenu && optionMenu.element.contains(event.target);
+    const shouldBeOpen = isOfSelf && !wasOpenBeforeClick;
     const state = shouldBeOpen ? 'shown' : 'hidden';
 
     if (isOfSelf) {
@@ -92,7 +93,11 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
       event.delegateTarget = element; // eslint-disable-line no-param-reassign
     }
 
-    this.changeState(state, getLaunchingDetails(event));
+    this.changeState(state, getLaunchingDetails(event), () => {
+      if (state === 'hidden' && isOfMenu) {
+        element.focus();
+      }
+    });
   }
 
   /**
@@ -103,9 +108,10 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
   _handleKeyPress(event) {
     const key = event.which;
     if (key === 13) {
-      const element = this.element;
+      const { element, optionMenu, options } = this;
       const isOfSelf = element.contains(event.target);
-      const shouldBeOpen = isOfSelf && !element.classList.contains(this.options.classShown);
+      const isOfMenu = optionMenu && optionMenu.element.contains(event.target);
+      const shouldBeOpen = isOfSelf && !element.classList.contains(options.classShown);
       const state = shouldBeOpen ? 'shown' : 'hidden';
 
       if (isOfSelf) {
@@ -115,7 +121,11 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
         event.delegateTarget = element; // eslint-disable-line no-param-reassign
       }
 
-      this.changeState(state, getLaunchingDetails(event));
+      this.changeState(state, getLaunchingDetails(event), () => {
+        if (state === 'hidden' && isOfMenu) {
+          element.focus();
+        }
+      });
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes #595.

### Added

Code to put focus back on the trigger button upon selection in menu item.

## Testing / Reviewing

Testing should make sure overflow menu is not broken.