### PR TITLE
Indicate focus only when the browser does

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -51,7 +51,7 @@
       outline: none;
 
       .#{$prefix}--accordion__arrow {
-        @include focus-outline('border', $touch: false);
+        @include focus-outline('border', $mouse: false, $touch: false);
         overflow: visible; // safari fix
         outline-offset: -0.5px; // safari fix
       }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -24,9 +24,9 @@
       outline: none;
 
       .#{$prefix}--accordion__arrow {
-        @include focus-outline('border');
+        @include focus-outline('border', $touch: false);
         overflow: visible; // safari fix
-        outline-offset: -.5px; // safari fix
+        outline-offset: -0.5px; // safari fix
       }
     }
 
@@ -51,9 +51,9 @@
       outline: none;
 
       .#{$prefix}--accordion__arrow {
-        @include focus-outline('border');
+        @include focus-outline('border', $touch: false);
         overflow: visible; // safari fix
-        outline-offset: -.5px; // safari fix
+        outline-offset: -0.5px; // safari fix
       }
     }
   }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -49,11 +49,19 @@
     text-decoration: none;
     border-bottom: 1px solid transparent;
 
-    &:hover,
-    &:focus {
+    &:hover {
       outline: none;
       color: $brand-01;
       border-bottom: 1px solid $brand-01;
+    }
+
+    &:focus {
+      outline: none;
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $brand-01;
+        border-bottom: 1px solid $brand-01;
+      }
     }
 
     // Applies to Firefox only

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -35,79 +35,83 @@
   }
 
   .#{$prefix}--btn--primary {
-    @include button-theme(
-      $brand-01,
-      transparent,
-      $inverse-01,
-      $brand-02,
-      $ui-01
-    );
+    @include button-theme($brand-01, transparent, $inverse-01, $brand-02, $ui-01);
   }
 
   .#{$prefix}--btn--secondary {
-    @include button-theme(
-      transparent,
-      $brand-01,
-      $brand-01,
-      $brand-01,
-      $brand-01
-    );
+    @include button-theme(transparent, $brand-01, $brand-01, $brand-01, $brand-01);
 
-    &:hover,
-    &:focus {
+    &:hover {
       color: $inverse-01;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $inverse-01;
+      }
     }
 
     &:active {
       color: $brand-01;
     }
 
-    &:hover > .#{$prefix}--btn__icon,
-    &:focus > .#{$prefix}--btn__icon {
+    &:hover > .#{$prefix}--btn__icon {
       fill: $inverse-01;
     }
 
-    &:hover:disabled,
-    &:focus:disabled {
+    &:focus > .#{$prefix}--btn__icon {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        fill: $inverse-01;
+      }
+    }
+
+    &:active > .#{$prefix}--btn__icon {
+      fill: $brand-01;
+    }
+
+    &:hover:disabled {
       color: $brand-01;
+    }
+
+    &:focus:disabled {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $brand-01;
+      }
     }
   }
 
   .#{$prefix}--btn--tertiary {
-    @include button-theme(
-      transparent,
-      $ui-05,
-      $ui-05,
-      $ui-05,
-      $ui-05
-    );
+    @include button-theme(transparent, $ui-05, $ui-05, $ui-05, $ui-05);
 
-    &:hover,
-    &:focus {
+    &:hover {
       color: $inverse-01;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $inverse-01;
+      }
     }
 
     &:active {
       color: $ui-05;
     }
 
-    &:hover:disabled,
-    &:focus:disabled {
+    &:hover:disabled {
       color: $ui-05;
+    }
+
+    &:focus:disabled {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $ui-05;
+      }
     }
   }
 
   .#{$prefix}--btn--ghost {
-    @include button-theme(
-      transparent,
-      transparent,
-      $brand-01,
-      $brand-01,
-      $brand-01
-    );
+    @include button-theme(transparent, transparent, $brand-01, $brand-01, $brand-01);
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       color: $inverse-01;
 
       .#{$prefix}--btn__icon {
@@ -115,28 +119,50 @@
       }
     }
 
-    .#{$prefix}--btn__icon {
-      margin-left: $spacing-xs;
+    &:hover {
+      @include hover-focus;
     }
 
-    &:hover:disabled,
-    &:focus:disabled {
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
+      }
+    }
+
+    &:active,
+    &:active:focus {
+      // active:focus overrides [data-input-method] :focus
       color: $brand-01;
 
       .#{$prefix}--btn__icon {
         fill: $brand-01;
       }
     }
+
+    .#{$prefix}--btn__icon {
+      margin-left: $spacing-xs;
+    }
+
+    @mixin hover-focus-2 {
+      color: $brand-01;
+
+      .#{$prefix}--btn__icon {
+        fill: $brand-01;
+      }
+    }
+    &:hover:disabled {
+      @include hover-focus-2;
+    }
+
+    &:focus:disabled {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus-2;
+      }
+    }
   }
 
   .#{$prefix}--btn--danger {
-    @include button-theme(
-      transparent,
-      $support-01,
-      $support-01,
-      $support-01,
-      $support-01
-    );
+    @include button-theme(transparent, $support-01, $support-01, $support-01, $support-01);
 
     &:hover {
       color: $inverse-01;
@@ -144,29 +170,43 @@
     }
 
     &:focus {
-      color: $inverse-01;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $inverse-01;
+      }
     }
 
-    &:hover:disabled,
-    &:focus:disabled {
+    &:active,
+    &:active:focus {
+      // active:focus overrides [data-input-method] :focus
+      color: $support-01;
+    }
+
+    &:hover:disabled {
       color: $support-01;
       border: $button-border-width solid $support-01;
+    }
+
+    &:focus:disabled {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $support-01;
+        border: $button-border-width solid $support-01;
+      }
     }
   }
 
   .#{$prefix}--btn--danger--primary {
-    @include button-theme(
-      $support-01,
-      transparent,
-      $inverse-01,
-      darken($support-01, 10%),
-      $ui-01
-    );
+    @include button-theme($support-01, transparent, $inverse-01, darken($support-01, 10%), $ui-01);
 
-    &:hover:disabled,
-    &:focus:disabled {
+    &:hover:disabled {
       color: $ui-01;
       border: $button-border-width solid $support-01;
+    }
+
+    &:focus:disabled {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $ui-01;
+        border: $button-border-width solid $support-01;
+      }
     }
   }
 

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -41,23 +41,41 @@
   border-color: $border-color;
   color: $font-color;
 
-  &:focus,
   &:hover {
     background-color: $hover-bg-color;
   }
 
   &:focus {
-    border: $button-border-width solid $ui-02;
-    outline: $button-border-width solid $hover-bg-color;
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      background-color: $hover-bg-color;
+    }
   }
 
-  &:disabled:hover,
-  &:disabled:focus {
+  &:focus {
+    outline: none;
+
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      border: $button-border-width solid $ui-02;
+      outline: $button-border-width solid $hover-bg-color;
+    }
+  }
+
+  &:disabled:hover {
     background-color: $bg-color;
   }
 
-  &:active {
+  &:disabled:focus {
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      background-color: $bg-color;
+    }
+  }
+
+  &:active,
+  &:active:focus {
+    // :active:focus overrides [data-input-method] :focus
     background-color: darken($bg-color, 20%);
+    border: $button-border-width solid $ui-02;
+    outline: $button-border-width solid $hover-bg-color;
   }
 
   .#{$prefix}--btn__icon {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -29,7 +29,7 @@
       border: 1px solid $ui-04;
 
       &:focus {
-        @include focus-outline('border');
+        @include focus-outline('border', $touch: false);
       }
     }
 
@@ -73,7 +73,7 @@
       @include typescale('zeta');
 
       &:focus {
-        @include focus-outline('border');
+        @include focus-outline('border', $mouse: false, $touch: false);
       }
     }
 
@@ -178,15 +178,22 @@
       background: none;
       border: none;
 
-      &:hover,
-      &:focus {
+      &:hover {
         .#{$prefix}--app-actions__button--icon {
           fill: $brand-01;
         }
       }
 
       &:focus {
-        @include focus-outline('border');
+        @include interaction-wrapper($mouse: false, $touch: false) {
+          .#{$prefix}--app-actions__button--icon {
+            fill: $brand-01;
+          }
+        }
+      }
+
+      &:focus {
+        @include focus-outline('border', $mouse: false, $touch: false);
       }
     }
 

