### PR TITLE
Remove margin-bottom for Skeleton Heading

### DIFF
--- a/src/components/skeleton/_skeleton-text.scss
+++ b/src/components/skeleton/_skeleton-text.scss
@@ -10,6 +10,5 @@
 
   .#{$prefix}--skeleton__heading {
     height: 1.5rem;
-    margin-bottom: $spacing-sm;
   }
 }


### PR DESCRIPTION
Usually the heading is inside a container placed as if it is a heading already, adding margin to the bottom of the skeleton heading seems to circumvent this.

### Removed

Margin-bottom of skeleton headings
