### PR TITLE
fix(tile): Add padding value to height calculation for above the fold on expandable tile

### DIFF
--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -32,7 +32,10 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
     const isExpandable = this.tileType === 'expandable';
     if (isExpandable) {
       const aboveTheFold = this.element.querySelector(this.options.selectorAboveTheFold);
-      const tilePadding = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding'), 10) * 2;
+      const tilePaddingTop = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding-top'), 10);
+      const tilePaddingBottom = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding-bottom'), 10);
+
+      const tilePadding = tilePaddingTop + tilePaddingBottom;
       if (aboveTheFold) {
         this.tileHeight = this.element.getBoundingClientRect().height;
         this.atfHeight = aboveTheFold.getBoundingClientRect().height + tilePadding;

--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -32,9 +32,10 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
     const isExpandable = this.tileType === 'expandable';
     if (isExpandable) {
       const aboveTheFold = this.element.querySelector(this.options.selectorAboveTheFold);
+      const tilePadding = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding'), 10);
       if (aboveTheFold) {
         this.tileHeight = this.element.getBoundingClientRect().height;
-        this.atfHeight = aboveTheFold.getBoundingClientRect().height;
+        this.atfHeight = aboveTheFold.getBoundingClientRect().height + tilePadding;
         this.element.style.maxHeight = `${this.atfHeight}px`;
       }
     }

--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -32,7 +32,7 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
     const isExpandable = this.tileType === 'expandable';
     if (isExpandable) {
       const aboveTheFold = this.element.querySelector(this.options.selectorAboveTheFold);
-      const tilePadding = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding'), 10);
+      const tilePadding = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding'), 10) * 2;
       if (aboveTheFold) {
         this.tileHeight = this.element.getBoundingClientRect().height;
         this.atfHeight = aboveTheFold.getBoundingClientRect().height + tilePadding;

--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -32,9 +32,9 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
     const isExpandable = this.tileType === 'expandable';
     if (isExpandable) {
       const aboveTheFold = this.element.querySelector(this.options.selectorAboveTheFold);
-      const tilePaddingTop = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding-top'), 10);
-      const tilePaddingBottom = parseInt(window.getComputedStyle(this.element, null).getPropertyValue('padding-bottom'), 10);
-
+      const getStyle = this.element.ownerDocument.defaultView.getComputedStyle(this.element, null);
+      const tilePaddingTop = parseInt(getStyle.getPropertyValue('padding-top'), 10);
+      const tilePaddingBottom = parseInt(getStyle.getPropertyValue('padding-bottom'), 10);
       const tilePadding = tilePaddingTop + tilePaddingBottom;
       if (aboveTheFold) {
         this.tileHeight = this.element.getBoundingClientRect().height;


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/594
_for vanilla repo only_

The expandable tile wasn't correctly calculating the height (was ignoring the padding value)

## Testing / Reviewing

Add content to the above/below areas of the expandable tile and make sure expandable tile works as expected. 
