### PR TITLE
feat(dropdown): added inline dropdown, style changes to dropdown, fixed link in data table readme 

### DIFF
--- a/src/components/data-table-v2/README.md
+++ b/src/components/data-table-v2/README.md
@@ -69,7 +69,7 @@ The update to tables splits out the `scss` files into multiple partial files wit
 ### FAQ
 
 **How do I sort the tables**
-The table component does not sort the table for you, rather it emits an event and toggles the sort UI. It is up to the user to re-render the table rows sorted; you can see this in action `here`.
+The table component does not sort the table for you, rather it emits an event and toggles the sort UI. It is up to the user to re-render the table rows sorted; you can see this in action [in the React Storybook](http://react.carbondesignsystem.com/?selectedKind=DataTable&selectedStory=with%20sorting&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
 
 **How do I use the expandable rows**
 If you would like to programmatically expand table rows, you can add the `bx--expandable-row-v2` to the `selectorParentRows` elements.

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -21,7 +21,7 @@
     position: relative;
     list-style: none;
     display: block;
-    background-color: $field-02;
+    background-color: $field-01;
     width: 100%;
     height: rem(40px);
     cursor: pointer;
@@ -35,10 +35,6 @@
       outline: 1px solid transparent;
       box-shadow: 0 -1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
     }
-  }
-
-  .#{$prefix}--dropdown--light {
-    background-color: $field-02;
   }
 
   .#{$prefix}--dropdown--up {
@@ -55,8 +51,7 @@
     }
   }
 
-  .#{$prefix}--dropdown__arrow,
-  .#{$prefix}--dropdown-text svg {
+  .#{$prefix}--dropdown__arrow {
     fill: $brand-01;
     position: absolute;
     right: 1rem;
@@ -130,8 +125,7 @@
   }
 
   .#{$prefix}--dropdown--open {
-    .#{$prefix}--dropdown__arrow,
-    .#{$prefix}--dropdown-text svg {
+    .#{$prefix}--dropdown__arrow {
       transform: rotate(-180deg);
     }
 
@@ -201,8 +195,7 @@
       outline: none;
     }
 
-    .#{$prefix}--dropdown__arrow,
-    .#{$prefix}--dropdown-text svg {
+    .#{$prefix}--dropdown__arrow {
       position: relative;
       top: -2px;
       left: 8px;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -21,7 +21,7 @@
     position: relative;
     list-style: none;
     display: block;
-    background-color: $field-01;
+    background-color: $field-02;
     width: 100%;
     height: rem(40px);
     cursor: pointer;
@@ -35,6 +35,10 @@
       outline: 1px solid transparent;
       box-shadow: 0 -1px 0 0 $brand-01, 1px 0 0 0 $brand-01, -1px 0 0 0 $brand-01;
     }
+  }
+
+  .#{$prefix}--dropdown--light {
+    background-color: $field-02;
   }
 
   .#{$prefix}--dropdown--up {
@@ -51,7 +55,8 @@
     }
   }
 
-  .#{$prefix}--dropdown__arrow {
+  .#{$prefix}--dropdown__arrow,
+  .#{$prefix}--dropdown-text svg {
     fill: $brand-01;
     position: absolute;
     right: 1rem;
@@ -64,7 +69,7 @@
   }
 
   .#{$prefix}--dropdown[data-value=''] .#{$prefix}--dropdown-text {
-    color: $text-03;
+    color: $text-01;
   }
 
   .#{$prefix}--dropdown-text {
@@ -105,16 +110,18 @@
     display: block;
     color: currentColor;
     text-decoration: none;
+    font-weight: normal;
     padding: $spacing-md $spacing-lg $spacing-md $spacing-md;
     text-overflow: ellipsis;
     overflow: hidden;
 
     &:hover,
     &:focus {
-      background-color: $brand-01;
-      color: $inverse-01;
+      background-color: $field-01;
+      color: $text-01;
       outline: 1px solid transparent;
       text-decoration: underline;
+      color: $text-01;
     }
   }
 
@@ -123,7 +130,8 @@
   }
 
   .#{$prefix}--dropdown--open {
-    .#{$prefix}--dropdown__arrow {
+    .#{$prefix}--dropdown__arrow,
+    .#{$prefix}--dropdown-text svg {
       transform: rotate(-180deg);
     }
 
@@ -152,6 +160,63 @@
 
     &:focus {
       outline: none;
+    }
+  }
+
+  .#{$prefix}--dropdown--inline {
+    background-color: transparent;
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus .#{$prefix}--dropdown-text {
+      @include focus-outline('border');
+    }
+
+    &[data-value=''] .#{$prefix}--dropdown-text {
+      color: $brand-01;
+    }
+
+    .#{$prefix}--dropdown-text {
+      display: inline-block;
+      padding-right: 1.5rem;
+      overflow: visible;
+      color: $brand-01;
+    }
+
+    .#{$prefix}--dropdown-text:hover {
+      background-color: $field-01;
+    }
+
+    &.#{$prefix}--dropdown--open:focus {
+      box-shadow: none;
+    }
+
+    &.#{$prefix}--dropdown--open:focus .#{$prefix}--dropdown-list {
+      @include layer('overlay');
+    }
+
+    &.#{$prefix}--dropdown--open:focus .#{$prefix}--dropdown-text {
+      outline: none;
+    }
+
+    .#{$prefix}--dropdown__arrow,
+    .#{$prefix}--dropdown-text svg {
+      position: relative;
+      top: -2px;
+      left: 8px;
+      right: 0;
+      bottom: 0;
+    }
+
+    .#{$prefix}--dropdown-link {
+      font-weight: normal;
+    }
+
+    .#{$prefix}--dropdown-link:hover {
+      background-color: $field-01;
+      color: $text-01;
     }
   }
 }

