### PR TITLE
fix(tile): check if is--expanded is set when tile component is loaded

### DIFF
--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -90,15 +90,15 @@
 
     svg {
       border-radius: 50%;
-      background-color: rgba($ui-01, .25);
-      fill: rgba($brand-01, .25);
+      background-color: rgba($ui-01, 0.25);
+      fill: rgba($brand-01, 0.25);
     }
   }
 
   .#{$prefix}--tile__chevron {
     position: absolute;
-    bottom: .5rem;
-    right: .5rem;
+    bottom: 0.5rem;
+    right: 0.5rem;
     height: 1rem;
 
     svg {
@@ -133,7 +133,7 @@
     transition: $transition--base $carbon--standard-easing;
 
     .#{$prefix}--tile__chevron svg {
-      transform: rotate(-180deg) translateY(4px);
+      transform: rotate(-180deg);
     }
 
     .#{$prefix}--tile-content__below-the-fold {

--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -41,7 +41,12 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
         this.atfHeight = aboveTheFold.getBoundingClientRect().height + tilePadding;
         this.element.style.maxHeight = `${this.atfHeight}px`;
       }
+
+      if (this.element.classList.contains(this.options.classExpandedTile)) {
+        this._setTileHeight();
+      }
     }
+
     this.element.addEventListener('click', evt => {
       const input = eventMatches(evt, this.options.selectorTileInput);
       if (!input) {


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/781

Checks on load for `bx--tile--is-expanded`, and if it exisits, sets the correct tile height. Currently, the tile height is only calculated on click / keypress.

Also fixed the position of the chevron.

![expandabletile](https://user-images.githubusercontent.com/11928039/40255281-41a2035a-5aac-11e8-8a00-33153f91ac11.gif)


### Added
- Check for `bx--tile--is-expanded` on load, calculated correct height

### Removed
- `translateY(4px)` on Chevron that was throwing off the position

## Testing / Reviewing

Can use this markup to test:
```html
<div data-tile="expandable" class="bx--tile bx--tile--expandable bx--tile--is-expanded" tabindex="0">
  <button class="bx--tile__chevron">
    <svg width="12" height="8" viewBox="0 0 12 8" fill-rule="evenodd">
      <path d="M10.6 0L6 4.7 1.4 0 0 1.4l6 6.1 6-6.1z"></path>
    </svg>
  </button>
  <div class="bx--tile-content">
    <span data-tile-atf class="bx--tile-content__above-the-fold">
      Above the fold content here
    </span>
    <span class="bx--tile-content__below-the-fold">
      Rest of the content here
      <br> More content here Rest of the content here
      <br> More content here Rest of the content here
      <br> More content here Rest of the content here
      <br> More content here
    </span>
  </div>
</div>
```