### PR TITLE
fix(table): removes selected class from row on cancel click

### DIFF
--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -122,6 +122,11 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
 
   _actionBarCancel = () => {
     const inputs = [...this.element.querySelectorAll(this.options.selectorCheckbox)];
+    const row = [...this.element.querySelectorAll(this.options.selectorTableSelected)];
+
+    row.forEach(item => {
+      item.classList.remove(this.options.classTableSelected);
+    });
 
     inputs.forEach(item => {
       item.checked = false;
@@ -267,6 +272,7 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
       selectorChildRow: '[data-child-row]',
       selectorTableBody: 'tbody',
       selectorTableSort: `.${prefix}--table-sort-v2`,
+      selectorTableSelected: `.${prefix}--data-table-v2--selected`,
       classExpandableRow: `${prefix}--expandable-row-v2`,
       classExpandableRowHidden: `${prefix}--expandable-row--hidden-v2`,
       classExpandableRowHover: `${prefix}--expandable-row--hover-v2`,


### PR DESCRIPTION
## Overview

Resolves #675 

## Testing / Reviewing

Make sure data table isn't broken and selected class is removed when you click the cancel button.
