### PR TITLE
fix(tile): add aria-label attribute to chevron

### DIFF
--- a/src/components/tile/tile--expandable.hbs
+++ b/src/components/tile/tile--expandable.hbs
@@ -1,5 +1,5 @@
 <div data-tile="expandable" class="bx--tile bx--tile--expandable" tabindex="0">
-  <button class="bx--tile__chevron">
+  <button aria-label="expand menu" class="bx--tile__chevron">
     <svg width="12" height="7" viewBox="0 0 12 7">
       <path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
     </svg>


### PR DESCRIPTION
Closes #1366 

Adds an aria-label to the menu expand button.
