### PR TITLE
fix(docs) : Readme update urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install -S carbon-components
 
 # :books: Documentation
 
-* See our documentation site [here](http://carbondesignsystem.com/getting-started/developers) for full how-to docs and guidelines
+* See our documentation site [here](http://www.carbondesignsystem.com/getting-started/developers) for full how-to docs and guidelines
 * [Contributing](/docs/contributing.md): Guidelines for making contributions to this repo.
 
 ## Contributors


### PR DESCRIPTION

## Overview
http://carbondesignsystem.com/getting-started/developers  does not resolve correctly to your docs page

Looks like is a general issues across your repos ... probably some dns resolving thing on your servers :( 