### PR TITLE
fix(modal): use flex box for footer

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -105,7 +105,8 @@
 
   .#{$prefix}--modal-footer {
     margin-top: auto;
-    text-align: right;
+    display: flex;
+    justify-content: flex-end;
     background-color: $modal-footer-background-color;
     margin-left: rem(-24px);
     margin-right: rem(-24px);


### PR DESCRIPTION
## Overview

Fixes #790.

### Changed

Changed modal footer from `display:block` to `display:flex`.

## Testing / Reviewing

Testing should make sure modal is not broken with any browsers.