### PR TITLE
fix(modal): fix typo in floating menus list

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -191,7 +191,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
       selectorInit: '[data-modal]',
       selectorModalClose: '[data-modal-close]',
       selectorPrimaryFocus: '[data-modal-primary-focus]',
-      selectorsFloatingMenus: [`.${prefix}--overflow-menu-options`, '.bx-tooltip'],
+      selectorsFloatingMenus: [`.${prefix}--overflow-menu-options`, '.${prefix}--tooltip'],
       classVisible: 'is-visible',
       attribInitTarget: 'data-modal-target',
       initEventNames: ['click'],


### PR DESCRIPTION
## Overview

Another fix for #668. Fixed a typo in modal's `selectorsFloatingMenus` option that caused modal code sets keyboard focus back to modal when tooltip gets focus as it's shown (thus the tooltip gets hidden immediately).

### Changed

`selectorsFloatingMenus` option in modal.

## Testing / Reviewing

Testing should make sure modal is not broken.