### PR TITLE
feat(text-input): add tooltip on hover of password visibility toggle

### DIFF
--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -79,15 +79,15 @@
     }
 
     &[data-toggle-password-visibility] + .#{$prefix}--text-input--password__visibility {
-      top: rem(-40px);
+      top: rem(-28px);
+      right: rem(12px);
       display: flex;
       justify-content: center;
       align-self: flex-end;
       align-items: center;
       order: 3;
-      height: rem(40px);
-      width: rem(40px);
-      margin-top: rem(-40px);
+      height: rem(16px);
+      width: rem(16px);
       padding: 0;
       border: 0;
       background: none;

--- a/src/components/text-input/text-input.hbs
+++ b/src/components/text-input/text-input.hbs
@@ -5,7 +5,7 @@
   {{else}}
   <input id="text-input-3" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility">
+  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -25,7 +25,7 @@
   {{else}}
   <input data-invalid id="text-input-4" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility">
+  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -47,7 +47,7 @@
   {{else}}
   <input id="text-input-5" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility">
+  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -69,7 +69,7 @@
   {{else}}
   <input id="text-input-6" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility">
+  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -92,7 +92,7 @@
   {{else}}
   <input id="text-input-7" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility disabled>
-  <button class="bx--text-input--password__visibility">
+  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>

--- a/src/components/text-input/text-input.js
+++ b/src/components/text-input/text-input.js
@@ -36,14 +36,16 @@ export default class TextInput extends mixin(createComponent, initComponentBySea
    * @param {boolean} obj.passwordIsVisible - The visibility of the password in the
    * input field
    */
-  _setIconVisibility = ({ iconVisibilityOn, iconVisibilityOff, passwordIsVisible }) => {
+  _setIconVisibility = ({ iconVisibilityOn, iconVisibilityOff, passwordIsVisible, selectorPasswordVisibilityButton }) => {
     if (passwordIsVisible) {
       iconVisibilityOn.setAttribute('hidden', true);
       iconVisibilityOff.removeAttribute('hidden');
+      selectorPasswordVisibilityButton.setAttribute('aria-label', 'Hide password');
       return;
     }
     iconVisibilityOn.removeAttribute('hidden');
     iconVisibilityOff.setAttribute('hidden', true);
+    selectorPasswordVisibilityButton.setAttribute('aria-label', 'Show password');
   };
 
   /**
@@ -60,10 +62,12 @@ export default class TextInput extends mixin(createComponent, initComponentBySea
     const iconVisibilityOn = button.querySelector(this.options.svgIconVisibilityOn);
     const iconVisibilityOff = button.querySelector(this.options.svgIconVisibilityOff);
     const input = element.querySelector(this.options.selectorPasswordField);
+    const selectorPasswordVisibilityButton = element.querySelector(this.options.selectorPasswordVisibilityButton);
     this._setIconVisibility({
       iconVisibilityOn,
       iconVisibilityOff,
       passwordIsVisible,
+      selectorPasswordVisibilityButton,
     });
     input.type = passwordIsVisible ? 'text' : 'password';
   };


### PR DESCRIPTION
Closes #1164

This PR will display a tooltip describing the action of the password visibility toggle button on its hover state

#### Changelog

**Changed**

- tooltip classes added to password visibility toggle button
- toggle button positioning and dimensions modified due to `position: relative` inheritance from tooltip styles

![kapture 2018-10-04 at 11 43 33](https://user-images.githubusercontent.com/8265238/46489345-c22f4880-c7ca-11e8-88c1-5bfd05272461.gif)
