### PR TITLE
chore(components): warn some deprecated components

### DIFF
--- a/src/components/carousel/_carousel.scss
+++ b/src/components/carousel/_carousel.scss
@@ -8,79 +8,81 @@
 @import '../../globals/scss/css--typography';
 
 @include exports('carousel') {
-  .#{$prefix}--carousel {
-    display: flex;
-    align-items: center;
-  }
-  .#{$prefix}--carousel-container {
-    max-width: rem(810px);
-    overflow: hidden;
-    padding: 0 1px;
-  }
-  .#{$prefix}--filmstrip {
-    display: flex;
-    justify-content: space-between;
-    transition: transform 100ms $carbon--ease-in;
-    padding: rem(24px) 0;
-    width: auto;
-  }
-  .#{$prefix}--filmstrip-btn {
-    @include button-reset;
-    height: rem(20px);
-    width: rem(20px);
-    margin-bottom: 1rem;
-    margin-right: rem(3px);
-    margin-left: rem(3px);
+  @include deprecate('`carousel` component in `carbon-components` has been deprecated.') {
+    .#{$prefix}--carousel {
+      display: flex;
+      align-items: center;
+    }
+    .#{$prefix}--carousel-container {
+      max-width: rem(810px);
+      overflow: hidden;
+      padding: 0 1px;
+    }
+    .#{$prefix}--filmstrip {
+      display: flex;
+      justify-content: space-between;
+      transition: transform 100ms $carbon--ease-in;
+      padding: rem(24px) 0;
+      width: auto;
+    }
+    .#{$prefix}--filmstrip-btn {
+      @include button-reset;
+      height: rem(20px);
+      width: rem(20px);
+      margin-bottom: 1rem;
+      margin-right: rem(3px);
+      margin-left: rem(3px);
 
-    &:hover {
+      &:hover {
+        cursor: pointer;
+      }
+
+      &:focus {
+        @include focus-outline;
+      }
+    }
+
+    .#{$prefix}--carousel__btn {
+      @include button-reset(false);
       cursor: pointer;
-    }
+      padding: 0;
 
-    &:focus {
+      &:first-child {
+        margin-right: 1.25rem;
+      }
+
+      &:last-child {
+        margin-left: 1.25rem;
+      }
+
+      &:focus {
+        @include focus-outline;
+      }
+
+      &:last-of-type {
+        transform: rotate(180deg);
+      }
+
+      svg {
+        height: rem(24px);
+        width: rem(16px);
+        fill: $brand-01;
+      }
+    }
+    .#{$prefix}--carousel__item {
+      @include button-reset;
+      padding: 0;
+      line-height: 0;
+      margin-right: rem(20px);
+      cursor: pointer;
+
+      &:hover,
+      &:focus {
+        @include focus-outline;
+      }
+    }
+    .#{$prefix}--carousel__item--active {
       @include focus-outline;
     }
-  }
-
-  .#{$prefix}--carousel__btn {
-    @include button-reset(false);
-    cursor: pointer;
-    padding: 0;
-
-    &:first-child {
-      margin-right: 1.25rem;
-    }
-
-    &:last-child {
-      margin-left: 1.25rem;
-    }
-
-    &:focus {
-      @include focus-outline;
-    }
-
-    &:last-of-type {
-      transform: rotate(180deg);
-    }
-
-    svg {
-      height: rem(24px);
-      width: rem(16px);
-      fill: $brand-01;
-    }
-  }
-  .#{$prefix}--carousel__item {
-    @include button-reset;
-    padding: 0;
-    line-height: 0;
-    margin-right: rem(20px);
-    cursor: pointer;
-
-    &:hover,
-    &:focus {
-      @include focus-outline;
-    }
-  }
-  .#{$prefix}--carousel__item--active {
-    @include focus-outline;
   }
 }

