### PR TITLE
chore(travis): update Yarn CLI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
   firefox: 'latest-esr'
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.1
   - export PATH=$HOME/.yarn/bin:$PATH
   - tar -xjf /tmp/firefox-latest-esr.tar.bz2 --directory /tmp
   - export PATH="/tmp/firefox:$PATH"


### PR DESCRIPTION
Update Yarn CLI version to v1.12.1

#### Changelog

**New**

**Changed**

- `.travis.yml` updated to install Yarn CLI v1.12.1

**Removed**

#### Testing / Reviewing
