### PR TITLE
chore(devenv): stop reloading server upon change in template

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,8 +71,8 @@ gulp.task('dev-server', cb => {
   let started;
   const options = {
     script: './server.js',
-    ext: 'hbs js',
-    watch: ['demo/**/*.hbs', 'src/**/*.hbs', 'src/**/*.config.js', 'server.js'],
+    ext: 'js',
+    watch: ['server.js', 'tools/templates.js'],
     env: {
       PORT: cloptions.port,
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "browser-sync": "~2.10.0",
     "carbon-addons-cloud": "^1.8.0",
     "carbon-components-react": "^5.8.0",
+    "chokidar": "^2.0.0",
     "classnames": "^2.2.0",
     "commander": "^2.13.0",
     "core-js": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,6 +2113,25 @@ chokidar@1.7.0, chokidar@^1.2.0, chokidar@^1.4.1, chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chokidar@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.0"
+    braces "^2.3.0"
+    glob-parent "^3.1.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    lodash.debounce "^4.0.8"
+    normalize-path "^2.1.1"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+    upath "^1.0.5"
+  optionalDependencies:
+    fsevents "^1.2.2"
+
 chokidar@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.3.tgz#dcbd4f6cbb2a55b4799ba8a840ac527e5f4b1176"
@@ -4606,7 +4625,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.1.2:
+fsevents@^1.0.0, fsevents@^1.1.2, fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -11270,7 +11289,7 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-upath@^1.0.0:
+upath@^1.0.0, upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 


### PR DESCRIPTION
## Overview

This PR improves the dev workflow, by preventing the dev server from being reloaded upon change in markup.

### Added

* A mechanism to clear Fractal data cache and Handlebars template cache
* A mechanism to watch for change in templates to clear cache and reload browser

### Removed

* `nodemon` watcher for templates

## Testing / Reviewing

Testing should make sure our dev env is not broken.