### PR TITLE
feat: add support for feature flags and experimental features

### DIFF
--- a/src/globals/grid/_grid.scss
+++ b/src/globals/grid/_grid.scss
@@ -1,3 +1,4 @@
+@import '../scss/feature-flags';
 @import '../scss/mixins';
 @import './classic/classic';
 @import './experimental/experimental';

--- a/src/globals/grid/_grid.scss
+++ b/src/globals/grid/_grid.scss
@@ -1,16 +1,18 @@
-@import '../scss/import-once';
+@import '../scss/mixins';
 @import './classic/classic';
 @import './experimental/experimental';
 @import './experimental/fallback';
 
 @include exports('grid') {
-  @if global-variable-exists('css--use-experimental-grid') == true and $css--use-experimental-grid == true {
-    @if global-variable-exists('css--use-experimental-grid-fallback') == true and $css--use-experimental-grid-fallback == true {
+  @include experimental('grid') {
+    @include experimental('grid--fallback') {
       @include grid-experimental-fallback;
-    } @else {
-      @include grid-experimental;
     }
-  } @else {
+
+    @include grid-experimental;
+  }
+
+  @include stable('grid') {
     @include grid;
   }
 }

--- a/src/globals/scss/_feature-flags.scss
+++ b/src/globals/scss/_feature-flags.scss
@@ -6,3 +6,11 @@ $feature-flags: (
   grid: false,
   grid--fallback: false,
 ) !default;
+
+@if global-variable-exists(css--use-experimental-grid) == true {
+  $feature-flags: map-set($feature-flags, grid, $css--use-experimental-grid);
+}
+
+@if global-variable-exists(css--use-experimental-grid-fallback) == true {
+  $feature-flags: map-set($feature-flags, grid, $css--use-experimental-grid-fallback);
+}

--- a/src/globals/scss/_feature-flags.scss
+++ b/src/globals/scss/_feature-flags.scss
@@ -2,15 +2,46 @@
 // 🎌 Feature Flags
 //-------------------------
 
-$feature-flags: (
-  grid: false,
-  grid--fallback: false,
-) !default;
+// Initialize our feature flag map with default values
+$feature-flags: () !default;
 
+// We supported a flag for experimental grid in the past that we want to keep
+// supporting till our next major release. These two @if statements will assign
+// these values over into the map if they are defined.
 @if global-variable-exists(css--use-experimental-grid) == true {
-  $feature-flags: map-set($feature-flags, grid, $css--use-experimental-grid);
+  $feature-flags: map-merge(
+    $feature-flags,
+    (
+      grid: $css--use-experimental-grid,
+    )
+  );
 }
 
 @if global-variable-exists(css--use-experimental-grid-fallback) == true {
-  $feature-flags: map-set($feature-flags, grid, $css--use-experimental-grid-fallback);
+  $feature-flags: map-merge(
+    $feature-flags,
+    (
+      grid--fallback: $css--use-experimental-grid-fallback,
+    )
+  );
+}
+
+// However, if we don't have those flags available let's go ahead and add in
+// some defaults for the grid and grid--fallback
+@if map-has-key($feature-flags, grid) == false {
+  $feature-flags: map-merge(
+    $feature-flags,
+    (
+      grid: false,
+    )
+  );
+}
+
+@if map-has-key($feature-flags, grid--fallback) == false {
+  $feature-flags: map-merge(
+    $feature-flags,
+    (
+      grid--fallback: false,
+    )
+  );
 }

--- a/src/globals/scss/_feature-flags.scss
+++ b/src/globals/scss/_feature-flags.scss
@@ -1,0 +1,8 @@
+//-------------------------
+// 🎌 Feature Flags
+//-------------------------
+
+$feature-flags: (
+  grid: false,
+  grid--fallback: false,
+) !default;

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -12,6 +12,7 @@
 // Misc
 // ---------------------------------------------
 
+@import 'feature-flags';
 @import 'vars';
 @import 'css--reset';
 @import 'typography';
@@ -192,6 +193,18 @@
       right: auto;
       opacity: 0.3;
     }
+  }
+}
+
+@mixin experimental($feature) {
+  @if global-variable-exists(feature-flags) == true and map-get($feature-flags, $feature) == true {
+    @content;
+  }
+}
+
+@mixin stable($feature) {
+  @if global-variable-exists(feature-flags) == true and map-get($feature-flags, $feature) == false {
+    @content;
   }
 }
 

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -9,6 +9,10 @@ $css--use-layer: true !default;
 $css--reset: true !default;
 $css--typography: true !default;
 $css--plex: true !default;
+// TODO: remove in next major release. Synced in `feature-flags` as an adapter
+// in the interim
+$css--use-experimental-grid: false !default;
+$css--use-experimental-grid-fallback: false !default;
 
 @import 'feature-flags';
 @import 'colors';

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -5,13 +5,12 @@
 $css--font-face: true !default;
 $css--helpers: true !default;
 $css--body: true !default;
-$css--use-experimental-grid: false !default;
-$css--use-experimental-grid-fallback: false !default;
 $css--use-layer: true !default;
 $css--reset: true !default;
 $css--typography: true !default;
 $css--plex: true !default;
 
+@import 'feature-flags';
 @import 'colors';
 @import 'vars';
 @import 'mixins';


### PR DESCRIPTION
Adds in support for feature flags in `_feature-flags.scss`, and includes some mixins for toggling based on `experimental` or `stable` variants of a feature.

#### Changelog

**New**

- `experimental` and `stable` mixins in `_helper-mixins.scss`

**Changed**

- `grid` code now uses updated feature flags

**Removed**
