### PR TITLE
fix(data-table-v2): remove left positioning from sort icon

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-sort.scss
+++ b/src/components/data-table-v2/_data-table-v2-sort.scss
@@ -25,7 +25,6 @@
   .#{$prefix}--table-sort-v2 {
     @include button-reset(false);
     position: relative;
-    left: 2px;
     font: inherit;
     cursor: pointer;
     display: flex;


### PR DESCRIPTION
## Overview

Resolves #682

### Added

### Removed

### Changed

* Removed relative position from sort icon