### PR TITLE
chore(devenv): go away from path-based routing

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,2 +1,1 @@
 root: demo
-pushstate: enabled

--- a/demo/js/components/RootPage.js
+++ b/demo/js/components/RootPage.js
@@ -161,6 +161,11 @@ class RootPage extends Component {
     portSassBuild: PropTypes.number,
 
     /**
+     * `true` to use query args for routing.
+     */
+    routeWithQueryArgs: PropTypes.bool,
+
+    /**
      * `true` to use static full render page.
      */
     useStaticFullRenderPage: PropTypes.bool,
@@ -201,8 +206,19 @@ class RootPage extends Component {
   componentDidMount() {
     const { componentItems } = this.props;
     if (!this.state.selectedNavItemId && componentItems) {
+      const { search } = location;
+      const nameInQueryArg =
+        search &&
+        search
+          .replace(/^\??(.*?)\/?$/, '$1')
+          .split('&')
+          .reduce((o, item) => {
+            const pair = item.split('=');
+            o[pair[0]] = pair[1];
+            return o;
+          }, {}).nav;
       const pathnameTokens = /^\/demo\/([\w-]+)$/.exec(location.pathname);
-      const name = (pathnameTokens && pathnameTokens[1]) || '';
+      const name = nameInQueryArg || (pathnameTokens && pathnameTokens[1]) || '';
       const selectedNavItem = (name && componentItems.find(item => item.name === name)) || componentItems[0];
       if (selectedNavItem) {
         this.switchTo(selectedNavItem.id);
@@ -366,12 +382,13 @@ class RootPage extends Component {
    * @param {string} selectedNavItemId The ID of the newly selected component.
    */
   switchTo(selectedNavItemId) {
+    const { routeWithQueryArgs } = this.props;
     this.setState({ selectedNavItemId }, () => {
       const { componentItems } = this.state;
       const selectedNavItem = componentItems && componentItems.find(item => item.id === selectedNavItemId);
       const { name } = selectedNavItem || {};
       if (name) {
-        history.pushState({ name }, name, `/demo/${name}`);
+        history.pushState({ name }, name, !routeWithQueryArgs ? `/demo/${name}` : `/?nav=${name}`);
       }
       this._populateCurrent();
     });

--- a/demo/js/components/boot-nav.js
+++ b/demo/js/components/boot-nav.js
@@ -26,6 +26,7 @@ pollForBrowserSync(() => {
       componentItems: window.componentItems,
       docItems: window.docItems,
       portSassBuild: window.portSassBuild,
+      routeWithQueryArgs: window.routeWithQueryArgs,
       useStaticFullRenderPage: window.useStaticFullRenderPage,
     };
     ReactDOM.render(<RootPage {...props} />, renderRoot);

--- a/demo/views/demo-nav-data.hbs
+++ b/demo/views/demo-nav-data.hbs
@@ -20,6 +20,9 @@
   {{#if portSassBuild}}
     var portSassBuild = {{portSassBuild}}
   {{/if}}
+  {{#if routeWithQueryArgs}}
+    var routeWithQueryArgs = {{routeWithQueryArgs}}
+  {{/if}}
   {{#if useStaticFullRenderPage}}
     var useStaticFullRenderPage = {{useStaticFullRenderPage}}
   {{/if}}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -363,6 +363,7 @@ gulp.task('html:dev', () =>
                 body: contents.get('demo-nav-data')({
                   componentItems,
                   docItems,
+                  routeWithQueryArgs: true,
                   useStaticFullRenderPage: true,
                 }),
               })


### PR DESCRIPTION
Originally reported by @emyarod 🙏 - CF static file buildpack seems to get flaky with the option that enabled path-based routing.
This change go away from that option for now given that.

Refs #1162.

#### Changelog

**Changed**

- Went away from path-based routing

**Removed**

- CF setting that enabled path-based routing

#### Testing / Reviewing

Testing should make sure our dev env and CF deployment are not broken.
