### PR TITLE
fix(tooltip-icon): Show styled tooltip in IE11

### DIFF
--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -223,6 +223,7 @@
     display: inline-flex;
     align-items: center;
     cursor: pointer;
+    overflow: visible;
 
     path {
       fill: $brand-01;


### PR DESCRIPTION
## Overview

Resolves #859


_IE sets the default overflow to hidden on buttons so the pseudo elements were not showing (thank you stack overflow)_ 🙌