### PR TITLE
feat(docs): add docs for avt1 testing

### DIFF
--- a/docs/avt1guiance.md
+++ b/docs/avt1guiance.md
@@ -34,7 +34,7 @@ On the main frame (the one open by default) there's a detailed list of all viola
 
 Whenever any new UI code is introduced or existing code is changed or updated we should run DAP on the new code so we can make sure it meets or exceeds IBM's accessibility standards.
 
-DAP is actually mega thorough and can catch a lot of obvious errors in your markup, but it comes with a caveat. **A mountain of false positives**. Typically we're not auditing a webpage or a website as a whole, but a single component in isolation -- sadly this was not DAP's intended purpose and so it throws a lot of false positive violations that you'll first need to sift through and ignore if we're going to be keeping and recording this audit. If you're just testing while you develop or before you push a PR, feel free to just disregard them.
+DAP is always evolving its rulesets but unfortunately it can report false positives when testing exclusively on a component. Typically we're not auditing a webpage or a website as a whole, but a single component in isolation -- sadly this was not DAP's intended purpose and so it throws a lot of false positive violations that you'll first need to sift through and ignore if we're going to be keeping and recording this audit. If you're just testing while you develop or before you push a PR, feel free to just disregard them.
 
 If the component fails or has a violation an issue should be made so that someone can fix the problem. Feel free to include in the issue any relevant information you think would helpful, but make sure to at least include these points:
 

