### PR TITLE
feat(truncation): add truncation classes

### DIFF
--- a/src/globals/scss/_helper-classes.scss
+++ b/src/globals/scss/_helper-classes.scss
@@ -1,4 +1,4 @@
-.bx--text-truncate--end {
+.#{$prefix}--text-truncate--end {
   width: 100%;
   display: inline-block;
   text-overflow: ellipsis;
@@ -6,7 +6,7 @@
   overflow: hidden;
 }
 
-.bx--text-truncate--front {
+.#{$prefix}--text-truncate--front {
   width: 100%;
   display: inline-block;
   direction: rtl;

--- a/src/globals/scss/_helper-classes.scss
+++ b/src/globals/scss/_helper-classes.scss
@@ -1,4 +1,4 @@
-.bx--end-line {
+.bx--text-truncate--end {
   width: 100%;
   display: inline-block;
   text-overflow: ellipsis;
@@ -6,7 +6,7 @@
   overflow: hidden;
 }
 
-.bx--front-line {
+.bx--text-truncate--front {
   width: 100%;
   display: inline-block;
   direction: rtl;

--- a/src/globals/scss/_helper-classes.scss
+++ b/src/globals/scss/_helper-classes.scss
@@ -1,0 +1,16 @@
+.bx--end-line {
+  width: 100%;
+  display: inline-block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.bx--front-line {
+  width: 100%;
+  display: inline-block;
+  direction: rtl;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -1,6 +1,16 @@
-$breakpoints: (bp--xs--major: 500px, bp--sm--major: 768px, bp--md--major: 992px, bp--lg--major: 1200px);
+@import 'helper-classes';
 
-$padding: ('mobile': 3%, 'xs': 5%);
+$breakpoints: (
+  bp--xs--major: 500px,
+  bp--sm--major: 768px,
+  bp--md--major: 992px,
+  bp--lg--major: 1200px
+);
+
+$padding: (
+  'mobile': 3%,
+  'xs': 5%
+);
 
 @function padding($value) {
   @if map-has-key($padding, $value) {


### PR DESCRIPTION
## Adds in Truncation Classes

**Frontline truncation:** `.bx--text-truncate--front`
**Endline truncation:** `.bx--text-truncate--end`

The user will need to add `title` to populate the tooltip when the truncated text is hovered over. The user will also need to configure the `width` of the container (or the text element itself) to calculate _when_ truncation will start.

**Example Usage:**
```html
<div class="container">
  <span title="123456789" class="bx--text-truncate--front">123456789</span>
</div>
```

```css
.container { 
  width: 65px; 
}
```

```css
.bx--text-truncate--front {
  width: 100%;
  display: inline-block;
  direction: rtl;
  text-overflow: ellipsis;
  white-space: nowrap;
  overflow: hidden;
}
```

**Result:**
![screen shot 2018-05-09 at 1 22 51 pm](https://media.github.ibm.com/user/1679/files/1c695894-538c-11e8-8cd2-bb0b1cac151b)


**Midline truncation:** Will create an example since this will require javascript.

### Added
- `_helper-classes.scss` file under `globals/scss`
- `@import 'helper-classes'` in `_layout.scss`
- `.bx--text-truncate--front` and `.bx--text-truncate--end` classes


## Testing / Reviewing
Can use the example above to test out both classes
