### PR TITLE
fix(select): Select inline form validation text alignment

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -144,6 +144,10 @@
       font-weight: 600;
       box-shadow: none;
 
+      &:hover {
+        background-color: $color__white;
+      }
+
       &:focus {
         @include focus-outline('border');
       }

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -154,10 +154,10 @@
       }
 
       &[data-invalid] {
-        outline: 1px solid $support-01;
         color: $text-01;
 
         &:focus {
+          outline: 1px solid $support-01;
           box-shadow: none;
         }
       }

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -123,7 +123,6 @@
   .#{$prefix}--select--inline {
     display: grid;
     grid-template-columns: auto auto;
-    display: -ms-grid;
 
     // Targets IE10+ browsers: Display grid auto not supported
     @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -121,14 +121,22 @@
   }
 
   .#{$prefix}--select--inline {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+    display: grid;
+    grid-template-columns: auto auto;
+    display: -ms-grid;
+
+    // Targets IE10+ browsers: Display grid auto not supported
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
 
     .#{$prefix}--label {
       white-space: nowrap;
       margin: 0 $spacing-xs 0 0;
       font-weight: 400;
+      align-self: center;
     }
 
     .#{$prefix}--select-input {
@@ -141,16 +149,17 @@
         @include focus-outline('border');
       }
 
+      ~ .#{$prefix}--select__arrow {
+        bottom: auto;
+        top: 1rem;
+      }
+
       &[data-invalid] {
         outline: 1px solid $support-01;
         color: $text-01;
 
         &:focus {
           box-shadow: none;
-        }
-
-        ~ .#{$prefix}--select__arrow {
-          bottom: 1rem;
         }
       }
 
@@ -160,9 +169,13 @@
       }
 
       ~ .#{$prefix}--form-requirement {
-        position: absolute;
-        bottom: -1.5rem;
-        left: 5.05rem;
+        grid-column-start: 2;
+
+        // Targets IE10+ browsers: Display grid auto not supported
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          position: absolute;
+          bottom: -1.5rem;
+        }
       }
     }
   }

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -155,6 +155,7 @@
 
       &[data-invalid] {
         color: $text-01;
+        outline-offset: 2px;
 
         &:focus {
           outline: 1px solid $support-01;


### PR DESCRIPTION
## Overview

Resolves #921 

This PR will maintain consistent positioning of the validation text on inline `Select` components

### Changed

* Use CSS Grid to position validation text under dropdown input (shoutout #932)

Inline invalid Select

![image](https://user-images.githubusercontent.com/8265238/41936473-e881ae90-7952-11e8-9def-4f86d2a32d66.png)

Focused inline invalid Select

![image](https://user-images.githubusercontent.com/8265238/41936492-f398561c-7952-11e8-8a61-654f7c2d5d61.png)