### PR TITLE
(Should hold merging until design review completes): feat(form): icon-based form validation UI

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -18,6 +18,7 @@
     flex-direction: column;
     flex: 1;
     align-items: flex-start;
+    position: relative;
   }
 
   .#{$prefix}--form-item--light input,

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -57,6 +57,7 @@
       opacity: 0.5;
       cursor: not-allowed;
       pointer-events: none;
+      order: 4;
     }
 
     & ~ .#{$prefix}--form-requirement {
@@ -69,6 +70,21 @@
       &::before {
         display: none;
       }
+    }
+
+    & ~ .#{$prefix}--form-requirement--inline {
+      position: absolute;
+      right: rem(32px);
+      bottom: 0.625rem;
+      margin-top: 0;
+
+      svg path {
+        fill: $support-01;
+      }
+    }
+
+    & ~ .#{$prefix}--form-requirement--inline ~ .#{$prefix}--number__controls {
+      bottom: 0.625rem;
     }
   }
 

--- a/src/components/number-input/number-input.config.js
+++ b/src/components/number-input/number-input.config.js
@@ -9,12 +9,20 @@ module.exports = {
         Number inputs are similar to text fields, but contain controls used to increase or decrease an incremental value.
         The Number Input component can be passed a starting value, a min, a max, and the step.
       `,
+      context: {
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
+      },
     },
     {
       name: 'light',
       label: 'Number Input (Light)',
       context: {
         light: true,
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
       },
     },
   ],

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -40,6 +40,39 @@
 </div>
 
 <div class="bx--form-item">
+  <div data-invalid data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}}">
+    <label for="number-input" class="bx--label">Number Input label</label>
+    <input id="number-input" type="number" min="0" max="100" value="1">
+    <div class="bx--form-requirement--inline" aria-describedby="{{tooltipId}}">
+      <div data-tooltip-trigger data-tooltip-supports-hover data-tooltip-target="#{{tooltipId}}" role="tooltip" class="bx--tooltip__trigger">
+        <div role="button" tabindex="0" aria-haspopup="true" aria-expanded="false">
+          <svg fill-rule="evenodd" height="16" role="img" viewBox="0 0 16 16" width="16" aria-label="tooltip" alt="tooltip">
+            <title>tooltip</title>
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z"></path>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div class="bx--number__controls">
+      <button class="bx--number__control-btn up-icon">
+        <svg width="10" height="5" viewBox="0 0 10 5">
+          <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
+        </svg>
+      </button>
+      <button class="bx--number__control-btn down-icon">
+        <svg width="10" height="5" viewBox="0 0 10 5">
+          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+<div id="{{tooltipId}}" data-floating-menu-direction="bottom" class="bx--tooltip" data-avoid-focus-on-open>
+  <span class="bx--tooltip__caret"></span>
+  <p>Invalid number</p>
+</div>
+
+<div class="bx--form-item">
   <div data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}}">
     <label for="number-input" class="bx--label">Number Input label</label>
     <input id="number-input" type="number" min="0" max="100" value="1">

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -79,6 +79,17 @@
         display: none;
       }
     }
+
+    & ~ .#{$prefix}--form-requirement--inline {
+      position: absolute;
+      right: rem(32px);
+      bottom: 0.625rem;
+      margin-top: 0;
+
+      svg path {
+        fill: $support-01;
+      }
+    }
   }
 
   .#{$prefix}--select--light .#{$prefix}--select-input {

--- a/src/components/select/select.config.js
+++ b/src/components/select/select.config.js
@@ -97,5 +97,40 @@ module.exports = {
         items,
       },
     },
+    {
+      name: 'invalid-inline',
+      label: 'Select (Invalid inline)',
+      context: {
+        invalidInline: true,
+        items,
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
+      },
+    },
+    {
+      name: 'inline-invalid-inline',
+      label: 'Inline Select (Invalid inline)',
+      context: {
+        inline: true,
+        invalidInline: true,
+        items,
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
+      },
+    },
+    {
+      name: 'light-invalid-inline',
+      label: 'Select (Light/Invalid inline)',
+      context: {
+        light: true,
+        invalidInline: true,
+        items,
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
+      },
+    },
   ],
 };

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -18,9 +18,25 @@
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>
     {{#if invalid}}
-    <div class="bx--form-requirement">
-      Validation message here
-    </div>
+      <div class="bx--form-requirement">
+        Validation message here
+      </div>
+    {{/if}}
+    {{#if invalidInline}}
+      <div class="bx--form-requirement--inline">
+        <div data-tooltip-trigger data-tooltip-supports-hover data-tooltip-target="#{{tooltipId}}" role="tooltip" class="bx--tooltip__trigger">
+          <div role="button" tabindex="0" aria-haspopup="true" aria-expanded="false">
+            <svg fill-rule="evenodd" height="16" role="img" viewBox="0 0 16 16" width="16" aria-label="tooltip" alt="tooltip">
+              <title>tooltip</title>
+              <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z"></path>
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div id="{{tooltipId}}" data-floating-menu-direction="bottom" class="bx--tooltip" data-avoid-focus-on-open>
+        <span class="bx--tooltip__caret"></span>
+        <p>Validation message here</p>
+      </div>
     {{/if}}
   </div>
 </div>

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -74,6 +74,17 @@
         display: none;
       }
     }
+
+    & ~ .#{$prefix}--form-requirement--inline {
+      position: absolute;
+      right: rem(12px);
+      bottom: 0.625rem;
+      margin-top: 0;
+
+      svg path {
+        fill: $support-01;
+      }
+    }
   }
 
   .#{$prefix}--text-input--light {

--- a/src/components/text-input/text-input.config.js
+++ b/src/components/text-input/text-input.config.js
@@ -10,12 +10,20 @@ module.exports = {
         field is used when the input anticipated by the user is a single line of
         text as opposed to a paragraph.
       `,
+      context: {
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
+      },
     },
     {
       name: 'light',
       label: 'Text Input (Light)',
       context: {
         light: true,
+        tooltipId: `__carbon-tooltip_${Math.random()
+          .toString(36)
+          .substr(2)}`,
       },
     },
   ],

