### PR TITLE
Form item

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -17,7 +17,6 @@
     flex-direction: column;
     flex: 1;
     align-items: flex-start;
-    margin-bottom: $spacing-lg;
   }
 
   .#{$prefix}--form-item--light input,


### PR DESCRIPTION
Removes margins from `bx--form-item`. Any spacing between form items should be done on the end user side. These extra margins were causing issues in `Pagination` on the React side