### PR TITLE
fix(tooltip): fix tooltip a11y issues

### DIFF
--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -247,7 +247,7 @@
       border-radius: 4px;
       color: $inverse-01;
       font-weight: 400;
-      content: attr(title);
+      content: attr(aria-label);
       transform: translateX(-50%);
       white-space: nowrap;
       pointer-events: none;

--- a/src/components/tooltip/tooltip--icon.hbs
+++ b/src/components/tooltip/tooltip--icon.hbs
@@ -1,7 +1,8 @@
 <div class="bx--tooltip--icon">
-  <button class="bx--tooltip__trigger bx--tooltip--icon__top" title="Filter">
+  <button class="bx--tooltip__trigger bx--tooltip--icon__top" aria-label="Filter">
     <svg width="16" height="12" viewBox="0 0 16 12">
-      <path d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
+      <path d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"
+      />
     </svg>
   </button>
 </div>


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/880

### Changed

- Tooltip text is now populated by `aria-label` and not `title` to avoid duplicate tooltips/voiceover 


## Testing / Reviewing

- Hover over `TooltipIcon` and ensure two tooltips do not appear
