### PR TITLE
feat(overflow-menu): add in experimental overflow

### DIFF
--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -4,6 +4,7 @@ import eventedShowHideState from '../../globals/js/mixins/evented-show-hide-stat
 import trackBlur from '../../globals/js/mixins/track-blur';
 import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
 import optimizedResize from '../../globals/js/misc/resize';
+import componentsX from '../../globals/js/feature-flags';
 
 /**
  * The structure for the position of floating menu.
@@ -58,6 +59,27 @@ export const getFloatingPosition = ({
   const { top = 0, left = 0 } = offset;
   const refCenterHorizontal = (refLeft + refRight) / 2;
   const refCenterVertical = (refTop + refBottom) / 2;
+
+  if (componentsX) {
+    return {
+      [DIRECTION_LEFT]: {
+        left: refLeft - width + scrollX - left,
+        top: refTop - 4 + scrollY + top,
+      },
+      [DIRECTION_TOP]: {
+        left: refCenterHorizontal + scrollX + left - 16,
+        top: refTop - height + scrollY - top - 4,
+      },
+      [DIRECTION_RIGHT]: {
+        left: refRight + scrollX + left,
+        top: refTop - 4 + scrollY + top,
+      },
+      [DIRECTION_BOTTOM]: {
+        left: refCenterHorizontal + scrollX + left - 16,
+        top: refBottom + scrollY + top - 4,
+      },
+    }[direction];
+  }
 
   return {
     [DIRECTION_LEFT]: {

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -64,19 +64,19 @@ export const getFloatingPosition = ({
     return {
       [DIRECTION_LEFT]: {
         left: refLeft - width + scrollX - left,
-        top: refTop - 4 + scrollY + top,
+        top: refTop + scrollY + top,
       },
       [DIRECTION_TOP]: {
         left: refCenterHorizontal + scrollX + left - 16,
-        top: refTop - height + scrollY - top - 4,
+        top: refTop - height + scrollY - top,
       },
       [DIRECTION_RIGHT]: {
         left: refRight + scrollX + left,
-        top: refTop - 4 + scrollY + top,
+        top: refTop + scrollY + top,
       },
       [DIRECTION_BOTTOM]: {
         left: refCenterHorizontal + scrollX + left - 16,
-        top: refBottom + scrollY + top - 4,
+        top: refBottom + scrollY + top,
       },
     }[direction];
   }

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -4,7 +4,6 @@ import eventedShowHideState from '../../globals/js/mixins/evented-show-hide-stat
 import trackBlur from '../../globals/js/mixins/track-blur';
 import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
 import optimizedResize from '../../globals/js/misc/resize';
-import componentsX from '../../globals/js/feature-flags';
 
 /**
  * The structure for the position of floating menu.
@@ -59,27 +58,6 @@ export const getFloatingPosition = ({
   const { top = 0, left = 0 } = offset;
   const refCenterHorizontal = (refLeft + refRight) / 2;
   const refCenterVertical = (refTop + refBottom) / 2;
-
-  if (componentsX) {
-    return {
-      [DIRECTION_LEFT]: {
-        left: refLeft - width + scrollX - left,
-        top: refTop + scrollY + top,
-      },
-      [DIRECTION_TOP]: {
-        left: refCenterHorizontal + scrollX + left - 16,
-        top: refTop - height + scrollY - top,
-      },
-      [DIRECTION_RIGHT]: {
-        left: refRight + scrollX + left,
-        top: refTop + scrollY + top,
-      },
-      [DIRECTION_BOTTOM]: {
-        left: refCenterHorizontal + scrollX + left - 16,
-        top: refBottom + scrollY + top,
-      },
-    }[direction];
-  }
 
   return {
     [DIRECTION_LEFT]: {

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -313,6 +313,10 @@
     &:focus {
       @include focus-outline('outline');
     }
+
+    &::-moz-focus-inner {
+      border: none;
+    }
   }
 
   .#{$prefix}--overflow-menu-options__option:hover {

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -230,8 +230,6 @@
     background-color: $inverse-01;
     width: 11.25rem;
     list-style: none;
-    margin-top: $spacing-2xs;
-    padding: 0 0 $spacing-xs;
     left: 100px;
     top: 0;
   }
@@ -247,6 +245,7 @@
     align-items: center;
     width: 100%;
     padding: 0;
+    transition: background-color $transition--base;
   }
 
   .#{$prefix}--overflow-menu--divider {
@@ -257,6 +256,7 @@
     @include reset;
     @include typescale('zeta');
     @include font-family;
+    @include focus-outline('reset');
     font-weight: 400;
     width: 100%;
     height: 100%;
@@ -271,12 +271,10 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    transition: outline $transition--base;
 
     &:focus {
-      outline: 1px solid transparent;
-      text-decoration: underline;
-      background-color: $hover-row;
-      text-decoration: underline;
+      @include focus-outline('outline');
     }
 
     .#{$prefix}--overflow-menu-options__option--danger & {
@@ -288,13 +286,7 @@
   }
 
   .#{$prefix}--overflow-menu-options__option:hover {
-    background-color: $hover-row;
-  }
-
-  .#{$prefix}--overflow-menu-options__option:hover .#{$prefix}--overflow-menu-options__btn {
-    text-decoration: none;
-    background-color: $hover-row;
-    text-decoration: none;
+    background-color: $hover-field;
   }
 
   .#{$prefix}--overflow-menu-options__option--danger {

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -207,21 +207,21 @@
     }
   }
 
+  .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open {
+    background-color: $ui-01;
+    transition: none;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
+  }
+
   .#{$prefix}--overflow-menu__icon {
     height: rem(16px);
     width: rem(16px);
     fill: $ui-05;
   }
 
-  .#{$prefix}--overflow-menu--open {
-    @include layer('overlay');
-    background-color: $ui-01;
-    z-index: z('floating');
-  }
-
   .#{$prefix}--overflow-menu-options {
     @include reset;
-    @include layer('overlay');
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
     display: none;
     flex-direction: column;
     align-items: flex-start;
@@ -232,6 +232,42 @@
     list-style: none;
     left: 100px;
     top: 0;
+
+    &::after {
+      content: '';
+      position: absolute;
+      display: block;
+      background-color: $ui-01;
+      transition: background-color $transition--base;
+    }
+  }
+
+  .#{$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+    top: rem(-3px);
+    left: 0;
+    width: rem(32px);
+    height: rem(3px);
+  }
+
+  .#{$prefix}--overflow-menu-options[data-floating-menu-direction='top']::after {
+    bottom: rem(-6px);
+    left: 0;
+    width: rem(32px);
+    height: rem(6px);
+  }
+
+  .#{$prefix}--overflow-menu-options[data-floating-menu-direction='left']::after {
+    right: rem(-6px);
+    top: 0;
+    height: rem(32px);
+    width: rem(6px);
+  }
+
+  .#{$prefix}--overflow-menu-options[data-floating-menu-direction='right']::after {
+    top: 0;
+    left: rem(-6px);
+    height: rem(32px);
+    width: rem(6px);
   }
 
   .#{$prefix}--overflow-menu-options--open {
@@ -244,6 +280,7 @@
     background-color: transparent;
     align-items: center;
     width: 100%;
+    height: rem(32px);
     padding: 0;
     transition: background-color $transition--base;
   }
@@ -264,24 +301,17 @@
     display: inline-block;
     background-color: transparent;
     text-align: left;
-    padding: $spacing-xs $spacing-md;
+    padding: 0 $spacing-md;
     cursor: pointer;
     color: $text-01;
     max-width: 11.25rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    transition: outline $transition--base;
+    transition: outline $transition--base, background-color $transition--base, color $transition--base;
 
     &:focus {
       @include focus-outline('outline');
-    }
-
-    .#{$prefix}--overflow-menu-options__option--danger & {
-      &:focus {
-        outline: 1px solid transparent;
-        text-decoration: underline;
-      }
     }
   }
 
@@ -293,35 +323,26 @@
     border-top: 1px solid $ui-03;
   }
 
-  .#{$prefix}--overflow-menu-options__option--danger {
-    .#{$prefix}--overflow-menu-options__btn {
-      &:hover,
-      &:focus {
-        color: $inverse-01;
-        background-color: $support-01;
-      }
-    }
+  .#{$prefix}--overflow-menu-options__option--danger .#{$prefix}--overflow-menu-options__btn:hover,
+  .#{$prefix}--overflow-menu-options__option--danger .#{$prefix}--overflow-menu-options__btn:focus {
+    color: $inverse-01;
+    background-color: $support-01;
   }
 
   .#{$prefix}--overflow-menu-options__option--disabled:hover {
     background-color: $ui-01;
+    cursor: not-allowed;
   }
 
   .#{$prefix}--overflow-menu-options__option--disabled .#{$prefix}--overflow-menu-options__btn {
-    color: $text-01;
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
+    color: $disabled;
+    pointer-events: none;
 
-  .#{$prefix}--overflow-menu-options__option--disabled:hover .#{$prefix}--overflow-menu-options__btn {
-    color: $text-01;
-    opacity: 0.5;
-    background-color: $ui-01;
-
+    &:hover,
     &:active,
     &:focus {
+      @include focus-outline('reset');
       background-color: $ui-01;
-      pointer-events: none;
     }
   }
 

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -13,7 +13,7 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 
-@include exports('overflow-menu') {
+@mixin overflow-menu {
   .#{$prefix}--overflow-menu {
     @include reset;
     position: relative;
@@ -182,5 +182,170 @@
     &:before {
       left: 145px;
     }
+  }
+}
+
+@mixin overflow-menu--x {
+  .#{$prefix}--overflow-menu {
+    @include reset;
+    @include focus-outline('reset');
+    position: relative;
+    width: rem(32px);
+    height: rem(32px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: outline $transition--base, background-color $transition--base;
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+
+    &:hover {
+      background-color: $hover-field;
+    }
+  }
+
+  .#{$prefix}--overflow-menu__icon {
+    height: rem(16px);
+    width: rem(16px);
+    fill: $ui-05;
+  }
+
+  .#{$prefix}--overflow-menu--open {
+    @include layer('overlay');
+    background-color: $ui-01;
+    z-index: z('floating');
+  }
+
+  .#{$prefix}--overflow-menu-options {
+    @include reset;
+    @include layer('overlay');
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    position: absolute;
+    z-index: z('floating');
+    background-color: $inverse-01;
+    width: 11.25rem;
+    list-style: none;
+    margin-top: $spacing-2xs;
+    padding: 0 0 $spacing-xs;
+    left: 100px;
+    top: 0;
+  }
+
+  .#{$prefix}--overflow-menu-options--open {
+    display: flex;
+  }
+
+  .#{$prefix}--overflow-menu-options__option {
+    @include reset;
+    display: flex;
+    background-color: transparent;
+    align-items: center;
+    width: 100%;
+    padding: 0;
+  }
+
+  .#{$prefix}--overflow-menu--divider {
+    border-top: 1px solid $ui-03;
+  }
+
+  .#{$prefix}--overflow-menu-options__btn {
+    @include reset;
+    @include typescale('zeta');
+    @include font-family;
+    font-weight: 400;
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: inline-block;
+    background-color: transparent;
+    text-align: left;
+    padding: $spacing-xs $spacing-md;
+    cursor: pointer;
+    color: $text-01;
+    max-width: 11.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:focus {
+      outline: 1px solid transparent;
+      text-decoration: underline;
+      background-color: $hover-row;
+      text-decoration: underline;
+    }
+
+    .#{$prefix}--overflow-menu-options__option--danger & {
+      &:focus {
+        outline: 1px solid transparent;
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .#{$prefix}--overflow-menu-options__option:hover {
+    background-color: $hover-row;
+  }
+
+  .#{$prefix}--overflow-menu-options__option:hover .#{$prefix}--overflow-menu-options__btn {
+    text-decoration: none;
+    background-color: $hover-row;
+    text-decoration: none;
+  }
+
+  .#{$prefix}--overflow-menu-options__option--danger {
+    border-top: 1px solid $ui-03;
+  }
+
+  .#{$prefix}--overflow-menu-options__option--danger {
+    .#{$prefix}--overflow-menu-options__btn {
+      &:hover,
+      &:focus {
+        color: $inverse-01;
+        background-color: $support-01;
+      }
+    }
+  }
+
+  .#{$prefix}--overflow-menu-options__option--disabled:hover {
+    background-color: $ui-01;
+  }
+
+  .#{$prefix}--overflow-menu-options__option--disabled .#{$prefix}--overflow-menu-options__btn {
+    color: $text-01;
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .#{$prefix}--overflow-menu-options__option--disabled:hover .#{$prefix}--overflow-menu-options__btn {
+    color: $text-01;
+    opacity: 0.5;
+    background-color: $ui-01;
+
+    &:active,
+    &:focus {
+      background-color: $ui-01;
+      pointer-events: none;
+    }
+  }
+
+  .#{$prefix}--overflow-menu--flip {
+    left: -140px;
+
+    &:before {
+      left: 145px;
+    }
+  }
+}
+
+@include exports('overflow-menu') {
+  @if feature-flag-enabled('components-x') {
+    @include overflow-menu--x;
+  } @else {
+    @include overflow-menu;
   }
 }

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -7,6 +7,7 @@ import handles from '../../globals/js/mixins/handles';
 import FloatingMenu, { DIRECTION_TOP, DIRECTION_BOTTOM } from '../floating-menu/floating-menu';
 import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
 import on from '../../globals/js/misc/on';
+import componentsX from '../../globals/js/feature-flags';
 
 /**
  * The CSS property names of the arrow keyed by the floating menu direction.
@@ -38,6 +39,7 @@ export const getMenuOffset = (menuBody, direction) => {
   if (!triggerButtonPositionProp || !triggerButtonPositionFactor) {
     console.warn('Wrong floating menu direction:', direction); // eslint-disable-line no-console
   }
+
   const menuWidth = menuBody.offsetWidth;
   const arrowStyle = menuBody.ownerDocument.defaultView.getComputedStyle(menuBody, ':before');
   const values = [triggerButtonPositionProp, 'left', 'width', 'height', 'border-top-width'].reduce(
@@ -54,6 +56,46 @@ export const getMenuOffset = (menuBody, direction) => {
       top: Math.sqrt(borderTopWidth ** 2 * 2) + triggerButtonPositionFactor * values[triggerButtonPositionProp],
     };
   }
+
+  // if (componentsX) {
+  //   return {
+  //     [DIRECTION_LEFT]: {
+  //       left: refLeft - width + scrollX - left,
+  //       top: refTop + scrollY + top,
+  //     },
+  //     [DIRECTION_TOP]: {
+  //       left: refCenterHorizontal + scrollX + left - 16,
+  //       top: refTop - height + scrollY - top,
+  //     },
+  //     [DIRECTION_RIGHT]: {
+  //       left: refRight + scrollX + left,
+  //       top: refTop + scrollY + top,
+  //     },
+  //     [DIRECTION_BOTTOM]: {
+  //       left: refCenterHorizontal + scrollX + left - 16,
+  //       top: refBottom + scrollY + top,
+  //     },
+  //   }[direction];
+  // }
+
+  console.log(menuWidth / 2);
+
+  if (componentsX) {
+    if (triggerButtonPositionProp === 'top') {
+      return {
+        left: menuWidth / 2 - 16,
+        top: 0,
+      };
+    }
+
+    if (triggerButtonPositionProp === 'bottom') {
+      return {
+        left: menuWidth / 2 - 16,
+        top: 0,
+      };
+    }
+  }
+
   return undefined;
 };
 

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -4,10 +4,10 @@ import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedShowHideState from '../../globals/js/mixins/evented-show-hide-state';
 import handles from '../../globals/js/mixins/handles';
-import FloatingMenu, { DIRECTION_TOP, DIRECTION_BOTTOM } from '../floating-menu/floating-menu';
+import FloatingMenu, { DIRECTION_TOP, DIRECTION_BOTTOM, DIRECTION_LEFT, DIRECTION_RIGHT } from '../floating-menu/floating-menu';
 import getLaunchingDetails from '../../globals/js/misc/get-launching-details';
 import on from '../../globals/js/misc/on';
-import componentsX from '../../globals/js/feature-flags';
+import { componentsX } from '../../globals/js/feature-flags';
 
 /**
  * The CSS property names of the arrow keyed by the floating menu direction.
@@ -16,6 +16,8 @@ import componentsX from '../../globals/js/feature-flags';
 const triggerButtonPositionProps = {
   [DIRECTION_TOP]: 'bottom',
   [DIRECTION_BOTTOM]: 'top',
+  [DIRECTION_LEFT]: 'left',
+  [DIRECTION_RIGHT]: 'right',
 };
 
 /**
@@ -25,6 +27,8 @@ const triggerButtonPositionProps = {
 const triggerButtonPositionFactors = {
   [DIRECTION_TOP]: -2,
   [DIRECTION_BOTTOM]: -1,
+  [DIRECTION_LEFT]: -2,
+  [DIRECTION_RIGHT]: -1,
 };
 
 /**
@@ -41,6 +45,7 @@ export const getMenuOffset = (menuBody, direction) => {
   }
 
   const menuWidth = menuBody.offsetWidth;
+  const menuHeight = menuBody.offsetHeight;
   const arrowStyle = menuBody.ownerDocument.defaultView.getComputedStyle(menuBody, ':before');
   const values = [triggerButtonPositionProp, 'left', 'width', 'height', 'border-top-width'].reduce(
     (o, name) => ({
@@ -57,41 +62,18 @@ export const getMenuOffset = (menuBody, direction) => {
     };
   }
 
-  // if (componentsX) {
-  //   return {
-  //     [DIRECTION_LEFT]: {
-  //       left: refLeft - width + scrollX - left,
-  //       top: refTop + scrollY + top,
-  //     },
-  //     [DIRECTION_TOP]: {
-  //       left: refCenterHorizontal + scrollX + left - 16,
-  //       top: refTop - height + scrollY - top,
-  //     },
-  //     [DIRECTION_RIGHT]: {
-  //       left: refRight + scrollX + left,
-  //       top: refTop + scrollY + top,
-  //     },
-  //     [DIRECTION_BOTTOM]: {
-  //       left: refCenterHorizontal + scrollX + left - 16,
-  //       top: refBottom + scrollY + top,
-  //     },
-  //   }[direction];
-  // }
-
-  console.log(menuWidth / 2);
-
   if (componentsX) {
-    if (triggerButtonPositionProp === 'top') {
+    if (triggerButtonPositionProp === 'top' || triggerButtonPositionProp === 'bottom') {
       return {
         left: menuWidth / 2 - 16,
         top: 0,
       };
     }
 
-    if (triggerButtonPositionProp === 'bottom') {
+    if (triggerButtonPositionProp === 'left' || triggerButtonPositionProp === 'right') {
       return {
-        left: menuWidth / 2 - 16,
-        top: 0,
+        left: 0,
+        top: menuHeight / 2 - 16,
       };
     }
   }

--- a/src/components/ui-shell/_product-switcher.scss
+++ b/src/components/ui-shell/_product-switcher.scss
@@ -133,34 +133,34 @@
     color: $shell-header-text-02;
   }
 
-  // .#{$prefix}--overflow-menu {
-  //   display: none;
-  //   justify-content: center;
-  //   align-items: center;
-  //   width: mini-units(5);
-  // }
+  .#{$prefix}--product-switcher__product-list .#{$prefix}--overflow-menu {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    width: mini-units(5);
+  }
 
-  // .#{$prefix}--overflow-menu > svg {
-  //   fill: $shell-header-text-02;
-  // }
+  .#{$prefix}--product-switcher__product-list .#{$prefix}--overflow-menu > svg {
+    fill: $shell-header-text-02;
+  }
 
-  // .#{$prefix}--overflow-menu:hover {
-  //   background: $shell-header-bg-04;
-  // }
+  .#{$prefix}--product-switcher__product-list .#{$prefix}--overflow-menu:hover {
+    background: $shell-header-bg-04;
+  }
 
-  // .#{$prefix}--overflow-menu:hover > svg {
-  //   fill: $shell-header-text-02;
-  // }
+  .#{$prefix}--product-switcher__product-list .#{$prefix}--overflow-menu:hover > svg {
+    fill: $shell-header-text-02;
+  }
 
-  // .#{$prefix}--overflow-menu:focus {
-  //   display: flex;
-  //   outline: none;
-  //   box-shadow: inset 0 0 0 3px $shell-header-link;
-  // }
+  .#{$prefix}--product-switcher__product-list .#{$prefix}--overflow-menu:focus {
+    display: flex;
+    outline: none;
+    box-shadow: inset 0 0 0 3px $shell-header-link;
+  }
 
-  // .#{$prefix}--overflow-menu-options__option:hover {
-  //   background: $shell-header-bg-03;
-  // }
+  .#{$prefix}--product-switcher__product-list .#{$prefix}--overflow-menu-options__option:hover {
+    background: $shell-header-bg-03;
+  }
 
   .#{$prefix}--product-list__item:hover .#{$prefix}--overflow-menu {
     display: flex;

--- a/src/components/ui-shell/_product-switcher.scss
+++ b/src/components/ui-shell/_product-switcher.scss
@@ -133,41 +133,11 @@
     color: $shell-header-text-02;
   }
 
-<<<<<<< HEAD
-  .#{$prefix}--overflow-menu {
-    display: none;
-    justify-content: center;
-    align-items: center;
-    width: mini-units(5);
-  }
-
-  .#{$prefix}--overflow-menu > svg {
-    fill: $shell-header-text-02;
-  }
-
-  .#{$prefix}--overflow-menu:hover {
-    background: $shell-header-bg-04;
-  }
-
-  .#{$prefix}--overflow-menu:hover > svg {
-    fill: $shell-header-text-02;
-  }
-
-  .#{$prefix}--overflow-menu:focus {
-    display: flex;
-    outline: none;
-    box-shadow: inset 0 0 0 3px $shell-header-link;
-  }
-
-  .#{$prefix}--overflow-menu-options__option:hover {
-    background: $shell-header-bg-03;
-  }
-=======
   // .#{$prefix}--overflow-menu {
   //   display: none;
   //   justify-content: center;
   //   align-items: center;
-  //   width: units(5);
+  //   width: mini-units(5);
   // }
 
   // .#{$prefix}--overflow-menu > svg {
@@ -191,7 +161,6 @@
   // .#{$prefix}--overflow-menu-options__option:hover {
   //   background: $shell-header-bg-03;
   // }
->>>>>>> feat(overflow-menu): start work on experimental overflow menu
 
   .#{$prefix}--product-list__item:hover .#{$prefix}--overflow-menu {
     display: flex;

--- a/src/components/ui-shell/_product-switcher.scss
+++ b/src/components/ui-shell/_product-switcher.scss
@@ -133,6 +133,7 @@
     color: $shell-header-text-02;
   }
 
+<<<<<<< HEAD
   .#{$prefix}--overflow-menu {
     display: none;
     justify-content: center;
@@ -161,6 +162,36 @@
   .#{$prefix}--overflow-menu-options__option:hover {
     background: $shell-header-bg-03;
   }
+=======
+  // .#{$prefix}--overflow-menu {
+  //   display: none;
+  //   justify-content: center;
+  //   align-items: center;
+  //   width: units(5);
+  // }
+
+  // .#{$prefix}--overflow-menu > svg {
+  //   fill: $shell-header-text-02;
+  // }
+
+  // .#{$prefix}--overflow-menu:hover {
+  //   background: $shell-header-bg-04;
+  // }
+
+  // .#{$prefix}--overflow-menu:hover > svg {
+  //   fill: $shell-header-text-02;
+  // }
+
+  // .#{$prefix}--overflow-menu:focus {
+  //   display: flex;
+  //   outline: none;
+  //   box-shadow: inset 0 0 0 3px $shell-header-link;
+  // }
+
+  // .#{$prefix}--overflow-menu-options__option:hover {
+  //   background: $shell-header-bg-03;
+  // }
+>>>>>>> feat(overflow-menu): start work on experimental overflow menu
 
   .#{$prefix}--product-list__item:hover .#{$prefix}--overflow-menu {
     display: flex;

--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -27,7 +27,7 @@ module.exports = {
       main: true,
     }),
     commonjs({
-      include: 'node_modules/**',
+      include: ['node_modules/**', 'src/globals/js/feature-flags.js'],
       sourceMap: true,
       namedExports: {
         'node_modules/react/index.js': [


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1292

Adds in experimental `OverflowMenu` component

#### Changelog

**New**

- Experimental Overflow Menu styles

**Changed**

- Added in feature check for `componentsX` in `FloatingMenu.js` to calculate accordingly (@asudoh let me know if this seems okay, it's the first time we've had to modify js logic). Seems to be causing errors on the build, however. Let me know how we should go about this. 

**Removed**

- Extra styles

#### Testing / Reviewing

Ensure Overflow menu styles are correct, works in each direction by changing the direction in `overflow-menu.config.js`

![screen shot 2018-11-05 at 3 00 45 pm](https://user-images.githubusercontent.com/11928039/48026658-4d726580-e10c-11e8-8c42-0fce3569fb3f.png)
