### PR TITLE
fix(select): added disabled styling to option in select

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -62,6 +62,10 @@
     color: $text-01; // For the options to show in IE11
   }
 
+  .#{$prefix}--select-option[disabled] {
+    opacity: 0.5;
+  }
+
   // Override some Firefox user-agent styles
   @-moz-document url-prefix() {
     .#{$prefix}--select-option {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -64,6 +64,7 @@
 
   .#{$prefix}--select-option[disabled] {
     opacity: 0.5;
+    cursor: not-allowed;
   }
 
   // Override some Firefox user-agent styles

--- a/src/components/select/select.html
+++ b/src/components/select/select.html
@@ -5,7 +5,7 @@
       <option class="bx--select-option" disabled selected hidden>Choose an option</option>
       <option class="bx--select-option" value="solong">A much longer option that is worth having around to check how text flows</option>
       <optgroup class="bx--select-optgroup" label="Category 1">
-        <option disabled class="bx--select-option" value="option1">Option 1</option>
+        <option class="bx--select-option" value="option1">Option 1</option>
         <option class="bx--select-option" value="option2">Option 2</option>
       </optgroup>
       <optgroup class="bx--select-optgroup" label="Category 2">

--- a/src/components/select/select.html
+++ b/src/components/select/select.html
@@ -5,7 +5,7 @@
       <option class="bx--select-option" disabled selected hidden>Choose an option</option>
       <option class="bx--select-option" value="solong">A much longer option that is worth having around to check how text flows</option>
       <optgroup class="bx--select-optgroup" label="Category 1">
-        <option class="bx--select-option" value="option1">Option 1</option>
+        <option disabled class="bx--select-option" value="option1">Option 1</option>
         <option class="bx--select-option" value="option2">Option 2</option>
       </optgroup>
       <optgroup class="bx--select-optgroup" label="Category 2">


### PR DESCRIPTION
## Overview

Closes https://github.com/carbon-design-system/carbon-components/issues/652

Apparently, Firefox needs disabled styling specified in order for the options in a select to look disabled.

### Added

- Added disabled styling to option in a select

## Testing / Reviewing

Disable an option and test it in Firefox.