### PR TITLE
fix(breadcrumb):  fix breadcrumb on smaller screens

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -11,7 +11,7 @@
   .#{$prefix}--breadcrumb {
     @include typescale('zeta');
     @include font-family;
-    display: none;
+    display: inline;
 
     @include breakpoint(bp--xs--major) {
       display: flex;


### PR DESCRIPTION
## Overview
solve part of  https://github.com/carbon-design-system/carbon-components-react/issues/608
Put the property `display: none` to `display: inline` so that  breadcrumb switching into a liste instead disappear on smaller screens.

### Added
### Removed
### Changed
## Testing / Reviewing

