### PR TITLE
fix(pagination): fix layout issue of select box

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -110,6 +110,9 @@ $css--helpers: true;
     .#{$prefix}--select--inline {
       margin-right: 0;
       width: auto;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
     }
 
     .#{$prefix}--select-input {
@@ -126,7 +129,7 @@ $css--helpers: true;
       }
     }
 
-    .#{$prefix}--select__arrow {
+    .#{$prefix}--select--inline .#{$prefix}--select-input ~ .#{$prefix}--select__arrow {
       right: 0.3rem;
       top: 0.625rem;
     }


### PR DESCRIPTION
Fixes IBM/carbon-components-react#1095.

### Added

* Some styles to make the text in pagination’s select box center

### Changed

* The CSS selector for the trigger button of pagination’s select box to ensure it takes the precedence

## Testing / Reviewing

Testing should make sure pagination component is not broken.