### PR TITLE
feat(slider): add experimental slider

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -138,6 +138,10 @@
     height: rem(14px);
   }
 
+  input[type='number'] {
+    font-family: $font-family-mono;
+  }
+
   input[data-invalid],
   textarea[data-invalid],
   select[data-invalid],

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -177,7 +177,7 @@
 
   .#{$prefix}--number input[type='number'] {
     @include typescale('zeta');
-    @include font-family;
+    font-family: $font-family-mono;
     box-sizing: border-box;
     display: inline-flex;
     width: 100%;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -34,10 +34,6 @@
     order: 0;
   }
 
-  .#{$prefix}--slider__range-label:nth-of-type(2) {
-    order: 2;
-  }
-
   .#{$prefix}--slider-text-input {
     order: 3;
   }
@@ -66,6 +62,7 @@
 
     &:last-of-type {
       margin-right: $spacing-md;
+      order: 2;
     }
   }
 
@@ -175,10 +172,6 @@
     order: 0;
   }
 
-  .#{$prefix}--slider__range-label:nth-of-type(2) {
-    order: 2;
-  }
-
   .#{$prefix}--slider-text-input {
     order: 3;
   }
@@ -218,6 +211,7 @@
 
     &:last-of-type {
       margin-right: $spacing-md;
+      order: 2;
     }
   }
 

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -270,7 +270,7 @@
     &:focus {
       // 20px / 14px = 1.4285714286
       transform: translate(-50%, -50%) scale(1.4285714286);
-      box-shadow: inset 0 0 0 1px $brand-01, inset 0 0 0 2px $ui-01;
+      box-shadow: inset 0 0 0 2px $brand-01, inset 0 0 0 3px $ui-01;
       background-color: $brand-01;
     }
 

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -14,7 +14,7 @@
 @import '../form/form';
 @import '../text-input/text-input';
 
-@include exports('slider') {
+@mixin slider {
   .#{$prefix}--slider-container {
     display: flex;
     align-items: center;
@@ -27,6 +27,19 @@
     margin: 0 $spacing-md;
     max-width: rem(640px);
     min-width: rem(200px);
+    order: 1;
+  }
+
+  .#{$prefix}--slider__range-label:first-of-type {
+    order: 0;
+  }
+
+  .#{$prefix}--slider__range-label:nth-of-type(2) {
+    order: 2;
+  }
+
+  .#{$prefix}--slider-text-input {
+    order: 3;
   }
 
   .#{$prefix}--slider--disabled {
@@ -86,6 +99,7 @@
     transition: transform 100ms $carbon--standard-easing, background 100ms $carbon--standard-easing;
     cursor: pointer;
     outline: none;
+    z-index: 2;
 
     &--clicked {
       transition: left $transition--base $carbon--standard-easing;
@@ -110,7 +124,7 @@
   .#{$prefix}--slider-text-input,
   .#{$prefix}-slider-text-input {
     width: rem(60px);
-    min-width: 0;
+    min-width: rem(60px);
     height: 2rem;
     padding: 0;
     text-align: center;
@@ -138,5 +152,185 @@
     left: 50%;
     cursor: default;
     pointer-events: none;
+  }
+}
+
+@mixin slider--x {
+  .#{$prefix}--slider-container {
+    display: flex;
+    align-items: center;
+    user-select: none;
+  }
+
+  .#{$prefix}--slider {
+    position: relative;
+    width: 100%;
+    margin: 0 $spacing-md;
+    max-width: rem(640px);
+    min-width: rem(200px);
+    order: 1;
+  }
+
+  .#{$prefix}--slider__range-label:first-of-type {
+    order: 0;
+  }
+
+  .#{$prefix}--slider__range-label:nth-of-type(2) {
+    order: 2;
+  }
+
+  .#{$prefix}--slider-text-input {
+    order: 3;
+  }
+
+  .#{$prefix}--slider--disabled ~ .#{$prefix}--slider__range-label {
+    color: $disabled;
+  }
+
+  .#{$prefix}--slider--disabled .#{$prefix}--slider__thumb {
+    background-color: $ui-03;
+
+    &:hover {
+      transform: translate(-50%, -50%);
+      cursor: not-allowed;
+    }
+
+    &:focus {
+      box-shadow: none;
+      outline: none;
+      background-color: $ui-03;
+    }
+
+    &:active {
+      background: $ui-03;
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  .#{$prefix}--slider--disabled .#{$prefix}--slider__track {
+    cursor: not-allowed;
+  }
+
+  .#{$prefix}--slider__range-label {
+    @include typescale('zeta');
+    font-family: $font-family-mono;
+    color: $text-01;
+
+    &:last-of-type {
+      margin-right: $spacing-md;
+    }
+  }
+
+  .#{$prefix}--slider__track {
+    position: absolute;
+    width: 100%;
+    height: rem(2px);
+    background: $ui-03;
+    cursor: pointer;
+    transform: translate(0%, -50%);
+  }
+
+  .#{$prefix}--slider__track:before {
+    content: '';
+    position: absolute;
+    display: inline-block;
+    height: rem(4px);
+    width: rem(2px);
+    left: 50%;
+    transform: translate(-50%, 0);
+    top: rem(-5px);
+    background: $ui-03;
+  }
+
+  .#{$prefix}--slider__filled-track {
+    position: absolute;
+    width: 100%;
+    height: rem(2px);
+    background: $ui-05;
+    transform-origin: left;
+    pointer-events: none;
+    transform: translate(0%, -50%);
+    transition: background $transition--base;
+  }
+
+  .#{$prefix}--slider__thumb {
+    position: absolute;
+    height: rem(14px);
+    width: rem(14px);
+    background: $ui-05;
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px transparent, inset 0 0 0 2px transparent;
+    top: 0;
+    transform: translate(-50%, -50%);
+    transition: transform $transition--base $carbon--standard-easing, background $transition--base $carbon--standard-easing,
+      box-shadow $transition--base $carbon--standard-easing;
+    cursor: pointer;
+    outline: none;
+    z-index: 3;
+
+    &:hover {
+      // 20px / 14px = 1.4285714286
+      transform: translate(-50%, -50%) scale(1.4285714286);
+    }
+
+    &:focus {
+      // 20px / 14px = 1.4285714286
+      transform: translate(-50%, -50%) scale(1.4285714286);
+      box-shadow: inset 0 0 0 1px $brand-01, inset 0 0 0 2px $ui-01;
+      background-color: $brand-01;
+    }
+
+    &:active {
+      transform: translate(-50%, -50%) scale(1.4285714286);
+      box-shadow: inset 0 0 0 2px $brand-01;
+    }
+  }
+
+  .#{$prefix}--slider__input {
+    display: none;
+  }
+
+  .#{$prefix}--slider-text-input,
+  .#{$prefix}-slider-text-input {
+    width: rem(64px);
+    height: 2rem;
+    padding: 0;
+    text-align: center;
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      display: none;
+    }
+  }
+
+  .#{$prefix}--slider__thumb:focus ~ .#{$prefix}--slider__filled-track {
+    background-color: $brand-01;
+  }
+
+  // Skeleton state
+  .#{$prefix}--slider-container.#{$prefix}--skeleton .#{$prefix}--slider__range-label {
+    @include skeleton;
+    width: rem(20px);
+    height: rem(12px);
+  }
+
+  .#{$prefix}--slider-container.#{$prefix}--skeleton .#{$prefix}--slider__track {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .#{$prefix}--slider-container.#{$prefix}--skeleton .#{$prefix}--slider__thumb {
+    left: 50%;
+    cursor: default;
+    pointer-events: none;
+  }
+}
+
+@include exports('slider') {
+  @if feature-flag-enabled('components-x') {
+    @include slider--x;
+  } @else {
+    @include slider;
   }
 }

