### PR TITLE
fix(content-switcher): make sure icons are visible when active

### DIFF
--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -193,7 +193,7 @@
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected .#{$prefix}--content-switcher__icon {
-    fill: $text-01;
+    fill: $inverse-01;
   }
 }
 


### PR DESCRIPTION
Icons were not visible when experimental `ContentSwitcher` was active