### PR TITLE
Content switcher accessibility

### DIFF
--- a/src/components/content-switcher/content-switcher--with-icon.html
+++ b/src/components/content-switcher/content-switcher--with-icon.html
@@ -1,13 +1,13 @@
-<div data-content-switcher class="bx--content-switcher">
-  <button class="bx--content-switcher-btn bx--content-switcher--selected" data-target=".demo--panel2--opt-1">
+<div data-content-switcher class="bx--content-switcher"role="tablist" aria-label="Demo switch content">
+  <button class="bx--content-switcher-btn bx--content-switcher--selected" data-target=".demo--panel2--opt-1" role="tab" aria-selected="true">
     <svg class="bx--content-switcher__icon" width="16" height="16" viewBox="0 0 16 16"><path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 9H9v3H7V9H4V7h3V4h2v3h3v2z"></path></svg>
     First section
   </button>
-  <button class="bx--content-switcher-btn" data-target=".demo--panel2--opt-2">
+  <button class="bx--content-switcher-btn" data-target=".demo--panel2--opt-2" role="tab">
       <svg class="bx--content-switcher__icon" width='12' height='9' viewBox='0 0 12 9' fill-rule='evenodd'><path d='M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z'></path></svg>
       Second section
   </button>
-  <button class="bx--content-switcher-btn" data-target=".demo--panel2--opt-3">
+  <button class="bx--content-switcher-btn" data-target=".demo--panel2--opt-3" role="tab">
     <svg class="bx--content-switcher__icon" width='16' height='15' viewBox='0 0 16 15' fill-rule='evenodd'><path d='M8.11 11.75l-4.5 3.2c-.2.1-.5 0-.4-.3l1.5-5.1-4.6-3.2c-.2-.2-.1-.5.1-.5l5.5-.5 2-5.2c.1-.2.4-.2.5 0l2 5.2 5.5.5c.2 0 .3.3.1.4l-4.5 3.3 1.5 5.1c.1.2-.2.4-.4.3l-4.3-3.2z'></path> </svg>
     Third section
   </button>

--- a/src/components/content-switcher/content-switcher.html
+++ b/src/components/content-switcher/content-switcher.html
@@ -1,6 +1,6 @@
-<div data-content-switcher class="bx--content-switcher">
-  <button class="bx--content-switcher-btn bx--content-switcher--selected" data-target=".demo--panel--opt-1">First section</button>
-  <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-2">Second section</button>
-  <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-3">Third section</button>
+<div data-content-switcher class="bx--content-switcher" role="tablist" aria-label="Demo switch content">
+  <button class="bx--content-switcher-btn bx--content-switcher--selected" data-target=".demo--panel--opt-1" role="tab" aria-selected="true">First section</button>
+  <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-2" role="tab">Second section</button>
+  <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-3" role="tab">Third section</button>
 </div>
   

--- a/src/components/content-switcher/content-switcher.js
+++ b/src/components/content-switcher/content-switcher.js
@@ -74,6 +74,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
 
     selectorButtons.forEach(button => {
       if (button !== item) {
+        button.setAttribute('aria-selected', false);
         button.classList.toggle(this.options.classActive, false);
         [...button.ownerDocument.querySelectorAll(button.dataset.target)].forEach(element => {
           element.setAttribute('hidden', '');
@@ -83,6 +84,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
     });
 
     item.classList.toggle(this.options.classActive, true);
+    item.setAttribute('aria-selected', true);
     [...item.ownerDocument.querySelectorAll(item.dataset.target)].forEach(element => {
       element.removeAttribute('hidden');
       element.setAttribute('aria-hidden', 'false');

--- a/tests/spec/content-switcher_spec.js
+++ b/tests/spec/content-switcher_spec.js
@@ -48,6 +48,13 @@ describe('Test content switcher', function() {
       expect(buttons[0].classList.contains(instance.options.classActive)).toBe(false);
     });
 
+    it('Should update aria-selected upon clicking', function() {
+      const event = new CustomEvent('click', { bubbles: true });
+      buttons[1].dispatchEvent(event);
+      expect(buttons[1].getAttribute('aria-selected')).toBe('true');
+      expect(buttons[0].getAttribute('aria-selected')).toBe('false');
+    });
+
     it('Should provide a way to cancel switching item upon clicking', async function() {
       const eventBeforeSelected = await new Promise(resolve => {
         events.on(element, 'content-switcher-beingselected', event => {
@@ -90,11 +97,24 @@ describe('Test content switcher', function() {
       expect(buttons[1].classList.contains('bx--content-switcher--selected')).toBe(true);
     });
 
+    it('Should update aria-selected when using setActive method', function() {
+      instance.setActive(buttons[1]);
+      expect(buttons[0].getAttribute('aria-selected')).toBe('false');
+      expect(buttons[1].getAttribute('aria-selected')).toBe('true');
+    });
+
     it('Should update active item upon an API call', async function() {
       const item = await promisify(instance.setActive, { context: instance })(buttons[1]);
       expect(item).toBe(buttons[1]);
       expect(buttons[0].classList.contains('bx--content-switcher--selected')).toBe(false);
       expect(buttons[1].classList.contains('bx--content-switcher--selected')).toBe(true);
+    });
+
+    it('Should update aria-selected upon an API call', async function() {
+      const item = await promisify(instance.setActive, { context: instance })(buttons[1]);
+      expect(item).toBe(buttons[1]);
+      expect(buttons[0].getAttribute('aria-selected')).toBe('false');
+      expect(buttons[1].getAttribute('aria-selected')).toBe('true');
     });
 
     it('Should provide a way to cancel switching item upon an API call', async function() {

--- a/tests/spec/data-table-v2_spec.js
+++ b/tests/spec/data-table-v2_spec.js
@@ -1,7 +1,7 @@
 import EventManager from '../utils/event-manager';
 import DataTableV2 from '../../src/components/data-table-v2/data-table-v2';
 import HTML from '../../src/components/data-table-v2/data-table-v2.html';
-import ExpandableHTML from '../../src/components/data-table-v2/data-table-v2-expandable.html';
+import ExpandableHTML from '../../src/components/data-table-v2/data-table-v2--expandable.html';
 
 describe('Dropdown', function() {
   describe('Constructor', function() {

--- a/tests/spec/interior-left-nav_spec.js
+++ b/tests/spec/interior-left-nav_spec.js
@@ -1,6 +1,6 @@
 import InteriorLeftNav from '../../src/components/interior-left-nav/interior-left-nav';
 import InteriorLeftNavHtml from '../../src/components/interior-left-nav/interior-left-nav.html';
-import KeepOpen from '../../src/components/interior-left-nav/interior-left-nav-keep-open.html';
+import KeepOpen from '../../src/components/interior-left-nav/interior-left-nav--keep-open.html';
 
 describe('Test interior left nav', function() {
   describe('Constructor', function() {


### PR DESCRIPTION
## Overview

Resolves #804 

This sets roles for the content switcher and sets aria-selected for the selected tab.

### Changed

Set  content switcher role to tablist

Set role for each tab to tab

Set aria-selected="true" for selected tab

Set aria-selected="false" for non-selected tabs

Set label for the content switcher

## Testing / Reviewing

Start a screen reader

Navigate to the content switcher

Screen reader should indicate that this is a tab list

Switch tabs

Screen reader should properly indicate new selected tab