### PR TITLE
fix: Update form elements to have a 1px transparent bottom border for HC mode

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -61,6 +61,7 @@
     box-shadow: 0 1px 0 0 $text-02;
     order: 2;
     color: $text-01;
+    border-bottom: 1px solid transparent;
 
     &:focus,
     &.#{$prefix}--focused {

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -32,6 +32,7 @@
     box-shadow: 0 1px 0 0 $text-02;
     order: 2;
     border-radius: 0;
+    border-bottom: 1px solid transparent;
 
     & ~ .#{$prefix}--label {
       order: 1;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -34,6 +34,7 @@
     order: 2;
     border-radius: 0;
     cursor: pointer;
+    border-bottom: 1px solid transparent;
 
     // Hide default select arrow in IE10+
     &::-ms-expand {

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -25,6 +25,7 @@
     box-shadow: 0 1px 0 0 $text-02;
     order: 2;
     resize: vertical;
+    border-bottom: 1px solid transparent;
 
     & ~ .#{$prefix}--label {
       order: 1;

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -26,6 +26,7 @@
     border: none;
     box-shadow: 0 1px 0 0 $text-02;
     order: 2;
+    border-bottom: 1px solid transparent;
 
     & ~ .#{$prefix}--label {
       order: 1;

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -22,6 +22,7 @@
   .#{$prefix}--time-picker__input {
     display: flex;
     flex-direction: column;
+    border-bottom: 1px solid transparent;
   }
 
   .#{$prefix}--time-picker .#{$prefix}--select-input {


### PR DESCRIPTION
## Overview

Resolves #883 

Text inputs aren't visible in high contrast mode because the box-shadow doesn't display. 

## Testing / Reviewing

Check that date picker, number input, text input, text area, select aren't broken
