### PR TITLE
(fix) RTL styles for Accordion

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -65,6 +65,7 @@
     padding: $spacing-2xs $spacing-3xs $spacing-2xs $spacing-2xs;
     margin: $accordion-arrow-margin;
     fill: $ui-05;
+    transform: rotate(0)/*rtl:180deg*/;
   }
 
   .#{$prefix}--accordion__title {
@@ -96,6 +97,7 @@
     }
 
     .#{$prefix}--accordion__arrow {
+      /*rtl:ignore*/
       transform: rotate(90deg);
       fill: $brand-01;
     }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -65,7 +65,7 @@
     padding: $spacing-2xs $spacing-3xs $spacing-2xs $spacing-2xs;
     margin: $accordion-arrow-margin;
     fill: $ui-05;
-    transform: rotate(0)/*rtl:rotate(180deg)*/;
+    transform: rotate(0) /*rtl:rotate(180deg)*/;
   }
 
   .#{$prefix}--accordion__title {

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -65,7 +65,7 @@
     padding: $spacing-2xs $spacing-3xs $spacing-2xs $spacing-2xs;
     margin: $accordion-arrow-margin;
     fill: $ui-05;
-    transform: rotate(0)/*rtl:180deg*/;
+    transform: rotate(0)/*rtl:rotate(180deg)*/;
   }
 
   .#{$prefix}--accordion__title {


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/914

I've added styles that are harmless for LTR mode and resolve issue in RTL mode.

Fixed:
![image](https://user-images.githubusercontent.com/20794308/41658013-cada50e0-749d-11e8-89be-e8cdeac52dd5.png)
![image](https://user-images.githubusercontent.com/20794308/41658059-f8ba2a8a-749d-11e8-93b5-f6c04143e7e2.png)

Testing / Reviewing
Run Accordion on RTL screen,
Verify arrow direction when open and closed.