### PR TITLE
fix(components): misc fixes for v9

### DIFF
--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -115,6 +115,7 @@
     padding: 0;
     height: rem(32px);
     width: rem(32px);
+    overflow: visible;
 
     &:focus {
       @include focus-outline('border');
@@ -226,7 +227,7 @@
     padding-bottom: 0;
   }
 
-  /* 
+  /*
     Deprecated class names will be removed in v10.x
   */
 

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -156,9 +156,11 @@
 
   .#{$prefix}--dropdown--inline {
     background-color: transparent;
+    box-shadow: none;
 
     &:focus {
       outline: none;
+      box-shadow: none;
     }
 
     &:focus .#{$prefix}--dropdown-text {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -143,7 +143,7 @@
     }
 
     .#{$prefix}--select__arrow {
-      top: auto;
+      top: 40%;
     }
   }
 }


### PR DESCRIPTION
## Overview

- Removed box-shadow on inline dropdown as this one shouldn't have the underline. 
- Also fixed a bug with the time picker in Firefox.
- Fixed banner not showing up on IE11

closes https://github.com/carbon-design-system/carbon-components/issues/857

### Changed

- Inline Dropdown: removed box-shadow both on default and focus
- TimePicker: fixed top position on arrows to fix bug in Firefox
- CodeSnippet: fixed banner not showing up on IE11