### PR TITLE
fix(data-table): add border to row instead of column

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-core.scss
+++ b/src/components/data-table-v2/_data-table-v2-core.scss
@@ -21,11 +21,13 @@
       @include typescale('zeta');
       background-color: $ui-02;
       font-weight: 700;
+      border-right: 1px solid $ui-03;
     }
 
     tbody {
       @include typescale('zeta');
       background-color: $ui-01;
+      border-right: 1px solid $ui-03;
     }
 
     tr {
@@ -72,7 +74,6 @@
 
       &:last-of-type {
         padding-right: $spacing-lg;
-        border-right: 1px solid $ui-03;
       }
     }
 


### PR DESCRIPTION
Closes #1124 

Adds border to outer row to account for any hidden columns 

#### Changelog

**New**

- added border to entire row on `thead` and `tbody`

**Removed**

- border from `td:last-of-type` 

#### Testing / Reviewing

Check to see data table is not broken
