### PR TITLE
fix(structured-list): Update header alignment to bottom to match designs

### DIFF
--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -91,7 +91,7 @@
     height: rem(40px);
     text-align: left;
     text-transform: $structured-list-text-transform;
-    vertical-align: middle;
+    vertical-align: bottom;
   }
 
   .#{$prefix}--structured-list-tbody {


### PR DESCRIPTION
## Overview

Resolves #721

Updates header alignment so when text wraps it will align to the bottom.



