### PR TITLE
feat(accordion): support div as title

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -71,6 +71,9 @@
 
   .#{$prefix}--accordion__title {
     margin: $accordion-title-margin;
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 400;
   }
 
   .#{$prefix}--accordion__content {

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -70,9 +70,9 @@
   }
 
   .#{$prefix}--accordion__title {
+    @include typescale('epsilon');
+    @include line-height('body');
     margin: $accordion-title-margin;
-    font-size: 1rem;
-    line-height: 1.5;
     font-weight: 400;
   }
 

--- a/src/components/accordion/accordion.hbs
+++ b/src/components/accordion/accordion.hbs
@@ -5,7 +5,7 @@
         <svg class="bx--accordion__arrow" width="7" height="12" viewBox="0 0 7 12">
           <path fill-rule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
         </svg>
-        <p class="bx--accordion__title">{{title}}</p>
+        <div class="bx--accordion__title">{{title}}</div>
       </button>
       <div id="{{paneId}}" class="bx--accordion__content">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna


### PR DESCRIPTION
Refs IBM/carbon-components-react#1178.

#### Changelog

**New**

- Some style to support `<div>` as accordion title.

#### Testing / Reviewing

Testing should make sure accordion is not broken, even if a consumer keeps using `<p>` as accordion title.
