### PR TITLE
feat(date-picker): Add in experimental date picker

### DIFF
--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -190,3 +190,7 @@
 .indigo {
   background-color: rgba(indigo, 0.2);
 }
+
+.component-example__live .bx--form-item {
+  margin-bottom: 2rem;
+}

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -10,7 +10,7 @@
 @import '../form/form';
 @import 'flatpickr.scss';
 
-@include exports('date-picker') {
+@mixin date-picker {
   .#{$prefix}--date-picker {
     display: flex;
     align-items: flex-start;
@@ -459,5 +459,466 @@
     @include skeleton;
     width: rem(75px);
     height: rem(14px);
+  }
+}
+
+@mixin date-picker--x {
+  .#{$prefix}--date-picker {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .#{$prefix}--date-picker--light .#{$prefix}--date-picker__input {
+    background: $field-02;
+  }
+
+  .#{$prefix}--date-picker ~ .#{$prefix}--label {
+    order: 1;
+  }
+
+  .#{$prefix}--date-picker-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .#{$prefix}--date-picker.#{$prefix}--date-picker--simple {
+    .#{$prefix}--date-picker__input {
+      width: 7.25rem;
+    }
+  }
+
+  .#{$prefix}--date-picker.#{$prefix}--date-picker--simple.#{$prefix}--date-picker--short {
+    .#{$prefix}--date-picker__input {
+      width: 5.7rem;
+    }
+  }
+
+  .#{$prefix}--date-picker.#{$prefix}--date-picker--single {
+    .#{$prefix}--date-picker__input {
+      min-width: 9.25rem;
+    }
+  }
+
+  .#{$prefix}--date-picker__input {
+    @include reset;
+    @include typescale('zeta');
+    @include focus-outline('reset');
+    font-family: $font-family-mono;
+    display: block;
+    position: relative;
+    height: rem(32px);
+    max-width: rem(288px);
+    padding: 0 $spacing-md;
+    background-color: $field-01;
+    border: none;
+    order: 2;
+    color: $text-01;
+    border-bottom: 1px solid $ui-04;
+    transition: $transition--base all;
+
+    &:focus,
+    &.#{$prefix}--focused {
+      @include focus-outline('outline');
+    }
+
+    &:hover {
+      cursor: pointer;
+      background-color: $hover-field;
+    }
+
+    &[data-invalid],
+    &[data-invalid]:focus {
+      @include focus-outline('invalid');
+    }
+
+    & ~ .#{$prefix}--form-requirement {
+      order: 3;
+      color: $support-01;
+      font-weight: 400;
+      margin-top: $spacing-2xs;
+      overflow: visible;
+
+      &::before {
+        display: none;
+      }
+    }
+
+    &:disabled {
+      color: $disabled;
+      background-color: $disabled-background-color;
+      border-bottom: 1px solid transparent;
+      cursor: not-allowed;
+    }
+
+    &:disabled:hover {
+      border-bottom: 1px solid transparent;
+    }
+
+    &::placeholder {
+      @include placeholder-colors;
+    }
+  }
+
+  .#{$prefix}--date-picker__icon {
+    position: absolute;
+    top: 1.75rem;
+    right: 1rem;
+    fill: $ui-05;
+    cursor: pointer;
+    z-index: 1;
+
+    &:hover {
+      fill: $hover-primary;
+    }
+  }
+
+  .#{$prefix}--date-picker--nolabel .#{$prefix}--date-picker__icon {
+    top: rem(14px);
+  }
+
+  .#{$prefix}--date-picker__icon ~ .#{$prefix}--date-picker__input {
+    padding-right: $spacing-3xl;
+  }
+
+  .#{$prefix}--date-picker--range {
+    display: flex;
+    position: relative;
+  }
+
+  .#{$prefix}--date-picker--range > .#{$prefix}--date-picker-container:first-child {
+    margin-right: rem(1px);
+  }
+
+  .#{$prefix}--date-picker--range .#{$prefix}--date-picker__icon {
+    display: none;
+  }
+
+  .#{$prefix}--date-picker--range .#{$prefix}--date-picker__input {
+    width: rem(143.5px);
+
+    // THIS SHOULD BE MOVED TO AN INLINE SVG IN NEXT MAJOR RELEASE
+    background-image: url("data:image/svg+xml;charset=UTF-8, %3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 16' width='14' height='16' class='ibm-icons ibm-icons--error--filled' fill='%23171717'%3e%3cpath d='M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z' fill-rule='nonzero' /%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: calc(100% - 1rem) 50%;
+  }
+
+  .#{$prefix}--date-picker__calendar,
+  .flatpickr-calendar.open {
+    @include layer('pop-out');
+    background-color: $ui-01;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: $spacing-2xs $spacing-2xs $spacing-xs $spacing-2xs;
+    width: rem(288px) !important;
+    border-radius: 0;
+    border: none;
+    overflow: hidden;
+    margin-top: -2px;
+
+    &:before,
+    &:after {
+      display: none;
+    }
+
+    &:focus {
+      outline: 1px solid $brand-01;
+    }
+  }
+
+  .#{$prefix}--date-picker__month,
+  .flatpickr-month {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: rem(40px);
+    margin-bottom: $spacing-2xs;
+  }
+
+  .#{$prefix}--date-picker__month .flatpickr-prev-month,
+  .#{$prefix}--date-picker__month .flatpickr-next-month,
+  .flatpickr-month .flatpickr-prev-month,
+  .flatpickr-month .flatpickr-next-month {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    height: rem(40px);
+    width: rem(40px);
+    padding: 0;
+    fill: $text-01;
+    transition: background-color $transition--base;
+
+    &:hover {
+      background-color: $hover-field;
+    }
+  }
+
+  .flatpickr-current-month .numInputWrapper {
+    width: 7ch;
+  }
+
+  .#{$prefix}--date-picker__month .flatpickr-current-month,
+  .flatpickr-month .flatpickr-current-month {
+    @include typescale('zeta');
+    padding: 0;
+  }
+
+  .#{$prefix}--date-picker__month .flatpickr-current-month svg,
+  .flatpickr-month .flatpickr-current-month svg {
+    fill: $text-01;
+  }
+
+  .#{$prefix}--date-picker__month .flatpickr-current-month .cur-month,
+  .flatpickr-month .flatpickr-current-month .cur-month {
+    margin-right: 0.25rem;
+    color: $text-01;
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper .numInput,
+  .flatpickr-month .numInputWrapper .numInput {
+    font-weight: 600;
+    color: $text-01;
+    background-color: $field-01;
+    border: none;
+    border-radius: 0;
+    padding: $spacing-2xs;
+
+    &:focus {
+      outline: 1px solid $brand-01;
+    }
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowUp,
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowDown,
+  .flatpickr-month .numInputWrapper span.arrowUp,
+  .flatpickr-month .numInputWrapper span.arrowDown {
+    left: 2.6rem;
+    border: none;
+    width: rem(12px);
+
+    &:hover {
+      background: none;
+
+      &:after {
+        border-bottom-color: $brand-02;
+        border-top-color: $brand-02;
+      }
+    }
+
+    &:after {
+      border-bottom-color: $brand-01;
+      border-top-color: $brand-01;
+    }
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowUp,
+  .flatpickr-month .numInputWrapper span.arrowUp {
+    top: 4px;
+  }
+
+  .#{$prefix}--date-picker__month .numInputWrapper span.arrowDown,
+  .flatpickr-month .numInputWrapper span.arrowDown {
+    top: 11px;
+  }
+
+  span.#{$prefix}--date-picker__weekday,
+  span.flatpickr-weekday {
+    @include typescale('zeta');
+    color: $text-01;
+    font-weight: 400;
+  }
+
+  .#{$prefix}--date-picker__day,
+  .flatpickr-day {
+    @include typescale('zeta');
+    @include focus-outline('reset');
+    height: rem(40px);
+    width: rem(40px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $text-01;
+    border-radius: 0;
+    border: none;
+    transition: all $transition--base;
+
+    &:hover {
+      background: $hover-row;
+    }
+
+    &:focus {
+      outline: none;
+      background: $ui-03;
+    }
+  }
+
+  .#{$prefix}--date-picker__days .nextMonthDay,
+  .#{$prefix}--date-picker__days .prevMonthDay {
+    color: $next-month-color;
+  }
+
+  .#{$prefix}--date-picker__day.today,
+  .flatpickr-day.today {
+    position: relative;
+    color: $brand-01;
+
+    &::after {
+      content: '';
+      position: absolute;
+      display: block;
+      bottom: rem(7px);
+      left: 50%;
+      transform: translateX(-50%);
+      height: rem(4px);
+      width: rem(4px);
+      background: $brand-01;
+    }
+  }
+
+  .#{$prefix}--date-picker__day.today.no-border,
+  .flatpickr-day.today.no-border {
+    border: none;
+  }
+
+  .#{$prefix}--date-picker__day.today.selected {
+    border: 2px solid $brand-01;
+    &::after {
+      display: none;
+    }
+  }
+
+  .#{$prefix}--date-picker__day.disabled,
+  .flatpickr-day.disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    color: $ui-05;
+
+    &:hover {
+      background: transparent;
+    }
+  }
+
+  .#{$prefix}--date-picker__day.inRange,
+  .flatpickr-day.inRange {
+    background: $in-range-background-color;
+    color: $text-01;
+  }
+
+  .#{$prefix}--date-picker__day.selected,
+  .flatpickr-day.selected {
+    color: $inverse-01;
+    background: $brand-01;
+  }
+
+  .#{$prefix}--date-picker__day.startRange.selected,
+  .flatpickr-day.startRange.selected {
+    box-shadow: none;
+    z-index: 2;
+  }
+
+  .#{$prefix}--date-picker__day.endRange.inRange,
+  .flatpickr-day.endRange.inRange {
+    @include focus-outline('outline');
+    background: $ui-01;
+    z-index: 3;
+  }
+
+  .#{$prefix}--date-picker__day.endRange.inRange.selected,
+  .flatpickr-day.endRange.inRange.selected {
+    color: $inverse-01;
+    background: $brand-01;
+  }
+
+  .#{$prefix}--date-picker__day.startRange.inRange:not(.selected),
+  .flatpickr-day.startRange.inRange:not(.selected) {
+    @include focus-outline('outline');
+    background: $ui-01;
+    z-index: 3;
+  }
+
+  .#{$prefix}--date-picker__days,
+  .dayContainer {
+    width: 100%;
+    min-width: auto;
+  }
+
+  .flatpickr-innerContainer,
+  .flatpickr-rContainer {
+    width: 100%;
+  }
+
+  .#{$prefix}--date-picker__weekdays,
+  .flatpickr-weekdays,
+  .flatpickr-weekdaycontainer {
+    width: 100%;
+  }
+
+  .flatpickr-weekdays {
+    height: rem(40px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .flatpickr-weekdaycontainer {
+    display: flex;
+  }
+
+  .flatpickr-months {
+    display: flex;
+    width: 100%;
+    position: relative;
+  }
+
+  .flatpickr-prev-month,
+  .flatpickr-next-month {
+    padding-top: 5px;
+  }
+
+  .flatpickr-prev-month:hover svg,
+  .flatpickr-next-month:hover svg {
+    fill: $text-01;
+  }
+
+  .flatpickr-next-month.disabled,
+  .flatpickr-prev-month.disabled {
+    svg {
+      fill: $ui-05;
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      svg {
+        fill: $ui-05;
+      }
+    }
+  }
+
+  // Skeleton State
+  .#{$prefix}--date-picker.#{$prefix}--skeleton input,
+  .#{$prefix}--date-picker__input.#{$prefix}--skeleton {
+    @include skeleton;
+    width: 100%;
+
+    &::-webkit-input-placeholder {
+      color: transparent;
+    }
+  }
+
+  .#{$prefix}--date-picker.#{$prefix}--skeleton .#{$prefix}--label {
+    @include skeleton;
+    width: rem(75px);
+    height: rem(14px);
+  }
+}
+
+@include exports('date-picker') {
+  @if feature-flag-enabled('components-x') {
+    @include date-picker--x;
+  } @else {
+    @include date-picker;
   }
 }

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -671,7 +671,7 @@
 
   .#{$prefix}--date-picker__month .flatpickr-current-month .cur-month,
   .flatpickr-month .flatpickr-current-month .cur-month {
-    margin-right: 0.25rem;
+    margin-right: $spacing-2xs;
     color: $text-01;
   }
 
