### PR TITLE
feat(select): add experimental select

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -177,6 +177,7 @@
 
   .#{$prefix}--number input[type='number'] {
     @include typescale('zeta');
+    @include focus-outline('reset');
     font-family: $font-family-mono;
     box-sizing: border-box;
     display: inline-flex;
@@ -185,22 +186,21 @@
     padding-left: $spacing-md;
     padding-right: $spacing-xl;
     font-weight: 300;
-    height: rem(40px);
+    height: rem(32px);
     color: $text-01;
     background-color: $field-01;
     border: none;
     order: 2;
     border-radius: 0;
     border-bottom: 1px solid $ui-04;
-    transition: background $transition--base;
+    transition: all $transition--base;
 
     & ~ .#{$prefix}--label {
       order: 1;
     }
 
     &:focus {
-      outline: 2px solid $brand-01;
-      outline-offset: -2px;
+      @include focus-outline('outline');
     }
 
     &:hover {
@@ -257,8 +257,8 @@
     justify-content: center;
     align-items: center;
     left: auto;
-    right: 0.5rem;
-    bottom: 0.625rem;
+    right: 0.25rem;
+    bottom: 0.5rem;
   }
 
   .#{$prefix}--number__control-btn {
@@ -291,12 +291,11 @@
     }
 
     input[type='number'] {
-      outline: 2px solid $support-01;
-      outline-offset: -2px;
+      @include focus-outline('invalid');
     }
 
     .#{$prefix}--number__controls {
-      bottom: 2rem;
+      bottom: 1.875rem;
     }
   }
 

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -212,7 +212,7 @@
     height: rem(32px);
     appearance: none;
     display: block;
-    width: 100%;
+    width: rem(224px);
     min-width: rem(128px);
     max-width: rem(448px);
     padding: 0 $spacing-2xl 0 $spacing-md;
@@ -312,58 +312,74 @@
       flex-direction: row;
       align-items: center;
     }
+  }
 
-    .#{$prefix}--label {
-      white-space: nowrap;
-      margin: 0 $spacing-xs 0 0;
-      font-weight: 400;
-      align-self: center;
+  .#{$prefix}--select--inline .#{$prefix}--label {
+    @include typescale('zeta');
+    white-space: nowrap;
+    margin: 0 $spacing-xs 0 0;
+    align-self: center;
+  }
+
+  .#{$prefix}--select--inline .#{$prefix}--select-input {
+    background-color: transparent;
+    color: $text-01;
+    border-bottom: none;
+    padding-left: $spacing-xs;
+    padding-right: $spacing-lg;
+
+    &:hover {
+      background-color: $ui-01;
     }
 
-    .#{$prefix}--select-input {
+    &:focus {
+      @include focus-outline('outline');
+    }
+  }
+
+  .#{$prefix}--select--inline .#{$prefix}--select__arrow {
+    bottom: auto;
+    top: 0.875rem;
+    right: $spacing-xs;
+  }
+
+  .#{$prefix}--select--inline[data-invalid] {
+    @include focus-outline('invalid');
+  }
+
+  .#{$prefix}--select--inline .bx--select-input:disabled {
+    color: $disabled;
+    cursor: not-allowed;
+
+    &:hover {
       background-color: transparent;
-      color: $brand-01;
-      font-weight: 600;
-      box-shadow: none;
-
-      &:hover {
-        background-color: $color__white;
-      }
-
-      &:focus {
-        @include focus-outline('border');
-      }
-
-      ~ .#{$prefix}--select__arrow {
-        bottom: auto;
-        top: 1rem;
-      }
-
-      &[data-invalid] {
-        color: $text-01;
-        outline-offset: 2px;
-
-        &:focus {
-          outline: 1px solid $support-01;
-          box-shadow: none;
-        }
-      }
-
-      &:disabled ~ * {
-        opacity: 0.5;
-        cursor: not-allowed;
-      }
-
-      ~ .#{$prefix}--form-requirement {
-        grid-column-start: 2;
-
-        // Targets IE10+ browsers: Display grid auto not supported
-        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-          position: absolute;
-          bottom: -1.5rem;
-        }
-      }
     }
