### PR TITLE
fix(ui-shell): make updates to platform header and nav

### DIFF
--- a/src/components/ui-shell/README.md
+++ b/src/components/ui-shell/README.md
@@ -1,5 +1,26 @@
 # UI Shell
 
+## Platform Navigation
+
+Platform Navigation has the following cases for configuration:
+
+- Can have one or more sections. A section is a collection of links or categories.
+- A link will have to have an href and title, and optionally an icon.
+- A category will have a collection of links, and optionally an icon.
+- State variations:
+  - Item link
+  - Item link selected
+  - Item link with icon
+  - Item link with icon and selected
+  - Category collapsed
+  - Category expanded
+  - Category with icon and collapsed
+  - Category with icon and expanded
+  - Category item
+  - Category item selected
+  - Category with icon and category item
+  - Category with icon and category item selected
+
 ## Tokens
 
 ## Header & header-panel

--- a/src/components/ui-shell/_platform-header.scss
+++ b/src/components/ui-shell/_platform-header.scss
@@ -53,12 +53,15 @@
   //--------------------------------------------------------------------------
   a.#{$prefix}--platform-header__name {
     text-decoration: none;
-    // TODO: sync type styles
     font-size: rem(14px);
-    font-weight: 600;
+    font-weight: 400;
     letter-spacing: 0.1px;
     line-height: 20px;
     user-select: none;
+  }
+
+  .#{$prefix}--platform-header__platform-name {
+    font-weight: 600;
   }
 
   a.#{$prefix}--platform-header__name,
@@ -75,7 +78,7 @@
 
   .#{$prefix}--platform-header__links {
     display: flex;
-    margin-left: units(34);
+    margin-left: units(3);
     height: 100%;
   }
 

--- a/src/components/ui-shell/_platform-nav.scss
+++ b/src/components/ui-shell/_platform-nav.scss
@@ -39,8 +39,25 @@
   // Platform Nav Item
   //----------------------------------------------------------------------------
   .#{$prefix}--platform__nav-item {
+    position: relative;
     display: flex;
     align-items: center;
+  }
+
+  .#{$prefix}--platform__nav-item--active > a.#{$prefix}--platform__nav-link {
+    color: $ibm-colors__white;
+    font-weight: bold;
+  }
+
+  .#{$prefix}--platform__nav-item--active::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    background-color: $ibm-colors__blue--60;
   }
 
   //----------------------------------------------------------------------------
@@ -54,6 +71,8 @@
     font-size: rem(14px);
     font-weight: 400;
     width: 100%;
+    min-height: get-fixed-size(5);
+    padding-left: get-fixed-size(2);
   }
 
   a.#{$prefix}--platform__nav-link:hover {
@@ -64,6 +83,10 @@
   a.#{$prefix}--platform__nav-link:focus {
     outline: get-fixed-size(0.5) solid $ibm-colors__blue--60;
     outline-offset: get-fixed-size(-0.5);
+  }
+
+  .#{$prefix}--platform__nav-item--icon > a.#{$prefix}--platform__nav-link {
+    padding-left: 0;
   }
 
   //----------------------------------------------------------------------------
@@ -98,6 +121,12 @@
     color: $ibm-colors__gray--10;
     font-size: rem(14px);
     font-weight: 400;
+    min-height: get-fixed-size(5);
+    padding-left: get-fixed-size(2);
+  }
+
+  .#{$prefix}--platform__nav-item--icon .#{$prefix}--platform__category-title {
+    padding-left: 0;
   }
 
   .#{$prefix}--platform__category-items {
@@ -109,7 +138,31 @@
     display: flex;
     align-items: center;
     min-height: get-fixed-size(5);
+    padding-left: get-fixed-size(4);
+  }
+
+  .#{$prefix}--platform__category-item {
+    position: relative;
+  }
+
+  .#{$prefix}--platform__nav-item--icon .#{$prefix}--platform__category-item > a.#{$prefix}--platform__nav-link {
     padding-left: get-fixed-size(7);
+  }
+
+  .#{$prefix}--platform__category-item--active::after {
+    content: '';
+    position: absolute;
+    display: block;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    background-color: $ibm-colors__blue--60;
+  }
+
+  .#{$prefix}--platform__category-item--active > a.#{$prefix}--platform__nav-link {
+    font-weight: 600;
+    color: $ibm-colors__white;
   }
 
   .#{$prefix}--platform__category--expanded .#{$prefix}--platform__category-title {

--- a/src/components/ui-shell/_platform-nav.scss
+++ b/src/components/ui-shell/_platform-nav.scss
@@ -137,7 +137,7 @@
   .#{$prefix}--platform__category-item > a.#{$prefix}--platform__nav-link {
     display: flex;
     align-items: center;
-    min-height: get-fixed-size(5);
+    min-height: get-fixed-size(4);
     padding-left: get-fixed-size(4);
   }
 

