### PR TITLE
fix(search): support large search without icons

### DIFF
--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -88,7 +88,7 @@
     right: rem(100px);
   }
 
-  .#{$prefix}--search--lg:last-child .#{$prefix}--search-close {
+  .#{$prefix}--search--lg .#{$prefix}--search-close:last-child {
     right: rem(12px);
   }
 

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -88,6 +88,10 @@
     right: rem(100px);
   }
 
+  .#{$prefix}--search--lg:last-child .#{$prefix}--search-close {
+    right: rem(12px);
+  }
+
   .#{$prefix}--search-button {
     @include reset;
     border: 0;


### PR DESCRIPTION
Ensures search clear icon offset is calculated differently without icons. 

Closes https://github.com/carbon-design-system/carbon-components/issues/600