+
+    & ~ * {
+      cursor: not-allowed;
+    }
+  }
+
+  .#{$prefix}--select--inline .#{$prefix}--form-requirement {
+    grid-column-start: 2;
+
+    // Targets IE10+ browsers: Display grid auto not supported
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      position: absolute;
+      bottom: -1.5rem;
+    }
+  }
+
+  .#{$prefix}--select--inline .bx--select-input:disabled {
+    cursor: not-allowed;
+    // THIS SHOULD BE MOVED TO AN INLINE SVG IN NEXT MAJOR RELEASE
+    background-image: url("data:image/svg+xml;charset=UTF-8, %3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='16' height='16' class='ibm-icons ibm-icons--error--filled' fill='%23bebebe'%3e%3cpath d='M6.95 26.66A14 14 0 0 0 26.67 6.93zM16 2A14 14 0 0 0 5.35 25.07L25.08 5.34A13.93 13.93 0 0 0 16 2z'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: calc(100% - 8px) 50%;
+  }
+
+  .#{$prefix}--select--inline .bx--select-input:disabled ~ .#{$prefix}--select__arrow {
+    display: none;
   }
 
   //Skeleton State

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -219,10 +219,9 @@
     color: $text-01;
     background-color: $field-01;
     border: none;
-    border-bottom: 1px solid $ui-05;
+    border-bottom: 1px solid $ui-04;
     border-radius: 0;
     cursor: pointer;
-    border-bottom: 1px solid transparent;
     transition: outline $transition--base, background-color $transition--base;
 
     // Hide default select arrow in IE10+

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -12,7 +12,7 @@
 @import '../../globals/scss/import-once';
 @import '../form/form';
 
-@include exports('select') {
+@mixin select {
   .#{$prefix}--select {
     @include reset;
     position: relative;
@@ -194,5 +194,194 @@
 
   .#{$prefix}--select.#{$prefix}--skeleton .#{$prefix}--select-input {
     display: none;
+  }
+}
+
+@mixin select--x {
+  .#{$prefix}--select {
+    @include reset;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .#{$prefix}--select-input {
+    @include font-family;
+    @include typescale('zeta');
+    @include focus-outline('reset');
+    height: rem(32px);
+    appearance: none;
+    display: block;
+    width: 100%;
+    min-width: rem(128px);
+    max-width: rem(448px);
+    padding: 0 $spacing-2xl 0 $spacing-md;
+    color: $text-01;
+    background-color: $field-01;
+    border: none;
+    border-bottom: 1px solid $ui-05;
+    border-radius: 0;
+    cursor: pointer;
+    border-bottom: 1px solid transparent;
+    transition: outline $transition--base, background-color $transition--base;
+
+    // Hide default select arrow in IE10+
+    &::-ms-expand {
+      display: none;
+    }
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+
+    &:hover {
+      background-color: $hover-field;
+    }
+
+    &[data-invalid],
+    &[data-invalid]:focus {
+      @include focus-outline('invalid');
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      background: $disabled-background-color;
+      color: $disabled;
+      border-bottom: 1px solid $disabled-background-color;
+    }
+
+    ~ .#{$prefix}--form-requirement {
+      order: 3;
+      color: $support-01;
+      font-weight: 400;
+      margin-top: $spacing-2xs;
+    }
+  }
+
+  .#{$prefix}--select-input:disabled ~ .bx--select__arrow {
+    fill: $disabled;
+  }
+
+  .#{$prefix}--select--light .#{$prefix}--select-input {
+    background: $field-02;
+  }
+
+  .#{$prefix}--select__arrow {
+    fill: $ui-05;
+    position: absolute;
+    right: 1rem;
+    bottom: 0.75rem;
+    width: rem(10px);
+    height: rem(5px);
+    pointer-events: none;
+  }
+
+  &[data-invalid] ~ .#{$prefix}--select__arrow {
+    bottom: 2.125rem;
+  }
+
+  .#{$prefix}--select-optgroup,
+  .#{$prefix}--select-option {
+    color: $text-01; // For the options to show in IE11
+  }
+
+  .#{$prefix}--select-option[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  // Override some Firefox user-agent styles
+  @-moz-document url-prefix() {
+    .#{$prefix}--select-option {
+      background-color: $ui-01;
+      color: $text-01;
+    }
+
+    .#{$prefix}--select-optgroup {
+      color: $text-01;
+    }
+  }
+
+  .#{$prefix}--select--inline {
+    display: grid;
+    grid-template-columns: auto auto;
+
+    // Targets IE10+ browsers: Display grid auto not supported
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+
+    .#{$prefix}--label {
+      white-space: nowrap;
+      margin: 0 $spacing-xs 0 0;
+      font-weight: 400;
+      align-self: center;
+    }
+
+    .#{$prefix}--select-input {
+      background-color: transparent;
+      color: $brand-01;
+      font-weight: 600;
+      box-shadow: none;
+
+      &:hover {
+        background-color: $color__white;
+      }
+
+      &:focus {
+        @include focus-outline('border');
+      }
+
+      ~ .#{$prefix}--select__arrow {
+        bottom: auto;
+        top: 1rem;
+      }
+
+      &[data-invalid] {
+        color: $text-01;
+        outline-offset: 2px;
+
+        &:focus {
+          outline: 1px solid $support-01;
+          box-shadow: none;
+        }
+      }
+
+      &:disabled ~ * {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      ~ .#{$prefix}--form-requirement {
+        grid-column-start: 2;
+
+        // Targets IE10+ browsers: Display grid auto not supported
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+          position: absolute;
+          bottom: -1.5rem;
+        }
+      }
+    }
+  }
+
+  //Skeleton State
+  .#{$prefix}--select.#{$prefix}--skeleton {
+    @include skeleton;
+    width: 100%;
+    height: 2.5rem;
+  }
+
+  .#{$prefix}--select.#{$prefix}--skeleton .#{$prefix}--select-input {
+    display: none;
+  }
+}
+
+@include exports('select') {
+  @if feature-flag-enabled('components-x') {
+    @include select--x;
+  } @else {
+    @include select;
   }
 }

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -1,26 +1,21 @@
 <div class="bx--form-item">
   <div class="bx--select{{#if inline}} bx--select--inline{{/if}}{{#if light}} bx--select--light{{/if}}">
     <label for="select-id" class="bx--label">Select label</label>
