### PR TITLE
fix(form): make the form validation style of list box more specific

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -53,7 +53,7 @@
   input[data-invalid],
   textarea[data-invalid],
   select[data-invalid],
-  div[data-invalid] {
+  .#{$prefix}--list-box[data-invalid] {
     box-shadow: 0 2px 0px 0px $support-01;
 
     ~ .#{$prefix}--form-requirement {


### PR DESCRIPTION
Fixes #1051.

#### Changelog

**Changed**

- Selector of form validation style for React list box, to be more specific.

#### Testing / Reviewing

Testing should make sure form validation styles of number input and list box not broken.
