### PR TITLE
fix(floating-menu): fix an issue with IE11 tooltip handling blur event

### DIFF
--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -117,7 +117,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlu
       this.changeState('hidden', getLaunchingDetails(event));
       const { refNode } = this.options;
       if (this.element.contains(event.relatedTarget) && refNode && event.target !== refNode) {
-        refNode.focus();
+        HTMLElement.prototype.focus.call(refNode); // SVGElement in IE11 does not have `.focus()` method
       }
     }
   }

--- a/src/globals/js/misc/event-matches.js
+++ b/src/globals/js/misc/event-matches.js
@@ -8,13 +8,14 @@ export default function eventMatches(event, selector) {
   // <svg> in IE does not have `Element#msMatchesSelector()` (that should be copied to `Element#matches()` by a polyfill).
   // Also a weird behavior is seen in IE where DOM tree seems broken when `event.target` is on <svg>.
   // Therefore this function simply returns `undefined` when `event.target` is on <svg>.
-  if (typeof event.target.matches === 'function') {
-    if (event.target.matches(selector)) {
+  const { target, currentTarget } = event;
+  if (typeof target.matches === 'function') {
+    if (target.matches(selector)) {
       // If event target itself matches the given selector, return it
-      return event.target;
-    } else if (event.target.matches(`${selector} *`)) {
-      const closest = event.target.closest(selector);
-      if (event.currentTarget.contains(closest)) {
+      return target;
+    } else if (target.matches(`${selector} *`)) {
+      const closest = target.closest(selector);
+      if ((currentTarget.nodeType === Node.DOCUMENT_NODE ? currentTarget.documentElement : currentTarget).contains(closest)) {
         return closest;
       }
     }


### PR DESCRIPTION
## Overview

This fix also includes another issue in IE11 which does not have `document.contains()`.
Fixes #668.

### Changed

* Use `HTMLElement.prototype.focus()` for focusing on SVG
* Check for document node before calling `.contains()` and use `.documentElement` in such case

## Testing / Reviewing

Testing should make sure tooltip is not broken.