--- a/src/components/carousel/_carousel.scss
+++ b/src/components/carousel/_carousel.scss
@@ -36,7 +36,7 @@
     }
 
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
   }
 
@@ -54,7 +54,7 @@
     }
 
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
 
     &:last-of-type {
@@ -74,12 +74,15 @@
     margin-right: rem(20px);
     cursor: pointer;
 
-    &:hover,
+    &:hover {
+      @include focus-outline; // hover
+    }
+
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
   }
   .#{$prefix}--carousel__item--active {
-    @include focus-outline;
+    @include focus-outline; // active
   }
 }

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -85,7 +85,7 @@
 
   .#{$prefix}--checkbox:focus + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label__focus::before {
-    @include focus-outline('blurred');
+    @include focus-outline('blurred', $mouse: false, $touch: false);
   }
 
   // Indeterminate dash
@@ -134,7 +134,7 @@
 
   .#{$prefix}--checkbox:focus + .#{$prefix}--checkbox-label .#{$prefix}--checkbox-appearance,
   .#{$prefix}--checkbox:focus + .#{$prefix}--checkbox-appearance {
-    @include focus-outline('blurred');
+    @include focus-outline('blurred', $mouse: false, $touch: false);
   }
 
   .#{$prefix}--checkbox-checkmark {

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -79,7 +79,7 @@
     width: rem(32px);
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
   }
 

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -28,13 +28,17 @@
     color: $brand-01;
 
     &:focus {
-      outline: 1px solid transparent;
-      box-shadow: 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
-      background-color: $brand-02;
-      z-index: 2;
-      border-color: $brand-02;
-      text-decoration: underline;
-      color: $inverse-01;
+      outline: none;
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        outline: 1px solid transparent;
+        box-shadow: 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
+        background-color: $brand-02;
+        z-index: 2;
+        border-color: $brand-02;
+        text-decoration: underline;
+        color: $inverse-01;
+      }
     }
 
     &:hover {
@@ -75,8 +79,10 @@
     }
 
     &:focus {
-      box-shadow: -2px 0 0 0 $color__blue-20, 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
-      z-index: 0;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        box-shadow: -2px 0 0 0 $color__blue-20, 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
+        z-index: 0;
+      }
     }
   }
 
@@ -89,8 +95,10 @@
     }
 
     &:focus {
-      box-shadow: 2px 0 0 0 $color__blue-20, 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
-      z-index: 0;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        box-shadow: 2px 0 0 0 $color__blue-20, 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
+        z-index: 0;
+      }
     }
   }
 

--- a/src/components/data-table-v2/_data-table-v2-action.scss
+++ b/src/components/data-table-v2/_data-table-v2-action.scss
@@ -9,8 +9,11 @@
     position: relative;
 
     &:focus {
-      box-shadow: inset 0px 0px 0px 1px $brand-01;
-      outline: 0;
+      outline: none;
+
+      @include interaction-wrapper($touch: false) {
+        box-shadow: inset 0px 0px 0px 1px $brand-01;
+      }
     }
   }
 
@@ -39,7 +42,7 @@
   }
 
   &:focus {
-    @include focus-outline;
+    @include focus-outline($mouse: false, $touch: false);
     > .#{$prefix}--toolbar-action__icon {
       fill: $brand-01;
     }
@@ -87,7 +90,7 @@
   visibility: hidden;
 
   &:focus {
-    @include focus-outline;
+    @include focus-outline($touch: false);
   }
 
   .#{$prefix}--btn {
@@ -99,8 +102,7 @@
   }
 
   .#{$prefix}--btn--ghost {
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       background-color: $ui-01;
       color: $brand-01;
 
@@ -109,9 +111,16 @@
       }
     }
 
+    &:hover {
+      @include hover-focus;
+    }
+
     &:focus {
-      border: 2px solid $brand-01;
-      outline: 2px solid $ui-02;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
+        border: 2px solid $brand-01;
+        outline: 2px solid $ui-02;
+      }
     }
   }
 }
@@ -159,9 +168,14 @@
   cursor: pointer;
   transition: border $transition--base $carbon--standard-easing;
 
-  &:hover,
-  &:focus {
+  &:hover {
     border-bottom: 1px solid $ui-01;
+  }
+
+  &:focus {
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      border-bottom: 1px solid $ui-01;
+    }
   }
 }
 

--- a/src/components/data-table-v2/_data-table-v2-core.scss
+++ b/src/components/data-table-v2/_data-table-v2-core.scss
@@ -78,11 +78,14 @@
 
     &:focus {
       outline: 0;
-      opacity: 1;
-      box-shadow: none;
 
-      .#{$prefix}--overflow-menu__icon {
-        box-shadow: inset 0px 0px 0px 1px $brand-01;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        opacity: 1;
+        box-shadow: none;
+
+        .#{$prefix}--overflow-menu__icon {
+          box-shadow: inset 0px 0px 0px 1px $brand-01;
+        }
       }
     }
   }

--- a/src/components/data-table-v2/_data-table-v2-expandable.scss
+++ b/src/components/data-table-v2/_data-table-v2-expandable.scss
@@ -76,10 +76,14 @@ tr.#{$prefix}--expandable-row--hover-v2 {
   @include button-reset(false);
 
   &:focus {
-    outline: 1px solid transparent;
+    outline: none;
 
-    svg {
-      box-shadow: inset 0px 0px 0px 1px $brand-01;
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      outline: 1px solid transparent;
+
+      svg {
+        box-shadow: inset 0px 0px 0px 1px $brand-01;
+      }
     }
   }
 }

--- a/src/components/data-table-v2/_data-table-v2-inline-edit.scss
+++ b/src/components/data-table-v2/_data-table-v2-inline-edit.scss
@@ -22,12 +22,15 @@
   }
 
   &:focus {
-    @include focus-outline;
-    padding: $spacing-3xs;
+    @include focus-outline($mouse: false, $touch: false);
 
-    .#{$prefix}--inline-edit-label__icon {
-      width: auto;
-      opacity: 1;
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      padding: $spacing-3xs;
+
+      .#{$prefix}--inline-edit-label__icon {
+        width: auto;
+        opacity: 1;
+      }
     }
   }
 }

--- a/src/components/data-table-v2/_data-table-v2-sort.scss
+++ b/src/components/data-table-v2/_data-table-v2-sort.scss
@@ -32,11 +32,13 @@
   &:focus {
     outline: 0;
 
-    svg {
-      opacity: 1;
-      outline: 1px solid $brand-01;
-      fill: $brand-01;
-      outline-offset: -0.5px; // safari fix
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      svg {
+        opacity: 1;
+        outline: 1px solid $brand-01;
+        fill: $brand-01;
+        outline-offset: -0.5px; // safari fix
+      }
     }
   }
 }

--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -43,10 +43,13 @@
       font-weight: 600;
 
       &:focus {
-        outline: 1px solid transparent;
+        outline: none;
+        @include interaction-wrapper($mouse: false, $touch: false) {
+          outline: 1px solid transparent;
+        }
 
         span {
-          @include focus-outline('border');
+          @include focus-outline('border', $mouse: false, $touch: false);
         }
       }
     }
@@ -128,16 +131,29 @@
   .#{$prefix}--table-body .#{$prefix}--table-row {
     border: 1px solid transparent;
 
-    &:first-child:hover,
-    &:first-child:focus {
+    &:first-child:hover {
       border-left: 2px solid $brand-02;
       outline: 1px solid $brand-02;
     }
 
-    &:not(:first-child):hover,
-    &:not(:first-child):focus {
+    &:first-child:focus {
+      outline: none;
+      @include interaction-wrapper($touch: false) {
+        border-left: 2px solid $brand-02;
+        outline: 1px solid $brand-02;
+      }
+    }
+
+    &:not(:first-child):hover {
       border-left: 2px solid $brand-02;
       outline: 1px solid $brand-02;
+    }
+
+    &:not(:first-child):focus {
+      @include interaction-wrapper($touch: false) {
+        border-left: 2px solid $brand-02;
+        outline: 1px solid $brand-02;
+      }
     }
   }
 
@@ -162,10 +178,13 @@
     cursor: pointer;
 
     &:focus {
-      outline: 1px solid transparent;
+      outline: none;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        outline: 1px solid transparent;
+      }
 
       svg {
-        @include focus-outline('border');
+        @include focus-outline('border', $mouse: false, $touch: false);
       }
     }
   }

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -52,7 +52,7 @@
 
     &:focus,
     &.#{$prefix}--focused {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &:disabled {
