### PR TITLE
feat(tooltip): support close on ESC key

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -58,6 +58,11 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
   constructor(element, options) {
     super(element, options);
     this._hookOn(element);
+    this.manage(
+      on(this.element.ownerDocument, 'keydown', event => {
+        this._handleKeyDown(event);
+      })
+    );
   }
 
   /**
@@ -167,6 +172,24 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
     }
     if (!shouldPreventClose) {
       this.changeState(state, details);
+    }
+  }
+
+  /**
+   * Handles key press on document.
+   * @param {Event} event The triggering event.
+   * @private
+   */
+  _handleKeyDown(event) {
+    const key = event.which;
+    const { element, tooltip } = this;
+    const isOfMenu = tooltip && tooltip.element.contains(event.target);
+    if (key === 27) {
+      this.changeState('hidden', getLaunchingDetails(event), () => {
+        if (isOfMenu) {
+          element.focus();
+        }
+      });
     }
   }
 

--- a/tests/spec/tooltip_spec.js
+++ b/tests/spec/tooltip_spec.js
@@ -22,6 +22,8 @@ describe('Test tooltip', function() {
 
     const element = container.querySelector('[data-tooltip-trigger]');
     const floating = container.querySelector('.bx--tooltip');
+    const hasFocusin = 'onfocusin' in window;
+    const focusinEventName = hasFocusin ? 'focusin' : 'focus';
     let tooltip;
 
     beforeAll(function() {
@@ -34,16 +36,30 @@ describe('Test tooltip', function() {
     });
 
     it('Should show the tooltip upon clicking/focusing', function() {
-      const hasFocusin = 'onfocusin' in window;
-      const focusinEventName = hasFocusin ? 'focusin' : 'focus';
       element.dispatchEvent(new CustomEvent(focusinEventName, { bubbles: true }));
       expect(floating.classList.contains('bx--tooltip--shown')).toBe(true);
     });
 
     it('Should hide the tooltip upon bluring', function() {
+      element.dispatchEvent(new CustomEvent(focusinEventName, { bubbles: true }));
       floating.classList.add('bx--tooltip--shown');
       element.dispatchEvent(new CustomEvent('blur', { bubbles: true }));
       expect(floating.classList.contains('bx--tooltip--shown')).toBe(false);
+    });
+
+    it('Should hide the tooltip upon hitting ESC key', function() {
+      element.dispatchEvent(new CustomEvent(focusinEventName, { bubbles: true }));
+      floating.classList.add('bx--tooltip--shown');
+      element.dispatchEvent(Object.assign(new CustomEvent('keydown', { bubbles: true }), { which: 27 }));
+      expect(floating.classList.contains('bx--tooltip--shown')).toBe(false);
+    });
+
+    it('Should move the focus back to the trigger node upon hitting ESC key on tooltip', function() {
+      element.dispatchEvent(new CustomEvent(focusinEventName, { bubbles: true }));
+      floating.classList.add('bx--tooltip--shown');
+      floating.dispatchEvent(Object.assign(new CustomEvent('keydown', { bubbles: true }), { which: 27 }));
+      expect(floating.classList.contains('bx--tooltip--shown')).toBe(false);
+      expect(document.activeElement).toBe(element);
     });
 
     afterEach(function() {


### PR DESCRIPTION
Fixes #1264.

#### Changelog

**New**

- Support for hitting ESC key to close tooltip.

#### Testing / Reviewing

Testing should make sure non-small tooltip is not broken.
