### PR TITLE
chore(devenv): use Yarn in CF

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,6 +1,7 @@
 *
 !package.json
 !server.js
+!yarn.lock
 !demo/
 demo/*
 !demo/demo.js


### PR DESCRIPTION
This change makes CF use Yarn instead of NPM.

#### Changelog

**Changed**

- `.cfignore` not to ignore `yarn.lock`

#### Testing / Reviewing

Testing should ensure `cf push` now works.