### PR TITLE
chore(feature-flags): warn usage of non-default feature flags

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -247,7 +247,7 @@ gulp.task('sass:compiled', () => {
   buildStyles(true); // Minified CSS
 });
 
-let useExperimenalFeatures = cloptions.useExperimentalFeatures;
+let useExperimenalFeatures = !!cloptions.useExperimentalFeatures;
 
 gulp.task('sass:dev', () =>
   gulp

--- a/src/globals/scss/_feature-flags.scss
+++ b/src/globals/scss/_feature-flags.scss
@@ -5,13 +5,41 @@
 // Initialize our feature flag map with default values
 $feature-flags: () !default;
 
-$feature-flags: map-merge(
-  (
-    components-x: false,
-    ui-shell: false,
-  ),
-  $feature-flags
+// Default feature flag values
+$default-feature-flags: (
+  components-x: false,
+  ui-shell: false,
 );
+
+$did-warn-diverged-feature-flags: false !default !global;
+
+/// Look for user-defined feature flags that are different from default ones,
+/// and warn them before merging them.
+/// @param {Map} $dst - The feature flags to merge to (default feature flags).
+/// @param {Map} $src - The feature flags to merge from (user-defined feature flags).
+/// @returns {Map} - The result of `map-merge($dst, $src)`.
+@function merge-feature-flags($dst, $src) {
+  @if (not $did-warn-diverged-feature-flags) {
+    $diverged: ();
+
+    @each $name, $value in $src {
+      @if (map-has-key($dst, $name) == true and map-get($dst, $name) != $value) {
+        $diverged: append($diverged, $name);
+      }
+    }
+
+    @if (length($diverged) > 0) {
+      @warn 'Usage of non-default feature flags was found: #{$diverged}. ' +
+        'Feature/code under non-default feature flags are either experimental, deprecated, or support for edge cases. ' +
+        'They are subject to change any time. Use them at your own risk.';
+      $did-warn-diverged-feature-flags: true !global;
+    }
+  }
+
+  @return map-merge($dst, $src);
+}
+
+$feature-flags: merge-feature-flags($default-feature-flags, $feature-flags);
 
 // We supported a flag for experimental grid in the past that we want to keep
 // supporting till our next major release. These two @if statements will assign


### PR DESCRIPTION
This change is for emit a warning in our Sass build, for usage of non-default feature flags. Non-default feature flags are for experimental features, deprecated features or features covering (very) edge cases, and subject to change any time.

#### Changelog

**New**

- Code to detect non-default feature flags in our Sass build.

#### Testing / Reviewing

Testing should make sure our styles are not broken.