### PR TITLE
chore(devenv): some clean-ups

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,6 +108,11 @@ Supported [properties in `.config.js`](https://fractal.build/guide/components/co
   - `context`: The data used for rendering `.hbs`
   - `view`: The basename of the `.hbs` file for variant markup (Unlike [default Fractal environment](https://fractal.build/guide/components/configuration#view), this property should point to the basename of a `.hbs` file under `demo` directory or `src` directory, _without_ its path)
   - `preview`: The basename of the `.hbs` file for the markup that lays out the variant markup, in "full render" mode (Unlike [default Fractal environment](https://fractal.build/guide/components/configuration#preview), this property should point to the basename of a `.hbs` file under `demo` directory or `src` directory, _without_ `@` symbol)
+  - `meta`: Some metadata. Carbon vanilla development environment reads the following ones specifically:
+    - `linkOnly`: Only full-page demo is allowed
+    - `useIframe`: Use of `<iframe>` for non full-page demo
+    - `xVersionOnly`: Supports "experimental" theme only
+    - `xVersionNotSupported`: "Experimental" theme is not supported
 
 What `.hbs` file is used for rendering a variant is determined by searching for `.hbs` files in `demo` or `src` directory and find one whose basename matches one of the following (the priority is the following order):
 

--- a/demo/js/components/CodePage/CodePage.js
+++ b/demo/js/components/CodePage/CodePage.js
@@ -10,33 +10,23 @@ import ComponentExample from '../ComponentExample/ComponentExample';
 const CodePage = ({ metadata, hideViewFullRender, useStaticFullRenderPage }) => {
   const md = new Markdown({ html: true });
   const subItems = metadata.items || [];
+  const useSingleVariant = !metadata.isCollection && subItems.length <= 1;
   /* eslint-disable react/no-danger */
-  const componentContent =
-    !metadata.isCollection && subItems.length <= 1 ? (
+  const componentContent = subItems.filter(item => !item.isHidden).map(item => (
+    <div key={item.id} className="component-variation">
+      {!useSingleVariant && <h2 className="component-variation__name">{item.label}</h2>}
+      {!useSingleVariant && item.notes && <p>{item.notes}</p>}
       <ComponentExample
-        hideViewFullRender={hideViewFullRender}
-        useStaticFullRenderPage={useStaticFullRenderPage}
+        variant={item.handle.replace(/--default$/, '')}
         component={metadata.name}
-        htmlFile={metadata.renderedContent}
-        linkOnly={metadata.linkOnly}
-        useIframe={metadata.useIframe}
+        htmlFile={item.renderedContent}
+        hideViewFullRender={hideViewFullRender}
+        linkOnly={metadata.meta.linkOnly}
+        useIframe={metadata.meta.useIframe}
+        useStaticFullRenderPage={useStaticFullRenderPage}
       />
-    ) : (
-      subItems.filter(item => !item.isHidden).map(item => (
-        <div key={item.id} className="component-variation">
-          <h2 className="component-variation__name">{item.label}</h2>
-          {item.notes && metadata.notes !== item.notes && <p>{item.notes}</p>}
-          <ComponentExample
-            variant={item.handle.replace(/--default$/, '')}
-            component={metadata.name}
-            htmlFile={item.renderedContent}
-            linkOnly={metadata.linkOnly}
-            useIframe={metadata.useIframe}
-            useStaticFullRenderPage={useStaticFullRenderPage}
-          />
-        </div>
-      ))
-    );
+    </div>
+  ));
 
   return (
     <div className="page code-page test">

--- a/demo/js/components/RootPage.js
+++ b/demo/js/components/RootPage.js
@@ -19,31 +19,24 @@ const checkStatus = response => {
 };
 
 /**
- * @param {Object[]} componentItems The components data.
- * @returns {Object[]} The components data with the contents of all components cleared.
+ * @param {Object[]} componentItems List of Fractal Component instance data.
+ * @returns {Object[]} List of Fractal Component instance data with the contents of all components cleared.
  */
 const clearContent = componentItems =>
-  componentItems.map(
-    item =>
-      !item.items
-        ? {
-            ...item,
-            renderedContent: undefined,
-          }
-        : {
-            ...item,
-            items: item.items.map(subItem => ({
-              ...subItem,
-              renderedContent: undefined,
-            })),
-          }
-  );
+  componentItems.map(item => ({
+    ...item,
+    items: item.items.map(subItem => ({
+      ...subItem,
+      renderedContent: undefined,
+    })),
+  }));
 
 /**
- * @param {Object[]} componentItems The components data.
+ * @param {Object[]} componentItems List of Fractal Component instance data.
  * @param {string} id The component ID.
  * @param {Object|string} content The content. String for component content, object for variant content (keyed by variant ID).
- * @returns {Object[]} The components data with the content of the given component ID populated with the given content.
+ * @returns {Object[]}
+ *   List of Fractal Component instance data with the content of the given component ID populated with the given content.
  */
 const applyContent = (componentItems, id, content) => {
   if (Object(content) === content) {
@@ -82,7 +75,7 @@ const applyContent = (componentItems, id, content) => {
 };
 
 /**
- * @param {Object[]} componentItems The components data.
+ * @param {Object[]} componentItems List of Fractal Component instance data.
  * @returns {Object[]} The component data with `isHidden` moved to `meta.isDefaultHidden`.
  */
 const preserveDefaultHidden = componentItems =>
@@ -92,6 +85,7 @@ const preserveDefaultHidden = componentItems =>
       ...item,
       meta: {
         ...meta,
+        // `hidden` in config data is set to `isHidden` in Fractal Component instance
         isDefaultHidden: item.isHidden,
       },
       ...(!subItems
@@ -103,7 +97,7 @@ const preserveDefaultHidden = componentItems =>
   });
 
 /**
- * @param {Object[]} componentItems The components data.
+ * @param {Object[]} componentItems List of Fractal Component instance data.
  * @param {boolean} isComponentsX `true` if the current style is of the experimental version.
  * @returns {Object[]} The component data with `isHidden` calculated with `meta.isDefaultHidden` and `isComponentsX`.
  */

--- a/demo/js/components/boot-nav.js
+++ b/demo/js/components/boot-nav.js
@@ -21,11 +21,28 @@ const pollForBrowserSync = callback => {
   }
 };
 
+/**
+ * Normalize Fractal Component instance data so the data structure can be shared with non-Fractal environment.
+ * @param {Object} data The Fractal Component instance data
+ * @param {string} [data.notes] The notes of the component.
+ * @param {Object[]} [data.variants] The variants of the component.
+ * @returns {Object} The normalized version of the Fractal Component instance data.
+ */
+const normalizeComponentItem = ({ notes, variants, items = [], ...other }) => ({
+  ...other,
+  notes,
+  items: (!variants || !variants.items ? items : variants.items).map(subItem => ({
+    ...subItem,
+    // Avoid using notes copied from component to variant
+    notes: notes === subItem.notes ? undefined : subItem.notes,
+  })),
+});
+
 pollForBrowserSync(() => {
   const renderRoot = document.querySelector('[data-renderroot]');
   if (renderRoot) {
     const props = {
-      componentItems: window.componentItems,
+      componentItems: window.componentItems.map(normalizeComponentItem),
       docItems: window.docItems,
       portSassBuild: window.portSassBuild,
       routeWithQueryArgs: window.routeWithQueryArgs,

--- a/demo/views/demo-nav-data.hbs
+++ b/demo/views/demo-nav-data.hbs
@@ -1,22 +1,6 @@
 <script>
-  var needIframe = [
-    'detail-page-header',
-    'footer',
-    'grid',
-    'unified-header'
-  ];
-  var linkOnly = [
-    'ui-shell'
-  ];
-  var componentItems = {{{JSONstringify componentItems}}}.map(function (item) {
-    if (linkOnly.indexOf(item.name) >= 0) {
-      item.linkOnly = true;
-    } else if (needIframe.indexOf(item.name) >= 0) {
-      item.useIframe = true;
-    }
-    return item;
-  });
-  var docItems = {{{JSONstringify docItems}}};
+  var componentItems = {{{JSONstringify componentSource}}}.items;
+  var docItems = {{{JSONstringify docSource}}}.items;
   {{#if portSassBuild}}
     var portSassBuild = {{portSassBuild}}
   {{/if}}

--- a/demo/views/layouts/demo-nav.hbs
+++ b/demo/views/layouts/demo-nav.hbs
@@ -20,7 +20,7 @@
   <body>
     <div data-renderroot></div>
     <input aria-label="inpute-text-offleft" type="text" class="offleft" />
-    {{{body}}}
+    {{{yield}}}
     <script src="/demo.js"></script>
   </body>
 </html>

--- a/demo/views/layouts/preview.hbs
+++ b/demo/views/layouts/preview.hbs
@@ -20,7 +20,7 @@
 
   <body class="bx--body demo--container" data-floating-menu-container>
     <div class="demo--container__panel" data-card-list>
-      {{{body}}}
+      {{{yield}}}
     </div>
 
     <!-- Pseudo element to demonstrate focus-wrap behavior (focus trap) -->

--- a/demo/views/layouts/ui-shell-preview.hbs
+++ b/demo/views/layouts/ui-shell-preview.hbs
@@ -10,7 +10,7 @@
     <link rel="stylesheet" type="text/css" href="/demo.css">
   </head>
   <body>
-    {{{body}}}
+    {{{yield}}}
 
     <!-- Scripts -->
     <!-- <script src="/carbon-components.min.js"></script> -->

--- a/server.js
+++ b/server.js
@@ -56,47 +56,6 @@ const reDemoComponentPath = pathRegexp('/demo/:component');
 const reCodePath = pathRegexp('/code/:component');
 const demoStaticRoute = serveStatic('demo');
 
-/**
- * @param {ComponentCollection|Component} metadata The component data.
- * @returns {Promise<ComponentCollection|Component>}
- *   The normalized component data,
- *   esp. with README.md content assigned to `.notes` property for component with variants (`ComponentCollection`).
- *   Fractal automatically populate `.notes` for component without variants (`Component`).
- */
-const normalizeMetadata = metadata => {
-  const items = metadata.isCollection ? metadata : !metadata.isCollated && metadata.variants && metadata.variants();
-  const visibleItems = items && items.filter(item => !item.isHidden);
-  const metadataJSON = typeof metadata.toJSON !== 'function' ? metadata : metadata.toJSON();
-  if (!metadata.isCollection && visibleItems && visibleItems.size === 1) {
-    const firstVariant = visibleItems.first();
-    return Object.assign(metadataJSON, {
-      context: firstVariant.context,
-      notes: firstVariant.notes,
-      preview: firstVariant.preview,
-      variants: undefined,
-    });
-  }
-  return Object.assign(metadataJSON, {
-    items: !items || items.size <= 1 ? undefined : items.map(normalizeMetadata).toJSON().items,
-    variants: undefined,
-  });
-};
-
-/**
- * @returns {Promise<(ComponentCollection|Component)[]>} The promise resolved with the list of nav items.
- */
-const getNavItems = () =>
-  templates.cache
-    .get()
-    .then(({ componentSource, docSource, contents }) =>
-      Promise.all([Promise.all(componentSource.items().map(normalizeMetadata)), docSource.items(), contents])
-    )
-    .then(([componentItems, docItems, contents]) => ({
-      componentItems,
-      docItems,
-      contents,
-    }));
-
 function noopRoute(req, res, next) {
   next();
 }
@@ -109,14 +68,15 @@ function navRoute(req, res, next) {
   } else if (name !== '/' && path.relative('src/components', `src/components/${name}`).substr(0, 2) === '..') {
     res.status(404).end();
   } else {
-    getNavItems()
-      .then(({ componentItems, docItems, contents }) => {
+    templates.cache
+      .get()
+      .then(({ componentSource, docSource, contents }) => {
         res.setHeader('Content-Type', 'text/html');
         res.end(
           contents.get('demo-nav')({
-            body: contents.get('demo-nav-data')({
-              componentItems,
-              docItems,
+            yield: contents.get('demo-nav-data')({
+              componentSource,
+              docSource,
               portSassBuild: process.env.PORT_SASS_DEV_BUILD,
             }),
           })

--- a/src/components/footer/footer.config.js
+++ b/src/components/footer/footer.config.js
@@ -12,6 +12,9 @@ const items = [
 ];
 
 module.exports = {
+  meta: {
+    useIframe: true,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/grid/grid.config.js
+++ b/src/components/grid/grid.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    useIframe: true,
+  },
+  variants: [
+    {
+      name: 'default',
+      label: 'Grid',
+    },
+  ],
+};

--- a/src/components/ui-shell/ui-shell.config.js
+++ b/src/components/ui-shell/ui-shell.config.js
@@ -221,6 +221,7 @@ module.exports = {
   preview: 'ui-shell-preview',
   meta: {
     xVersionOnly: true,
+    linkOnly: true,
   },
   context: {
     header,

--- a/src/components/unified-header/unified-header.config.js
+++ b/src/components/unified-header/unified-header.config.js
@@ -2,4 +2,7 @@
 
 module.exports = {
   hidden: true,
+  meta: {
+    useIframe: true,
+  },
 };

--- a/tools/templates.js
+++ b/tools/templates.js
@@ -55,7 +55,7 @@ const getContents = glob =>
     return Promise.all(
       filePaths.map(filePath =>
         readFile(filePath, { encoding: 'utf8' }).then(content => {
-          contents.set(path.basename(filePath, '.hbs'), content);
+          contents.set(path.basename(filePath, path.extname(filePath)), content);
         })
       )
     ).then(() => contents);
@@ -136,7 +136,7 @@ const renderComponent = ({ layout, concat } = {}, handle) =>
           if (template) {
             const body = template(context);
             const layoutTemplate = layout !== false && (contents.get(item.preview) || contents.get(layout));
-            renderedItems.set(item, !layoutTemplate ? body : layoutTemplate(Object.assign({ body }, context)));
+            renderedItems.set(item, !layoutTemplate ? body : layoutTemplate(Object.assign({ yield: body }, context)));
           }
         });
       }


### PR DESCRIPTION
#### Changelog

**Changed**

- Introduced the ability to set the following in `meta` property of Fractal config
    - Only full-page demo is allowed (`meta.linkOnly`)
    - Usage of `<iframe>` for non full-page demo (`meta.useIframe`)
- Use `yield` property for the body content for preview to align better with Fractal
- Simplified dev env UI (`<RootPage>`/`<CodePage>`) by consolidating the rendering logic of live demo to one for component variants
- Moved Fractal data structure normalization logic from server to client, to simplify server logic abit

#### Testing / Reviewing

Testing should make sure our dev env is not broken.