### PR TITLE
fix(letter-spacing): Remove letter-spacing

### DIFF
--- a/demo/js/components/PageHeader/page-header.scss
+++ b/demo/js/components/PageHeader/page-header.scss
@@ -34,11 +34,11 @@
 
 .page-header__title {
   @include typescale('mega');
+  @include letter-spacing;
   color: $text-01;
   font-weight: 300;
   margin: -1.15rem 0 0 -3px;
   line-height: 1.25;
-  letter-spacing: 0;
   padding: 0;
   transition: $transition--base $bx--standard-easing;
 

--- a/demo/scss/_markdown-page.scss
+++ b/demo/scss/_markdown-page.scss
@@ -58,11 +58,11 @@
     margin-bottom: 4rem;
 
     strong {
+      @include letter-spacing;
       font-size: 1.125rem;
       line-height: 1.5;
       font-weight: 600;
       word-wrap: break-word;
-      letter-spacing: 0;
     }
   }
 
@@ -187,7 +187,7 @@
           line-height: 1.25;
 
           strong {
-            letter-spacing: 0;
+            @include letter-spacing;
           }
 
           &:first-child {
@@ -216,14 +216,7 @@
     }
   }
 
-  main[data-page='style-overview-typography']
-    &
-    hr
-    + hr
-    + table
-    tbody
-    tr
-    td:nth-child(2) {
+  main[data-page='style-overview-typography'] & hr + hr + table tbody tr td:nth-child(2) {
     @media all and (max-width: 600px) {
       text-align: left;
       font-size: 3rem;
@@ -456,12 +449,12 @@
       margin-bottom: 3rem;
 
       strong {
+        @include letter-spacing;
         position: absolute;
         top: 0;
         left: 0;
         z-index: 2;
         color: $color__white;
-        letter-spacing: 0;
         font-size: 1.625rem;
         top: 2.2rem;
         left: 1.625rem;

--- a/demo/scss/_page.scss
+++ b/demo/scss/_page.scss
@@ -61,6 +61,7 @@ td {
 
   .page__desc {
     @include font-smoothing;
+    @include letter-spacing;
     max-width: 38rem;
     color: $text-01;
     word-wrap: break-word;
@@ -68,7 +69,6 @@ td {
     line-height: 1.5;
     font-weight: 600;
     padding-bottom: 1rem;
-    letter-spacing: 0;
 
     span {
       color: $brand-01;
@@ -95,9 +95,9 @@ td {
 
     h1 {
       @include typescale('mega');
+      @include letter-spacing;
       font-weight: 300;
       line-height: 1.25;
-      letter-spacing: 0px;
 
       &#helvetica-neue-light {
         font-weight: 300;
@@ -151,7 +151,7 @@ td {
         display: block;
         background-color: $brand-01;
         position: absolute;
-        top: -.5rem;
+        top: -0.5rem;
         left: 0;
       }
 
@@ -170,10 +170,10 @@ td {
 
     h3 {
       @include typescale('delta');
+      @include letter-spacing;
       color: $brand-01;
       padding: 4rem 0 1rem;
       font-weight: 600;
-      letter-spacing: 0;
 
       & + h4 {
         padding-top: 0;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -171,9 +171,9 @@
   }
 
   .#{$prefix}--btn--sm {
+    @include letter-spacing;
     height: 2rem;
     padding: $button-padding-sm;
-    letter-spacing: 0;
   }
 
   .#{$prefix}--btn--secondary + .#{$prefix}--btn--primary,

--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -99,7 +99,6 @@
     @include reset;
     @include typescale('omega');
     font-weight: 600;
-    letter-spacing: 1px;
     text-align: left;
     text-transform: $data-table-heading-transform;
     height: rem(40px);

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -80,10 +80,10 @@
   .#{$prefix}--modal-header__label {
     @include reset;
     @include typescale('omega');
+    @include letter-spacing;
     color: $text-01;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
     margin-bottom: $spacing-xs;
   }
 

--- a/src/components/module/_module.scss
+++ b/src/components/module/_module.scss
@@ -41,7 +41,7 @@
       .#{$prefix}--module__title {
         @include typescale('zeta');
         @include font-smoothing;
-        letter-spacing: 0;
+        @include letter-spacing;
         font-weight: 600;
         color: $text-01;
       }

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -74,8 +74,8 @@
 
   .#{$prefix}--toast-notification__title {
     @include typescale('zeta');
+    @include letter-spacing;
     font-weight: 600;
-    letter-spacing: 0;
     line-height: 1;
     padding-bottom: $spacing-3xs;
   }

--- a/src/components/unified-header/_account-switcher.scss
+++ b/src/components/unified-header/_account-switcher.scss
@@ -54,7 +54,7 @@
 
   .#{$prefix}--account-switcher__toggle--text {
     @include typescale('legal');
-    letter-spacing: 0.5px;
+    @include letter-spacing;
     overflow: hidden;
     display: inline-flex;
     white-space: nowrap;

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -68,7 +68,7 @@ $typescale-map: (
 }
 
 @mixin letter-spacing {
-  letter-spacing: 0.5px;
+  letter-spacing: 0;
 }
 
 $font-size-map: (
@@ -81,8 +81,8 @@ $font-size-map: (
   '16' : 1rem,
   '14' : 0.875rem,
   '12' : 0.75rem,
-  '11' : 0.6875rem,
- );
+  '11' : 0.6875rem
+);
 
 @mixin font-size($size) {
   @if map-has-key($font-size-map, $size) {


### PR DESCRIPTION
## Overview

<img width="636" alt="screen shot 2018-05-04 at 12 06 16 pm" src="https://user-images.githubusercontent.com/11928039/39641385-93cfbede-4f93-11e8-880a-8d97e9ed4a68.png">


With the introduction of Plex, we no longer need `letter-spacing` applied. Fixed the mixin to set `letter-spacing: 0` and found a few hard-coded values and switched them to use the mixin. 

### Changed

`@letter-spacing` now sets `letter-spacing: 0` instead of `letter-spacing: 0.5px`


## Testing / Reviewing
- Check and ensure components are not receiving any `letter-spacing`
