### PR TITLE
feat(notification): add experimental notification 

### DIFF
--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -196,7 +196,7 @@
     width: rem(48px);
     min-width: rem(48px);
     max-width: rem(48px);
-    transition: outline $transition--base;
+    transition: outline $transition--base, background-color $transition--base;
 
     &:focus {
       @include focus-outline('outline');

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -118,8 +118,6 @@
     color: $text-01;
     margin-top: $spacing-md;
     margin-bottom: $spacing-md;
-    border-left-width: rem(2px);
-    border-left-style: solid;
 
     @include breakpoint(md) {
       max-width: rem(608px);
@@ -156,7 +154,6 @@
 
   .#{$prefix}--inline-notification__details {
     display: flex;
-    align-items: center;
     margin: 0 $spacing-md;
   }
 
@@ -166,11 +163,13 @@
     min-height: rem(20px);
     min-width: rem(20px);
     margin-right: $spacing-md;
+    margin-top: rem(14px);
   }
 
   .#{$prefix}--inline-notification__text-wrapper {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     padding: $spacing-sm 0;
   }
 

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -121,15 +121,15 @@
     border-left-width: rem(2px);
     border-left-style: solid;
 
-    @include exp-breakpoint(md) {
+    @include breakpoint(md) {
       max-width: rem(608px);
     }
 
-    @include exp-breakpoint(lg) {
+    @include breakpoint(lg) {
       max-width: rem(736px);
     }
 
-    @include exp-breakpoint(max) {
+    @include breakpoint(max) {
       max-width: rem(832px);
     }
   }

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -13,7 +13,7 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
 
-@include exports('inline-notifications') {
+@mixin inline-notifications {
   .#{$prefix}--inline-notification {
     @include reset;
     @include font-family;
@@ -100,5 +100,103 @@
     position: absolute;
     top: 3px;
     right: 1px;
+  }
+}
+
+@mixin inline-notifications--x {
+  .#{$prefix}--inline-notification {
+    @include reset;
+    @include font-family;
+    @include font-smoothing;
+    @include typescale('zeta');
+    display: flex;
+    height: rem(48px);
+    max-width: rem(288px);
+    color: $text-01;
+    margin-top: $spacing-md;
+    margin-bottom: $spacing-md;
+    border-left-width: rem(2px);
+    border-left-style: solid;
+  }
+
+  .#{$prefix}--inline-notification--error {
+    @include notification--experimental($support-01, $notification-error-background-color);
+  }
+
+  .#{$prefix}--inline-notification--success {
+    @include notification--experimental($support-02, $notification-success-background-color);
+  }
+
+  .#{$prefix}--inline-notification--info {
+    @include notification--experimental($support-04, $notification-info-background-color);
+  }
+
+  .#{$prefix}--inline-notification--info .bx--inline-notification__icon {
+    display: none;
+  }
+
+  .#{$prefix}--inline-notification--warning {
+    @include notification--experimental($support-03, $notification-warning-background-color);
+  }
+
+  .#{$prefix}--inline-notification__details {
+    display: flex;
+    align-items: center;
+    margin: 0 $spacing-md;
+    width: 100%;
+  }
+
+  .#{$prefix}--inline-notification__icon {
+    height: rem(20px);
+    width: rem(20px);
+    min-height: rem(20px);
+    min-width: rem(20px);
+    margin-right: $spacing-md;
+  }
+
+  .#{$prefix}--inline-notification__text-wrapper {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .#{$prefix}--inline-notification__title {
+    @include typescale('zeta');
+    font-weight: 600;
+    margin: 0 $spacing-2xs 0 0;
+    white-space: nowrap;
+  }
+
+  .#{$prefix}--inline-notification__subtitle {
+    @include typescale('zeta');
+    min-width: 200px;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .#{$prefix}--inline-notification__close-button {
+    @include focus-outline('reset');
+    background: transparent;
+    border: none;
+    border-left: 1px solid $ui-02;
+    cursor: pointer;
+    padding: 0;
+    height: rem(48px);
+    width: rem(48px);
+    transition: outline $transition--base;
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+  }
+}
+
+@include exports('inline-notifications') {
+  @if feature-flag-enabled('components-x') {
+    @include inline-notifications--x;
+  } @else {
+    @include inline-notifications;
   }
 }

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -171,6 +171,7 @@
     flex-wrap: wrap;
     align-items: center;
     padding: $spacing-sm 0;
