### PR TITLE
chore(components): better error for null arg for .init() call

### DIFF
--- a/src/globals/js/mixins/init-component-by-event.js
+++ b/src/globals/js/mixins/init-component-by-event.js
@@ -24,7 +24,7 @@ export default function(ToMix) {
      */
     static init(target = document, options = {}) {
       const effectiveOptions = Object.assign(Object.create(this.options), options);
-      if (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE) {
+      if (!target || (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE)) {
         throw new TypeError('DOM document or DOM element should be given to search for and initialize this widget.');
       }
       if (target.nodeType === Node.ELEMENT_NODE && target.matches(effectiveOptions.selectorInit)) {

--- a/src/globals/js/mixins/init-component-by-launcher.js
+++ b/src/globals/js/mixins/init-component-by-launcher.js
@@ -26,7 +26,7 @@ export default function(ToMix) {
      */
     static init(target = document, options = {}) {
       const effectiveOptions = Object.assign(Object.create(this.options), options);
-      if (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE) {
+      if (!target || (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE)) {
         throw new TypeError('DOM document or DOM element should be given to search for and initialize this widget.');
       }
       if (target.nodeType === Node.ELEMENT_NODE && target.matches(effectiveOptions.selectorInit)) {

--- a/src/globals/js/mixins/init-component-by-search.js
+++ b/src/globals/js/mixins/init-component-by-search.js
@@ -14,7 +14,7 @@ export default function(ToMix) {
      */
     static init(target = document, options = {}) {
       const effectiveOptions = Object.assign(Object.create(this.options), options);
-      if (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE) {
+      if (!target || (target.nodeType !== Node.ELEMENT_NODE && target.nodeType !== Node.DOCUMENT_NODE)) {
         throw new TypeError('DOM document or DOM element should be given to search for and initialize this widget.');
       }
       if (target.nodeType === Node.ELEMENT_NODE && target.matches(effectiveOptions.selectorInit)) {

--- a/tests/spec/mixins/init-component-by-launcher_spec.js
+++ b/tests/spec/mixins/init-component-by-launcher_spec.js
@@ -23,6 +23,12 @@ describe('Test init component by launcher', function() {
     createdByLauncher = spyCreatedByLauncher;
   };
 
+  it('Should throw if given element is null', function() {
+    expect(() => {
+      Class.init(null);
+    }).toThrowError(TypeError, 'DOM document or DOM element should be given to search for and initialize this widget.');
+  });
+
   it('Should throw if given element is neither a DOM element or a document', function() {
     expect(() => {
       Class.init(document.createTextNode(''));

--- a/tests/spec/mixins/init-component-by-search_spec.js
+++ b/tests/spec/mixins/init-component-by-search_spec.js
@@ -13,6 +13,12 @@ describe('Test init component by search', function() {
     static components = new WeakMap();
   };
 
+  it('Should throw if given element is null', function() {
+    expect(() => {
+      Class.init(null);
+    }).toThrowError(TypeError, 'DOM document or DOM element should be given to search for and initialize this widget.');
+  });
+
   it('Should throw if given element is neither a DOM element or a document', function() {
     expect(() => {
       Class.init(document.createTextNode(''));


### PR DESCRIPTION
## Overview

`null` arg for `.init()` call scenario used to throw internally.
This change gives a error with better explanation.

### Added

* Check for `null` in `init()` calls

## Testing / Reviewing

Testing should make sure no component is broken.