### PR TITLE
chore(build): support for generating static HTML with feature flags

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -394,7 +394,7 @@ gulp.task('html:dev', ['scripts:dev:feature-flags'], () =>
   )
 );
 
-gulp.task('html:source', () => {
+gulp.task('html:source', ['scripts:dev:feature-flags'], () => {
   const names = {
     'notification--default': 'inline-notification',
     'notification--toast': 'toast-notification',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -351,7 +351,7 @@ gulp.task('sass:source', () => {
   return gulp.src(srcFiles).pipe(gulp.dest('scss'));
 });
 
-gulp.task('html:dev', () =>
+gulp.task('html:dev', ['scripts:dev:feature-flags'], () =>
   Promise.all([mkdirp(path.resolve(__dirname, 'demo/code')), mkdirp(path.resolve(__dirname, 'demo/component'))]).then(() =>
     templates.cache.get().then(({ componentSource, docSource, contents }) =>
       Promise.all([

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@
 /* eslint import/no-extraneous-dependencies: [2, {"devDependencies": true}] */
 
 const path = require('path');
-const Module = require('module');
 const pathRegexp = require('path-to-regexp');
 const browserSync = require('browser-sync');
 const serveStatic = require('serve-static');
@@ -51,14 +50,6 @@ if (devMode) {
     .on('change', invokeWatchCallback)
     .on('unlink', invokeWatchCallback);
 }
-
-const origResolveFilename = Module._resolveFilename;
-Module._resolveFilename = function resolveModule(request, parentModule, ...other) {
-  const newRequest = !/feature-flags$/i.test(request)
-    ? request
-    : path.relative(path.dirname(parentModule.id), path.resolve(__dirname, 'demo/feature-flags.js'));
-  return origResolveFilename.call(this, newRequest, parentModule, ...other);
-};
 
 const reComponentPath = pathRegexp('/component/:component');
 const reDemoComponentPath = pathRegexp('/demo/:component');

--- a/tools/templates.js
+++ b/tools/templates.js
@@ -4,9 +4,20 @@ const globby = require('globby');
 const { promisify } = require('bluebird');
 const fs = require('fs');
 const path = require('path');
+const Module = require('module');
 const expressHandlebars = require('express-handlebars');
 const helpers = require('handlebars-helpers');
 const Fractal = require('@frctl/fractal');
+
+const origResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function resolveModule(request, parentModule, ...other) {
+  const devFeatureFlags = path.resolve(__dirname, '../demo/feature-flags.js');
+  const newRequest =
+    !/feature-flags$/i.test(request) || !fs.existsSync(devFeatureFlags)
+      ? request
+      : path.relative(path.dirname(parentModule.id), devFeatureFlags);
+  return origResolveFilename.call(this, newRequest, parentModule, ...other);
+};
 
 const handlebars = expressHandlebars.create({
   defaultLayout: 'demo-nav',


### PR DESCRIPTION
Refs #1149.

#### Changelog

**Changed**

- Moved the dependency injection logic to change feature logic from `server.js` to `templates.js`, so it can be used from Gulp build logic, too.
- Changed `html:dev` Gulp task to build static HTML with feature flags in use

#### Testing / Reviewing

Testing should make sure our production build or our dev env, including CF deployment, are not broken.