### PR TITLE
chore(jsdoc): fix JSDoc crash

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -271,7 +271,7 @@ gulp.task('jsdoc', cb => {
     .src('./src/**/*.js')
     .pipe(
       babel({
-        plugins: ['transform-class-properties'],
+        plugins: ['transform-class-properties', 'transform-object-rest-spread'],
         babelrc: false,
       })
     )


### PR DESCRIPTION
## Overview

Fixes a crash with Gulp `jsdoc` task.

### Added

Running `transform-object-rest-spread` plugin before letting `jsdoc` parse the code.

## Testing / Reviewing

Testing should make sure JSDoc works well.