### PR TITLE
feat(feature-flags): allow default feature flag value per feature

### DIFF
--- a/src/globals/scss/_feature-flags.scss
+++ b/src/globals/scss/_feature-flags.scss
@@ -3,10 +3,15 @@
 //-------------------------
 
 // Initialize our feature flag map with default values
-$feature-flags: (
-  components-x: false,
-  ui-shell: false,
-) !default;
+$feature-flags: () !default;
+
+$feature-flags: map-merge(
+  (
+    components-x: false,
+    ui-shell: false,
+  ),
+  $feature-flags
+);
 
 // We supported a flag for experimental grid in the past that we want to keep
 // supporting till our next major release. These two @if statements will assign


### PR DESCRIPTION
This change introduces a mechanism to allow consumer application to define a subset of feature flags and use the default ones for the remainders, instead of using all default ones or defining all feature flags.

#### Changelog

**Changed**

- Default feature flags and user-set feature flags are now merged, instead of overwritten

#### Testing / Reviewing

Testing should make sure our styles are not broken.