### PR TITLE
fix(colors): updated tokens for tile and input fields

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -58,7 +58,7 @@
     padding: 0 $spacing-md;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 2;
     color: $text-01;
 

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -23,7 +23,7 @@
     display: block;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 1;
     width: 100%;
     height: rem(40px);

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -23,7 +23,7 @@ $list-box-menu-width: rem(300px);
     max-height: $list-box-height;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 1;
     cursor: pointer;
     color: $text-01;

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -29,7 +29,7 @@
     color: $text-01;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 2;
     border-radius: 0;
 

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -30,7 +30,7 @@
     color: $text-01;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 2;
     border-radius: 0;
     cursor: pointer;

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -22,7 +22,7 @@
     color: $text-01;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 2;
     resize: vertical;
 

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -24,7 +24,7 @@
     color: $text-01;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
     order: 2;
 
     & ~ .#{$prefix}--label {

--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -18,7 +18,7 @@
     min-width: 8rem;
     min-height: 4rem;
     background-color: $ui-01;
-    border: 1px solid $ui-02;
+    border: 1px solid $ui-03;
     position: relative;
     padding: $spacing-md;
 
@@ -34,7 +34,7 @@
     cursor: pointer;
 
     &:hover {
-      border: 1px solid $ui-03;
+      border: 1px solid $ui-04;
     }
 
     &:hover,
@@ -67,7 +67,7 @@
 
   .#{$prefix}--tile--is-clicked {
     @include layer('flat');
-    border: 1px solid $ui-03;
+    border: 1px solid $ui-04;
   }
 
   .#{$prefix}--tile__checkmark,

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -45,7 +45,7 @@
     height: rem(40px);
     padding: 0 $spacing-md;
     order: 2;
-    box-shadow: 0 1px 0 0 $text-02;
+    box-shadow: 0 1px 0 0 $ui-05;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
@mari I changed the token to box shadow from `text-02` to `ui-05`, they are the same hex value. Just wanted to reserve text for text. If we went with text-02 for a specific reason let me know. 

Also made a change to tile border based on feedback from Mina.