### PR TITLE
chore(devenv): avoid getting BrowserSync proxy being stalled

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,22 +7,12 @@ const path = require('path');
 const express = require('express'); // eslint-disable-line
 const Fractal = require('@frctl/fractal'); // eslint-disable-line
 
-const webpack = require('webpack'); // eslint-disable-line
-const webpackDevMiddleware = require('webpack-dev-middleware'); // eslint-disable-line
-const webpackHotMiddleware = require('webpack-hot-middleware'); // eslint-disable-line
-
 const readFile = promisify(fs.readFile);
 
 const app = express();
 const adaro = require('adaro'); // eslint-disable-line
 
 const port = process.env.PORT || 8080;
-
-const config = require('./tools/webpack.dev.config');
-
-const compiler = webpack(config);
-app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }));
-app.use(webpackHotMiddleware(compiler));
 
 const fractal = Fractal.create();
 fractal.components.set('path', path.join(__dirname, 'src/components'));


### PR DESCRIPTION
## Overview

I hit an issue with dev env where BrowserSync proxy getting stall (not being able to handle any requests from certain point, though direct access to the proxy target works well). It happens the most often when I hit an URL to dev env while WebPack dev server is building our JS code.

To address this, this PR moves WebPack Express middlewares from our dev server to BrowserSync.

### Changed

Moved WebPack Express middlewares from our dev server to BrowserSync.

## Testing / Reviewing

Testing should make sure our dev env is not broken.