-    <select {{#if invalid}}data-invalid{{/if}} id="select-id" class="bx--select-input">
+    <select {{#if invalid}} data-invalid{{/if}} id="select-id" class="bx--select-input">
       {{#each items}}
-        {{#if items}}
-          <optgroup class="bx--select-optgroup" label="{{label}}">
-            {{#each items}}
-              <option class="bx--select-option" value="{{value}}"{{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}</option>
-            {{/each}}
-          </optgroup>
-        {{else}}
-          <option class="bx--select-option" value="{{value}}"{{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}</option>
-        {{/if}}
-      {{/each}}
-    </select>
-    <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
-      <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-    </svg>
-    {{#if invalid}}
-    <div class="bx--form-requirement">
-      Validation message here
-    </div>
-    {{/if}}
+      {{#if items}}
+      <optgroup class="bx--select-optgroup" label="{{label}}">
+        {{#each items}}
+        <option class="bx--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if
+          hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}} <option class="bx--select-option"
+          value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}
+          </option> {{/if}} {{/each}} </select> <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+          </svg>
+          {{#if invalid}}
+          <div class="bx--form-requirement">
+            Validation message here
+          </div>
+          {{/if}}
   </div>
 </div>

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -123,6 +123,7 @@
   .#{$prefix}--text-input {
     @include reset;
     @include typescale('zeta');
+    @include focus-outline('reset');
     background-color: $field-01;
     width: 100%;
     height: rem(32px);
@@ -130,9 +131,7 @@
     color: $text-01;
     border: none;
     border-bottom: 1px solid $ui-04;
-    outline: 2px solid transparent;
     transition: $transition--base all;
-    outline-offset: -2px;
   }
 
   .#{$prefix}--text-input:hover {


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1211

Adds in experimental `Select`

#### Changelog

**New**

- Experimental `Select`, Experimental `InlineSelect`

**Changed**

- Unnested selectors in `select.scss`
- Updated `text-input.scss` and `number-input.scss` to use the focus outline mixin (Blocked by https://github.com/IBM/carbon-components/pull/1337)
- Updated `NumberInput` height (`40px` --> `32px`) and adjusted arrows accordingly

**Removed**

- Old unnecessary styles 

#### Testing / Reviewing

Will add a staging link once Date Picker styles have been merged in, as this relies on styles from that PR

![screen shot 2018-10-26 at 11 07 31 am](https://user-images.githubusercontent.com/11928039/47578592-60688700-d90f-11e8-8529-0edfdc33e880.png)