--- a/src/components/slider/slider.hbs
+++ b/src/components/slider/slider.hbs
@@ -2,13 +2,13 @@
   <label for="slider" class="bx--label">Slider label</label>
   <div class="bx--slider-test">
   <div class="bx--slider-container">
-    <span class="bx--slider__range-label">0</span>
     <div class="bx--slider" data-slider data-slider-input-box="#{{inputId}}">
+      <div class="bx--slider__thumb" tabindex="0"></div>
       <div class="bx--slider__track"></div>
       <div class="bx--slider__filled-track"></div>
-      <div class="bx--slider__thumb" tabindex="0"></div>
-      <input id="slider" class="bx--slider__input" type="range" step="1" min="0" max="100" value="50">
+      <input id="slider" class="bx--slider__input" type="range" step="1" min="0" max="100" value="0">
     </div>
+    <span class="bx--slider__range-label">0</span>
     <span class="bx--slider__range-label">100</span>
     <input id="{{inputId}}" type="number" class="bx--text-input bx--slider-text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="0">
   </div>

--- a/tests/spec/slider_spec.js
+++ b/tests/spec/slider_spec.js
@@ -89,10 +89,13 @@ describe('Test slider', function() {
       slider = new Slider(document.querySelector('[data-slider]'));
       thumb = document.querySelector('.bx--slider__thumb');
       mockRaf.step({ count: 1 });
+      slider.setValue(50);
     });
     it('Should stepUp value on up/right key', function() {
       const event = new CustomEvent('keydown', { bubbles: true });
       event.which = 39;
+      thumb.dispatchEvent(event);
+      mockRaf.step({ count: 1 });
       thumb.dispatchEvent(event);
       mockRaf.step({ count: 1 });
       expect(slider.getInputProps().value).toBe(51);
@@ -104,6 +107,8 @@ describe('Test slider', function() {
     it('Should stepDown value on down/left key', function() {
       const event = new CustomEvent('keydown', { bubbles: true });
       event.which = 40;
+      thumb.dispatchEvent(event);
+      mockRaf.step({ count: 1 });
       thumb.dispatchEvent(event);
       mockRaf.step({ count: 1 });
       expect(slider.getInputProps().value).toBe(49);


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1265

Adds in experimental `Slider` component

#### Changelog

**New**

- Experimental slider and styles

**Changed**

- Since `disabled` styles are applied via the `bx--slider--disabled` class, I moved `bx--slider` first in the HTML order, and used `flex-order` to reposition them. Let me know if you think this will cause any problems.
- Moved the slider around in the HTML as well, so I could use the adjacent selector for focus states. Added a z-index for backward compatibility.

**Removed**

- Extra styles

#### Testing / Reviewing

[Staging link](http://carbon-dev-environment-exp-slider-chatty-kangaroo.mybluemix.net/?nav=slider)

![screen shot 2018-10-22 at 3 37 34 pm](https://user-images.githubusercontent.com/11928039/47317972-6f4df180-d610-11e8-830e-d0e2a864756f.png)
