### PR TITLE
chore(devenv): transpile pseudo module created in build process

### DIFF
--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -43,7 +43,11 @@ module.exports = {
       },
     }),
     babel({
-      exclude: 'node_modules/**',
+      exclude: ['node_modules/**'],
+      plugins: ['external-helpers'],
+    }),
+    babel({
+      include: ['node_modules/markdown-it/**'],
       plugins: ['external-helpers'],
     }),
     replace({


### PR DESCRIPTION
This should fix IE11 issue in CF deployment CC @joshblack 🙏 

#### Changelog

**New**

- Code ensuring that a pseudo module created during CF deployment build process is transpiled.

#### Testing / Reviewing

Testing should make sure our CF deployment is not broken.