--- a/docs/avt1guiance.md
+++ b/docs/avt1guiance.md
@@ -1,0 +1,53 @@
+# Automated Verification Testing (AVT) stage 1
+
+## Introduction👋
+
+AVT1 testing is done with a browser extension developed by IBM called the Dynamic Assessment Plugin (DAP). It's a great first step to locking down and ensuring inclusivity and accessibility in your websites and components.
+
+## Installing DAP🔧
+
+1. Grab the plugin while connected to IBM's W3 [from here](https:/aat.w3ibm.mybluemix.net/auth/tools/dap.html).
+
+   _Be Warned: Make sure you only download the latest plugin from the specific link above which should be version >1.7. The IBM DAP plugin available to the public in the Chrome extension marketplace is unmaintained and will not support the latest rulesets._
+
+2. At the top left of [this page](https://ibm.biz/BdYkML) is a button that will copy to your clipboard the Authentication Token you'll need to access IBM's rulesets. Click it.
+3. With the plugin installed and your token copied head into DAP's options found inside the plugin dropdown menu and paste the token into the Authentication form and hit apply.
+4. Now that DAP's authenticated the Supported Rulesets section in the options menu of the plugin should be populated. Typically you're going to want the latest ruleset unless someone has told you otherwise.
+5. Hit the apply button at the bottom of the page.
+
+## Using DAP👷
+
+Let's DAP! It's pretty straight forward, but there are a few gotchas. For consistency's sake we'll use DAP on the [Dynamic Assessment Plug-in Homepage](https://ibm.biz/BdYkM9).
+
+Head over to the page and hit `cmd-option-c` to open up your dev tools. DAP is tucked away inside a drop down menu inside a panel. From the default Elements panel hit the >> icon below the X on the far right. You should see `DAP`. Click that to fire up DAP for this page.
+
+_Be Warned: You can only run DAP with internal IBM rulesets if you're connected to W3. On an IBM campus this isn't a problem, but if you're abroad fire up the Cisco AnyConnect Secure Mobility Client._
+
+Hit the play button and wait for the scan to finish. **We've got violations!**. At the time of writing there are 7 Violations, 9 Potential Violations, and 2 Manual Checks. There's also multiple "frames", but if you're testing single components or a group of components in a Storybook environment you can ignore those✋.
+
+On the main frame (the one open by default) there's a detailed list of all violation types. Clicking into each violation type gives you more nested dropdowns -- one for each violation found on the page of that specific type. Each violation's dropdown gives you two further options:
+
+1.  A description of the general violation with a ? icon that when clicked will take you to further documentation detailing the violation and most helpfully how to fix it.
+2.  A description of this particular instance of a violation (say for instance an image with no alt attribute). And a crossed out eyeball you can click to ignore this violation which is helpful when printing reports for posterity's sake.
+
+## Running an AVT1 Audit📋
+
+Whenever any new UI code is introduced or existing code is changed or updated we should run DAP on the new code so we can make sure it meets or exceeds IBM's accessibility standards.
+
+DAP is actually mega thorough and can catch a lot of obvious errors in your markup, but it comes with a caveat. **A mountain of false positives**. Typically we're not auditing a webpage or a website as a whole, but a single component in isolation -- sadly this was not DAP's intended purpose and so it throws a lot of false positive violations that you'll first need to sift through and ignore if we're going to be keeping and recording this audit. If you're just testing while you develop or before you push a PR, feel free to just disregard them.
+
+If the component fails or has a violation an issue should be made so that someone can fix the problem. Feel free to include in the issue any relevant information you think would helpful, but make sure to at least include these points:
+
+1. The environment where the failure happened. The browser make and version as well as the ruleset and operating system.
+2. A description of the failure (copy an pasted from DAP's logs is fine).
+3. A screenshot of the particular offending code.
+4. Steps to reproduce the violation for anyone who may want to tackle the issue but may not have read this guide.
+
+If running DAP produces no violations (that's awesome🎉) we still want to record and keep proof that DAP was run so we can make sure we're staying on top of accessibility testing for each component as they change and get updated per each release. To do that:
+
+1. Click the hamburger menu in the top right of the DAP panel and select Download Report.
+2. In the modal select JSON and five your report a helpful name in this format `componentname_subtype.html` and then download.
+
+   _Be warned: Occasional clicking the Download Report button wont work. This can be a serious pain if the dev has already gone through and ignored false positives. I've had a 100% success rate with Download Report if after I open the DAP panel in my dev tools I then reload the page with the panel open. 😞 -- D.A._
+
+3. [Follow this link](https://ibm.biz/BdYkMA) and select the folder that corresponds with the ruleset the component was tested against and drop the JSON file in there.

--- a/docs/avt1guiance.md
+++ b/docs/avt1guiance.md
@@ -6,7 +6,7 @@ AVT1 testing is done with a browser extension developed by IBM called the Dynami
 
 ## Installing DAP🔧
 
-1. Grab the plugin while connected to IBM's W3 [from here](https:/aat.w3ibm.mybluemix.net/auth/tools/dap.html).
+1. Grab the plugin while connected to IBM's W3 [from here](https://ibm.biz/BdYkWF).
 
    _Be Warned: Make sure you only download the latest plugin from the specific link above which should be version >1.7. The IBM DAP plugin available to the public in the Chrome extension marketplace is unmaintained and will not support the latest rulesets._
 

--- a/docs/avt1guiance.md
+++ b/docs/avt1guiance.md
@@ -48,6 +48,6 @@ If running DAP produces no violations (that's awesome🎉) we still want to reco
 1. Click the hamburger menu in the top right of the DAP panel and select Download Report.
 2. In the modal select JSON and five your report a helpful name in this format `componentname_subtype.html` and then download.
 
-   _Be warned: Occasional clicking the Download Report button wont work. This can be a serious pain if the dev has already gone through and ignored false positives. I've had a 100% success rate with Download Report if after I open the DAP panel in my dev tools I then reload the page with the panel open. 😞 -- D.A._
+   _Be warned: Occasionally clicking the Download Report button won't work. This can be a serious pain if the dev has already gone through and ignored false positives. I've had a 100% success rate with Download Report if after I open the DAP panel in my dev tools I then reload the page with the panel open. 😞 -- D.A._
 
 3. [Follow this link](https://ibm.biz/BdYkMA) and select the folder that corresponds with the ruleset the component was tested against and drop the JSON file in there.


### PR DESCRIPTION
Closes #1406

Adds documentation for the install, utilization of DAP and and a primer on how to audit and open issues.

The link to download the plugin was flagged as 'Invalid' by the Snip tool. Happy to take it out if it's not gonna work.