### PR TITLE
docs(components): add examples

### DIFF
--- a/src/components/content-switcher/README.md
+++ b/src/components/content-switcher/README.md
@@ -9,12 +9,42 @@
 
 ### Javascript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { ContentSwitcher } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var ContentSwitcher = CarbonComponents.ContentSwitcher;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-content-switcher` is an element with `[data-content-switcher]` attribute
+ContentSwitcher.create(document.getElementById('my-content-switcher'));
+```
+
 #### Public Methods
 
 | Name      | Params                        | Description                                                                                                           |
 |-----------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | setActive | item: `HTMLElement`, callback: `Function` | Uses `data-target` attribute to show a content panel using the given CSS selector. Non-active targets will be hidden. You can also pass in an optional callback function, see FAQ for details |
 | release   |                               | Deletes the instance and removes document event listeners                                                             |
+
+##### Example - Changing the active item
+
+```javascript
+// `#my-content-switcher` is an element with `[data-content-switcher]` attribute
+var contentSwitcherInstance = ContentSwitcher.create(document.getElementById('my-content-switcher'));
+// `#my-content-switcher-btn-1` is one of the `<button>`s with `bx--content-switcher-btn` class
+contentSwitcherInstance.setActive(document.getElementById('my-content-switcher-btn-1'));
+```
 
 #### Options
 
@@ -33,6 +63,27 @@
 |--------------------------------|--------------------------------------------------------------------|
 | content-switcher-beingselected | Custom event fired before a button is selected in content-switcher |
 | content-switcher-selected      | Custom event fired after a button is selected in content-switcher  |
+
+##### Example - Preventing a content switcher item from being selected in a certain condition
+
+```javascript
+document.addEventListener('content-switcher-beingselected', function (evt) {
+  if (!myApplication.shouldContentSwitcherItemBeSelected(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all content switcher items being selected to an analytics library
+
+```javascript
+document.addEventListener('content-switcher-selected', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Content switcher item selected',
+    id: evt.target.id,
+  });
+});
+```
 
 #### Classes
 
@@ -83,7 +134,7 @@ Below is an HTML setup for Content Switcher that will do the following:
 Use `setActive` class method to preset the selection on a Content Switcher; doing this will avoid manually adding `bx--content-switcher--selected` modifier class and `hidden` attributes on HTML.
 
 ```html
-<div data-content-switcher class="bx--content-switcher">
+<div data-content-switcher id="my-content-switcher" class="bx--content-switcher">
   <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-1">Option 1</button>
   <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-2">Option 2</button>
   <button class="bx--content-switcher-btn" data-target=".demo--panel--opt-3">Option 3</button>
@@ -102,8 +153,10 @@ Use `setActive` class method to preset the selection on a Content Switcher; doin
 ```js
 // Get HTMLelement for button to preselect it with setActive
 const button = document.querySelector('[data-target=".demo--panel--opt-2"]');
-// Initialize an instance of ContentSwitcher with init(), create() or new ContentSwitcher(element)
-const instance = ContentSwitcher.init();
+// Initialize an instance of ContentSwitcher with init(), create(element) or new ContentSwitcher(element)
+ContentSwitcher.init();
+// Grab an ContentSwitcher instance
+const instance = ContentSwitcher.components.get(document.getElementById('my-content-switcher'));
 // Use setActive
 instance.setActive(button);
 ```

--- a/src/components/data-table-v2/README.md
+++ b/src/components/data-table-v2/README.md
@@ -25,12 +25,41 @@ The update to tables splits out the `scss` files into multiple partial files wit
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { DataTableV2 } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var DataTableV2 = CarbonComponents.DataTableV2;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-data-table-v2` is an element with `[data-data-table-v2]` attribute
+DataTableV2.create(document.getElementById('my-data-table-v2'));
+```
+
 #### Public Methods
 
 | Name        | Params | Descriptions                                                                                                      |
 |-------------|--------|-------------------------------------------------------------------------------------------------------------------|
 | release     |        | Deletes the instance and removes document event listeners                                                         |
 | refreshRows |        | When adding in new table rows, reinitialize parent-child relationships. Not required if not using expandable rows |
+
+##### Example - Keeping data table in sync with dynamic change in rows list (For expantable table)
+
+```javascript
+// `#my-data-table-v2` is an element with `[data-data-table-v2]` attribute
+var dataTableV2Instance = DataTableV2.create(document.getElementById('my-data-table-v2'));
+dataTableV2Instance.refreshRows();
+```
 
 #### Events
 
@@ -43,6 +72,27 @@ The update to tables splits out the `scss` files into multiple partial files wit
 | eventTrigger             | [data-event]                     | Data attribute for clickable events        |
 | eventParentContainer     | [data-parent-row]                | Data attribute for event container         |
 
+##### Example - Preventing a table expando from being toggled in a certain condition
+
+```javascript
+document.addEventListener('data-table-v2-beforetoggleexpand', function (evt) {
+  if (!myApplication.shouldToggleExpando(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Sorting table content
+
+```javascript
+document.addEventListener('data-table-v2-aftertogglesort', function (evt) {
+  // `evt.target` will be `div.bx--data-table-v2-container`
+  // `evt.detail.element` will be `button.bx--table-sort-v2` whose sorting is changed,
+  // and will have `bx--table-sort-v2--ascending` class or not depending on the sorting state
+  evt.target.querySelector('tbody').innerHTML
+    = myApplication.resortTableContent(evt.target, evt.detail.element);
+});
+```
 
 #### Options
 

--- a/src/components/date-picker/README.md
+++ b/src/components/date-picker/README.md
@@ -1,6 +1,25 @@
 ### JavaScript
 
-The date picker is built on top of [Flatpickr](https://chmln.github.io/flatpickr/), so the [events](https://chmln.github.io/flatpickr/events/) and [config options](https://chmln.github.io/flatpickr/options/) that come with Flatpickr is therefore available to the date picker. This includes methods for setting a min date, max date, disabling date(s), specifiying a range of dates, and more.
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { DatePicker } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var DatePicker = CarbonComponents.DatePicker;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-date-picker` is an element with `[data-date-picker]` attribute
+DatePicker.create(document.getElementById('my-date-picker'));
+```
 
 #### Public Methods
 
@@ -26,6 +45,18 @@ The date picker is built on top of [Flatpickr](https://chmln.github.io/flatpickr
 | attribType | data-date-picker-type       | Specifies the calendar mode (single or range) |
 | dateFormat | 'm/d/Y' | The date format given to the calendar instance |
 
+The date picker is built on top of [Flatpickr](https://chmln.github.io/flatpickr/), so many of the [events](https://chmln.github.io/flatpickr/events/) and [config options](https://chmln.github.io/flatpickr/options/) that come with Flatpickr is therefore available to the date picker options. This includes methods for setting a min date, max date, disabling date(s), specifiying a range of dates, and more.
+
+##### Example - Getting notified of date picker dropdown being closed
+
+```javascript
+// `#my-date-picker` is an element with `[data-date-picker]` attribute
+DatePicker.create(document.getElementById('my-date-picker'), {
+  onClose() {
+    console.log('Date picker dropdown closed!');
+  },
+});
+```
 
 ### FAQ 
 

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -12,6 +12,27 @@ Use these modifiers with `.bx--dropdown` class.
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { Dropdown } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var Dropdown = CarbonComponents.Dropdown;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-dropdown` is an element with `[data-dropdown]` attribute
+Dropdown.create(document.getElementById('my-dropdown'));
+```
+
 #### Public Methods
 
 | Name                 | Params                 | Description                                                                                                                                                                      |
@@ -21,6 +42,15 @@ Use these modifiers with `.bx--dropdown` class.
 | navigate             | direction: `Number`    | Moves the focus up or down                                                                                                                                                       |
 | select               | itemToSelect: `Object` | Handles clicking on the dropdown options, doing the following: Changing text to selected option, removing selected option from options when selected, and emitting custom events |
 | setCloseOnBlur       |                        | Sets an event handler to document for "close on blue" behavior                                                                                                                   |
+
+##### Example - Changing the active item
+
+```javascript
+// `#my-dropdown` is an element with `[data-dropdown]` attribute
+var dropdownInstance = Dropdown.create(document.getElementById('my-dropdown'));
+// `#my-dropdown-link-1` is one of the `<a>`s with `bx--dropdown-link` class
+dropdownInstance.select(document.getElementById('my-dropdown-link-1'));
+```
 
 #### Options
 
@@ -37,3 +67,24 @@ Use these modifiers with `.bx--dropdown` class.
 |------------------------|--------------------------------------------------------|
 | dropdown-beingselected | Custom event fired before a dropdown item is selected |
 | dropdown-selected      | Custom event fired after a dropdown item is selected  |
+
+##### Example - Preventing a dropdown item from being selected in a certain condition
+
+```javascript
+document.addEventListener('dropdown-beingselected', function (evt) {
+  if (!myApplication.shouldDropdownItemBeSelected(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all dropdown items being selected to an analytics library
+
+```javascript
+document.addEventListener('dropdown-selected', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Dropdown item selected',
+    id: evt.target.id,
+  });
+});
+```

--- a/src/components/file-uploader/README.md
+++ b/src/components/file-uploader/README.md
@@ -1,11 +1,41 @@
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { FileUploader } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var FileUploader = CarbonComponents.FileUploader;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-file` is an element with `[data-file]` attribute
+FileUploader.create(document.getElementById('my-file'));
+```
+
 #### Public Methods
 
 | Name     | Params                                 | Description                                                                                                       |
 |----------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 | setState | state: `String`, selectIndex: `Number` | After files are added, call this method to change `state` of the filenames (`'upload'`, `'complete'`, `'edit'`).  |
 | release  |                                        | Deletes the instance                                                                                              |
+
+##### Example - Changing the uploading state
+
+```javascript
+// `#my-file` is an element with `[data-file]` attribute
+var fileUploaderInstance = FileUploader.create(document.getElementById('my-file'));
+// Makes the 2nd file shown as its uploading complete
+fileUploaderInstance.setState('complete', 1);
+```
 
 #### Options
 

--- a/src/components/inline-loading/README.md
+++ b/src/components/inline-loading/README.md
@@ -1,0 +1,54 @@
+### JavaScript
+
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { InlineLoading } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var InlineLoading = CarbonComponents.InlineLoading;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-inline-loading` is an element with `[data-inline-loading]` attribute
+InlineLoading.create(document.getElementById('my-inline-loading'));
+```
+
+#### Static properties
+
+| Name    | Type   | Description                                                                  |
+|---------|--------|------------------------------------------------------------------------------|
+| states  | Object | The loading states. Contains `INACTIVE`, `ACTIVE` and `FINISHED` properties. |
+
+#### Public Methods
+
+| Name     | Params         | Description                                                 |
+|----------|----------------|-------------------------------------------------------------|
+| release  |                | Deletes the instance                                        |
+| setState | state : string | Sets the active/inactive/finished state                     |
+
+##### Example - Transitioning the loading spinner to the finished state
+
+```javascript
+// `#my-inline-loading` is an element with `[data-inline-loading]` attribute
+var inlineLoadingInstance = InlineLoading.create(document.getElementById('my-inline-loading'));
+inlineLoadingInstance.setState(InlineLoading.states.FINISHED);
+```
+
+#### Options
+
+| Option               | Default Selector                    | Description                                                     |
+|----------------------|-------------------------------------|-----------------------------------------------------------------|
+| selectorInit         | [data-inline-loading]               | The CSS selector to find the inline loading components          |
+| selectorSpinner      | [data-inline-loading-spinner]       | The CSS selector to find the spinner                            |
+| selectorFinished     | [data-inline-loading-finished]      | The CSS selector to find the "finished" icon                    |  
+| selectorTextActive   | [data-inline-loading-text-active]   | The CSS selector to find the text describing the active state   |
+| selectorTextFinished | [data-inline-loading-text-finished] | The CSS selector to find the text describing the finished state |
+| classLoadingStop     | .bx--loading--stop                  | The CSS class for spinner's stopped state                       |

--- a/src/components/inline-loading/inline-loading.js
+++ b/src/components/inline-loading/inline-loading.js
@@ -64,7 +64,7 @@ class InlineLoading extends mixin(createComponent, initComponentBySearch, handle
 
   /**
    * The list of states.
-   * @type {Object{<string, string}}
+   * @type {Object<string, string>}
    */
   static states = {
     INACTIVE: 'inactive',

--- a/src/components/loading/README.md
+++ b/src/components/loading/README.md
@@ -12,6 +12,27 @@ Use these modifiers with `.bx--loading` class.
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { Loading } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var Loading = CarbonComponents.Loading;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-loading` is an element with `[data-loading]` attribute
+Loading.create(document.getElementById('my-loading'));
+```
+
 #### Public Methods
 
 | Name     | Params           | Description                                                 |
@@ -22,6 +43,14 @@ Use these modifiers with `.bx--loading` class.
 | isActive |                  | Returns current state                                       |
 | end      |                  | Runs end animation and then delete the element from the DOM |
 
+##### Example - Activating the loading spinner
+
+```javascript
+// `#my-loading` is an element with `[data-loading]` attribute
+var loadingInstance = Loading.create(document.getElementById('my-loading'));
+loadingInstance.set(true);
+```
+
 #### Options
 
 | Option                  | Default Selector          | Description                                                      |
@@ -30,3 +59,10 @@ Use these modifiers with `.bx--loading` class.
 | selectorLoadingOverlay  | .bx--loading-overlay      | The selector for the loading overlay.                            |
 | classLoadingOverlayStop | bx--loading-overlay--stop | The class for the loading overlay's stopped state.               |  
 | active                  | true                      | A boolean value representing the initial state of the component. |
+
+##### Example - Activating upon instantiating
+
+```javascript
+// `#my-loading` is an element with `[data-loading]` attribute
+Loading.create(document.getElementById('my-loading'), { active: true });
+```

--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -10,6 +10,35 @@ Use these modifiers with `.bx--modal` class.
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { Modal } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var Modal = CarbonComponents.Modal;
+```
+
+#### Instantiating
+
+##### For one with a trigger button (a `<button>` with `data-modal-target` attribute)
+
+```javascript
+Modal.init();
+```
+
+##### For one without a trigger button
+
+```javascript
+// `#my-modal` is an element with `[data-modal]` attribute
+Modal.create(document.getElementById('my-modal'));
+```
+
 #### Public Methods
 
 | Name              | Params           | Description          |
@@ -17,6 +46,14 @@ Use these modifiers with `.bx--modal` class.
 | release           |                  | Deletes the instance |
 | show              |                  | Show the modal       |
 | hide              |                  | Hide the modal       |
+
+##### Example - Showing modal
+
+```javascript
+// `#my-modal` is an element with `[data-modal]` attribute
+var modalInstance = Modal.create(document.getElementById('my-modal'));
+modalInstance.show();
+```
 
 #### Options
 
@@ -36,6 +73,27 @@ Use these modifiers with `.bx--modal` class.
 | eventAfterShown   | 'modal-shown'       |
 | eventBeforeHidden | 'modal-beinghidden' |
 | eventAfterHidden  | 'modal-hidden'      |
+
+##### Example - Preventing modals from being closed in a certain condition
+
+```javascript
+document.addEventListener('modal-beinghidden', function (evt) {
+  if (myApplication.shouldModalKeptOpen(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all modals being closed to an analytics library
+
+```javascript
+document.addEventListener('modal-hidden', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Modal hidden',
+    id: evt.target.id,
+  });
+});
+```
 
 ### FAQ
 

--- a/src/components/notification/README.md
+++ b/src/components/notification/README.md
@@ -30,6 +30,27 @@ Use these modifiers with `.bx--toast-notification` class.
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { Notification } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var Notification = CarbonComponents.Notification;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-notification` is an element with `[data-notification]` attribute
+Notification.create(document.getElementById('my-notification'));
+```
+
 #### Public Methods
 
 | Name    | Params | Description                                                                       |
@@ -37,6 +58,13 @@ Use these modifiers with `.bx--toast-notification` class.
 | remove  |        | Removes the component, deletes the instance, and removes document event listeners |
 | release |        | Delete the instance                                                               |
 
+##### Example - Removing a notification
+
+```javascript
+// `#my-notification` is an element with `[data-notification]` attribute
+notificationInstance = Notification.create(document.getElementById('my-notification'));
+notificationInstance.remove();
+```
 
 #### Options
 
@@ -47,6 +75,26 @@ Use these modifiers with `.bx--toast-notification` class.
 | eventBeforeDeleteNotification | `notification-before-delete` | Event before deleting the notification                    |
 | eventAfterDeleteNotification  | `notification-after-delete`  | Event after deleting the notification                     |
 
+##### Example - Preventing a notification from being removed in a certain condition
+
+```javascript
+document.addEventListener('notification-before-delete', function (evt) {
+  if (!myApplication.shouldNotificationBeRemoved(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all notifications being removed to an analytics library
+
+```javascript
+document.addEventListener('notification-after-delete', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Notification removed',
+    id: evt.target.id,
+  });
+});
+```
 
 ### FAQ 
 

--- a/src/components/overflow-menu/README.md
+++ b/src/components/overflow-menu/README.md
@@ -11,6 +11,27 @@ Use these modifiers with .bx--overflow-menu-options class.
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { OverflowMenu } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var OverflowMenu = CarbonComponents.OverflowMenu;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-overflow-menu` is an element with `[data-overflow-menu]` attribute
+OverflowMenu.create(document.getElementById('my-overflow-menu'));
+```
+
 #### Public Methods
 
 | Name                 | Params          | Description                                                        |
@@ -27,6 +48,53 @@ Use these modifiers with .bx--overflow-menu-options class.
 | `selectorOptionMenu`        | `.bx--overflow-menu-options`             | The CSS selector to find the contents of the menu
 | `objMenuOffset`    | `{ top: 3, left: 61`        | An object containing the top and left offset values in px
 | `objMenuOffsetFlip`    | `{ top: 3, left: -61`        | An object containing the top and left offset values in px for the "flipped" state
+
+##### Example - Changing menu position by 8 pixels vertically
+
+```javascript
+// `#my-overflow-menu` is an element with `[data-overflow-menu]` attribute
+OverflowMenu.create(document.getElementById('my-overflow-menu'), {
+  objMenuOffset(menuBody, direction) {
+    const { objMenuOffset: offset } = OverflowMenu.options;
+    const { top, left } = typeof offset !== 'function' ? offset:
+      offset(menuBody, direction);
+    return {
+      top: top + 8,
+      left,
+    };
+  },
+});
+```
+
+#### Events
+
+| Event Name                  | Description                                         |
+|-----------------------------|-----------------------------------------------------|
+| 'floating-menu-beingshown'  | The custom event fired before the menu gets open.   |
+| 'floating-menu-shown'       | The custom event fired after the menu gets open.    |
+| 'floating-menu-beinghidden' | The custom event fired before the menu gets closed. |
+| 'floating-menu-hidden'      | The custom event fired after the menu gets closed.  |
+
+##### Example - Preventing menu from being closed in a certain condition
+
+```javascript
+document.addEventListener('floating-menu-beinghidden', function (evt) {
+  if (myApplication.shouldMenuKeptOpen(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all overflow menus being closed to an analytics library
+
+```javascript
+document.addEventListener('floating-menu-hidden', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Overflow menu closed',
+    id: evt.target.id,
+  });
+});
+```
 
 ### HTML
 

--- a/src/components/progress-indicator/README.md
+++ b/src/components/progress-indicator/README.md
@@ -12,6 +12,27 @@ Use these modifiers with `.bx--progress` class.
 
 ### Javascript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { ProgressIndicator } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var ProgressIndicator = CarbonComponents.ProgressIndicator;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-progress` is an element with `[data-progress]` attribute
+ProgressIndicator.create(document.getElementById('my-progress'));
+```
+
 #### Public Methods
 
 | Name       | Params                   | Description                                                                                                                                                                                                                                                    |
@@ -19,6 +40,18 @@ Use these modifiers with `.bx--progress` class.
 | getSteps   |                          | Returns Array of Objects with `element` and `order` key/value pairs. The `element` key contains a step element. The `order` key is what order the step element is, order starts counting from 1 (the first step element) to whatever the last step element is. |
 | getCurrent |                          | Returns an Object with data of the current step (`element` and `order` key/value pairs)                                                                                                                                                                        |
 | setCurrent | newCurrentStep: `Number` | Changes the current step with the given `index` number. (ex. `setCurrent(0)` sets the first step as the current step)                                                                                                                                          |
+
+##### Example - Changing the current step
+
+```javascript
+// `#my-progress` is an element with `[data-progress]` attribute
+var progressIndicatorInstance = ProgressIndicator.create(document.getElementById('my-progress'));
+// Sets the 2nd step current
+progressIndicatorInstance.setCurrent(1);
+```
+
+- All index numbers less than the current index will be complete
+- All index numbers greater than the current index will be incomplete
 
 #### Options
 
@@ -61,23 +94,3 @@ Once `ProgressIndicator` instance is initialized, simply add or remove Progress 
 ```
 
 Note that each progress step will need a modifier class. In the example above, it is `bx--progress-step--complete`, but the JavaScript will set this to the appropriate modifier class relative to the current step as indicated by `bx--progress-step--incomplete`.
-
-#### How to set current Progress step 
-
-Use the `setCurrent(index)` class method. The `index` number corresponds to a progress step.
-
-```js
-const instance = ProgressIndicator.create(document.querySelector('[data-progress]'));
-
-// Sets the first progress step as the current step
-instance.setCurrent(0)
-
-// Sets the second progress step as the current step
-instance.setCurrent(1)
-
-// Sets the third progress step as the current step
-instance.setCurrent(2)
-```
-
-- All index numbers less than the current index will be complete
-- All index numbers greater than the current index will be incomplete

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -12,6 +12,43 @@ Modifiers are used with various classes for Tabs.
 
 ### JavaScript
 
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { Tabs } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var Tabs = CarbonComponents.Tabs;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-tabs` is an element with `[data-tabs]` attribute
+Tabs.create(document.getElementById('my-tabs'));
+```
+
+#### Public Methods
+
+| Name      | Params                        | Description                                                                                                           |
+|-----------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| setActive | item: `HTMLElement`, callback: `Function` | Uses `data-target` attribute to show a content panel using the given CSS selector. Non-active targets will be hidden. You can also pass in an optional callback function, see FAQ in Content Switcher for details |
+| release   |                               | Deletes the instance and removes document event listeners                                                             |
+
+##### Example - Changing the active item
+
+```javascript
+// `#my-tabs` is an element with `[data-tabs]` attribute
+var tabsInstance = Tabs.create(document.getElementById('my-tabs'));
+// `#my-tab-item-1` is one of the `<li>`s with `bx--tabs__nav-item` class
+tabsInstance.setActive(document.getElementById('my-tab-item-1'));
+```
+
 #### Options
 
 | Option                 | Default Selector              | Description                                                                            |
@@ -34,3 +71,24 @@ Modifiers are used with various classes for Tabs.
 |---------------------|-----------------------------------------------------------------------------------------------------------------|
 | tab-beingselected   | The name of the custom event fired before a tab is selected. Cancellation of this event stops selection of tab. |
 | tab-selected        | The name of the custom event fired after a tab is selected                                                      |
+
+##### Example - Preventing a tab from being selected in a certain condition
+
+```javascript
+document.addEventListener('tab-beingselected', function (evt) {
+  if (!myApplication.shouldTabItemBeSelected(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all tab items being selected to an analytics library
+
+```javascript
+document.addEventListener('tab-selected', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Tab selected',
+    id: evt.target.id,
+  });
+});
+```

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -1,4 +1,25 @@
-### JavaScript
+### JavaScript (Applied *only* to click-to-open tooltip)
+
+#### Getting component class reference
+
+##### ES2015
+
+```javascript
+import { Tooltip } from 'carbon-components';
+```
+
+##### With pre-build bundle (`carbon-components.min.js`)
+
+```javascript
+var Tooltip = CarbonComponents.Tooltip;
+```
+
+#### Instantiating
+
+```javascript
+// `#my-tooltip-trigger` is an element with `[data-tooltip-trigger]` attribute
+Tooltip.create(document.getElementById('my-tooltip-trigger'));
+```
 
 #### Attributes
 
@@ -15,12 +36,67 @@
 | hide    |        | Hides the tooltip.                                         |
 | release |        | Deletes the instance and removes document event listeners. |
 
+##### Example - Showing tooltip
+
+```javascript
+// `#my-tooltip-trigger` is an element with `[data-tooltip-trigger]` attribute
+var tooltipInstance = Tooltip.create(document.getElementById('my-tooltip-trigger'));
+tooltipInstance.show();
+```
+
 #### Options
 
 | Option                   | Default Selector                | Description                                                                            |
 |--------------------------|---------------------------------|----------------------------------------------------------------------------------------|
 | `selectorInit`           | `[data-tooltip-trigger]`        | The CSS selector to find the tooltip.
 | `objMenuOffset`          | `{ top: 10, left: 0 }`          | An object containing the top and left offset values in px
+
+##### Example - Changing menu position by 8 pixels vertically
+
+```javascript
+// `#my-tooltip-trigger` is an element with `[data-tooltip-trigger]` attribute
+Tooltip.create(document.getElementById('my-tooltip-trigger'), {
+  objMenuOffset(menuBody, direction) {
+    const { objMenuOffset: offset } = Tooltip.options;
+    const { top, left } = typeof offset !== 'function' ? offset:
+      offset(menuBody, direction);
+    return {
+      top: top + 8,
+      left,
+    };
+  },
+});
+```
+
+#### Events
+
+| Event Name                  | Description                                         |
+|-----------------------------|-----------------------------------------------------|
+| 'floating-menu-beingshown'  | The custom event fired before the menu gets open.   |
+| 'floating-menu-shown'       | The custom event fired after the menu gets open.    |
+| 'floating-menu-beinghidden' | The custom event fired before the menu gets closed. |
+| 'floating-menu-hidden'      | The custom event fired after the menu gets closed.  |
+
+##### Example - Preventing click-to-open tooltip from being closed in a certain condition
+
+```javascript
+document.addEventListener('floating-menu-beinghidden', function (evt) {
+  if (myApplication.shouldTooltipKeptOpen(evt.target)) {
+    evt.preventDefault();
+  }
+});
+```
+
+##### Example - Notifying events of all click-to-open tooltips being hidden to an analytics library
+
+```javascript
+document.addEventListener('floating-menu-hidden', function (evt) {
+  myAnalyticsLibrary.send({
+    action: 'Tooltip hidden',
+    id: evt.target.id,
+  });
+});
+```
 
 ### Interactive tooltip
 


### PR DESCRIPTION
## Overview

This PR adds usage example for several components, especially ones with:

* Frequently used methods
* Frequently used options
* Frequently used events

### Added

Usage examples for several components.

## Testing / Reviewing

Testing should make sure no document is broken.