### PR TITLE
fix(text-input): reduce bottom margin on password visibility toggle

### DIFF
--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -89,6 +89,7 @@
       height: rem(16px);
       width: rem(16px);
       padding: 0;
+      margin-bottom: -1rem;
       border: 0;
       background: none;
       cursor: pointer;


### PR DESCRIPTION
Closes #1376 
Closes https://github.com/carbon-design-system/carbon-website/issues/281

This PR will prevent the password validation toggle from pushing content below it further down from where it should be

#### Changelog

**Changed**

- reduce the bottom margin of the password validation toggle button on the text input component