### PR TITLE
fix(notification): add aria-label to button

### DIFF
--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -16,10 +16,9 @@
         <p class="bx--{{../variant}}-notification__caption">{{timestamp}}</p>
       {{/is}}
     </div>
-    <button data-notification-btn class="bx--{{../variant}}-notification__close-button" type="button">
-      <svg class="bx--{{../variant}}-notification{{#is ../variant "inline"}}__close{{/is}}-icon" aria-label="close" width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-        <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z" fill-rule="nonzero"
-        />
+    <button data-notification-btn class="bx--{{../variant}}-notification__close-button" type="button" aria-label="close">
+      <svg aria-hidden="true" class="bx--{{../variant}}-notification{{#is ../variant "inline"}}__close{{/is}}-icon" width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+        <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z" fill-rule="nonzero" />
       </svg>
     </button>
   </div>


### PR DESCRIPTION
Closes #1290

Add `aria-label` to button.

#### Changelog

**New**

**Changed**

- `notification`
  - `aria-label` is now on `button`
  - `aria-hidden` is now on `svg`

**Removed**

#### Testing / Reviewing