+    max-width: 75%;
   }
 
   .#{$prefix}--inline-notification__title {

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -7,6 +7,7 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/spacing';
 @import '../../globals/scss/layer';
+@import '../../globals/scss/layout';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/mixins';
@@ -110,13 +111,27 @@
     @include font-smoothing;
     @include typescale('zeta');
     display: flex;
-    height: rem(48px);
+    height: auto;
+    min-height: rem(48px);
+    min-width: rem(288px);
     max-width: rem(288px);
     color: $text-01;
     margin-top: $spacing-md;
     margin-bottom: $spacing-md;
     border-left-width: rem(2px);
     border-left-style: solid;
+
+    @include exp-breakpoint(md) {
+      max-width: rem(608px);
+    }
+
+    @include exp-breakpoint(lg) {
+      max-width: rem(736px);
+    }
+
+    @include exp-breakpoint(max) {
+      max-width: rem(832px);
+    }
   }
 
   .#{$prefix}--inline-notification--error {
@@ -143,7 +158,6 @@
     display: flex;
     align-items: center;
     margin: 0 $spacing-md;
-    width: 100%;
   }
 
   .#{$prefix}--inline-notification__icon {
@@ -156,8 +170,8 @@
 
   .#{$prefix}--inline-notification__text-wrapper {
     display: flex;
-    align-items: center;
-    width: 100%;
+    flex-wrap: wrap;
+    padding: $spacing-sm 0;
   }
 
   .#{$prefix}--inline-notification__title {
@@ -169,22 +183,19 @@
 
   .#{$prefix}--inline-notification__subtitle {
     @include typescale('zeta');
-    min-width: 200px;
-    width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    word-break: break-word;
   }
 
   .#{$prefix}--inline-notification__close-button {
     @include focus-outline('reset');
     background: transparent;
     border: none;
-    border-left: 1px solid $ui-02;
     cursor: pointer;
     padding: 0;
     height: rem(48px);
     width: rem(48px);
+    min-width: rem(48px);
+    max-width: rem(48px);
     transition: outline $transition--base;
 
     &:focus {

--- a/src/components/notification/_mixins.scss
+++ b/src/components/notification/_mixins.scss
@@ -23,7 +23,13 @@
   border-color: $color;
   background: $background-color;
 
-  .#{$prefix}--inline-notification__icon {
+  .#{$prefix}--inline-notification__icon,
+  .#{$prefix}--toast-notification__icon {
     fill: $color;
+  }
+
+  .#{$prefix}--inline-notification__close-button:hover,
+  .#{$prefix}--toast-notification__close-button:hover {
+    background-color: darken($background-color, 15%);
   }
 }

--- a/src/components/notification/_mixins.scss
+++ b/src/components/notification/_mixins.scss
@@ -18,3 +18,12 @@
 @mixin notification--color($color) {
   border-left: 6px solid $color;
 }
+
+@mixin notification--experimental($color, $background-color) {
+  border-color: $color;
+  background: $background-color;
+
+  .#{$prefix}--inline-notification__icon {
+    fill: $color;
+  }
+}

--- a/src/components/notification/_mixins.scss
+++ b/src/components/notification/_mixins.scss
@@ -20,16 +20,11 @@
 }
 
 @mixin notification--experimental($color, $background-color) {
-  border-color: $color;
+  border-left: 3px solid $color;
   background: $background-color;
 
   .#{$prefix}--inline-notification__icon,
   .#{$prefix}--toast-notification__icon {
     fill: $color;
-  }
-
-  .#{$prefix}--inline-notification__close-button:hover,
-  .#{$prefix}--toast-notification__close-button:hover {
-    background-color: darken($background-color, 15%);
   }
 }

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -118,7 +118,7 @@
       margin-top: $spacing-md;
     }
 
-    @include exp-breakpoint(max) {
+    @include breakpoint(max) {
       width: rem(352px);
     }
   }

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -7,6 +7,7 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/spacing';
 @import '../../globals/scss/layer';
