### PR TITLE
chore(travis): update to node8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - node_modules
 
 node_js:
-  - "6"
+  - "8"
 
 dist: trusty
 


### PR DESCRIPTION
## Overview

Recent upgrade of `semantic-release` seems to require node 8.x. This PR updates our `.travis.yml` to catch up with that.

### Changed

`.travis.yml` to use node 8.x.

## Testing / Reviewing

Testing should make sure our Travis build it not broken.