### PR TITLE
fix(form): fixed button width

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -16,7 +16,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
-    margin-right: $spacing-md;
+    align-items: flex-start;
     margin-bottom: $spacing-lg;
   }
 


### PR DESCRIPTION
## Overview

After making the form item a flex container, the buttons got a width of 100% so added `align-items: flex-start` to fix this. Also removed the right margin on the form item as people have been complaining about this messing up their layouts. 

### Changed

- `bx--form-item`
