### PR TITLE
chore(devenv): stop using iframe except for several components

### DIFF
--- a/demo/js/components/CodePage/CodePage.js
+++ b/demo/js/components/CodePage/CodePage.js
@@ -37,7 +37,12 @@ const CodePage = ({ metadata, hideViewFullRender }) => {
   const subItems = getSubItems(metadata).filter(item => !item.isHidden);
   const componentContent =
     !metadata.isCollection && subItems.length <= 1 ? (
-      <ComponentExample hideViewFullRender={hideViewFullRender} component={metadata.name} htmlFile={getContent(metadata)} />
+      <ComponentExample
+        hideViewFullRender={hideViewFullRender}
+        component={metadata.name}
+        htmlFile={getContent(metadata)}
+        useIframe={metadata.useIframe}
+      />
     ) : (
       subItems.map(item => (
         <div key={item.id} className="component-variation">
@@ -46,6 +51,7 @@ const CodePage = ({ metadata, hideViewFullRender }) => {
             variant={item.handle.replace(/--default$/, '')}
             component={metadata.name}
             htmlFile={getContent(item)}
+            useIframe={metadata.useIframe}
           />
         </div>
       ))

--- a/demo/js/components/ComponentExample/ComponentExample.js
+++ b/demo/js/components/ComponentExample/ComponentExample.js
@@ -1,81 +1,174 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'carbon-components-react';
 import classnames from 'classnames';
 
 import CodeExample from '../CodeExample/CodeExample';
 
+const forEach = Array.prototype.forEach;
+
 /**
  * The UI to show live code as well as its source.
  */
-const ComponentExample = ({ htmlFile, component, variant, codepenSlug, hideViewFullRender }) => {
-  const classNames = classnames({
-    'component-example__live--rendered': true,
-    [component]: true,
-  });
+class ComponentExample extends Component {
+  static propTypes = {
+    /**
+     * The source code.
+     */
+    htmlFile: PropTypes.string,
 
-  const lightUIclassnames = classnames({
-    'component-example': true,
-    'bx--global-light-ui': component === 'tabs',
-  });
+    /**
+     * The component name.
+     */
+    component: PropTypes.string,
 
-  const codepenLink = codepenSlug && `https://codepen.io/team/carbon/full/${codepenSlug}/`;
-  const componentLink = variant ? `/component/${component}/${variant}` : `/component/${component}`;
+    /**
+     * The component variant name.
+     */
+    variant: PropTypes.string,
 
-  const viewFullRender = hideViewFullRender ? null : (
-    <Link className="component-example__view-full-render" target="_blank" href={codepenLink || componentLink}>
-      {codepenLink ? 'View on CodePen' : 'View full render'}
-    </Link>
-  );
+    /**
+     * `true` to hide "view full render" link.
+     */
+    hideViewFullRender: PropTypes.bool,
 
-  return (
-    <div className={lightUIclassnames}>
-      <div className="svg--sprite" aria-hidden="true" />
-      <div className="component-example__live">
-        <iframe
-          className={classNames}
-          data-role="window"
-          src={componentLink}
-          sandbox="allow-same-origin allow-scripts allow-forms"
-          marginWidth="0"
-          marginHeight="0"
-          frameBorder="0"
-          vspace="0"
-          hspace="0"
-          scrolling="yes"
-        />
-        {viewFullRender}
+    /**
+     * `true` to use `<iframe>`.
+     */
+    useIframe: PropTypes.bool,
+
+    /**
+     * The slug of the CodePen link.
+     */
+    codepenSlug: PropTypes.string,
+  };
+
+  componentDidMount() {
+    this._instantiateComponents();
+  }
+
+  componentWillUpdate({ component }) {
+    const { component: prevComponent } = this.props;
+    if (prevComponent !== component) {
+      this._releaseComponents();
+    }
+  }
+
+  componentDidUpdate({ component }) {
+    const { component: prevComponent } = this.props;
+    if (prevComponent !== component) {
+      this._instantiateComponents();
+    }
+  }
+
+  componentWillUnmount() {
+    this._releaseComponents();
+  }
+
+  /**
+   * The container where the live demo HTML code should be put into.
+   * @type {HTMLElement}
+   * @private
+   */
+  _container = null;
+
+  /**
+   * Instantiate/release Carbon components as the container for the live demo HTML code is mounted/unmounted.
+   * @param {HTMLElement} container The container where the live demo HTML code should be put into.
+   */
+  _setContainer = container => {
+    this._container = container;
+  };
+
+  /**
+   * Instantiates Carbon components for non-`<iframe>` mode.
+   */
+  _instantiateComponents = () => {
+    const container = this._container;
+    const components = container.ownerDocument.defaultView.CarbonComponents;
+    if (components) {
+      const componentClasses = Object.keys(components)
+        .map(key => components[key])
+        .filter(Clz => typeof Clz.init === 'function');
+      componentClasses.filter(Clz => !Clz.forLazyInit).forEach(Clz => {
+        Clz.init(container);
+      });
+    }
+  };
+
+  /**
+   * Releases Carbon components for non-`<iframe>` mode.
+   */
+  _releaseComponents = () => {
+    const container = this._container;
+    const components = container.ownerDocument.defaultView.CarbonComponents;
+    if (components) {
+      Object.keys(components)
+        .map(key => components[key])
+        .filter(Clz => typeof Clz.init === 'function')
+        .forEach(Clz => {
+          forEach.call(container.querySelectorAll(Clz.options.selectorInit), element => {
+            const instance = Clz.components.get(element);
+            if (instance) {
+              instance.release();
+            }
+          });
+        });
+    }
+  };
+
+  render() {
+    const { htmlFile, component, variant, codepenSlug, hideViewFullRender, useIframe } = this.props;
+    const classNames = classnames({
+      'component-example__live--rendered': true,
+      [component]: true,
+    });
+
+    const lightUIclassnames = classnames({
+      'component-example': true,
+      'bx--global-light-ui': component === 'tabs',
+    });
+
+    const codepenLink = codepenSlug && `https://codepen.io/team/carbon/full/${codepenSlug}/`;
+    const componentLink = variant ? `/component/${component}/${variant}` : `/component/${component}`;
+
+    const viewFullRender = hideViewFullRender ? null : (
+      <Link className="component-example__view-full-render" target="_blank" href={codepenLink || componentLink}>
+        {codepenLink ? 'View on CodePen' : 'View full render'}
+      </Link>
+    );
+
+    /* eslint-disable react/no-danger */
+    return (
+      <div className={lightUIclassnames}>
+        <div className="svg--sprite" aria-hidden="true" />
+        <div className="component-example__live">
+          {useIframe ? (
+            <iframe
+              className={classNames}
+              data-role="window"
+              src={componentLink}
+              sandbox="allow-same-origin allow-scripts allow-forms"
+              marginWidth="0"
+              marginHeight="0"
+              frameBorder="0"
+              vspace="0"
+              hspace="0"
+              scrolling="yes"
+              ref={this._setContainer}
+            />
+          ) : (
+            <div className={classNames}>
+              <div dangerouslySetInnerHTML={{ __html: htmlFile }} ref={this._setContainer} />
+            </div>
+          )}
+          {viewFullRender}
+        </div>
+        <CodeExample htmlFile={htmlFile} />
       </div>
-      <CodeExample htmlFile={htmlFile} />
-    </div>
-  );
-};
-
-ComponentExample.propTypes = {
-  /**
-   * The source code.
-   */
-  htmlFile: PropTypes.string,
-
-  /**
-   * The component name.
-   */
-  component: PropTypes.string,
-
-  /**
-   * The component variant name.
-   */
-  variant: PropTypes.string,
-
-  /**
-   * `true` to hide "view full render" link.
-   */
-  hideViewFullRender: PropTypes.bool,
-
-  /**
-   * The slug of the CodePen link.
-   */
-  codepenSlug: PropTypes.string,
-};
+    );
+    /* eslint-enable react/no-danger */
+  }
+}
 
 export default ComponentExample;

--- a/demo/views/demo-nav.dust
+++ b/demo/views/demo-nav.dust
@@ -21,7 +21,19 @@
     <div data-renderroot></div>
     <input aria-label="inpute-text-offleft" type="text" class="offleft" />
     <script>
-      var componentItems = {componentItems|js|s};
+      var needIframe = [
+        'detail-page-header',
+        'footer',
+        'grid',
+        'interior-left-nav',
+        'lightbox',
+        'module',
+        'order-summary',
+        'unified-header',
+      ];
+      var componentItems = {componentItems|js|s}.map(
+        item => (needIframe.indexOf(item.name) >= 0 ? { ...item, useIframe: true } : item)
+      );
       var docItems = {docItems|js|s};
     </script>
     <script src="/demo/demo.js"></script>


### PR DESCRIPTION
## Overview

In our dev env, opening a component demo page with multiple variants (e.g. `localhost:3000/demo/tile`) seems to hang `browser-sync`. While the root cause has not been found yet, there are several signs that multiple `<iframe>`s connecting to `browser-sync` is the culprit. This change is for avoiding such `<iframe>`, probably temporarily, to avoid such issue.

### Changed

Going away from `<iframe>` for most of the components (except for components whose demo does not work well with `<iframe>`).

## Testing / Reviewing

Testing should make sure our dev env is not broken.