### PR TITLE
fix(experimental-colors): update some experimental colors

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -152,16 +152,6 @@
     border-top: 1px solid $ui-03;
     overflow: hidden;
 
-    &:focus {
-      outline: none;
-
-      .#{$prefix}--accordion__arrow {
-        @include focus-outline('border');
-        overflow: visible; // safari fix
-        outline-offset: -0.5px; // safari fix
-      }
-    }
-
     &:last-child {
       border-bottom: 1px solid $ui-03;
     }
@@ -177,23 +167,26 @@
     padding: rem(7px) 0;
     flex-direction: $accordion-flex-direction;
     width: 100%;
-    margin: 0; // safari fix
+    margin: 0;
+    transition: background-color $transition--base;
+
+    &:hover {
+      background-color: $hover-field;
+    }
 
     &:focus {
       outline: none;
 
       .#{$prefix}--accordion__arrow {
-        @include focus-outline('border');
-        overflow: visible; // safari fix
-        outline-offset: -0.5px; // safari fix
+        @include focus-outline('outline');
+        outline-offset: 0px;
       }
-    }
-    &:hover {
-      background-color: $field-01;
     }
   }
 
   .#{$prefix}--accordion__arrow {
+    @include focus-outline('reset');
+    outline-offset: 0px;
     transition: all $transition--base $carbon--standard-easing;
     height: 1.25rem;
     width: 1.25rem;
@@ -215,19 +208,18 @@
   .#{$prefix}--accordion__content {
     transition: all $transition--expansion $carbon--ease-out;
     padding-left: $spacing-md;
+    padding-right: 25%;
     height: 0;
     visibility: hidden;
     opacity: 0;
 
     p {
       @include typescale('zeta');
-      padding-right: 20%;
     }
   }
 
   .#{$prefix}--accordion__item--active {
     overflow: visible;
-    border-top: 1px solid transparent;
 
     .#{$prefix}--accordion__content {
       padding-bottom: $spacing-lg;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -220,10 +220,10 @@
     &:hover:disabled,
     &:focus:disabled {
       background: transparent;
-      color: $ibm-colors__gray--30;
+      color: $disabled;
 
       & > .#{$prefix}--btn__icon {
-        fill: $ibm-colors__gray--30;
+        fill: $disabled;
       }
     }
 
@@ -245,7 +245,7 @@
     }
 
     &:active {
-      background-color: $ibm-colors__gray--30;
+      background-color: $active-01;
     }
 
     .#{$prefix}--btn__icon {
@@ -255,12 +255,12 @@
     &:disabled,
     &:hover:disabled,
     &:focus:disabled {
-      color: $ibm-colors__gray--30;
+      color: $disabled;
       background: transparent;
       border-color: transparent;
 
       .#{$prefix}--btn__icon {
-        fill: $ibm-colors__gray--30;
+        fill: $disabled;
       }
     }
   }
@@ -284,7 +284,7 @@
     &:hover:disabled,
     &:focus:disabled {
       color: $ui-04;
-      border: $button-border-width solid $ibm-colors__gray--30;
+      border: $button-border-width solid $disabled;
     }
   }
 

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -758,7 +758,7 @@
 
   .#{$prefix}--date-picker__days .nextMonthDay,
   .#{$prefix}--date-picker__days .prevMonthDay {
-    color: $date-picker-next-month-color;
+    color: $text-02;
   }
 
   .#{$prefix}--date-picker__day.today,

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -315,12 +315,16 @@
   }
 
   .#{$prefix}--dropdown-item {
-    transition: opacity $transition--expansion cubic-bezier(0, 0, 0.38, 0.9);
+    transition: opacity $transition--expansion cubic-bezier(0, 0, 0.38, 0.9), background-color $transition--base;
     opacity: 0;
     margin-top: -1px;
 
     &:hover {
-      background-color: $ui-03;
+      background-color: $hover-field;
+    }
+
+    &:active {
+      background-color: $active-01;
     }
 
     &:first-of-type {

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -252,7 +252,6 @@
       height: rem(24px);
       width: rem(48px);
       border-radius: rem(15px);
-      border: 1px solid $ui-04;
       top: 0;
     }
 
@@ -343,11 +342,17 @@
   //----------------------------------------------
   // Focus
   // ---------------------------------------------
+  .#{$prefix}--toggle + .#{$prefix}--toggle__label,
+  .#{$prefix}--toggle + .#{$prefix}--toggle__label {
+    .#{$prefix}--toggle__appearance:before {
+      transition: box-shadow $transition--base;
+      box-shadow: 0 0 0 2px transparent;
+    }
+  }
   .#{$prefix}--toggle:focus + .#{$prefix}--toggle__label,
   .#{$prefix}--toggle:active + .#{$prefix}--toggle__label {
     .#{$prefix}--toggle__appearance:before {
       box-shadow: 0 0 0 2px $focus;
-      border-color: $focus;
     }
   }
 

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -231,7 +231,7 @@
   // Slider
 
   // Toggle
-  $toggle-background-color: $ibm-colors__green--30 !default !global;
+  $toggle-background-color: $ibm-colors__green--50 !default !global;
 
   // Skeleton Loading
   $skeleton: rgba($color__blue-51, 0.1) !default !global; //old $field-01 TODO: Define for experimental

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -128,6 +128,8 @@
   $support-03: $ibm-colors__yellow--20 !default !global;
   $support-04: $ibm-colors__blue--70 !default !global;
 
+  $active-01: $ibm-colors__gray--30 !default !global;
+
   // TODO: Define for experimental
   $nav-01: $color__navy-gray-1 !default !global;
   $nav-02: $color__blue-90 !default !global;
@@ -203,7 +205,6 @@
 
   // Date Picker
   $date-picker-in-range-background-color: $ibm-colors__blue--20 !default !global;
-  $date-picker-next-month-color: $ibm-colors__gray--60 !default !global;
 
   // Modal
   $modal-border-top: $brand-01 4px solid !default !global;


### PR DESCRIPTION
After working on the color audit with @IBM/carbon-designers, we've decided to change a few color values / update some component behaviors 

#### Changelog

**New**

- `$active-01` color token 

**Changed**

- `Accordion` has been updated to match specs
- Used color tokens where appropriate
- `Toggle` now uses `$ibm-colors__green--50`, not `$ibm-colors__green--30`. Borders have been removed. 
- `Dropdown` now uses correct background color on hover

**Removed**

- `DatePicker` specific color token, changed to `$text-02`

#### Testing / Reviewing

Ensure nothing looks CrAzY
