### PR TITLE
fix(tooltip): Firefox overflowing text when you have a long enough string without spaces

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -210,7 +210,7 @@ When you're at a good stopping place and you're ready for feedback from other co
 > - `<scope>` The scope could be anything specifying place of the commit change or the thing(s) that changed.
 >
 > __Commit message format:__
-> ```
+```
 <type>(<scope>): <subject>
 <BLANK LINE>
 <body>

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -51,6 +51,7 @@
     padding: $spacing-lg;
     border: 1px solid $ui-04;
     z-index: z('floating');
+    word-wrap: break-word;
 
     p {
       @include font-family;


### PR DESCRIPTION
## Overview

While using Carbon Components React In Firefox, if strings get too long without spaces, the text will flow outside of the tooltip

![screen shot 2018-04-27 at 3 31 46 pm](https://user-images.githubusercontent.com/33705160/39383814-4ab0bc2a-4a30-11e8-9880-c829058079f4.png)

https://codesandbox.io/s/n4o33kvp8m

### Changed

Added css to .bx--tooltip

## Testing / Reviewing

Add the following string to a Tooltip and hover over in Firefox:
ibmcloud.public.iaas-telemetry.us-south.xxx01.0e8df11f-abcd-47a0-8468-12596966a59d

Tested in several versions of carbon-components-react up to version 5.44
