### PR TITLE
fix(data-table): add a width to the expand icon container

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-expandable.scss
+++ b/src/components/data-table-v2/_data-table-v2-expandable.scss
@@ -69,6 +69,10 @@
     }
   }
 
+  .#{$prefix}--table-expand-v2 {
+    width: 2.25rem;
+  }
+
   .#{$prefix}--table-expand-v2[data-previous-value='collapsed'] .#{$prefix}--table-expand-v2__svg {
     transform: rotate(90deg);
     transition: transform 200ms $carbon--standard-easing;

--- a/src/components/data-table-v2/_data-table-v2-expandable.scss
+++ b/src/components/data-table-v2/_data-table-v2-expandable.scss
@@ -70,7 +70,7 @@
   }
 
   .#{$prefix}--table-expand-v2 {
-    width: 2.25rem;
+    width: 2.5rem;
   }
 
   .#{$prefix}--table-expand-v2[data-previous-value='collapsed'] .#{$prefix}--table-expand-v2__svg {


### PR DESCRIPTION
Closes #1260 

#### Changelog

**New**

- added width to icon expand container to prevent slight width change on rows when expanding. 


#### Testing / Reviewing

Check dev environment is not broken.
Check DataTableV2 expandable
