### PR TITLE
fix(notification): add correct icon svgs for different types

### DIFF
--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -2,9 +2,26 @@
   <div data-notification class="bx--{{../variant}}-notification bx--{{../variant}}-notification--{{type}}" role="alert">
     <div class="bx--{{../variant}}-notification__details">
       {{#is ../variant "inline"}}
-        <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-          <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
-        </svg>
+        {{#is type "error"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
+          </svg>
+        {{/is}}
+         {{#is type "info"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
+          </svg>
+        {{/is}}
+         {{#is type "success"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
+          </svg>
+        {{/is}}
+         {{#is type "warning"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
+          </svg>
+        {{/is}}
         <div class="bx--{{../variant}}-notification__text-wrapper">
           <p class="bx--{{../variant}}-notification__title">{{title}}</p>
           <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -12,7 +12,7 @@
             <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
           </svg>
         {{/is}}
-         {{#is type "success"}}
+        {{#is type "success"}}
           <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
           </svg>

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -7,7 +7,7 @@
             <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
           </svg>
         {{/is}}
-         {{#is type "info"}}
+        {{#is type "info"}}
           <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
           </svg>

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -17,7 +17,7 @@
             <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
           </svg>
         {{/is}}
-         {{#is type "warning"}}
+        {{#is type "warning"}}
           <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
           </svg>


### PR DESCRIPTION
Closes #1327 

Adds missing icons for different notification types
<img width="422" alt="screen shot 2018-10-24 at 11 36 13 am" src="https://user-images.githubusercontent.com/2753488/47446654-50bb3800-d781-11e8-905b-decf86fd522d.png">

