### PR TITLE
Ensure correct positioning of checkmark in checkbox

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -53,9 +53,10 @@
 
   // Checkmark
   .#{$prefix}--checkbox-label::after {
+    box-sizing: border-box;
     content: '';
-    width: 7px;
-    height: 3px;
+    width: 9px;
+    height: 5px;
     background: none;
     /*rtl:ignore*/
     border-left: 2px solid $inverse-01;


### PR DESCRIPTION
Closes #1066 

Fixes bug where checkmark assumed `box-sizing: content-box`. This meant that global CSS reset code would break the checkmark.

![45126981-c1f44c80-b13b-11e8-9255-e523aabeaa8c](https://user-images.githubusercontent.com/5886107/45179613-a3935d00-b1de-11e8-8e17-fd2c3eaa6364.png)
![45127014-ef40fa80-b13b-11e8-9738-8a95b839c0c7](https://user-images.githubusercontent.com/5886107/45179618-a4c48a00-b1de-11e8-907c-32061af6e1cb.png)

```css
  *,
  *::before,
  *::after {
    box-sizing: border-box;
  }
```

#### Changelog

**New**

- Explicitly specifies `box-sizing: border-box`

**Changed**

- Modifies `width` and `height` to work with that `box-sizing` property.

**Removed**

- Nothing