@@ -122,7 +122,9 @@
     }
 
     &:focus {
-      outline: 1px solid $brand-01;
+      @include interaction-wrapper($touch: false) {
+        outline: 1px solid $brand-01;
+      }
     }
   }
 
@@ -181,7 +183,10 @@
     padding: $spacing-2xs;
 
     &:focus {
-      outline: 1px solid $brand-01;
+      outline: none;
+      @include interaction-wrapper($touch: false) {
+        outline: 1px solid $brand-01;
+      }
     }
   }
 
@@ -245,7 +250,10 @@
 
     &:focus {
       outline: none;
-      background: $ui-04;
+
+      @include interaction-wrapper($touch: false) {
+        background: $ui-04;
+      }
     }
   }
 

--- a/src/components/date-picker/_flatpickr.scss
+++ b/src/components/date-picker/_flatpickr.scss
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   touch-action: manipulation;
   background: #fff;
-  box-shadow: 1px 0 0 #e6e6e6, -1px 0 0 #e6e6e6, 0 1px 0 #e6e6e6, 0 -1px 0 #e6e6e6, 0 3px 13px rgba(0,0,0,0.08);
+  box-shadow: 1px 0 0 #e6e6e6, -1px 0 0 #e6e6e6, 0 1px 0 #e6e6e6, 0 -1px 0 #e6e6e6, 0 3px 13px rgba(0, 0, 0, 0.08);
 }
 
 .flatpickr-calendar.open,
