### PR TITLE
fix(ui-shell): remove redundant role='button'

### DIFF
--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -261,7 +261,7 @@
   //----------------------------------------------------------------------------
   // Side-nav > Navigation > {Menu,Submenu}
   //----------------------------------------------------------------------------
-  .#{$prefix}--side-nav__submenu[aria-haspopup='true'][role='button'] {
+  .#{$prefix}--side-nav__submenu[aria-haspopup='true'] {
     @include button-reset($width: true);
 
     display: flex;
@@ -291,6 +291,14 @@
 
   .#{$prefix}--side-nav__submenu[aria-expanded='true'] .#{$prefix}--side-nav__submenu-chevron > svg {
     transform: rotate(180deg);
+  }
+
+  .#{$prefix}--side-nav__menu[role='menu'] {
+    display: none;
+  }
+
+  .#{$prefix}--side-nav__submenu[aria-expanded='true'] + .#{$prefix}--side-nav__menu[role='menu'] {
+    display: block;
   }
 
   .#{$prefix}--side-nav__menu[role='menu'] a.#{$prefix}--side-nav__link[role='menuitem'] {
@@ -379,7 +387,7 @@
   // Variants - Fixed
   //----------------------------------------------------------------------------
   .#{$prefix}--side-nav--fixed a.#{$prefix}--side-nav__link,
-  .#{$prefix}--side-nav--fixed .#{$prefix}--side-nav__submenu[role='button'][aria-haspopup='true'] {
+  .#{$prefix}--side-nav--fixed .#{$prefix}--side-nav__submenu[aria-haspopup='true'] {
     padding-left: mini-units(2);
   }
 

--- a/src/components/ui-shell/side-nav.hbs
+++ b/src/components/ui-shell/side-nav.hbs
@@ -76,7 +76,7 @@
       <li class="bx--side-nav__item">
         <button
           class="bx--side-nav__submenu"
-          role="button"
+          type="button"
           aria-haspopup="true"
           aria-expanded="false">
           <div class="bx--side-nav__icon">
@@ -124,7 +124,7 @@
       <li class="bx--side-nav__item bx--side-nav__item--active">
         <button
           class="bx--side-nav__submenu"
-          role="button"
+          type="button"
           aria-haspopup="true"
           aria-expanded="true">
           <div class="bx--side-nav__icon">


### PR DESCRIPTION
Quick fix for https://github.com/IBM/carbon-components-react/pull/1539. We had a redundant `role="button"` on a `<button>` tag that should be a `type` 🤦‍♂️ 

#### Changelog

**New**

**Changed**

- UI Shell
  - Edit `role="button"` to `type="button"`

**Removed**

#### Testing / Reviewing
