### PR TITLE
fix(overflow-menu): add truncation for strings to avoid wrapping text

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -101,6 +101,10 @@
     padding: $spacing-xs $spacing-md;
     cursor: pointer;
     color: $text-01;
+    max-width: 11.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &:focus {
       outline: 1px solid transparent;

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -41,7 +41,7 @@
       <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Option 1</button>
     </li>
     <li class="bx--overflow-menu-options__option">
-      <button class="bx--overflow-menu-options__btn">Option 2</button>
+      <button class="bx--overflow-menu-options__btn" title="An example option that is really long to show what should be done to handle long text">An example option that is really long to show what should be done to handle long text</button>
     </li>
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn">Option 3</button>


### PR DESCRIPTION
## Overview

Resolves https://github.com/carbon-design-system/carbon-components/issues/917

Overflow Menu items should not wrap lines, this adds truncation once a string hits the max-width of an overflow item. A `title` attribute can be added to show information on hover for texts that are too long.

![example](https://user-images.githubusercontent.com/11928039/42104540-9177cb24-7b92-11e8-8a9c-7685b466cac1.png)

### Added

- Truncation on long strings in OverflowMenu

## Testing / Reviewing

Check OverflowMenu (The second one) and hover over the second option and ensure the full string is shown 
