### PR TITLE
fix(date-picker): fix disabled day / month styles

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -325,6 +325,7 @@
   .#{$prefix}--date-picker__day.disabled,
   .flatpickr-day.disabled {
     cursor: not-allowed;
+    opacity: 0.5;
     color: $ui-05;
 
     &:hover {
@@ -408,6 +409,26 @@
   .flatpickr-prev-month,
   .flatpickr-next-month {
     padding-top: 5px;
+  }
+
+  .flatpickr-prev-month:hover svg,
+  .flatpickr-next-month:hover svg {
+    fill: $brand-01;
+  }
+
+  .flatpickr-next-month.disabled,
+  .flatpickr-prev-month.disabled {
+    svg {
+      fill: $ui-05;
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      svg {
+        fill: $ui-05;
+      }
+    }
   }
 
   // Skeleton State


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/884
Refs https://github.com/carbon-design-system/carbon-components-react/issues/994

### Added

- Disabled styles for month arrows
- Disabled styles for days

### Changed

- Disabled styles for month arrows on hover


## Testing / Reviewing

Open ranged date picker, paste this in to console, ensure disabled styles work properly

```js
const datePickerRef = document.querySelector('[data-date-picker]');
window.CarbonComponents.DatePicker.init(datePickerRef);
const datePicker = window.CarbonComponents.DatePicker.components.get(datePickerRef);

datePicker.calendar.set('minDate', 'today');
```
