### PR TITLE
fix(slider): fix duplicate ID in demo

### DIFF
--- a/src/components/slider/slider.config.js
+++ b/src/components/slider/slider.config.js
@@ -9,12 +9,16 @@ module.exports = {
         A slider enables the user to specify a numeric value which must be no less than a given value, 
         and no more than another given value. 
       `,
+      context: {
+        inputId: 'slider-input-box',
+      },
     },
     {
       name: 'light',
       label: 'Light',
       context: {
         light: true,
+        inputId: 'slider-input-box-light',
       },
     },
   ],

--- a/src/components/slider/slider.hbs
+++ b/src/components/slider/slider.hbs
@@ -3,13 +3,13 @@
   <div class="bx--slider-test">
   <div class="bx--slider-container">
     <span class="bx--slider__range-label">0</span>
-    <div class="bx--slider" data-slider data-slider-input-box="#slider-input-box">
+    <div class="bx--slider" data-slider data-slider-input-box="#{{inputId}}">
       <div class="bx--slider__track"></div>
       <div class="bx--slider__filled-track"></div>
       <div class="bx--slider__thumb" tabindex="0"></div>
       <input id="slider" class="bx--slider__input" type="range" step="1" min="0" max="100" value="50">
     </div>
     <span class="bx--slider__range-label">100</span>
-    <input id="slider-input-box" type="number" class="bx--text-input bx--slider-text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="0">
+    <input id="{{inputId}}" type="number" class="bx--text-input bx--slider-text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="0">
   </div>
 </div>


### PR DESCRIPTION
## Overview

This PR fixes duplicate ID found in slider demo. Such bug caused sliding light version changing non-light version's value.

### Added

* Different IDs for different versions of slider, in their HandleBars configurations

## Testing / Reviewing

Testing should make sure slider demo is not broken.