--- a/src/components/dropdown/dropdown--inline.html
+++ b/src/components/dropdown/dropdown--inline.html
@@ -1,0 +1,26 @@
+<ul data-dropdown data-dropdown-type="inline" data-value class="bx--dropdown bx--dropdown--inline" tabindex="0">
+  <li class="bx--dropdown-text">Inline Dropdown label
+    <svg class="bx--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+      <path d="M10 0L5 5 0 0z"></path>
+    </svg>
+  </li>
+  <li>
+    <ul class="bx--dropdown-list">
+      <li data-option data-value="all" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 1</a>
+      </li>
+      <li data-option data-value="cloudFoundry" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 2</a>
+      </li>
+      <li data-option data-value="staging" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 3</a>
+      </li>
+      <li data-option data-value="dea" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 4</a>
+      </li>
+      <li data-option data-value="router" class="bx--dropdown-item">
+        <a class="bx--dropdown-link" href="javascript:void(0)">Option 5</a>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/src/components/dropdown/dropdown--inline.html
+++ b/src/components/dropdown/dropdown--inline.html
@@ -1,5 +1,6 @@
 <ul data-dropdown data-dropdown-type="inline" data-value class="bx--dropdown bx--dropdown--inline" tabindex="0">
-  <li class="bx--dropdown-text">Inline Dropdown label
+  <li class="bx--dropdown-text">
+    <span class="bx--dropdown-text__inner">Inline Dropdown label</span>
     <svg class="bx--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
       <path d="M10 0L5 5 0 0z"></path>
     </svg>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -141,19 +141,13 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
       detail: { item: itemToSelect },
     });
 
-    const caretHTML = `
-    <svg width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
-      <path d="M10 0L5 5 0 0z"></path>
-    </svg>
-    `;
-
     if (this.element.dispatchEvent(eventStart)) {
       if (this.element.dataset.dropdownType !== 'navigation') {
-        const text = this.element.querySelector(this.options.selectorText);
-        if (text && this.element.dataset.dropdownType !== 'inline') {
+        const selectorText =
+          this.element.dataset.dropdownType !== 'inline' ? this.options.selectorText : this.options.selectorTextInner;
+        const text = this.element.querySelector(selectorText);
+        if (text) {
           text.innerHTML = itemToSelect.innerHTML;
-        } else {
-          text.innerHTML = `${itemToSelect.innerHTML} ${caretHTML}`;
         }
         itemToSelect.classList.add(this.options.classSelected);
       }
@@ -197,6 +191,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @type {Object}
    * @property {string} selectorInit The CSS selector to find selectors.
    * @property {string} [selectorText] The CSS selector to find the element showing the selected item.
+   * @property {string} [selectorTextInner] The CSS selector to find the element showing the selected item, used for inline mode.
    * @property {string} [selectorItem] The CSS selector to find clickable areas in dropdown items.
    * @property {string} [selectorItemSelected] The CSS selector to find the clickable area in the selected dropdown item.
    * @property {string} [classSelected] The CSS class for the selected dropdown item.
@@ -212,6 +207,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
     return {
       selectorInit: '[data-dropdown]',
       selectorText: `.${prefix}--dropdown-text`,
+      selectorTextInner: `.${prefix}--dropdown-text__inner`,
       selectorItem: `.${prefix}--dropdown-link`,
       selectorItemSelected: `.${prefix}--dropdown--selected`,
       classSelected: `${prefix}--dropdown--selected`,

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -141,11 +141,19 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
       detail: { item: itemToSelect },
     });
 
+    const caretHTML = `
+    <svg width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+      <path d="M10 0L5 5 0 0z"></path>
+    </svg>
+    `;
+
     if (this.element.dispatchEvent(eventStart)) {
       if (this.element.dataset.dropdownType !== 'navigation') {
         const text = this.element.querySelector(this.options.selectorText);
-        if (text) {
+        if (text && this.element.dataset.dropdownType !== 'inline') {
           text.innerHTML = itemToSelect.innerHTML;
+        } else {
+          text.innerHTML = `${itemToSelect.innerHTML} ${caretHTML}`;
         }
         itemToSelect.classList.add(this.options.classSelected);
       }

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -1,3 +1,8 @@
+#### Inline Select width
+
+The width of the inline select box should be the width of the default placeholder text + 16px/1rem of padding.
+There should be 10px of padding between the placeholder text and the caret.
+
 #### Using Form Validation
 
 Carbon Components provides HTML attributes and CSS to enable form validation for each input or control.


### PR DESCRIPTION
## Overview

Closes #694 
Closes #200 

- Added Inline Dropdown as this was missing from the vanilla repo (only available as the Multi-select component)
- Made some style changes to the Dropdown component to match the Design Kit
- Changed the filename of Inline Select so it shows up in the dev environment
- Added in a link in the Data Tables README

### Added

- `dropdown--inline.html`

### Changed

- `inline-select.html` to `select--inline.html`
- `README.md` for `data-table-v2`

## Testing / Reviewing

Make sure inline Dropdown works as expected.
