### PR TITLE
(fix) RTL styles for FileUploader

### DIFF
--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -62,6 +62,9 @@
     color: $text-01;
     margin-right: $spacing-md;
     height: 1.875rem;
+    /*rtl:ignore*/
+    direction:ltr;
+    justify-content: flex-start;/*rtl:{flex-end}*/
   }
 
   .#{$prefix}--file__state-container {


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/908

I've added two styles that are harmless for LTR mode and resolve issue in RTL mode.

Fixed:
![image](https://user-images.githubusercontent.com/20794308/41596138-07843d3e-73d2-11e8-97f5-61769574ff19.png)

## Testing / Reviewing
Run FileLoader on RTL screen, load file with Hebrew/Arabic at the beginning of its name.
Verify filename is displayed correctly.