--- a/src/components/carousel/carousel.config.js
+++ b/src/components/carousel/carousel.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  hidden: true,
   variants: [
     {
       name: 'default',

--- a/src/components/fab/_fab.scss
+++ b/src/components/fab/_fab.scss
@@ -7,46 +7,48 @@
 @import '../../globals/scss/import-once';
 
 @include exports('fab') {
-  .#{$prefix}--fab {
-    @include reset;
-    @include rotate(0, $transition--base);
-    display: inline-block;
-    width: rem(72px);
-    height: rem(72px);
-    text-decoration: none;
-    filter: drop-shadow(0px 3px 3px 0 $box-shadow);
+  @include deprecate('`fab` component in `carbon-components` has been deprecated.') {
+    .#{$prefix}--fab {
+      @include reset;
+      @include rotate(0, $transition--base);
+      display: inline-block;
+      width: rem(72px);
+      height: rem(72px);
+      text-decoration: none;
+      filter: drop-shadow(0px 3px 3px 0 $box-shadow);
 
-    &__hidden {
-      @include hidden;
-      color: $color__white;
-    }
-
-    // Styles for "Open" state
-    &__svg {
-      width: 100%;
-
-      .#{$prefix}--fab__hexagon {
-        transition: fill $transition--base;
-        fill: $color__blue-40;
+      &__hidden {
+        @include hidden;
+        color: $color__white;
       }
 
-      .#{$prefix}--fab__plus-icon {
-        @include rotate(0, $transition--base);
-        fill: $color__white;
+      // Styles for "Open" state
+      &__svg {
+        width: 100%;
+
+        .#{$prefix}--fab__hexagon {
+          transition: fill $transition--base;
+          fill: $color__blue-40;
+        }
+
+        .#{$prefix}--fab__plus-icon {
+          @include rotate(0, $transition--base);
+          fill: $color__white;
+        }
       }
-    }
 
-    // Styles for "Closed" state
-    &[data-state='closed'] {
-      @include rotate(90deg, $transition--base);
+      // Styles for "Closed" state
+      &[data-state='closed'] {
+        @include rotate(90deg, $transition--base);
 
-      .#{$prefix}--fab__hexagon {
-        transition: fill $transition--base;
-        fill: $color__navy-gray-5;
-      }
+        .#{$prefix}--fab__hexagon {
+          transition: fill $transition--base;
+          fill: $color__navy-gray-5;
+        }
 
-      .#{$prefix}--fab__plus-icon {
-        @include rotate(-45deg, $transition--base);
+        .#{$prefix}--fab__plus-icon {
+          @include rotate(-45deg, $transition--base);
+        }
       }
     }
   }

--- a/src/components/fab/fab.config.js
+++ b/src/components/fab/fab.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  hidden: true,
+};

--- a/src/components/floating-menu/floating-menu.config.js
+++ b/src/components/floating-menu/floating-menu.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  hidden: true,
+};

--- a/src/components/interior-left-nav/interior-left-nav.config.js
+++ b/src/components/interior-left-nav/interior-left-nav.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  hidden: true,
+};

--- a/src/components/lightbox/_lightbox.scss
+++ b/src/components/lightbox/_lightbox.scss
@@ -9,48 +9,50 @@
 @import '../../globals/scss/layer';
 
 @include exports('lightbox') {
-  .#{$prefix}--lightbox {
-    width: rem(1056px);
-    @include layer('pop-out');
-  }
-  .#{$prefix}--lightbox__main {
-    position: relative;
-  }
-  .#{$prefix}--lightbox__btn {
-    border: 0;
-    background: transparent;
-    cursor: pointer;
-    position: absolute;
-    top: 50%;
+  @include deprecate('`lightbox` component in `carbon-components` has been deprecated.') {
+    .#{$prefix}--lightbox {
+      width: rem(1056px);
+      @include layer('pop-out');
+    }
+    .#{$prefix}--lightbox__main {
+      position: relative;
+    }
+    .#{$prefix}--lightbox__btn {
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+      position: absolute;
+      top: 50%;
 
-    &:first-of-type {
-      left: rem(-32px);
+      &:first-of-type {
+        left: rem(-32px);
+      }
+
+      &:last-of-type {
+        right: rem(-32px);
+        transform: rotate(180deg);
+      }
+
+      &:focus {
+        @include focus-outline;
+      }
+
+      svg {
+        height: rem(24px);
+        fill: $ui-05;
+      }
+    }
+    .#{$prefix}--lightbox__item {
+      display: none;
+      width: 100%;
+    }
+    .#{$prefix}--lightbox__item--shown {
+      display: block;
     }
 
-    &:last-of-type {
-      right: rem(-32px);
-      transform: rotate(180deg);
+    .#{$prefix}--lightbox__footer {
+      background: $ui-01;
+      overflow: hidden;
     }
-
-    &:focus {
-      @include focus-outline;
-    }
-
-    svg {
-      height: rem(24px);
-      fill: $ui-05;
-    }
-  }
-  .#{$prefix}--lightbox__item {
-    display: none;
-    width: 100%;
-  }
-  .#{$prefix}--lightbox__item--shown {
-    display: block;
-  }
-
-  .#{$prefix}--lightbox__footer {
-    background: $ui-01;
-    overflow: hidden;
   }
 }

--- a/src/components/lightbox/lightbox.config.js
+++ b/src/components/lightbox/lightbox.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  hidden: true,
   variants: [
     {
       name: 'default',

--- a/src/components/unified-header/unified-header.config.js
+++ b/src/components/unified-header/unified-header.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  hidden: true,
+};


### PR DESCRIPTION
This change also hides deprecated components in dev env.

Fixes #1153.

#### Changelog

**New**

- Warn usage of the following components as deprecated:
    - Carousel
    - Interior left nav
    - Light box

**Changed**

- Hid the following components from the dev env:
    - Carousel
    - Floating action button
    - Floating menu
    - Interior left nav
    - Light box
    - Unified header

#### Testing / Reviewing

Testing should make sure our components, and our dev env is not broken.
