### PR TITLE
fix(modal): stop taking over focus when Flatpickr gets it

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -191,7 +191,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
       selectorInit: '[data-modal]',
       selectorModalClose: '[data-modal-close]',
       selectorPrimaryFocus: '[data-modal-primary-focus]',
-      selectorsFloatingMenus: [`.${prefix}--overflow-menu-options`, `.${prefix}--tooltip`],
+      selectorsFloatingMenus: [`.${prefix}--overflow-menu-options`, `.${prefix}--tooltip`, '.flatpickr-calendar'],
       classVisible: 'is-visible',
       attribInitTarget: 'data-modal-target',
       initEventNames: ['click'],


### PR DESCRIPTION
## Overview

Fixes #655.

### Added

* Flatpickr dropdown to the list of “floating menu in modal”, to prevent modal code from taking over focus when Flatpicker gets it.

## Testing / Reviewing

Testing should make sure modal is not broken.