@@ -754,7 +754,7 @@
 
   .#{$prefix}--date-picker__days .nextMonthDay,
   .#{$prefix}--date-picker__days .prevMonthDay {
-    color: $next-month-color;
+    color: $date-picker-next-month-color;
   }
 
   .#{$prefix}--date-picker__day.today,
@@ -800,7 +800,7 @@
 
   .#{$prefix}--date-picker__day.inRange,
   .flatpickr-day.inRange {
-    background: $in-range-background-color;
+    background: $date-picker-in-range-background-color;
     color: $text-01;
   }
 

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -496,7 +496,7 @@
 
   .#{$prefix}--date-picker.#{$prefix}--date-picker--single {
     .#{$prefix}--date-picker__input {
-      min-width: 9.25rem;
+      width: rem(288px);
     }
   }
 
@@ -512,7 +512,6 @@
     padding: 0 $spacing-md;
     background-color: $field-01;
     border: none;
-    order: 2;
     color: $text-01;
     border-bottom: 1px solid $ui-04;
     transition: $transition--base all;
@@ -574,7 +573,7 @@
   }
 
   .#{$prefix}--date-picker--nolabel .#{$prefix}--date-picker__icon {
-    top: rem(14px);
+    top: rem(8px);
   }
 
   .#{$prefix}--date-picker__icon ~ .#{$prefix}--date-picker__input {
