### PR TITLE
fix(data-table-v2): fix the icon that becomes small when column header wraps

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-sort.scss
+++ b/src/components/data-table-v2/_data-table-v2-sort.scss
@@ -54,6 +54,6 @@
     height: rem(9px);
     padding: $spacing-3xs;
     width: auto;
-    max-width: 14px;
+    min-width: 14px;
   }
 }


### PR DESCRIPTION

## Overview

Resolves   #720

fix the icon that becomes small when column header wraps


### Added

### Removed

### Changed

apply `min-width` instead of  `max-width`

## Testing / Reviewing

