### PR TITLE
fix(text-input): update text input colors

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -115,7 +115,7 @@
     @include reset;
     @include font-family;
     @include typescale('omega');
-    color: $text-01;
+    color: $text-02;
     font-weight: $input-label-weight;
     display: inline-block;
     vertical-align: baseline;

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -129,15 +129,14 @@
     padding: 0 $spacing-xl 0 $spacing-md;
     color: $text-01;
     border: none;
-    outline: 1px solid $ui-04;
-    outline-offset: -1px;
-    padding-bottom: 1px;
+    border-bottom: 1px solid $ui-04;
+    outline: 2px solid transparent;
+    transition: $transition--base all;
+    outline-offset: -2px;
   }
 
   .#{$prefix}--text-input:hover {
-    color: $text-01;
-    outline: 1px solid $brand-01;
-    outline-offset: -1px;
+    background-color: $hover-field;
   }
 
   .#{$prefix}--text-input:focus,
@@ -170,6 +169,7 @@
     // THIS SHOULD BE MOVED TO AN INLINE SVG IN NEXT MAJOR RELEASE
     background-image: url("data:image/svg+xml;charset=UTF-8, %3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='16' height='16' class='ibm-icons ibm-icons--error--filled' fill='%23bebebe'%3e%3cpath d='M6.95 26.66A14 14 0 0 0 26.67 6.93zM16 2A14 14 0 0 0 5.35 25.07L25.08 5.34A13.93 13.93 0 0 0 16 2z'/%3e%3c/svg%3e");
     outline: none;
+    background-color: $disabled-bg;
   }
 
   .#{$prefix}--text-input:disabled::-webkit-input-placeholder {

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -170,6 +170,7 @@
     background-image: url("data:image/svg+xml;charset=UTF-8, %3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='16' height='16' class='ibm-icons ibm-icons--error--filled' fill='%23bebebe'%3e%3cpath d='M6.95 26.66A14 14 0 0 0 26.67 6.93zM16 2A14 14 0 0 0 5.35 25.07L25.08 5.34A13.93 13.93 0 0 0 16 2z'/%3e%3c/svg%3e");
     outline: none;
     background-color: $disabled-bg;
+    border-bottom: 1px solid transparent;
   }
 
   .#{$prefix}--text-input:disabled::-webkit-input-placeholder {

--- a/src/globals/scss/_theme.scss
+++ b/src/globals/scss/_theme.scss
@@ -141,11 +141,13 @@
   $hover-danger: darken($support-01, 10%) !default !global;
   $hover-secondary: $brand-01 !default !global;
   $hover-row: rgba($brand-02, 0.1) !default !global;
+  $hover-field: #e5e5e5 !default !global;
 
   // Global
   $input-border: 1px solid transparent !default !global;
   $input-label-weight: 400 !default !global;
   $disabled: $ibm-colors__gray--30 !default !global;
+  $disabled-bg: $ibm-colors__gray--10 !default !global;
   $focus: $ibm-colors__blue--60 !default !global;
 
   // Link


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1231

Preview Link: http://carbon-dev-environment-tippiest-dialer.mybluemix.net/?nav=text-input

Updates `Text Input` based on new designs to closer align with `Select`/`Dropdown` and other form elements.

#### Changelog

**New**

- `$hover-field`, to be used for all hover interactions on form elements. 
- `$disabled-bg`, to go along with the `$disabled` variable.
- Transitions

**Changed**

- Colors in different states

**Removed**

- Extraneous code 

#### Testing / Reviewing

Ensure the components match the new specs

![screen shot 2018-10-11 at 10 48 42 am](https://user-images.githubusercontent.com/11928039/46816952-a7695080-cd43-11e8-83f6-5c5f1d59a667.png)

