### PR TITLE
fix(content-switcher): update experimental colors

### DIFF
--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -125,6 +125,7 @@
     @include font-smoothing;
     @include typescale('zeta');
     @include font-family;
+    @include focus-outline('reset');
     background-color: $ui-01;
     display: flex;
     align-items: center;
@@ -134,8 +135,6 @@
     border: none;
     color: $text-02;
     transition: all $transition--base $carbon--standard-easing;
-    outline: 2px solid transparent;
-    outline-offset: -2px;
     position: relative;
 
     &:focus {
@@ -161,7 +160,7 @@
     display: block;
     height: rem(16px);
     width: rem(1px);
-    background-color: $ui-04;
+    background-color: $content-switcher-divider;
     position: absolute;
     z-index: 2;
     right: rem(-1px);
@@ -188,8 +187,8 @@
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected {
-    background-color: $ui-03;
-    color: $text-01;
+    background-color: $ui-05;
+    color: $inverse-01;
     z-index: 3;
   }
 

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -111,7 +111,7 @@
   $brand-01: $ibm-colors__blue--60 !default !global;
   $brand-02: $ibm-colors__blue--80 !default !global;
   $brand-03: $ibm-colors__blue--60 !default !global;
-  $inverse-01: $ibm-colors__white !default !global;
+  $inverse-01: $ibm-colors__gray--10 !default !global;
   $inverse-02: $ibm-colors__white !default !global; // TODO: Define for experimental
   $ui-01: $ibm-colors__gray--10 !default !global;
   $ui-02: $ibm-colors__white !default !global;
@@ -194,6 +194,7 @@
   // Content Switcher
   $content-switcher-border-radius: 0px !default !global;
   $content-switcher-option-border: 1px solid $brand-01 !default !global;
+  $content-switcher-divider: $ibm-colors__gray--30 !default !global;
 
   // Data Table
   $data-table-heading-transform: uppercase !default !global;


### PR DESCRIPTION
Updates Experimental `ContentSwitcher` colors

![screen shot 2018-10-30 at 10 42 23 am](https://user-images.githubusercontent.com/11928039/47730713-b8b1c880-dc30-11e8-94d4-03283bc34da0.png)

#### Changelog

**New**

- New variable, `$content-switcher-divider` which uses `ibm-gray-30`

**Changed**

- Changed `inverse-01` text color to `ibm-gray-10` across the board (was white)

#### Testing / Reviewing

![screen shot 2018-10-30 at 10 43 46 am](https://user-images.githubusercontent.com/11928039/47730706-b485ab00-dc30-11e8-8b32-0e0061b085b2.png)