@@ -35,7 +35,7 @@
 
 .flatpickr-calendar.animate.open {
   -webkit-animation: fpFadeInDown 300ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeInDown 300ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeInDown 300ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .flatpickr-calendar.inline {
@@ -127,16 +127,16 @@
 }
 .flatpickr-month {
   background: transparent;
-  color: rgba(0,0,0,0.9);
-  fill: rgba(0,0,0,0.9);
+  color: rgba(0, 0, 0, 0.9);
+  fill: rgba(0, 0, 0, 0.9);
   height: 28px;
   line-height: 1;
   text-align: center;
   position: relative;
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   overflow: hidden;
 }
 .flatpickr-prev-month,
@@ -156,14 +156,14 @@
 }
 .flatpickr-prev-month.flatpickr-prev-month,
 .flatpickr-next-month.flatpickr-prev-month {
-/*
+  /*
         /*rtl:begin:ignore*/
-/*
+  /*
         */
   left: 0;
-/*
+  /*
         /*rtl:end:ignore*/
-/*
+  /*
         */
 }
 /*
@@ -172,14 +172,14 @@
         /*rtl:end:ignore*/
 .flatpickr-prev-month.flatpickr-next-month,
 .flatpickr-next-month.flatpickr-next-month {
-/*
+  /*
         /*rtl:begin:ignore*/
-/*
+  /*
         */
   right: 0;
-/*
+  /*
         /*rtl:end:ignore*/
-/*
+  /*
         */
 }
 /*
@@ -223,18 +223,18 @@
   line-height: 50%;
   opacity: 0;
   cursor: pointer;
-  border: 1px solid rgba(57,57,57,0.05);
+  border: 1px solid rgba(57, 57, 57, 0.05);
   box-sizing: border-box;
 }
 .numInputWrapper span:hover {
-  background: rgba(0,0,0,0.1);
+  background: rgba(0, 0, 0, 0.1);
 }
 .numInputWrapper span:active {
-  background: rgba(0,0,0,0.2);
+  background: rgba(0, 0, 0, 0.2);
 }
 .numInputWrapper span:after {
   display: block;
-  content: "";
+  content: '';
   position: absolute;
   top: 33%;
 }
@@ -245,7 +245,7 @@
 .numInputWrapper span.arrowUp:after {
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-bottom: 4px solid rgba(57,57,57,0.6);
+  border-bottom: 4px solid rgba(57, 57, 57, 0.6);
 }
 .numInputWrapper span.arrowDown {
   top: 50%;
@@ -253,17 +253,17 @@
 .numInputWrapper span.arrowDown:after {
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-top: 4px solid rgba(57,57,57,0.6);
+  border-top: 4px solid rgba(57, 57, 57, 0.6);
 }
 .numInputWrapper span svg {
   width: inherit;
   height: auto;
 }
 .numInputWrapper span svg path {
-  fill: rgba(0,0,0,0.5);
+  fill: rgba(0, 0, 0, 0.5);
 }
 .numInputWrapper:hover {
-  background: rgba(0,0,0,0.05);
+  background: rgba(0, 0, 0, 0.05);
 }
 .numInputWrapper:hover span {
   opacity: 1;
@@ -282,31 +282,31 @@
   display: inline-block;
   text-align: center;
   -webkit-transform: translate3d(0px, 0px, 0px);
-          transform: translate3d(0px, 0px, 0px);
+  transform: translate3d(0px, 0px, 0px);
 }
 .flatpickr-current-month.slideLeft {
   -webkit-transform: translate3d(-100%, 0px, 0px);
-          transform: translate3d(-100%, 0px, 0px);
+  transform: translate3d(-100%, 0px, 0px);
   -webkit-animation: fpFadeOut 400ms ease, fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeOut 400ms ease, fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeOut 400ms ease, fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-current-month.slideLeftNew {
   -webkit-transform: translate3d(100%, 0px, 0px);
-          transform: translate3d(100%, 0px, 0px);
+  transform: translate3d(100%, 0px, 0px);
   -webkit-animation: fpFadeIn 400ms ease, fpSlideLeftNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeIn 400ms ease, fpSlideLeftNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeIn 400ms ease, fpSlideLeftNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-current-month.slideRight {
   -webkit-transform: translate3d(100%, 0px, 0px);
-          transform: translate3d(100%, 0px, 0px);
+  transform: translate3d(100%, 0px, 0px);
   -webkit-animation: fpFadeOut 400ms ease, fpSlideRight 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeOut 400ms ease, fpSlideRight 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeOut 400ms ease, fpSlideRight 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-current-month.slideRightNew {
   -webkit-transform: translate3d(0, 0, 0px);
-          transform: translate3d(0, 0, 0px);
+  transform: translate3d(0, 0, 0px);
   -webkit-animation: fpFadeIn 400ms ease, fpSlideRightNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeIn 400ms ease, fpSlideRightNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeIn 400ms ease, fpSlideRightNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-current-month span.cur-month {
   font-family: inherit;
@@ -317,7 +317,7 @@
   padding: 0;
 }
 .flatpickr-current-month span.cur-month:hover {
-  background: rgba(0,0,0,0.05);
+  background: rgba(0, 0, 0, 0.05);
 }
 .flatpickr-current-month .numInputWrapper {
   width: 6ch;
@@ -325,10 +325,10 @@
   display: inline-block;
 }
 .flatpickr-current-month .numInputWrapper span.arrowUp:after {
-  border-bottom-color: rgba(0,0,0,0.9);
+  border-bottom-color: rgba(0, 0, 0, 0.9);
 }
 .flatpickr-current-month .numInputWrapper span.arrowDown:after {
-  border-top-color: rgba(0,0,0,0.9);
+  border-top-color: rgba(0, 0, 0, 0.9);
 }
 .flatpickr-current-month input.cur-year {
   background: transparent;
@@ -353,7 +353,7 @@
 .flatpickr-current-month input.cur-year[disabled],
 .flatpickr-current-month input.cur-year[disabled]:hover {
   font-size: 100%;
-  color: rgba(0,0,0,0.5);
+  color: rgba(0, 0, 0, 0.5);
   background: transparent;
   pointer-events: none;
 }
@@ -366,22 +366,22 @@
   display: -ms-flexbox;
   display: flex;
   -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
   height: 28px;
 }
 span.flatpickr-weekday {
   cursor: default;
   font-size: 90%;
   background: transparent;
-  color: rgba(0,0,0,0.54);
+  color: rgba(0, 0, 0, 0.54);
   line-height: 1;
   margin: 0;
   text-align: center;
   display: block;
   -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-weight: bolder;
 }
 .dayContainer,
@@ -412,37 +412,37 @@ span.flatpickr-weekday {
   display: -webkit-flex;
   display: flex;
   -webkit-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   -ms-flex-pack: justify;
   -webkit-justify-content: space-around;
-          justify-content: space-around;
+  justify-content: space-around;
   -webkit-transform: translate3d(0px, 0px, 0px);
-          transform: translate3d(0px, 0px, 0px);
+  transform: translate3d(0px, 0px, 0px);
   opacity: 1;
 }
 .flatpickr-calendar.animate .dayContainer.slideLeft {
   -webkit-animation: fpFadeOut 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeOut 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeOut 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-calendar.animate .dayContainer.slideLeft,
 .flatpickr-calendar.animate .dayContainer.slideLeftNew {
   -webkit-transform: translate3d(-100%, 0px, 0px);
-          transform: translate3d(-100%, 0px, 0px);
+  transform: translate3d(-100%, 0px, 0px);
 }
 .flatpickr-calendar.animate .dayContainer.slideLeftNew {
   -webkit-animation: fpFadeIn 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeIn 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeIn 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideLeft 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-calendar.animate .dayContainer.slideRight {
   -webkit-animation: fpFadeOut 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideRight 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeOut 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideRight 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeOut 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideRight 400ms cubic-bezier(0.23, 1, 0.32, 1);
   -webkit-transform: translate3d(100%, 0px, 0px);
-          transform: translate3d(100%, 0px, 0px);
+  transform: translate3d(100%, 0px, 0px);
 }
 .flatpickr-calendar.animate .dayContainer.slideRightNew {
   -webkit-animation: fpFadeIn 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideRightNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
-          animation: fpFadeIn 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideRightNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeIn 400ms cubic-bezier(0.23, 1, 0.32, 1), fpSlideRightNew 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .flatpickr-day {
   background: none;
@@ -454,8 +454,8 @@ span.flatpickr-weekday {
   font-weight: 400;
   width: 14.2857143%;
   -webkit-flex-basis: 14.2857143%;
-      -ms-flex-preferred-size: 14.2857143%;
-          flex-basis: 14.2857143%;
+  -ms-flex-preferred-size: 14.2857143%;
+  flex-basis: 14.2857143%;
   max-width: 40px;
   height: 40px;
   line-height: 40px;
@@ -463,8 +463,8 @@ span.flatpickr-weekday {
   display: inline-block;
   position: relative;
   -webkit-justify-content: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   text-align: center;
 }
 // .flatpickr-day.inRange,
@@ -608,14 +608,14 @@ span.flatpickr-weekday {
   display: flex;
 }
 .flatpickr-time:after {
-  content: "";
+  content: '';
   display: table;
   clear: both;
 }
 .flatpickr-time .numInputWrapper {
   -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   width: 40%;
   height: 40px;
   float: left;
@@ -669,13 +669,13 @@ span.flatpickr-weekday {
   font-weight: bold;
   width: 2%;
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   -webkit-align-self: center;
-      -ms-flex-item-align: center;
-              -ms-grid-row-align: center;
-          align-self: center;
+  -ms-flex-item-align: center;
+  -ms-grid-row-align: center;
+  align-self: center;
 }
 .flatpickr-time .flatpickr-am-pm {
   outline: 0;
@@ -684,9 +684,14 @@ span.flatpickr-weekday {
   text-align: center;
   font-weight: 400;
 }
-.flatpickr-time .flatpickr-am-pm:hover,
-.flatpickr-time .flatpickr-am-pm:focus {
+.flatpickr-time .flatpickr-am-pm:hover {
   background: #f0f0f0;
+}
+
+.flatpickr-time .flatpickr-am-pm:focus {
+  @include interaction-wrapper($mouse: false, $touch: false) {
+    background: #f0f0f0;
+  }
 }
 .flatpickr-input[readonly] {
   cursor: pointer;
@@ -695,104 +700,104 @@ span.flatpickr-weekday {
   from {
     opacity: 0;
     -webkit-transform: translate3d(0, -20px, 0);
-            transform: translate3d(0, -20px, 0);
+    transform: translate3d(0, -20px, 0);
   }
   to {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0);
-            transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
   }
 }
 @keyframes fpFadeInDown {
   from {
     opacity: 0;
     -webkit-transform: translate3d(0, -20px, 0);
-            transform: translate3d(0, -20px, 0);
+    transform: translate3d(0, -20px, 0);
   }
   to {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0);
-            transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
   }
 }
 @-webkit-keyframes fpSlideLeft {
   from {
     -webkit-transform: translate3d(0px, 0px, 0px);
-            transform: translate3d(0px, 0px, 0px);
+    transform: translate3d(0px, 0px, 0px);
   }
   to {
     -webkit-transform: translate3d(-100%, 0px, 0px);
-            transform: translate3d(-100%, 0px, 0px);
+    transform: translate3d(-100%, 0px, 0px);
   }
 }
 @keyframes fpSlideLeft {
   from {
     -webkit-transform: translate3d(0px, 0px, 0px);
-            transform: translate3d(0px, 0px, 0px);
+    transform: translate3d(0px, 0px, 0px);
   }
   to {
     -webkit-transform: translate3d(-100%, 0px, 0px);
-            transform: translate3d(-100%, 0px, 0px);
+    transform: translate3d(-100%, 0px, 0px);
   }
 }
 @-webkit-keyframes fpSlideLeftNew {
   from {
     -webkit-transform: translate3d(100%, 0px, 0px);
-            transform: translate3d(100%, 0px, 0px);
+    transform: translate3d(100%, 0px, 0px);
   }
   to {
     -webkit-transform: translate3d(0px, 0px, 0px);
-            transform: translate3d(0px, 0px, 0px);
+    transform: translate3d(0px, 0px, 0px);
   }
 }
 @keyframes fpSlideLeftNew {
   from {
     -webkit-transform: translate3d(100%, 0px, 0px);
-            transform: translate3d(100%, 0px, 0px);
+    transform: translate3d(100%, 0px, 0px);
   }
   to {
     -webkit-transform: translate3d(0px, 0px, 0px);
-            transform: translate3d(0px, 0px, 0px);
+    transform: translate3d(0px, 0px, 0px);
   }
 }
 @-webkit-keyframes fpSlideRight {
   from {
     -webkit-transform: translate3d(0, 0, 0px);
-            transform: translate3d(0, 0, 0px);
+    transform: translate3d(0, 0, 0px);
   }
   to {
     -webkit-transform: translate3d(100%, 0px, 0px);
-            transform: translate3d(100%, 0px, 0px);
+    transform: translate3d(100%, 0px, 0px);
   }
 }
 @keyframes fpSlideRight {
   from {
     -webkit-transform: translate3d(0, 0, 0px);
-            transform: translate3d(0, 0, 0px);
+    transform: translate3d(0, 0, 0px);
   }
   to {
     -webkit-transform: translate3d(100%, 0px, 0px);
-            transform: translate3d(100%, 0px, 0px);
+    transform: translate3d(100%, 0px, 0px);
   }
 }
 @-webkit-keyframes fpSlideRightNew {
   from {
     -webkit-transform: translate3d(-100%, 0, 0px);
-            transform: translate3d(-100%, 0, 0px);
+    transform: translate3d(-100%, 0, 0px);
   }
   to {
     -webkit-transform: translate3d(0, 0, 0px);
-            transform: translate3d(0, 0, 0px);
+    transform: translate3d(0, 0, 0px);
   }
 }
 @keyframes fpSlideRightNew {
   from {
     -webkit-transform: translate3d(-100%, 0, 0px);
-            transform: translate3d(-100%, 0, 0px);
+    transform: translate3d(-100%, 0, 0px);
   }
   to {
     -webkit-transform: translate3d(0, 0, 0px);
-            transform: translate3d(0, 0, 0px);
+    transform: translate3d(0, 0, 0px);
   }
 }
 @-webkit-keyframes fpFadeOut {

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -28,12 +28,16 @@
     color: $text-01;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &.#{$prefix}--dropdown--open:focus {
-      outline: 1px solid transparent;
-      box-shadow: 0 -1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
+      outline: none;
+
+      @include interaction-wrapper($touch: false) {
+        outline: 1px solid transparent;
+        box-shadow: 0 -1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
+      }
     }
   }
 
@@ -95,12 +99,23 @@
     text-overflow: ellipsis;
     overflow: hidden;
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       background-color: $brand-01;
       color: $inverse-01;
       outline: 1px solid transparent;
       text-decoration: underline;
+    }
+
+    &:hover {
+      @include hover-focus;
+    }
+
+    &:focus {
+      outline: none;
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
+      }
     }
   }
 
@@ -119,8 +134,10 @@
     }
 
     &:focus {
-      .#{$prefix}--dropdown-list {
-        box-shadow: 0 1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
+      @include interaction-wrapper($touch: false) {
+        .#{$prefix}--dropdown-list {
+          box-shadow: 0 1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
+        }
       }
     }
 

--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -86,7 +86,7 @@
     cursor: pointer;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: true, $touch: false);
     }
   }
 

--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -44,20 +44,24 @@
           padding: 0;
 
           &:focus {
-            outline: 1px solid transparent;
+            outline: none;
 
-            &:not(.left-nav-list__item--has-children) {
-              background-color: $color__gray-2;
-            }
+            @include interaction-wrapper($mouse: false, $touch: false) {
+              outline: 1px solid transparent;
 
-            .left-nav-list__item-link {
-              color: $color__blue-51;
-              text-decoration: underline;
-            }
+              &:not(.left-nav-list__item--has-children) {
+                background-color: $color__gray-2;
+              }
 
-            .left-nav-list--nested .left-nav-list__item-link {
-              color: $color__blue-90;
-              text-decoration: none;
+              .left-nav-list__item-link {
+                color: $color__blue-51;
+                text-decoration: underline;
+              }
+
+              .left-nav-list--nested .left-nav-list__item-link {
+                color: $color__blue-90;
+                text-decoration: none;
+              }
             }
           }
 
@@ -159,10 +163,14 @@
             justify-content: space-between;
 
             &:focus {
-              outline: 1px solid transparent;
-              background-color: $color__gray-2;
-              color: $color__blue-51;
-              text-decoration: underline;
+              outline: none;
+
+              @include interaction-wrapper($mouse: false, $touch: false) {
+                outline: 1px solid transparent;
+                background-color: $color__gray-2;
+                color: $color__blue-51;
+                text-decoration: underline;
+              }
             }
           }
 
@@ -268,9 +276,14 @@
           margin-bottom: rem(50px);
         }
 
-        &:hover,
-        &:focus {
+        &:hover {
           background-color: rgba($color__blue-51, 0.3);
+        }
+
+        &:focus {
+          @include interaction-wrapper($mouse: false, $touch: false) {
+            background-color: rgba($color__blue-51, 0.3);
+          }
         }
       }
 
@@ -287,7 +300,7 @@
         padding: 0.25rem;
 
         &:focus {
-          @include focus-outline('border');
+          @include focus-outline('border', $mouse: false, $touch: false);
         }
       }
 
@@ -306,9 +319,14 @@
       cursor: pointer;
       background-color: rgba($color__blue-51, 0.1);
 
-      &:hover,
-      &:focus {
+      &:hover {
         background-color: rgba($color__blue-51, 0.3);
+      }
+
+      &:focus {
+        @include interaction-wrapper($touch: false) {
+          background-color: rgba($color__blue-51, 0.3);
+        }
       }
 
       ul,

--- a/src/components/lightbox/_lightbox.scss
+++ b/src/components/lightbox/_lightbox.scss
@@ -31,7 +31,7 @@
     }
 
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
 
     svg {

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -26,17 +26,19 @@
     }
 
     &:active,
-    &:hover,
-    &:focus {
+    &:hover {
       color: $brand-02;
     }
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        color: $brand-02;
+      }
     }
 
-    &[aria-disabled="true"] {
-      opacity: .5;
+    &[aria-disabled='true'] {
+      opacity: 0.5;
       pointer-events: none;
     }
   }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -7,6 +7,7 @@
 @import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
+@import '../../globals/scss/helper-mixins';
 
 $list-box-width: 100%;
 $list-box-height: rem(40px);
@@ -87,7 +88,11 @@ $list-box-menu-width: rem(300px);
 
   .#{$prefix}--list-box__field:focus,
   .#{$prefix}--list-box__field[aria-expanded='true'] {
-    outline: 1px solid $brand-01;
+    outline: none;
+
+    @include interaction-wrapper($touch: false) {
+      outline: 1px solid $brand-01;
+    }
   }
 
   .#{$prefix}--list-box__field[disabled] {
@@ -149,7 +154,10 @@ $list-box-menu-width: rem(300px);
   }
 
   .#{$prefix}--list-box__selection:focus {
-    outline: 1px solid $brand-01;
+    outline: none;
+    @include interaction-wrapper($touch: false) {
+      outline: 1px solid $brand-01;
+    }
   }
 
   // Modifier for a selection to show that multiple selections have been made
@@ -177,10 +185,16 @@ $list-box-menu-width: rem(300px);
     margin-left: rem(5px);
   }
 
-  .#{$prefix}--list-box__selection--multi:focus,
   .#{$prefix}--list-box__selection--multi:hover {
     background-color: $brand-02;
     outline: none;
+  }
+
+  .#{$prefix}--list-box__selection--multi:focus {
+    @include interaction-wrapper($touch: false) {
+      background-color: $brand-02;
+      outline: none;
+    }
   }
 
   // Descendant of a `list-box` that displays a list of options to select

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -130,7 +130,7 @@
     padding: 0.25rem 0.25rem 0.125rem;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
   }
 

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -88,7 +88,7 @@
     position: relative;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
   }
 

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -59,7 +59,7 @@
     position: relative;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
   }
 

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -30,7 +30,7 @@
     border-radius: 0;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &:disabled {
@@ -76,7 +76,7 @@
     height: rem(10px);
 
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
 
     &:hover {

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -21,6 +21,8 @@
     cursor: pointer;
 
     &:focus {
+      outline: none;
+
       @include interaction-wrapper($mouse: false, $touch: false) {
         outline: 1px solid transparent;
         box-shadow: 0 0 0 1px $brand-01;
@@ -109,6 +111,8 @@
     cursor: pointer;
 
     &:focus {
+      outline: none;
+
       @include interaction-wrapper($mouse: false, $touch: false) {
         outline: 1px solid transparent;
         background-color: $brand-01;

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -21,8 +21,10 @@
     cursor: pointer;
 
     &:focus {
-      outline: 1px solid transparent;
-      box-shadow: 0 0 0 1px $brand-01;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        outline: 1px solid transparent;
+        box-shadow: 0 0 0 1px $brand-01;
+      }
     }
   }
 
@@ -32,9 +34,14 @@
     padding: 0.5rem;
     fill: $ui-05;
 
-    &:hover,
-    &:focus {
+    &:hover {
       fill: $brand-01;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        fill: $brand-01;
+      }
     }
   }
 
@@ -102,14 +109,18 @@
     cursor: pointer;
 
     &:focus {
-      outline: 1px solid transparent;
-      background-color: $brand-01;
-      color: $inverse-01;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        outline: 1px solid transparent;
+        background-color: $brand-01;
+        color: $inverse-01;
+      }
     }
 
     .#{$prefix}--overflow-menu-options__option--danger & {
       &:focus {
-        background-color: $support-01;
+        @include interaction-wrapper($mouse: false, $touch: false) {
+          background-color: $support-01;
+        }
       }
     }
   }

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -72,7 +72,7 @@ $css--helpers: true;
     }
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
 
     &:disabled:hover {
@@ -116,7 +116,7 @@ $css--helpers: true;
       font-weight: 600;
 
       &:focus {
-        @include focus-outline('border');
+        @include focus-outline('border', $touch: false);
       }
     }
 
@@ -135,7 +135,7 @@ $css--helpers: true;
       text-align: center;
 
       &:focus {
-        @include focus-outline('border');
+        @include focus-outline('border', $touch: false);
       }
     }
   }

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -65,6 +65,6 @@
   }
 
   .#{$prefix}--radio-button:focus + .#{$prefix}--radio-button__label .#{$prefix}--radio-button__appearance {
-    @include focus-outline('blurred');
+    @include focus-outline('blurred', $mouse: false, $touch: false);
   }
 }

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -36,7 +36,7 @@
     width: 100%;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &::placeholder {
@@ -99,7 +99,7 @@
     height: rem(40px);
     width: rem(40px);
     min-width: rem(40px);
-    margin-left: $spacing-2xs;;
+    margin-left: $spacing-2xs;
     background-color: $ui-01;
     position: relative;
     padding: 0;
@@ -116,16 +116,32 @@
     width: 1rem;
   }
 
-  .#{$prefix}--search-button:hover,
-  .#{$prefix}--search-button:focus {
+  @mixin hover-focus {
     cursor: pointer;
     background-color: $brand-01;
     outline: 1px solid transparent;
   }
 
-  .#{$prefix}--search-button:hover svg,
-  .#{$prefix}--search-button:focus svg {
+  .#{$prefix}--search-button:hover {
+    @include hover-focus;
+  }
+
+  .#{$prefix}--search-button:focus {
+    outline: none;
+
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      @include hover-focus;
+    }
+  }
+
+  .#{$prefix}--search-button:hover svg {
     fill: $ui-01;
+  }
+
+  .#{$prefix}--search-button:focus svg {
+    @include interaction-wrapper($mouse: false, $touch: false) {
+      fill: $ui-01;
+    }
   }
 
   .#{$prefix}--search-close--hidden {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -37,7 +37,7 @@
     }
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &:disabled {

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -98,7 +98,7 @@
       transform: translate(-50%, -50%) scale(1.05);
     }
     &:focus {
-      @include focus-outline('blurred');
+      @include focus-outline('blurred', $mouse: false, $touch: false);
     }
     &:active {
       background: darken($brand-01, 5%);

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -72,7 +72,8 @@
     }
 
     &:focus:not(.#{$prefix}--structured-list-row--header-row) {
-      @include focus-outline('border');
+      // list row
+      @include focus-outline('border', $touch: false);
     }
   }
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -45,7 +45,7 @@
     }
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
 
     @include breakpoint(bp--sm--major) {
@@ -59,7 +59,7 @@
     color: $text-01;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
   }
 
@@ -101,13 +101,23 @@
     padding: 0;
     cursor: pointer;
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       background-color: $brand-01;
 
       @include breakpoint(bp--sm--major) {
         outline: 1px solid transparent;
         background: transparent;
+      }
+    }
+    &:hover {
+      @include hover-focus;
+    }
+
+    &:focus {
+      outline: none;
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
       }
     }
 
@@ -131,7 +141,9 @@
         color: $brand-01;
 
         &:focus {
-          color: $brand-01;
+          @include interaction-wrapper($mouse: false, $touch: false) {
+            color: $brand-01;
+          }
         }
       }
     }
@@ -155,9 +167,13 @@
     text-overflow: ellipsis;
 
     &:focus {
-      outline: 1px solid transparent;
-      background-color: $brand-01;
-      color: $inverse-01;
+      outline: none;
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        outline: 1px solid transparent;
+        background-color: $brand-01;
+        color: $inverse-01;
+      }
     }
 
     @include breakpoint(bp--sm--major) {
@@ -169,10 +185,14 @@
       }
 
       &:focus {
-        background-color: transparent;
-        color: $text-01;
-        outline: 1px solid transparent;
-        box-shadow: 0 0 0 1px $brand-01;
+        outline: none;
+
+        @include interaction-wrapper($mouse: false, $touch: false) {
+          background-color: transparent;
+          color: $text-01;
+          outline: 1px solid transparent;
+          box-shadow: 0 0 0 1px $brand-01;
+        }
       }
     }
   }

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -25,7 +25,7 @@
     resize: vertical;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &::-webkit-input-placeholder {

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -30,7 +30,7 @@
     }
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &:disabled {

--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -23,7 +23,7 @@
     padding: $spacing-md;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
   }
 
@@ -37,8 +37,7 @@
       border: 1px solid $ui-04;
     }
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       .#{$prefix}--tile__checkmark {
         opacity: 1;
       }
@@ -47,12 +46,22 @@
         fill: $brand-01;
       }
     }
+
+    &:hover {
+      @include hover-focus;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
+      }
+    }
   }
 
   .#{$prefix}--tile--clickable,
   .#{$prefix}--tile--expandable {
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $mouse: false, $touch: false);
     }
   }
 
@@ -62,7 +71,9 @@
 
   .#{$prefix}--tile--selectable:focus {
     outline: none;
-    border: 1px solid $brand-01;
+    @include interaction-wrapper($touch: false) {
+      border: 1px solid $brand-01;
+    }
   }
 
   .#{$prefix}--tile--is-clicked {
@@ -78,7 +89,7 @@
     background: transparent;
 
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
   }
 
@@ -90,15 +101,15 @@
 
     svg {
       border-radius: 50%;
-      background-color: rgba($ui-01, .25);
-      fill: rgba($brand-01, .25);
+      background-color: rgba($ui-01, 0.25);
+      fill: rgba($brand-01, 0.25);
     }
   }
 
   .#{$prefix}--tile__chevron {
     position: absolute;
-    bottom: .5rem;
-    right: .5rem;
+    bottom: 0.5rem;
+    right: 0.5rem;
     height: 1rem;
 
     svg {
@@ -143,10 +154,16 @@
   }
 
   .#{$prefix}--tile--is-selected,
-  .#{$prefix}--tile--is-selected:hover,
-  .#{$prefix}--tile--is-selected:focus {
+  .#{$prefix}--tile--is-selected:hover {
     border: 1px solid $brand-01;
     outline: none;
+  }
+
+  .#{$prefix}--tile--is-selected:focus {
+    @include interaction-wrapper($touch: false) {
+      border: 1px solid $brand-01;
+      outline: none;
+    }
   }
 
   .#{$prefix}--tile-input:checked {

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -37,7 +37,7 @@
     padding: 0 $spacing-md;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('border', $touch: false);
     }
 
     &:disabled {

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -143,17 +143,20 @@
 
   .#{$prefix}--toggle:focus + .#{$prefix}--toggle__label {
     .#{$prefix}--toggle__appearance:before {
-      outline: 1px solid transparent;
+      outline: none;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        outline: 1px solid transparent;
+      }
     }
 
     .#{$prefix}--toggle__appearance:after {
-      @include focus-outline('blurred');
+      @include focus-outline('blurred', $mouse: false, $touch: false);
     }
   }
 
   .#{$prefix}--toggle--small:focus + .#{$prefix}--toggle__label {
     .#{$prefix}--toggle__appearance:before {
-      @include focus-outline('blurred');
+      @include focus-outline('blurred', $mouse: false, $touch: false);
     }
 
     .#{$prefix}--toggle__appearance:after {

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -94,7 +94,7 @@ $css--helpers: true;
     width: rem(32px);
 
     &:focus {
-      @include focus-outline;
+      @include focus-outline($mouse: false, $touch: false);
     }
   }
 

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -28,6 +28,8 @@
       cursor: pointer;
 
       &:focus {
+        outline: none;
+
         @include interaction-wrapper($mouse: false, $touch: false) {
           @include focus-outline('border');
           fill: $brand-02;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -28,15 +28,24 @@
       cursor: pointer;
 
       &:focus {
-        @include focus-outline('border');
+        @include interaction-wrapper($mouse: false, $touch: false) {
+          @include focus-outline('border');
+          fill: $brand-02;
+        }
+      }
+    }
+
+    &:hover {
+      svg {
         fill: $brand-02;
       }
     }
 
-    &:hover,
     &:focus {
-      svg {
-        fill: $brand-02;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        svg {
+          fill: $brand-02;
+        }
       }
     }
   }
@@ -162,8 +171,7 @@
       content: '';
     }
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       svg {
         fill: $brand-02;
       }
@@ -174,12 +182,21 @@
         display: block;
       }
     }
+    &:hover {
+      @include hover-focus;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
+      }
+    }
 
     &:focus {
       outline: 1px solid transparent;
 
       svg {
-        @include focus-outline('border');
+        @include focus-outline('border', $mouse: false, $touch: false);
       }
     }
   }

--- a/src/components/unified-header/_account-switcher.scss
+++ b/src/components/unified-header/_account-switcher.scss
@@ -32,8 +32,7 @@
     background-color: $nav-01;
     cursor: pointer;
 
-    &:focus,
-    &:hover {
+    @mixin hover-focus {
       outline: 0;
       background-color: $color__navy-gray-3; // anna
 
@@ -44,6 +43,16 @@
       svg {
         fill: $color__blue-30; // anna
       }
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
+      }
+    }
+
+    &:hover {
+      @include hover-focus;
     }
   }
 
@@ -243,13 +252,22 @@
   .#{$prefix}--account-switcher__menu__item .#{$prefix}--dropdown-item {
     background-color: $color__navy-gray-3; // anna
 
-    > .#{$prefix}--dropdown-link:hover,
-    .#{$prefix}--dropdown-link:focus {
+    @mixin hover-focus {
       background-color: $color__blue-30; // anna
       color: $color__blue-90; // anna
 
       svg {
         fill: $color__blue-90; // anna
+      }
+    }
+
+    > .#{$prefix}--dropdown-link:hover {
+      @include hover-focus;
+    }
+
+    > .#{$prefix}--dropdown-link:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
       }
     }
   }

--- a/src/components/unified-header/_global-header.scss
+++ b/src/components/unified-header/_global-header.scss
@@ -29,10 +29,19 @@
     color: $color__white; // anna
     position: relative;
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       .#{$prefix}--logo__text {
         color: $color__blue-20; // anna
+      }
+    }
+
+    &:hover {
+      @include hover-focus;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
       }
     }
   }
@@ -105,8 +114,11 @@
 
     &:focus {
       outline: 0;
-      background-color: $color__navy-gray-3; // anna
-      color: $color__blue-30; // anna
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        background-color: $color__navy-gray-3; // anna
+        color: $color__blue-30; // anna
+      }
     }
 
     &:last-child {
@@ -136,8 +148,11 @@
 
     &:focus {
       outline: 0;
-      background-color: $color__navy-gray-3; // anna
-      color: $color__blue-30; // anna
+
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        background-color: $color__navy-gray-3; // anna
+        color: $color__blue-30; // anna
+      }
     }
   }
 
@@ -147,15 +162,17 @@
 
     &:focus {
       outline: 0;
-      background-color: $color__navy-gray-3; // anna
+      @include interaction-wrapper($touch: false) {
+        background-color: $color__navy-gray-3; // anna
 
-      .#{$prefix}--dropdown__menu-text {
-        color: $color__blue-30; // anna
-      }
+        .#{$prefix}--dropdown__menu-text {
+          color: $color__blue-30; // anna
+        }
 
-      .#{$prefix}--dropdown__menu-text,
-      .#{$prefix}--dropdown__list {
-        outline: 0;
+        .#{$prefix}--dropdown__menu-text,
+        .#{$prefix}--dropdown__list {
+          outline: 0;
+        }
       }
     }
   }

--- a/src/components/unified-header/_left-nav-trigger.scss
+++ b/src/components/unified-header/_left-nav-trigger.scss
@@ -1,5 +1,20 @@
 @import '../../globals/scss/import-once';
 
+@mixin hover-focus($color, $doSpan: true) {
+  background-color: $color;
+
+  $span: '';
+
+  @if $doSpan {
+    $span: 'span,';
+  }
+
+  #{$span} span:before,
+  span:after {
+    background: $color__white;
+  }
+}
+
 @include exports('left-nav-trigger') {
   .#{$prefix}--left-nav__trigger {
     @include reset;
@@ -14,14 +29,13 @@
       outline: 0;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $color__blue-30;
+    &:hover {
+      @include hover-focus($color__blue-30);
+    }
 
-      span,
-      span:before,
-      span:after {
-        background: $color__white;
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus($color__blue-30);
       }
     }
   }
@@ -86,14 +100,13 @@
       outline: 0;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $nav-06;
+    &:hover {
+      @include hover-focus($nav-06);
+    }
 
-      span,
-      span:before,
-      span:after {
-        background: $color__white;
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus($nav-06);
       }
     }
   }
@@ -108,13 +121,13 @@
       background: $nav-06;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $nav-06;
+    &:hover {
+      @include hover-focus($nav-06, false);
+    }
 
-      span:before,
-      span:after {
-        background: $color__white;
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus($nav-06, false);
       }
     }
   }
@@ -130,14 +143,12 @@
       outline: 0;
     }
 
-    &:hover,
+    &:hover {
+      @include hover-focus($nav-04);
+    }
     &:focus {
-      background-color: $nav-04;
-
-      span,
-      span:before,
-      span:after {
-        background: $color__white;
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus($nav-04);
       }
     }
   }
@@ -152,14 +163,12 @@
       background: $nav-04;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $nav-04;
+    &:hover {
+      @include hover-focus($nav-04, false);
+    }
 
-      span:before,
-      span:after {
-        background: $color__white;
-      }
+    &:focus {
+      @include hover-focus($nav-04, false);
     }
   }
 
@@ -174,15 +183,12 @@
       outline: 0;
     }
 
-    &:hover,
-    &:focus {
-      background-color: $nav-08;
+    &:hover {
+      @include hover-focus($nav-06);
+    }
 
-      span,
-      span:before,
-      span:after {
-        background: $color__white;
-      }
+    &:focus {
+      @include hover-focus($nav-06);
     }
   }
 
@@ -196,14 +202,11 @@
       background: $nav-08;
     }
 
-    &:hover,
+    &:hover {
+      @include hover-focus($nav-08, false);
+    }
     &:focus {
-      background-color: $nav-08;
-
-      span:before,
-      span:after {
-        background: $color__white;
-      }
+      @include hover-focus($nav-08, false);
     }
   }
 }

--- a/src/components/unified-header/_topnav.scss
+++ b/src/components/unified-header/_topnav.scss
@@ -119,12 +119,20 @@
     font-weight: 600;
     margin-right: 1rem;
 
-    &:hover,
-    &:focus {
+    @mixin hover-focus {
       color: $color__blue-30; // anna
 
       .#{$prefix}--top-nav__left-container__link--icon {
         fill: $color__blue-30; // anna
+      }
+    }
+    &:hover {
+      @include hover-focus;
+    }
+
+    &:focus {
+      @include interaction-wrapper($mouse: false, $touch: false) {
+        @include hover-focus;
       }
     }
   }
@@ -144,8 +152,7 @@
 
   .#{$prefix}--top-nav__left-container {
     .#{$prefix}--dropdown {
-      &:focus,
-      &:hover {
+      @mixin hover-focus {
         outline: 0;
 
         .#{$prefix}--dropdown__arrow use {
@@ -156,6 +163,15 @@
           background-color: $color__navy-gray-3; // anna
           color: $color__blue-30; // anna
         }
+      }
+
+      &:focus {
+        @include interaction-wrapper($touch: false) {
+          @include hover-focus;
+        }
+      }
+      &:hover {
+        @include hover-focus;
       }
     }
 
@@ -181,10 +197,15 @@
     .#{$prefix}--dropdown-link {
       padding: 0.6rem 0.75rem;
 
-      &:hover,
-      &:focus {
+      &:hover {
         background-color: $color__blue-30; // anna
         color: $color__blue-90; // anna
+      }
+      &:focus {
+        @include interaction-wrapper($mouse: false, $touch: false) {
+          background-color: $color__blue-30; // anna
+          color: $color__blue-90; // anna
+        }
       }
     }
   }
@@ -220,8 +241,7 @@
       color: $color__blue-30; // anna
     }
 
-    .#{$prefix}--dropdown:hover,
-    .#{$prefix}--dropdown:focus {
+    @mixin hover-focus {
       outline: 0;
       background-color: $color__navy-gray-3; // anna
 
@@ -233,6 +253,14 @@
         fill: $color__blue-30; // anna
       }
     }
+    .#{$prefix}--dropdown:hover {
+      @include hover-focus;
+    }
+    .#{$prefix}--dropdown:focus {
+      @include interaction-wrapper($touch: false) {
+        @include hover-focus;
+      }
+    }
 
     .#{$prefix}--dropdown__trial-content,
     .#{$prefix}--dropdown__credit-content {
@@ -241,11 +269,18 @@
       flex-direction: column;
       padding: 1rem;
 
-      &:focus,
-      &:hover {
+      @mixin hover-focus {
         outline: 0;
         background-color: initial;
         color: $inverse-01;
+      }
+      &:focus {
+        @include interaction-wrapper($touch: false) {
+          @include hover-focus;
+        }
+      }
+      &:hover {
+        @include hover-focus;
       }
     }
 
@@ -287,10 +322,17 @@
 
   .#{$prefix}--top-nav__right-container__item:last-child {
     .#{$prefix}--dropdown {
-      &:focus,
-      &:hover {
+      @mixin hover-focus {
         background-color: $color__navy-gray-3; // anna
         outline: 0;
+      }
+      &:focus {
+        @include interaction-wrapper($touch: false) {
+          @include hover-focus;
+        }
+      }
+      &:hover {
+        @include hover-focus;
       }
     }
 

--- a/src/globals/js/boot.js
+++ b/src/globals/js/boot.js
@@ -1,4 +1,5 @@
 import settings from './settings';
+import '../../globals/js/misc/focus-input-method-monitor';
 import * as components from './components';
 
 /**

--- a/src/globals/js/misc/focus-input-method-monitor.js
+++ b/src/globals/js/misc/focus-input-method-monitor.js
@@ -9,7 +9,8 @@ const state = function state() {
 };
 const interact = function interact(type) {
   // performance.now is better cross browser than event.timestamp
-  if (performance.now > lastTimeStamp + debounce) {
+  const timestamp = performance.now();
+  if (timestamp > lastTimeStamp + debounce || type !== 'mouse') {
     // debounce helps us detect simulated mouse events that happen near touch
     lastTimeStamp = performance.now();
     lastInteraction = type;

--- a/src/globals/js/misc/focus-input-method-monitor.js
+++ b/src/globals/js/misc/focus-input-method-monitor.js
@@ -2,15 +2,16 @@ let lastInteraction = 'none';
 let lastActiveElement = null;
 let lastTimeStamp = 0;
 
-const debounce = 100; // ms
+const debounce = 1000; // ms - simulated mouse events observed 600ms after touch
 const attr = 'data-input-method';
 const state = function state() {
   return { lastInteraction, lastActiveElement };
 };
-const interact = function interact(type, e) {
-  if (e.timeStamp > lastTimeStamp + debounce) {
+const interact = function interact(type) {
+  // performance.now is better cross browser than event.timestamp
+  if (performance.now > lastTimeStamp + debounce) {
     // debounce helps us detect simulated mouse events that happen near touch
-    lastTimeStamp = e.timeStamp;
+    lastTimeStamp = performance.now();
     lastInteraction = type;
   }
 };
@@ -19,10 +20,10 @@ const init = () => {
   lastActiveElement = document.activeElement;
 
   document.body.setAttribute(attr, 'none');
-  document.body.addEventListener('mousedown', e => interact('mouse', e), true);
-  document.body.addEventListener('pointerdown', e => interact(e.pointerType ? e.pointerType : 'mouse', e), true);
-  document.body.addEventListener('touchstart', e => interact('touch', e), true);
-  document.body.addEventListener('keydown', e => interact('keyboard', e), true);
+  document.body.addEventListener('mousedown', () => interact('mouse'), true);
+  document.body.addEventListener('pointerdown', e => interact(e.pointerType ? e.pointerType : 'mouse'), true);
+  document.body.addEventListener('touchstart', () => interact('touch'), true);
+  document.body.addEventListener('keydown', () => interact('keyboard'), true);
 
   document.body.addEventListener(
     'focus',

--- a/src/globals/js/misc/focus-input-method-monitor.js
+++ b/src/globals/js/misc/focus-input-method-monitor.js
@@ -1,0 +1,41 @@
+let lastInteraction = 'none';
+let lastActiveElement = null;
+let lastTimeStamp = 0;
+
+const debounce = 100; // ms
+const attr = 'data-input-method';
+const state = function state() {
+  return { lastInteraction, lastActiveElement };
+};
+const interact = function interact(type, e) {
+  if (e.timeStamp > lastTimeStamp + debounce) {
+    // debounce helps us detect simulated mouse events that happen near touch
+    lastTimeStamp = e.timeStamp;
+    lastInteraction = type;
+  }
+};
+
+const init = () => {
+  lastActiveElement = document.activeElement;
+
+  document.body.setAttribute(attr, 'none');
+  document.body.addEventListener('mousedown', e => interact('mouse', e), true);
+  document.body.addEventListener('pointerdown', e => interact(e.pointerType ? e.pointerType : 'mouse', e), true);
+  document.body.addEventListener('touchstart', e => interact('touch', e), true);
+  document.body.addEventListener('keydown', e => interact('keyboard', e), true);
+
+  document.body.addEventListener(
+    'focus',
+    () => {
+      if (document.activeElement !== lastActiveElement) {
+        // only update attribute on actual focus changes
+        document.body.setAttribute(attr, lastInteraction);
+        lastActiveElement = document.activeElement;
+      }
+    },
+    true
+  );
+};
+init();
+
+export default { state };

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -43,14 +43,49 @@
   }
 }
 
-@mixin focus-outline($type: 'border') {
-  @if ($type == 'border') {
-    outline: 1px solid $brand-01;
-  }
+// interaction wrapper function allows CSS to be styled based on the users last interaction
+// Requires data-input-method to be applied in javascript
+@mixin interaction-wrapper($keyboard: true, $mouse: true, $touch: true) {
+  @if $keyboard and $mouse and $touch {
+    // If all three are true no need for data-input-method check
+    @content;
+  } @else {
+    body:not([data-input-method]) & {
+      // not yet initialised, default to showing focus indicator
+      @content;
+    }
 
-  @if ($type == 'blurred') {
-    box-shadow: 0 0 0 3px $color__blue-20;
-    outline: 1px solid transparent;
+    @if $keyboard != false {
+      [data-input-method='keyboard'] & {
+        @content;
+      }
+    }
+    @if $mouse != false {
+      [data-input-method='mouse'] & {
+        @content;
+      }
+    }
+    @if $touch != false {
+      [data-input-method='touch'] & {
+        @content;
+      }
+    }
+  }
+}
+
+// Enhanced focus-outline mixin used to turn off focus indicators in certain scenarios
+@mixin focus-outline($type: 'border', $keyboard: true, $mouse: true, $touch: true) {
+  outline: none; // off by default
+
+  @include interaction-wrapper($keyboard, $mouse, $touch) {
+    @if ($type == 'border') {
+      outline: 1px solid $brand-01;
+    }
+
+    @if ($type == 'blurred') {
+      box-shadow: 0 0 0 3px $color__blue-20;
+      outline: 1px solid transparent;
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

Carbon currently displays focus indicators regardless of the interaction that caused the focus event. This is in contrast to browsers Chrome, Firefox, Safari which distinguish between focus events raised following keyboard, mouse and touch events as follows.

- Following keyboard events focus is always shown
- Following mouse events focus is shown except on buttons, links, checkboxes, radio buttons and range selectors.
- Following touch events (IOS) focus is never shown.

### Added

globals/js/misc/focus-input-method-monitor.js - sets a body tag attribute to indicate the last interaction type: keyboard, mouse, touch
globals/scss/_helper-mixins.scss - Added interaction-wrapper mixin

### Changed

Updated each focus event to display focus state only as described above.

## Testing / Reviewing

Visit every focusable element and verify that: it shows focus on keyboard use, based on above rules does not show focus state for mouse and touch events. 