### PR TITLE
fix(modal): use backtick for template string

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -191,7 +191,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
       selectorInit: '[data-modal]',
       selectorModalClose: '[data-modal-close]',
       selectorPrimaryFocus: '[data-modal-primary-focus]',
-      selectorsFloatingMenus: [`.${prefix}--overflow-menu-options`, '.${prefix}--tooltip'],
+      selectorsFloatingMenus: [`.${prefix}--overflow-menu-options`, `.${prefix}--tooltip`],
       classVisible: 'is-visible',
       attribInitTarget: 'data-modal-target',
       initEventNames: ['click'],


### PR DESCRIPTION
## Fix typo

Resolves https://github.com/carbon-design-system/carbon-components/issues/704