### PR TITLE
fix(data-table): fix escape key TypeError

### DIFF
--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -117,7 +117,10 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
     });
 
     this._actionBarToggle(this.state.checkboxCount > 0);
-    this.countEl.textContent = this.state.checkboxCount;
+
+    if (this.batchActionEl) {
+      this.countEl.textContent = this.state.checkboxCount;
+    }
   };
 
   _actionBarCancel = () => {
@@ -134,7 +137,10 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
 
     this.state.checkboxCount = 0;
     this._actionBarToggle(false);
-    this.countEl.textContent = this.state.checkboxCount;
+
+    if (this.batchActionEl) {
+      this.countEl.textContent = this.state.checkboxCount;
+    }
   };
 
   _actionBarToggle = toggleOn => {
@@ -153,12 +159,13 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
     if (toggleOn) {
       this.batchActionEl.dataset.active = true;
       this.batchActionEl.classList.add(this.options.classActionBarActive);
-    } else {
+    } else if (this.batchActionEl) {
       this.batchActionEl.dataset.active = false;
       this.batchActionEl.classList.remove(this.options.classActionBarActive);
     }
-
-    this.batchActionEl.addEventListener('transitionend', transition);
+    if (this.batchActionEl) {
+      this.batchActionEl.addEventListener('transitionend', transition);
+    }
   };
 
   _expandableRowsInit = expandableRows => {


### PR DESCRIPTION
## Overview

Resolves https://github.com/IBM/carbon-components/issues/967

Adds checks to ensure Batch Action bar exists before trying to manipulate that element 

### Added

- Checks to make sure `this.batchActionEl` exists. Does not exist on `expandableDataTable`, so it was throwing errors. 

## Testing / Reviewing

- Type something into the search for both Default and Expandable DataTables and press `escape` key. Make sure no errors appear in the console
