### PR TITLE
fix(content-switcher): adds class for hidden content, don't rely solely on `hidden`

### DIFF
--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -79,7 +79,6 @@
     }
 
     &:focus {
-      // box-shadow: -2px 0 0 0 $color__blue-20, 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
       z-index: 0;
     }
   }
@@ -93,7 +92,6 @@
     }
 
     &:focus {
-      // box-shadow: 2px 0 0 0 $color__blue-20, 0 2px 0 0 $color__blue-20, 0 -2px 0 0 $color__blue-20;
       z-index: 0;
     }
   }
@@ -109,5 +107,9 @@
       border-color: $hover-primary;
       background-color: $hover-primary;
     }
+  }
+
+  .#{$prefix}--content-switcher--hidden {
+    display: none;
   }
 }

--- a/src/components/content-switcher/content-switcher.js
+++ b/src/components/content-switcher/content-switcher.js
@@ -78,6 +78,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
         button.classList.toggle(this.options.classActive, false);
         [...button.ownerDocument.querySelectorAll(button.dataset.target)].forEach(element => {
           element.setAttribute('hidden', '');
+          element.classList.add(this.options.classHidden);
           element.setAttribute('aria-hidden', 'true');
         });
       }
@@ -87,6 +88,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
     item.setAttribute('aria-selected', true);
     [...item.ownerDocument.querySelectorAll(item.dataset.target)].forEach(element => {
       element.removeAttribute('hidden');
+      element.classList.remove(this.options.classHidden);
       element.setAttribute('aria-hidden', 'false');
     });
 
@@ -139,6 +141,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
    * @property {string} [selectorButton] The CSS selector to find switcher buttons.
    * @property {string} [selectorButtonSelected] The CSS selector to find the selected switcher button.
    * @property {string} [classActive] The CSS class for switcher button's selected state.
+   * * @property {string} [classHidden] The CSS class for the contents hidden state.
    * @property {string} [eventBeforeSelected]
    *   The name of the custom event fired before a switcher button is selected.
    *   Cancellation of this event stops selection of content switcher button.
@@ -150,6 +153,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
       selectorInit: '[data-content-switcher]',
       selectorButton: `input[type="radio"], .${prefix}--content-switcher-btn`,
       classActive: `${prefix}--content-switcher--selected`,
+      classHidden: `${prefix}--content-switcher--hidden`,
       eventBeforeSelected: 'content-switcher-beingselected',
       eventAfterSelected: 'content-switcher-selected',
     };


### PR DESCRIPTION
## Adds class for hidden content, don't rely solely on `hidden`

Resolves https://github.com/carbon-design-system/carbon-components/issues/743

We were relying solely on `hidden` attribute, which can be overriden by css display properties. Adds in an extra class that sets `display: none;` to enforce the contents hidden-ness.

### Added

- `.bx--content-switcher--hidden` which hides content

### Removed

- Extra, commented-out code 

## Testing / Reviewing

Ensure hidden classes are added to hidden content sections, here is an exmaple block that can be pasted in to `content-switcher.hbs`

```html
<div class="demo--panel--opt-1">
  <h1>test 1</h1>
</div>
<div class="demo--panel--opt-2">
  <h1>test 2</h1>
</div>
<div class="demo--panel--opt-3">
  <h1>test 3</h1>
</div>
```
