### PR TITLE
fix(multi-select): fixed hover width and hover color

### DIFF
--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -73,16 +73,11 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box__field {
     @include button-reset;
     position: relative;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    width: 100%;
     height: 100%;
     padding: 0 1rem;
     cursor: pointer;
-  }
-
-  .#{$prefix}--list-box__field:hover {
-    background: $field-01;
   }
 
   .#{$prefix}--list-box__field:focus,


### PR DESCRIPTION
## Overview

Closes https://github.com/carbon-design-system/carbon-components/issues/633

Removed hover background color on Filter dropdown and made sure the hover color only takes up the space of the label and doesn't go further than the dropdown list.

### Changed

- `_list-box.scss`

## Testing / Reviewing

Best way to test it is to add the CSS I added on the website preview as the changes will not be reflected in the dev environment correctly.