### PR TITLE
JS feature flags

### DIFF
--- a/demo/js/components/ComponentExample/ComponentExample.js
+++ b/demo/js/components/ComponentExample/ComponentExample.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { Link } from 'carbon-components-react';
 import classnames from 'classnames';
 
+import * as components from '../../../components';
+
 import CodeExample from '../CodeExample/CodeExample';
-import InlineLoadingDemoButton from '../../inline-loading-demo-button';
 
 const forEach = Array.prototype.forEach;
 
@@ -92,10 +93,6 @@ class ComponentExample extends Component {
   _instantiateComponents = () => {
     const container = this._container;
     if (container) {
-      const components = {
-        ...(container.ownerDocument.defaultView.CarbonComponents || {}),
-        InlineLoadingDemoButton,
-      };
       const componentClasses = Object.keys(components)
         .map(key => components[key])
         .filter(Clz => typeof Clz.init === 'function');
@@ -111,10 +108,6 @@ class ComponentExample extends Component {
   _releaseComponents = () => {
     const container = this._container;
     if (container) {
-      const components = {
-        ...(container.ownerDocument.defaultView.CarbonComponents || {}),
-        InlineLoadingDemoButton,
-      };
       Object.keys(components)
         .map(key => components[key])
         .filter(Clz => typeof Clz.init === 'function')

--- a/demo/js/components/RootPage.js
+++ b/demo/js/components/RootPage.js
@@ -271,7 +271,7 @@ class RootPage extends Component {
       }, 100);
       return;
     }
-    const { oldIsComponentsX, componentItems } = this.state;
+    const { isComponentsX: oldIsComponentsX, componentItems } = this.state;
     const isComponentsX = Array.prototype.some.call(
       link.sheet.cssRules,
       rule =>

--- a/demo/js/components/RootPage.js
+++ b/demo/js/components/RootPage.js
@@ -20,6 +20,27 @@ const checkStatus = response => {
 
 /**
  * @param {Object[]} componentItems The components data.
+ * @returns {Object[]} The components data with the contents of all components cleared.
+ */
+const clearContent = componentItems =>
+  componentItems.map(
+    item =>
+      !item.items
+        ? {
+            ...item,
+            renderedContent: undefined,
+          }
+        : {
+            ...item,
+            items: item.items.map(subItem => ({
+              ...subItem,
+              renderedContent: undefined,
+            })),
+          }
+  );
+
+/**
+ * @param {Object[]} componentItems The components data.
  * @param {string} id The component ID.
  * @param {Object|string} content The content. String for component content, object for variant content (keyed by variant ID).
  * @returns {Object[]} The components data with the content of the given component ID populated with the given content.
@@ -250,16 +271,23 @@ class RootPage extends Component {
       }, 100);
       return;
     }
+    const { oldIsComponentsX, componentItems } = this.state;
     const isComponentsX = Array.prototype.some.call(
       link.sheet.cssRules,
       rule =>
         /^\.bx--body$/.test(rule.selectorText) &&
         /^rgb\(255,\s*255,\s*255\)$/.test(rule.style.getPropertyValue('background-color'))
     );
-    this.setState({
-      componentItems: applyComponentsX(this.state.componentItems, isComponentsX),
-      isComponentsX,
-    });
+    if (oldIsComponentsX !== isComponentsX) {
+      this.setState(
+        {
+          // TODO: Load/navigate
+          componentItems: applyComponentsX(clearContent(componentItems), isComponentsX),
+          isComponentsX,
+        },
+        this._populateCurrent
+      );
+    }
   }
 
   /**
@@ -300,6 +328,29 @@ class RootPage extends Component {
   }
 
   /**
+   * Populates the content of current selection.
+   */
+  _populateCurrent() {
+    const { componentItems, selectedNavItemId } = this.state;
+    const metadata = componentItems && componentItems.find(item => item.id === selectedNavItemId);
+    const subItems = metadata.items || [];
+    const hasRenderedContent =
+      !metadata.isCollection && subItems.length <= 1 ? metadata.renderedContent : subItems.every(item => item.renderedContent);
+    if (!hasRenderedContent) {
+      fetch(`/code/${metadata.name}`)
+        .then(checkStatus)
+        .then(response => {
+          const contentType = response.headers.get('content-type');
+          return contentType && contentType.includes('application/json') ? response.json() : response.text();
+        })
+        .then(responseContent => {
+          // Re-evaluate `this.state.componentItems` as it may have been changed during loading contents
+          this.setState({ componentItems: applyContent(this.state.componentItems, selectedNavItemId, responseContent) });
+        });
+    }
+  }
+
+  /**
    * Toggles usage of experimental CSS upon user event.
    * @param {Object} evt The event.
    * @private
@@ -320,22 +371,7 @@ class RootPage extends Component {
       if (name) {
         history.pushState({ name }, name, `/demo/${name}`);
       }
-      const metadata = componentItems && componentItems.find(item => item.id === selectedNavItemId);
-      const subItems = metadata.items || [];
-      const hasRenderedContent =
-        !metadata.isCollection && subItems.length <= 1 ? metadata.renderedContent : subItems.every(item => item.renderedContent);
-      if (!hasRenderedContent) {
-        fetch(`/code/${metadata.name}`)
-          .then(checkStatus)
-          .then(response => {
-            const contentType = response.headers.get('content-type');
-            return contentType && contentType.includes('application/json') ? response.json() : response.text();
-          })
-          .then(responseContent => {
-            // Re-evaluate `this.state.componentItems` as it may have been changed during loading contents
-            this.setState({ componentItems: applyContent(this.state.componentItems, selectedNavItemId, responseContent) });
-          });
-      }
+      this._populateCurrent();
     });
   }
 

--- a/src/globals/js/README.md
+++ b/src/globals/js/README.md
@@ -1,0 +1,62 @@
+# Feature flags
+
+[`feature-flags.js`](./feature-flags.js) contains the list of the default values of compile-time feature flags.
+
+Build toolchain can replace variable here and/or the references in order to apply non-default values to those feature flags.
+
+## Example: Render `foo` if `aFeatureFlag` is `true`, render `bar` otherwise
+
+`my-component.config.js`:
+
+```javascript
+const { aFeatureFlag } = require('/path/to/feature-flags');
+...
+module.exports = {
+  variants: [
+    {
+      name: 'default',
+      label: 'My component',
+      context: {
+        aFeatureFlag,
+        ...
+      },
+    },
+    ...
+  ],
+};
+```
+
+`my-component.hbs`:
+
+```handlebars
+<div>
+  {{#if aFeatureFlag}}
+    foo
+  {{else}}
+    bar
+  {{/if}}
+</div>
+```
+
+## Example: Emit `foo` upon clicking on component's element if `aFeatureFlag` is `true`, emit `bar` otherwise
+
+```javascript
+import mixin from '/path/to/globals/js/misc/mixin';
+import createComponent from '/path/to/globals/js/mixins/create-component';
+import initComponentBySearch from '/path/to/globals/js/mixins/init-component-by-search';
+import handles from '/path/to/globals/js/mixins/handles';
+import on from '/path/to/globals/js/misc/on';
+
+import { aFeatureFlag } from '/path/to/globals/js/feature-flags';
+
+class MyClass extends mixin(createComponent, initComponentBySearch, handles) {
+  constructor(element, options) {
+    super(element, options);
+    this.manage(
+      on(this.element, 'click', () => {
+        console.log(aFeatureFlag ? 'foo' : 'bar');
+      })
+    );
+  }
+}
+```

--- a/src/globals/js/feature-flags.js
+++ b/src/globals/js/feature-flags.js
@@ -1,0 +1,55 @@
+/**
+ * This file contains the list of the default values of compile-time feature flags.
+ *
+ * Build toolchain can replace variable here and/or the references
+ * in order to apply non-default values to those feature flags.
+ *
+ * @example Render `foo` if `aFeatureFlag` is `true`, render `bar` otherwise.
+ * // `my-component.config.js`
+ * const { aFeatureFlag } = require('/path/to/feature-flags');
+ * ...
+ * module.exports = {
+ *   variants: [
+ *     {
+ *       name: 'default',
+ *       label: 'My component',
+ *       context: {
+ *         aFeatureFlag,
+ *         ...
+ *       },
+ *     },
+ *     ...
+ *   ],
+ * };
+ *
+ * // `my-component.hbs`
+ * <div>
+ *   {{#if aFeatureFlag}}
+ *     foo
+ *   {{else}}
+ *     bar
+ *   {{/if}}
+ * </div>
+ *
+ * @example Emit `foo` upon clicking on component's element if `aFeatureFlag` is `true`, emit `bar` otherwise.
+ * import mixin from '/path/to/globals/js/misc/mixin';
+ * import createComponent from '/path/to/globals/js/mixins/create-component';
+ * import initComponentBySearch from '/path/to/globals/js/mixins/init-component-by-search';
+ * import handles from '/path/to/globals/js/mixins/handles';
+ * import on from '/path/to/globals/js/misc/on';
+ *
+ * import { aFeatureFlag } from '/path/to/globals/js/feature-flags';
+ *
+ * class MyClass extends mixin(createComponent, initComponentBySearch, handles) {
+ *   constructor(element, options) {
+ *     super(element, options);
+ *     this.manage(
+ *       on(this.element, 'click', () => {
+ *         console.log(aFeatureFlag ? 'foo' : 'bar');
+ *       })
+ *     );
+ *   }
+ * }
+ */
+
+exports.componentsX = false;

--- a/tools/INTERNALS.md
+++ b/tools/INTERNALS.md
@@ -1,0 +1,39 @@
+# Theme switcher
+
+The theme switcher allows Carbon developers/contributors to switch experimental Carbon theme in our vanilla development environment.
+The theme switcher involves several internal mechanisms.
+This section explains some of those.
+
+## Temporary JavaScript feature flags
+
+The build toolchain has a mechanism to create a temporary feature flags (`demo/feature-flags.js`) from the original JavaScript feature flags (`src/globals/js/feature-flags.js`).
+Tempoary feature flags contain the effective feature flag values, which changes upon theme switcher.
+
+In our vanilla development environment, requests for the original JavaScript feature flags (`src/globals/js/feature-flags.js`) are re-routed to temporary feature flags (`demo/feature-flags.js`) to reflect the up-to-date feature flag values in the UI.
+
+## Theme switcher server
+
+There is a mini-server implemented with [vanilla node.js HTTP API](https://nodejs.org/api/http.html) as [a Gulp task](https://github.com/IBM/carbon-components/blob/v9.23.0/gulpfile.js#L280-L302), that triggers build tasks associated with theme change, with its new effective feature flag values:
+
+1. Sass build
+2. Build to create a tempoarary JavaScript feature flags
+
+When [the theme switcher toggle button](https://github.com/IBM/carbon-components/blob/v9.23.0/demo/js/components/RootPage.js#L357-L364) is clicked on, it simply sends a request to [the theme switcher server](https://github.com/IBM/carbon-components/blob/v9.23.0/demo/js/components/RootPage.js#L302-L309).
+The builds described above will trigger subsequent UI updates.
+
+## Detecting change in temporary JavaScript feature flags
+
+When change in temporary JavaScript feature flags are detected, the following happens:
+
+1. Invalidation of some caches:
+   - [Handlebars templates and their configurations (`.config.js`)](https://github.com/IBM/carbon-components/blob/v9.23.0/tools/templates.js#L65)
+   - node.js module cache for temporary JavaScript feature flags
+2. WebPack (partial) build with the temporary JavaScript feature flags, which auto-updates the component JavaScript code
+
+## Detecting new effective theme
+
+Once Sass build finishes upon switching theme, [code to detect effective CSSOM](https://github.com/IBM/carbon-components/blob/v9.23.0/demo/js/components/RootPage.js#L276-L300), and then [code to detect effective theme](https://github.com/IBM/carbon-components/blob/v9.23.0/demo/js/components/RootPage.js#L230-L263) run. The latter updates UI states, which causes:
+
+1. [Update the theme switcher toggle button](https://github.com/IBM/carbon-components/blob/v9.23.0/demo/js/components/RootPage.js#L362)
+2. [Update shown/hidden states of some components with the new detected theme](https://github.com/IBM/carbon-components/blob/v9.23.0/demo/js/components/RootPage.js#L84-L101)
+3. Reload the component demo HTML with the fresh Handlebars template/configuration

--- a/tools/rollup.config.js
+++ b/tools/rollup.config.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     resolve(),
     commonjs({
-      include: 'node_modules/**',
+      include: ['node_modules/**', 'src/globals/js/feature-flags.js'],
       sourceMap: false,
     }),
     babel({

--- a/tools/webpack.dev.config.js
+++ b/tools/webpack.dev.config.js
@@ -4,6 +4,26 @@ const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 
+class FeatureFlagProxyPlugin {
+  /**
+   * A WebPack resolver plugin that proxies module request
+   * for `src/globals/js/feature-flags` to `demo/js/feature-flags`,
+   * which is a file generated from `src/globals/js/feature-flags` with effective feature flag values.
+   */
+  constructor() {
+    this.source = 'before-described-relative';
+  }
+
+  apply(resolver) {
+    resolver.plugin(this.source, (request, callback) => {
+      if (/feature-flags$/i.test(request.path)) {
+        request.path = path.resolve(__dirname, '../demo/feature-flags');
+      }
+      callback();
+    });
+  }
+}
+
 module.exports = {
   devtool: 'source-maps',
   entry: ['webpack-hot-middleware/client?reload=true', path.resolve(__dirname, '../demo/index')],
@@ -51,6 +71,7 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules'],
+    plugins: [new FeatureFlagProxyPlugin()],
   },
   plugins: [new webpack.ProgressPlugin(), new webpack.HotModuleReplacementPlugin()],
 };


### PR DESCRIPTION
Fixes #1149. This change introduces feature flags for vanilla JavaScript, which works for:

1. Conditionally render contents upon feature flags, in our Handlbebars code
2. Conditionally execute our vanilla JavaScript component code

#### Changelog

**New**

- [`src/globals/js/feature-flags.js`](https://github.com/IBM/carbon-components/commit/a5718d3b00f0067d6ded17454c541f7f50e2bc5c#diff-472b70a50eac6910b895d2920bb5aa83) - Written in CJS instead of EJS, given it's used for back-end (Handlebars) code as well
- The following dev env, to switch feature flag values back and force upon clicking on theme switcher:
    - A document explaining all the following: https://github.com/IBM/carbon-components/blob/a5718d3b00f0067d6ded17454c541f7f50e2bc5c/tools/INTERNALS.md
    - [Code (in `gulpfile.js`)](https://github.com/IBM/carbon-components/blob/a5718d3b00f0067d6ded17454c541f7f50e2bc5c/gulpfile.js#L157-L171) to generate temporary feature flags (`demo/feature-flags.js`) that reflects effective feature flag values in dev env, from original feature flags (`src/globals/js/feature-flags.js`)
    - A mechanism to re-route `src/globals/js/feature-flags.js` imports to `demo/feature-flags.js`, to reflect effective feature flag values in dev env ([in `server.js`](https://github.com/IBM/carbon-components/blob/a5718d3b00f0067d6ded17454c541f7f50e2bc5c/server.js#L55-L61) and a [change to `webpack.dev.config.js`](https://github.com/IBM/carbon-components/commit/a5718d3b00f0067d6ded17454c541f7f50e2bc5c#diff-ee328e04a04a023b25141cf8c0346dae))
    - A mechanism to clear component HTML cache, upon toggling theme switcher ([change to `RootPage.js`](https://github.com/IBM/carbon-components/commit/a5718d3b00f0067d6ded17454c541f7f50e2bc5c#diff-365cc59d22ba265b0b71ebf7dd28e550))
    - A mechanism to clear [server-side Handlebars template/config cache](https://github.com/IBM/carbon-components/blob/a5718d3b00f0067d6ded17454c541f7f50e2bc5c/server.js#L33) as well as [node.js module cache of `demo/feature-flags.js`](https://github.com/IBM/carbon-components/blob/a5718d3b00f0067d6ded17454c541f7f50e2bc5c/server.js#L31), upon toggling theme switcher (in `server.js`)
    - Code to ensure WebPack HMR works for vanilla JavaScript component code, upon toggling theme switcher ([change to `ComponentExamples.js`](https://github.com/IBM/carbon-components/commit/a5718d3b00f0067d6ded17454c541f7f50e2bc5c#diff-fd2ea6152cec15f55affc445edf0830e))

#### Testing / Reviewing

Testing should make sure our dev env and builds are not broken.