--- a/src/components/ui-shell/_platform-side-nav.scss
+++ b/src/components/ui-shell/_platform-side-nav.scss
@@ -49,6 +49,7 @@ $shell-side-nav-accent-01: $ibm-colors__blue--60;
     transition: width 0.11s cubic-bezier(0.2, 0, 1, 0.9);
     // Useful to toggle this property to see what's going on when not expanded
     overflow: hidden;
+    border-top: 1px solid $ibm-colors__gray--80;
   }
 
   .#{$prefix}--side-nav:hover,
@@ -142,16 +143,6 @@ $shell-side-nav-accent-01: $ibm-colors__blue--60;
     background-color: $shell-side-nav-bg-02;
   }
 
-  .#{$prefix}--side-nav__category--active::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 2px;
-    background-color: $shell-side-nav-accent-01;
-  }
-
   .#{$prefix}--side-nav__category-header {
     display: flex;
     align-items: center;
@@ -193,8 +184,8 @@ $shell-side-nav-accent-01: $ibm-colors__blue--60;
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 2px;
-    width: 3px;
+    left: 0;
+    width: 4px;
     background-color: $shell-side-nav-accent-01;
   }
 
@@ -208,6 +199,11 @@ $shell-side-nav-accent-01: $ibm-colors__blue--60;
     font-weight: 400;
     width: 100%;
     padding-left: get-fixed-size(7);
+  }
+
+  .#{$prefix}--side-nav__category-item--active > a {
+    font-weight: 600;
+    color: $ibm-colors__white;
   }
 
   .#{$prefix}--side-nav__category-item > a:hover {

--- a/src/components/ui-shell/platform-header.hbs
+++ b/src/components/ui-shell/platform-header.hbs
@@ -8,7 +8,7 @@
   {{/if}}
   </button>
   <a class="bx--platform-header__name" href="#" title="{{header.name}}">
-    {{header.name}}
+    {{header.company}} <span class="bx--platform-header__platform-name">{{header.platform}}</span>
   </a>
   {{> platform-header-nav }}
   <div class="bx--platform-header__global">