+@import '../../globals/scss/layout';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/mixins';
@@ -102,11 +103,10 @@
     @include font-family;
     @include font-smoothing;
     display: flex;
-    // justify-content: space-between;
-    width: 16.875rem;
+    justify-content: space-between;
+    width: rem(288px);
     height: auto;
     padding-left: $spacing-md;
-    background-color: $ui-01;
     color: $text-01;
     margin-top: $spacing-xs;
     margin-bottom: $spacing-xs;
@@ -116,6 +116,10 @@
 
     &:first-child {
       margin-top: $spacing-md;
+    }
+
+    @include exp-breakpoint(max) {
+      width: rem(352px);
     }
   }
 
@@ -135,6 +139,15 @@
     @include notification--experimental($support-03, $notification-warning-background-color);
   }
 
+  .#{$prefix}--toast-notification__icon {
+    height: rem(20px);
+    width: rem(20px);
+    min-height: rem(20px);
+    min-width: rem(20px);
+    margin-right: $spacing-md;
+    margin-top: $spacing-md;
+  }
+
   .#{$prefix}--toast-notification__close-button {
     @include focus-outline('reset');
     background-color: transparent;
@@ -146,7 +159,7 @@
     width: rem(48px);
     min-height: rem(48px);
     min-width: rem(48px);
-    transition: outline $transition--base;
+    transition: outline $transition--base, background-color $transition--base;
 
     &:focus {
       @include focus-outline('outline');

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -103,7 +103,6 @@
     @include font-family;
     @include font-smoothing;
     display: flex;
-    justify-content: space-between;
     width: rem(288px);
     height: auto;
     padding-left: $spacing-md;
@@ -111,8 +110,6 @@
     margin-top: $spacing-xs;
     margin-bottom: $spacing-xs;
     margin-right: $spacing-md;
-    border-left-width: rem(3px);
-    border-left-style: solid;
 
     &:first-child {
       margin-top: $spacing-md;
@@ -148,12 +145,16 @@
     margin-top: $spacing-md;
   }
 
+  .#{$prefix}--toast-notification__details {
+    margin-right: $spacing-md;
+  }
+
   .#{$prefix}--toast-notification__close-button {
     @include focus-outline('reset');
     background-color: transparent;
     border: none;
     cursor: pointer;
-    margin-left: $spacing-md;
+    margin-left: auto;
     padding: 0;
     height: rem(48px);
     width: rem(48px);

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -13,7 +13,7 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
 
-@include exports('toast-notifications') {
+@mixin toast-notifications {
   .#{$prefix}--toast-notification {
     @include reset;
     @include font-family;
@@ -93,5 +93,91 @@
     @include typescale('omega');
     color: $text-02;
     line-height: 1;
+  }
+}
+
+@mixin toast-notifications--x {
+  .#{$prefix}--toast-notification {
+    @include reset;
+    @include font-family;
+    @include font-smoothing;
+    display: flex;
+    // justify-content: space-between;
+    width: 16.875rem;
+    height: auto;
+    padding-left: $spacing-md;
+    background-color: $ui-01;
+    color: $text-01;
+    margin-top: $spacing-xs;
+    margin-bottom: $spacing-xs;
+    margin-right: $spacing-md;
+    border-left-width: rem(3px);
+    border-left-style: solid;
+
+    &:first-child {
+      margin-top: $spacing-md;
+    }
+  }
+
+  .#{$prefix}--toast-notification--error {
+    @include notification--experimental($support-01, $notification-error-background-color);
+  }
+
+  .#{$prefix}--toast-notification--success {
+    @include notification--experimental($support-02, $notification-success-background-color);
+  }
+
+  .#{$prefix}--toast-notification--info {
+    @include notification--experimental($support-04, $notification-info-background-color);
+  }
+
+  .#{$prefix}--toast-notification--warning {
+    @include notification--experimental($support-03, $notification-warning-background-color);
+  }
+
+  .#{$prefix}--toast-notification__close-button {
+    @include focus-outline('reset');
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    margin-left: $spacing-md;
+    padding: 0;
+    height: rem(48px);
+    width: rem(48px);
+    min-height: rem(48px);
+    min-width: rem(48px);
+    transition: outline $transition--base;
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+  }
+
+  .#{$prefix}--toast-notification__title {
+    @include typescale('zeta');
+    @include letter-spacing;
+    font-weight: 600;
+    margin-top: 1rem;
+  }
+
+  .#{$prefix}--toast-notification__subtitle {
+    @include typescale('zeta');
+    color: $text-01;
+    margin-top: 0;
+    margin-bottom: $spacing-lg;
+  }
+
+  .#{$prefix}--toast-notification__caption {
+    @include typescale('zeta');
+    color: $text-01;
+    margin-bottom: $spacing-md;
+  }
+}
+
+@include exports('toast-notifications') {
+  @if feature-flag-enabled('components-x') {
+    @include toast-notifications--x;
+  } @else {
+    @include toast-notifications;
   }
 }

