### PR TITLE
fix(pagination): fix text input position in pagination V1

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -138,6 +138,7 @@ $css--helpers: true;
       font-weight: 600;
       text-align: center;
       box-shadow: none;
+      order: 0;
 
       &:focus {
         @include focus-outline('border');


### PR DESCRIPTION
## Overview

Fixes the wrong position of text input in pagination V1.

### Added

`order: 0` for text input in pagination V1 as the default text input puts a different order by default.

## Testing / Reviewing

Testing should make sure pagination is not broken.