### PR TITLE
feat(overflow-menu): add flip-up option

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -59,19 +59,27 @@
     display: flex;
   }
 
-  .#{$prefix}--overflow-menu-options:before {
-    content: '';
-    position: absolute;
-    display: block;
-    width: rem(8px);
-    height: rem(8px);
-    z-index: -1;
-    transform: rotate(45deg);
-    background-color: $inverse-01;
-    border-top: 1px solid $ui-03;
-    border-left: 1px solid $ui-03;
-    top: -5px;
-    left: 24px;
+  .#{$prefix}--overflow-menu-options {
+    &:before {
+      content: '';
+      position: absolute;
+      display: block;
+      width: rem(8px);
+      height: rem(8px);
+      z-index: -1;
+      transform: rotate(45deg);
+      background-color: $inverse-01;
+      border-top: 1px solid $ui-03;
+      border-left: 1px solid $ui-03;
+      top: -5px;
+      left: 24px;
+    }
+
+    &[data-floating-menu-direction='top']:before {
+      transform: rotate(225deg);
+      top: auto;
+      bottom: -5px;
+    }
   }
 
   .#{$prefix}--overflow-menu-options__option {

--- a/src/components/overflow-menu/overflow-menu.config.js
+++ b/src/components/overflow-menu/overflow-menu.config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+  variants: [
+    {
+      name: 'default',
+      label: 'Overflow Menu',
+      notes: `
+        Overflow Menu is used when additional options are available to the user and there is a space constraint.
+        Create Overflow Menu Item components for each option on the menu.
+      `,
+      context: {
+        direction: 'bottom',
+      },
+    },
+    {
+      name: 'up',
+      label: 'Up',
+      context: {
+        direction: 'top',
+      },
+    },
+  ],
+};

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -6,7 +6,7 @@
       <circle cx="1.5" cy="13.5" r="1.5" />
     </g>
   </svg>
-  <ul class="bx--overflow-menu-options" tabindex="-1">
+  <ul class="bx--overflow-menu-options" tabindex="-1" data-floating-menu-direction="{{direction}}">
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Option 1</button>
     </li>
@@ -36,7 +36,7 @@
       <circle cx="1.5" cy="13.5" r="1.5" />
     </g>
   </svg>
-  <ul class="bx--overflow-menu-options bx--overflow-menu--flip" tabindex="-1">
+  <ul class="bx--overflow-menu-options bx--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="{{direction}}">
     <li class="bx--overflow-menu-options__option">
       <button class="bx--overflow-menu-options__btn" data-floating-menu-primary-focus>Option 1</button>
     </li>


### PR DESCRIPTION
## Overview

Fixes #966.

### Added

* Style to support floating menu’s `data-floating-menu-position` in overflow menu (Note: Only supports `top` and `bottom` for now)
* Code to support overflow menu’s arrow pointing down

## Testing / Reviewing

Testing should make sure overflow menu is not broken.