### PR TITLE
fix(list): removes redundant for attribute for implicit label

### DIFF
--- a/src/components/structured-list/structured-list.hbs
+++ b/src/components/structured-list/structured-list.hbs
@@ -45,8 +45,8 @@
         {{/if}}
       {{else}}
         {{#if ../selectable}}
-          <label for="{{row.id}}" aria-label="{{row.selectionLabel}}" class="bx--structured-list-row{{#if row.selected}} bx--structured-list-row--selected{{/if}}" tabindex="0">
-            <input tabindex="-1" id="{{row.id}}" class="bx--structured-list-input" value="{{row.value}}" type="radio" name="{{../group}}" title="{{row.selectionLabel}}"{{#if row.selected}} checked{{/if}} />
+          <label aria-label="{{row.selectionLabel}}" class="bx--structured-list-row{{#if row.selected}} bx--structured-list-row--selected{{/if}}" tabindex="0">
+            <input tabindex="-1" class="bx--structured-list-input" value="{{row.value}}" type="radio" name="{{../group}}" title="{{row.selectionLabel}}"{{#if row.selected}} checked{{/if}} />
             <div class="bx--structured-list-td">
               <svg class="bx--structured-list-svg" width="16" height="16" viewBox="0 0 16 16">
                 <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"


### PR DESCRIPTION
Closes #1365 

Removes a redundant for attribute in the labeling for a selectable table element that was causing a DAP error.