### PR TITLE
fix(modal): prevent escape key event from bubbling up

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -131,6 +131,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
     this._handleKeydownListener = this.manage(
       on(this.element.ownerDocument.body, 'keydown', evt => {
         if (evt.which === 27) {
+          evt.stopPropagation();
           this.hide(evt);
         }
       })


### PR DESCRIPTION
Closes #https://github.com/IBM/carbon-components/issues/1109

Prevent escape keypress from bubbling up and possibly closing other elements

#### Changelog

**New**

- Added `evt.stopPropagation()` to `Modal` `_handleKeydownListener`


