### PR TITLE
fix(search): ensure search clear icon shows in firefox

### DIFF
--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -75,6 +75,7 @@
     height: 1rem;
     width: 1rem;
     top: calc(50% - 0.5rem);
+    z-index: 1;
   }
 
   .#{$prefix}--search-magnifier {

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -75,6 +75,7 @@
     height: 1rem;
     width: 1rem;
     top: calc(50% - 0.5rem);
+    // Ensure clear icon is rendered in Firefox (#1127)
     z-index: 1;
   }
 


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1127

Add `z-index` to make sure clear icon is visible in Firefox

**New**

- `z-index` to clear icon 

#### Testing / Reviewing

Check search in Firefox
