### PR TITLE
fix(code-snippet): fixed config file to remove light class from the inline version

### DIFF
--- a/src/components/code-snippet/code-snippet.config.js
+++ b/src/components/code-snippet/code-snippet.config.js
@@ -36,7 +36,6 @@ module.exports = {
       `,
       context: {
         variant: 'inline',
-        light: 'false',
       },
     },
     {

--- a/src/components/code-snippet/code-snippet.hbs
+++ b/src/components/code-snippet/code-snippet.hbs
@@ -1,6 +1,6 @@
 {{#is variant "inline"}}
 <p>Here is an example of a text that a user would be reading. In this paragraph would be
-  <button data-copy-btn="" class="bx--snippet bx--snippet--inline {{#if light}} bx--snippet--light{{/if}}" aria-label="Copy code"
+  <button data-copy-btn="" class="bx--snippet bx--snippet--inline{{#if light}} bx--snippet--light{{/if}}" aria-label="Copy code"
     tabindex="0">
     <code>inline code</code>
     <div class="bx--btn--copy__feedback" data-feedback="Copied!"></div>


### PR DESCRIPTION
## Overview

Changed the config file for the code snippet as the non-light inline version was being rendered with the light class.

### Changed

- Removed `light: 'false'` in `code-snippet.config.js`
- Fixed a whitespace in `code-snippet.hbs`

## Testing / Reviewing

Make sure that the inline code snippet renders without the `bx--snippet--light` class.