### PR TITLE
chore(devenv): support HMR for tooltip, modal, etc.

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -4,6 +4,7 @@ import './js/components/boot-nav';
 import './js/prism';
 
 import * as components from '../src/globals/js/components';
+import lazyInitHandles from '../src/globals/js/boot';
 
 export * from '../src/bundle';
 
@@ -11,6 +12,10 @@ if (typeof module !== 'undefined' && module.hot) {
   const forEach = Array.prototype.forEach;
 
   module.hot.dispose(() => {
+    // Releases handles for event handlers to lazily instantiate components that have been replaced with new ones by HMR
+    for (let h = lazyInitHandles.pop(); h; h = lazyInitHandles.pop()) {
+      h.release();
+    }
     // Releases component instances of (old) component classes that have been replaced with new ones by HMR
     Object.keys(components)
       .map(key => components[key])

--- a/src/globals/js/boot.js
+++ b/src/globals/js/boot.js
@@ -2,6 +2,12 @@ import settings from './settings';
 import * as components from './components';
 
 /**
+ * The handles for event handlers to lazily instantiate components.
+ * @type {Handle[]}
+ */
+const lazyInitHandles = [];
+
+/**
  * Instantiates components automatically
  * by searching for elements with `data-component-name` (e.g. `data-loading`) attribute
  * or upon DOM events (e.g. clicking) on such elements.
@@ -14,7 +20,10 @@ const init = () => {
     .filter(component => typeof component.init === 'function');
   if (!settings.disableAutoInit) {
     componentClasses.forEach(Clz => {
-      Clz.init();
+      const h = Clz.init();
+      if (h) {
+        lazyInitHandles.push(h);
+      }
     });
   }
 };
@@ -26,3 +35,5 @@ if (document.readyState === 'loading') {
   // Let consumer have chance to see if it wants automatic instantiation disabled, and then run automatic instantiation otherwise
   setTimeout(init, 0);
 }
+
+export default lazyInitHandles;


### PR DESCRIPTION
## Overview

Fixes HMR not happening with our tooltip component.

### Added

* Default export to `src/globals/js/boot.js`, which is a list of handles for event handlers that instantiates tooltip, etc.
* Code to clean-up above handles when Carbon modules are replaced with new ones as WebPack builds stuffs

## Testing / Reviewing

Testing should make sure the dev env is not broken.