### PR TITLE
fix(select): match select height to other form elements

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -21,10 +21,11 @@
   .#{$prefix}--select-input {
     @include font-family;
     @include typescale('zeta');
+    height: rem(40px);
     appearance: none;
     display: block;
     width: 100%;
-    padding: $spacing-sm $spacing-2xl $spacing-sm $spacing-md;
+    padding: 0 $spacing-2xl 0 $spacing-md;
     color: $text-01;
     background-color: $field-01;
     border: $input-border;


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/715

Matches `select` height to other form elements.

### Changed

- Removed top/bottom padding from `select` and instead used a hardcoded `rem(40px)` to handle padding. This matches the convention on other form elements 
