### PR TITLE
chore(devenv): instantiate/release components as component markup is updated

### DIFF
--- a/demo/js/components/ComponentExample/ComponentExample.js
+++ b/demo/js/components/ComponentExample/ComponentExample.js
@@ -47,16 +47,16 @@ class ComponentExample extends Component {
     this._instantiateComponents();
   }
 
-  componentWillUpdate({ component }) {
-    const { component: prevComponent } = this.props;
-    if (prevComponent !== component) {
+  componentWillUpdate({ component, htmlFile }) {
+    const { component: prevComponent, htmlFile: prevHtmlFile } = this.props;
+    if (prevComponent !== component || prevHtmlFile !== htmlFile) {
       this._releaseComponents();
     }
   }
 
-  componentDidUpdate({ component }) {
-    const { component: prevComponent } = this.props;
-    if (prevComponent !== component) {
+  componentDidUpdate({ component, htmlFile }) {
+    const { component: prevComponent, htmlFile: prevHtmlFile } = this.props;
+    if (prevComponent !== component || prevHtmlFile !== htmlFile) {
       this._instantiateComponents();
     }
   }


### PR DESCRIPTION
## Overview

In our devenv, component markup may come late via XHR. There was a bug where sometimes component instances are not created for DOM elements created from the XHR response. First revealed with accordion demo (not being able to open/close the sections) as an intermittent issue. This PR addresses such issue.

### Added

Code that runs upon `cWU` and `cDU` on component live demo, to detect if component markup has been changed, and if so, re-instantiates Carbon components in the component markup.

## Testing / Reviewing

Testing should make sure our dev env is not broken.