### PR TITLE
fix(notification): use consistent classname

### DIFF
--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -201,6 +201,12 @@
     &:focus {
       @include focus-outline('outline');
     }
+
+    .#{$prefix}--inline-notification__close-icon {
+      height: rem(10px);
+      width: rem(10px);
+      fill: $ui-05;
+    }
   }
 }
 

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -65,6 +65,7 @@
     }
   }
 
+  .#{$prefix}--toast-notification__close-icon,
   .#{$prefix}--toast-notification__icon {
     height: 10px;
     width: 10px;
@@ -164,6 +165,12 @@
 
     &:focus {
       @include focus-outline('outline');
+    }
+
+    .#{$prefix}--toast-notification__close-icon {
+      height: rem(10px);
+      width: rem(10px);
+      fill: $ui-05;
     }
   }
 

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -85,8 +85,8 @@
     {{/is}}
   </div>
   <button data-notification-btn class="bx--{{../variant}}-notification__close-button" type="button" aria-label="close">
-    <svg aria-hidden="true" class="bx--{{../variant}}-notification{{#is ../variant "inline"}}__close{{/is}}-icon" width="10"
-      height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+    <svg aria-hidden="true" class="bx--{{../variant}}-notification__close-icon" width="10" height="10" viewBox="0 0 10 10"
+      xmlns="http://www.w3.org/2000/svg">
       <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
         fill-rule="nonzero" />
     </svg>


### PR DESCRIPTION
Changes `notification` close icons to use similar class names. Refs https://github.com/IBM/carbon-components-react/pull/1537/files#r231726402

`.#{$prefix}--toast-notification__close-icon` now matches `.#{$prefix}--inline-notification__close-icon`

#### Changelog

**New**

- `.#{$prefix}--toast-notification__close-icon` 

**Changed**

- `.#{$prefix}--toast-notification__icon` becomes `.#{$prefix}--toast-notification__close-icon`. Retains old selector for backwards compatibility.

**Removed**

- The variant in handlebars the added the `__close`

#### Testing / Reviewing

Ensure close icon looks correct in both regular and experimental modes.


