### PR TITLE
fix(combo-box): fixes multiple border issue on exp combo-box

### DIFF
--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -10,8 +10,26 @@
 @import '../../globals/scss/theme';
 @import '../list-box/list-box';
 
-@include exports('combo-box') {
+@mixin combo-box {
   .#{$prefix}--combo-box > .#{$prefix}--list-box__field {
     padding: 0;
+  }
+}
+
+@mixin combo-box--x {
+  .#{$prefix}--combo-box > .#{$prefix}--list-box__field {
+    padding: 0;
+  }
+
+  .#{$prefix}--combo-box.#{$prefix}--list-box {
+    border-bottom: none;
+  }
+}
+
+@include exports('combo-box') {
+  @if feature-flag-enabled('components-x') {
+    @include combo-box--x;
+  } @else {
+    @include combo-box;
   }
 }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -302,7 +302,7 @@ $list-box-menu-width: rem(300px);
     max-height: rem(32px);
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $ui-05;
+    border-bottom: 1px solid $ui-04;
     order: 1;
     cursor: pointer;
     color: $text-01;


### PR DESCRIPTION
Refs issues found in https://github.com/IBM/carbon-components/pull/1381

Removes double border on experimental `MultiSelect` and `ComboBox`

#### Changelog

**Changed**

- New experimental section for `combo-box.scss`
- Changed from `box-shadow` to `border-bottom`

#### Testing / Reviewing

Ensure only one border shows up on experimental `MultiSelect` and `ComboBox`
