### PR TITLE
chore(devenv): fix dev env for older browsers

### DIFF
--- a/demo/views/demo-nav.dust
+++ b/demo/views/demo-nav.dust
@@ -31,9 +31,9 @@
         'order-summary',
         'unified-header',
       ];
-      var componentItems = {componentItems|js|s}.map(
-        item => (needIframe.indexOf(item.name) >= 0 ? { ...item, useIframe: true } : item)
-      );
+      var componentItems = {componentItems|js|s}.map(function (item) {
+        return needIframe.indexOf(item.name) >= 0 ? Object.assign(item, { useIframe: true }) : item;
+      });
       var docItems = {docItems|js|s};
     </script>
     <script src="/demo/demo.js"></script>


### PR DESCRIPTION
## Overview

Fixes #640. Sorry @alisonjoseph for this!

### Removed

Inadvertent addition of object spread operator, etc. in `<script>` tag in `.dust`

## Testing / Reviewing

Testing should make sure the dev env is not broken.