### PR TITLE
fix(number-input): adjust positioning a bit

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -156,12 +156,12 @@
   }
 
   .#{$prefix}--number--helpertext:not([data-invalid]) .#{$prefix}--number__controls {
-    top: unset;
+    top: auto;
     bottom: 0.625rem;
   }
 
   .#{$prefix}--number--helpertext[data-invalid] .#{$prefix}--number__controls {
-    top: unset;
+    top: auto;
     bottom: 2rem;
   }
 
@@ -318,12 +318,12 @@
   }
 
   .#{$prefix}--number--helpertext:not([data-invalid]) .#{$prefix}--number__controls {
-    top: unset;
+    top: auto;
     bottom: 0.375rem;
   }
 
   .#{$prefix}--number--helpertext[data-invalid] .#{$prefix}--number__controls {
-    top: unset;
+    top: auto;
     bottom: 1.75rem;
   }
 

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -155,8 +155,14 @@
     top: 2.25rem;
   }
 
-  .#{$prefix}--number--helpertext:not(.#{$prefix}--number--nolabel) .#{$prefix}--number__controls {
-    top: 3.625rem;
+  .#{$prefix}--number--helpertext:not([data-invalid]) .#{$prefix}--number__controls {
+    top: unset;
+    bottom: 0.625rem;
+  }
+
+  .#{$prefix}--number--helpertext[data-invalid] .#{$prefix}--number__controls {
+    top: unset;
+    bottom: 2rem;
   }
 
   .#{$prefix}--number--light input[type='number'] {
@@ -265,8 +271,8 @@
     justify-content: center;
     align-items: center;
     left: auto;
-    right: 0.25rem;
-    top: 2rem;
+    right: 0.4rem;
+    top: 1.875rem;
   }
 
   .#{$prefix}--number__control-btn {
@@ -304,15 +310,21 @@
   }
 
   .#{$prefix}--number--nolabel .#{$prefix}--number__controls {
-    top: 0.625rem;
+    top: 0.375rem;
   }
 
   .#{$prefix}--number--helpertext .#{$prefix}--number__controls {
     top: 2.25rem;
   }
 
-  .#{$prefix}--number--helpertext:not(.#{$prefix}--number--nolabel) .#{$prefix}--number__controls {
-    top: 3.625rem;
+  .#{$prefix}--number--helpertext:not([data-invalid]) .#{$prefix}--number__controls {
+    top: unset;
+    bottom: 0.375rem;
+  }
+
+  .#{$prefix}--number--helpertext[data-invalid] .#{$prefix}--number__controls {
+    top: unset;
+    bottom: 1.75rem;
   }
 
   .#{$prefix}--number--light input[type='number'] {


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1391

Adjusts Number Input arrow positioning

#### Changelog

**Changed**
- Experimental and base styles 
- Changed from `.#{$prefix}--number--helpertext:not(.#{$prefix}--number--nolabel)` to `.#{$prefix}--number--helpertext:not([data-invalid])`, and then positioned off the bottom. Since I don't see a time when they will not have a label but have helper text, this seems to make more sense. Will also allow for helper text to wrap without affecting the arrows. There now exists the problem of wrapping helper and invalid text, which I'm not sure how we'd handle. 


#### Testing / Reviewing

Make sure the arrows render correctly when helper text wraps 
