### PR TITLE
fix(danger-button): Add correct hover color for icon

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -36,23 +36,11 @@
   }
 
   .#{$prefix}--btn--primary {
-    @include button-theme(
-      $brand-01,
-      transparent,
-      $inverse-01,
-      $brand-02,
-      $ui-01
-    );
+    @include button-theme($brand-01, transparent, $inverse-01, $brand-02, $ui-01);
   }
 
   .#{$prefix}--btn--secondary {
-    @include button-theme(
-      transparent,
-      $brand-01,
-      $brand-01,
-      $brand-01,
-      $brand-01
-    );
+    @include button-theme(transparent, $brand-01, $brand-01, $brand-01, $brand-01);
 
     &:hover,
     &:focus {
@@ -75,13 +63,7 @@
   }
 
   .#{$prefix}--btn--tertiary {
-    @include button-theme(
-      transparent,
-      $ui-05,
-      $ui-05,
-      $ui-05,
-      $ui-05
-    );
+    @include button-theme(transparent, $ui-05, $ui-05, $ui-05, $ui-05);
 
     &:hover,
     &:focus {
@@ -99,13 +81,7 @@
   }
 
   .#{$prefix}--btn--ghost {
-    @include button-theme(
-      transparent,
-      transparent,
-      $brand-01,
-      $brand-01,
-      $brand-01
-    );
+    @include button-theme(transparent, transparent, $brand-01, $brand-01, $brand-01);
 
     &:hover,
     &:focus {
@@ -131,13 +107,7 @@
   }
 
   .#{$prefix}--btn--danger {
-    @include button-theme(
-      transparent,
-      $support-01,
-      $support-01,
-      $support-01,
-      $support-01
-    );
+    @include button-theme(transparent, $support-01, $support-01, $support-01, $support-01);
 
     &:hover {
       color: $inverse-01;
@@ -153,16 +123,15 @@
       color: $support-01;
       border: $button-border-width solid $support-01;
     }
+
+    &:hover > .#{$prefix}--btn__icon,
+    &:focus > .#{$prefix}--btn__icon {
+      fill: $inverse-01;
+    }
   }
 
   .#{$prefix}--btn--danger--primary {
-    @include button-theme(
-      $support-01,
-      transparent,
-      $inverse-01,
-      darken($support-01, 10%),
-      $ui-01
-    );
+    @include button-theme($support-01, transparent, $inverse-01, darken($support-01, 10%), $ui-01);
 
     &:hover:disabled,
     &:focus:disabled {


### PR DESCRIPTION
## Overview

Resolves #792

## Testing / Reviewing
```
<button class="bx--btn bx--btn--danger" type="button" aria-label="danger">Secondary danger button
  <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
      <path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path>
  </svg>
</button>
```
