### PR TITLE
fix(FileUploader): reduce size of loading svg

### DIFF
--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -72,8 +72,8 @@
     align-items: center;
 
     .#{$prefix}--loading {
-      width: 1.125rem;
-      height: 1.125rem;
+      width: 1rem;
+      height: 1rem;
       margin-right: $spacing-xs;
     }
 


### PR DESCRIPTION
## Overview

`carbon-react`'s file uploader currently has inline styles for reducing the width and height of the loading SVG when a file is being uploaded. This PR will make the two implementations of the Carbon file uploader consistent in styles.

related: https://github.com/IBM/carbon-components-react/pull/1105

### Changed

dimensions of file uploader loading SVG

## Testing / Reviewing

Create file uploader instance

Upload file and set its state to `'upload'`
