### PR TITLE
chore(devenv): introduce link-only mode in component example

### DIFF
--- a/demo/js/components/CodePage/CodePage.js
+++ b/demo/js/components/CodePage/CodePage.js
@@ -17,6 +17,7 @@ const CodePage = ({ metadata, hideViewFullRender }) => {
         hideViewFullRender={hideViewFullRender}
         component={metadata.name}
         htmlFile={metadata.renderedContent}
+        linkOnly={metadata.linkOnly}
         useIframe={metadata.useIframe}
       />
     ) : (
@@ -28,6 +29,7 @@ const CodePage = ({ metadata, hideViewFullRender }) => {
             variant={item.handle.replace(/--default$/, '')}
             component={metadata.name}
             htmlFile={item.renderedContent}
+            linkOnly={metadata.linkOnly}
             useIframe={metadata.useIframe}
           />
         </div>

--- a/demo/js/components/ComponentExample/ComponentExample.js
+++ b/demo/js/components/ComponentExample/ComponentExample.js
@@ -34,6 +34,11 @@ class ComponentExample extends Component {
     hideViewFullRender: PropTypes.bool,
 
     /**
+     * `true` to use a link (only) for the live demo.
+     */
+    linkOnly: PropTypes.bool,
+
+    /**
      * `true` to use `<iframe>`.
      */
     useIframe: PropTypes.bool,
@@ -86,16 +91,18 @@ class ComponentExample extends Component {
    */
   _instantiateComponents = () => {
     const container = this._container;
-    const components = {
-      ...(container.ownerDocument.defaultView.CarbonComponents || {}),
-      InlineLoadingDemoButton,
-    };
-    const componentClasses = Object.keys(components)
-      .map(key => components[key])
-      .filter(Clz => typeof Clz.init === 'function');
-    componentClasses.filter(Clz => !Clz.forLazyInit).forEach(Clz => {
-      Clz.init(container);
-    });
+    if (container) {
+      const components = {
+        ...(container.ownerDocument.defaultView.CarbonComponents || {}),
+        InlineLoadingDemoButton,
+      };
+      const componentClasses = Object.keys(components)
+        .map(key => components[key])
+        .filter(Clz => typeof Clz.init === 'function');
+      componentClasses.filter(Clz => !Clz.forLazyInit).forEach(Clz => {
+        Clz.init(container);
+      });
+    }
   };
 
   /**
@@ -103,25 +110,27 @@ class ComponentExample extends Component {
    */
   _releaseComponents = () => {
     const container = this._container;
-    const components = {
-      ...(container.ownerDocument.defaultView.CarbonComponents || {}),
-      InlineLoadingDemoButton,
-    };
-    Object.keys(components)
-      .map(key => components[key])
-      .filter(Clz => typeof Clz.init === 'function')
-      .forEach(Clz => {
-        forEach.call(container.querySelectorAll(Clz.options.selectorInit), element => {
-          const instance = Clz.components.get(element);
-          if (instance) {
-            instance.release();
-          }
+    if (container) {
+      const components = {
+        ...(container.ownerDocument.defaultView.CarbonComponents || {}),
+        InlineLoadingDemoButton,
+      };
+      Object.keys(components)
+        .map(key => components[key])
+        .filter(Clz => typeof Clz.init === 'function')
+        .forEach(Clz => {
+          forEach.call(container.querySelectorAll(Clz.options.selectorInit), element => {
+            const instance = Clz.components.get(element);
+            if (instance) {
+              instance.release();
+            }
+          });
         });
-      });
+    }
   };
 
   render() {
-    const { htmlFile, component, variant, codepenSlug, hideViewFullRender, useIframe } = this.props;
+    const { htmlFile, component, variant, codepenSlug, hideViewFullRender, linkOnly, useIframe } = this.props;
 
     const classNamesContainer = classnames('component-example__live', {
       'component-example__live--with-iframe': useIframe,
@@ -136,46 +145,58 @@ class ComponentExample extends Component {
       'bx--global-light-ui': component === 'tabs',
     });
 
+    const viewFullRenderClassNames = classnames({
+      'component-example__view-full-render': true,
+      'component-example__view-full-render--link-only': linkOnly,
+    });
+
     const codepenLink = codepenSlug && `https://codepen.io/team/carbon/full/${codepenSlug}/`;
     const variantSuffix = (component === variant && '--default') || '';
     const componentLink = variant ? `/component/${variant}${variantSuffix}` : `/component/${component}`;
 
     const viewFullRender = hideViewFullRender ? null : (
-      <Link className="component-example__view-full-render" target="_blank" href={codepenLink || componentLink}>
+      <Link className={viewFullRenderClassNames} target="_blank" href={codepenLink || componentLink}>
         {codepenLink ? 'View on CodePen' : 'View full render'}
       </Link>
     );
 
-    /* eslint-disable react/no-danger */
+    let liveExample = null;
+    if (useIframe) {
+      liveExample = (
+        <iframe
+          className={classNames}
+          data-role="window"
+          src={componentLink}
+          sandbox="allow-same-origin allow-scripts allow-forms"
+          marginWidth="0"
+          marginHeight="0"
+          frameBorder="0"
+          vspace="0"
+          hspace="0"
+          scrolling="yes"
+          ref={this._setContainer}
+        />
+      );
+    } else if (!linkOnly) {
+      /* eslint-disable react/no-danger */
+      liveExample = (
+        <div className={classNames}>
+          <div dangerouslySetInnerHTML={{ __html: htmlFile }} ref={this._setContainer} />}
+        </div>
+      );
+      /* eslint-enable react/no-danger */
+    }
+
     return (
       <div className={lightUIclassnames}>
         <div className="svg--sprite" aria-hidden="true" />
         <div className={classNamesContainer}>
-          {useIframe ? (
-            <iframe
-              className={classNames}
-              data-role="window"
-              src={componentLink}
-              sandbox="allow-same-origin allow-scripts allow-forms"
-              marginWidth="0"
-              marginHeight="0"
-              frameBorder="0"
-              vspace="0"
-              hspace="0"
-              scrolling="yes"
-              ref={this._setContainer}
-            />
-          ) : (
-            <div className={classNames}>
-              <div dangerouslySetInnerHTML={{ __html: htmlFile }} ref={this._setContainer} />
-            </div>
-          )}
+          {liveExample}
           {viewFullRender}
         </div>
         <CodeExample htmlFile={htmlFile} />
       </div>
     );
-    /* eslint-enable react/no-danger */
   }
 }
 

--- a/demo/js/components/ComponentExample/component-example.scss
+++ b/demo/js/components/ComponentExample/component-example.scss
@@ -35,4 +35,8 @@
     padding: 0.5rem 1rem;
     z-index: 9999;
   }
+
+  &__view-full-render--link-only {
+    position: relative;
+  }
 }

--- a/demo/views/demo-nav-data.hbs
+++ b/demo/views/demo-nav-data.hbs
@@ -3,11 +3,15 @@
     'detail-page-header',
     'footer',
     'grid',
-    'unified-header',
-    'ui-shell',
+    'unified-header'
+  ];
+  var linkOnly = [
+    'ui-shell'
   ];
   var componentItems = {{{JSONstringify componentItems}}}.map(function (item) {
-    if (needIframe.indexOf(item.name) >= 0) {
+    if (linkOnly.indexOf(item.name) >= 0) {
+      item.linkOnly = true;
+    } else if (needIframe.indexOf(item.name) >= 0) {
       item.useIframe = true;
     }
     return item;


### PR DESCRIPTION
Workarounds BrowserSync/browser-sync#650.

#### Changelog

**New**

- `linkOnly` prop in `<ComponentExample>` in dev env, that stops showing the live demo in nav mode and puts (only) the link to live demo instead

**Changed**

- UI shell demo to use above `linkOnly` mode

#### Testing / Reviewing

Testing should make sure our dev env is not broken.