### PR TITLE
fix(text-01): changed hex value to be consitent

### DIFF
--- a/src/globals/scss/_colors.scss
+++ b/src/globals/scss/_colors.scss
@@ -3,7 +3,7 @@ $color__blue-20: #7cc7ff !default;
 $color__blue-30: #5aaafa !default;
 $color__blue-40: #5596e6 !default;
 $color__blue-50: #4178be !default;
-$color__blue-90: #152934 !default;
+$color__blue-90: #152935 !default;
 $color__navy-gray-1: #0f212e !default;
 $color__navy-gray-2: #20343e !default;
 $color__navy-gray-3: #2d3f49 !default;


### PR DESCRIPTION
We were using two different hex values for text-01 across the system (design mostly). We are using `#152935` as opposed to `#152934` since this was the color originally inherited from the IDL color palette. 