### PR TITLE
fix(tabs): fix for mobile tab selection not closing the dropdown

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -80,11 +80,12 @@ class Tab extends ContentSwitcher {
    * @param {Event} event The event triggering this method.
    */
   _handleKeyDown(event) {
-    const triggerNode = this.element.querySelector(this.options.selectorTrigger);
-    if (triggerNode && triggerNode.offsetParent) {
+    const triggerNode = eventMatches(event, this.options.selectorTrigger);
+    if (triggerNode) {
       if (event.which === 13) {
         this._updateMenuState();
       }
+      return;
     }
 
     const direction = {


### PR DESCRIPTION
## Overview

During the review effort of #934, @tw15egan found that mobile tab selection not working. This PR is for addressing that issue.

### Added

* Code to detect an event is really from mobile tabs's menu trigger button before toggling menu's open/closed state. This prevents the code handling event from menu item that also toggles the same state.

## Testing / Reviewing

Testing should make sure there is no regression in tab.