### PR TITLE
chore(devenv): re-route feature flags to reflect dev env config

### DIFF
--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 const babel = require('rollup-plugin-babel');
@@ -19,6 +20,9 @@ module.exports = {
             }
           `;
         }
+        if (id === path.resolve(__dirname, '../src/globals/js/feature-flags.js')) {
+          return `export * from ${JSON.stringify('../../../demo/feature-flags')}`;
+        }
         return undefined;
       },
     },
@@ -27,7 +31,7 @@ module.exports = {
       main: true,
     }),
     commonjs({
-      include: 'node_modules/**',
+      include: ['node_modules/**', 'demo/feature-flags.js'],
       sourceMap: true,
       namedExports: {
         'node_modules/react/index.js': [


### PR DESCRIPTION
Refs #1149.

#### Changelog

**New**

- A mechanism to proxy imports from `src/globals/js/feature-flags` to `demo/feature-flags.js`. The latter reflects the one used in our Gulp task (`-e` option).

@tw15egan Thanks again for pointing out this issue! Given we now define the content of `src/globals/js/feature-flags` module content in `rollup.config.dev.js` as ESM, we no longer need to apply `rollup-plugin-commonjs` plugin to that module. We now need to apply `rollup-plugin-commonjs` to `demo/feature-flags.js` instead.

#### Testing / Reviewing

Testing should make sure our dev env is not broken.