### PR TITLE
fix(structured-list): flatten sass

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,18 +45,20 @@ Follow BEM naming convention for classes. Again, the only thing we do differentl
 .#{$prefix}--block--modifier
 ```
 
-Avoid nesting selectors, this will make it easier to maintain in the future
+Avoid nesting selectors, this will make it easier to maintain in the future.
 
 ```scss
 <-- Don't do this -->
 .#{$prefix}--inline-notification {
-  .#{$prefix}--inline-notification__details {
-    ...
+  &:hover {
+    svg {
+      ...
+    }
   }
 }
 
 <!-- Do this instead -->
-.#{$prefix}--inline-notification .#{$prefix}--inline-notification__details {
+.#{$prefix}--inline-notification svg {
   ...
 }
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,6 +45,22 @@ Follow BEM naming convention for classes. Again, the only thing we do differentl
 .#{$prefix}--block--modifier
 ```
 
+Avoid nesting selectors, this will make it easier to maintain in the future
+
+```scss
+<-- Don't do this -->
+.#{$prefix}--inline-notification {
+  .#{$prefix}--inline-notification__details {
+    ...
+  }
+}
+
+<!-- Do this instead -->
+.#{$prefix}--inline-notification .#{$prefix}--inline-notification__details {
+  ...
+}
+```
+
 ### Start a new `block` or `element`?
 
 A nested element can use a new block name as long as the styles are independent of the parent.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,16 +50,22 @@ Avoid nesting selectors, this will make it easier to maintain in the future.
 ```scss
 <-- Don't do this -->
 .#{$prefix}--inline-notification {
-  &:hover {
-    svg {
-      ...
+  .#{$prefix}--btn {
+    &:hover {
+      svg {
+        ...
+      }
     }
   }
 }
 
 <!-- Do this instead -->
-.#{$prefix}--inline-notification:hover svg {
-  ...
+.#{$prefix}--inline-notification .#{$prefix}--btn {
+    &:hover svg {
+      ...
+    }
+  }
+
 }
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,7 +65,6 @@ Avoid nesting selectors, this will make it easier to maintain in the future.
       ...
     }
   }
-
 }
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Avoid nesting selectors, this will make it easier to maintain in the future.
 }
 
 <!-- Do this instead -->
