### PR TITLE
fix(code-snippet): ensure bx--btn--copy for inline copy button

### DIFF
--- a/src/components/code-snippet/code-snippet.hbs
+++ b/src/components/code-snippet/code-snippet.hbs
@@ -1,6 +1,6 @@
 {{#is variant "inline"}}
 <p>Here is an example of a text that a user would be reading. In this paragraph would be
-  <button data-copy-btn="" class="bx--snippet bx--snippet--inline{{#if light}} bx--snippet--light{{/if}}" aria-label="Copy code"
+  <button data-copy-btn="" class="bx--snippet bx--snippet--inline bx--btn--copy{{#if light}} bx--snippet--light{{/if}}" aria-label="Copy code"
     tabindex="0">
     <code>inline code</code>
     <div class="bx--btn--copy__feedback" data-feedback="Copied!"></div>


### PR DESCRIPTION
## Overview

Fixes #870.

### Added

`bx--btn--copy` class to inline code snippet button.

## Testing / Reviewing

Testing should make sure inline code snippet is not broken.