### PR TITLE
fix(input): remove red focus ring when input marked as required firefox

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -50,6 +50,11 @@
     }
   }
 
+  // Fix for red ring when input is marked required in Firefox, refs #744
+  input:not(output):not([data-invalid]):-moz-ui-invalid {
+    box-shadow: none;
+  }
+
   .#{$prefix}--form-requirement {
     @include reset;
     @include typescale('omega');


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/744

Removes red focus ring that was only visible in Firefox

### Added
- Mozilla specific override to remove focus ring when an input is marked as required

## Testing / Reviewing
- Add `required` to an input and ensure that no red ring appears in Firefox
