### PR TITLE
chore(devenv): apply autoprefixer in dev env

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.1.0",
     "adaro": "1.0.4",
+    "autoprefixer": "^8.2.0",
     "babel-core": "^6.22.0",
     "babel-eslint": "^7.0.0",
     "babel-loader": "^7.1.0",
@@ -113,6 +114,7 @@
     "minimatch": "^3.0.0",
     "mock-raf": "^1.0.0",
     "nodemon": "1.9.1",
+    "postcss-loader": "^2.1.0",
     "prettier": "^1.7.0",
     "prop-types": "^15.6.0",
     "pump": "^1.0.2",

--- a/tools/webpack.dev.config.js
+++ b/tools/webpack.dev.config.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const autoprefixer = require('autoprefixer');
 
 module.exports = {
   devtool: 'source-maps',
@@ -31,6 +32,12 @@ module.exports = {
           },
           {
             loader: 'css-loader',
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              plugins: [autoprefixer],
+            },
           },
           {
             loader: 'sass-loader',


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/pull/683#issuecomment-379897603

This fix applies `autoprefixer` in dev env.

### Added

Adds `autoprefixer` (back) in dev env.

## Testing / Reviewing

Testing should make sure the dev env is not broken.