### PR TITLE
fix: remove unnecessary license text

### DIFF
--- a/src/globals/fonts/LICENSE_helvetica.md
+++ b/src/globals/fonts/LICENSE_helvetica.md
@@ -1,7 +1,3 @@
 # Terms of Use
 
 The Helvetica Neue license includes unlimited usage for all IBM software, either on premise or Software as a Service (SaaS). This license allows you to use the fonts for _"IBM branded software products installed on customer workstations, servers, tablets and mobile devices"_. This includes _"all platforms that support font data installation"_, as well as _"IBM server based software products where the font remains on IBM servers"_ on an unlimited number of servers or CPUs.
-
-All web properties are typically required to include a tracking code to count the number of page views the fonts are viewed on. If you choose not use the tracking code but want to use the fonts, you will need to track page views through another means, like IBM Customer Analytics, for example. If you count your own page views, in December of each calendar year, please email a numeric value of total annual page views to Daniel Kuehn: dkuehn@us.ibm.com, who will send the additional traffic numbers to Monotype.
-
-For the Monotype agreement, web properties means ibm.com pages and other ibm operated sites (e.g. developerworks) - not SaaS offerings (IBM server based software products where the font remains on IBM servers). As for business partners, they need to get their own font licenses. Get the tracking code to include https://github.ibm.com/Design/fonts/blob/master/LICENSE.md.


### PR DESCRIPTION
from Daniel

> I just found an addendum to our license agreement that explains that our web content is no longer covered by the license. Sorry, but we should get rid of the second and third paragraphs.