### PR TITLE
feat(Select): add inline invalid Select component styles

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -68,7 +68,7 @@
       cursor: not-allowed;
     }
 
-    & ~ .#{$prefix}--form-requirement {
+    ~ .#{$prefix}--form-requirement {
       order: 3;
       color: $support-01;
       font-weight: 400;
@@ -141,9 +141,28 @@
         @include focus-outline('border');
       }
 
+      &[data-invalid] {
+        outline: 1px solid $support-01;
+        color: $text-01;
+
+        &:focus {
+          box-shadow: none;
+        }
+
+        ~ .#{$prefix}--select__arrow {
+          bottom: 1rem;
+        }
+      }
+
       &:disabled ~ * {
         opacity: 0.5;
         cursor: not-allowed;
+      }
+
+      ~ .#{$prefix}--form-requirement {
+        position: absolute;
+        bottom: -1.5rem;
+        left: 5.05rem;
       }
     }
   }

--- a/src/components/select/select.config.js
+++ b/src/components/select/select.config.js
@@ -35,6 +35,14 @@ module.exports = {
       },
     },
     {
+      name: 'inline-invalid',
+      label: 'Inline Select (Invalid)',
+      context: {
+        inline: true,
+        invalid: true,
+      },
+    },
+    {
       name: 'light-invalid',
       label: 'Select (Light/Invalid)',
       context: {

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -1,8 +1,5 @@
 <div class="bx--form-item">
   <div class="bx--select{{#if inline}} bx--select--inline{{/if}}{{#if light}} bx--select--light{{/if}}">
-    {{#if inline}}
-    <label for="select-id" class="bx--label">Select label</label>
-    {{/if}}
     <select {{#if invalid}}data-invalid{{/if}} id="select-id" class="bx--select-input">
       <option class="bx--select-option" disabled selected hidden>Choose an option</option>
       <option class="bx--select-option" value="solong">A much longer option that is worth having around to check how text flows</option>
@@ -18,9 +15,8 @@
     <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>
-    {{#unless inline}}
     <label for="select-id" class="bx--label">Select label</label>
-    {{/unless}} {{#if invalid}}
+    {{#if invalid}}
     <div class="bx--form-requirement">
       Validation message here
     </div>


### PR DESCRIPTION
## Overview

Resolves #918 

This PR will add validation styles to the inline `Select` component.

### Added

* Add styles for inline validation `Select` component

* Add storybook example for inline invalid `Select`

### Changed

* Removed conditional check for `invalid` attribute when rendering `label`

It looks like refactoring this does not change anything visually. Rendering the `label` in the same location with respect to its sibling elements allows for more shared styles between inline and non-inline `Select` components. Would like some more input on this change from the core team.

## Testing / Reviewing

Build the storybook and take a look at the `Select` component additions
