### PR TITLE
chore(devenv): support for alternate layout template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,14 +88,15 @@ Component variants can be specified by either:
 - Adding an item to `variants` in `.config.js` file (In this case, a `.hbs` file whose basename is exactly the same as the component name should be defined)
 - Adding a `.hbs` file to component directory (Note: If there is a `.hbs` file whose basename is exactly the same as the component name, other `.hbs` files has to be in `componentname--variantname.hbs` format)
 - `.hbs` files are rendered with the data given via `variants[n].context` property (see below)
-- Supported properties in `.config.js` are the following:
+- Supported [properties in `.config.js`](https://fractal.build/guide/components/configuration) are the following:
   - [`default`](https://fractal.build/guide/components/configuration#default)
-  - [`variants`](https://fractal.build/guide/components/configuration#variant-properties) - An array of objects with the following properties:
+  - [`variants`](https://fractal.build/guide/components/configuration#variant-properties) - An array of objects, supporitng the following properties:
     - `name`
     - `label`
     - `notes`
     - `context`
-    - (`preview` - Unlike [Fractal](https://fractal.build/guide/components/configuration#preview), this property should point to a `.hbs` file under `demo` directory or `src` directory, _without_ `@` symbol)
+    - (`view` - Unlike [Fractal](https://fractal.build/guide/components/configuration#preview), this property should point to the basename of a `.hbs` file under `demo` directory or `src` directory, _without_ its path)
+    - (`preview` - Unlike [Fractal](https://fractal.build/guide/components/configuration#preview), this property should point to the basename of a `.hbs` file under `demo` directory or `src` directory, _without_ `@` symbol)
 
 ## Start Contributing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,7 +260,7 @@ gulp.task('html:source', () => {
     'notification--default': 'inline-notification',
     'notification--toast': 'toast-notification',
   };
-  return templates.render().then(renderedItems => {
+  return templates.render({ layout: false }).then(renderedItems => {
     const promises = [];
     renderedItems.forEach((rendered, item) => {
       const dirname = path.dirname(path.resolve(__dirname, 'html', item.relViewPath));

--- a/server.js
+++ b/server.js
@@ -150,7 +150,7 @@ function codeRoute(req, res, next) {
     res.end();
   } else {
     templates
-      .render({}, name)
+      .render({ layout: false }, name)
       .then(renderedItems => {
         const o = {};
         renderedItems.forEach((rendered, item) => {

--- a/tools/templates.js
+++ b/tools/templates.js
@@ -103,10 +103,10 @@ const renderComponent = ({ layout, concat } = {}, handle) =>
         const filteredItems = !handle || handle === metadata.handle ? items : items.filter(item => handle === item.handle);
         filteredItems.forEach(item => {
           const { handle: itemHandle, baseHandle, context } = item;
-          const template = contents.get(item.preview) || contents.get(itemHandle) || contents.get(baseHandle);
+          const template = contents.get(item.view) || contents.get(itemHandle) || contents.get(baseHandle);
           if (template) {
             const body = template(context);
-            const layoutTemplate = contents.get(layout);
+            const layoutTemplate = contents.get(item.preview) || contents.get(layout);
             renderedItems.set(item, !layoutTemplate ? body : layoutTemplate(Object.assign({ body }, context)));
           }
         });

--- a/tools/templates.js
+++ b/tools/templates.js
@@ -86,7 +86,7 @@ const cache = {
 
 /**
  * @param {Object} [options] The options.
- * @param {string} [options.layout] The Handlebars template name to lay out stuffs.
+ * @param {string} [options.layout] The default Handlebars template name to lay out stuffs. `false` to force empty layout.
  * @param {boolean} [options.concat] Setting `true` here returns rendered contents all concatenated, instead of returning a map.
  * @param {string} [handle]
  *   The internal component name seen in Fractal.
@@ -106,7 +106,7 @@ const renderComponent = ({ layout, concat } = {}, handle) =>
           const template = contents.get(item.view) || contents.get(itemHandle) || contents.get(baseHandle);
           if (template) {
             const body = template(context);
-            const layoutTemplate = contents.get(item.preview) || contents.get(layout);
+            const layoutTemplate = layout !== false && (contents.get(item.preview) || contents.get(layout));
             renderedItems.set(item, !layoutTemplate ? body : layoutTemplate(Object.assign({ body }, context)));
           }
         });


### PR DESCRIPTION
A misc change to make our demo template rendering more flexible.

#### Changelog

**New**

- Ability to change the layout template for rendering component demo (via `.preview`)

**Changed**

- The configuration property name for rendering component demo markup itself, from `.preview` to `.view`, to better align to Fractal

#### Testing / Reviewing

Testing should make sure our dev env is not broken.