### PR TITLE
feat(grid): add offset capability

### DIFF
--- a/src/components/grid/grid.hbs
+++ b/src/components/grid/grid.hbs
@@ -18,7 +18,9 @@
     </div>
     <div class="bx--col-xs-12 bx--col-sm-6 red">
       <p>Background color over entire column, not just content space</p>
-
+    </div>
+    <div class="bx--row">
+      <div class="bx--offset-xs-2 bx--col-xs-10">This content is offset. Offset adds a left-margin for x columns.</div>
     </div>
   </div>
 </div>

--- a/src/globals/grid/classic/_classic.scss
+++ b/src/globals/grid/classic/_classic.scss
@@ -8,15 +8,15 @@ $grid-breakpoints: (
   md: 768px,
   lg: 992px,
   xl: 1200px,
-  xxl: 1600px
+  xxl: 1600px,
 );
 $gutter-breakpoints: (
   xs: 5px,
-  sm: 10px
+  sm: 10px,
 );
 $grid-gutter-breakpoints: (
   xs: 3%,
-  sm: 5%
+  sm: 5%,
 );
 
 @mixin grid {
@@ -67,6 +67,10 @@ $grid-gutter-breakpoints: (
     .#{$prefix}--col-xs-#{$i} {
       flex-basis: (100% * $i / $columns);
     }
+
+    .#{$prefix}--offset-xs-#{$i} {
+      margin-left: (100% * $i / $columns);
+    }
   }
 
   @each $breakpoint in map-keys($grid-breakpoints) {
@@ -79,6 +83,10 @@ $grid-gutter-breakpoints: (
       @for $i from 1 through $columns {
         .#{$prefix}--col-#{$breakpoint}-#{$i} {
           flex-basis: (100% * $i / $columns);
+        }
+
+        .#{$prefix}--offset-#{$breakpoint}-#{$i} {
+          margin-left: (100% * $i / $columns);
         }
       }
     }


### PR DESCRIPTION
## Overview

Resolves #288 
This PR adds an offset capability in the grid - instead of using empty DOM nodes to specify an empty space, developers can now add an offset class to their cells. This makes programming easier, and improves the performance and readability of the markup.

The offset functionality must be used with the grid columns functionality. It works with the same pattern.

*Former usage:*
```
<div class="bx--row">
  <div class="bx--col-xs-2"><!-- only exists to provide an offset --></div>
  <div class="bx--col-xs-6">Offset content</div>
</div>
```

*New usage:*
```
<div class="bx--row">
  <div class="bx--offset-xs-2 bx--col-xs-6">Offset content</div>
</div>
```

Full HTML with multiple examples: https://github.com/rodet/carbon-offset-demo

![image](https://user-images.githubusercontent.com/343696/42825757-010e3d70-89e3-11e8-9dfc-d0a0e6f8a70b.png)

### Added

Classes `bx--offset-xs-{column}` and `bx--offset-{breakpoint}-{column}` to enable a left margin fitting the grid size.

### Removed

Nothing

### Changed

Commas at the end of the breakpoint definitions (was added by the tooling apparently)

## Testing / Reviewing

Check https://github.com/rodet/carbon-offset-demo
