### PR TITLE
chore(release): let semantic-release release manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@frctl/fractal": "^1.1.0",
+    "@semantic-release/commit-analyzer": "^2.0.0",
     "adaro": "1.0.4",
     "babel-core": "^6.22.0",
     "babel-eslint": "^7.0.0",
@@ -181,6 +182,7 @@
         "fix",
         "perf",
         "refactor",
+        "release",
         "revert",
         "style",
         "test"
@@ -198,6 +200,9 @@
       "prettier:staged",
       "git add"
     ]
+  },
+  "release": {
+    "analyzeCommits": "./tools/analyze-commits.js"
   },
   "maintainers": [
     {

--- a/tools/analyze-commits.js
+++ b/tools/analyze-commits.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const commitAnayzer = require('@semantic-release/commit-analyzer');
+
+const reCommit = /^release(\(([\w$.\-* ]*)\))?:/i;
+
+module.exports = (pluginConfig, ref, cb) => {
+  // eslint-disable-next-line no-console
+  console.log(
+    `Commits:\n${ref.commits
+      .map(({ message }) => message.split('\n')[0])
+      .reverse()
+      .join('\n')}`
+  );
+  if (ref.commits.every(({ message }) => !reCommit.test(message))) {
+    cb(null);
+  } else {
+    commitAnayzer(pluginConfig, ref, cb);
+  }
+};


### PR DESCRIPTION
## Overview

This PR is for getting better control of our release process with `semantic-release`, which would help our consumers' release process.

### Changed

`semantic-release` stops triggering a release unless there is a commit whose subject starts with `release:` or `release(subheader)`.

## Testing / Reviewing

Testing should make sure our release process is not broken. I have run some dry-runs and it seems to work well.