### PR TITLE
fix(tabs): fix for mobile tab selection not closing the dropdown (#941)

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -66,7 +66,7 @@ class Tab extends ContentSwitcher {
     const trigger = eventMatches(event, this.options.selectorTrigger);
     if (button) {
       super._handleClick(event);
-      this._updateMenuState();
+      this._updateMenuState(false);
     }
     if (trigger) {
       this._updateMenuState();
@@ -113,11 +113,12 @@ class Tab extends ContentSwitcher {
 
   /**
    * Shows/hides the drop down menu used in narrow mode.
+   * @param {boolean} [force] `true` to show the menu, `false` to hide the menu, otherwise toggles the menu.
    */
-  _updateMenuState() {
+  _updateMenuState(force) {
     const menu = this.element.querySelector(this.options.selectorMenu);
     if (menu) {
-      menu.classList.toggle(this.options.classHidden);
+      menu.classList.toggle(this.options.classHidden, typeof force === 'undefined' ? force : !force);
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes #867.
Closes #934.

### Added

* A mechanism to force open/closed state of the dropdown in the mobile mode of tab

### Changed

* Clicking on menu item in the mobile mode of tab closes the menu, instead of toggling, using above mechanism

## Testing / Reviewing

Testing should make sure our tabs component is not broken.