### PR TITLE
feat(tooltip): handle hover-over on tooltip

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash.debounce';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -56,21 +57,23 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
    */
   constructor(element, options) {
     super(element, options);
-    ['mouseover', 'mouseout', 'focus', 'blur', 'touchleave', 'touchcancel'].forEach(name => {
-      this.manage(
-        on(this.element, name, event => {
-          this._handleHover(event);
-        })
-      );
-    });
+    this._hookOn(element);
   }
+
+  /**
+   * The debounced version of the event handler.
+   * @type {Function}
+   * @private
+   */
+  _debouncedHandleHover = debounce(this._handleHover, 200);
 
   /**
    * A method called when this widget is created upon events.
    * @param {Event} event The event triggering the creation.
    */
   createdByEvent(event) {
-    this._handleHover(event);
+    const { relatedTarget, type } = event;
+    this._debouncedHandleHover({ relatedTarget, type, details: getLaunchingDetails(event) });
   }
 
   /**
@@ -92,6 +95,7 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
         classShown: this.options.classShown,
         offset: this.options.objMenuOffset,
       });
+      this._hookOn(tooltip);
       this.children.push(this.tooltip);
     }
 
@@ -101,11 +105,30 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
   }
 
   /**
-   * Handles hover/focus events.
-   * @param {Event} event The event.
+   * Attaches event handlers to show/hide the tooltip.
+   * @param {Element} element The element to attach the events to.
    * @private
    */
-  _handleHover(event) {
+  _hookOn(element) {
+    ['mouseover', 'mouseout', 'focus', 'blur', 'touchleave', 'touchcancel'].forEach(name => {
+      this.manage(
+        on(element, name, event => {
+          const { relatedTarget, type } = event;
+          this._debouncedHandleHover({ relatedTarget, type, details: getLaunchingDetails(event) });
+        })
+      );
+    });
+  }
+
+  /**
+   * Handles hover/focus events.
+   * @param {Object} params The parameters.
+   * @param {number} params.relatedTarget For `mouseover` event, indicates where the mouse pointer is gone.
+   * @param {string} params.type The event type triggering this method.
+   * @param {Object} params.details The event details.
+   * @private
+   */
+  _handleHover({ relatedTarget, type, details }) {
     const state = {
       mouseover: 'shown',
       mouseout: 'hidden',
@@ -113,8 +136,15 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
       blur: 'hidden',
       touchleave: 'hidden',
       touchcancel: 'hidden',
-    }[event.type];
-    this.changeState(state, getLaunchingDetails(event));
+    }[type];
+    // Note: SVGElement in IE11 does not have `.contains()`
+    const shouldPreventClose =
+      type === 'mouseout' &&
+      relatedTarget &&
+      ((this.element.contains && this.element.contains(relatedTarget)) || this.tooltip.element.contains(relatedTarget));
+    if (!shouldPreventClose) {
+      this.changeState(state, details);
+    }
   }
 
   static components = new WeakMap();

--- a/tests/spec/tooltip_spec.js
+++ b/tests/spec/tooltip_spec.js
@@ -26,7 +26,11 @@ describe('Test tooltip', function() {
 
     beforeAll(function() {
       document.body.appendChild(container);
-      tooltip = new Tooltip(element);
+      return Tooltip.__with__({
+        debounce: fn => fn,
+      })(() => {
+        tooltip = new Tooltip(element);
+      });
     });
 
     it('Should show the tooltip upon hovering over', function() {
@@ -81,13 +85,21 @@ describe('Test tooltip', function() {
     });
 
     it('Should create an instance upon hovering over', function() {
-      element.dispatchEvent(new CustomEvent('mouseover', { bubbles: true }));
-      expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
+      return Tooltip.__with__({
+        debounce: fn => fn,
+      })(() => {
+        element.dispatchEvent(new CustomEvent('mouseover', { bubbles: true }));
+        expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
+      });
     });
 
     it('Should create an instance upon focusing', function() {
-      element.dispatchEvent(new CustomEvent('focus', { bubbles: true }));
-      expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
+      return Tooltip.__with__({
+        debounce: fn => fn,
+      })(() => {
+        element.dispatchEvent(new CustomEvent('focus', { bubbles: true }));
+        expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
+      });
     });
 
     afterEach(function() {


### PR DESCRIPTION
Fixes #266.

## Overview

This PR is for preventing tooltip from being closed when the mouse is on the open tooltip.

### Added

* Code to detect if the mouse is is on the open tooltip
* Code to debounce event handlers that open/close tooltip (Moving mouse cursor from the trigger button to the open tooltip causes mouse pointer to go to another element between them, and thus detecting mouse position right after the mouse cursor goes out of the trigger button will detect another element)

## Testing / Reviewing

Testing should make sure tooltip is not broken.