--- a/src/components/notification/notification.config.js
+++ b/src/components/notification/notification.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { componentsX } = require('../../globals/js/feature-flags');
+
 const items = [
   {
     type: 'info',
@@ -36,6 +38,7 @@ module.exports = {
       context: {
         variant: 'inline',
         items,
+        componentsX,
       },
     },
     {
@@ -48,6 +51,7 @@ module.exports = {
       context: {
         variant: 'toast',
         items,
+        componentsX,
       },
     },
   ],

--- a/src/components/notification/notification.config.js
+++ b/src/components/notification/notification.config.js
@@ -17,7 +17,7 @@ const items = [
     type: 'success',
     title: 'Notification title',
     subtitle:
-      'WARNING: The default font path (https://unpkg.com/carbon-components@latest/src/globals/fonts) should be used only for demonstration/evaluation purposes.',
+      'Our goal is to become better at our craft and raise our collective knowledge by sharing experiences, best practices, what we have recently learned or what we are working on.',
     timestamp: 'Time stamp [00:00:00]',
   },
   {

--- a/src/components/notification/notification.config.js
+++ b/src/components/notification/notification.config.js
@@ -2,13 +2,13 @@
 
 const items = [
   {
-    type: 'error',
+    type: 'info',
     title: 'Notification title',
     subtitle: 'Subtitle text goes here.',
     timestamp: 'Time stamp [00:00:00]',
   },
   {
-    type: 'info',
+    type: 'error',
     title: 'Notification title',
     subtitle: 'Subtitle text goes here.',
     timestamp: 'Time stamp [00:00:00]',
@@ -16,7 +16,8 @@ const items = [
   {
     type: 'success',
     title: 'Notification title',
-    subtitle: 'Subtitle text goes here.',
+    subtitle:
+      'WARNING: The default font path (https://unpkg.com/carbon-components@latest/src/globals/fonts) should be used only for demonstration/evaluation purposes.',
     timestamp: 'Time stamp [00:00:00]',
   },
   {

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -1,42 +1,63 @@
 {{#each items}}
-  <div data-notification class="bx--{{../variant}}-notification bx--{{../variant}}-notification--{{type}}" role="alert">
-    <div class="bx--{{../variant}}-notification__details">
-      {{#is ../variant "inline"}}
-        {{#is type "error"}}
-          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
-          </svg>
-        {{/is}}
-        {{#is type "info"}}
-          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
-          </svg>
-        {{/is}}
-        {{#is type "success"}}
-          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
-          </svg>
-        {{/is}}
-        {{#is type "warning"}}
-          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-            <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
-          </svg>
-        {{/is}}
-        <div class="bx--{{../variant}}-notification__text-wrapper">
-          <p class="bx--{{../variant}}-notification__title">{{title}}</p>
-          <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>
-        </div>
-      {{/is}}
-      {{#is ../variant "toast"}}
-        <h3 class="bx--{{../variant}}-notification__title">{{title}}</h3>
-        <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>
-        <p class="bx--{{../variant}}-notification__caption">{{timestamp}}</p>
-      {{/is}}
+<div data-notification class="bx--{{../variant}}-notification bx--{{../variant}}-notification--{{type}}" role="alert">
+  {{#is ../variant "toast"}}
+  {{#if ../componentsX}}
+  {{#is type "error"}}
+  <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
+  </svg>
+  {{/is}}
+  {{#is type "success"}}
+  <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
+  </svg>
+  {{/is}}
+  {{#is type "warning"}}
+  <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
+  </svg>
+  {{/is}}
+  {{/if}}
+  {{/is}}
+  <div class="bx--{{../variant}}-notification__details">
+    {{#is ../variant "inline"}}
+    {{#is type "error"}}
+    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
+    </svg>
+    {{/is}}
+    {{#is type "info"}}
+    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
+    </svg>
+    {{/is}}
+    {{#is type "success"}}
+    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
+    </svg>
+    {{/is}}
+    {{#is type "warning"}}
+    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+      <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
+    </svg>
+    {{/is}}
+    <div class="bx--{{../variant}}-notification__text-wrapper">
+      <p class="bx--{{../variant}}-notification__title">{{title}}</p>
+      <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>
     </div>
-    <button data-notification-btn class="bx--{{../variant}}-notification__close-button" type="button" aria-label="close">
-      <svg aria-hidden="true" class="bx--{{../variant}}-notification{{#is ../variant "inline"}}__close{{/is}}-icon" width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-        <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z" fill-rule="nonzero" />
-      </svg>
-    </button>
+    {{/is}}
+    {{#is ../variant "toast"}}
+    <h3 class="bx--{{../variant}}-notification__title">{{title}}</h3>
+    <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>
+    <p class="bx--{{../variant}}-notification__caption">{{timestamp}}</p>
+    {{/is}}
   </div>
+  <button data-notification-btn class="bx--{{../variant}}-notification__close-button" type="button" aria-label="close">
+    <svg aria-hidden="true" class="bx--{{../variant}}-notification{{#is ../variant "inline"}}__close{{/is}}-icon" width="10"
+      height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+        fill-rule="nonzero" />
+    </svg>
+  </button>
+</div>
 {{/each}}

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -13,8 +13,21 @@
   </svg>
   {{/is}}
   {{#is type "warning"}}
-  <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-    <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
+  <svg class="bx--{{../variant}}-notification__icon" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <path d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
+        id="a" />
+      <path d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z" id="b" />
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+      <path d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
+        fill="#FDD13A" />
+      <g>
+        <path d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z" fill="#171717"
+          fill-rule="nonzero" />
+      </g>
+      <path d="M0 0h20v20H0z" />
+    </g>
   </svg>
   {{/is}}
   {{/if}}
@@ -37,9 +50,28 @@
     </svg>
     {{/is}}
     {{#is type "warning"}}
+    {{#if ../componentsX}}
+    <svg class="bx--{{../variant}}-notification__icon" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <path d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
+          id="a" />
+        <path d="M.55.006h1.406v5H.55v-5zm.7 8.119a.938.938 0 1 1 0-1.875.938.938 0 0 1 0 1.875z" id="b" />
+      </defs>
+      <g fill="none" fill-rule="evenodd">
+        <path d="M18.675 16.575l-8.125-15a.625.625 0 0 0-1.1 0l-8.125 15a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3h16.25a.625.625 0 0 0 .55-.925z"
+          fill="#FDD13A" />
+        <g>
+          <path d="M9.3 6.881h1.406v5H9.3v-5zM10 15a.938.938 0 1 1 0-1.875A.938.938 0 0 1 10 15z" fill="#171717"
+            fill-rule="nonzero" />
+        </g>
+        <path d="M0 0h20v20H0z" />
+      </g>
+    </svg>
+    {{else}}
     <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
       <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
     </svg>
+    {{/if}}
     {{/is}}
     <div class="bx--{{../variant}}-notification__text-wrapper">
       <p class="bx--{{../variant}}-notification__title">{{title}}</p>

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -4,12 +4,20 @@ $breakpoints: (
   bp--xs--major: 500px,
   bp--sm--major: 768px,
   bp--md--major: 992px,
-  bp--lg--major: 1200px
+  bp--lg--major: 1200px,
+);
+
+$exp-breakpoints: (
+  sm: 320px,
+  md: 672px,
+  lg: 1056px,
+  xlg: 1312px,
+  max: 1584px,
 );
 
 $padding: (
   'mobile': 3%,
-  'xs': 5%
+  'xs': 5%,
 );
 
 @function padding($value) {
@@ -32,6 +40,27 @@ $padding: (
 @mixin breakpoint($size) {
   @if map-has-key($breakpoints, $size) {
     @media screen and (min-width: map-get($breakpoints, $size)) {
+      @content;
+    }
+  } @else {
+    @media (min-width: $size) {
+      @content;
+    }
+  }
+}
+
+//-------------------------------------
+// @mixin: exp-breakpoint($size)
+//-------------------------------------
+// usage:
+// @include exp-breakpoint(md) {
+//    - styles here --
+// }
+//-------------------------------------
+
+@mixin exp-breakpoint($size) {
+  @if map-has-key($exp-breakpoints, $size) {
+    @media screen and (min-width: map-get($exp-breakpoints, $size)) {
       @content;
     }
   } @else {
@@ -69,7 +98,7 @@ $z-indexes: (
   footer: 5000,
   hidden: - 1,
   overflowHidden: - 1,
-  floating: 10000
+  floating: 10000,
 );
 
 //-------------------------------------

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -5,9 +5,6 @@ $breakpoints: (
   bp--sm--major: 768px,
   bp--md--major: 992px,
   bp--lg--major: 1200px,
-);
-
-$exp-breakpoints: (
   sm: 320px,
   md: 672px,
   lg: 1056px,
@@ -40,27 +37,6 @@ $padding: (
 @mixin breakpoint($size) {
   @if map-has-key($breakpoints, $size) {
     @media screen and (min-width: map-get($breakpoints, $size)) {
-      @content;
-    }
-  } @else {
-    @media (min-width: $size) {
-      @content;
-    }
-  }
-}
-
-//-------------------------------------
-// @mixin: exp-breakpoint($size)
-//-------------------------------------
-// usage:
-// @include exp-breakpoint(md) {
-//    - styles here --
-// }
-//-------------------------------------
-
-@mixin exp-breakpoint($size) {
-  @if map-has-key($exp-breakpoints, $size) {
-    @media screen and (min-width: map-get($exp-breakpoints, $size)) {
       @content;
     }
   } @else {

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -124,9 +124,9 @@
   $field-01: $ibm-colors__gray--10 !default !global;
   $field-02: $ibm-colors__gray--10 !default !global; // TODO: Define for experimental
   $support-01: $ibm-colors__red--60 !default !global;
-  $support-02: $ibm-colors__green--50 !default !global;
+  $support-02: $ibm-colors__green--60 !default !global;
   $support-03: $ibm-colors__yellow--20 !default !global;
-  $support-04: $ibm-colors__blue--50 !default !global;
+  $support-04: $ibm-colors__blue--70 !default !global;
 
   // TODO: Define for experimental
   $nav-01: $color__navy-gray-1 !default !global;
@@ -208,6 +208,12 @@
   // Modal
   $modal-border-top: $brand-01 4px solid !default !global;
   $modal-footer-background-color: $ui-03 !default !global;
+
+  // Notification
+  $notification-info-background-color: $ibm-colors__blue--10 !default !global;
+  $notification-error-background-color: $ibm-colors__red--10 !default !global;
+  $notification-warning-background-color: rgba(#fdd13a, 0.15) !default !global;
+  $notification-success-background-color: $ibm-colors__green--10 !default !global;
 
   // Progress Indicator
   $progress-indicator-bar-width: 1px inset transparent !default !global;


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1295

Adds in experimental `Notification`

#### Changelog

**New**

- Experimental `Notification`
- A few new color variables
- ~`@mixin exp-breakpoint($size)`, which utilizes the new breakpoint scale~ Added to existing breakpoint mixin

**Changed**

- Changed the `notification.hbs` file to conditionally render icons on toast components
- Added long text to test long strings (will remove before merge)

**Removed**

- Extra styles

#### Testing / Reviewing

[Staging Link](http://carbon-dev-environment-exp-notification-active-lemur.mybluemix.net/?nav=notification)

<img width="478" alt="screen shot 2018-10-30 at 3 40 11 pm" src="https://user-images.githubusercontent.com/11928039/47748995-1b6b8a00-dc5a-11e8-8ced-a510e4e89ed5.png">
