### PR TITLE
Fix/misaligned number controls

### DIFF
--- a/src/components/number-input/README.md
+++ b/src/components/number-input/README.md
@@ -2,13 +2,13 @@
 
 #### Options
 
-| Option       | Default Selector     | Description                               |
-|--------------|----------------------|-------------------------------------------|
-| selectorInit | [data-numberinput]   | The CSS seletor to find number input HTML |
+| Option       | Default Selector   | Description                                |
+| ------------ | ------------------ | ------------------------------------------ |
+| selectorInit | [data-numberinput] | The CSS selector to find number input HTML |
 
 #### Events
 
 | Name   | Description                                                       |
-|--------|-------------------------------------------------------------------|
+| ------ | ----------------------------------------------------------------- |
 | click  | Increases and decreases value attribute of number-input           |
 | change | Emitted when click event inceases or decreases number-input value |

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -95,7 +95,7 @@
     align-items: center;
     left: auto;
     right: 0.5rem;
-    bottom: 0.625rem;
+    top: 2rem;
   }
 
   .#{$prefix}--number__control-btn {
@@ -144,10 +144,6 @@
 
     input[type='number']:focus ~ .#{$prefix}--label {
       color: $support-01;
-    }
-
-    .#{$prefix}--number__controls {
-      bottom: 2rem;
     }
   }
 
@@ -258,7 +254,7 @@
     align-items: center;
     left: auto;
     right: 0.5rem;
-    bottom: 0.625rem;
+    top: 2rem;
   }
 
   .#{$prefix}--number__control-btn {
@@ -293,10 +289,6 @@
     input[type='number'] {
       outline: 2px solid $support-01;
       outline-offset: -2px;
-    }
-
-    .#{$prefix}--number__controls {
-      bottom: 2rem;
     }
   }
 

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -147,6 +147,18 @@
     }
   }
 
+  .#{$prefix}--number--nolabel .#{$prefix}--number__controls {
+    top: 0.625rem;
+  }
+
+  .#{$prefix}--number--helpertext .#{$prefix}--number__controls {
+    top: 2.25rem;
+  }
+
+  .#{$prefix}--number--helpertext:not(.#{$prefix}--number--nolabel) .#{$prefix}--number__controls {
+    top: 3.625rem;
+  }
+
   .#{$prefix}--number--light input[type='number'] {
     background: $field-02;
   }
@@ -290,6 +302,18 @@
       outline: 2px solid $support-01;
       outline-offset: -2px;
     }
+  }
+
+  .#{$prefix}--number--nolabel .#{$prefix}--number__controls {
+    top: 0.625rem;
+  }
+
+  .#{$prefix}--number--helpertext .#{$prefix}--number__controls {
+    top: 2.25rem;
+  }
+
+  .#{$prefix}--number--helpertext:not(.#{$prefix}--number--nolabel) .#{$prefix}--number__controls {
+    top: 3.625rem;
   }
 
   .#{$prefix}--number--light input[type='number'] {

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -40,7 +40,28 @@
 </div>
 
 <div class="bx--form-item">
-  <div data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}}">
+  <div data-invalid data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}} bx--number--nolabel">
+    <input id="number-input" type="number" min="0" max="100" value="1">
+    <div class="bx--number__controls">
+      <button class="bx--number__control-btn up-icon">
+        <svg width="10" height="5" viewBox="0 0 10 5">
+          <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
+        </svg>
+      </button>
+      <button class="bx--number__control-btn down-icon">
+        <svg width="10" height="5" viewBox="0 0 10 5">
+          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+        </svg>
+      </button>
+    </div>
+    <div class="bx--form-requirement">
+      Invalid number
+    </div>
+  </div>
+</div>
+
+<div class="bx--form-item">
+  <div data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}} bx--number--helpertext">
     <label for="number-input" class="bx--label">Number Input label</label>
     <input id="number-input" type="number" min="0" max="100" value="1">
     <div class="bx--number__controls">


### PR DESCRIPTION
Closes #1312 

This PR addresses the misalignment of number input controls in the presence of invalid text error.

#### Changelog
**Changed**
- Use `top` to position number controls instead of `bottom`
- Adjust for input label / helpertext presence to calculate position offset
- Added new input demo (without label) in NumberInput demo page
- Fix a typo in number input README

#### Testing / Reviewing
Use the NumberInput demo page to test out. The last input demo has both helpertext and label. Test out the following remaining scenarios:
- **With only helper text:** Remove label, Add `bx--number--nolabel` class
- **With only label:** Remove helpertext, Remove `bx--number--helpertext` class
- **Without label and helper text:** Remove label and helpertext, Add `bx--number--nolabel` class, Remove `bx--number--helpertext` class