### PR TITLE
fix(dropdown): added tabindex logic to dropdown

### DIFF
--- a/src/components/dropdown/dropdown.html
+++ b/src/components/dropdown/dropdown.html
@@ -6,19 +6,19 @@
   <li>
     <ul class="bx--dropdown-list">
       <li data-option data-value="all" class="bx--dropdown-item">
-        <a class="bx--dropdown-link" href="javascript:void(0)">Option 1</a>
+        <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 1</a>
       </li>
       <li data-option data-value="cloudFoundry" class="bx--dropdown-item">
-        <a class="bx--dropdown-link" href="javascript:void(0)">Option 2</a>
+        <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 2</a>
       </li>
       <li data-option data-value="staging" class="bx--dropdown-item">
-        <a class="bx--dropdown-link" href="javascript:void(0)">Option 3</a>
+        <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 3</a>
       </li>
       <li data-option data-value="dea" class="bx--dropdown-item">
-        <a class="bx--dropdown-link" href="javascript:void(0)">Option 4</a>
+        <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 4</a>
       </li>
       <li data-option data-value="router" class="bx--dropdown-item">
-        <a class="bx--dropdown-link" href="javascript:void(0)">Option 5</a>
+        <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 5</a>
       </li>
     </ul>
   </li>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -94,6 +94,14 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
           this.element.focus();
         }
       });
+      const listItems = [...this.element.querySelectorAll(this.options.selectorItem)];
+      listItems.forEach(item => {
+        if (this.element.classList.contains(this.options.classOpen)) {
+          item.tabIndex = 0;
+        } else {
+          item.tabIndex = -1;
+        }
+      });
     }
   }
 

--- a/src/components/order-summary/order-summary.html
+++ b/src/components/order-summary/order-summary.html
@@ -8,10 +8,18 @@
       </svg>
       <li>
         <ul class="bx--dropdown-list">
-          <li data-option data-value="all" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">USD</a></li>
-          <li data-option data-value="cloudFoundry" class="bx--dropdown-item"><a class="bx--dropdown-link" title="NOKNOKNOKNOKNOK" ref="javascript:void(0)">NOKNOKNOKNOKNOK</a></li>
-          <li data-option data-value="staging" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">GBP</a></li>
-          <li data-option data-value="dea" class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">WWW</a></li>
+          <li data-option data-value="all" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">USD</a>
+          </li>
+          <li data-option data-value="cloudFoundry" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" title="NOKNOKNOKNOKNOK" ref="javascript:void(0)" tabindex="-1">NOKNOKNOKNOKNOK</a>
+          </li>
+          <li data-option data-value="staging" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">GBP</a>
+          </li>
+          <li data-option data-value="dea" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">WWW</a>
+          </li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
## Overview

closes https://github.com/carbon-design-system/carbon-components/issues/577

Added tab-index logic similar to what's in the Interior Left Nav for a11y purposes. Changes the tab-index from -1 to 0 when the dropdown is open. This also fixes an a11y bug found in the Order Summary.

### Changed

`dropdown.js`

## Testing / Reviewing

Make sure tabbing through the dropdown component works as expected.