### PR TITLE
chore: introduce lint-staged

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ demo/*.css
 demo/*.map
 demo/*.js
 demo/js/prism.js
+demo/scss/_prism.scss
 demo/hot
 !demo/index.js
 dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "printWidth": 130,
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "es5"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,6 @@ const autoprefixer = require('gulp-autoprefixer');
 
 // Javascript deps
 const babel = require('gulp-babel');
-const eslint = require('gulp-eslint');
 const uglify = require('gulp-uglify');
 const pump = require('pump');
 const { promisify } = require('bluebird');
@@ -257,38 +256,6 @@ gulp.task('html:source', () => {
 
   return gulp.src(srcFiles).pipe(gulp.dest('html'));
 });
-
-/**
- * Lint
- */
-
-gulp.task('lint', () =>
-  gulp
-    .src([
-      'gulpfile.js',
-      'server.js',
-      'src/**/*.js',
-      'tests/**/*.js',
-      'tools/**/*.js',
-      'demo/**/*.js',
-      '!demo/js/prism.js',
-      '!demo/hot/**/*.js',
-    ])
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError())
-    .pipe(
-      eslint.results(results => {
-        const count = results.warningCount;
-        if (count > 0) {
-          throw new gutil.PluginError('gulp-eslint', {
-            name: 'ESLintWarning',
-            message: `Has ${count} warning${count > 1 ? 's' : ''}`,
-          });
-        }
-      })
-    )
-);
 
 /**
  * JSDoc

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "gulp-autoprefixer": "~3.0.1",
     "gulp-axe-webdriver": "^1.4.0",
     "gulp-babel": "^6.1.2",
-    "gulp-eslint": "^3.0.0",
     "gulp-jsdoc3": "^0.2.1",
     "gulp-nodemon": "^2.2.0",
     "gulp-rename": "^1.2.2",
@@ -106,6 +105,7 @@
     "karma-sourcemap-loader": "~0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "^2.0.0",
+    "lint-staged": "^6.1.0",
     "lolex": "1.4.0",
     "markdown-it": "^8.4.0",
     "merge-stream": "^1.0.0",
@@ -151,9 +151,13 @@
     "build-dev": "gulp build:dev",
     "commitmsg": "validate-commit-msg",
     "dev": "gulp serve",
-    "lint": "gulp lint",
+    "lint": "eslint .",
+    "lint:staged": "eslint",
     "prebuild": "gulp clean",
+    "precommit": "lint-staged",
     "prepublishOnly": "npm run build",
+    "prettier": "prettier --write \"**/*.{scss,css,js}\"",
+    "prettier:staged": "prettier --write",
     "start": "node server.js",
     "test": "gulp test",
     "test:unit": "gulp test:unit",
@@ -182,6 +186,17 @@
       ],
       "warnOnFail": false
     }
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier:staged",
+      "lint:staged",
+      "git add"
+    ],
+    "*.{css,scss}": [
+      "prettier:staged",
+      "git add"
+    ]
   },
   "maintainers": [
     {


### PR DESCRIPTION
## Overview

This change is for linting/formatting staged files upon commit.

### Added

`lint-staged` and its associated scripts in package.json.

### Removed

The Gulp task for linting because it does not work well with `lint-staged`.

### Changed

`.eslintignore`/`.prettierignore` files so that running ESLint/Prettier from top-level directory wouldn’t cause a problem.

## Testing / Reviewing

Testing should make sure no dev workflow is broken.