### PR TITLE
chore(devenv): apply height only for iframe mode

### DIFF
--- a/demo/js/components/ComponentExample/ComponentExample.js
+++ b/demo/js/components/ComponentExample/ComponentExample.js
@@ -119,8 +119,12 @@ class ComponentExample extends Component {
 
   render() {
     const { htmlFile, component, variant, codepenSlug, hideViewFullRender, useIframe } = this.props;
-    const classNames = classnames({
-      'component-example__live--rendered': true,
+
+    const classNamesContainer = classnames('component-example__live', {
+      'component-example__live--with-iframe': useIframe,
+    });
+
+    const classNames = classnames('component-example__live--rendered', {
       [component]: true,
     });
 
@@ -142,7 +146,7 @@ class ComponentExample extends Component {
     return (
       <div className={lightUIclassnames}>
         <div className="svg--sprite" aria-hidden="true" />
-        <div className="component-example__live">
+        <div className={classNamesContainer}>
           {useIframe ? (
             <iframe
               className={classNames}

--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -13,7 +13,7 @@
 @import '../js/components/SideNavToggle/side-nav-toggle.scss';
 
 [data-renderroot] {
-  .component-example__live {
+  .component-example__live--with-iframe {
     height: 25rem;
 
     iframe {

--- a/demo/views/demo-nav.dust
+++ b/demo/views/demo-nav.dust
@@ -25,10 +25,6 @@
         'detail-page-header',
         'footer',
         'grid',
-        'interior-left-nav',
-        'lightbox',
-        'module',
-        'order-summary',
         'unified-header',
       ];
       var componentItems = {componentItems|js|s}.map(


### PR DESCRIPTION
## Overview

Fixes #646.

### Removed

Forced `height` for non-`<iframe>` mode in dev env’s live demo.

## Testing / Reviewing

Testing should make sure the dev env is not broken.