### PR TITLE
fix(font-face): bring missing $css--font-face reference back

### DIFF
--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -57,9 +57,11 @@ $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !defa
 }
 
 @include exports('css--font-face') {
-  @if global-variable-exists('css--plex') and $css--plex == true {
-    @include plex-font-face;
-  } @else {
-    @include helvetica-font-face;
+  @if not global-variable-exists('css--font-face') or $css--font-face == true {
+    @if global-variable-exists('css--plex') and $css--plex == true {
+      @include plex-font-face;
+    } @else {
+      @include helvetica-font-face;
+    }
   }
 }

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -2,7 +2,7 @@
 // 🌍 Global
 //-------------------------
 
-$css--font-face: false !default;
+$css--font-face: true !default;
 $css--helpers: true !default;
 $css--body: true !default;
 $css--use-experimental-grid: false !default;


### PR DESCRIPTION
## Overview

Fixes #777. We seem to have lost reference to `$css—font-face` variable at some point. This PR brings it back.

### Added

* Reference to `$css--font-face` back. The default seems to have been `false` in `7.x`, but now `true` because earlier `8.x` ignored it effectively making `true` the default and making `false` the default will make it a breaking change.

## Testing / Reviewing

Testing will make sure CSS build generates the same content as before, esp. wrt `@font-face` existence.