### PR TITLE
fixed sass-loader errors:

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -95,10 +95,6 @@
     pointer-events: none;
   }
 
-  &[data-invalid] ~ .#{$prefix}--select__arrow {
-    bottom: 2.25rem;
-  }
-
   .#{$prefix}--select-optgroup,
   .#{$prefix}--select-option {
     color: $text-01; // For the options to show in IE11

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -116,8 +116,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @if (length($deprecations--reasons) > 0) {
   $deprecations--message: '';
   @each $reason in $deprecations--reasons {
-    $deprecations--message: '#{$deprecations--message}
-REASON: #{$reason}';
+    $deprecations--message: '#{$deprecations--message} REASON: #{$reason}';
   }
 
   @warn $deprecations--message;


### PR DESCRIPTION
Closes #

After creating a jhipster angular6 application, including carbon-components fails because of scss errors from sass-loader / webpack
This PR fixes it

#### Changelog
**Removed**
- linebreak in styles.scss
- seemingly invalid scss code in _select.scss

#### Testing / Reviewing
Steps to reproduce: create new jhipster application, https://www.jhipster.tech/installation/

in main folder:
> npm i --save-dev carbon-components-angular carbon-components

add to src/main/webapp/content/scss/global.scss:
@import "~carbon-components/scss/globals/scss/styles.scss";

start application (./gradlew in main folder)

sass-loader errors that are fixed

ERROR in ./src/main/webapp/content/scss/global.scss (./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/sass-loader/lib/loader.js??ref--11-3!./src/main/webapp/content/scss/global.scss)
Module build failed:
    $deprecations--message: '#{$deprecations--message}
                                                     ^
      Expected '.fixed sass-loader error:

ERROR in ./src/main/webapp/content/scss/global.scss (./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/sass-loader/lib/loader.js??ref--11-3!./src/main/webapp/content/scss/global.scss)
Module build failed:
    $deprecations--message: '#{$deprecations--message}
                                                     ^
      Expected '.
ERROR in ./src/main/webapp/content/scss/global.scss (./node_modules/css-loader!./node_modules/postcss-loader/lib!./node_modules/sass-loader/lib/loader.js??ref--11-3!./src/main/webapp/content/scss/global.scss)
Module build failed:
  &[data-invalid] ~ .#{$prefix}--select__arrow {
 ^
      Top-level selectors may not contain the parent selector "&".