### PR TITLE
fix(card): Prevent overflowing text

### DIFF
--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -61,6 +61,12 @@
       background-color: $ui-03;
       padding-left: 1rem;
       padding-right: 1rem;
+
+      > .#{$prefix}--btn {
+        @include text-overflow();
+        margin-right: 0.25rem;
+        flex: 1;
+      }
     }
 
     .#{$prefix}--card-footer__link {
@@ -78,16 +84,18 @@
       flex-direction: column;
       align-items: $card-flex-align;
       padding-top: 1rem;
+      width: 100%;
     }
 
     .#{$prefix}--about__title {
       font-weight: 400;
       padding-top: 1.5rem;
+      width: 100%;
     }
 
     .#{$prefix}--about__title--name {
       @include typescale('delta');
-      @include text-overflow(rem(180px));
+      @include text-overflow();
       font-weight: 400;
       margin: 0;
       line-height: 1.2;
@@ -96,16 +104,14 @@
 
     .#{$prefix}--about__title--link {
       @include typescale('omega');
-      @include text-overflow(rem(180px));
-      display: inline;
+      @include text-overflow();
       font-weight: 400;
       text-align: center;
     }
 
     .#{$prefix}--about__title--additional-info {
       @include typescale('omega');
-      @include text-overflow(rem(180px));
-      display: inline;
+      @include text-overflow();
       font-weight: 400;
       padding: 0;
       margin: 0;

--- a/src/components/card/card--with-status.html
+++ b/src/components/card/card--with-status.html
@@ -31,8 +31,8 @@
         <img src="/globals/assets/images/placeholder-icon-32x32.svg" alt="" class="bx--about__icon--img" />
       </figure>
       <header class="bx--about__title">
-        <p id="card-title-1" class="bx--about__title--name bx--type-gamma">Card Name</p>
-        <a href="" class="bx--link bx--about__title--link">Secondary Information</a>
+        <p id="card-title-1" class="bx--about__title--name bx--type-gamma" title="Card Name">Card Name</p>
+        <a href="" class="bx--link bx--about__title--link" title="Secondary Information">Secondary Information</a>
       </header>
     </div>
   </div>

--- a/src/components/card/card.html
+++ b/src/components/card/card.html
@@ -32,12 +32,12 @@
       </figure>
       <header class="bx--about__title">
         <p id="card-title-2" class="bx--about__title--name bx--type-gamma" title="Card Name">Card Name</p>
-        <p class="bx--about__title--additional-info bx--type-delta">Secondary Information</p>
+        <p class="bx--about__title--additional-info bx--type-delta" title="Secondary Information">Secondary Information</p>
       </header>
   </div>
   </section>
   <footer class="bx--card-footer">
-    <button class="bx--btn bx--btn--primary bx--btn--sm" type="button">View credentials</button>
+    <button class="bx--btn bx--btn--primary bx--btn--sm" type="button" title="View credentials">View credentials</button>
     <a href="" class="bx--card-footer__link">Docs</a>
   </footer>
 </article>

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -16,12 +16,16 @@
 @import 'css--reset';
 @import 'typography';
 
-@mixin text-overflow($width) {
+@mixin text-overflow($width: false) {
   display: block;
-  width: $width;
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  // apply a width if width parameter exists
+  @if ($width) {
+    width: $width;
+  }
 }
 
 @mixin placeholder-colors {


### PR DESCRIPTION
Fixes #576 

Component affected: Card

- added feature to allow parameter to be optional for `text-overflow()`mixin
- adjusted title and button areas to support overflowing text (properly showing ellipses when text is too long
- added `title` attribute to code examples, so when user hovers over truncated text, the full text should show

Note: Spoke with @tay-aitken and she suggested the `Secondary Information` section ideally should span 2 lines then show ellipses. However, due to the nature of CSS, ellipses only works on line 1. There are other ways to provide ellipses on a 2nd line which require a little more CSS work using pseudo-elements, but figure this is in a good state that tackles the scope of the original issue.

Non-truncated example:
![screen shot 2018-03-02 at 3 50 40 pm](https://user-images.githubusercontent.com/940113/36923650-8d559f08-1e31-11e8-91be-db6e21885af1.png)

Truncated example:
![screen shot 2018-03-02 at 3 50 33 pm](https://user-images.githubusercontent.com/940113/36923653-8e8fffd0-1e31-11e8-8721-4875e97b491d.png)
