### PR TITLE
fix(fonts): Move Plex as a peer dependency, update

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@frctl/fractal": "^1.1.0",
-    "@ibm/plex": "^1.0.0",
     "adaro": "1.0.4",
     "babel-core": "^6.22.0",
     "babel-eslint": "^7.0.0",
@@ -230,5 +229,8 @@
     "exports": false,
     "name": "carbon-components",
     "needs": "^1.2.1"
+  },
+  "peerDependencies": {
+    "@ibm/plex": "^1.0.1"
   }
 }

--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -1,4 +1,4 @@
-$font-prefix: 'https://unpkg.com/@ibm/plex@v1.0.0' !default;
+$font-prefix: 'https://unpkg.com/@ibm/plex@v1.0.1' !default;
 
 @import 'import-once';
 @import '@ibm/plex/scss/mono/italic/index';

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,9 +68,9 @@
     js-beautify "^1.6.2"
     lodash "^4.12.0"
 
-"@ibm/plex@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ibm/plex/-/plex-1.0.0.tgz#afac8ec2f8a126eb517eb043a9af4d7224538bee"
+"@ibm/plex@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ibm/plex/-/plex-1.0.1.tgz#5bd7186bdf1c2daa491aa37a6e9a3e4e4a945d94"
 
 "@semantic-release/commit-analyzer@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Overview

Resolves #611 

### Changed

- Moves `@ibm/plex` to a peerDependencies for those compiling their own scss
- Bumps the `@ibm/plex` version number to v1.0.1 (has no change for web use though)
