### PR TITLE
chore(git): update gitignore for *.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist
 # OSX
 .DS_Store
 
-# Debug
-npm-debug.log
+# Logs
+*.log
 
 # Editors
 project.sublime-project


### PR DESCRIPTION
Noticed in #714 that `yarn-error.log` slipped through given that we only specifically ignore `npm-debug.log`. This PR updates `.gitignore` to exclude all `.log` files.