@@ -745,12 +744,11 @@
     transition: all $transition--base;
 
     &:hover {
-      background: $hover-row;
+      background: $hover-field;
     }
 
     &:focus {
-      outline: none;
-      background: $ui-03;
+      @include focus-outline('outline');
     }
   }
 
@@ -841,7 +839,7 @@
   .#{$prefix}--date-picker__days,
   .dayContainer {
     width: 100%;
-    min-width: auto;
+    min-width: 100%;
   }
 
   .flatpickr-innerContainer,

--- a/src/components/date-picker/date-picker--range.hbs
+++ b/src/components/date-picker/date-picker--range.hbs
@@ -2,7 +2,7 @@
 <div class="bx--form-item">
   <div data-date-picker data-date-picker-type="range" class="bx--date-picker bx--date-picker--range">
     <div class="bx--date-picker-container">
-       <label for="date-picker-1" class="bx--label">Start date label</label>
+      <label for="date-picker-1" class="bx--label">Start date label</label>
       <input type="text" id="date-picker-1" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input-from />
     </div>

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -120,6 +120,7 @@
     display: inline-block;
     vertical-align: baseline;
     margin-bottom: $spacing-xs;
+    line-height: rem(16px);
   }
 
   .#{$prefix}--label .#{$prefix}--tooltip__trigger {

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -141,12 +141,11 @@
 
   .#{$prefix}--text-input:focus,
   .#{$prefix}--text-input:active {
