### PR TITLE
fix(search): add button to search close icon for a11y

### DIFF
--- a/src/components/search/FAQ.md
+++ b/src/components/search/FAQ.md
@@ -1,0 +1,23 @@
+# FAQ
+
+## Table of Contents
+
+<!-- To run doctoc, just do `npx doctoc FAQ.md` in this directory! -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Why is the clear icon a button?](#why-is-the-clear-icon-a-button)
+- [The close icon isn't tab-able in Safari](#the-close-icon-isnt-tab-able-in-safari)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+## Why is the clear icon a button?
+
+The clear icon has been updated to use a `button` in order to be tab-able by various browsers. If the icon is just an SVG target, than unfortunately some screen readers may not be able to access it during the normal control flow.
+
+## The close icon isn't tab-able in Safari
+
+In order to tab to the close icon in an input in Safar, you'll have to use `<Option><Tab>` instead of the standard `<Tab>` keystroke.

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -73,11 +73,18 @@
   }
 
   .#{$prefix}--search-close {
-    transition: $transition--base;
+    @include button-reset(false);
+
+    transition: opacity $transition--base;
     fill: $ui-05;
     cursor: pointer;
     visibility: visible;
     opacity: 1;
+  }
+
+  .#{$prefix}--search-close:focus {
+    outline: 1px solid $brand-01;
+    outline-offset: 2px;
   }
 
   .#{$prefix}--search--sm .#{$prefix}--search-close {
@@ -99,7 +106,7 @@
     height: rem(40px);
     width: rem(40px);
     min-width: rem(40px);
-    margin-left: $spacing-2xs;;
+    margin-left: $spacing-2xs;
     background-color: $ui-01;
     position: relative;
     padding: 0;

--- a/src/components/search/search-large.html
+++ b/src/components/search/search-large.html
@@ -5,9 +5,11 @@
   </svg>
   <label class="bx--label" id="search-input-label-2" for="search__input-1">Search</label>
   <input class="bx--search-input" type="text" role="search" id="search__input-1" placeholder="Search" aria-labelledby="search-input-label-2">
-  <svg class="bx--search-close bx--search-close--hidden" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-    <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm3.5 10.1l-1.4 1.4L8 9.4l-2.1 2.1-1.4-1.4L6.6 8 4.5 5.9l1.4-1.4L8 6.6l2.1-2.1 1.4 1.4L9.4 8l2.1 2.1z"></path>
-  </svg>
+  <button class="bx--search-close bx--search-close--hidden" title="Clear search input" aria-label="Clear search input">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+      <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm3.5 10.1l-1.4 1.4L8 9.4l-2.1 2.1-1.4-1.4L6.6 8 4.5 5.9l1.4-1.4L8 6.6l2.1-2.1 1.4 1.4L9.4 8l2.1 2.1z"></path>
+    </svg>
+  </button>
   <button class="bx--search-button" type="button" aria-label="Filter button">
     <svg class="bx--search-filter" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
       <path d="M5 0C3.7 0 2.6.8 2.2 2H0v2h2.2C2.6 5.2 3.7 6 5 6c1.3 0 2.4-.8 2.8-2H16V2H7.8C7.4.8 6.3 0 5 0zm0 4c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1zM5 10c-1.3 0-2.4.8-2.8 2H0v2h2.2c.4 1.2 1.5 2 2.8 2 1.3 0 2.4-.8 2.8-2H16v-2H7.8c-.4-1.2-1.5-2-2.8-2zm0 4c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"></path>

--- a/src/components/search/search-small.html
+++ b/src/components/search/search-small.html
@@ -5,7 +5,10 @@
   </svg>
   <label id="search-input-label-1" class="bx--label" for="search__input-2">Search</label>
   <input class="bx--search-input" type="text" id="search__input-2" role="search" placeholder="Search" aria-labelledby="search-input-label-1">
-  <svg class="bx--search-close bx--search-close--hidden" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
-    <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm3.5 10.1l-1.4 1.4L8 9.4l-2.1 2.1-1.4-1.4L6.6 8 4.5 5.9l1.4-1.4L8 6.6l2.1-2.1 1.4 1.4L9.4 8l2.1 2.1z"></path>
-  </svg>
+  <button class="bx--search-close bx--search-close--hidden" title="Clear search
+  input" aria-label="Clear search input">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
+      <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm3.5 10.1l-1.4 1.4L8 9.4l-2.1 2.1-1.4-1.4L6.6 8 4.5 5.9l1.4-1.4L8 6.6l2.1-2.1 1.4 1.4L9.4 8l2.1 2.1z"></path>
+    </svg>
+  </button>
 </div>


### PR DESCRIPTION
## Overview

Resolves #730 

Updates SVG markup in a Search to use a button for a11y.

### Added

### Removed

### Changed

* Search component now uses a `button` in its markup
* Search scss now includes `button-reset` in its selector for `bx--search-close`


## Testing / Reviewing

* Is the search button tab-able, focusable, etc.
* Does the search button announce the right text to a screenreader, e.g. "Clear search input"
