### PR TITLE
fix(tooltip): fix for click-outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "mock-raf": "^1.0.0",
     "nodemon": "1.9.1",
     "postcss-loader": "^2.1.0",
-    "prettier": "^1.7.0",
+    "prettier": "^1.13.0",
     "promise": "^8.0.1",
     "prop-types": "^15.6.0",
     "pump": "^1.0.2",

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -111,7 +111,7 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState,
     const { value, min, max, step } = this.getInputProps();
 
     const range = max - min;
-    const valuePercentage = (value - min) / range * 100;
+    const valuePercentage = ((value - min) / range) * 100;
 
     let left;
     let newValue;
@@ -132,7 +132,7 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState,
         if (direction !== undefined) {
           const multiplier = evt.shiftKey === true ? range / step / this.options.stepMultiplier : 1;
           const stepMultiplied = step * multiplier;
-          const stepSize = stepMultiplied / range * 100;
+          const stepSize = (stepMultiplied / range) * 100;
           left = valuePercentage + stepSize * direction;
           newValue = Number(value) + stepMultiplied * direction;
         }
@@ -146,8 +146,8 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState,
 
         const track = this.track.getBoundingClientRect();
         const unrounded = (evt.clientX - track.left) / track.width;
-        const rounded = Math.round(range * unrounded / step) * step;
-        left = rounded / range * 100;
+        const rounded = Math.round((range * unrounded) / step) * step;
+        left = (rounded / range) * 100;
         newValue = rounded + min;
       }
     }

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -124,11 +124,11 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
           element,
           name,
           event => {
-            const { target, type } = event;
+            const { relatedTarget, type } = event;
             const hadContextMenu = this._hasContextMenu;
             this._hasContextMenu = type === 'contextmenu';
             this._debouncedHandleClick({
-              target,
+              relatedTarget,
               type: type === 'focusin' ? 'focus' : type,
               hadContextMenu,
               details: getLaunchingDetails(event),
@@ -143,14 +143,13 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
   /**
    * Handles click/focus events.
    * @param {Object} params The parameters.
-   * @param {number} params.target
+   * @param {Element} params.relatedTarget The element that focus went to. (For `blur` event)
    * @param {string} params.type The event type triggering this method.
    * @param {boolean} params.hadContextMenu
    * @param {Object} params.details The event details.
    * @private
    */
-
-  _handleClick({ target, type, hadContextMenu, details }) {
+  _handleClick({ relatedTarget, type, hadContextMenu, details }) {
     const state = {
       focus: 'shown',
       blur: 'hidden',
@@ -162,7 +161,8 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
     if (type === 'blur') {
       // Note: SVGElement in IE11 does not have `.contains()`
       const wentToSelf =
-        (target && (this.element.contains && this.element.contains(target))) || this.tooltip.element.contains(target);
+        (relatedTarget && (this.element.contains && this.element.contains(relatedTarget))) ||
+        (this.tooltip && this.tooltip.element.contains(relatedTarget));
       shouldPreventClose = hadContextMenu || wentToSelf;
     }
     if (!shouldPreventClose) {

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -143,6 +143,7 @@ module.exports = function(config) {
                   // - Not meeting the code coverage standard set here, which shouldn't have happened
                   // - Very browser dependent code that wouldn't get code coverage unless we run the suite with Sauce Labs
                   // That said, new files should never be added, except for misc code that is very broser-specific
+                  'src/components/code-snippet/code-snippet.js',
                   'src/components/copy-button/copy-button.js',
                   'src/components/detail-page-header/detail-page-header.js',
                   'src/components/interior-left-nav/interior-left-nav.js',

--- a/tests/spec/floating-menu_spec.js
+++ b/tests/spec/floating-menu_spec.js
@@ -430,16 +430,16 @@ describe('Test floating menu', function() {
     it('Should focus back on the trigger button when floating menu loses focus', function() {
       const hasFocusin = 'onfocusin' in window;
       const focusinEventName = hasFocusin ? 'focusin' : 'focus';
-      spyOn(refNode, 'focus');
       primaryFocusNode.focus();
       menu.changeState('shown', {});
+      spyOn(HTMLElement.prototype, 'focus');
       // Firefox does not fire `onfocus` event with `input.focus()` call, presumably when the window does not have focus
       input.dispatchEvent(
         Object.assign(new CustomEvent(focusinEventName, { bubbles: true }), {
           relatedTarget: primaryFocusNode,
         })
       );
-      expect(refNode.focus).toHaveBeenCalledTimes(1);
+      expect(HTMLElement.prototype.focus).toHaveBeenCalledTimes(1);
     });
 
     afterEach(function() {

--- a/tests/spec/modal_spec.js
+++ b/tests/spec/modal_spec.js
@@ -29,7 +29,7 @@ describe('Test modal', function() {
         selectorInit: '[data-modal]',
         selectorModalClose: '[data-modal-close]',
         selectorPrimaryFocus: '[data-modal-primary-focus]',
-        selectorsFloatingMenus: ['.bx--overflow-menu-options', '.bx-tooltip'],
+        selectorsFloatingMenus: ['.bx--overflow-menu-options', '.bx--tooltip', '.flatpickr-calendar'],
         classVisible: 'is-visible',
         attribInitTarget: 'data-modal-target',
         initEventNames: ['click'],

--- a/tests/spec/search_spec.js
+++ b/tests/spec/search_spec.js
@@ -36,44 +36,6 @@ describe('Test Search', function() {
     });
   });
 
-  describe('Toggling between views', function() {
-    let gridIcon;
-    let listIcon;
-    let toggle;
-    let instance;
-    const container = document.createElement('div');
-    container.innerHTML = searchHTML;
-
-    beforeAll(function() {
-      document.body.appendChild(container);
-      instance = new Search(document.querySelector('[data-search]'));
-      toggle = container.querySelector('.bx--search-button[data-search-toggle]');
-      gridIcon = container.querySelector('div[data-search-view="grid"]');
-      listIcon = container.querySelector('div[data-search-view="list"]');
-    });
-
-    it('Should show grid view by default', function() {
-      expect(gridIcon.classList.contains('bx--search-view--hidden')).toBe(false);
-    });
-
-    it('Should show list view after click', function() {
-      toggle.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(gridIcon.classList.contains('bx--search-view--hidden')).toBe(true);
-      expect(listIcon.classList.contains('bx--search-view--hidden')).toBe(false);
-    });
-
-    it('Should show grid view after second click', function() {
-      toggle.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(gridIcon.classList.contains('bx--search-view--hidden')).toBe(false);
-      expect(listIcon.classList.contains('bx--search-view--hidden')).toBe(true);
-    });
-
-    afterAll(function() {
-      instance.release();
-      document.body.removeChild(container);
-    });
-  });
-
   describe('Clearing the search bar', function() {
     let input;
     let clearIcon;

--- a/tests/spec/tooltip_spec.js
+++ b/tests/spec/tooltip_spec.js
@@ -33,19 +33,10 @@ describe('Test tooltip', function() {
       });
     });
 
-    it('Should show the tooltip upon hovering over', function() {
-      element.dispatchEvent(new CustomEvent('mouseover', { bubbles: true }));
-      expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
-    });
-
-    it('Should hide the tooltip upon hovering out', function() {
-      floating.classList.add('bx--tooltip--shown');
-      element.dispatchEvent(new CustomEvent('mouseout', { bubbles: true }));
-      expect(floating.classList.contains('bx--tooltip--shown')).toBe(false);
-    });
-
-    it('Should show the tooltip upon focusing', function() {
-      element.dispatchEvent(new CustomEvent('focus', { bubbles: true }));
+    it('Should show the tooltip upon clicking/focusing', function() {
+      const hasFocusin = 'onfocusin' in window;
+      const focusinEventName = hasFocusin ? 'focusin' : 'focus';
+      element.dispatchEvent(new CustomEvent(focusinEventName, { bubbles: true }));
       expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
     });
 
@@ -84,20 +75,13 @@ describe('Test tooltip', function() {
       initContext = Tooltip.init();
     });
 
-    it('Should create an instance upon hovering over', function() {
+    it('Should create an instance upon clicking/focusing', function() {
+      const hasFocusin = 'onfocusin' in window;
+      const focusinEventName = hasFocusin ? 'focusin' : 'focus';
       return Tooltip.__with__({
         debounce: fn => fn,
       })(() => {
-        element.dispatchEvent(new CustomEvent('mouseover', { bubbles: true }));
-        expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
-      });
-    });
-
-    it('Should create an instance upon focusing', function() {
-      return Tooltip.__with__({
-        debounce: fn => fn,
-      })(() => {
-        element.dispatchEvent(new CustomEvent('focus', { bubbles: true }));
+        element.dispatchEvent(new CustomEvent(focusinEventName, { bubbles: true }));
         expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
       });
     });

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 yarn build
 yarn lint
 yarn test:unit -- -b ChromeHeadless_Travis -b Firefox

--- a/yarn.lock
+++ b/yarn.lock
@@ -9018,9 +9018,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
+prettier@^1.13.0:
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
## Overview

This PR fixes broken “click outside” feature of tooltip.

Also this change fixes all unit test failures, and ensures that any unit test failure fails Travis.

### Removed

* Several test cases that are no longer relevant.

### Changed

* Fix to the code looking at the wrong element for “where focus went to” detection.
* Code to ensure failing any command in `ci-check` script fails the script.
* Fix to several test cases.

## Testing / Reviewing

Testing should make sure tooltip is not broken, esp. keyboard navigation.