### PR TITLE
feat(dropdown): a way to skip keyboard nav for hidden item

### DIFF
--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -55,12 +55,13 @@ dropdownInstance.select(document.getElementById('my-dropdown-link-1'));
 
 #### Options
 
-| Option               | Default Selector        | Description                                                           |
-| -------------------- | ----------------------- | --------------------------------------------------------------------- |
-| selectorInit         | [data-dropdown]         | The selector to find the dropdown component                           |
-| selectorItem         | .bx--dropdown-link      | The selector to find the clickable area in the selected dropdown item |
-| selectorItemSelected | .bx--dropdown--selected | The selector to find the clickable area in the selected dropdown item |
-| classSelected        | bx--dropdown--selected  | The class for the selected dropdown item.                             |
+| Option               | Default Selector              | Description                                                                                      |
+| -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ |
+| selectorInit         | [data-dropdown]               | The selector to find the dropdown component                                                      |
+| selectorItem         | .bx--dropdown-link            | The selector to find the clickable area in the selected dropdown item                            |
+| selectorItemSelected | .bx--dropdown--selected       | The selector to find the clickable area in the selected dropdown item                            |
+| selectorItemHidden   | [hidden],[aria-hidden="true"] | The selector to find hidden dropdown items. Used to skip dropdown items for keyboard navigation. |
+| classSelected        | bx--dropdown--selected        | The class for the selected dropdown item.                                                        |
 
 #### Events
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -128,7 +128,11 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
       return items[handleUnderflow(handleOverflow(index, items.length), items.length)];
     };
     for (let current = getNextItem(start); current && current !== start; current = getNextItem(current)) {
-      if (!current.matches(this.options.selectorItemSelected)) {
+      if (
+        !current.matches(this.options.selectorItemHidden) &&
+        !current.parentNode.matches(this.options.selectorItemHidden) &&
+        !current.matches(this.options.selectorItemSelected)
+      ) {
         current.focus();
         break;
       }
@@ -201,6 +205,9 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @property {string} [selectorText] The CSS selector to find the element showing the selected item.
    * @property {string} [selectorTextInner] The CSS selector to find the element showing the selected item, used for inline mode.
    * @property {string} [selectorItem] The CSS selector to find clickable areas in dropdown items.
+   * @property {string} [selectorItemHidden]
+   *   The CSS selector to find hidden dropdown items.
+   *   Used to skip dropdown items for keyboard navigation.
    * @property {string} [selectorItemSelected] The CSS selector to find the clickable area in the selected dropdown item.
    * @property {string} [classSelected] The CSS class for the selected dropdown item.
    * @property {string} [classOpen] The CSS class for the open state.
@@ -218,6 +225,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
       selectorTextInner: `.${prefix}--dropdown-text__inner`,
       selectorItem: `.${prefix}--dropdown-link`,
       selectorItemSelected: `.${prefix}--dropdown--selected`,
+      selectorItemHidden: `[hidden],[aria-hidden="true"]`,
       classSelected: `${prefix}--dropdown--selected`,
       classOpen: `${prefix}--dropdown--open`,
       classDisabled: `${prefix}--dropdown--disabled`,

--- a/tests/spec/dropdown_spec.js
+++ b/tests/spec/dropdown_spec.js
@@ -288,6 +288,10 @@ describe('Dropdown', function() {
     beforeEach(function() {
       itemNodes.forEach(item => {
         item.classList.remove('bx--dropdown--selected');
+        item.removeAttribute('hidden');
+        item.parentNode.removeAttribute('hidden');
+        item.removeAttribute('aria-hidden');
+        item.parentNode.removeAttribute('aria-hidden');
       });
       element.classList.add('bx--dropdown--open');
       element.focus();
@@ -415,6 +419,82 @@ describe('Dropdown', function() {
         return itemNodes[0];
       });
       itemNodes[1].classList.add('bx--dropdown--selected');
+      itemNodes.forEach(item => {
+        spyOn(item, 'focus');
+      });
+      const defaultPrevented = !element.dispatchEvent(
+        Object.assign(new CustomEvent('keydown', { cancelable: true }), {
+          which: 40,
+        })
+      );
+      expect(defaultPrevented, 'Canceling event').toBe(true);
+      expect(itemNodes[0].focus, 'Focus on 1st item').not.toHaveBeenCalled();
+      expect(itemNodes[1].focus, 'Focus on 2nd item').not.toHaveBeenCalled();
+      expect(itemNodes[2].focus, 'Focus on 3rd item').toHaveBeenCalledTimes(1);
+    });
+
+    it('Should skip items with hidden link', function() {
+      spyOn(dropdown, 'getCurrentNavigation').and.callFake(function() {
+        return itemNodes[0];
+      });
+      itemNodes[1].setAttribute('hidden', '');
+      itemNodes.forEach(item => {
+        spyOn(item, 'focus');
+      });
+      const defaultPrevented = !element.dispatchEvent(
+        Object.assign(new CustomEvent('keydown', { cancelable: true }), {
+          which: 40,
+        })
+      );
+      expect(defaultPrevented, 'Canceling event').toBe(true);
+      expect(itemNodes[0].focus, 'Focus on 1st item').not.toHaveBeenCalled();
+      expect(itemNodes[1].focus, 'Focus on 2nd item').not.toHaveBeenCalled();
+      expect(itemNodes[2].focus, 'Focus on 3rd item').toHaveBeenCalledTimes(1);
+    });
+
+    it('Should skip items with hidden container', function() {
+      spyOn(dropdown, 'getCurrentNavigation').and.callFake(function() {
+        return itemNodes[0];
+      });
+      itemNodes[1].parentNode.setAttribute('hidden', '');
+      itemNodes.forEach(item => {
+        spyOn(item, 'focus');
+      });
+      const defaultPrevented = !element.dispatchEvent(
+        Object.assign(new CustomEvent('keydown', { cancelable: true }), {
+          which: 40,
+        })
+      );
+      expect(defaultPrevented, 'Canceling event').toBe(true);
+      expect(itemNodes[0].focus, 'Focus on 1st item').not.toHaveBeenCalled();
+      expect(itemNodes[1].focus, 'Focus on 2nd item').not.toHaveBeenCalled();
+      expect(itemNodes[2].focus, 'Focus on 3rd item').toHaveBeenCalledTimes(1);
+    });
+
+    it('Should skip items with link with aria-hidden', function() {
+      spyOn(dropdown, 'getCurrentNavigation').and.callFake(function() {
+        return itemNodes[0];
+      });
+      itemNodes[1].setAttribute('aria-hidden', 'true');
+      itemNodes.forEach(item => {
+        spyOn(item, 'focus');
+      });
+      const defaultPrevented = !element.dispatchEvent(
+        Object.assign(new CustomEvent('keydown', { cancelable: true }), {
+          which: 40,
+        })
+      );
+      expect(defaultPrevented, 'Canceling event').toBe(true);
+      expect(itemNodes[0].focus, 'Focus on 1st item').not.toHaveBeenCalled();
+      expect(itemNodes[1].focus, 'Focus on 2nd item').not.toHaveBeenCalled();
+      expect(itemNodes[2].focus, 'Focus on 3rd item').toHaveBeenCalledTimes(1);
+    });
+
+    it('Should skip items with container with aria-hidden', function() {
+      spyOn(dropdown, 'getCurrentNavigation').and.callFake(function() {
+        return itemNodes[0];
+      });
+      itemNodes[1].parentNode.setAttribute('aria-hidden', 'true');
       itemNodes.forEach(item => {
         spyOn(item, 'focus');
       });


### PR DESCRIPTION
Fixes #1107.

#### Changelog

**New**

- `selectorItemHidden` option in `Dropdown` class, to let keyboard navigation code skip dropdown items matching that selector.

#### Testing / Reviewing

Testing should make sure dropdown is not broken.