--- a/src/components/text-input/text-input.hbs
+++ b/src/components/text-input/text-input.hbs
@@ -12,6 +12,25 @@
 </div>
 
 <div class="bx--form-item">
+  <label for="text-input-4" class="bx--label">Text Input label</label>
+  <input data-invalid id="text-input-4" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Optional placeholder text">
+  <div class="bx--form-requirement--inline" aria-describedby="{{tooltipId}}">
+    <div data-tooltip-trigger data-tooltip-supports-hover data-tooltip-target="#{{tooltipId}}" role="tooltip" class="bx--tooltip__trigger">
+      <div role="button" tabindex="0" aria-haspopup="true" aria-expanded="false">
+        <svg fill-rule="evenodd" height="16" role="img" viewBox="0 0 16 16" width="16" aria-label="tooltip" alt="tooltip">
+          <title>tooltip</title>
+          <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z"></path>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="{{tooltipId}}" data-floating-menu-direction="bottom" class="bx--tooltip" data-avoid-focus-on-open>
+  <span class="bx--tooltip__caret"></span>
+  <p>Validation message here</p>
+</div>
+
+<div class="bx--form-item">
   <label for="text-input-5" class="bx--label">Text Input label</label>
   <input id="text-input-5" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Optional placeholder text">
   <div class="bx--form__helper-text">


### PR DESCRIPTION
Refs IBM/carbon-components-react#1213.

![image](https://user-images.githubusercontent.com/1259051/45472368-051f7280-b76f-11e8-9374-7194e0d8806e.png)

Took tooltip approach rather than "icon plus message at the bottom” one to better align with the proposed table full edit UI. Having brought up table full edit UI, the code should serve some basis for table full edit’s form validation code.

#### Changelog

**New**

- New form validation UI with tooltip, for text input, number input and select. (Didn’t do text area as text area tends to have large UI and it raises “where the icon should be put?” question and means there should be enough screen estate for regular form validation message - But let us know there are better ideas)
- Hover-over tooltip code, brought back from `v8`, but now activated only when `data-tooltip-supports-hover` attribute is there in where `data-tooltip` is

#### Testing / Reviewing

Testing should make sure the new form validation UI works well, and existing form elements won’t be broken.