### PR TITLE
fix(content-switcher): control aria-hidden of target panels

### DIFF
--- a/src/components/content-switcher/content-switcher.js
+++ b/src/components/content-switcher/content-switcher.js
@@ -75,12 +75,18 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
     selectorButtons.forEach(button => {
       if (button !== item) {
         button.classList.toggle(this.options.classActive, false);
-        [...button.ownerDocument.querySelectorAll(button.dataset.target)].forEach(element => element.setAttribute('hidden', ''));
+        [...button.ownerDocument.querySelectorAll(button.dataset.target)].forEach(element => {
+          element.setAttribute('hidden', '');
+          element.setAttribute('aria-hidden', 'true');
+        });
       }
     });
 
     item.classList.toggle(this.options.classActive, true);
-    [...item.ownerDocument.querySelectorAll(item.dataset.target)].forEach(element => element.removeAttribute('hidden'));
+    [...item.ownerDocument.querySelectorAll(item.dataset.target)].forEach(element => {
+      element.removeAttribute('hidden');
+      element.setAttribute('aria-hidden', 'false');
+    });
 
     if (callback) {
       callback();


### PR DESCRIPTION
## Overview

Fixes #684.

### Added

Code to control `aria-hidden` for tab panels.

## Testing / Reviewing

Testing should ensure that content switcher and tabs are not broken.