-    outline: 2px solid $brand-01;
-    outline-offset: -2px;
+    @include focus-outline('outline');
   }
 
   .#{$prefix}--text-input::-webkit-input-placeholder {
-    color: $text-03;
+    @include placeholder-colors;
   }
 
   //-----------------------------
@@ -182,8 +181,7 @@
   //-----------------------------
   .#{$prefix}--text-input[data-invalid],
   .#{$prefix}--text-input:invalid {
-    outline: 2px solid $support-01;
-    outline-offset: -2px;
+    @include focus-outline('invalid');
     box-shadow: none;
     // THIS SHOULD BE MOVED TO AN INLINE SVG IN THE HTML IN NEXT MAJOR RELEASE
     background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='16' height='16' class='ibm-icons ibm-icons--warning--filled' fill='%23da1e28'%3e%3cpath d='M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm-1 6h2v11h-2zm1 17a1.5 1.5 0 1 1 1.5-1.5A1.5 1.5 0 0 1 16 25z'/%3e%3c/svg%3e ");

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -59,6 +59,16 @@
     outline: 2px solid $brand-01;
     outline-offset: -2px;
   }
+
+  @if ($type == 'invalid') {
+    outline: 2px solid $support-01;
+    outline-offset: -2px;
+  }
+
+  @if ($type == 'reset') {
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+  }
 }
 
 @mixin rotate($deg, $speed, $origin: center) {

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -200,6 +200,10 @@
   $data-table-heading-border-bottom: 1px solid $brand-01 !default !global;
   $data-table-row-height: 2rem !default !global;
 
+  // Date Picker
+  $in-range-background-color: $ibm-colors__blue--20 !default !global;
+  $next-month-color: $ibm-colors__gray--60 !default !global;
+
   // Modal
   $modal-border-top: $brand-01 4px solid !default !global;
   $modal-footer-background-color: $ui-03 !default !global;

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -201,8 +201,8 @@
   $data-table-row-height: 2rem !default !global;
 
   // Date Picker
-  $in-range-background-color: $ibm-colors__blue--20 !default !global;
-  $next-month-color: $ibm-colors__gray--60 !default !global;
+  $date-picker-in-range-background-color: $ibm-colors__blue--20 !default !global;
+  $date-picker-next-month-color: $ibm-colors__gray--60 !default !global;
 
   // Modal
   $modal-border-top: $brand-01 4px solid !default !global;


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1271

Adds in the Experimental `DatePicker` component

#### Changelog

**New**

- Experimental Date Picker
- Two new one-off Date Picker colors as variables

**Changed**

- Added in `invalid` and `reset` to the focus outline mixin. Can be used to add a red outline on invalid items. The reset should be placed on elements initially, so that a transition can be applied smoothly between static and focus/invalid states. 

**Removed**

- Extra styles

#### Testing / Reviewing

[Staging Link](http://carbon-dev-environment-exp-date-picker-courteous-emu.mybluemix.net/?nav=date-picker)

![screen shot 2018-10-25 at 1 46 37 pm](https://user-images.githubusercontent.com/11928039/47522927-6b161400-d85c-11e8-9d63-71bdc8f289fb.png)
