### PR TITLE
fix(breadcrumb): remove firefox border override

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -56,13 +56,6 @@
       color: $hover-primary-text;
       border-bottom: 1px solid $hover-primary-text;
     }
-
-    // Applies to Firefox only
-    @-moz-document url-prefix() {
-      & {
-        border-bottom: none;
-      }
-    }
   }
 
   // Skeleton State


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/902

Removes specific Firefox override that sets Breadcrumb border to `none`. This causes layout jumping. 

### Removed

- Specific Firefox override that sets Breadcrumb border to `none`.

