### PR TITLE
chore(devenv): support hot CSS injection

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,26 +62,31 @@ const axe = require('gulp-axe-webdriver');
 
 gulp.task('browser-sync', ['sass:dev'], cb => {
   let started;
-  nodemon({
+  const options = {
     script: './server.js',
     ext: 'dust js',
-    watch: ['./demo/views', './server.js'],
+    watch: ['demo/**/*.dust', 'server.js'],
     env: {
       PORT: cloptions.serverport,
     },
-  }).on('start', () => {
-    if (!started) {
-      started = true;
-      browserSync.init({
-        logPrefix: 'Carbon Components',
-        open: false,
-        port: cloptions.port,
-        proxy: `localhost:${cloptions.serverport}`,
-        timestamps: false,
-      });
-      cb();
-    }
-  });
+  };
+  nodemon(options)
+    .on('start', () => {
+      if (!started) {
+        started = true;
+        browserSync.init({
+          logPrefix: 'Carbon Components',
+          open: false,
+          port: cloptions.port,
+          proxy: `localhost:${cloptions.serverport}`,
+          timestamps: false,
+        });
+        cb();
+      }
+    })
+    .on('restart', () => {
+      browserSync.reload();
+    });
 });
 
 /**
@@ -220,7 +225,7 @@ gulp.task('sass:compiled', () => {
         })
       )
       .pipe(gulp.dest('css'))
-      .pipe(browserSync.stream());
+      .pipe(browserSync.stream({ match: '**/*.css' }));
   }
 
   buildStyles(); // Expanded CSS
@@ -243,7 +248,7 @@ gulp.task('sass:dev', () =>
     )
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('demo'))
-    .pipe(browserSync.stream())
+    .pipe(browserSync.stream({ match: '**/*.css' }))
 );
 
 gulp.task('sass:source', () => {


### PR DESCRIPTION
## Overview

Support hot CSS injection. Also ensures that changes to dev env Dust templates causes dev server reload and then UI reload.

### Changed

* Settings of `browser-sync` to support hot CSS injection.
* Settings of `nodemon` so that change in dev env Dust templates will cause dev server update and then UI reload.

## Testing / Reviewing

Testing should make sure dev env is not broken.