### PR TITLE
fix(tabs): remove duplicate click event handlers

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -61,7 +61,6 @@ class Tab extends ContentSwitcher {
    * @param {Event} event The event triggering this method.
    */
   _handleClick(event) {
-    super._handleClick(event);
     const button = eventMatches(event, this.options.selectorButton);
     const trigger = eventMatches(event, this.options.selectorTrigger);
     if (button) {


### PR DESCRIPTION
## Overview

Fixes #993.

### Removed

Duplicate click event handler in Tabs component.

## Testing / Reviewing

Testing should make sure tabs component is not broken.