--- a/src/components/ui-shell/platform-nav.hbs
+++ b/src/components/ui-shell/platform-nav.hbs
@@ -4,14 +4,28 @@
   <div class="bx--platform__nav-section">
     <ul class="bx--platform__nav-items">
       {{#each this.items}}
+        {{#if this.active}}
+          {{#if this.hasIcon}}
+        <li class="bx--platform__nav-item bx--platform__nav-item--active bx--platform__nav-item--icon">
+          {{else}}
+        <li class="bx--platform__nav-item bx--platform__nav-item--active">
+          {{/if}}
+        {{else}}
+          {{#if this.hasIcon}}
+        <li class="bx--platform__nav-item bx--platform__nav-item--icon">
+          {{else}}
         <li class="bx--platform__nav-item">
+          {{/if}}
+        {{/if}}
         {{#eq this.type "link"}}
           <a class="bx--platform__nav-link" href="{{ this.href }}">
+            {{#if this.hasIcon}}
             <div class="bx--platform__nav-icon">
               <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
                 <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
               </svg>
             </div>
+            {{/if}}
             {{ this.title }}
           </a>
         {{/eq}}
@@ -22,12 +36,14 @@
           <div class="bx--platform__category">
           {{/if}}
             <button class="bx--platform__category-toggle" aria-haspopup="true" aria-expanded="true" aria-controls="category-1-menu">
+              {{#if this.hasIcon}}
               <div class="bx--platform__nav-icon">
 
                 <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
                   <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
                 </svg>
               </div>
+              {{/if}}
               <div class="bx--platform__category-title">
                 {{ this.title }}
                 <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
@@ -37,7 +53,11 @@
             </button>
             <ul id="category-1-menu" class="bx--platform__category-items" role="menu">
               {{#each this.links}}
+                {{#if this.active}}
+                <li class="bx--platform__category-item bx--platform__category-item--active">
+                {{else}}
                 <li class="bx--platform__category-item">
+                {{/if}}
                   <a class="bx--platform__nav-link" href="{{ this.href }}" role="menuitem">
                     {{ this.title }}
                   </a>

--- a/src/components/ui-shell/ui-shell.config.js
+++ b/src/components/ui-shell/ui-shell.config.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const header = {
-  name: 'IBM [Platform]',
+  company: 'IBM',
+  platform: '[Platform]',
   links: [
     {
       href: '/component/ui-shell--default',
@@ -45,16 +46,16 @@ const sidenav = {
   },
   links: [
     {
-      category: 'L2 Category',
+      category: 'Category label',
       links: createSidebarLinks(2),
     },
     {
-      category: 'L2 Category',
+      category: 'Category label',
       links: createSidebarLinks(3, 1),
       active: true,
     },
     {
-      category: 'L2 Category',
+      category: 'Category label',
       links: createSidebarLinks(4),
     },
   ],
@@ -69,13 +70,15 @@ const nav = {
       items: [
         {
           type: 'link',
-          title: 'L1 link',
+          title: 'Item link',
           href: '/component/ui-shell--platform-navigation-expanded',
+          hasIcon: true,
         },
         {
           type: 'link',
-          title: 'L1 link',
+          title: 'Item link',
           href: '/component/ui-shell--platform-navigation-expanded',
+          hasIcon: true,
         },
       ],
     },
@@ -83,33 +86,39 @@ const nav = {
       items: [
         {
           type: 'link',
-          title: 'L1 link',
+          title: 'Item link',
           href: '/component/ui-shell--platform-navigation-expanded',
+          hasIcon: true,
+          active: true,
         },
         {
           type: 'link',
-          title: 'L1 link',
+          title: 'Item link',
           href: '/component/ui-shell--platform-navigation-expanded',
+          hasIcon: true,
         },
         {
           type: 'link',
-          title: 'L1 link',
+          title: 'Item link',
           href: '/component/ui-shell--platform-navigation-expanded',
+          hasIcon: true,
         },
         {
           type: 'category',
           title: 'L1 category',
+          hasIcon: true,
           links: [
             {
-              title: 'L2 link',
+              title: 'Nested link',
               href: '/component/ui-shell--platform-navigation-expanded',
             },
             {
-              title: 'L2 link',
+              title: 'Nested link',
               href: '/component/ui-shell--platform-navigation-expanded',
+              active: true,
             },
             {
-              title: 'L2 link',
+              title: 'Nested link',
               href: '/component/ui-shell--platform-navigation-expanded',
             },
           ],
@@ -130,16 +139,16 @@ module.exports = {
     sidenav,
   },
   variants: [
-    {
-      name: 'Side-nav expanded',
-      context: {
-        sidenav: {
-          state: {
-            expanded: true,
-          },
-        },
-      },
-    },
+    // {
+    // name: 'Side-nav expanded',
+    // context: {
+    // sidenav: {
+    // state: {
+    // expanded: true,
+    // },
+    // },
+    // },
+    // },
     {
       name: 'Platform nav expanded',
       context: {
@@ -161,13 +170,32 @@ module.exports = {
         },
       },
     },
+    {
+      name: 'Platform nav with no icons',
+      context: {
+        nav: {
+          state: {
+            expanded: true,
+            category: true,
+          },
+          sections: nav.sections.map(section => {
+            return {
+              items: section.items.map(item => ({
+                ...item,
+                hasIcon: false,
+              })),
+            };
+          }),
+        },
+      },
+    },
   ],
 };
 
 function createSidebarLinks(count, activeIndex) {
   return Array.from({ length: count }, (_, i) => {
     const link = {
-      title: 'L3 link',
+      title: 'Nested link',
       href: '/component/ui-shell--default',
     };
     if (i === activeIndex) {

--- a/src/components/ui-shell/ui-shell.config.js
+++ b/src/components/ui-shell/ui-shell.config.js
@@ -139,16 +139,16 @@ module.exports = {
     sidenav,
   },
   variants: [
-    // {
-    // name: 'Side-nav expanded',
-    // context: {
-    // sidenav: {
-    // state: {
-    // expanded: true,
-    // },
-    // },
-    // },
-    // },
+    {
+      name: 'Side-nav expanded',
+      context: {
+        sidenav: {
+          state: {
+            expanded: true,
+          },
+        },
+      },
+    },
     {
       name: 'Platform nav expanded',
       context: {


### PR DESCRIPTION
Closes #1111 

Makes updates to Platform Header and Navigation from #1111.

#### Changelog

**New**

**Changed**

- For full design changelog view #1111
  - [x] Remove full bar highlight on category expanded. Only highlight on the selected item now.
  - [x] All Selected link text weight: now semi-bold/600
  - [x] All Selected link text color: now #ffffff
  - [x] L1 / Left navigation menu: no longer has background color on selected. Just bar and semi-bolded text
  - [x] L1 / Left navigation menu variation without icons
  - [x] Side-nav panel now has a 1px (gray-80) border at the top
  - [x] L0/header links now start 24px from the edge of the platform/product name. No longer a fixed width distance.
  - [x] "IBM" in header should be regular weight 400 and not bold. The product/platform name (ie Cloud) should remain semi-bold/600

**Removed**

#### Testing / Reviewing

Preview URLs

- [Expanded Platform Navigation](http://carbon-dev-environment-nonlacteous-lich.mybluemix.net/component/ui-shell--platform-nav-with-no-icons)
- [Expanded Platform Navigation with icons](http://carbon-dev-environment-nonlacteous-lich.mybluemix.net/component/ui-shell--platform-nav-category-expanded)