-.#{$prefix}--inline-notification svg {
+.#{$prefix}--inline-notification:hover svg {
   ...
 }
 ```

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -2,9 +2,26 @@
   <div data-notification class="bx--{{../variant}}-notification bx--{{../variant}}-notification--{{type}}" role="alert">
     <div class="bx--{{../variant}}-notification__details">
       {{#is ../variant "inline"}}
-        <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-          <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
-        </svg>
+        {{#is type "error"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
+          </svg>
+        {{/is}}
+         {{#is type "info"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
+          </svg>
+        {{/is}}
+         {{#is type "success"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
+          </svg>
+        {{/is}}
+         {{#is type "warning"}}
+          <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
+          </svg>
+        {{/is}}
         <div class="bx--{{../variant}}-notification__text-wrapper">
           <p class="bx--{{../variant}}-notification__title">{{title}}</p>
           <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -197,49 +197,52 @@
     border-spacing: 0;
     margin-bottom: 5rem;
     background-color: transparent;
+  }
 
-    &.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-td,
-    &.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-th {
-      @include padding-td--condensed--x;
-    }
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-td,
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-th {
+    @include padding-td--condensed--x;
   }
 
   .#{$prefix}--structured-list-row {
     display: table-row;
     border-bottom: 1px solid $ui-03;
+  }
 
+  .#{$prefix}--structured-list-row
     .#{$prefix}--structured-list--selection
-      &:hover:not(.#{$prefix}--structured-list-row--header-row):not(.#{$prefix}--structured-list-row--selected) {
-      background-color: $ui_01;
-      cursor: pointer;
-      border-bottom: 1px solid $ui-01;
-    }
+    &:hover:not(.#{$prefix}--structured-list-row--header-row):not(.#{$prefix}--structured-list-row--selected) {
+    background-color: $ui_01;
+    cursor: pointer;
+    border-bottom: 1px solid $ui-01;
+  }
 
-    &.#{$prefix}--structured-list-row--selected {
-      background-color: $ui-03;
-    }
+  .#{$prefix}--structured-list-row.#{$prefix}--structured-list-row--selected {
+    background-color: $ui-03;
+  }
 
-    &.#{$prefix}--structured-list-row--header-row {
-      border-bottom: 1px solid $ui-03;
-      cursor: inherit;
-    }
+  .#{$prefix}--structured-list-row.#{$prefix}--structured-list-row--header-row {
+    border-bottom: 1px solid $ui-03;
+    cursor: inherit;
+  }
 
-    &:focus:not(.#{$prefix}--structured-list-row--header-row) {
-      @include focus-outline('outline');
-    }
+  .#{$prefix}--structured-list-row:focus:not(.#{$prefix}--structured-list-row--header-row) {
+    @include focus-outline('outline');
+  }
 
+  .#{$prefix}--structured-list-row
     .#{$prefix}--structured-list--selection
-      &:hover:not(.#{$prefix}--structured-list-row--header-row)
-      > .#{$prefix}--structured-list-td,
-    &.#{$prefix}--structured-list-row--selected > .#{$prefix}--structured-list-td {
-      color: $text-01;
-    }
+    &:hover:not(.#{$prefix}--structured-list-row--header-row)
+    > .#{$prefix}--structured-list-td,
+  &.#{$prefix}--structured-list-row--selected > .#{$prefix}--structured-list-td {
+    color: $text-01;
+  }
 
+  .#{$prefix}--structured-list-row
     .#{$prefix}--structured-list--selection
-      &:hover:not(.#{$prefix}--structured-list-row--header-row)
-      > .#{$prefix}--structured-list-td {
-      border-top: 1px solid $ui-01;
-    }
+    &:hover:not(.#{$prefix}--structured-list-row--header-row)
+    > .#{$prefix}--structured-list-td {
+    border-top: 1px solid $ui-01;
   }
 
   .#{$prefix}--structured-list-thead {
@@ -289,15 +292,15 @@
     fill: transparent;
     vertical-align: middle;
     transition: $transition--base $carbon--standard-easing;
+  }
 
-    .#{$prefix}--structured-list-row:hover & {
-      fill: $ibm-colors__gray--40;
-    }
+  .#{$prefix}--structured-list-row:hover .#{$prefix}--structured-list-svg {
+    fill: $ibm-colors__gray--40;
+  }
 
-    .#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-row &,
-    .#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-td & {
-      fill: $text-01;
-    }
+  .#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-row .#{$prefix}--structured-list-svg,
+  .#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-td .#{$prefix}--structured-list-svg {
+    fill: $text-01;
   }
 
   // Skeleton State

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -151,7 +151,7 @@
       }
     }
 
-    .bx--structured-list-th span {
+    .#{$prefix}--structured-list-th span {
       @include skeleton;
       width: 75%;
       height: 1rem;
@@ -315,7 +315,7 @@
     }
   }
 
-  .#{$prefix}--structured-list.#{$prefix}--skeleton .bx--structured-list-th span {
+  .#{$prefix}--structured-list.#{$prefix}--skeleton .#{$prefix}--structured-list-th span {
     @include skeleton;
     width: 75%;
     height: 1rem;

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -197,11 +197,11 @@
     border-spacing: 0;
     margin-bottom: 5rem;
     background-color: transparent;
-  }
 
-  .#{$prefix}--structured-list.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-td,
-  .#{$prefix}--structured-list.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-th {
-    @include padding-td--condensed--x;
+    &.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-td,
+    &.#{$prefix}--structured-list--condensed .#{$prefix}--structured-list-th {
+      @include padding-td--condensed--x;
+    }
   }
 
   .#{$prefix}--structured-list-row {
@@ -209,9 +209,8 @@
     border-bottom: 1px solid $ui-03;
   }
 
-  .#{$prefix}--structured-list-row
-    .#{$prefix}--structured-list--selection
-    &:hover:not(.#{$prefix}--structured-list-row--header-row):not(.#{$prefix}--structured-list-row--selected) {
+  .#{$prefix}--structured-list--selection
+    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row):not(.#{$prefix}--structured-list-row--selected) {
     background-color: $ui_01;
     cursor: pointer;
     border-bottom: 1px solid $ui-01;
@@ -230,17 +229,15 @@
     @include focus-outline('outline');
   }
 
-  .#{$prefix}--structured-list-row
-    .#{$prefix}--structured-list--selection
-    &:hover:not(.#{$prefix}--structured-list-row--header-row)
+  .#{$prefix}--structured-list--selection
+    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
     > .#{$prefix}--structured-list-td,
-  &.#{$prefix}--structured-list-row--selected > .#{$prefix}--structured-list-td {
+  .#{$prefix}--structured-list-row.#{$prefix}--structured-list-row--selected > .#{$prefix}--structured-list-td {
     color: $text-01;
   }
 
-  .#{$prefix}--structured-list-row
-    .#{$prefix}--structured-list--selection
-    &:hover:not(.#{$prefix}--structured-list-row--header-row)
+  .#{$prefix}--structured-list--selection
+    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row)
     > .#{$prefix}--structured-list-td {
     border-top: 1px solid $ui-01;
   }
@@ -304,36 +301,33 @@
   }
 
   // Skeleton State
-  .#{$prefix}--structured-list.#{$prefix}--skeleton {
-    .#{$prefix}--structured-list-th {
-      &:first-child {
-        width: 8%;
-      }
-
-      &:nth-child(3n + 2) {
-        width: 30%;
-      }
-
-      &:nth-child(3n + 3) {
-        width: 15%;
-      }
+  .#{$prefix}--structured-list.#{$prefix}--skeleton .#{$prefix}--structured-list-th {
+    &:first-child {
+      width: 8%;
     }
 
-    .bx--structured-list-th span {
-      @include skeleton;
-      width: 75%;
-      height: 1rem;
-      display: block;
+    &:nth-child(3n + 2) {
+      width: 30%;
+    }
+
+    &:nth-child(3n + 3) {
+      width: 15%;
     }
   }
 
-  .#{$prefix}--structured-list.#{$prefix}--structured-list--border.#{$prefix}--skeleton {
-    .#{$prefix}--structured-list-th:first-child {
-      width: 5%;
+  .#{$prefix}--structured-list.#{$prefix}--skeleton .bx--structured-list-th span {
+    @include skeleton;
+    width: 75%;
+    height: 1rem;
+    display: block;
+  }
 
-      span {
-        display: none;
-      }
+  .#{$prefix}--structured-list.#{$prefix}--structured-list--border.#{$prefix}--skeleton
+    .#{$prefix}--structured-list-th:first-child {
+    width: 5%;
+
+    span {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
@aledavila I noticed some weirdness with a structured list when trying to pull it into the website. 

This PR flattens all the sass to make it more readable. Apologize for not noticing this in your original PR.  Double checking w/ other @IBM/carbon-developers that we had agreed upon not nesting sass selectors to make it easier to edit. Do we have that in docs somewhere? We should 

### Added
Updated docs to mention flat sass selectors

### Testing
Check experimental structured list and make sure I didn't break anything with these updates 🙏 