### PR TITLE
fix(pagination): fix arrow

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -130,7 +130,7 @@ $css--helpers: true;
       }
     }
 
-    .#{$prefix}--select--inline .#{$prefix}--select-input ~ .#{$prefix}--select__arrow {
+    .#{$prefix}--select .#{$prefix}--select-input ~ .#{$prefix}--select__arrow {
       right: 0.3rem;
       top: 0.625rem;
     }


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1225

Fixes pagination arrow

#### Changelog

**Changed**

- Updated selector to target both `select` elements, not just `inline-select`

#### Testing / Reviewing

Make sure the arrow is positioned correctly 
