### PR TITLE
fix(date-picker): increase height on DatePicker, add styles for prev/next month days

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -297,6 +297,12 @@
     }
   }
 
+  .nextMonthDay,
+  .prevMonthDay {
+    opacity: 0.5;
+    color: $ui-05;
+  }
+
   .#{$prefix}--date-picker__day.today,
   .flatpickr-day.today {
     position: relative;

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -297,8 +297,8 @@
     }
   }
 
-  .nextMonthDay,
-  .prevMonthDay {
+  .#{$prefix}--date-picker__days .nextMonthDay,
+  .#{$prefix}--date-picker__days .prevMonthDay {
     opacity: 0.5;
     color: $ui-05;
   }

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -157,7 +157,7 @@
     justify-content: center;
     padding: $spacing-md $spacing-md $spacing-2xs;
     width: rem(285px) !important;
-    height: rem(230px);
+    height: rem(262px);
     border-radius: 0;
     border: none;
     overflow: hidden;
@@ -385,13 +385,13 @@
     width: rem(225px);
     min-width: rem(225px);
     max-width: rem(225px);
-    height: rem(132px);
+    height: rem(164px);
   }
 
   .flatpickr-innerContainer,
   .flatpickr-rContainer {
     width: rem(225px);
-    height: rem(168px);
+    height: rem(200px);
   }
 
   .#{$prefix}--date-picker__weekdays,


### PR DESCRIPTION
It is necessary to display a 6th row of weeks in the calendar for the
dates to show properly for all months

## Overview

Resolves https://github.com/IBM/carbon-components-react/issues/1055

### Changed

_date-picker.scss modified to add extra space in the calendar to display a 6th row of weeks which is necessary to display all days in a month for some months

## Testing / Reviewing

Assuming the change works, the calendar will display a 6th line of weeks.

The result was achieved by modifying the resulting CSS as follows:

```
.flatpickr-innerContainer,
.flatpickr-rContainer {
  width: 14.0625rem;
  height: 12.5rem; } /* orig 10.5rem = 168px */ /* New 200px = 12.5rem */

.bx--date-picker__days,
.dayContainer {
  width: 14.0625rem;
  min-width: 14.0625rem;
  max-width: 14.0625rem;
  height: 10.25rem; } /* orig 8.25rem = 132px */  /* New 164px = 10.25rem*/

  .bx--date-picker__calendar,
.flatpickr-calendar.open {
  -webkit-box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.1);
          box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.1);
  background-color: #fff;
  display: -ms-flexbox;
  display: flex;
  -ms-flex-direction: column;
      flex-direction: column;
  -ms-flex-align: center;
      align-items: center;
  -ms-flex-pack: center;
      justify-content: center;
  padding: 0.875rem 1rem 0.25rem;
  width: 17.8125rem;
  height: 16.375rem; /* orig 14.375rem = 230px */ /* New 16.375rem = 262px*/
  border-radius: 0;
  border: none;
  overflow: hidden;
  margin-top: -1px; }
```
