### PR TITLE
fix(text-input): switched from outline to border on focus

### DIFF
--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -12,9 +12,11 @@
         </svg>
       </button>
     </div>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae tellus
-      tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla facilisi.
-      Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>
+    <div class="bx--modal-content">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae
+        tellus tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla facilisi.
+        Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>
+    </div>
   </div>
 
   <div class="bx--modal-footer">

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -12,23 +12,16 @@
         </svg>
       </button>
     </div>
-
-    <div class="bx--modal-content">
-      <div class="bx--form-item">
-        <label for="text-input-1" class="bx--label">Text Input label</label>
-        <input id="text-input-1" type="text" class="bx--text-input" placeholder="Placeholder text">
-      </div>
-
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae
-        tellus tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla facilisi.
-        Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>
-    </div>
-
-    <div class="bx--modal-footer">
-      <button class="bx--btn bx--btn--secondary" type="button" data-modal-close>Secondary button</button>
-      <button class="bx--btn bx--btn--primary" type="button" data-modal-primary-focus>Primary button</button>
-    </div>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae tellus
+      tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla facilisi.
+      Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>
   </div>
+
+  <div class="bx--modal-footer">
+    <button class="bx--btn bx--btn--secondary" type="button" data-modal-close>Secondary button</button>
+    <button class="bx--btn bx--btn--primary" type="button" data-modal-primary-focus>Primary button</button>
+  </div>
+</div>
 </div>
 
 <button class="bx--btn bx--btn--danger--primary" type="button" data-modal-target="#modal--danger">Transactional Danger</button>

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -14,6 +14,11 @@
     </div>
 
     <div class="bx--modal-content">
+      <div class="bx--form-item">
+        <label for="text-input-1" class="bx--label">Text Input label</label>
+        <input id="text-input-1" type="text" class="bx--text-input" placeholder="Placeholder text">
+      </div>
+
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae
         tellus tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla facilisi.
         Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -30,6 +30,7 @@
     }
 
     &:focus {
+      outline: none;
       border: 1px solid $brand-01;
     }
 

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -30,7 +30,7 @@
     }
 
     &:focus {
-      @include focus-outline('border');
+      border: 1px solid $brand-01;
     }
 
     &:disabled {


### PR DESCRIPTION
## Overview

Closes #530 

Switched from using an outline to using border on focus for the text inputs to prevent the outline from being cut off in a modal in IE11/Firefox.

### Changed

- `_text-input.scss`

## Testing / Reviewing

Make sure that a text input is not cut off on focus anymore when used in a modal in IE11/Firefox.
