### PR TITLE
fix(small-toggle): hide tiny check

### DIFF
--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -87,7 +87,7 @@
   }
 
   .#{$prefix}--toggle__check {
-    fill: $ui-05;
+    fill: $ui-04;
     position: absolute;
     left: 6px;
     top: 6px;


### PR DESCRIPTION
## Overview

Resolves https://github.com/IBM/carbon-components/issues/968

Hide tiny checkmark

### Changed

- Matched checkmark color to background color

## Testing / Reviewing

- Ensure checkmark is not visible 
