### PR TITLE
feat(components): configurable CSS class prefix for templates

### DIFF
--- a/src/components/accordion/accordion--legacy.hbs
+++ b/src/components/accordion/accordion--legacy.hbs
@@ -1,13 +1,13 @@
-<ul data-accordion class="bx--accordion">
+<ul data-accordion class="{{@root.prefix}}--accordion">
   {{#each sections}}
-    <li tabindex="0" data-accordion-item class="bx--accordion__item">
-      <div class="bx--accordion__heading">
-        <svg class="bx--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+    <li tabindex="0" data-accordion-item class="{{@root.prefix}}--accordion__item">
+      <div class="{{@root.prefix}}--accordion__heading">
+        <svg class="{{@root.prefix}}--accordion__arrow" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
           <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
         </svg>
-        <p class="bx--accordion__title">{{title}}</p>
+        <p class="{{@root.prefix}}--accordion__title">{{title}}</p>
       </div>
-      <div class="bx--accordion__content">
+      <div class="{{@root.prefix}}--accordion__content">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
       </div>

--- a/src/components/accordion/accordion.config.js
+++ b/src/components/accordion/accordion.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/accordion/accordion.hbs
+++ b/src/components/accordion/accordion.hbs
@@ -1,13 +1,13 @@
-<ul data-accordion class="bx--accordion">
+<ul data-accordion class="{{@root.prefix}}--accordion">
   {{#each sections}}
-    <li data-accordion-item class="bx--accordion__item">
-      <button class="bx--accordion__heading" aria-expanded="false" aria-controls="{{paneId}}">
-        <svg class="bx--accordion__arrow" width="7" height="12" viewBox="0 0 7 12">
+    <li data-accordion-item class="{{@root.prefix}}--accordion__item">
+      <button class="{{@root.prefix}}--accordion__heading" aria-expanded="false" aria-controls="{{paneId}}">
+        <svg class="{{@root.prefix}}--accordion__arrow" width="7" height="12" viewBox="0 0 7 12">
           <path fill-rule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
         </svg>
-        <div class="bx--accordion__title">{{title}}</div>
+        <div class="{{@root.prefix}}--accordion__title">{{title}}</div>
       </button>
-      <div id="{{paneId}}" class="bx--accordion__content">
+      <div id="{{paneId}}" class="{{@root.prefix}}--accordion__content">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
       </div>

--- a/src/components/breadcrumb/breadcrumb.config.js
+++ b/src/components/breadcrumb/breadcrumb.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/breadcrumb/breadcrumb.hbs
+++ b/src/components/breadcrumb/breadcrumb.hbs
@@ -1,8 +1,8 @@
-<nav class="bx--breadcrumb bx--breadcrumb--no-trailing-slash" aria-label="breadcrumb">
+<nav class="{{@root.prefix}}--breadcrumb {{@root.prefix}}--breadcrumb--no-trailing-slash" aria-label="breadcrumb">
   {{#each items}}
-    <div class="bx--breadcrumb-item">
+    <div class="{{@root.prefix}}--breadcrumb-item">
       {{#if label}}
-        <a href="#" class="bx--link">{{label}}</a>
+        <a href="#" class="{{@root.prefix}}--link">{{label}}</a>
       {{/if}}
     </div>
   {{/each}}

--- a/src/components/button/button.config.js
+++ b/src/components/button/button.config.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
   default: 'primary',
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'primary',

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -1,11 +1,11 @@
-<button class="bx--btn bx--btn--{{variant}}{{#if small}} bx--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
   type="button">Button</button>
-<button class="bx--btn bx--btn--{{variant}}{{#if small}} bx--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
   type="button" disabled>Button</button>
-<button class="bx--btn bx--btn--{{variant}}{{#if small}} bx--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
   type="button">
   With icon
-  <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
   </svg>
 </button>

--- a/src/components/carousel/carousel.config.js
+++ b/src/components/carousel/carousel.config.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
   hidden: true,
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/carousel/carousel.hbs
+++ b/src/components/carousel/carousel.hbs
@@ -1,39 +1,39 @@
-<div class="bx--type-omega">Carousel Title</div>
-<div class="bx--carousel" data-carousel>
-  <button class="bx--carousel__btn" data-scroll-left>
-    <svg class="bx--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+<div class="{{@root.prefix}}--type-omega">Carousel Title</div>
+<div class="{{@root.prefix}}--carousel" data-carousel>
+  <button class="{{@root.prefix}}--carousel__btn" data-scroll-left>
+    <svg class="{{@root.prefix}}--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
       <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
     </svg>
   </button>
-  <div class="bx--carousel-container">
-    <div class="bx--filmstrip" tabindex="-1">
+  <div class="{{@root.prefix}}--carousel-container">
+    <div class="{{@root.prefix}}--filmstrip" tabindex="-1">
       {{#each items}}
-        <button class="bx--carousel__item" data-modal-target="#carousel-lightbox" data-carousel-item-index="{{@index}}">
+        <button class="{{@root.prefix}}--carousel__item" data-modal-target="#carousel-lightbox" data-carousel-item-index="{{@index}}">
           <img src="{{filmstripImageUrl}}">
         </button>
       {{/each}}
     </div>
   </div>
-  <button class="bx--carousel__btn" data-scroll-right>
-    <svg class="bx--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+  <button class="{{@root.prefix}}--carousel__btn" data-scroll-right>
+    <svg class="{{@root.prefix}}--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
       <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
     </svg>
   </button>
 </div>
 
-<div id="carousel-lightbox" class="bx--modal" data-modal>
-  <div class="bx--lightbox" data-lightbox data-lightbox-index="0">
-    <div class="bx--lightbox__main">
-      <button class="bx--lightbox__btn" data-scroll-left>
-        <svg class="bx--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+<div id="carousel-lightbox" class="{{@root.prefix}}--modal" data-modal>
+  <div class="{{@root.prefix}}--lightbox" data-lightbox data-lightbox-index="0">
+    <div class="{{@root.prefix}}--lightbox__main">
+      <button class="{{@root.prefix}}--lightbox__btn" data-scroll-left>
+        <svg class="{{@root.prefix}}--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
           <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
         </svg>
       </button>
       {{#each items}}
-        <img src="{{lightboxImageUrl}}" class="bx--lightbox__item">
+        <img src="{{lightboxImageUrl}}" class="{{@root.prefix}}--lightbox__item">
       {{/each}}
-      <button class="bx--lightbox__btn" data-scroll-right>
-        <svg class="bx--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+      <button class="{{@root.prefix}}--lightbox__btn" data-scroll-right>
+        <svg class="{{@root.prefix}}--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
           <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
         </svg>
       </button>

--- a/src/components/checkbox/checkbox.config.js
+++ b/src/components/checkbox/checkbox.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/checkbox/checkbox.hbs
+++ b/src/components/checkbox/checkbox.hbs
@@ -1,41 +1,41 @@
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Checkbox (input + label)</legend>
+<fieldset class="{{@root.prefix}}--fieldset">
+  <legend class="{{@root.prefix}}--label">Checkbox (input + label)</legend>
   <!-- input + label -->
-  <div class="bx--form-item bx--checkbox-wrapper">
-    <input id="bx--checkbox-new" class="bx--checkbox" type="checkbox" value="new" name="checkbox" checked>
-    <label for="bx--checkbox-new" class="bx--checkbox-label">Checkbox</label>
+  <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+    <input id="{{@root.prefix}}--checkbox-new" class="{{@root.prefix}}--checkbox" type="checkbox" value="new" name="checkbox" checked>
+    <label for="{{@root.prefix}}--checkbox-new" class="{{@root.prefix}}--checkbox-label">Checkbox</label>
   </div>
   <!-- input + label indeterminate -->
-  <div class="bx--form-item bx--checkbox-wrapper">
-    <input id="bx--checkbox-ind" class="bx--checkbox" type="checkbox" value="new" name="checkbox" aria-checked="mixed">
-    <label for="bx--checkbox-ind" class="bx--checkbox-label">Indeterminate checkbox</label>
+  <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+    <input id="{{@root.prefix}}--checkbox-ind" class="{{@root.prefix}}--checkbox" type="checkbox" value="new" name="checkbox" aria-checked="mixed">
+    <label for="{{@root.prefix}}--checkbox-ind" class="{{@root.prefix}}--checkbox-label">Indeterminate checkbox</label>
   </div>
   <!-- input + label disabled -->
-  <div class="bx--form-item bx--checkbox-wrapper">
-    <input id="bx--checkbox-disabled" class="bx--checkbox" type="checkbox" value="new" name="checkbox" disabled>
-    <label for="bx--checkbox-disabled" class="bx--checkbox-label">Disabled checkbox</label>
+  <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+    <input id="{{@root.prefix}}--checkbox-disabled" class="{{@root.prefix}}--checkbox" type="checkbox" value="new" name="checkbox" disabled>
+    <label for="{{@root.prefix}}--checkbox-disabled" class="{{@root.prefix}}--checkbox-label">Disabled checkbox</label>
   </div>
 </fieldset>
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Checkbox (input > label)</legend>
+<fieldset class="{{@root.prefix}}--fieldset">
+  <legend class="{{@root.prefix}}--label">Checkbox (input > label)</legend>
     <!-- label > input -->
-    <div class="bx--form-item bx--checkbox-wrapper">
-      <label for="bx--checkbox-new2" class="bx--checkbox-label">
-        <input id="bx--checkbox-new2" class="bx--checkbox" type="checkbox" value="yellow" name="checkbox" checked>
+    <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+      <label for="{{@root.prefix}}--checkbox-new2" class="{{@root.prefix}}--checkbox-label">
+        <input id="{{@root.prefix}}--checkbox-new2" class="{{@root.prefix}}--checkbox" type="checkbox" value="yellow" name="checkbox" checked>
         Checkbox
       </label>
     </div>
     <!-- label > input -->
-    <div class="bx--form-item bx--checkbox-wrapper">
-      <label for="bx--checkbox-ind2" class="bx--checkbox-label" data-contained-checkbox-state="mixed">
-        <input id="bx--checkbox-ind2" class="bx--checkbox" type="checkbox" value="yellow" name="checkbox" aria-checked="mixed">
+    <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+      <label for="{{@root.prefix}}--checkbox-ind2" class="{{@root.prefix}}--checkbox-label" data-contained-checkbox-state="mixed">
+        <input id="{{@root.prefix}}--checkbox-ind2" class="{{@root.prefix}}--checkbox" type="checkbox" value="yellow" name="checkbox" aria-checked="mixed">
         Indeterminate checkbox
       </label>
     </div>
     <!-- label > input -->
-    <div class="bx--form-item bx--checkbox-wrapper">
-      <label for="bx--checkbox-disabled2" class="bx--checkbox-label">
-        <input id="bx--checkbox-disabled2" class="bx--checkbox" type="checkbox" value="yellow" name="checkbox" disabled>
+    <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+      <label for="{{@root.prefix}}--checkbox-disabled2" class="{{@root.prefix}}--checkbox-label">
+        <input id="{{@root.prefix}}--checkbox-disabled2" class="{{@root.prefix}}--checkbox" type="checkbox" value="yellow" name="checkbox" disabled>
         Disabled checkbox
       </label>
     </div>

--- a/src/components/code-snippet/code-snippet.config.js
+++ b/src/components/code-snippet/code-snippet.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/code-snippet/code-snippet.hbs
+++ b/src/components/code-snippet/code-snippet.hbs
@@ -1,15 +1,15 @@
 {{#is variant "inline"}}
 <p>Here is an example of a text that a user would be reading. In this paragraph would be
-  <button data-copy-btn="" class="bx--snippet bx--snippet--inline bx--btn--copy{{#if light}} bx--snippet--light{{/if}}" aria-label="Copy code"
+  <button data-copy-btn="" class="{{@root.prefix}}--snippet {{@root.prefix}}--snippet--inline {{@root.prefix}}--btn--copy{{#if light}} {{@root.prefix}}--snippet--light{{/if}}" aria-label="Copy code"
     tabindex="0">
     <code>inline code</code>
-    <div class="bx--btn--copy__feedback" data-feedback="Copied!"></div>
+    <div class="{{@root.prefix}}--btn--copy__feedback" data-feedback="Copied!"></div>
   </button>
   that the user could look at and copy in to their code editor.</p>
 {{else}}
 
-<div class="bx--snippet bx--snippet--{{variant}}" {{#is variant "multi"}}data-code-snippet{{/is}}>
-  <div class="bx--snippet-container" aria-label="Code Snippet Text">
+<div class="{{@root.prefix}}--snippet {{@root.prefix}}--snippet--{{variant}}" {{#is variant "multi"}}data-code-snippet{{/is}}>
+  <div class="{{@root.prefix}}--snippet-container" aria-label="Code Snippet Text">
     <pre>
 <code>@mixin grid-container {
     width: 100%;
@@ -34,18 +34,18 @@
   );</code>
     </pre>
   </div>
-  <button data-copy-btn class="bx--snippet-button" aria-label="Copy code" tabindex="0">
-    <svg class="bx--snippet__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <button data-copy-btn class="{{@root.prefix}}--snippet-button" aria-label="Copy code" tabindex="0">
+    <svg class="{{@root.prefix}}--snippet__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path d="M1 10H0V2C0 .9.9 0 2 0h8v1H2c-.6 0-1 .5-1 1v8z" />
       <path d="M11 4.2V8h3.8L11 4.2zM15 9h-4c-.6 0-1-.4-1-1V4H4.5c-.3 0-.5.2-.5.5v10c0 .3.2.5.5.5h10c.3 0 .5-.2.5-.5V9zm-4-6c.1 0 .3.1.4.1l4.5 4.5c0 .1.1.3.1.4v6.5c0 .8-.7 1.5-1.5 1.5h-10c-.8 0-1.5-.7-1.5-1.5v-10C3 3.7 3.7 3 4.5 3H11z"
         + />
     </svg>
-    <div class="bx--btn--copy__feedback" data-feedback="Copied!"></div>
+    <div class="{{@root.prefix}}--btn--copy__feedback" data-feedback="Copied!"></div>
   </button>
   {{#is variant "multi"}}
-  <button class="bx--btn bx--btn--ghost bx--btn--sm bx--snippet-btn--expand" type="button">
-    <span class="bx--snippet-btn--text" data-show-more-text="Show more" data-show-less-text="Show less">Show more</span>
-    <svg class="bx--icon-chevron--down" width="12" height="7" viewBox="0 0 12 7" aria-label="Show more icon">
+  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--ghost {{@root.prefix}}--btn--sm {{@root.prefix}}--snippet-btn--expand" type="button">
+    <span class="{{@root.prefix}}--snippet-btn--text" data-show-more-text="Show more" data-show-less-text="Show less">Show more</span>
+    <svg class="{{@root.prefix}}--icon-chevron--down" width="12" height="7" viewBox="0 0 12 7" aria-label="Show more icon">
       <title>Show more icon</title>
       <path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
     </svg>

--- a/src/components/combo-box/combo-box.config.js
+++ b/src/components/combo-box/combo-box.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     id: 'downshift-1-item-0',
@@ -21,6 +23,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -1,8 +1,8 @@
-<div class="bx--form-item bx--combo-box bx--list-box{{#if disabled}} bx--list-box--disabled{{/if}}">
-  <div role="button" class="bx--list-box__field" aria-label="open menu" aria-expanded="false" aria-haspopup="true"
-    {{#if disabled}} disabled{{/if}}> <input class="bx--text-input" role="combobox" aria-autocomplete="list"
+<div class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false" aria-haspopup="true"
+    {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list"
     aria-expanded="false" autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." {{#if disabled}}
-    disabled{{/if}}> <div class="bx--list-box__menu-icon">
+    disabled{{/if}}> <div class="{{@root.prefix}}--list-box__menu-icon">
     <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Open menu" name="caret--down" role="img">
       <title>Close menu</title>
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -10,20 +10,20 @@
   </div>
 </div>
 </div>
-<div class="bx--form-item bx--combo-box bx--list-box{{#if disabled}} bx--list-box--disabled{{/if}}">
-  <div role="button" class="bx--list-box__field" aria-label="close menu" aria-expanded="true" aria-haspopup="true"
-    {{#if disabled}} disabled{{/if}}> <input class="bx--text-input" role="combobox" aria-autocomplete="list"
+<div class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true" aria-haspopup="true"
+    {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list"
     aria-expanded="true" autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..."
-    aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}> <div class="bx--list-box__menu-icon bx--list-box__menu-icon--open">
+    aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}> <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
     <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Open menu" name="caret--down" role="img">
       <title>Close menu</title>
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>
   </div>
 </div>
-<div class="bx--list-box__menu">
+<div class="{{@root.prefix}}--list-box__menu">
   {{#each items}}
-  <div class="bx--list-box__menu-item{{#if selected}} bx--list-box__menu-item--highlighted{{/if}}" id="{{id}}">{{label}}</div>
+  <div class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}" id="{{id}}">{{label}}</div>
   {{/each}}
 </div>
 </div>

--- a/src/components/content-switcher/content-switcher.config.js
+++ b/src/components/content-switcher/content-switcher.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     label: 'First section',
@@ -17,6 +19,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/content-switcher/content-switcher.hbs
+++ b/src/components/content-switcher/content-switcher.hbs
@@ -1,8 +1,8 @@
-<div data-content-switcher class="bx--content-switcher" role="tablist" aria-label="Demo switch content">
+<div data-content-switcher class="{{@root.prefix}}--content-switcher" role="tablist" aria-label="Demo switch content">
   {{#each items}}
-    <button class="bx--content-switcher-btn{{#if selected}} bx--content-switcher--selected{{/if}}" data-target="{{target}}" role="tab"{{#if selected}} aria-selected="true"{{/if}}>
+    <button class="{{@root.prefix}}--content-switcher-btn{{#if selected}} {{@root.prefix}}--content-switcher--selected{{/if}}" data-target="{{target}}" role="tab"{{#if selected}} aria-selected="true"{{/if}}>
       {{#if ../hasIcon}}
-      <svg class="bx--content-switcher__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+      <svg class="{{@root.prefix}}--content-switcher__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
         <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
       </svg>
       {{/if}}

--- a/src/components/copy-button/copy-button.config.js
+++ b/src/components/copy-button/copy-button.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/copy-button/copy-button.hbs
+++ b/src/components/copy-button/copy-button.hbs
@@ -1,7 +1,7 @@
-<button data-copy-btn class="bx--btn bx--btn--primary bx--btn--copy bx--btn--sm">
+<button data-copy-btn class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary {{@root.prefix}}--btn--copy {{@root.prefix}}--btn--sm">
   Copy button
-  <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16">
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16">
     <path d="M7.5 7.5H4v1h3.5V12h1V8.5H12v-1H8.5V4h-1v3.5zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
   </svg>
-  <div class="bx--btn--copy__feedback" data-feedback="Copied!"></div>
+  <div class="{{@root.prefix}}--btn--copy__feedback" data-feedback="Copied!"></div>
 </button>

--- a/src/components/data-table-v2/data-table-v2.config.js
+++ b/src/components/data-table-v2/data-table-v2.config.js
@@ -1,13 +1,15 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const iconAddSolid = `
-  <svg class="bx--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <svg class="${prefix}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
   </svg>
 `;
 
 const iconDownload = `
-  <svg class="bx--toolbar-action__icon" fill-rule="evenodd" height="16" name="download" role="img" viewBox="0 0 14 16" width="14"
+  <svg class="${prefix}--toolbar-action__icon" fill-rule="evenodd" height="16" name="download" role="img" viewBox="0 0 14 16" width="14"
     aria-label="Download" alt="Download">
     <title>Download</title>
     <path d="M7.506 11.03l4.137-4.376.727.687-5.363 5.672-5.367-5.67.726-.687 4.14 4.374V0h1v11.03z"></path>
@@ -16,7 +18,7 @@ const iconDownload = `
 `;
 
 const iconEdit = `
-  <svg class="bx--toolbar-action__icon" fill-rule="evenodd" height="16" name="edit" role="img" viewBox="0 0 16 16" width="16"
+  <svg class="${prefix}--toolbar-action__icon" fill-rule="evenodd" height="16" name="edit" role="img" viewBox="0 0 16 16" width="16"
     aria-label="Edit" alt="Edit">
     <title>Edit</title>
     <path d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"></path>
@@ -24,7 +26,7 @@ const iconEdit = `
 `;
 
 const iconSettings = `
-  <svg class="bx--toolbar-action__icon" fill-rule="evenodd" height="16" name="settings" role="img" viewBox="0 0 15 16" width="15"
+  <svg class="${prefix}--toolbar-action__icon" fill-rule="evenodd" height="16" name="settings" role="img" viewBox="0 0 15 16" width="15"
     aria-label="Settings" alt="Settings">
     <title>Settings</title>
     <path d="M7.53 10.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5zm0 1a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z"></path>
@@ -84,7 +86,7 @@ const columns = [
     name: 'select',
     title: 'Label name',
     checkbox: true,
-    checkboxId: 'bx--checkbox-20',
+    checkboxId: `${prefix}--checkbox-20`,
     checkboxName: 'checkbox-20',
     checkboxValue: 'green',
   },
@@ -176,7 +178,7 @@ const rows = [
   {
     id: 'row-id-13',
     select: {
-      id: 'bx--checkbox-13',
+      id: `${prefix}--checkbox-13`,
       name: 'checkbox-13',
       value: 'green',
       label: 'Label name',
@@ -196,7 +198,7 @@ const rows = [
   {
     id: 'row-id-14',
     select: {
-      id: 'bx--checkbox-14',
+      id: `${prefix}--checkbox-14`,
       name: 'checkbox-14',
       value: 'green',
       label: 'Label name',
@@ -216,7 +218,7 @@ const rows = [
   {
     id: 'row-id-15',
     select: {
-      id: 'bx--checkbox-15',
+      id: `${prefix}--checkbox-15`,
       name: 'checkbox-15',
       value: 'green',
       label: 'Label name',
@@ -236,7 +238,7 @@ const rows = [
   {
     id: 'row-id-11',
     select: {
-      id: 'bx--checkbox-11',
+      id: `${prefix}--checkbox-11`,
       name: 'checkbox-11',
       value: 'green',
       label: 'Label name',
@@ -256,7 +258,7 @@ const rows = [
   {
     id: 'row-id-12',
     select: {
-      id: 'bx--checkbox-12',
+      id: `${prefix}--checkbox-12`,
       name: 'checkbox-12',
       value: 'green',
       label: 'Label name',
@@ -351,6 +353,9 @@ const rowsEditable = [
 
 module.exports = {
   label: 'Data Table V2',
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/data-table-v2/data-table-v2.hbs
+++ b/src/components/data-table-v2/data-table-v2.hbs
@@ -1,33 +1,33 @@
 {{#if hasToolbar}}
-<div class="bx--data-table-v2-container" data-table-v2>
-  <h4 class="bx--data-table-v2-header">{{title}}</h4>
-  <section class="bx--table-toolbar">
+<div class="{{@root.prefix}}--data-table-v2-container" data-table-v2>
+  <h4 class="{{@root.prefix}}--data-table-v2-header">{{title}}</h4>
+  <section class="{{@root.prefix}}--table-toolbar">
     {{#if batchActions}}
-      <div class="bx--batch-actions" aria-label="Table Action Bar">
-        <div class="bx--action-list">
+      <div class="{{@root.prefix}}--batch-actions" aria-label="Table Action Bar">
+        <div class="{{@root.prefix}}--action-list">
           {{#each batchActions}}
-            <button class="bx--btn bx--btn--sm bx--btn--ghost" type="button">
+            <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--sm {{@root.prefix}}--btn--ghost" type="button">
               {{label}}
               {{{icon}}}
             </button>
           {{/each}}
         </div>
-        <div class="bx--batch-summary">
-          <p class="bx--batch-summary__para">{{{selectedItemsCounterLabel}}}</p>
-          <button data-event="action-bar-cancel" class="bx--batch-summary__cancel">{{cancelLabel}}</button>
+        <div class="{{@root.prefix}}--batch-summary">
+          <p class="{{@root.prefix}}--batch-summary__para">{{{selectedItemsCounterLabel}}}</p>
+          <button data-event="action-bar-cancel" class="{{@root.prefix}}--batch-summary__cancel">{{cancelLabel}}</button>
         </div>
       </div>
     {{/if}}
 
-    <div class="bx--toolbar-search-container">
-      <div data-search class="bx--search bx--search--sm bx--search--light" role="search">
-        <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
+    <div class="{{@root.prefix}}--toolbar-search-container">
+      <div data-search class="{{@root.prefix}}--search {{@root.prefix}}--search--sm {{@root.prefix}}--search--light" role="search">
+        <svg class="{{@root.prefix}}--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
           <path d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z"
             fill-rule="nonzero" />
         </svg>
-        <label id="{{searchLabelId}}" class="bx--label" for="{{searchInputId}}">{{searchLabel}}</label>
-        <input class="bx--search-input" type="text" id="{{searchInputId}}" role="search" placeholder="{{searchLabel}}" aria-labelledby="{{searchLabelId}}">
-        <button class="bx--search-close bx--search-close--hidden" title="{{clearSearchLabel}}" aria-label="{{clearSearchLabel}}">
+        <label id="{{searchLabelId}}" class="{{@root.prefix}}--label" for="{{searchInputId}}">{{searchLabel}}</label>
+        <input class="{{@root.prefix}}--search-input" type="text" id="{{searchInputId}}" role="search" placeholder="{{searchLabel}}" aria-labelledby="{{searchLabelId}}">
+        <button class="{{@root.prefix}}--search-close {{@root.prefix}}--search-close--hidden" title="{{clearSearchLabel}}" aria-label="{{clearSearchLabel}}">
           <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"
               fill-rule="evenodd" />
@@ -37,32 +37,32 @@
     </div>
 
     {{#if toolbarActions}}
-      <div class="bx--toolbar-content">
+      <div class="{{@root.prefix}}--toolbar-content">
         {{#each toolbarActions}}
-          <button class="bx--toolbar-action">
+          <button class="{{@root.prefix}}--toolbar-action">
             {{{icon}}}
           </button>
         {{/each}}
 
-        <button class="bx--btn bx--btn--sm bx--btn--primary">{{addNewLabel}}</button>
+        <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--sm {{@root.prefix}}--btn--primary">{{addNewLabel}}</button>
       </div>
     {{/if}}
   </section>
 {{/if}}
 
-<table class="bx--data-table-v2{{#if zebra}} bx--data-table-v2--zebra{{/if}}{{#if small}} bx--data-table-v2--compact{{/if}}">
+<table class="{{@root.prefix}}--data-table-v2{{#if zebra}} {{@root.prefix}}--data-table-v2--zebra{{/if}}{{#if small}} {{@root.prefix}}--data-table-v2--compact{{/if}}">
   <thead>
     <tr>
       {{#each columns}}
         <th>
           {{#if checkbox}}
-            <input data-event="select-all" id="{{checkboxId}}" class="bx--checkbox" type="checkbox" value="{{checkboxValue}}" name="{{checkboxName}}">
-            <label for="{{checkboxId}}" class="bx--checkbox-label" aria-label="{{title}}"></label>
+            <input data-event="select-all" id="{{checkboxId}}" class="{{@root.prefix}}--checkbox" type="checkbox" value="{{checkboxValue}}" name="{{checkboxName}}">
+            <label for="{{checkboxId}}" class="{{@root.prefix}}--checkbox-label" aria-label="{{title}}"></label>
           {{else if (not menu)}}
             {{#if sortable}}
-              <button class="bx--table-sort-v2" data-event="sort">
-                <span class="bx--table-header-label">{{title}}</span>
-                <svg class="bx--table-sort-v2__icon" width="10" height="5" viewBox="0 0 10 5" aria-label="{{../sortLabel}}" alt="{{../sortLabel}}">
+              <button class="{{@root.prefix}}--table-sort-v2" data-event="sort">
+                <span class="{{@root.prefix}}--table-header-label">{{title}}</span>
+                <svg class="{{@root.prefix}}--table-sort-v2__icon" width="10" height="5" viewBox="0 0 10 5" aria-label="{{../sortLabel}}" alt="{{../sortLabel}}">
                   <title>{{../sortLabel}}</title>
                   <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
                 </svg>
@@ -70,7 +70,7 @@
             {{else if small}}
               {{title}}
             {{else}}
-              <span class="bx--table-header-label">{{title}}</span>
+              <span class="{{@root.prefix}}--table-header-label">{{title}}</span>
             {{/if}}
           {{/if}}
         </th>
@@ -79,54 +79,54 @@
   </thead>
   <tbody>
     {{#each rows as |row|}}
-      <tr{{#if row.sectionContent}} class="bx--parent-row-v2" data-parent-row{{/if}}>
+      <tr{{#if row.sectionContent}} class="{{@root.prefix}}--parent-row-v2" data-parent-row{{/if}}>
         {{#each ../columns as |column|}}
           {{#with (lookup row column.name) as |data|}}
             {{#if column.section}}
-              <td class="bx--table-expand-v2" data-event="expand">
-                <button class="bx--table-expand-v2__button">
-                  <svg class="bx--table-expand-v2__svg" width="7" height="12" viewBox="0 0 7 12">
+              <td class="{{@root.prefix}}--table-expand-v2" data-event="expand">
+                <button class="{{@root.prefix}}--table-expand-v2__button">
+                  <svg class="{{@root.prefix}}--table-expand-v2__svg" width="7" height="12" viewBox="0 0 7 12">
                     <path fill-rule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
                   </svg>
                 </button>
               </td>
             {{else if column.checkbox}}
               <td>
-                <input data-event="select" id="{{data.id}}" class="bx--checkbox" type="checkbox" value="{{data.value}}" name="{{data.name}}">
-                <label for="{{data.id}}" class="bx--checkbox-label" aria-label="{{data.label}}"></label>
+                <input data-event="select" id="{{data.id}}" class="{{@root.prefix}}--checkbox" type="checkbox" value="{{data.value}}" name="{{data.name}}">
+                <label for="{{data.id}}" class="{{@root.prefix}}--checkbox-label" aria-label="{{data.label}}"></label>
               </td>
             {{else if column.menu}}
-              <td class="bx--table-overflow">
-                <div data-overflow-menu tabindex="0" aria-label="{{data.label}}" class="bx--overflow-menu">
-                  <svg class="bx--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
+              <td class="{{@root.prefix}}--table-overflow">
+                <div data-overflow-menu tabindex="0" aria-label="{{data.label}}" class="{{@root.prefix}}--overflow-menu">
+                  <svg class="{{@root.prefix}}--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
                     <g fill-rule="evenodd">
                       <circle cx="1.5" cy="1.5" r="1.5" />
                       <circle cx="1.5" cy="7.5" r="1.5" />
                       <circle cx="1.5" cy="13.5" r="1.5" />
                     </g>
                   </svg>
-                  <ul class="bx--overflow-menu-options{{#if data.flip}} bx--overflow-menu--flip{{/if}}">
+                  <ul class="{{@root.prefix}}--overflow-menu-options{{#if data.flip}} {{@root.prefix}}--overflow-menu--flip{{/if}}">
                     {{#each data.items}}
-                      <li class="bx--overflow-menu-options__option{{#if danger}} bx--overflow-menu-options__option--danger{{/if}}">
-                        <button class="bx--overflow-menu-options__btn">{{label}}</button>
+                      <li class="{{@root.prefix}}--overflow-menu-options__option{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}">
+                        <button class="{{@root.prefix}}--overflow-menu-options__btn">{{label}}</button>
                       </li>
                     {{/each}}
                   </ul>
                 </div>
               </td>
             {{else if (and row.editable column.editing)}}
-              <td class="bx--data-table-cell--editable bx--data-table-cell--editing">
-                <div class="bx--data-table__edit-field">
-                  <label class="bx--label" for="edit-cell:{{row.id}}:{{column.name}}">Edit Name: {{data}}</label>
-                  <input type="text" class="bx--text-input" id="edit-cell:{{row.id}}:{{column.name}}" value="{{data}}">
+              <td class="{{@root.prefix}}--data-table-cell--editable {{@root.prefix}}--data-table-cell--editing">
+                <div class="{{@root.prefix}}--data-table__edit-field">
+                  <label class="{{@root.prefix}}--label" for="edit-cell:{{row.id}}:{{column.name}}">Edit Name: {{data}}</label>
+                  <input type="text" class="{{@root.prefix}}--text-input" id="edit-cell:{{row.id}}:{{column.name}}" value="{{data}}">
                 </div>
-                <div class="bx--data-table__edit-actions">
-                  <button class="bx--btn bx--btn--secondary bx--btn--sm">{{../../../cancelLabel}}</button>
-                  <button class="bx--btn bx--btn--primary bx--btn--sm">{{../../../saveLabel}}</button>
+                <div class="{{@root.prefix}}--data-table__edit-actions">
+                  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--secondary {{@root.prefix}}--btn--sm">{{../../../cancelLabel}}</button>
+                  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary {{@root.prefix}}--btn--sm">{{../../../saveLabel}}</button>
                 </div>
               </td>
             {{else if column.editable}}
-              <td class="bx--data-table-cell--editable"><span class="bx--data-table-cell__content">{{data}}</span></td>
+              <td class="{{@root.prefix}}--data-table-cell--editable"><span class="{{@root.prefix}}--data-table-cell__content">{{data}}</span></td>
             {{else}}
               <td>{{data}}</td>
             {{/if}}
@@ -134,7 +134,7 @@
         {{/each}}
       </tr>
       {{#if row.sectionContent}}
-        <tr class="bx--expandable-row-v2 bx--expandable-row--hidden-v2" data-child-row>
+        <tr class="{{@root.prefix}}--expandable-row-v2 {{@root.prefix}}--expandable-row--hidden-v2" data-child-row>
           <td colspan="{{../columns.length}}">
             {{{row.sectionContent}}}
           </td>
@@ -146,52 +146,52 @@
 
 {{#if (not small)}}</div>{{/if}}
 {{#if hasPager}}
-  <div class="bx--pagination" data-pagination>
-    <div class="bx--pagination__left">
-      <span class="bx--pagination__text">Items per page:</span>
-      <div class="bx--select bx--select--inline">
-        <label for="select-id-pagination" class="bx--visually-hidden">Number of items per page</label>
-        <select id="select-id-pagination" class="bx--select-input" data-items-per-page>
-          <option class="bx--select-option" value="10" selected>10</option>
-          <option class="bx--select-option" value="20">20</option>
-          <option class="bx--select-option" value="30">30</option>
-          <option class="bx--select-option" value="40">40</option>
-          <option class="bx--select-option" value="50">50</option>
+  <div class="{{@root.prefix}}--pagination" data-pagination>
+    <div class="{{@root.prefix}}--pagination__left">
+      <span class="{{@root.prefix}}--pagination__text">Items per page:</span>
+      <div class="{{@root.prefix}}--select {{@root.prefix}}--select--inline">
+        <label for="select-id-pagination" class="{{@root.prefix}}--visually-hidden">Number of items per page</label>
+        <select id="select-id-pagination" class="{{@root.prefix}}--select-input" data-items-per-page>
+          <option class="{{@root.prefix}}--select-option" value="10" selected>10</option>
+          <option class="{{@root.prefix}}--select-option" value="20">20</option>
+          <option class="{{@root.prefix}}--select-option" value="30">30</option>
+          <option class="{{@root.prefix}}--select-option" value="40">40</option>
+          <option class="{{@root.prefix}}--select-option" value="50">50</option>
         </select>
-        <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
       </div>
-      <span class="bx--pagination__text">
+      <span class="{{@root.prefix}}--pagination__text">
         <span>|&nbsp;</span>
         <span data-displayed-item-range>1-10</span> of
         <span data-total-items>40</span> items</span>
     </div>
-    <div class="bx--pagination__right bx--pagination--inline">
-      <span class="bx--pagination__text">
+    <div class="{{@root.prefix}}--pagination__right {{@root.prefix}}--pagination--inline">
+      <span class="{{@root.prefix}}--pagination__text">
         <span data-displayed-page-number>1</span> of
         <span data-total-pages>4</span> pages</span>
-      <button class="bx--pagination__button bx--pagination__button--backward" data-page-backward aria-label="Backward button">
-        <svg class="bx--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
+      <button class="{{@root.prefix}}--pagination__button {{@root.prefix}}--pagination__button--backward" data-page-backward aria-label="Backward button">
+        <svg class="{{@root.prefix}}--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
           <path fill-rule="nonzero" d="M1.45 6.002L7 11.27l-.685.726L0 6.003 6.315 0 7 .726z" />
         </svg>
       </button>
-      <label for="page-number-input" class="bx--visually-hidden">Page number input</label>
-      <div class="bx--select bx--select--inline">
-        <label for="select-id-pagination" class="bx--visually-hidden">Number of items per page</label>
-        <select id="select-id-pagination" class="bx--select-input" data-page-number-input>
-          <option class="bx--select-option" value="1" selected>1</option>
-          <option class="bx--select-option" value="2">2</option>
-          <option class="bx--select-option" value="3">3</option>
-          <option class="bx--select-option" value="4">4</option>
-          <option class="bx--select-option" value="5">5</option>
+      <label for="page-number-input" class="{{@root.prefix}}--visually-hidden">Page number input</label>
+      <div class="{{@root.prefix}}--select {{@root.prefix}}--select--inline">
+        <label for="select-id-pagination" class="{{@root.prefix}}--visually-hidden">Number of items per page</label>
+        <select id="select-id-pagination" class="{{@root.prefix}}--select-input" data-page-number-input>
+          <option class="{{@root.prefix}}--select-option" value="1" selected>1</option>
+          <option class="{{@root.prefix}}--select-option" value="2">2</option>
+          <option class="{{@root.prefix}}--select-option" value="3">3</option>
+          <option class="{{@root.prefix}}--select-option" value="4">4</option>
+          <option class="{{@root.prefix}}--select-option" value="5">5</option>
         </select>
-        <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
       </div>
-      <button class="bx--pagination__button bx--pagination__button--forward" data-page-forward aria-label="Forward button">
-        <svg class="bx--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
+      <button class="{{@root.prefix}}--pagination__button {{@root.prefix}}--pagination__button--forward" data-page-forward aria-label="Forward button">
+        <svg class="{{@root.prefix}}--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
           <path fill-rule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
         </svg>
       </button>

--- a/src/components/data-table/data-table.config.js
+++ b/src/components/data-table/data-table.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const menuItems = [
   {
     label: 'Stop app',
@@ -29,7 +31,7 @@ const columns = [
     name: 'select',
     title: 'Label name',
     checkbox: true,
-    checkboxId: 'bx--checkbox-1',
+    checkboxId: `${prefix}--checkbox-1`,
     checkboxName: 'checkbox-1',
     checkboxValue: 'green',
   },
@@ -97,14 +99,14 @@ const rows = [
   },
   {
     sectionContent: `
-      <table class="bx--responsive-table bx--responsive-table--static-size">
+      <table class="${prefix}--responsive-table ${prefix}--responsive-table--static-size">
         <thead>
-          <tr class="bx--table-row">
-            <th class="bx--table-header">First Name</th>
-            <th class="bx--table-header">Last Name</th>
-            <th class="bx--table-header">House</th>
-            <th class="bx--table-header">Hello</th>
-            <th class="bx--table-header">Column</th>
+          <tr class="${prefix}--table-row">
+            <th class="${prefix}--table-header">First Name</th>
+            <th class="${prefix}--table-header">Last Name</th>
+            <th class="${prefix}--table-header">House</th>
+            <th class="${prefix}--table-header">Hello</th>
+            <th class="${prefix}--table-header">Column</th>
           </tr>
         </thead>
         <tbody>
@@ -250,6 +252,9 @@ const rows = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/data-table/data-table.hbs
+++ b/src/components/data-table/data-table.hbs
@@ -1,14 +1,14 @@
-<div class="bx--responsive-table-container" data-responsive-table>
-  <table class="bx--responsive-table{{#if simple}} bx--responsive-table--static-size{{/if}}" data-table>
-    <thead class="bx--table-head">
-      <tr class="bx--table-row">
+<div class="{{@root.prefix}}--responsive-table-container" data-responsive-table>
+  <table class="{{@root.prefix}}--responsive-table{{#if simple}} {{@root.prefix}}--responsive-table--static-size{{/if}}" data-table>
+    <thead class="{{@root.prefix}}--table-head">
+      <tr class="{{@root.prefix}}--table-row">
         {{#each columns}}
-          <th class="bx--table-header{{#if checkbox}} bx--table-select{{/if}}{{#if sortable}} bx--table-sort{{/if}}"{{#if sortable}} data-event="sort"{{/if}}>
+          <th class="{{@root.prefix}}--table-header{{#if checkbox}} {{@root.prefix}}--table-select{{/if}}{{#if sortable}} {{@root.prefix}}--table-sort{{/if}}"{{#if sortable}} data-event="sort"{{/if}}>
             {{#if checkbox}}
-              <input data-event="select-all" id="{{checkboxId}}" class="bx--checkbox" type="checkbox" value="{{checkboxValue}}" name="{{checkboxName}}">
-              <label for="{{checkboxId}}" class="bx--checkbox-label" aria-label="{{title}}">
-                <span class="bx--checkbox-appearance">
-                  <svg class="bx--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
+              <input data-event="select-all" id="{{checkboxId}}" class="{{@root.prefix}}--checkbox" type="checkbox" value="{{checkboxValue}}" name="{{checkboxName}}">
+              <label for="{{checkboxId}}" class="{{@root.prefix}}--checkbox-label" aria-label="{{title}}">
+                <span class="{{@root.prefix}}--checkbox-appearance">
+                  <svg class="{{@root.prefix}}--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
                     <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
                   </svg>
                 </span>
@@ -18,7 +18,7 @@
                 <span>{{title}}</span>
               {{/if}}
               {{#if sortable}}
-                <svg class="bx--table-sort__svg" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+                <svg class="{{@root.prefix}}--table-sort__svg" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
                   <path d="M10 0L5 5 0 0z"></path>
                 </svg>
               {{/if}}
@@ -27,40 +27,40 @@
         {{/each}}
       </tr>
     </thead>
-    <tbody class="bx--table-body">
+    <tbody class="{{@root.prefix}}--table-body">
       {{#each rows as |row|}}
-        <tr tabindex="0" class="bx--table-row bx--parent-row" data-parent-row>
+        <tr tabindex="0" class="{{@root.prefix}}--table-row {{@root.prefix}}--parent-row" data-parent-row>
           {{#each ../columns as |column|}}
             {{#with (lookup row column.name) as |data|}}
               {{#if column.section}}
-                <td tabindex="0" class="bx--table-expand" data-event="expand">
-                  <svg class="bx--table-expand__svg" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+                <td tabindex="0" class="{{@root.prefix}}--table-expand" data-event="expand">
+                  <svg class="{{@root.prefix}}--table-expand__svg" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
                     <path d="M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z"></path>
                   </svg>
                 </td>
               {{else if column.checkbox}}
-                <td class="bx--table-select">
-                  <input id="bx--checkbox-2" class="bx--checkbox" type="checkbox" value="green" name="{{data.id}}">
-                  <label for="bx--{{id}}" class="bx--checkbox-label" aria-label="{{data.label}}">
-                    <span class="bx--checkbox-appearance">
-                      <svg class="bx--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
+                <td class="{{@root.prefix}}--table-select">
+                  <input id="{{@root.prefix}}--checkbox-2" class="{{@root.prefix}}--checkbox" type="checkbox" value="green" name="{{data.id}}">
+                  <label for="{{@root.prefix}}--{{id}}" class="{{@root.prefix}}--checkbox-label" aria-label="{{data.label}}">
+                    <span class="{{@root.prefix}}--checkbox-appearance">
+                      <svg class="{{@root.prefix}}--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
                         <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
                       </svg>
                     </span>
                   </label>
                 </td>
               {{else if column.menu}}
-                <td class="bx--table-overflow">
-                  <div data-overflow-menu tabindex="0" aria-label="{{data.label}}" class="bx--overflow-menu">
-                    <svg class="bx--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
+                <td class="{{@root.prefix}}--table-overflow">
+                  <div data-overflow-menu tabindex="0" aria-label="{{data.label}}" class="{{@root.prefix}}--overflow-menu">
+                    <svg class="{{@root.prefix}}--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
                       <circle cx="2" cy="2" r="2"></circle>
                       <circle cx="2" cy="10" r="2"></circle>
                       <circle cx="2" cy="18" r="2"></circle>
                     </svg>
-                    <ul class="bx--overflow-menu-options{{#if data.flip}} bx--overflow-menu--flip{{/if}}" tabindex="-1">
+                    <ul class="{{@root.prefix}}--overflow-menu-options{{#if data.flip}} {{@root.prefix}}--overflow-menu--flip{{/if}}" tabindex="-1">
                       {{#each data.items}}
-                        <li class="bx--overflow-menu-options__option{{#if danger}} bx--overflow-menu-options__option--danger{{/if}}">
-                          <button class="bx--overflow-menu-options__btn"{{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}>{{label}}</button>
+                        <li class="{{@root.prefix}}--overflow-menu-options__option{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}">
+                          <button class="{{@root.prefix}}--overflow-menu-options__btn"{{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}>{{label}}</button>
                         </li>
                       {{/each}}
                     </ul>
@@ -73,7 +73,7 @@
           {{/each}}
         </tr>
         {{#if row.sectionContent}}
-          <tr class="bx--table-row bx--expandable-row bx--expandable-row--hidden">
+          <tr class="{{@root.prefix}}--table-row {{@root.prefix}}--expandable-row {{@root.prefix}}--expandable-row--hidden">
             <td colspan="{{../columns.length}}">
               {{{row.sectionContent}}}
             </td>

--- a/src/components/date-picker/date-picker--light.hbs
+++ b/src/components/date-picker/date-picker--light.hbs
@@ -1,22 +1,22 @@
 <!-- Basic without calendar (mm/yy only) -->
-<div class="bx--form-item">
-  <div class="bx--date-picker bx--date-picker--simple bx--date-picker--short bx--date-picker--light">
-    <div class="bx--date-picker-container">
-      <label for="date-picker-4" class="bx--label">Date Picker label</label>
-      <input type="text" id="date-picker-4" class="bx--date-picker__input" pattern="\d{1,2}/\d{4}" placeholder="mm/yyyy" data-date-picker-input
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--simple {{@root.prefix}}--date-picker--short {{@root.prefix}}--date-picker--light">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-4" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input type="text" id="date-picker-4" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{4}" placeholder="mm/yyyy" data-date-picker-input
       />
     </div>
   </div>
 </div>
 
 <!-- Basic without calendar -->
-<div class="bx--form-item">
-  <div class="bx--date-picker bx--date-picker--simple bx--date-picker--light">
-    <div class="bx--date-picker-container">
-      <label for="date-picker-6" class="bx--label">Date Picker label</label>
-      <input data-invalid type="text" id="date-picker-6" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--simple {{@root.prefix}}--date-picker--light">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-6" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input data-invalid type="text" id="date-picker-6" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid date format.
       </div>
     </div>

--- a/src/components/date-picker/date-picker--range-light.hbs
+++ b/src/components/date-picker/date-picker--range-light.hbs
@@ -1,17 +1,17 @@
 <!-- Ranged -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="range" class="bx--date-picker bx--date-picker--range bx--date-picker--light">
-    <div class="bx--date-picker-container">
-      <label for="date-picker-1" class="bx--label">Start date label</label>
-      <input type="text" id="date-picker-1" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="range" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--range {{@root.prefix}}--date-picker--light">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-1" class="{{@root.prefix}}--label">Start date label</label>
+      <input type="text" id="date-picker-1" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input-from />
     </div>
-    <div class="bx--date-picker-container">
-      <label for="date-picker-2" class="bx--label">End date label</label>
-      <input type="text" id="date-picker-2" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-2" class="{{@root.prefix}}--label">End date label</label>
+      <input type="text" id="date-picker-2" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input-to />
     </div>
-    <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+    <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
       <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
         fill-rule="nonzero" />
     </svg>

--- a/src/components/date-picker/date-picker--range.hbs
+++ b/src/components/date-picker/date-picker--range.hbs
@@ -1,17 +1,17 @@
 <!-- Ranged -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="range" class="bx--date-picker bx--date-picker--range">
-    <div class="bx--date-picker-container">
-      <label for="date-picker-1" class="bx--label">Start date label</label>
-      <input type="text" id="date-picker-1" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="range" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--range">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-1" class="{{@root.prefix}}--label">Start date label</label>
+      <input type="text" id="date-picker-1" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input-from />
     </div>
-    <div class="bx--date-picker-container">
-      <label for="date-picker-2" class="bx--label">End date label</label>
-      <input type="text" id="date-picker-2" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-2" class="{{@root.prefix}}--label">End date label</label>
+      <input type="text" id="date-picker-2" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input-to />
     </div>
-    <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+    <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
       <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
         fill-rule="nonzero" />
     </svg>

--- a/src/components/date-picker/date-picker--single-light-no-label.hbs
+++ b/src/components/date-picker/date-picker--single-light-no-label.hbs
@@ -1,28 +1,28 @@
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single bx--date-picker--light bx--date-picker--nolabel">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single {{@root.prefix}}--date-picker--light {{@root.prefix}}--date-picker--nolabel">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <input type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <input type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
     </div>
   </div>
 </div>
 
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single bx--date-picker--light bx--date-picker--nolabel">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single {{@root.prefix}}--date-picker--light {{@root.prefix}}--date-picker--nolabel">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <input data-invalid type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <input data-invalid type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid date format.
       </div>
     </div>

--- a/src/components/date-picker/date-picker--single-light.hbs
+++ b/src/components/date-picker/date-picker--single-light.hbs
@@ -1,30 +1,30 @@
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single bx--date-picker--light">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single {{@root.prefix}}--date-picker--light">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <label for="date-picker-3" class="bx--label">Date Picker label</label>
-      <input type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <label for="date-picker-3" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
     </div>
   </div>
 </div>
 
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single bx--date-picker--light">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single {{@root.prefix}}--date-picker--light">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <label for="date-picker-3" class="bx--label">Date Picker label</label>
-      <input data-invalid type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <label for="date-picker-3" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input data-invalid type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid date format.
       </div>
     </div>

--- a/src/components/date-picker/date-picker--single-no-label.hbs
+++ b/src/components/date-picker/date-picker--single-no-label.hbs
@@ -1,28 +1,28 @@
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single bx--date-picker--nolabel">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single {{@root.prefix}}--date-picker--nolabel">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <input type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <input type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
     </div>
   </div>
 </div>
 
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single bx--date-picker--nolabel">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single {{@root.prefix}}--date-picker--nolabel">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <input data-invalid type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <input data-invalid type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid date format.
       </div>
     </div>

--- a/src/components/date-picker/date-picker--single.hbs
+++ b/src/components/date-picker/date-picker--single.hbs
@@ -1,30 +1,30 @@
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <label for="date-picker-3" class="bx--label">Date Picker label</label>
-      <input type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <label for="date-picker-3" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
     </div>
   </div>
 </div>
 
 <!-- Basic with calendar -->
-<div class="bx--form-item">
-  <div data-date-picker data-date-picker-type="single" class="bx--date-picker bx--date-picker--single">
-    <div class="bx--date-picker-container">
-      <svg data-date-picker-icon class="bx--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
+<div class="{{@root.prefix}}--form-item">
+  <div data-date-picker data-date-picker-type="single" class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--single">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <svg data-date-picker-icon class="{{@root.prefix}}--date-picker__icon" width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <label for="date-picker-3" class="bx--label">Date Picker label</label>
-      <input data-invalid type="text" id="date-picker-3" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+      <label for="date-picker-3" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input data-invalid type="text" id="date-picker-3" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid date format.
       </div>
     </div>

--- a/src/components/date-picker/date-picker.config.js
+++ b/src/components/date-picker/date-picker.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/date-picker/date-picker.hbs
+++ b/src/components/date-picker/date-picker.hbs
@@ -1,22 +1,22 @@
 <!-- Basic without calendar (mm/yy only) -->
-<div class="bx--form-item">
-  <div class="bx--date-picker bx--date-picker--simple bx--date-picker--short">
-    <div class="bx--date-picker-container">
-      <label for="date-picker-4" class="bx--label">Date Picker label</label>
-      <input type="text" id="date-picker-4" class="bx--date-picker__input" pattern="\d{1,2}/\d{4}" placeholder="mm/yyyy" data-date-picker-input
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--simple {{@root.prefix}}--date-picker--short">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-4" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input type="text" id="date-picker-4" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{4}" placeholder="mm/yyyy" data-date-picker-input
       />
     </div>
   </div>
 </div>
 
 <!-- Basic without calendar -->
-<div class="bx--form-item">
-  <div class="bx--date-picker bx--date-picker--simple">
-    <div class="bx--date-picker-container">
-      <label for="date-picker-6" class="bx--label">Date Picker label</label>
-      <input data-invalid type="text" id="date-picker-6" class="bx--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--date-picker {{@root.prefix}}--date-picker--simple">
+    <div class="{{@root.prefix}}--date-picker-container">
+      <label for="date-picker-6" class="{{@root.prefix}}--label">Date Picker label</label>
+      <input data-invalid type="text" id="date-picker-6" class="{{@root.prefix}}--date-picker__input" pattern="\d{1,2}/\d{1,2}/\d{4}" placeholder="mm/dd/yyyy"
         data-date-picker-input />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid date format.
       </div>
     </div>

--- a/src/components/dropdown/dropdown.config.js
+++ b/src/components/dropdown/dropdown.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     label: 'Option 1',
@@ -24,6 +26,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/dropdown/dropdown.hbs
+++ b/src/components/dropdown/dropdown.hbs
@@ -1,23 +1,23 @@
-<ul data-dropdown{{#if inline}} data-dropdown-type="inline" {{/if}} data-value class="bx--dropdown{{#if up}} bx--dropdown--up{{/if}}{{#if light}} bx--dropdown--light{{/if}}{{#if inline}} bx--dropdown--inline{{/if}}"
+<ul data-dropdown{{#if inline}} data-dropdown-type="inline" {{/if}} data-value class="{{@root.prefix}}--dropdown{{#if up}} {{@root.prefix}}--dropdown--up{{/if}}{{#if light}} {{@root.prefix}}--dropdown--light{{/if}}{{#if inline}} {{@root.prefix}}--dropdown--inline{{/if}}"
   tabindex="0">
-  <li class="bx--dropdown-text">
+  <li class="{{@root.prefix}}--dropdown-text">
     {{#unless inline}} Dropdown label {{else}}
-    <span class="bx--dropdown-text__inner">Inline Dropdown label</span>
-    <svg class="bx--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+    <span class="{{@root.prefix}}--dropdown-text__inner">Inline Dropdown label</span>
+    <svg class="{{@root.prefix}}--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
       <path d="M10 0L5 5 0 0z"></path>
     </svg>
     {{/unless}}
   </li>
   {{#unless inline}}
-  <svg class="bx--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+  <svg class="{{@root.prefix}}--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
     <path d="M10 0L5 5 0 0z"></path>
   </svg>
   {{/unless}}
   <li>
-    <ul class="bx--dropdown-list">
+    <ul class="{{@root.prefix}}--dropdown-list">
       {{#each items}}
-        <li data-option data-value="{{value}}" class="bx--dropdown-item">
-          <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">{{label}}</a>
+        <li data-option data-value="{{value}}" class="{{@root.prefix}}--dropdown-item">
+          <a class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="-1">{{label}}</a>
         </li>
       {{/each}}
     </ul>

--- a/src/components/fab/fab.hbs
+++ b/src/components/fab/fab.hbs
@@ -1,7 +1,7 @@
-<a href="#" data-fab data-state="open" class="bx--fab" role="button" alt="Show Content">
-  <svg class="bx--fab__svg" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <polygon class="bx--fab__hexagon" fill-rule="evenodd" points="36 0 67.1769145 18 67.1769145 54 36 72 4.82308546 54 4.82308546 18 "></polygon>
-    <path class="bx--fab__plus-icon" stroke-width="1" d="M35.08,34.992 L26.98,34.992 L26.98,36.9 L35.08,36.9 L35.08,45 L36.988,45 L36.988,36.9 L45.088,36.9 L45.088,34.992 L36.988,34.992 L36.988,26.892 L35.08,26.892 L35.08,34.992 Z"></path>
+<a href="#" data-fab data-state="open" class="{{@root.prefix}}--fab" role="button" alt="Show Content">
+  <svg class="{{@root.prefix}}--fab__svg" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <polygon class="{{@root.prefix}}--fab__hexagon" fill-rule="evenodd" points="36 0 67.1769145 18 67.1769145 54 36 72 4.82308546 54 4.82308546 18 "></polygon>
+    <path class="{{@root.prefix}}--fab__plus-icon" stroke-width="1" d="M35.08,34.992 L26.98,34.992 L26.98,36.9 L35.08,36.9 L35.08,45 L36.988,45 L36.988,36.9 L45.088,36.9 L45.088,34.992 L36.988,34.992 L36.988,26.892 L35.08,26.892 L35.08,34.992 Z"></path>
   </svg>
-  <span class="bx--fab__hidden">show content</span>
+  <span class="{{@root.prefix}}--fab__hidden">show content</span>
 </a>

--- a/src/components/file-uploader/file-uploader.config.js
+++ b/src/components/file-uploader/file-uploader.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/file-uploader/file-uploader.hbs
+++ b/src/components/file-uploader/file-uploader.hbs
@@ -1,20 +1,20 @@
-<div class="bx--form-item">
-  <strong class="bx--label">Account photo</strong>
-  <p class="bx--label-description">only .jpg and .png files. 500kb max file size.</p>
-  <div class="bx--file" data-file>
+<div class="{{@root.prefix}}--form-item">
+  <strong class="{{@root.prefix}}--label">Account photo</strong>
+  <p class="{{@root.prefix}}--label-description">only .jpg and .png files. 500kb max file size.</p>
+  <div class="{{@root.prefix}}--file" data-file>
     <label
       for="your-file-importer-id-here"
-      class="bx--file-btn bx--btn bx--btn--secondary"
+      class="{{@root.prefix}}--file-btn {{@root.prefix}}--btn {{@root.prefix}}--btn--secondary"
       role="button"
       tabindex="0">Add files</label>
     <input
       type="file"
-      class="bx--file-input"
+      class="{{@root.prefix}}--file-input"
       id="your-file-importer-id-here"
       data-file-uploader
       data-target="[data-file-container]"
       multiple
     />
-    <div data-file-container class="bx--file-container"></div>
+    <div data-file-container class="{{@root.prefix}}--file-container"></div>
   </div>
 </div>

--- a/src/components/footer/footer.config.js
+++ b/src/components/footer/footer.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     title: 'Need Help?',
@@ -14,6 +16,9 @@ const items = [
 module.exports = {
   meta: {
     useIframe: true,
+  },
+  context: {
+    prefix,
   },
   variants: [
     {

--- a/src/components/footer/footer.hbs
+++ b/src/components/footer/footer.hbs
@@ -1,13 +1,13 @@
-<footer class="bx--footer bx--footer--bottom-fixed" role="contentinfo">
-  <div class="bx--footer-info">
+<footer class="{{@root.prefix}}--footer {{@root.prefix}}--footer--bottom-fixed" role="contentinfo">
+  <div class="{{@root.prefix}}--footer-info">
     {{#each items}}
-      <div class="bx--footer-info__item">
-        <p class="bx--footer-label">{{title}}</p>
-        <a class="bx--link" href="#">{{label}}Contact Bluemix Sales</a>
+      <div class="{{@root.prefix}}--footer-info__item">
+        <p class="{{@root.prefix}}--footer-label">{{title}}</p>
+        <a class="{{@root.prefix}}--link" href="#">{{label}}Contact Bluemix Sales</a>
       </div>
     {{/each}}
   </div>
-  <div class="bx--footer-cta">
-    <button class="bx--btn bx--btn--primary" type="submit">Create</button>
+  <div class="{{@root.prefix}}--footer-cta">
+    <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary" type="submit">Create</button>
   </div>
 </footer>

--- a/src/components/form/form.config.js
+++ b/src/components/form/form.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const selectItems = [
   {
     label: 'Choose an option',
@@ -40,6 +42,9 @@ const selectItems = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/form/form.hbs
+++ b/src/components/form/form.hbs
@@ -1,32 +1,32 @@
-<div class="bx--form-item">
-  <input id="text-input-3" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Optional placeholder text">
-  <label for="text-input-3" class="bx--label">Text Input label</label>
+<div class="{{@root.prefix}}--form-item">
+  <input id="text-input-3" type="text" class="{{@root.prefix}}--text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}" placeholder="Optional placeholder text">
+  <label for="text-input-3" class="{{@root.prefix}}--label">Text Input label</label>
 </div>
-<div class="bx--form-item">
-  <textarea id="text-area-2" class="bx--text-area{{#if light}} bx--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
-  <label for="text-area-2" class="bx--label">Text Area label</label>
+<div class="{{@root.prefix}}--form-item">
+  <textarea id="text-area-2" class="{{@root.prefix}}--text-area{{#if light}} {{@root.prefix}}--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
+  <label for="text-area-2" class="{{@root.prefix}}--label">Text Area label</label>
 </div>
-<div class="bx--form-item">
-  <div class="bx--select{{#if light}} bx--select--light{{/if}}">
-    <select id="select-id" class="bx--select-input">
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}">
+    <select id="select-id" class="{{@root.prefix}}--select-input">
       {{#each selectItems}}
         {{#if items}}
-          <optgroup class="bx--select-optgroup" label="{{label}}">
+          <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
             {{#each items}}
-              <option class="bx--select-option" value="{{value}}"{{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}</option>
+              <option class="{{@root.prefix}}--select-option" value="{{value}}"{{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}</option>
             {{/each}}
           </optgroup>
         {{else}}
-          <option class="bx--select-option" value="{{value}}"{{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}</option>
+          <option class="{{@root.prefix}}--select-option" value="{{value}}"{{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}</option>
         {{/if}}
       {{/each}}
     </select>
-    <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+    <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>
-    <label for="select-id" class="bx--label">Select label</label>
+    <label for="select-id" class="{{@root.prefix}}--label">Select label</label>
   </div>
 </div>
-<div class="bx--form-item">
-  <button class="bx--btn bx--btn--primary" type="button">Submit</button>
+<div class="{{@root.prefix}}--form-item">
+  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary" type="button">Submit</button>
 </div>

--- a/src/components/grid/grid.config.js
+++ b/src/components/grid/grid.config.js
@@ -1,8 +1,13 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
   meta: {
     useIframe: true,
+  },
+  context: {
+    prefix,
   },
   variants: [
     {

--- a/src/components/grid/grid.hbs
+++ b/src/components/grid/grid.hbs
@@ -1,14 +1,14 @@
-<div class="bx--grid">
-  <div class="bx--row">
-    <div class="bx--col-xs-12 bx--col-sm-6 indigo">
-      <div class="bx--row">
-        <div class="bx--col-xs-12 bx--col-sm-6">
+<div class="{{@root.prefix}}--grid">
+  <div class="{{@root.prefix}}--row">
+    <div class="{{@root.prefix}}--col-xs-12 {{@root.prefix}}--col-sm-6 indigo">
+      <div class="{{@root.prefix}}--row">
+        <div class="{{@root.prefix}}--col-xs-12 {{@root.prefix}}--col-sm-6">
           <div class="col-example">
-            <p>Content space for bx--col-xs-12 bx--col-sm-6</p>
+            <p>Content space for {{@root.prefix}}--col-xs-12 {{@root.prefix}}--col-sm-6</p>
           </div>
         </div>
-        <div class="bx--col-xs-12 bx--col-sm-6 green">
-          <p>Full space for bx--col-xs-12 bx--col-sm-6 (columns naturally have padding on them, adding a background color to
+        <div class="{{@root.prefix}}--col-xs-12 {{@root.prefix}}--col-sm-6 green">
+          <p>Full space for {{@root.prefix}}--col-xs-12 {{@root.prefix}}--col-sm-6 (columns naturally have padding on them, adding a background color to
             the column directly will effect the entire column, as opposed to using a child element in the example to the
             left). </p>
         </div>
@@ -16,11 +16,11 @@
 
       <p>Columns also expand to match the vertical size of the rest of the row (see red column)</p>
     </div>
-    <div class="bx--col-xs-12 bx--col-sm-6 red">
+    <div class="{{@root.prefix}}--col-xs-12 {{@root.prefix}}--col-sm-6 red">
       <p>Background color over entire column, not just content space</p>
     </div>
-    <div class="bx--row">
-      <div class="bx--offset-xs-2 bx--col-xs-10">This content is offset. Offset adds a left-margin for x columns.</div>
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--offset-xs-2 {{@root.prefix}}--col-xs-10">This content is offset. Offset adds a left-margin for x columns.</div>
     </div>
   </div>
 </div>

--- a/src/components/inline-loading/inline-loading.config.js
+++ b/src/components/inline-loading/inline-loading.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/inline-loading/inline-loading.hbs
+++ b/src/components/inline-loading/inline-loading.hbs
@@ -1,18 +1,18 @@
 <!-- Loading Success State -->
-<div data-inline-loading class="bx--inline-loading">
-  <div class="bx--inline-loading__animation">
-    <div data-inline-loading-spinner class="bx--loading bx--loading--small">
-      <svg class="bx--loading__svg" viewBox="-75 -75 150 150">
+<div data-inline-loading class="{{@root.prefix}}--inline-loading">
+  <div class="{{@root.prefix}}--inline-loading__animation">
+    <div data-inline-loading-spinner class="{{@root.prefix}}--loading {{@root.prefix}}--loading--small">
+      <svg class="{{@root.prefix}}--loading__svg" viewBox="-75 -75 150 150">
         <circle cx="0" cy="0" r="37.5"></circle>
       </svg>
     </div>
-    <svg data-inline-loading-finished hidden class="bx--inline-loading__checkmark-container bx--inline-loading__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
-      <polyline class="bx--inline-loading__checkmark" points="0.74 3.4 3.67 6.34 9.24 0.74"></polyline>
+    <svg data-inline-loading-finished hidden class="{{@root.prefix}}--inline-loading__checkmark-container {{@root.prefix}}--inline-loading__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+      <polyline class="{{@root.prefix}}--inline-loading__checkmark" points="0.74 3.4 3.67 6.34 9.24 0.74"></polyline>
     </svg>
   </div>
-  <p data-inline-loading-text-active class="bx--inline-loading__text">Loading data...</p>
-  <p data-inline-loading-text-finished hidden class="bx--inline-loading__text">Data loaded.</p>
+  <p data-inline-loading-text-active class="{{@root.prefix}}--inline-loading__text">Loading data...</p>
+  <p data-inline-loading-text-finished hidden class="{{@root.prefix}}--inline-loading__text">Data loaded.</p>
 </div>
 {{#if showToggleButton}}
-  <button data-inline-loading-demo-button class="bx--btn bx--btn--primary">Toggle state</button>
+  <button data-inline-loading-demo-button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary">Toggle state</button>
 {{/if}}

--- a/src/components/lightbox/lightbox.config.js
+++ b/src/components/lightbox/lightbox.config.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
   hidden: true,
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/lightbox/lightbox.hbs
+++ b/src/components/lightbox/lightbox.hbs
@@ -1,34 +1,34 @@
-<button class="bx--btn bx--btn--primary" type="button" data-modal-target="#lightbox" data-carousel-item-index="0">Open Lightbox</button>
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary" type="button" data-modal-target="#lightbox" data-carousel-item-index="0">Open Lightbox</button>
 
-<div id="lightbox" class="bx--modal" data-modal>
-  <div class="bx--lightbox" data-lightbox data-lightbox-index="0">
-    <div class="bx--lightbox__main">
-      <button class="bx--lightbox__btn" data-scroll-left>
-        <svg class="bx--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+<div id="lightbox" class="{{@root.prefix}}--modal" data-modal>
+  <div class="{{@root.prefix}}--lightbox" data-lightbox data-lightbox-index="0">
+    <div class="{{@root.prefix}}--lightbox__main">
+      <button class="{{@root.prefix}}--lightbox__btn" data-scroll-left>
+        <svg class="{{@root.prefix}}--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
           <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
         </svg>
       </button>
       {{#each items}}
-        <img src="{{lightboxImageUrl}}" class="bx--lightbox__item">
+        <img src="{{lightboxImageUrl}}" class="{{@root.prefix}}--lightbox__item">
       {{/each}}
-      <button class="bx--lightbox__btn" data-scroll-right>
-        <svg class="bx--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
+      <button class="{{@root.prefix}}--lightbox__btn" data-scroll-right>
+        <svg class="{{@root.prefix}}--pagination__button-icon" width="8" height="12" viewBox="0 0 8 12" fill-rule="evenodd">
           <path d="M7.5 10.6L2.8 6l4.7-4.6L6.1 0 0 6l6.1 6z"></path>
         </svg>
       </button>
     </div>
-    <div class="bx--lightbox__footer">
-      <div class="bx--filmstrip">
+    <div class="{{@root.prefix}}--lightbox__footer">
+      <div class="{{@root.prefix}}--filmstrip">
         {{#each items}}
-          <button class="bx--carousel__item" data-carousel-item-index="{{@index}}">
+          <button class="{{@root.prefix}}--carousel__item" data-carousel-item-index="{{@index}}">
             <img src="{{filmstripImageUrl}}">
           </button>
         {{/each}}
       </div>
-      <div class="bx--filmstrip-indicator-ctn">
-        <div class="bx--filmstrip-indicator bx--filmstrip-indicator--active"></div>
-        <div class="bx--filmstrip-indicator"></div>
-        <div class="bx--filmstrip-indicator"></div>
+      <div class="{{@root.prefix}}--filmstrip-indicator-ctn">
+        <div class="{{@root.prefix}}--filmstrip-indicator {{@root.prefix}}--filmstrip-indicator--active"></div>
+        <div class="{{@root.prefix}}--filmstrip-indicator"></div>
+        <div class="{{@root.prefix}}--filmstrip-indicator"></div>
       </div>
     </div>
   </div>

--- a/src/components/link/link.config.js
+++ b/src/components/link/link.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -1,2 +1,2 @@
-<a href="#" class="bx--link">Link</a>
-<a href="#" class="bx--link" tabindex="-1" aria-disabled="true">Link</a>
+<a href="#" class="{{@root.prefix}}--link">Link</a>
+<a href="#" class="{{@root.prefix}}--link" tabindex="-1" aria-disabled="true">Link</a>

--- a/src/components/list-box/list-box.config.js
+++ b/src/components/list-box/list-box.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     id: 'downshift-1-item-0',
@@ -21,6 +23,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/list-box/list-box.hbs
+++ b/src/components/list-box/list-box.hbs
@@ -1,7 +1,7 @@
-<div class="bx--form-item bx--list-box{{#if inline}} bx--list-box--inline{{/if}}{{#if light}} bx--list-box--light{{/if}}">
-  <div role="button" class="bx--list-box__field" tabindex="0" aria-label="open menu" aria-expanded="false" aria-haspopup="true">
-    <span class="bx--list-box__label">Label</span>
-    <div class="bx--list-box__menu-icon">
+<div class="{{@root.prefix}}--form-item {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu" aria-expanded="false" aria-haspopup="true">
+    <span class="{{@root.prefix}}--list-box__label">Label</span>
+    <div class="{{@root.prefix}}--list-box__menu-icon">
       <svg fill-rule="evenodd" height="5" name="caret--down" role="img" viewBox="0 0 10 5" width="10" aria-label="Open menu">
         <title>Open menu</title>
         <path d="M10 0L5 5 0 0z"></path>
@@ -9,19 +9,19 @@
     </div>
   </div>
 </div>
-<div class="bx--form-item bx--list-box{{#if inline}} bx--list-box--inline{{/if}}{{#if light}} bx--list-box--light{{/if}}">
-  <div role="button" class="bx--list-box__field" tabindex="0" aria-label="close menu" aria-expanded="true" aria-haspopup="true">
-    <span class="bx--list-box__label">Label</span>
-    <div class="bx--list-box__menu-icon bx--list-box__menu-icon--open">
+<div class="{{@root.prefix}}--form-item {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="close menu" aria-expanded="true" aria-haspopup="true">
+    <span class="{{@root.prefix}}--list-box__label">Label</span>
+    <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
       <svg fill-rule="evenodd" height="5" name="caret--down" role="img" viewBox="0 0 10 5" width="10" aria-label="Close menu">
         <title>Close menu</title>
         <path d="M10 0L5 5 0 0z"></path>
       </svg>
     </div>
   </div>
-  <div class="bx--list-box__menu">
+  <div class="{{@root.prefix}}--list-box__menu">
     {{#each items}}
-      <div class="bx--list-box__menu-item{{#if selected}} bx--list-box__menu-item--highlighted{{/if}}" id="{{id}}">{{label}}</div>
+      <div class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}" id="{{id}}">{{label}}</div>
     {{/each}}
   </div>
 </div>

--- a/src/components/list/list.config.js
+++ b/src/components/list/list.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/list/list.hbs
+++ b/src/components/list/list.hbs
@@ -1,10 +1,10 @@
-<{{tag}} class="bx--list--{{type}}">
-  <li class="bx--list__item">{{displayType}} List level 1
-    <{{tag}} class="bx--list--nested">
-      <li class="bx--list__item">{{displayType}} List level 2</li>
-      <li class="bx--list__item">{{displayType}} List level 2</li>
+<{{tag}} class="{{@root.prefix}}--list--{{type}}">
+  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1
+    <{{tag}} class="{{@root.prefix}}--list--nested">
+      <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
+      <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
     </{{tag}}>
   </li>
-  <li class="bx--list__item">{{displayType}} List level 1</li>
-  <li class="bx--list__item">{{displayType}} List level 1</li>
+  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1</li>
+  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1</li>
 </{{tag}}>

--- a/src/components/loading/loading.config.js
+++ b/src/components/loading/loading.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/loading/loading.hbs
+++ b/src/components/loading/loading.hbs
@@ -1,6 +1,6 @@
-{{#if overlay}}<div class="bx--loading-overlay">{{/if}}
-<div data-loading class="bx--loading{{#if small}} bx--loading--small{{/if}}">
-  <svg class="bx--loading__svg" viewBox="-75 -75 150 150">
+{{#if overlay}}<div class="{{@root.prefix}}--loading-overlay">{{/if}}
+<div data-loading class="{{@root.prefix}}--loading{{#if small}} {{@root.prefix}}--loading--small{{/if}}">
+  <svg class="{{@root.prefix}}--loading__svg" viewBox="-75 -75 150 150">
     <title>Loading</title>
     <circle cx="0" cy="0" r="37.5" />
   </svg>

--- a/src/components/modal/modal.config.js
+++ b/src/components/modal/modal.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',
@@ -13,8 +18,8 @@ module.exports = {
           .toString(36)
           .substr(2),
         hasFooter: true,
-        classPrimaryButton: 'bx--btn--primary',
-        classCloseButton: 'bx--btn--secondary',
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
       },
     },
     {
@@ -26,8 +31,8 @@ module.exports = {
           .toString(36)
           .substr(2),
         hasFooter: false,
-        classPrimaryButton: 'bx--btn--primary',
-        classCloseButton: 'bx--btn--secondary',
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
       },
     },
     {
@@ -39,9 +44,9 @@ module.exports = {
           .substr(2),
         hasFooter: true,
         labelPrimaryButton: 'Danger',
-        classModalSupplemental: 'bx--modal--danger',
-        classPrimaryButton: 'bx--btn--danger--primary',
-        classCloseButton: 'bx--btn--tertiary',
+        classModalSupplemental: `${prefix}--modal--danger`,
+        classPrimaryButton: `${prefix}--btn--danger--primary`,
+        classCloseButton: `${prefix}--btn--tertiary`,
       },
     },
     {
@@ -53,8 +58,8 @@ module.exports = {
           .substr(2),
         hasInput: true,
         hasFooter: true,
-        classPrimaryButton: 'bx--btn--primary',
-        classCloseButton: 'bx--btn--secondary',
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
       },
     },
   ],

--- a/src/components/modal/modal.hbs
+++ b/src/components/modal/modal.hbs
@@ -1,12 +1,12 @@
-<button class="bx--btn {{classPrimaryButton}}" type="button" data-modal-target="#modal-{{idSuffix}}">Show modal</button>
+<button class="{{@root.prefix}}--btn {{classPrimaryButton}}" type="button" data-modal-target="#modal-{{idSuffix}}">Show modal</button>
 
-<div data-modal id="modal-{{idSuffix}}" class="bx--modal {{classModalSupplemental}}" role="dialog" aria-modal="true" aria-labelledby="modal-{{idSuffix}}-label" aria-describedby="modal-{{idSuffix}}-heading" tabindex="-1">
-  <div class="bx--modal-container">
-    <div class="bx--modal-header">
-      <p class="bx--modal-header__label bx--type-delta" id="modal-{{idSuffix}}-label">Optional label</p>
-      <p class="bx--modal-header__heading bx--type-beta" id="modal-{{idSuffix}}-heading">Modal heading</p>
-      <button class="bx--modal-close" type="button" data-modal-close aria-label="close modal" {{#unless hasFooter}} data-modal-primary-focus{{/unless}}>
-        <svg class="bx--modal-close__icon" width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+<div data-modal id="modal-{{idSuffix}}" class="{{@root.prefix}}--modal {{classModalSupplemental}}" role="dialog" aria-modal="true" aria-labelledby="modal-{{idSuffix}}-label" aria-describedby="modal-{{idSuffix}}-heading" tabindex="-1">
+  <div class="{{@root.prefix}}--modal-container">
+    <div class="{{@root.prefix}}--modal-header">
+      <p class="{{@root.prefix}}--modal-header__label {{@root.prefix}}--type-delta" id="modal-{{idSuffix}}-label">Optional label</p>
+      <p class="{{@root.prefix}}--modal-header__heading {{@root.prefix}}--type-beta" id="modal-{{idSuffix}}-heading">Modal heading</p>
+      <button class="{{@root.prefix}}--modal-close" type="button" data-modal-close aria-label="close modal" {{#unless hasFooter}} data-modal-primary-focus{{/unless}}>
+        <svg class="{{@root.prefix}}--modal-close__icon" width="10" height="10" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
           <title>Close Modal</title>
           <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z" fill-rule="nonzero"
           />
@@ -14,11 +14,11 @@
       </button>
     </div>
 
-    <div class="bx--modal-content">
+    <div class="{{@root.prefix}}--modal-content">
       {{#if hasInput}}
-        <div class="bx--form-item">
-          <label for="text-input-{{idSuffix}}" class="bx--label">Text Input label</label>
-          <input id="text-input-{{idSuffix}}" type="text" class="bx--text-input" placeholder="Optional placeholder text" data-modal-primary-focus>
+        <div class="{{@root.prefix}}--form-item">
+          <label for="text-input-{{idSuffix}}" class="{{@root.prefix}}--label">Text Input label</label>
+          <input id="text-input-{{idSuffix}}" type="text" class="{{@root.prefix}}--text-input" placeholder="Optional placeholder text" data-modal-primary-focus>
         </div>
       {{else}}
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean id accumsan augue. Phasellus consequat augue vitae
@@ -28,9 +28,9 @@
     </div>
 
     {{#if hasFooter}}
-    <div class="bx--modal-footer">
-      <button class="bx--btn {{classCloseButton}}" type="button" data-modal-close>Secondary button</button>
-      <button class="bx--btn {{classPrimaryButton}}" type="button" {{#if labelPrimaryButton}}aria-label="{{labelPrimaryButton}}"
+    <div class="{{@root.prefix}}--modal-footer">
+      <button class="{{@root.prefix}}--btn {{classCloseButton}}" type="button" data-modal-close>Secondary button</button>
+      <button class="{{@root.prefix}}--btn {{classPrimaryButton}}" type="button" {{#if labelPrimaryButton}}aria-label="{{labelPrimaryButton}}"
         {{/if}}{{#unless hasInput}} data-modal-primary-focus{{/unless}}>Primary button</button>
     </div>
     {{/if}}

--- a/src/components/multi-select/multi-select.config.js
+++ b/src/components/multi-select/multi-select.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     id: 'downshift-1-item-0',
@@ -21,6 +23,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/multi-select/multi-select.hbs
+++ b/src/components/multi-select/multi-select.hbs
@@ -1,8 +1,8 @@
-<div class="bx--form-item bx--multi-select bx--list-box{{#if inline}} bx--list-box--inline{{/if}}">
-  <div role="button" class="bx--list-box__field" tabindex="0" aria-label="open menu" aria-expanded="false"
+<div class="{{@root.prefix}}--form-item {{@root.prefix}}--multi-select {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu" aria-expanded="false"
     aria-haspopup="true">
-    <span class="bx--list-box__label">Label</span>
-    <div class="bx--list-box__menu-icon">
+    <span class="{{@root.prefix}}--list-box__label">Label</span>
+    <div class="{{@root.prefix}}--list-box__menu-icon">
       <svg width="10" height="5" name="caret--down" role="img" viewBox="0 0 10 5" aria-label="Open menu">
         <title>Open menu</title>
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -10,25 +10,25 @@
     </div>
   </div>
 </div>
-<div class="bx--form-item bx--multi-select bx--list-box{{#if inline}} bx--list-box--inline{{/if}}">
-  <div role="button" class="bx--list-box__field" tabindex="0" aria-label="close menu" aria-expanded="true"
+<div class="{{@root.prefix}}--form-item {{@root.prefix}}--multi-select {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="close menu" aria-expanded="true"
     aria-haspopup="true">
-    <span class="bx--list-box__label">Label</span>
-    <div class="bx--list-box__menu-icon bx--list-box__menu-icon--open">
+    <span class="{{@root.prefix}}--list-box__label">Label</span>
+    <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
       <svg width="10" height="5" name="caret--down" role="img" viewBox="0 0 10 5" aria-label="Close menu">
         <title>Close menu</title>
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
     </div>
   </div>
-  <div class="bx--list-box__menu">
+  <div class="{{@root.prefix}}--list-box__menu">
     {{#each items}}
-    <div class="bx--list-box__menu-item" id="{{id}}">
-      <div class="bx--form-item bx--checkbox-wrapper">
-        <label for="{{id}}" title="{{label}}" class="bx--checkbox-label">
-          <input type="checkbox" name="Option 1" readonly="" tabindex="-1" class="bx--checkbox" id="{{id}}" value="on">
-          <span class="bx--checkbox-appearance"></span>
-          <span class="bx--checkbox-label-text">{{label}}</span>
+    <div class="{{@root.prefix}}--list-box__menu-item" id="{{id}}">
+      <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
+        <label for="{{id}}" title="{{label}}" class="{{@root.prefix}}--checkbox-label">
+          <input type="checkbox" name="Option 1" readonly="" tabindex="-1" class="{{@root.prefix}}--checkbox" id="{{id}}" value="on">
+          <span class="{{@root.prefix}}--checkbox-appearance"></span>
+          <span class="{{@root.prefix}}--checkbox-label-text">{{label}}</span>
         </label>
       </div>
     </div>

--- a/src/components/notification/notification.config.js
+++ b/src/components/notification/notification.config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
 const { componentsX } = require('../../globals/js/feature-flags');
 
 const items = [
@@ -31,6 +32,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -1,19 +1,19 @@
 {{#each items}}
-<div data-notification class="bx--{{../variant}}-notification bx--{{../variant}}-notification--{{type}}" role="alert">
+<div data-notification class="{{@root.prefix}}--{{../variant}}-notification {{@root.prefix}}--{{../variant}}-notification--{{type}}" role="alert">
   {{#is ../variant "toast"}}
   {{#if ../componentsX}}
   {{#is type "error"}}
-  <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
   </svg>
   {{/is}}
   {{#is type "success"}}
-  <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
   </svg>
   {{/is}}
   {{#is type "warning"}}
-  <svg class="bx--{{../variant}}-notification__icon" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+  <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
     <defs>
       <path d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
         id="a" />
@@ -32,26 +32,26 @@
   {{/is}}
   {{/if}}
   {{/is}}
-  <div class="bx--{{../variant}}-notification__details">
+  <div class="{{@root.prefix}}--{{../variant}}-notification__details">
     {{#is ../variant "inline"}}
     {{#is type "error"}}
-    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
       <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zM3.293 4.707l8 8 1.414-1.414-8-8-1.414 1.414z" fill-rule="evenodd" />
     </svg>
     {{/is}}
     {{#is type "info"}}
-    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
       <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm1-3V7H7v6h2zM8 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"></path>
     </svg>
     {{/is}}
     {{#is type "success"}}
-    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
       <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"></path>
     </svg>
     {{/is}}
     {{#is type "warning"}}
     {{#if ../componentsX}}
-    <svg class="bx--{{../variant}}-notification__icon" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+    <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <path d="M18.05 15.95L9.925.95a.625.625 0 0 0-1.1 0L.7 15.95a.625.625 0 0 0 0 .625.625.625 0 0 0 .55.3H17.5a.625.625 0 0 0 .55-.925z"
           id="a" />
@@ -68,24 +68,24 @@
       </g>
     </svg>
     {{else}}
-    <svg class="bx--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <svg class="{{@root.prefix}}--{{../variant}}-notification__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
       <path d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"></path>
     </svg>
     {{/if}}
     {{/is}}
-    <div class="bx--{{../variant}}-notification__text-wrapper">
-      <p class="bx--{{../variant}}-notification__title">{{title}}</p>
-      <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>
+    <div class="{{@root.prefix}}--{{../variant}}-notification__text-wrapper">
+      <p class="{{@root.prefix}}--{{../variant}}-notification__title">{{title}}</p>
+      <p class="{{@root.prefix}}--{{../variant}}-notification__subtitle">{{subtitle}}</p>
     </div>
     {{/is}}
     {{#is ../variant "toast"}}
-    <h3 class="bx--{{../variant}}-notification__title">{{title}}</h3>
-    <p class="bx--{{../variant}}-notification__subtitle">{{subtitle}}</p>
-    <p class="bx--{{../variant}}-notification__caption">{{timestamp}}</p>
+    <h3 class="{{@root.prefix}}--{{../variant}}-notification__title">{{title}}</h3>
+    <p class="{{@root.prefix}}--{{../variant}}-notification__subtitle">{{subtitle}}</p>
+    <p class="{{@root.prefix}}--{{../variant}}-notification__caption">{{timestamp}}</p>
     {{/is}}
   </div>
-  <button data-notification-btn class="bx--{{../variant}}-notification__close-button" type="button" aria-label="close">
-    <svg aria-hidden="true" class="bx--{{../variant}}-notification__close-icon" width="10" height="10" viewBox="0 0 10 10"
+  <button data-notification-btn class="{{@root.prefix}}--{{../variant}}-notification__close-button" type="button" aria-label="close">
+    <svg aria-hidden="true" class="{{@root.prefix}}--{{../variant}}-notification__close-icon" width="10" height="10" viewBox="0 0 10 10"
       xmlns="http://www.w3.org/2000/svg">
       <path d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
         fill-rule="nonzero" />

--- a/src/components/number-input/number-input.config.js
+++ b/src/components/number-input/number-input.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -1,14 +1,14 @@
-<div class="bx--form-item">
-  <div data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}}">
-    <label for="number-input" class="bx--label">Number Input label</label>
+<div class="{{@root.prefix}}--form-item">
+  <div data-numberinput class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}}">
+    <label for="number-input" class="{{@root.prefix}}--label">Number Input label</label>
     <input id="number-input" type="number" min="0" max="100" value="1">
-    <div class="bx--number__controls">
-      <button aria-label="increase number input" class="bx--number__control-btn up-icon">
+    <div class="{{@root.prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="bx--number__control-btn down-icon">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
@@ -17,66 +17,66 @@
   </div>
 </div>
 
-<div class="bx--form-item">
-  <div data-invalid data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}}">
-    <label for="number-input" class="bx--label">Number Input label</label>
+<div class="{{@root.prefix}}--form-item">
+  <div data-invalid data-numberinput class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}}">
+    <label for="number-input" class="{{@root.prefix}}--label">Number Input label</label>
     <input id="number-input" type="number" min="0" max="100" value="1">
-    <div class="bx--number__controls">
-      <button aria-label="increase number input" class="bx--number__control-btn up-icon">
+    <div class="{{@root.prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="bx--number__control-btn down-icon">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
       </button>
     </div>
-    <div class="bx--form-requirement">
+    <div class="{{@root.prefix}}--form-requirement">
       Invalid number
     </div>
   </div>
 </div>
 
-<div class="bx--form-item">
-  <div data-invalid data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}} bx--number--nolabel">
+<div class="{{@root.prefix}}--form-item">
+  <div data-invalid data-numberinput class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--nolabel">
     <input id="number-input" type="number" min="0" max="100" value="1">
-    <div class="bx--number__controls">
-      <button aria-label="increase number input" class="bx--number__control-btn up-icon">
+    <div class="{{@root.prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="bx--number__control-btn down-icon">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
       </button>
     </div>
-    <div class="bx--form-requirement">
+    <div class="{{@root.prefix}}--form-requirement">
       Invalid number
     </div>
   </div>
 </div>
 
-<div class="bx--form-item">
-  <div data-numberinput class="bx--number{{#if light}} bx--number--light{{/if}} bx--number--helpertext">
-    <label for="number-input" class="bx--label">Number Input label</label>
+<div class="{{@root.prefix}}--form-item">
+  <div data-numberinput class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
+    <label for="number-input" class="{{@root.prefix}}--label">Number Input label</label>
     <input id="number-input" type="number" min="0" max="100" value="1">
-    <div class="bx--number__controls">
-      <button aria-label="increase number input" class="bx--number__control-btn up-icon">
+    <div class="{{@root.prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="bx--number__control-btn down-icon">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
       </button>
     </div>
-    <div class="bx--form__helper-text">
+    <div class="{{@root.prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
   </div>

--- a/src/components/overflow-menu/overflow-menu.config.js
+++ b/src/components/overflow-menu/overflow-menu.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     title: 'An example option that is really long to show what should be done to handle long text',
@@ -26,6 +28,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -1,38 +1,38 @@
-<div data-overflow-menu tabindex="0" aria-label="Overflow" class="bx--overflow-menu" role="button" aria-haspopup="true"
+<div data-overflow-menu tabindex="0" aria-label="Overflow" class="{{@root.prefix}}--overflow-menu" role="button" aria-haspopup="true"
   aria-expanded="false">
-  <svg aria-hidden="true" class="bx--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
+  <svg aria-hidden="true" class="{{@root.prefix}}--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
     <g fill-rule="evenodd">
       <circle cx="1.5" cy="1.5" r="1.5" />
       <circle cx="1.5" cy="7.5" r="1.5" />
       <circle cx="1.5" cy="13.5" r="1.5" />
     </g>
   </svg>
-  <ul class="bx--overflow-menu-options" tabindex="-1" role="menu" aria-label="Overflow" data-floating-menu-direction="{{direction}}">
+  <ul class="{{@root.prefix}}--overflow-menu-options" tabindex="-1" role="menu" aria-label="Overflow" data-floating-menu-direction="{{direction}}">
     {{#each items}}
-    <li class="bx--overflow-menu-options__option{{#if disabled}} bx--overflow-menu-options__option--disabled{{/if}}{{#if danger}} bx--overflow-menu-options__option--danger{{/if}}"
+    <li class="{{@root.prefix}}--overflow-menu-options__option{{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled{{/if}}{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}"
       role="presentation">
-      <button class="bx--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}" {{/if}}
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}" {{/if}}
         {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}} tabindex="-1" {{/if}}>{{label}}</button>
     </li>
     {{/each}}
   </ul>
 </div>
 
-<div data-overflow-menu tabindex="0" aria-label="Overflow" class="bx--overflow-menu" role="button" aria-haspopup="true"
+<div data-overflow-menu tabindex="0" aria-label="Overflow" class="{{@root.prefix}}--overflow-menu" role="button" aria-haspopup="true"
   aria-expanded="false">
-  <svg aria-hidden="true" class="bx--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
+  <svg aria-hidden="true" class="{{@root.prefix}}--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
     <g fill-rule="evenodd">
       <circle cx="1.5" cy="1.5" r="1.5" />
       <circle cx="1.5" cy="7.5" r="1.5" />
       <circle cx="1.5" cy="13.5" r="1.5" />
     </g>
   </svg>
-  <ul class="bx--overflow-menu-options bx--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="{{direction}}"
+  <ul class="{{@root.prefix}}--overflow-menu-options {{@root.prefix}}--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="{{direction}}"
     role="menu" aria-label="Overflow">
     {{#each items}}
-    <li class="bx--overflow-menu-options__option{{#if disabled}} bx--overflow-menu-options__option--disabled{{/if}}{{#if danger}} bx--overflow-menu-options__option--danger{{/if}}"
+    <li class="{{@root.prefix}}--overflow-menu-options__option{{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled{{/if}}{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}"
       role="presentation">
-      <button class="bx--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}" {{/if}}
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}" {{/if}}
         {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}} tabindex="-1" {{/if}}>{{label}}</button>
     </li>
     {{/each}}

--- a/src/components/pagination/pagination.config.js
+++ b/src/components/pagination/pagination.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const itemsPerPageChoices = [
   {
     value: '10',
@@ -49,6 +51,9 @@ const pageNumberChoices = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/pagination/pagination.hbs
+++ b/src/components/pagination/pagination.hbs
@@ -1,55 +1,55 @@
-<div class="bx--pagination" data-pagination>
-  <div class="bx--pagination__left">
-    <div class="bx--select{{#is version "v2"}} bx--select--inline{{/is}}">
+<div class="{{@root.prefix}}--pagination" data-pagination>
+  <div class="{{@root.prefix}}--pagination__left">
+    <div class="{{@root.prefix}}--select{{#is version "v2"}} {{@root.prefix}}--select--inline{{/is}}">
       {{#is version "v2"}}
-        <label for="select-id-pagination" class="bx--pagination__text">Items per page: </label>
+        <label for="select-id-pagination" class="{{@root.prefix}}--pagination__text">Items per page: </label>
       {{/is}}
-      <select id="select-id-pagination" class="bx--select-input" data-items-per-page>
+      <select id="select-id-pagination" class="{{@root.prefix}}--select-input" data-items-per-page>
         {{#each itemsPerPageChoices}}
-          <option class="bx--select-option" value="{{value}}"{{#if selected}} selected{{/if}}>{{label}}</option>
+          <option class="{{@root.prefix}}--select-option" value="{{value}}"{{#if selected}} selected{{/if}}>{{label}}</option>
         {{/each}}
       </select>
-      <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd"/>
       </svg>
     </div>
     {{#isnt version "v2"}}
-      <span class="bx--pagination__text">Items per page&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+      <span class="{{@root.prefix}}--pagination__text">Items per page&nbsp;&nbsp;|&nbsp;&nbsp;</span>
     {{/isnt}}
-    <span class="bx--pagination__text">
+    <span class="{{@root.prefix}}--pagination__text">
       {{#is version "v2"}}
         <span>|&nbsp;</span>
       {{/is}}
       <span data-displayed-item-range>1-10</span> of
       <span data-total-items>40</span> items</span>
   </div>
-  <div class="bx--pagination__right{{#is version "v2"}} bx--pagination--inline{{/is}}">
-    <span class="bx--pagination__text">
+  <div class="{{@root.prefix}}--pagination__right{{#is version "v2"}} {{@root.prefix}}--pagination--inline{{/is}}">
+    <span class="{{@root.prefix}}--pagination__text">
       <span data-displayed-page-number>1</span> of
       <span data-total-pages>4</span> pages</span>
-    <button class="bx--pagination__button bx--pagination__button--backward" data-page-backward aria-label="Backward button">
-      <svg class="bx--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
+    <button class="{{@root.prefix}}--pagination__button {{@root.prefix}}--pagination__button--backward" data-page-backward aria-label="Backward button">
+      <svg class="{{@root.prefix}}--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
         <path fill-rule="nonzero" d="M1.45 6.002L7 11.27l-.685.726L0 6.003 6.315 0 7 .726z"/>
       </svg>
     </button>
-    <label for="page-number-input" class="bx--visually-hidden">Page number input</label>
+    <label for="page-number-input" class="{{@root.prefix}}--visually-hidden">Page number input</label>
     {{#isnt version "v2"}}
-      <input id="page-number-input" type="text" class="bx--text-input" placeholder="0" value="1" data-page-number-input>
+      <input id="page-number-input" type="text" class="{{@root.prefix}}--text-input" placeholder="0" value="1" data-page-number-input>
     {{else}}
-      <div class="bx--select bx--select--inline">
-        <label for="select-id-pagination" class="bx--visually-hidden">Page number</label>
-        <select id="select-id-pagination" class="bx--select-input" data-page-number-input>
+      <div class="{{@root.prefix}}--select {{@root.prefix}}--select--inline">
+        <label for="select-id-pagination" class="{{@root.prefix}}--visually-hidden">Page number</label>
+        <select id="select-id-pagination" class="{{@root.prefix}}--select-input" data-page-number-input>
           {{#each pageNumberChoices}}
-            <option class="bx--select-option" value="{{value}}"{{#if selected}} selected{{/if}}>{{label}}</option>
+            <option class="{{@root.prefix}}--select-option" value="{{value}}"{{#if selected}} selected{{/if}}>{{label}}</option>
           {{/each}}
         </select>
-        <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd"/>
         </svg>
       </div>
     {{/isnt}}
-    <button class="bx--pagination__button bx--pagination__button--forward" data-page-forward aria-label="Forward button">
-      <svg class="bx--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
+    <button class="{{@root.prefix}}--pagination__button {{@root.prefix}}--pagination__button--forward" data-page-forward aria-label="Forward button">
+      <svg class="{{@root.prefix}}--pagination__button-icon" width="7" height="12" viewBox="0 0 7 12">
         <path fill-rule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z"/>
       </svg>
     </button>

--- a/src/components/progress-indicator/progress-indicator.config.js
+++ b/src/components/progress-indicator/progress-indicator.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const steps = [
   {
     state: 'complete',
@@ -20,6 +22,9 @@ const steps = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/progress-indicator/progress-indicator.hbs
+++ b/src/components/progress-indicator/progress-indicator.hbs
@@ -1,6 +1,6 @@
-<ul data-progress data-progress-current class="bx--progress">
+<ul data-progress data-progress-current class="{{@root.prefix}}--progress">
   {{#each steps}}
-    <li class="bx--progress-step bx--progress-step--{{state}}">
+    <li class="{{@root.prefix}}--progress-step {{@root.prefix}}--progress-step--{{state}}">
       {{#is state "complete"}}
         <svg width="16" height="16" viewBox="0 0 16 16">
           <g fill-rule="nonzero">
@@ -20,8 +20,8 @@
           <circle cx="12" cy="12" r="12"></circle>
         </svg>
       {{/is}}
-      <p class="bx--progress-label">{{label}}</p>
-      <span class="bx--progress-line"></span>
+      <p class="{{@root.prefix}}--progress-label">{{label}}</p>
+      <span class="{{@root.prefix}}--progress-line"></span>
     </li>
   {{/each}}
 </ul>

--- a/src/components/radio-button/radio-button.config.js
+++ b/src/components/radio-button/radio-button.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     id: 'radio-button-1',
@@ -20,6 +22,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/radio-button/radio-button.hbs
+++ b/src/components/radio-button/radio-button.hbs
@@ -1,11 +1,11 @@
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Radio Button heading</legend>
-  <div class="bx--form-item">
-    <div class="bx--radio-button-group">
+<fieldset class="{{@root.prefix}}--fieldset">
+  <legend class="{{@root.prefix}}--label">Radio Button heading</legend>
+  <div class="{{@root.prefix}}--form-item">
+    <div class="{{@root.prefix}}--radio-button-group">
       {{#each items}}
-        <input id="{{id}}" class="bx--radio-button" type="radio" value="{{value}}" name="{{../group}}" tabindex="0"{{#is value ../selectedValue}} checked{{/is}}{{#if disabled}} disabled{{/if}}>
-        <label for="{{id}}" class="bx--radio-button__label">
-          <span class="bx--radio-button__appearance"></span>
+        <input id="{{id}}" class="{{@root.prefix}}--radio-button" type="radio" value="{{value}}" name="{{../group}}" tabindex="0"{{#is value ../selectedValue}} checked{{/is}}{{#if disabled}} disabled{{/if}}>
+        <label for="{{id}}" class="{{@root.prefix}}--radio-button__label">
+          <span class="{{@root.prefix}}--radio-button__appearance"></span>
           {{label}}
         </label>
       {{/each}}

--- a/src/components/search/search.config.js
+++ b/src/components/search/search.config.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
   default: 'large',
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'large',

--- a/src/components/search/search.hbs
+++ b/src/components/search/search.hbs
@@ -1,13 +1,13 @@
 {{#is suffix "sm"}}
-<div class="bx--form-item">{{/is}}
-  <div data-search role="search" class="bx--search bx--search--{{suffix}}{{#if light}} bx--search--light{{/if}}">
-    <label id="search-input-label-1" class="bx--label" for="search__input-1">Search</label>
-    <input class="bx--search-input" type="text" id="search__input-1" placeholder="Search">
-    <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
+<div class="{{@root.prefix}}--form-item">{{/is}}
+  <div data-search role="search" class="{{@root.prefix}}--search {{@root.prefix}}--search--{{suffix}}{{#if light}} {{@root.prefix}}--search--light{{/if}}">
+    <label id="search-input-label-1" class="{{@root.prefix}}--label" for="search__input-1">Search</label>
+    <input class="{{@root.prefix}}--search-input" type="text" id="search__input-1" placeholder="Search">
+    <svg class="{{@root.prefix}}--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
       <path d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z"
         fill-rule="nonzero" />
     </svg>
-    <button class="bx--search-close bx--search-close--hidden" title="Clear search
+    <button class="{{@root.prefix}}--search-close {{@root.prefix}}--search-close--hidden" title="Clear search
         input" aria-label="Clear search input">
       <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
         <path d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"

--- a/src/components/select/select.config.js
+++ b/src/components/select/select.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     label: 'Choose an option',
@@ -40,6 +42,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -1,19 +1,19 @@
-<div class="bx--form-item">
-  <div class="bx--select{{#if inline}} bx--select--inline{{/if}}{{#if light}} bx--select--light{{/if}}">
-    <label for="select-id" class="bx--label">Select label</label>
-    <select {{#if invalid}} data-invalid{{/if}} id="select-id" class="bx--select-input">
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}}">
+    <label for="select-id" class="{{@root.prefix}}--label">Select label</label>
+    <select {{#if invalid}} data-invalid{{/if}} id="select-id" class="{{@root.prefix}}--select-input">
       {{#each items}}
       {{#if items}}
-      <optgroup class="bx--select-optgroup" label="{{label}}">
+      <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
         {{#each items}}
-        <option class="bx--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if
-          hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}} <option class="bx--select-option"
+        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if
+          hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}} <option class="{{@root.prefix}}--select-option"
           value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}}
-          </option> {{/if}} {{/each}} </select> <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+          </option> {{/if}} {{/each}} </select> <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
           </svg>
           {{#if invalid}}
-          <div class="bx--form-requirement">
+          <div class="{{@root.prefix}}--form-requirement">
             Validation message here
           </div>
           {{/if}}

--- a/src/components/skeleton/skeleton.config.js
+++ b/src/components/skeleton/skeleton.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const tabItems = [
   {},
   {},
@@ -9,6 +11,9 @@ const tabItems = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/skeleton/skeleton.hbs
+++ b/src/components/skeleton/skeleton.hbs
@@ -1,113 +1,113 @@
 
 <p>Skeleton Text</p>
-<div class="bx--skeleton__text"></div>
-<div class="bx--skeleton__text bx--skeleton__heading"></div>
+<div class="{{@root.prefix}}--skeleton__text"></div>
+<div class="{{@root.prefix}}--skeleton__text {{@root.prefix}}--skeleton__heading"></div>
 
 <p>Button</p>
-<button class="bx--skeleton bx--btn" type="button"></button>
-&nbsp;<a class="bx--skeleton bx--btn" href="#" role="button"></a>
-&nbsp;<button class="bx--skeleton bx--btn bx--btn--sm" type="button"></button>
+<button class="{{@root.prefix}}--skeleton {{@root.prefix}}--btn" type="button"></button>
+&nbsp;<a class="{{@root.prefix}}--skeleton {{@root.prefix}}--btn" href="#" role="button"></a>
+&nbsp;<button class="{{@root.prefix}}--skeleton {{@root.prefix}}--btn {{@root.prefix}}--btn--sm" type="button"></button>
 
 <p>Code Snippet</p>
-<div class="bx--snippet bx--skeleton bx--snippet--single">
-  <div class="bx--snippet-container"><span></span></div>
+<div class="{{@root.prefix}}--snippet {{@root.prefix}}--skeleton {{@root.prefix}}--snippet--single">
+  <div class="{{@root.prefix}}--snippet-container"><span></span></div>
 </div>
-<div class="bx--snippet bx--skeleton bx--snippet--multi">
-  <div class="bx--snippet-container"><span></span><span></span><span></span></div>
+<div class="{{@root.prefix}}--snippet {{@root.prefix}}--skeleton {{@root.prefix}}--snippet--multi">
+  <div class="{{@root.prefix}}--snippet-container"><span></span><span></span><span></span></div>
 </div>
 
 <p>Label</p>
-<label class="bx--label bx--skeleton"></label>
+<label class="{{@root.prefix}}--label {{@root.prefix}}--skeleton"></label>
 
 <p>Breadcrumb</p>
-<div class="bx--breadcrumb bx--skeleton">
+<div class="{{@root.prefix}}--breadcrumb {{@root.prefix}}--skeleton">
   {{#each breadCrumbItems}}
-    <div class="bx--breadcrumb-item">
-      <a href="/#" class="bx--link">&nbsp;</a>
+    <div class="{{@root.prefix}}--breadcrumb-item">
+      <a href="/#" class="{{@root.prefix}}--link">&nbsp;</a>
     </div>
   {{/each}}
 </div>
 
 <p>Dropdown</p>
-<div class="bx--skeleton bx--dropdown-v2 bx--list-box bx--form-item">
-  <div role="button" class="bx--list-box__field">
-    <span class="bx--list-box__label"></span>
+<div class="{{@root.prefix}}--skeleton {{@root.prefix}}--dropdown-v2 {{@root.prefix}}--list-box {{@root.prefix}}--form-item">
+  <div role="button" class="{{@root.prefix}}--list-box__field">
+    <span class="{{@root.prefix}}--list-box__label"></span>
   </div>
 </div>
 
 <p>Progress Indicator</p>
-<ul class="bx--progress bx--skeleton">
+<ul class="{{@root.prefix}}--progress {{@root.prefix}}--skeleton">
   {{#each progressIndicatorItems}}
-    <li class="bx--progress-step bx--progress-step--incomplete">
+    <li class="{{@root.prefix}}--progress-step {{@root.prefix}}--progress-step--incomplete">
       <svg>
         <g>
           <circle cx="12" cy="12" r="12"></circle>
         </g>
       </svg>
-      <p class="bx--progress-label"></p>
-      <span class="bx--progress-line"></span>
+      <p class="{{@root.prefix}}--progress-label"></p>
+      <span class="{{@root.prefix}}--progress-line"></span>
     </li>
   {{/each}}
 </ul>
 
 <p>Toggle</p>
-<div class="bx--form-item">
-  <input type="checkbox" class="bx--toggle bx--skeleton" value="on">
-  <label class="bx--toggle__label bx--skeleton">
-    <span class="bx--toggle__text--left"></span><span class="bx--toggle__appearance"></span><span class="bx--toggle__text--right"></span>
+<div class="{{@root.prefix}}--form-item">
+  <input type="checkbox" class="{{@root.prefix}}--toggle {{@root.prefix}}--skeleton" value="on">
+  <label class="{{@root.prefix}}--toggle__label {{@root.prefix}}--skeleton">
+    <span class="{{@root.prefix}}--toggle__text--left"></span><span class="{{@root.prefix}}--toggle__appearance"></span><span class="{{@root.prefix}}--toggle__text--right"></span>
   </label>
 </div>
 
 <p>Small Toggle</p>
-<div class="bx--form-item">
-  <input type="checkbox" class="bx--toggle bx--toggle--small bx--skeleton" value="on">
-  <label class="bx--toggle__label bx--skeleton"><span class="bx--toggle__appearance"><svg class="bx--toggle__check" width="6px" height="5px" viewBox="0 0 6 5"><path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z"></path></svg></span>
+<div class="{{@root.prefix}}--form-item">
+  <input type="checkbox" class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small {{@root.prefix}}--skeleton" value="on">
+  <label class="{{@root.prefix}}--toggle__label {{@root.prefix}}--skeleton"><span class="{{@root.prefix}}--toggle__appearance"><svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5"><path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z"></path></svg></span>
   </label>
 </div>
 
 <p>Slider</p>
-<div class="bx--form-item">
-  <label class="bx--label bx--skeleton"></label>
-  <div class="bx--slider-container bx--skeleton"><span class="bx--slider__range-label"></span>
-    <div class="bx--slider">
-      <div class="bx--slider__track"></div>
-      <div class="bx--slider__filled-track"></div>
-      <div class="bx--slider__thumb"></div>
-    </div><span class="bx--slider__range-label"></span>
+<div class="{{@root.prefix}}--form-item">
+  <label class="{{@root.prefix}}--label {{@root.prefix}}--skeleton"></label>
+  <div class="{{@root.prefix}}--slider-container {{@root.prefix}}--skeleton"><span class="{{@root.prefix}}--slider__range-label"></span>
+    <div class="{{@root.prefix}}--slider">
+      <div class="{{@root.prefix}}--slider__track"></div>
+      <div class="{{@root.prefix}}--slider__filled-track"></div>
+      <div class="{{@root.prefix}}--slider__thumb"></div>
+    </div><span class="{{@root.prefix}}--slider__range-label"></span>
   </div>
 </div>
 
 <p>Tag</p>
-<span class="bx--tag bx--skeleton"></span>
+<span class="{{@root.prefix}}--tag {{@root.prefix}}--skeleton"></span>
 
 <p>Tabs</p>
-<nav class="bx--tabs bx--skeleton">
-  <div class="bx--tabs-trigger"><a href="javascript:void(0)" class="bx--tabs-trigger-text">&nbsp;</a>
+<nav class="{{@root.prefix}}--tabs {{@root.prefix}}--skeleton">
+  <div class="{{@root.prefix}}--tabs-trigger"><a href="javascript:void(0)" class="{{@root.prefix}}--tabs-trigger-text">&nbsp;</a>
     <svg width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
       <path d="M10 0L5 5 0 0z"></path>
     </svg>
   </div>
-  <ul class="bx--tabs__nav bx--tabs__nav--hidden">
+  <ul class="{{@root.prefix}}--tabs__nav {{@root.prefix}}--tabs__nav--hidden">
     {{#each tabItems}}
-      <li class="bx--tabs__nav-item{{#if selected}} bx--tabs__nav-item--selected{{/if}}"><a class="bx--tabs__nav-link" href="javascript:void(0)">&nbsp;</a>
+      <li class="{{@root.prefix}}--tabs__nav-item{{#if selected}} {{@root.prefix}}--tabs__nav-item--selected{{/if}}"><a class="{{@root.prefix}}--tabs__nav-link" href="javascript:void(0)">&nbsp;</a>
       </li>
     {{/each}}
   </ul>
 </nav>
 
 <p>Icon</p>
-<div class="bx--icon--skeleton"></div>
+<div class="{{@root.prefix}}--icon--skeleton"></div>
 
 <p>Select</p>
-<div class="bx--form-item">
-  <label class="bx--label bx--skeleton"></label>
-  <div class="bx--select bx--skeleton">
-    <select class="bx--select-input"></select>
+<div class="{{@root.prefix}}--form-item">
+  <label class="{{@root.prefix}}--label {{@root.prefix}}--skeleton"></label>
+  <div class="{{@root.prefix}}--select {{@root.prefix}}--skeleton">
+    <select class="{{@root.prefix}}--select-input"></select>
   </div>
 </div>
 
 <p>Data Table</p>
-<table class="bx--skeleton bx--data-table-v2">
+<table class="{{@root.prefix}}--skeleton {{@root.prefix}}--data-table-v2">
   <thead>
     <tr>
       <th></th>

--- a/src/components/slider/slider.config.js
+++ b/src/components/slider/slider.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/slider/slider.hbs
+++ b/src/components/slider/slider.hbs
@@ -1,15 +1,15 @@
-<div class="bx--form-item">
-  <div class="bx--slider-test">
-  <label class="bx--label">Slider label</label>
-  <div class="bx--slider-container">
-    <div class="bx--slider" data-slider data-slider-input-box="#{{inputId}}">
-      <div class="bx--slider__thumb" tabindex="0"></div>
-      <div class="bx--slider__track"></div>
-      <div class="bx--slider__filled-track"></div>
-      <input aria-label="slider" id="slider" class="bx--slider__input" type="range" step="1" min="0" max="100" value="0">
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--slider-test">
+  <label class="{{@root.prefix}}--label">Slider label</label>
+  <div class="{{@root.prefix}}--slider-container">
+    <div class="{{@root.prefix}}--slider" data-slider data-slider-input-box="#{{inputId}}">
+      <div class="{{@root.prefix}}--slider__thumb" tabindex="0"></div>
+      <div class="{{@root.prefix}}--slider__track"></div>
+      <div class="{{@root.prefix}}--slider__filled-track"></div>
+      <input aria-label="slider" id="slider" class="{{@root.prefix}}--slider__input" type="range" step="1" min="0" max="100" value="0">
     </div>
-    <label id="{{inputId}}_bottom-range-label" class="bx--slider__range-label">0</label>
-    <label id="{{inputId}}_top-range-label" class="bx--slider__range-label">100</label>
-    <input id="{{inputId}}" aria-labelledby="{{inputId}}_bottom-range-label {{inputId}}_top-range-label" type="number" class="bx--text-input bx--slider-text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="0">
+    <label id="{{inputId}}_bottom-range-label" class="{{@root.prefix}}--slider__range-label">0</label>
+    <label id="{{inputId}}_top-range-label" class="{{@root.prefix}}--slider__range-label">100</label>
+    <input id="{{inputId}}" aria-labelledby="{{inputId}}_bottom-range-label {{inputId}}_top-range-label" type="number" class="{{@root.prefix}}--text-input {{@root.prefix}}--slider-text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}" placeholder="0">
   </div>
 </div>

--- a/src/components/structured-list/structured-list.config.js
+++ b/src/components/structured-list/structured-list.config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
 const { componentsX } = require('../../globals/js/feature-flags');
 
 const columns = [
@@ -67,6 +68,9 @@ const rows = [
 /* eslint-enable max-len */
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/structured-list/structured-list.hbs
+++ b/src/components/structured-list/structured-list.hbs
@@ -1,40 +1,40 @@
-<section class="bx--structured-list{{#if hasBorder}} bx--structured-list--border{{/if}}{{#if selectable}} bx--structured-list--selection{{/if}}"{{#if selectable}} data-structured-list{{/if}}>
-  <div class="bx--structured-list-thead">
-    <div class="bx--structured-list-row bx--structured-list-row--header-row">
+<section class="{{@root.prefix}}--structured-list{{#if hasBorder}} {{@root.prefix}}--structured-list--border{{/if}}{{#if selectable}} {{@root.prefix}}--structured-list--selection{{/if}}"{{#if selectable}} data-structured-list{{/if}}>
+  <div class="{{@root.prefix}}--structured-list-thead">
+    <div class="{{@root.prefix}}--structured-list-row {{@root.prefix}}--structured-list-row--header-row">
       {{#if componentsX}}
       {{#each columns}}
-        <div class="bx--structured-list-th">{{title}}</div>
+        <div class="{{@root.prefix}}--structured-list-th">{{title}}</div>
       {{/each}}
       {{#if selectable}}
-        <div class="bx--structured-list-th"></div>
+        <div class="{{@root.prefix}}--structured-list-th"></div>
       {{/if}}
       {{else}}
       {{#if selectable}}
-        <div class="bx--structured-list-th"></div>
+        <div class="{{@root.prefix}}--structured-list-th"></div>
       {{/if}}
       {{#each columns}}
-        <div class="bx--structured-list-th">{{title}}</div>
+        <div class="{{@root.prefix}}--structured-list-th">{{title}}</div>
       {{/each}}
       {{/if}}
     </div>
   </div>
-  <div class="bx--structured-list-tbody">
+  <div class="{{@root.prefix}}--structured-list-tbody">
     {{#each rows as |row|}}
       {{#if ../componentsX}}
         {{#if ../selectable}}
-          <label for="{{row.id}}" aria-label="{{row.selectionLabel}}" class="bx--structured-list-row{{#if row.selected}} bx--structured-list-row--selected{{/if}}" tabindex="0">
+          <label for="{{row.id}}" aria-label="{{row.selectionLabel}}" class="{{@root.prefix}}--structured-list-row{{#if row.selected}} {{@root.prefix}}--structured-list-row--selected{{/if}}" tabindex="0">
         {{else}}
-          <div class="bx--structured-list-row">
+          <div class="{{@root.prefix}}--structured-list-row">
         {{/if}}
           {{#each ../columns as |column|}}
             {{#with (lookup row column.name) as |data|}}
-              <div class="bx--structured-list-td{{#if column.nowrap}} bx--structured-list-content--nowrap{{/if}}">{{data}}</div>
+              <div class="{{@root.prefix}}--structured-list-td{{#if column.nowrap}} {{@root.prefix}}--structured-list-content--nowrap{{/if}}">{{data}}</div>
             {{/with}}
           {{/each}}
         {{#if ../selectable}}
-            <input tabindex="-1" id="{{row.id}}" class="bx--structured-list-input" value="{{row.value}}" type="radio" name="{{../group}}" title="{{row.selectionLabel}}"{{#if row.selected}} checked{{/if}} />
-            <div class="bx--structured-list-td">
-              <svg class="bx--structured-list-svg" width="16" height="16" viewBox="0 0 16 16">
+            <input tabindex="-1" id="{{row.id}}" class="{{@root.prefix}}--structured-list-input" value="{{row.value}}" type="radio" name="{{../group}}" title="{{row.selectionLabel}}"{{#if row.selected}} checked{{/if}} />
+            <div class="{{@root.prefix}}--structured-list-td">
+              <svg class="{{@root.prefix}}--structured-list-svg" width="16" height="16" viewBox="0 0 16 16">
                 <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
                   fill-rule="evenodd" />
               </svg>
@@ -45,20 +45,20 @@
         {{/if}}
       {{else}}
         {{#if ../selectable}}
-          <label aria-label="{{row.selectionLabel}}" class="bx--structured-list-row{{#if row.selected}} bx--structured-list-row--selected{{/if}}" tabindex="0">
-            <input tabindex="-1" class="bx--structured-list-input" value="{{row.value}}" type="radio" name="{{../group}}" title="{{row.selectionLabel}}"{{#if row.selected}} checked{{/if}} />
-            <div class="bx--structured-list-td">
-              <svg class="bx--structured-list-svg" width="16" height="16" viewBox="0 0 16 16">
+          <label aria-label="{{row.selectionLabel}}" class="{{@root.prefix}}--structured-list-row{{#if row.selected}} {{@root.prefix}}--structured-list-row--selected{{/if}}" tabindex="0">
+            <input tabindex="-1" class="{{@root.prefix}}--structured-list-input" value="{{row.value}}" type="radio" name="{{../group}}" title="{{row.selectionLabel}}"{{#if row.selected}} checked{{/if}} />
+            <div class="{{@root.prefix}}--structured-list-td">
+              <svg class="{{@root.prefix}}--structured-list-svg" width="16" height="16" viewBox="0 0 16 16">
                 <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
                   fill-rule="evenodd" />
               </svg>
             </div>
         {{else}}
-          <div class="bx--structured-list-row">
+          <div class="{{@root.prefix}}--structured-list-row">
         {{/if}}
           {{#each ../columns as |column|}}
             {{#with (lookup row column.name) as |data|}}
-              <div class="bx--structured-list-td{{#if column.nowrap}} bx--structured-list-content--nowrap{{/if}}">{{data}}</div>
+              <div class="{{@root.prefix}}--structured-list-td{{#if column.nowrap}} {{@root.prefix}}--structured-list-content--nowrap{{/if}}">{{data}}</div>
             {{/with}}
           {{/each}}
         {{#if ../selectable}}

--- a/src/components/tabs/tabs.config.js
+++ b/src/components/tabs/tabs.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const items = [
   {
     linkId: 'tab-link-1',
@@ -40,6 +42,9 @@ const items = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/tabs/tabs.hbs
+++ b/src/components/tabs/tabs.hbs
@@ -1,14 +1,14 @@
-<nav data-tabs class="bx--tabs" role="navigation">
-  <div class="bx--tabs-trigger" tabindex="0">
-    <a href="javascript:void(0)" class="bx--tabs-trigger-text" tabindex="-1"></a>
+<nav data-tabs class="{{@root.prefix}}--tabs" role="navigation">
+  <div class="{{@root.prefix}}--tabs-trigger" tabindex="0">
+    <a href="javascript:void(0)" class="{{@root.prefix}}--tabs-trigger-text" tabindex="-1"></a>
     <svg width="10" height="5" viewBox="0 0 10 5">
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>
   </div>
-  <ul class="bx--tabs__nav bx--tabs__nav--hidden" role="tablist">
+  <ul class="{{@root.prefix}}--tabs__nav {{@root.prefix}}--tabs__nav--hidden" role="tablist">
     {{#each items}}
-      <li class="bx--tabs__nav-item{{#if selected}} bx--tabs__nav-item--selected{{/if}}" data-target=".{{panelClass}}" role="presentation">
-        <a id="{{linkId}}" class="bx--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="{{panelId}}"{{#if selected}} aria-selected="true"{{/if}}>{{label}}</a>
+      <li class="{{@root.prefix}}--tabs__nav-item{{#if selected}} {{@root.prefix}}--tabs__nav-item--selected{{/if}}" data-target=".{{panelClass}}" role="presentation">
+        <a id="{{linkId}}" class="{{@root.prefix}}--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="{{panelId}}"{{#if selected}} aria-selected="true"{{/if}}>{{label}}</a>
       </li>
     {{/each}}
   </ul>

--- a/src/components/tag/tag.config.js
+++ b/src/components/tag/tag.config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
 const { componentsX } = require('../../globals/js/feature-flags');
 
 const tags = !componentsX
@@ -85,6 +86,9 @@ const tags = !componentsX
     ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/tag/tag.hbs
+++ b/src/components/tag/tag.hbs
@@ -1,6 +1,6 @@
 {{#each tags}}
-<span class="bx--tag bx--tag--{{type}}">{{label}}</span>
+<span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--{{type}}">{{label}}</span>
 {{/each}}
 {{#if componentsX}}
-<span class="bx--tag bx--tag--basic" disabled>Component</span>
+<span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--basic" disabled>Component</span>
 {{/if}}

--- a/src/components/text-area/text-area.config.js
+++ b/src/components/text-area/text-area.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/text-area/text-area.hbs
+++ b/src/components/text-area/text-area.hbs
@@ -1,20 +1,20 @@
-<div class="bx--form-item">
-  <label for="text-area-2" class="bx--label">Text Area label</label>
-  <textarea id="text-area-2" class="bx--text-area bx--text-area--v2{{#if light}} bx--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
+<div class="{{@root.prefix}}--form-item">
+  <label for="text-area-2" class="{{@root.prefix}}--label">Text Area label</label>
+  <textarea id="text-area-2" class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
 </div>
 
-<div class="bx--form-item">
-  <label for="text-area-3" class="bx--label">Text Area label</label>
-  <textarea data-invalid id="text-area-3" class="bx--text-area bx--text-area--v2{{#if light}} bx--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
-  <div class="bx--form-requirement">
+<div class="{{@root.prefix}}--form-item">
+  <label for="text-area-3" class="{{@root.prefix}}--label">Text Area label</label>
+  <textarea data-invalid id="text-area-3" class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
+  <div class="{{@root.prefix}}--form-requirement">
     Validation message here
   </div>
 </div>
 
-<div class="bx--form-item">
-  <label for="text-area-4" class="bx--label">Text Area label</label>
-  <textarea id="text-area-4" class="bx--text-area bx--text-area--v2{{#if light}} bx--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
-  <div class="bx--form__helper-text">
+<div class="{{@root.prefix}}--form-item">
+  <label for="text-area-4" class="{{@root.prefix}}--label">Text Area label</label>
+  <textarea id="text-area-4" class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}" rows="4" cols="50" placeholder="Placeholder text."></textarea>
+  <div class="{{@root.prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
 </div>

--- a/src/components/text-input/text-input.config.js
+++ b/src/components/text-input/text-input.config.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/text-input/text-input.hbs
+++ b/src/components/text-input/text-input.hbs
@@ -1,11 +1,11 @@
-<div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper">
-  <label for="text-input-3" class="bx--label">Text Input label</label>
+<div {{#if password}} data-text-input {{/if}} class="{{@root.prefix}}--form-item {{@root.prefix}}--text-input-wrapper">
+  <label for="text-input-3" class="{{@root.prefix}}--label">Text Input label</label>
   {{#unless password}}
-  <input id="text-input-3" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Placeholder text">
+  <input id="text-input-3" type="text" class="{{@root.prefix}}--text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
   {{else}}
-  <input id="text-input-3" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
+  <input id="text-input-3" type="password" class="{{@root.prefix}}--text-input {{#if light}} {{@root.prefix}}--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
+  <button class="{{@root.prefix}}--text-input--password__visibility {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -17,15 +17,15 @@
   {{/unless}}
 </div>
 
-<div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper">
-  <label for="text-input-4" class="bx--label">Text Input label</label>
+<div {{#if password}} data-text-input {{/if}} class="{{@root.prefix}}--form-item {{@root.prefix}}--text-input-wrapper">
+  <label for="text-input-4" class="{{@root.prefix}}--label">Text Input label</label>
   {{#unless password}}
-  <input data-invalid id="text-input-4" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}"
+  <input data-invalid id="text-input-4" type="text" class="{{@root.prefix}}--text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}"
     placeholder="Placeholder text">
   {{else}}
-  <input data-invalid id="text-input-4" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
+  <input data-invalid id="text-input-4" type="password" class="{{@root.prefix}}--text-input {{#if light}} {{@root.prefix}}--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
+  <button class="{{@root.prefix}}--text-input--password__visibility {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -35,22 +35,22 @@
     </svg>
   </button>
   {{/unless}}
-  <div class="bx--form-requirement">
+  <div class="{{@root.prefix}}--form-requirement">
     Validation message here
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper">
-  <label for="text-input-5" class="bx--label">Text Input label</label>
-  <div class="bx--form__helper-text">
+<div {{#if password}} data-text-input {{/if}} class="{{@root.prefix}}--form-item {{@root.prefix}}--text-input-wrapper">
+  <label for="text-input-5" class="{{@root.prefix}}--label">Text Input label</label>
+  <div class="{{@root.prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
   {{#unless password}}
-  <input id="text-input-5" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Placeholder text">
+  <input id="text-input-5" type="text" class="{{@root.prefix}}--text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
   {{else}}
-  <input id="text-input-5" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
+  <input id="text-input-5" type="password" class="{{@root.prefix}}--text-input {{#if light}} {{@root.prefix}}--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
+  <button class="{{@root.prefix}}--text-input--password__visibility {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -62,17 +62,17 @@
   {{/unless}}
 </div>
 
-<div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper" style="width: 320px">
-  <label for="text-input-6" class="bx--label">Text Input label</label>
-  <div class="bx--form__helper-text">
+<div {{#if password}} data-text-input {{/if}} class="{{@root.prefix}}--form-item {{@root.prefix}}--text-input-wrapper" style="width: 320px">
+  <label for="text-input-6" class="{{@root.prefix}}--label">Text Input label</label>
+  <div class="{{@root.prefix}}--form__helper-text">
     Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
   </div>
   {{#unless password}}
-  <input id="text-input-6" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Placeholder text">
+  <input id="text-input-6" type="text" class="{{@root.prefix}}--text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
   {{else}}
-  <input id="text-input-6" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
+  <input id="text-input-6" type="password" class="{{@root.prefix}}--text-input {{#if light}} {{@root.prefix}}--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility>
-  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
+  <button class="{{@root.prefix}}--text-input--password__visibility {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>
@@ -84,15 +84,15 @@
   {{/unless}}
 </div>
 
-<div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper">
-  <label for="text-input-7" class="bx--label bx--label--disabled">Text Input label</label>
+<div {{#if password}} data-text-input {{/if}} class="{{@root.prefix}}--form-item {{@root.prefix}}--text-input-wrapper">
+  <label for="text-input-7" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Text Input label</label>
   {{#unless password}}
-  <input id="text-input-7" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Placeholder text"
+  <input id="text-input-7" type="text" class="{{@root.prefix}}--text-input{{#if light}} {{@root.prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
     disabled>
   {{else}}
-  <input id="text-input-7" type="password" class="bx--text-input {{#if light}} bx--text-input--light{{/if}}"
+  <input id="text-input-7" type="password" class="{{@root.prefix}}--text-input {{#if light}} {{@root.prefix}}--text-input--light{{/if}}"
     placeholder="Placeholder text" data-toggle-password-visibility disabled>
-  <button class="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom" aria-label="Show password">
+  <button class="{{@root.prefix}}--text-input--password__visibility {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Show password">
     <svg class="icon--visibility-off" hidden="true" width="16" height="16" viewBox="0 0 16 16">
       <path d="M11.846 3.45L15.293.007 16 .714l-3.284 3.281c1.261.902 2.377 2.212 3.347 3.93C14.02 11.642 11.333 13.5 8 13.5c-1.392 0-2.667-.324-3.822-.973L.703 16l-.706-.708 3.323-3.32C2.071 11.042.976 9.694.035 7.924 2.012 4.308 4.667 2.5 8 2.5c1.395 0 2.677.317 3.846.95zm-6.928 8.338c.944.477 1.97.712 3.082.712 2.795 0 5.076-1.483 6.907-4.568-.866-1.417-1.833-2.486-2.91-3.219l-1.55 1.55a3 3 0 0 1-4.185 4.182l-1.344 1.343zm-.882-.533l1.518-1.517A3 3 0 0 1 9.74 5.556l1.364-1.363A7.02 7.02 0 0 0 8 3.5c-2.798 0-5.047 1.439-6.819 4.432.842 1.465 1.792 2.568 2.855 3.323zm2.948-1.532a2 2 0 0 0 2.74-2.738l-2.74 2.738zm-.707-.707l2.74-2.738a2 2 0 0 0-2.74 2.738z"></path>
     </svg>

--- a/src/components/tile/tile--clickable.hbs
+++ b/src/components/tile/tile--clickable.hbs
@@ -1,1 +1,1 @@
-<a data-tile="clickable" class="bx--tile bx--tile--clickable" tabindex="0"></a>
+<a data-tile="clickable" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--clickable" tabindex="0"></a>

--- a/src/components/tile/tile--expandable.hbs
+++ b/src/components/tile/tile--expandable.hbs
@@ -1,14 +1,14 @@
-<div data-tile="expandable" class="bx--tile bx--tile--expandable" tabindex="0">
-  <button aria-label="expand menu" class="bx--tile__chevron">
+<div data-tile="expandable" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--expandable" tabindex="0">
+  <button aria-label="expand menu" class="{{@root.prefix}}--tile__chevron">
     <svg width="12" height="7" viewBox="0 0 12 7">
       <path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
     </svg>
   </button>
-  <div class="bx--tile-content">
-    <span data-tile-atf class="bx--tile-content__above-the-fold">
+  <div class="{{@root.prefix}}--tile-content">
+    <span data-tile-atf class="{{@root.prefix}}--tile-content__above-the-fold">
       <!-- Above the fold content here -->
     </span>
-    <span class="bx--tile-content__below-the-fold">
+    <span class="{{@root.prefix}}--tile-content__below-the-fold">
       <!-- Rest of the content here -->
     </span>
   </div>

--- a/src/components/tile/tile--grid.hbs
+++ b/src/components/tile/tile--grid.hbs
@@ -1,20 +1,20 @@
-<div class="bx--grid">
+<div class="{{@root.prefix}}--grid">
 
-  <div class="bx--tile-container" style="width: 100%">
-    <div class="bx--row">
-      <div class="bx--col bx--col-md-12">
-        <div data-tile="expandable" class="bx--tile bx--tile--expandable" tabindex="0">
-          <button class="bx--tile__chevron">
+  <div class="{{@root.prefix}}--tile-container" style="width: 100%">
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-12">
+        <div data-tile="expandable" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--expandable" tabindex="0">
+          <button class="{{@root.prefix}}--tile__chevron">
             <svg width="12" height="7" viewBox="0 0 12 7">
               <path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
             </svg>
           </button>
-          <div class="bx--tile-content">
-            <span data-tile-atf class="bx--tile-content__above-the-fold" style="height: 200px">
+          <div class="{{@root.prefix}}--tile-content">
+            <span data-tile-atf class="{{@root.prefix}}--tile-content__above-the-fold" style="height: 200px">
               <!-- Above the fold content here -->
               <h2>Above the fold content here</h2>
             </span>
-            <span class="bx--tile-content__below-the-fold" style="height: 400px">
+            <span class="{{@root.prefix}}--tile-content__below-the-fold" style="height: 400px">
               <!-- Rest of the content here -->
               <h2>Below the fold content here</h2>
             </span>
@@ -22,89 +22,89 @@
         </div>
       </div>
     </div>
-    <div class="bx--row">
-      <div class="bx--col bx--col-sm-6 bx--col-xs-6">
-        <label for="tile-id-1" aria-label="tile" class="bx--tile bx--tile--selectable" data-tile="selectable" tabindex="0">
-          <input tabindex="-1" id="tile-id-1" class="bx--tile-input" data-tile-input value="tile" type="checkbox" name="tiles" title="tile"
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-sm-6 {{@root.prefix}}--col-xs-6">
+        <label for="tile-id-1" aria-label="tile" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--selectable" data-tile="selectable" tabindex="0">
+          <input tabindex="-1" id="tile-id-1" class="{{@root.prefix}}--tile-input" data-tile-input value="tile" type="checkbox" name="tiles" title="tile"
           />
-          <div class="bx--tile__checkmark">
+          <div class="{{@root.prefix}}--tile__checkmark">
             <svg width="16" height="16" viewBox="0 0 16 16">
               <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
                 fill-rule="evenodd" />
             </svg>
           </div>
-          <div class="bx--tile-content">
+          <div class="{{@root.prefix}}--tile-content">
             <!-- Tile content here -->
           </div>
         </label>
       </div>
-      <div class="bx--col bx--col-sm-6 bx--col-xs-6">
-        <label for="tile-id-2" aria-label="tile-2" class="bx--tile bx--tile--selectable" data-tile="selectable" tabindex="0">
-          <input tabindex="-1" id="tile-id-2" class="bx--tile-input" data-tile-input value="tile-2" type="checkbox" name="tiles" title="tile-2"
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-sm-6 {{@root.prefix}}--col-xs-6">
+        <label for="tile-id-2" aria-label="tile-2" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--selectable" data-tile="selectable" tabindex="0">
+          <input tabindex="-1" id="tile-id-2" class="{{@root.prefix}}--tile-input" data-tile-input value="tile-2" type="checkbox" name="tiles" title="tile-2"
           />
-          <div class="bx--tile__checkmark">
+          <div class="{{@root.prefix}}--tile__checkmark">
             <svg width="16" height="16" viewBox="0 0 16 16">
               <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
                 fill-rule="evenodd" />
             </svg>
           </div>
-          <div class="bx--tile-content">
+          <div class="{{@root.prefix}}--tile-content">
             <!-- Tile content here -->
           </div>
         </label>
       </div>
     </div>
-    <div class="bx--row">
-      <div class="bx--col bx--col-md-4 bx--col-sm-4">
-        <a data-tile="clickable" class="bx--tile bx--tile--clickable" tabindex="0"></a>
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-4 {{@root.prefix}}--col-sm-4">
+        <a data-tile="clickable" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--clickable" tabindex="0"></a>
       </div>
-      <div class="bx--col bx--col-md-4 bx--col-sm-4">
-        <a data-tile="clickable" class="bx--tile bx--tile--clickable" tabindex="0"></a>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-4 {{@root.prefix}}--col-sm-4">
+        <a data-tile="clickable" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--clickable" tabindex="0"></a>
       </div>
-      <div class="bx--col bx--col-md-4 bx--col-sm-4">
-        <a data-tile="clickable" class="bx--tile bx--tile--clickable" tabindex="0"></a>
-      </div>
-    </div>
-    <div class="bx--row">
-      <div class="bx--col bx--col-md-3 bx--col-sm-12">
-        <div class="bx--tile"></div>
-      </div>
-      <div class="bx--col bx--col-md-3 bx--col-sm-12">
-        <div class="bx--tile"></div>
-      </div>
-      <div class="bx--col bx--col-md-3 bx--col-sm-12">
-        <div class="bx--tile"></div>
-      </div>
-      <div class="bx--col bx--col-md-3 bx--col-sm-12">
-        <div class="bx--tile"></div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-4 {{@root.prefix}}--col-sm-4">
+        <a data-tile="clickable" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--clickable" tabindex="0"></a>
       </div>
     </div>
-    <div class="bx--row">
-      <div class="bx--col bx--col-lg-2 bx--col-md-12">
-        <div class="bx--tile"></div>
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-3 {{@root.prefix}}--col-sm-12">
+        <div class="{{@root.prefix}}--tile"></div>
       </div>
-      <div class="bx--col bx--col-lg-2 bx--col-md-12">
-        <div class="bx--tile"></div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-3 {{@root.prefix}}--col-sm-12">
+        <div class="{{@root.prefix}}--tile"></div>
       </div>
-      <div class="bx--col bx--col-lg-2 bx--col-md-12">
-        <div class="bx--tile"></div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-3 {{@root.prefix}}--col-sm-12">
+        <div class="{{@root.prefix}}--tile"></div>
       </div>
-      <div class="bx--col bx--col-lg-2 bx--col-md-12">
-        <div class="bx--tile"></div>
-      </div>
-      <div class="bx--col bx--col-lg-2 bx--col-md-12">
-        <div class="bx--tile"></div>
-      </div>
-      <div class="bx--col bx--col-lg-2 bx--col-md-12">
-        <div class="bx--tile"></div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-3 {{@root.prefix}}--col-sm-12">
+        <div class="{{@root.prefix}}--tile"></div>
       </div>
     </div>
-    <div class="bx--row">
-      <div class="bx--col bx--col-md-8 bx--col-sm-8">
-        <div class="bx--tile"></div>
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-lg-2 {{@root.prefix}}--col-md-12">
+        <div class="{{@root.prefix}}--tile"></div>
       </div>
-      <div class="bx--col bx--col-md-4 bx--col-sm-4">
-        <div class="bx--tile"></div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-lg-2 {{@root.prefix}}--col-md-12">
+        <div class="{{@root.prefix}}--tile"></div>
+      </div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-lg-2 {{@root.prefix}}--col-md-12">
+        <div class="{{@root.prefix}}--tile"></div>
+      </div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-lg-2 {{@root.prefix}}--col-md-12">
+        <div class="{{@root.prefix}}--tile"></div>
+      </div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-lg-2 {{@root.prefix}}--col-md-12">
+        <div class="{{@root.prefix}}--tile"></div>
+      </div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-lg-2 {{@root.prefix}}--col-md-12">
+        <div class="{{@root.prefix}}--tile"></div>
+      </div>
+    </div>
+    <div class="{{@root.prefix}}--row">
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-8 {{@root.prefix}}--col-sm-8">
+        <div class="{{@root.prefix}}--tile"></div>
+      </div>
+      <div class="{{@root.prefix}}--col {{@root.prefix}}--col-md-4 {{@root.prefix}}--col-sm-4">
+        <div class="{{@root.prefix}}--tile"></div>
       </div>
     </div>
   </div>

--- a/src/components/tile/tile--selectable.hbs
+++ b/src/components/tile/tile--selectable.hbs
@@ -1,13 +1,13 @@
-<label for="tile-id" aria-label="tile" class="bx--tile bx--tile--selectable" data-tile="selectable" tabindex="0">
-  <input tabindex="-1" data-tile-input id="tile-id" class="bx--tile-input" value="tile" type="checkbox" name="tiles" title="tile"
+<label for="tile-id" aria-label="tile" class="{{@root.prefix}}--tile {{@root.prefix}}--tile--selectable" data-tile="selectable" tabindex="0">
+  <input tabindex="-1" data-tile-input id="tile-id" class="{{@root.prefix}}--tile-input" value="tile" type="checkbox" name="tiles" title="tile"
   />
-  <div class="bx--tile__checkmark">
+  <div class="{{@root.prefix}}--tile__checkmark">
     <svg width="16" height="16" viewBox="0 0 16 16">
       <path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
         fill-rule="evenodd" />
     </svg>
   </div>
-  <div class="bx--tile-content">
+  <div class="{{@root.prefix}}--tile-content">
     <!-- Tile content here -->
   </div>
 </label>

--- a/src/components/tile/tile.config.js
+++ b/src/components/tile/tile.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/tile/tile.hbs
+++ b/src/components/tile/tile.hbs
@@ -1,1 +1,1 @@
-<div class="bx--tile"></div>
+<div class="{{@root.prefix}}--tile"></div>

--- a/src/components/time-picker/time-picker--light.hbs
+++ b/src/components/time-picker/time-picker--light.hbs
@@ -1,31 +1,31 @@
-<div class="bx--form-item">
-  <div class="bx--time-picker bx--time-picker--light">
-    <div class="bx--time-picker__input">
-      <input id="time-picker-1" type="text" class="bx--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker {{@root.prefix}}--time-picker--light">
+    <div class="{{@root.prefix}}--time-picker__input">
+      <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
         placeholder="hh:mm" maxlength="5" />
-      <div class="bx--form-requirement">
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid time.
       </div>
-      <label for="time-picker-1" class="bx--label">Select a time</label>
+      <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
     </div>
-    <div class="bx--time-picker__select bx--select {{#if componentsX}}{{else}}bx--select--inline{{/if}}">
-      <label for="select-id-1" class="bx--label bx--visually-hidden">Select AM/PM</label>
-      <select id="select-id-1" class="bx--select-input">
-        <option class="bx--select-option" value="AM">AM</option>
-        <option class="bx--select-option" value="PM">PM</option>
+    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      <label for="select-id-1" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-1" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
       </select>
-      <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
     </div>
-    <div class="bx--time-picker__select bx--select {{#if componentsX}}{{else}}bx--select--inline{{/if}}">
-      <label for="select-id-2" class="bx--label bx--visually-hidden">Select time zone</label>
-      <select id="select-id-2" class="bx--select-input">
-        <option class="bx--select-option" value="option-1">Time zone 1</option>
-        <option class="bx--select-option" value="option-2">Time zone 2</option>
-        <option class="bx--select-option" value="option-3">Time zone 3</option>
+    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time zone</label>
+      <select id="select-id-2" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
     </div>

--- a/src/components/time-picker/time-picker.config.js
+++ b/src/components/time-picker/time-picker.config.js
@@ -1,8 +1,12 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
 const { componentsX } = require('../../globals/js/feature-flags');
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/time-picker/time-picker.hbs
+++ b/src/components/time-picker/time-picker.hbs
@@ -1,31 +1,31 @@
-<div class="bx--form-item">
-  <div class="bx--time-picker">
-    <div class="bx--time-picker__input">
-      <input id="time-picker-1" type="text" class="bx--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker">
+    <div class="{{@root.prefix}}--time-picker__input">
+      <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
         placeholder="hh:mm" maxlength="5" />
-      <label for="time-picker-1" class="bx--label">Select a time</label>
-      <div class="bx--form-requirement">
+      <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
+      <div class="{{@root.prefix}}--form-requirement">
         Invalid time.
       </div>
     </div>
-    <div class="bx--time-picker__select bx--select {{#if componentsX}}{{else}}bx--select--inline{{/if}}">
-      <label for="select-id-1" class="bx--label bx--visually-hidden">Select AM/PM</label>
-      <select id="select-id-1" class="bx--select-input">
-        <option class="bx--select-option" value="AM">AM</option>
-        <option class="bx--select-option" value="PM">PM</option>
+    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      <label for="select-id-1" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-1" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
       </select>
-      <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
     </div>
-    <div class="bx--time-picker__select bx--select {{#if componentsX}}{{else}}bx--select--inline{{/if}}">
-      <label for="select-id-2" class="bx--label bx--visually-hidden">Select time zone</label>
-      <select id="select-id-2" class="bx--select-input">
-        <option class="bx--select-option" value="option-1">Time zone 1</option>
-        <option class="bx--select-option" value="option-2">Time zone 2</option>
-        <option class="bx--select-option" value="option-3">Time zone 3</option>
+    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time zone</label>
+      <select id="select-id-2" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      <svg class="bx--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
     </div>

--- a/src/components/toggle/toggle--small.hbs
+++ b/src/components/toggle/toggle--small.hbs
@@ -1,25 +1,25 @@
-<div class="bx--form-item">
-  <input class="bx--toggle bx--toggle--small" id="toggle4" type="checkbox" aria-label="Label Name">
-  <label class="bx--toggle__label" for="toggle4">
-    <span class="bx--toggle__text--left">Off</span>
-    <span class="bx--toggle__appearance">
-      <svg class="bx--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+<div class="{{@root.prefix}}--form-item">
+  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle4" type="checkbox" aria-label="Label Name">
+  <label class="{{@root.prefix}}--toggle__label" for="toggle4">
+    <span class="{{@root.prefix}}--toggle__text--left">Off</span>
+    <span class="{{@root.prefix}}--toggle__appearance">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
         <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z"/>
       </svg>
     </span>
-    <span class="bx--toggle__text--right">On</span>
+    <span class="{{@root.prefix}}--toggle__text--right">On</span>
   </label>
 </div>
 
-<div class="bx--form-item">
-  <input class="bx--toggle bx--toggle--small" id="toggle5" type="checkbox" aria-label="Label Name" disabled>
-  <label class="bx--toggle__label" for="toggle5"> 
-    <span class="bx--toggle__text--left">Off</span>
-    <span class="bx--toggle__appearance">
-      <svg class="bx--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+<div class="{{@root.prefix}}--form-item">
+  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle5" type="checkbox" aria-label="Label Name" disabled>
+  <label class="{{@root.prefix}}--toggle__label" for="toggle5"> 
+    <span class="{{@root.prefix}}--toggle__text--left">Off</span>
+    <span class="{{@root.prefix}}--toggle__appearance">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
         <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z"/>
       </svg>
     </span>
-    <span class="bx--toggle__text--right">On</span>
+    <span class="{{@root.prefix}}--toggle__text--right">On</span>
   </label>
 </div>

--- a/src/components/toggle/toggle.config.js
+++ b/src/components/toggle/toggle.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/toggle/toggle.hbs
+++ b/src/components/toggle/toggle.hbs
@@ -1,29 +1,29 @@
-<div class="bx--form-item">
-  <input class="bx--toggle" id="toggle1" type="checkbox">
-  <label class="bx--toggle__label" for="toggle1">
-    <span class="bx--toggle__text--left">Off</span>
-    <span class="bx--toggle__appearance"></span>
-    <span class="bx--toggle__text--right">On</span>
+<div class="{{@root.prefix}}--form-item">
+  <input class="{{@root.prefix}}--toggle" id="toggle1" type="checkbox">
+  <label class="{{@root.prefix}}--toggle__label" for="toggle1">
+    <span class="{{@root.prefix}}--toggle__text--left">Off</span>
+    <span class="{{@root.prefix}}--toggle__appearance"></span>
+    <span class="{{@root.prefix}}--toggle__text--right">On</span>
   </label>
 </div>
 
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Toggle w/ Label</legend>
-  <div class="bx--form-item">
-    <input class="bx--toggle" id="toggle2" type="checkbox">
-    <label class="bx--toggle__label" for="toggle2">
-    <span class="bx--toggle__text--left">Off</span>
-    <span class="bx--toggle__appearance"></span>
-    <span class="bx--toggle__text--right">On</span>
+<fieldset class="{{@root.prefix}}--fieldset">
+  <legend class="{{@root.prefix}}--label">Toggle w/ Label</legend>
+  <div class="{{@root.prefix}}--form-item">
+    <input class="{{@root.prefix}}--toggle" id="toggle2" type="checkbox">
+    <label class="{{@root.prefix}}--toggle__label" for="toggle2">
+    <span class="{{@root.prefix}}--toggle__text--left">Off</span>
+    <span class="{{@root.prefix}}--toggle__appearance"></span>
+    <span class="{{@root.prefix}}--toggle__text--right">On</span>
   </label>
   </div>
 </fieldset>
 
-<div class="bx--form-item">
-  <input class="bx--toggle" id="toggle3" type="checkbox" disabled>
-  <label class="bx--toggle__label" for="toggle3">
-    <span class="bx--toggle__text--left">Off</span>
-    <span class="bx--toggle__appearance"></span>
-    <span class="bx--toggle__text--right">On</span>
+<div class="{{@root.prefix}}--form-item">
+  <input class="{{@root.prefix}}--toggle" id="toggle3" type="checkbox" disabled>
+  <label class="{{@root.prefix}}--toggle__label" for="toggle3">
+    <span class="{{@root.prefix}}--toggle__text--left">Off</span>
+    <span class="{{@root.prefix}}--toggle__appearance"></span>
+    <span class="{{@root.prefix}}--toggle__text--right">On</span>
   </label>
 </div>

--- a/src/components/toolbar/toolbar.config.js
+++ b/src/components/toolbar/toolbar.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 const filterOptions = [
   {
     id: 'filter-option-1',
@@ -33,6 +35,9 @@ const rowHeightOptions = [
 ];
 
 module.exports = {
+  context: {
+    prefix,
+  },
   variants: [
     {
       name: 'default',

--- a/src/components/toolbar/toolbar.hbs
+++ b/src/components/toolbar/toolbar.hbs
@@ -1,14 +1,14 @@
-<div class="bx--toolbar" data-toolbar>
-  <div class="bx--search bx--search--sm bx--toolbar-search" role="search" data-search data-toolbar-search>
-    <label for="search__input" class="bx--label">Search</label>
-    <input type="text" class="bx--search-input" id="search__input" placeholder="Search">
-    <button class="bx--toolbar-search__btn" aria-label="Toolbar search">
-      <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
+<div class="{{@root.prefix}}--toolbar" data-toolbar>
+  <div class="{{@root.prefix}}--search {{@root.prefix}}--search--sm {{@root.prefix}}--toolbar-search" role="search" data-search data-toolbar-search>
+    <label for="search__input" class="{{@root.prefix}}--label">Search</label>
+    <input type="text" class="{{@root.prefix}}--search-input" id="search__input" placeholder="Search">
+    <button class="{{@root.prefix}}--toolbar-search__btn" aria-label="Toolbar search">
+      <svg class="{{@root.prefix}}--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
         <path d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z"
           fill-rule="nonzero" />
       </svg>
     </button>
-    <button class="bx--search-close bx--search-close--hidden" title="Clear search
+    <button class="{{@root.prefix}}--search-close {{@root.prefix}}--search-close--hidden" title="Clear search
         input" aria-label="Clear search input">
       <svg width="16" height="16" viewBox="0 0 16 16">
         <path d="M8 7.293L5.525 4.818l-.707.707L7.293 8l-2.475 2.475.707.707L8 8.707l2.475 2.475.707-.707L8.707 8l2.475-2.475-.707-.707L8 7.293zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"
@@ -16,21 +16,21 @@
       </svg>
     </button>
   </div>
-  <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">
-    <svg class="bx--overflow-menu__icon bx--toolbar-filter-icon" width="16" height="12" viewBox="0 0 16 12">
+  <div data-overflow-menu class="{{@root.prefix}}--overflow-menu" tabindex="0" aria-label="List of options">
+    <svg class="{{@root.prefix}}--overflow-menu__icon {{@root.prefix}}--toolbar-filter-icon" width="16" height="12" viewBox="0 0 16 12">
       <g fill-rule="nonzero">
         <path d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"
         />
       </g>
     </svg>
-    <ul class="bx--overflow-menu-options">
-      <li class="bx--toolbar-menu__title">FILTER BY</li>
+    <ul class="{{@root.prefix}}--overflow-menu-options">
+      <li class="{{@root.prefix}}--toolbar-menu__title">FILTER BY</li>
       {{#each filterOptions}}
-        <li class="bx--toolbar-menu__option">
-          <input id="{{id}}" class="bx--checkbox" type="checkbox" value="{{value}}" name="checkbox">
-          <label for="{{id}}" class="bx--checkbox-label">
-            <span class="bx--checkbox-appearance">
-              <svg class="bx--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
+        <li class="{{@root.prefix}}--toolbar-menu__option">
+          <input id="{{id}}" class="{{@root.prefix}}--checkbox" type="checkbox" value="{{value}}" name="checkbox">
+          <label for="{{id}}" class="{{@root.prefix}}--checkbox-label">
+            <span class="{{@root.prefix}}--checkbox-appearance">
+              <svg class="{{@root.prefix}}--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
                 <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
               </svg>
             </span>
@@ -40,25 +40,25 @@
       {{/each}}
     </ul>
   </div>
-  <div data-overflow-menu class="bx--overflow-menu" tabindex="0" aria-label="List of options">
-    <svg class="bx--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
+  <div data-overflow-menu class="{{@root.prefix}}--overflow-menu" tabindex="0" aria-label="List of options">
+    <svg class="{{@root.prefix}}--overflow-menu__icon" width="4" height="20" viewBox="0 0 4 20" fill-rule="evenodd">
       <circle cx="2" cy="2" r="2"></circle>
       <circle cx="2" cy="10" r="2"></circle>
       <circle cx="2" cy="18" r="2"></circle>
     </svg>
-    <ul class="bx--overflow-menu-options">
-      <li class="bx--overflow-menu-options__option">
-        <button type="button" class="bx--overflow-menu-options__btn">Refresh table</button>
+    <ul class="{{@root.prefix}}--overflow-menu-options">
+      <li class="{{@root.prefix}}--overflow-menu-options__option">
+        <button type="button" class="{{@root.prefix}}--overflow-menu-options__btn">Refresh table</button>
       </li>
-      <hr class="bx--toolbar-menu__divider" />
-      <li class="bx--toolbar-menu__title">ROW HEIGHT</li>
-      <fieldset data-row-height class="bx--radio-button-group">
-        <legend class="bx--visually-hidden">Select table row height</legend>
+      <hr class="{{@root.prefix}}--toolbar-menu__divider" />
+      <li class="{{@root.prefix}}--toolbar-menu__title">ROW HEIGHT</li>
+      <fieldset data-row-height class="{{@root.prefix}}--radio-button-group">
+        <legend class="{{@root.prefix}}--visually-hidden">Select table row height</legend>
         {{#each rowHeightOptions}}
-          <li class="bx--toolbar-menu__option">
-            <input id="{{id}}" class="bx--radio-button" type="radio" value="{{value}}" name="radio"{{#if selected}} checked{{/if}}>
-            <label for="{{id}}" class="bx--radio-button__label">
-              <span class="bx--radio-button__appearance"></span>
+          <li class="{{@root.prefix}}--toolbar-menu__option">
+            <input id="{{id}}" class="{{@root.prefix}}--radio-button" type="radio" value="{{value}}" name="radio"{{#if selected}} checked{{/if}}>
+            <label for="{{id}}" class="{{@root.prefix}}--radio-button__label">
+              <span class="{{@root.prefix}}--radio-button__appearance"></span>
               {{label}}
             </label>
           </li>

--- a/src/components/tooltip/tooltip--definition.hbs
+++ b/src/components/tooltip/tooltip--definition.hbs
@@ -1,9 +1,9 @@
-<div class="bx--tooltip--definition">
-  <button class="bx--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
+<div class="{{@root.prefix}}--tooltip--definition">
+  <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
     Definition Tooltip
   </button>
-  <div id="definition-tooltip" role="tooltip" class="bx--tooltip--definition__bottom">
-    <span class="bx--tooltip__caret"></span>
+  <div id="definition-tooltip" role="tooltip" class="{{@root.prefix}}--tooltip--definition__bottom">
+    <span class="{{@root.prefix}}--tooltip__caret"></span>
     <p>Brief description of the dotted, underlined word above.</p>
   </div>
 </div>

--- a/src/components/tooltip/tooltip--icon.hbs
+++ b/src/components/tooltip/tooltip--icon.hbs
@@ -1,5 +1,5 @@
-<div class="bx--tooltip--icon">
-  <button class="bx--tooltip__trigger bx--tooltip--icon__top" aria-label="Filter">
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top" aria-label="Filter">
     <svg width="16" height="12" viewBox="0 0 16 12">
       <path d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
     </svg>

--- a/src/components/tooltip/tooltip.config.js
+++ b/src/components/tooltip/tooltip.config.js
@@ -3,7 +3,6 @@
 const { prefix } = require('../../globals/js/settings');
 
 module.exports = {
-  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/tooltip/tooltip.hbs
+++ b/src/components/tooltip/tooltip.hbs
@@ -1,6 +1,6 @@
-<div id="tooltip-label" class="bx--tooltip__label" aria-describedby="unique-tooltip">
+<div id="tooltip-label" class="{{@root.prefix}}--tooltip__label" aria-describedby="unique-tooltip">
   Tooltip label
-  <div tabindex="0" aria-labelledby="tooltip-label" data-tooltip-trigger data-tooltip-target="#unique-tooltip" role="tooltip" class="bx--tooltip__trigger">
+  <div tabindex="0" aria-labelledby="tooltip-label" data-tooltip-trigger data-tooltip-target="#unique-tooltip" role="tooltip" class="{{@root.prefix}}--tooltip__trigger">
     <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
       <g fill-rule="evenodd">
         <path d="M8 14.5a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="nonzero" />
@@ -10,13 +10,13 @@
     </svg>
   </div>
 </div>
-<div id="unique-tooltip" data-floating-menu-direction="bottom" class="bx--tooltip" data-avoid-focus-on-open>
-  <span class="bx--tooltip__caret"></span>
+<div id="unique-tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip" data-avoid-focus-on-open>
+  <span class="{{@root.prefix}}--tooltip__caret"></span>
   <p>This is some tooltip text. This box shows the maximum amount of text that should appear inside. If more room is
     needed
     please use a modal instead.</p>
-  <div class="bx--tooltip__footer">
-    <a href="#" class="bx--link">Learn More</a>
-    <button class="bx--btn bx--btn--primary" type="button">Create</button>
+  <div class="{{@root.prefix}}--tooltip__footer">
+    <a href="#" class="{{@root.prefix}}--link">Learn More</a>
+    <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary" type="button">Create</button>
   </div>
 </div>

--- a/src/components/ui-shell/header-nav.hbs
+++ b/src/components/ui-shell/header-nav.hbs
@@ -9,34 +9,34 @@
   Most noticeably, the first menuitem in a submenu should receive a tabindex of
   "0", while the rest should get "-1"
 -->
-<nav class="bx--header__nav" aria-label="Platform Name">
-  <ul class="bx--header__menu-bar" role="menubar" aria-label="Platform Name">
+<nav class="{{@root.prefix}}--header__nav" aria-label="Platform Name">
+  <ul class="{{@root.prefix}}--header__menu-bar" role="menubar" aria-label="Platform Name">
     {{#each header.navLinks}}
       {{#if href}}
         <li>
-          <a class="bx--header__menu-item" href="javascript:void(0)" role="menuitem" tabindex="0">
+          <a class="{{@root.prefix}}--header__menu-item" href="javascript:void(0)" role="menuitem" tabindex="0">
             {{this.title}}
           </a>
         </li>
       {{else}}
-        <li class="bx--header__submenu">
+        <li class="{{@root.prefix}}--header__submenu">
           <a
-            class="bx--header__menu-item bx--header__menu-title"
+            class="{{@root.prefix}}--header__menu-item {{@root.prefix}}--header__menu-title"
             role="menuitem"
             aria-haspopup="true"
             aria-expanded="{{this.state.expanded}}"
             href="javascript:void(0)"
             tabindex="0">
             {{this.title}}
-            <svg class="bx--header__menu-arrow" width="12" height="7" aria-hidden="true">
+            <svg class="{{@root.prefix}}--header__menu-arrow" width="12" height="7" aria-hidden="true">
               <path d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z"/>
             </svg>
           </a>
-          <ul class="bx--header__menu" role="menu" aria-label="{{this.title}}">
+          <ul class="{{@root.prefix}}--header__menu" role="menu" aria-label="{{this.title}}">
             {{#each this.items}}
               <li role="none">
-                <a class="bx--header__menu-item" role="menuitem" href="{{this.href}}" tabindex="-1">
-                  <span class="bx--text-truncate--end">
+                <a class="{{@root.prefix}}--header__menu-item" role="menuitem" href="{{this.href}}" tabindex="-1">
+                  <span class="{{@root.prefix}}--text-truncate--end">
                     {{this.title}}
                   </span>
                 </a>

--- a/src/components/ui-shell/header.hbs
+++ b/src/components/ui-shell/header.hbs
@@ -1,21 +1,21 @@
-<header class="bx--header" role="banner" aria-label="IBM Platform Name">
-  <a class="bx--skip-to-content" href="#main-content" tabindex="0">Skip to main content</a>
+<header class="{{@root.prefix}}--header" role="banner" aria-label="IBM Platform Name">
+  <a class="{{@root.prefix}}--skip-to-content" href="#main-content" tabindex="0">Skip to main content</a>
   {{#if nav.state.expanded}}
-  <button class="bx--header__menu-trigger bx--header__action
-  bx--header__action--active" aria-label="Close menu" title="Close menu">
+  <button class="{{@root.prefix}}--header__menu-trigger {{@root.prefix}}--header__action
+  {{@root.prefix}}--header__action--active" aria-label="Close menu" title="Close menu">
     <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M17.414 16L24 9.414 22.586 8 16 14.586 9.414 8 8 9.414 14.586 16 8 22.586 9.414 24 16 17.414 22.586 24 24 22.586 17.414 16z"/></svg>
   {{else}}
-  <button class="bx--header__menu-trigger bx--header__action" aria-label="Open menu" title="Open menu">
+  <button class="{{@root.prefix}}--header__menu-trigger {{@root.prefix}}--header__action" aria-label="Open menu" title="Open menu">
     <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M4 6h24v2H4zm0 18h24v2H4zm0-9h24v2H4z"/></svg>
   {{/if}}
   </button>
-  <a class="bx--header__name" href="#" title="{{header.name}}">
-    {{header.company}} <span class="bx--header__name">{{header.platform}}</span>
+  <a class="{{@root.prefix}}--header__name" href="#" title="{{header.name}}">
+    {{header.company}} <span class="{{@root.prefix}}--header__name">{{header.platform}}</span>
   </a>
   {{> header-nav }}
-  <div class="bx--header__global">
+  <div class="{{@root.prefix}}--header__global">
     {{#each header.actions}}
-    <button class="bx--header__action" aria-label="{{this.title}} " title="{{this.title}}">
+    <button class="{{@root.prefix}}--header__action" aria-label="{{this.title}} " title="{{this.title}}">
       <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
         <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
       </svg>

--- a/src/components/ui-shell/nav.hbs
+++ b/src/components/ui-shell/nav.hbs
@@ -1,26 +1,26 @@
 {{#if nav.state.expanded}}
-<div class="bx--navigation">
+<div class="{{@root.prefix}}--navigation">
   {{#each nav.sections}}
-  <div class="bx--navigation-section">
-    <ul class="bx--navigation-items">
+  <div class="{{@root.prefix}}--navigation-section">
+    <ul class="{{@root.prefix}}--navigation-items">
       {{#each this.items}}
         {{#if this.active}}
           {{#if this.hasIcon}}
-        <li class="bx--navigation-item bx--navigation-item--active bx--navigation-item--icon">
+        <li class="{{@root.prefix}}--navigation-item {{@root.prefix}}--navigation-item--active {{@root.prefix}}--navigation-item--icon">
           {{else}}
-        <li class="bx--navigation-item bx--navigation-item--active">
+        <li class="{{@root.prefix}}--navigation-item {{@root.prefix}}--navigation-item--active">
           {{/if}}
         {{else}}
           {{#if this.hasIcon}}
-        <li class="bx--navigation-item bx--navigation-item--icon">
+        <li class="{{@root.prefix}}--navigation-item {{@root.prefix}}--navigation-item--icon">
           {{else}}
-        <li class="bx--navigation-item">
+        <li class="{{@root.prefix}}--navigation-item">
           {{/if}}
         {{/if}}
         {{#eq this.type "link"}}
-          <a class="bx--navigation-link" href="{{ this.href }}">
+          <a class="{{@root.prefix}}--navigation-link" href="{{ this.href }}">
             {{#if this.hasIcon}}
-            <div class="bx--navigation-icon">
+            <div class="{{@root.prefix}}--navigation-icon">
               <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
                 <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
               </svg>
@@ -31,34 +31,34 @@
         {{/eq}}
         {{#eq this.type "category"}}
           {{#if ../../nav.state.category}}
-          <div class="bx--navigation__category bx--navigation__category--expanded">
+          <div class="{{@root.prefix}}--navigation__category {{@root.prefix}}--navigation__category--expanded">
           {{else}}
-          <div class="bx--navigation__category">
+          <div class="{{@root.prefix}}--navigation__category">
           {{/if}}
-            <button class="bx--navigation__category-toggle" aria-haspopup="true" aria-expanded="true" aria-controls="category-1-menu">
+            <button class="{{@root.prefix}}--navigation__category-toggle" aria-haspopup="true" aria-expanded="true" aria-controls="category-1-menu">
               {{#if this.hasIcon}}
-              <div class="bx--navigation-icon">
+              <div class="{{@root.prefix}}--navigation-icon">
 
                 <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
                   <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
                 </svg>
               </div>
               {{/if}}
-              <div class="bx--navigation__category-title">
+              <div class="{{@root.prefix}}--navigation__category-title">
                 {{ this.title }}
                 <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
                   <path d="M16 22L6 12l1.414-1.414L16 19.172l8.586-8.586L26 12 16 22z"/>
                 </svg>
               </div>
             </button>
-            <ul id="category-1-menu" class="bx--navigation__category-items" role="menu">
+            <ul id="category-1-menu" class="{{@root.prefix}}--navigation__category-items" role="menu">
               {{#each this.links}}
                 {{#if this.active}}
-                <li class="bx--navigation__category-item bx--navigation__category-item--active">
+                <li class="{{@root.prefix}}--navigation__category-item {{@root.prefix}}--navigation__category-item--active">
                 {{else}}
-                <li class="bx--navigation__category-item">
+                <li class="{{@root.prefix}}--navigation__category-item">
                 {{/if}}
-                  <a class="bx--navigation-link" href="{{ this.href }}" role="menuitem">
+                  <a class="{{@root.prefix}}--navigation-link" href="{{ this.href }}" role="menuitem">
                     {{ this.title }}
                   </a>
                 </li>

--- a/src/components/ui-shell/product-switcher.hbs
+++ b/src/components/ui-shell/product-switcher.hbs
@@ -1,18 +1,18 @@
 {{#if switcher.state.expanded}}
-  <aside class="bx--panel--overlay bx--panel--expanded">
+  <aside class="{{@root.prefix}}--panel--overlay {{@root.prefix}}--panel--expanded">
 {{else}}
-  <aside class="bx--panel--overlay">
+  <aside class="{{@root.prefix}}--panel--overlay">
 {{/if}}
-    <div class="bx--product-switcher">
-      <div class="bx--product-switcher__search">
-        <div class="bx--form-item">
-          <div data-search class="bx--search bx--search--sm bx--search--shell" role="search">
-            <label id="search-input-label-1" class="bx--label" for="search__input-1">Search</label>
-            <input class="bx--search-input" type="text" role="search" id="search__input-1" placeholder="Search all products" aria-labelledby="search-input-label-2">
-            <svg class="bx--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
+    <div class="{{@root.prefix}}--product-switcher">
+      <div class="{{@root.prefix}}--product-switcher__search">
+        <div class="{{@root.prefix}}--form-item">
+          <div data-search class="{{@root.prefix}}--search {{@root.prefix}}--search--sm {{@root.prefix}}--search--shell" role="search">
+            <label id="search-input-label-1" class="{{@root.prefix}}--label" for="search__input-1">Search</label>
+            <input class="{{@root.prefix}}--search-input" type="text" role="search" id="search__input-1" placeholder="Search all products" aria-labelledby="search-input-label-2">
+            <svg class="{{@root.prefix}}--search-magnifier" width="16" height="16" viewBox="0 0 16 16">
                 <path d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z" fill-rule="nonzero" />
             </svg>
-            <button class="bx--search-close bx--search-close--hidden" title="Clear search input" aria-label="Clear search input">
+            <button class="{{@root.prefix}}--search-close {{@root.prefix}}--search-close--hidden" title="Clear search input" aria-label="Clear search input">
               <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                 <path d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
               </svg>
@@ -21,39 +21,39 @@
         </div>
       </div>
       {{#if switcher.state.showAll}}
-        <div class="bx--product-switcher__item">
-          <button aria-label="Back" tabindex="0" class="bx--product-switcher__back-btn">
-            <svg class="bx--product-switcher__back-arrow" width="20" height="20" viewBox="0 0 16 14">
+        <div class="{{@root.prefix}}--product-switcher__item">
+          <button aria-label="Back" tabindex="0" class="{{@root.prefix}}--product-switcher__back-btn">
+            <svg class="{{@root.prefix}}--product-switcher__back-arrow" width="20" height="20" viewBox="0 0 16 14">
               <path d="M4.044 8.003l4.09 3.905-1.374 1.453-6.763-6.356L6.759.639 8.135 2.09 4.043 6.003h11.954v2H4.044z" />
             </svg>
             Back
           </button>
         </div>
-        <ul class="bx--product-switcher__product-list">
+        <ul class="{{@root.prefix}}--product-switcher__product-list">
           {{#each switcher.allLinks}}
-            <li class="bx--product-list__item">
-              <a class="bx--product-link" tabindex="0" href="#">
-                <div class="bx--product-switcher__icon">
+            <li class="{{@root.prefix}}--product-list__item">
+              <a class="{{@root.prefix}}--product-link" tabindex="0" href="#">
+                <div class="{{@root.prefix}}--product-switcher__icon">
                   <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
                     <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
                   </svg>
                 </div>
-                <span class="bx--product-link__name">{{ this.title }}</span>
+                <span class="{{@root.prefix}}--product-link__name">{{ this.title }}</span>
               </a>
-              <div data-overflow-menu tabindex="0" aria-label="Overflow menu description" class="bx--overflow-menu">
-                  <svg class="bx--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
+              <div data-overflow-menu tabindex="0" aria-label="Overflow menu description" class="{{@root.prefix}}--overflow-menu">
+                  <svg class="{{@root.prefix}}--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
                     <g fill-rule="evenodd">
                       <circle cx="1.5" cy="1.5" r="1.5" />
                       <circle cx="1.5" cy="7.5" r="1.5" />
                       <circle cx="1.5" cy="13.5" r="1.5" />
                     </g>
                   </svg>
-                  <ul class="bx--overflow-menu-options bx--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="bottom">
-                    <li class="bx--overflow-menu-options__option bx--overflow__item">
-                      <button class="bx--overflow-menu-options__btn" title="Option 1" data-floating-menu-primary-focus>Option 1</button>
+                  <ul class="{{@root.prefix}}--overflow-menu-options {{@root.prefix}}--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="bottom">
+                    <li class="{{@root.prefix}}--overflow-menu-options__option {{@root.prefix}}--overflow__item">
+                      <button class="{{@root.prefix}}--overflow-menu-options__btn" title="Option 1" data-floating-menu-primary-focus>Option 1</button>
                     </li>
-                    <li class="bx--overflow-menu-options__option">
-                      <button class="bx--overflow-menu-options__btn">Option 2</button>
+                    <li class="{{@root.prefix}}--overflow-menu-options__option">
+                      <button class="{{@root.prefix}}--overflow-menu-options__btn">Option 2</button>
                     </li>
                   </ul>
                 </div>
@@ -61,28 +61,28 @@
           {{/each}}
         </ul>
       {{else}}
-        <p class="bx--product-switcher__subheader">My Products</p>
-        <ul class="bx--product-switcher__product-list">
+        <p class="{{@root.prefix}}--product-switcher__subheader">My Products</p>
+        <ul class="{{@root.prefix}}--product-switcher__product-list">
           {{#each switcher.links}}
-            <li class="bx--product-list__item">
-              <a class="bx--product-link" tabindex="0" href="#">
-                <div class="bx--product-switcher__icon">
+            <li class="{{@root.prefix}}--product-list__item">
+              <a class="{{@root.prefix}}--product-link" tabindex="0" href="#">
+                <div class="{{@root.prefix}}--product-switcher__icon">
                   <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
                     <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
                   </svg>
                 </div>
-                <span class="bx--product-link__name">{{ this.title }}</span>
+                <span class="{{@root.prefix}}--product-link__name">{{ this.title }}</span>
               </a>
-              <div data-overflow-menu tabindex="0" aria-label="Overflow menu description" class="bx--overflow-menu">
+              <div data-overflow-menu tabindex="0" aria-label="Overflow menu description" class="{{@root.prefix}}--overflow-menu">
                   <svg width="3" height="15" viewBox="0 0 3 15">
                     <path d="M0 1.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 1 1-3 0M0 7.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 1 1-3 0M0 13.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 1 1-3 0"></path>
                   </svg>
-                  <ul class="bx--overflow-menu-options bx--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="bottom">
-                    <li class="bx--overflow-menu-options__option bx--overflow__item">
-                      <button class="bx--overflow-menu-options__btn" title="Option 1" data-floating-menu-primary-focus>Option 1</button>
+                  <ul class="{{@root.prefix}}--overflow-menu-options {{@root.prefix}}--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="bottom">
+                    <li class="{{@root.prefix}}--overflow-menu-options__option {{@root.prefix}}--overflow__item">
+                      <button class="{{@root.prefix}}--overflow-menu-options__btn" title="Option 1" data-floating-menu-primary-focus>Option 1</button>
                     </li>
-                    <li class="bx--overflow-menu-options__option">
-                      <button class="bx--overflow-menu-options__btn">Option 2</button>
+                    <li class="{{@root.prefix}}--overflow-menu-options__option">
+                      <button class="{{@root.prefix}}--overflow-menu-options__btn">Option 2</button>
                     </li>
                   </ul>
                 </div>
@@ -92,8 +92,8 @@
 
         {{#if switcher.state.showAll}}
         {{else}}
-          <div class="bx--product-switcher__item">
-            <button aria-label="Show All Applications" tabindex="0" class="bx--product-switcher__all-btn">
+          <div class="{{@root.prefix}}--product-switcher__item">
+            <button aria-label="Show All Applications" tabindex="0" class="{{@root.prefix}}--product-switcher__all-btn">
               View all products
             </button>
           </div>

--- a/src/components/ui-shell/side-nav-fixed.hbs
+++ b/src/components/ui-shell/side-nav-fixed.hbs
@@ -1,31 +1,31 @@
-<aside class="bx--side-nav bx--side-nav--fixed" data-side-nav>
-  <nav class="bx--side-nav__navigation" role="navigation" aria-label="Side navigation">
-    <ul class="bx--side-nav__items">
-      <li class="bx--side-nav__item">
-        <a class="bx--side-nav__link" href="javascript:void(0)">
-          <span class="bx--side-nav__link-text">Link</span>
+<aside class="{{@root.prefix}}--side-nav {{@root.prefix}}--side-nav--fixed" data-side-nav>
+  <nav class="{{@root.prefix}}--side-nav__navigation" role="navigation" aria-label="Side navigation">
+    <ul class="{{@root.prefix}}--side-nav__items">
+      <li class="{{@root.prefix}}--side-nav__item">
+        <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
+          <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
         </a>
       </li>
-      <li class="bx--side-nav__item bx--side-nav__item--active">
+      <li class="{{@root.prefix}}--side-nav__item {{@root.prefix}}--side-nav__item--active">
         <a
-          class="bx--side-nav__link bx--side-nav__link--current"
+          class="{{@root.prefix}}--side-nav__link {{@root.prefix}}--side-nav__link--current"
           href="javascript:void(0)"
           aria-current="page">
-          <span class="bx--side-nav__link-text">
+          <span class="{{@root.prefix}}--side-nav__link-text">
             Link with really long text that should wrap - active
           </span>
         </a>
       </li>
-      <li class="bx--side-nav__item">
+      <li class="{{@root.prefix}}--side-nav__item">
         <button
-          class="bx--side-nav__submenu"
+          class="{{@root.prefix}}--side-nav__submenu"
           role="button"
           aria-haspopup="true"
           aria-expanded="false">
-          <span class="bx--side-nav__submenu-title">
+          <span class="{{@root.prefix}}--side-nav__submenu-title">
             Category title that is really long and probably should overflow
           </span>
-          <div class="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small {{@root.prefix}}--side-nav__submenu-chevron">
             <svg
               aria-hidden="true"
               width="20"
@@ -36,34 +36,34 @@
             </svg>
           </div>
         </button>
-        <ul class="bx--side-nav__menu" role="menu" hidden="">
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
+        <ul class="{{@root.prefix}}--side-nav__menu" role="menu" hidden="">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
               Link
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
               Link
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="menuitem">
-            <a class="bx--side-nav__link" href="javascript:void(0)">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               Link
             </a>
           </li>
         </ul>
       </li>
-      <li class="bx--side-nav__item bx--side-nav__item--active">
+      <li class="{{@root.prefix}}--side-nav__item {{@root.prefix}}--side-nav__item--active">
         <button
-          class="bx--side-nav__submenu"
+          class="{{@root.prefix}}--side-nav__submenu"
           role="button"
           aria-haspopup="true"
           aria-expanded="true">
-          <span class="bx--side-nav__submenu-title">
+          <span class="{{@root.prefix}}--side-nav__submenu-title">
             Category title that is really long and probably should overflow
           </span>
-          <div class="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small {{@root.prefix}}--side-nav__submenu-chevron">
             <svg
               aria-hidden="true"
               width="20"
@@ -74,37 +74,37 @@
             </svg>
           </div>
         </button>
-        <ul class="bx--side-nav__menu" role="menu">
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
-              <span class="bx--side-nav__link-text">
+        <ul class="{{@root.prefix}}--side-nav__menu" role="menu">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+              <span class="{{@root.prefix}}--side-nav__link-text">
                 Link with really long text that probably should be truncated
               </span>
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
             <a
-              class="bx--side-nav__link"
+              class="{{@root.prefix}}--side-nav__link"
               href="javascript:void(0)"
               role="menuitem"
               aria-current="page">
-              <span class="bx--side-nav__link-text">
+              <span class="{{@root.prefix}}--side-nav__link-text">
                 Link with really long text that probably should be truncated
               </span>
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
-              <span class="bx--side-nav__link-text">Link</span>
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+              <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
             <a
-              class="bx--side-nav__link"
+              class="{{@root.prefix}}--side-nav__link"
               href="javascript:void(0)"
               role="menuitem"
               aria-current="page">
-              <span class="bx--side-nav__link-text">Link</span>
+              <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
             </a>
           </li>
         </ul>

--- a/src/components/ui-shell/side-nav-footer.hbs
+++ b/src/components/ui-shell/side-nav-footer.hbs
@@ -1,16 +1,16 @@
-<footer class="bx--side-nav__footer">
+<footer class="{{@root.prefix}}--side-nav__footer">
   <button
-    class="bx--side-nav__toggle"
+    class="{{@root.prefix}}--side-nav__toggle"
     role="button"
     title="Close the side navigation menu">
-    <div class="bx--side-nav__icon">
+    <div class="{{@root.prefix}}--side-nav__icon">
       {{#if expanded}}
       <svg aria-hidden="true"width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M17.414 16L24 9.414 22.586 8 16 14.586 9.414 8 8 9.414 14.586 16 8 22.586 9.414 24 16 17.414 22.586 24 24 22.586 17.414 16z"/></svg>
       {{else}}
       <svg aria-hidden="true"width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M22 16L12 26l-1.414-1.414L19.172 16l-8.586-8.586L12 6l10 10z"/></svg>
       {{/if}}
     </div>
-    <span class="bx--assistive-text">
+    <span class="{{@root.prefix}}--assistive-text">
       Toggle the expansion state of the navigation
     </span>
   </button>

--- a/src/components/ui-shell/side-nav-header.hbs
+++ b/src/components/ui-shell/side-nav-header.hbs
@@ -1,6 +1,6 @@
 {{#if sidenav.title}}
-<header class="bx--side-nav__header">
-  <div class="bx--side-nav__icon">
+<header class="{{@root.prefix}}--side-nav__header">
+  <div class="{{@root.prefix}}--side-nav__icon">
     <svg
       width="20"
       height="20"
@@ -10,37 +10,37 @@
       <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
     </svg>
   </div>
-  <div class="bx--side-nav__details">
+  <div class="{{@root.prefix}}--side-nav__details">
     <h2
-      class="bx--side-nav__title"
+      class="{{@root.prefix}}--side-nav__title"
       title="{{ sidenav.title.text }}">
       {{ sidenav.title.text }}
     </h2>
     {{#if sidenav.title.subMenu }}
-    <div class="bx--side-nav__switcher">
-      <label for="side-nav-switcher" class="bx--assistive-text">
+    <div class="{{@root.prefix}}--side-nav__switcher">
+      <label for="side-nav-switcher" class="{{@root.prefix}}--assistive-text">
         {{ sidenav.title.subMenu.label }}
       </label>
-      <select id="side-nav-switcher" class="bx--side-nav__select" name="Switcher">
+      <select id="side-nav-switcher" class="{{@root.prefix}}--side-nav__select" name="Switcher">
         <option
-          class="bx--side-nav__option"
+          class="{{@root.prefix}}--side-nav__option"
           disabled=""
           hidden=""
           value=""
           selected="">
           {{ sidenav.title.subMenu.label }}
         </option>
-        <option class="bx--side-nav__option" value="Option 1">
+        <option class="{{@root.prefix}}--side-nav__option" value="Option 1">
           Option 1
         </option>
-        <option class="bx--side-nav__option" value="Option 2">
+        <option class="{{@root.prefix}}--side-nav__option" value="Option 2">
           Option 2
         </option>
-        <option class="bx--side-nav__option" value="Option 3">
+        <option class="{{@root.prefix}}--side-nav__option" value="Option 3">
           Option 3
         </option>
       </select>
-      <div class="bx--side-nav__switcher-chevron">
+      <div class="{{@root.prefix}}--side-nav__switcher-chevron">
         <svg
           aria-hidden="true"
           width="20"

--- a/src/components/ui-shell/side-nav.hbs
+++ b/src/components/ui-shell/side-nav.hbs
@@ -1,14 +1,14 @@
 {{#if sidenav.state.expanded}}
-<aside class="bx--side-nav bx--side-nav--expanded" data-side-nav>
+<aside class="{{@root.prefix}}--side-nav {{@root.prefix}}--side-nav--expanded" data-side-nav>
 {{else}}
-<aside class="bx--side-nav" data-side-nav>
+<aside class="{{@root.prefix}}--side-nav" data-side-nav>
 {{/if}}
-  <nav class="bx--side-nav__navigation" role="navigation" aria-label="Side navigation">
+  <nav class="{{@root.prefix}}--side-nav__navigation" role="navigation" aria-label="Side navigation">
     {{> side-nav-header sidenav=sidenav }}
-    <ul class="bx--side-nav__items">
-      <li class="bx--side-nav__item">
-        <a class="bx--side-nav__link" href="javascript:void(0)">
-          <div class="bx--side-nav__icon bx--side-nav__icon--small">
+    <ul class="{{@root.prefix}}--side-nav__items">
+      <li class="{{@root.prefix}}--side-nav__item">
+        <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg
               width="20"
               height="20"
@@ -18,12 +18,12 @@
               <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
-          <span class="bx--side-nav__link-text">Link</span>
+          <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
         </a>
       </li>
-      <li class="bx--side-nav__item bx--side-nav__item--active">
-        <a class="bx--side-nav__link" href="javascript:void(0)" aria-current="page">
-          <div class="bx--side-nav__icon bx--side-nav__icon--small">
+      <li class="{{@root.prefix}}--side-nav__item {{@root.prefix}}--side-nav__item--active">
+        <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" aria-current="page">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg
               width="20"
               height="20"
@@ -33,12 +33,12 @@
               <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
-          <span class="bx--side-nav__link-text">Link - active</span>
+          <span class="{{@root.prefix}}--side-nav__link-text">Link - active</span>
         </a>
       </li>
-      <li class="bx--side-nav__item">
-        <a class="bx--side-nav__link" href="javascript:void(0)">
-          <div class="bx--side-nav__icon bx--side-nav__icon--small">
+      <li class="{{@root.prefix}}--side-nav__item">
+        <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg
               width="20"
               height="20"
@@ -48,17 +48,17 @@
               <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
-          <span class="bx--side-nav__link-text">
+          <span class="{{@root.prefix}}--side-nav__link-text">
             Link with really long text that should wrap
           </span>
         </a>
       </li>
-      <li class="bx--side-nav__item bx--side-nav__item--active">
+      <li class="{{@root.prefix}}--side-nav__item {{@root.prefix}}--side-nav__item--active">
         <a
-          class="bx--side-nav__link bx--side-nav__link--current"
+          class="{{@root.prefix}}--side-nav__link {{@root.prefix}}--side-nav__link--current"
           href="javascript:void(0)"
           aria-current="page">
-          <div class="bx--side-nav__icon bx--side-nav__icon--small">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg
               width="20"
               height="20"
@@ -68,18 +68,18 @@
               <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
-          <span class="bx--side-nav__link-text">
+          <span class="{{@root.prefix}}--side-nav__link-text">
             Link with really long text that should wrap - active
           </span>
         </a>
       </li>
-      <li class="bx--side-nav__item">
+      <li class="{{@root.prefix}}--side-nav__item">
         <button
-          class="bx--side-nav__submenu"
+          class="{{@root.prefix}}--side-nav__submenu"
           type="button"
           aria-haspopup="true"
           aria-expanded="false">
-          <div class="bx--side-nav__icon">
+          <div class="{{@root.prefix}}--side-nav__icon">
             <svg
               width="20"
               height="20"
@@ -89,10 +89,10 @@
               <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
-          <span class="bx--side-nav__submenu-title">
+          <span class="{{@root.prefix}}--side-nav__submenu-title">
             Category title that is really long and probably should overflow
           </span>
-          <div class="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small {{@root.prefix}}--side-nav__submenu-chevron">
             <svg
               aria-hidden="true"
               width="20"
@@ -103,31 +103,31 @@
             </svg>
           </div>
         </button>
-        <ul class="bx--side-nav__menu" role="menu" hidden="">
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
+        <ul class="{{@root.prefix}}--side-nav__menu" role="menu" hidden="">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
               Link
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
               Link
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="menuitem">
-            <a class="bx--side-nav__link" href="javascript:void(0)">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               Link
             </a>
           </li>
         </ul>
       </li>
-      <li class="bx--side-nav__item bx--side-nav__item--active">
+      <li class="{{@root.prefix}}--side-nav__item {{@root.prefix}}--side-nav__item--active">
         <button
-          class="bx--side-nav__submenu"
+          class="{{@root.prefix}}--side-nav__submenu"
           type="button"
           aria-haspopup="true"
           aria-expanded="true">
-          <div class="bx--side-nav__icon">
+          <div class="{{@root.prefix}}--side-nav__icon">
             <svg
               width="20"
               height="20"
@@ -137,10 +137,10 @@
               <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
-          <span class="bx--side-nav__submenu-title">
+          <span class="{{@root.prefix}}--side-nav__submenu-title">
             Category title that is really long and probably should overflow
           </span>
-          <div class="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron">
+          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small {{@root.prefix}}--side-nav__submenu-chevron">
             <svg
               aria-hidden="true"
               width="20"
@@ -151,37 +151,37 @@
             </svg>
           </div>
         </button>
-        <ul class="bx--side-nav__menu" role="menu">
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
-              <span class="bx--side-nav__link-text">
+        <ul class="{{@root.prefix}}--side-nav__menu" role="menu">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+              <span class="{{@root.prefix}}--side-nav__link-text">
                 Link with really long text that probably should be truncated
               </span>
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
             <a
-              class="bx--side-nav__link"
+              class="{{@root.prefix}}--side-nav__link"
               href="javascript:void(0)"
               role="menuitem"
               aria-current="page">
-              <span class="bx--side-nav__link-text">
+              <span class="{{@root.prefix}}--side-nav__link-text">
                 Link with really long text that probably should be truncated
               </span>
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
-            <a class="bx--side-nav__link" href="javascript:void(0)" role="menuitem">
-              <span class="bx--side-nav__link-text">Link</span>
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+              <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
             </a>
           </li>
-          <li class="bx--side-nav__menu-item" role="none">
+          <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
             <a
-              class="bx--side-nav__link"
+              class="{{@root.prefix}}--side-nav__link"
               href="javascript:void(0)"
               role="menuitem"
               aria-current="page">
-              <span class="bx--side-nav__link-text">Link</span>
+              <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
             </a>
           </li>
         </ul>

--- a/src/components/ui-shell/ui-shell.config.js
+++ b/src/components/ui-shell/ui-shell.config.js
@@ -1,3 +1,5 @@
+const { prefix } = require('../../globals/js/settings');
+
 const header = {
   company: 'IBM',
   platform: '[Platform]',
@@ -224,6 +226,7 @@ module.exports = {
     linkOnly: true,
   },
   context: {
+    prefix,
     header,
     nav,
     sidenav,

--- a/src/components/unified-header/unified-header.config.js
+++ b/src/components/unified-header/unified-header.config.js
@@ -1,8 +1,13 @@
 'use strict';
 
+const { prefix } = require('../../globals/js/settings');
+
 module.exports = {
   hidden: true,
   meta: {
     useIframe: true,
+  },
+  context: {
+    prefix,
   },
 };

--- a/src/components/unified-header/unified-header.hbs
+++ b/src/components/unified-header/unified-header.hbs
@@ -1,102 +1,102 @@
 <!-- Unified Header -->
-<div data-unified-header class="bx--unified-header bx--unified-header--apps" tabindex="0">
+<div data-unified-header class="{{@root.prefix}}--unified-header {{@root.prefix}}--unified-header--apps" tabindex="0">
 
   <!-- Super Global Header -->
-  <nav role="navigation" class="bx--top-nav" aria-label="Top Header">
-      <ul role="menubar" class="bx--top-nav__left-container" aria-hidden="false">
-        <li role="menuitem" class="bx--top-nav__left-container__item">
-          <a class="bx--top-nav__left-container__link" href="#" tabindex="0">
-            <svg class="bx--top-nav__left-container__link--icon">
+  <nav role="navigation" class="{{@root.prefix}}--top-nav" aria-label="Top Header">
+      <ul role="menubar" class="{{@root.prefix}}--top-nav__left-container" aria-hidden="false">
+        <li role="menuitem" class="{{@root.prefix}}--top-nav__left-container__item">
+          <a class="{{@root.prefix}}--top-nav__left-container__link" href="#" tabindex="0">
+            <svg class="{{@root.prefix}}--top-nav__left-container__link--icon">
               <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--header--help"></use>
             </svg>
             Docs
           </a>
         </li>
       </ul>
-      <ul role="menubar" class="bx--top-nav__right-container">
-        <li data-trial class="bx--top-nav__right-container__item">
-          <ul data-dropdown data-value class="bx--dropdown" tabindex="0">
-            <li class="bx--dropdown-text">29 Trial Days Remaining</li>
-            <svg class="bx--dropdown__arrow">
+      <ul role="menubar" class="{{@root.prefix}}--top-nav__right-container">
+        <li data-trial class="{{@root.prefix}}--top-nav__right-container__item">
+          <ul data-dropdown data-value class="{{@root.prefix}}--dropdown" tabindex="0">
+            <li class="{{@root.prefix}}--dropdown-text">29 Trial Days Remaining</li>
+            <svg class="{{@root.prefix}}--dropdown__arrow">
               <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
             </svg>
             <li>
-              <ul class="bx--dropdown-list">
-                <li class="bx--dropdown__trial-content">
-                  <p class="bx--dropdown__trial-content--desc">Keep your account going by adding your credit card. Don’t worry. We won’t charge you unless you go over your free monthly allowance.</p>
-                  <button class='bx--btn' type='button'>Add credit card</button>
-                  <a href="#" class="bx--link">Apply promo code</a>
+              <ul class="{{@root.prefix}}--dropdown-list">
+                <li class="{{@root.prefix}}--dropdown__trial-content">
+                  <p class="{{@root.prefix}}--dropdown__trial-content--desc">Keep your account going by adding your credit card. Don’t worry. We won’t charge you unless you go over your free monthly allowance.</p>
+                  <button class='{{@root.prefix}}--btn' type='button'>Add credit card</button>
+                  <a href="#" class="{{@root.prefix}}--link">Apply promo code</a>
                 </li>
               </ul>
             </li>
           </ul>
         </li>
-        <li data-credit class="bx--top-nav__right-container__item">
-          <ul data-dropdown data-value class="bx--dropdown" tabindex="0">
-            <li class="bx--dropdown-text">$132 Credit Expires 12/6</li>
+        <li data-credit class="{{@root.prefix}}--top-nav__right-container__item">
+          <ul data-dropdown data-value class="{{@root.prefix}}--dropdown" tabindex="0">
+            <li class="{{@root.prefix}}--dropdown-text">$132 Credit Expires 12/6</li>
             <li>
-              <svg class="bx--dropdown__arrow">
+              <svg class="{{@root.prefix}}--dropdown__arrow">
                 <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
               </svg>
             </li>
             <li>
-              <ul class="bx--dropdown-list">
-                <li class="bx--dropdown-item bx--dropdown__credit-content">
+              <ul class="{{@root.prefix}}--dropdown-list">
+                <li class="{{@root.prefix}}--dropdown-item {{@root.prefix}}--dropdown__credit-content">
                   <div>
-                    <p class="bx--dropdown__credit-content--heading">Initial Credit Value</p>
-                    <p class="bx--dropdown__credit-content--desc">$200</p>
+                    <p class="{{@root.prefix}}--dropdown__credit-content--heading">Initial Credit Value</p>
+                    <p class="{{@root.prefix}}--dropdown__credit-content--desc">$200</p>
                   </div>
                   <div>
-                    <p class="bx--dropdown__credit-content--heading">Expires</p>
-                    <p class="bx--dropdown__credit-content--desc">12/25/2016</p>
+                    <p class="{{@root.prefix}}--dropdown__credit-content--heading">Expires</p>
+                    <p class="{{@root.prefix}}--dropdown__credit-content--desc">12/25/2016</p>
                   </div>
                   <div>
-                    <p class="bx--dropdown__credit-content--heading">Spend Rate</p>
-                    <p class="bx--dropdown__credit-content--desc">$1.33/day</p>
+                    <p class="{{@root.prefix}}--dropdown__credit-content--heading">Spend Rate</p>
+                    <p class="{{@root.prefix}}--dropdown__credit-content--desc">$1.33/day</p>
                   </div>
                 </li>
               </ul>
             </li>
           </ul>
         </li>
-        <li role="menuitem" class="bx--top-nav__right-container__item">
-          <ul role="menu" data-profile-switcher class="bx--account-switcher">
-            <li tabindex="0" data-profile-switcher-toggle class="bx--account-switcher__toggle">
-              <p data-switcher-account-sl class="bx--account-switcher__toggle--text"></p>
-              <p data-switcher-account class="bx--account-switcher__toggle--text"></p>
-              <p class="bx--account-switcher__toggle--text">|</p>
-              <p data-switcher-region class="bx--account-switcher__toggle--text"></p>
-              <p data-switcher-org class="bx--account-switcher__toggle--text"></p>
-              <p data-switcher-space class="bx--account-switcher__toggle--text"></p>
+        <li role="menuitem" class="{{@root.prefix}}--top-nav__right-container__item">
+          <ul role="menu" data-profile-switcher class="{{@root.prefix}}--account-switcher">
+            <li tabindex="0" data-profile-switcher-toggle class="{{@root.prefix}}--account-switcher__toggle">
+              <p data-switcher-account-sl class="{{@root.prefix}}--account-switcher__toggle--text"></p>
+              <p data-switcher-account class="{{@root.prefix}}--account-switcher__toggle--text"></p>
+              <p class="{{@root.prefix}}--account-switcher__toggle--text">|</p>
+              <p data-switcher-region class="{{@root.prefix}}--account-switcher__toggle--text"></p>
+              <p data-switcher-org class="{{@root.prefix}}--account-switcher__toggle--text"></p>
+              <p data-switcher-space class="{{@root.prefix}}--account-switcher__toggle--text"></p>
             </li>
-            <li role="menuitem" data-switcher-menu class="bx--account-switcher__menu__container">
-              <ul role="menu" class="bx--account-switcher__menu">
-                <li role="menuitem" class="bx--account-switcher__menu__item">
-                  <p class="bx--account-switcher__menu__item--title">Account</p>
-                  <ul role="menu" data-dropdown data-value="Logans_account_123456789_1234" class="bx--dropdown" tabindex="0">
-                    <li data-dropdown-account class="bx--dropdown-text">Logans_account_123456789_1234</li>
+            <li role="menuitem" data-switcher-menu class="{{@root.prefix}}--account-switcher__menu__container">
+              <ul role="menu" class="{{@root.prefix}}--account-switcher__menu">
+                <li role="menuitem" class="{{@root.prefix}}--account-switcher__menu__item">
+                  <p class="{{@root.prefix}}--account-switcher__menu__item--title">Account</p>
+                  <ul role="menu" data-dropdown data-value="Logans_account_123456789_1234" class="{{@root.prefix}}--dropdown" tabindex="0">
+                    <li data-dropdown-account class="{{@root.prefix}}--dropdown-text">Logans_account_123456789_1234</li>
                     <li>
-                      <svg class="bx--dropdown__arrow">
+                      <svg class="{{@root.prefix}}--dropdown__arrow">
                         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
                       </svg>
                     </li>
-                    <li aria-haspopup="true" class="bx--dropdown--scroll">
-                      <ul role="menu" aria-hidden="true" class="bx--dropdown-list">
-                        <li role="menuitem" data-option data-value="all" class="bx--dropdown-item"><span class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">someone_at_a_company@email.com</span></li>
-                        <li role="menuitem" data-option data-value="all" class="bx--dropdown-item"><span class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">TJs_accoqwejqwhekjqwgehgunt_54321</span></li>
-                        <li role="menuitem" data-option data-value="all" class="bx--dropdown-item">
-                          <span class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">
+                    <li aria-haspopup="true" class="{{@root.prefix}}--dropdown--scroll">
+                      <ul role="menu" aria-hidden="true" class="{{@root.prefix}}--dropdown-list">
+                        <li role="menuitem" data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">someone_at_a_company@email.com</span></li>
+                        <li role="menuitem" data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">TJs_accoqwejqwhekjqwgehgunt_54321</span></li>
+                        <li role="menuitem" data-option data-value="all" class="{{@root.prefix}}--dropdown-item">
+                          <span class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">
                             <span data-dropdown-account-sl-linked>sl123456</span>
-                              <svg class="bx--account-switcher__linked-icon">
+                              <svg class="{{@root.prefix}}--account-switcher__linked-icon">
                                 <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--link"></use>
                               </svg>
                             <span data-dropdown-account-linked>Logans_account_123456789_1234</span>
                           </span>
                         </li>
-                        <li role="menuitem" data-option data-value="all" class="bx--dropdown-item">
-                          <span class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">
+                        <li role="menuitem" data-option data-value="all" class="{{@root.prefix}}--dropdown-item">
+                          <span class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">
                             <span data-dropdown-account-sl-linked>s7777</span>
-                            <svg class="bx--account-switcher__linked-icon">
+                            <svg class="{{@root.prefix}}--account-switcher__linked-icon">
                               <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--link"></use>
                             </svg>
                             <span data-dropdown-account-linked>TJs_account_123456789_1234</span>
@@ -106,87 +106,87 @@
                     </li>
                   </ul>
                 </li>
-                <li class="bx--account-switcher__menu__item">
-                  <p class="bx--account-switcher__menu__item--title">Region</p>
-                  <ul data-dropdown data-value="US South" class="bx--dropdown" tabindex="0">
-                    <li data-dropdown-region class="bx--dropdown-text">US South</li>
-                    <svg class="bx--dropdown__arrow">
+                <li class="{{@root.prefix}}--account-switcher__menu__item">
+                  <p class="{{@root.prefix}}--account-switcher__menu__item--title">Region</p>
+                  <ul data-dropdown data-value="US South" class="{{@root.prefix}}--dropdown" tabindex="0">
+                    <li data-dropdown-region class="{{@root.prefix}}--dropdown-text">US South</li>
+                    <svg class="{{@root.prefix}}--dropdown__arrow">
                       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
                     </svg>
-                    <li class="bx--dropdown--scroll">
-                      <ul class="bx--dropdown-list">
-                        <li data-option data-value="all" class="bx--dropdown-item"><span class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">US South</span></li>
-                        <li data-option data-value="all" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Sydney</span></li>
-                        <li data-option data-value="cloudFoundry" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">United Kingdom</span></li>
+                    <li class="{{@root.prefix}}--dropdown--scroll">
+                      <ul class="{{@root.prefix}}--dropdown-list">
+                        <li data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">US South</span></li>
+                        <li data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Sydney</span></li>
+                        <li data-option data-value="cloudFoundry" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">United Kingdom</span></li>
                       </ul>
                     </li>
                   </ul>
                 </li>
-                <li class="bx--account-switcher__menu__item">
-                  <p class="bx--account-switcher__menu__item--title">Organization</p>
-                  <ul data-dropdown data-value="Organization 1" class="bx--dropdown" tabindex="0">
-                    <li data-dropdown-org class="bx--dropdown-text">Organization 1</li>
-                    <svg class="bx--dropdown__arrow">
+                <li class="{{@root.prefix}}--account-switcher__menu__item">
+                  <p class="{{@root.prefix}}--account-switcher__menu__item--title">Organization</p>
+                  <ul data-dropdown data-value="Organization 1" class="{{@root.prefix}}--dropdown" tabindex="0">
+                    <li data-dropdown-org class="{{@root.prefix}}--dropdown-text">Organization 1</li>
+                    <svg class="{{@root.prefix}}--dropdown__arrow">
                       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
                     </svg>
-                    <li class="bx--dropdown--scroll">
-                      <ul class="bx--dropdown-list">
-                        <li data-option data-value="all" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">someone_at_a_company@email.com</span></li>
-                        <li data-option data-value="cloudFoundry" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Organization q2332434341sddsf2</span></li>
-                        <li data-option data-value="staging" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Organization 3</span></li>
-                        <li data-option data-value="dea" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Organization 4</span></li>
-                        <li data-option data-value="router" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Organization 5</span></li>
+                    <li class="{{@root.prefix}}--dropdown--scroll">
+                      <ul class="{{@root.prefix}}--dropdown-list">
+                        <li data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">someone_at_a_company@email.com</span></li>
+                        <li data-option data-value="cloudFoundry" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Organization q2332434341sddsf2</span></li>
+                        <li data-option data-value="staging" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Organization 3</span></li>
+                        <li data-option data-value="dea" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Organization 4</span></li>
+                        <li data-option data-value="router" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Organization 5</span></li>
                       </ul>
                     </li>
                   </ul>
                 </li>
-                <li class="bx--account-switcher__menu__item">
-                  <p class="bx--account-switcher__menu__item--title">Space</p>
-                  <ul data-dropdown data-value="Space 2" class="bx--dropdown" tabindex="0">
-                    <li data-dropdown-space class="bx--dropdown-text">Space 2</li>
-                    <svg class="bx--dropdown__arrow">
+                <li class="{{@root.prefix}}--account-switcher__menu__item">
+                  <p class="{{@root.prefix}}--account-switcher__menu__item--title">Space</p>
+                  <ul data-dropdown data-value="Space 2" class="{{@root.prefix}}--dropdown" tabindex="0">
+                    <li data-dropdown-space class="{{@root.prefix}}--dropdown-text">Space 2</li>
+                    <svg class="{{@root.prefix}}--dropdown__arrow">
                       <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--caret--down"></use>
                     </svg>
-                    <li class="bx--dropdown--scroll">
-                      <ul class="bx--dropdown-list">
-                        <li data-option data-value="all" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Dev</span></li>
-                        <li data-option data-value="all" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Space 2</span></li>
-                        <li data-option data-value="cloudFoundry" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Space 3</span></li>
-                        <li data-option data-value="staging" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Space 4</span></li>
-                        <li data-option data-value="dea" class="bx--dropdown-item"><span  class="bx--dropdown-link" href="javascript:void(0)" tabindex="0">Space 5</span></li>
+                    <li class="{{@root.prefix}}--dropdown--scroll">
+                      <ul class="{{@root.prefix}}--dropdown-list">
+                        <li data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Dev</span></li>
+                        <li data-option data-value="all" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Space 2</span></li>
+                        <li data-option data-value="cloudFoundry" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Space 3</span></li>
+                        <li data-option data-value="staging" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Space 4</span></li>
+                        <li data-option data-value="dea" class="{{@root.prefix}}--dropdown-item"><span  class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="0">Space 5</span></li>
                       </ul>
                     </li>
                   </ul>
                 </li>
-                <li class="bx--account-switcher__menu__item">
-                  <a href="#" class="bx--link">Manage Organizations</a>
-                  <a href="#" class="bx--link">Create A Space</a>
+                <li class="{{@root.prefix}}--account-switcher__menu__item">
+                  <a href="#" class="{{@root.prefix}}--link">Manage Organizations</a>
+                  <a href="#" class="{{@root.prefix}}--link">Create A Space</a>
                 </li>
               </ul>
             </li>
           </ul>
         </li>
-        <li class="bx--top-nav__right-container__item">
-          <ul data-dropdown data-value class="bx--dropdown" tabindex="0">
-            <li data-top-nav-profile-image class="bx--dropdown-text--profile-image">
+        <li class="{{@root.prefix}}--top-nav__right-container__item">
+          <ul data-dropdown data-value class="{{@root.prefix}}--dropdown" tabindex="0">
+            <li data-top-nav-profile-image class="{{@root.prefix}}--dropdown-text--profile-image">
               <div class="profile-image">
-                <svg class="bx--dropdown__profile-dropdown--picture">
+                <svg class="{{@root.prefix}}--dropdown__profile-dropdown--picture">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--user"></use>
                 </svg>
               </div>
             </li>
-            <li class="bx--dropdown__profile-dropdown">
-              <ul class="bx--dropdown-list">
-                <li data-option data-value="all" class="bx--dropdown-item">
-                  <svg class="bx--dropdown__profile-dropdown--picture">
+            <li class="{{@root.prefix}}--dropdown__profile-dropdown">
+              <ul class="{{@root.prefix}}--dropdown-list">
+                <li data-option data-value="all" class="{{@root.prefix}}--dropdown-item">
+                  <svg class="{{@root.prefix}}--dropdown__profile-dropdown--picture">
                     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--user"></use>
                   </svg>
-                  <div class="bx--dropdown__profile-dropdown--information">
+                  <div class="{{@root.prefix}}--dropdown__profile-dropdown--information">
                     <p>Erlich Bachman Erlich Bachman</p>
-                    <div class="bx--dropdown__profile-dropdown__container">
-                      <a class="bx--link" href="javascript:void(0)">Profile</a>
+                    <div class="{{@root.prefix}}--dropdown__profile-dropdown__container">
+                      <a class="{{@root.prefix}}--link" href="javascript:void(0)">Profile</a>
                       <p>|</p>
-                      <a class="bx--link" href="javascript:void(0)">Log Out</a>
+                      <a class="{{@root.prefix}}--link" href="javascript:void(0)">Log Out</a>
                     </div>
                   </div>
                 </li>
@@ -199,105 +199,105 @@
   <!-- End Super Global Header -->
 
   <!-- Global Header -->
-  <header role="banner" class="bx--global-header">
-    <div class="bx--global-header__left-container">
-      <div class="bx--left-nav__trigger bx--left-nav__trigger--apps" data-left-nav-toggle="open" tabindex="0">
-        <div class="bx--left-nav__trigger--btn">
+  <header role="banner" class="{{@root.prefix}}--global-header">
+    <div class="{{@root.prefix}}--global-header__left-container">
+      <div class="{{@root.prefix}}--left-nav__trigger {{@root.prefix}}--left-nav__trigger--apps" data-left-nav-toggle="open" tabindex="0">
+        <div class="{{@root.prefix}}--left-nav__trigger--btn">
           <span></span>
         </div>
       </div>
-      <div class="bx--global-header__left-nav bx--left-nav--active" data-left-nav-container aria-expanded="false">
-        <div class="bx--left-nav__close-row"></div>
-        <div data-left-nav-current-section="apps" class="bx--left-nav__header">
-          <svg data-left-nav-current-section-icon="apps" class="bx--left-nav__header--taxonomy-icon">
+      <div class="{{@root.prefix}}--global-header__left-nav {{@root.prefix}}--left-nav--active" data-left-nav-container aria-expanded="false">
+        <div class="{{@root.prefix}}--left-nav__close-row"></div>
+        <div data-left-nav-current-section="apps" class="{{@root.prefix}}--left-nav__header">
+          <svg data-left-nav-current-section-icon="apps" class="{{@root.prefix}}--left-nav__header--taxonomy-icon">
             <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
           </svg>
-          <a data-left-nav-current-section-title tabindex="0" class="bx--left-nav__header--title">Apps</a>
+          <a data-left-nav-current-section-title tabindex="0" class="{{@root.prefix}}--left-nav__header--title">Apps</a>
         </div>
-        <nav class="bx--left-nav" data-left-nav role="navigation" aria-label="Left Navigation">
-          <ul data-left-nav-sections class="bx--left-nav__sections">
-            <li data-left-nav-section="services" class="bx--left-nav__section bx--left-nav__section--services">
-              <a href="javascript:void(0)" class="bx--left-nav__section--anchor" tabindex="0">
-                <svg data-left-nav-section-icon="services" class="bx--left-nav__section--taxonomy-icon">
+        <nav class="{{@root.prefix}}--left-nav" data-left-nav role="navigation" aria-label="Left Navigation">
+          <ul data-left-nav-sections class="{{@root.prefix}}--left-nav__sections">
+            <li data-left-nav-section="services" class="{{@root.prefix}}--left-nav__section {{@root.prefix}}--left-nav__section--services">
+              <a href="javascript:void(0)" class="{{@root.prefix}}--left-nav__section--anchor" tabindex="0">
+                <svg data-left-nav-section-icon="services" class="{{@root.prefix}}--left-nav__section--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
-                <span data-left-nav-section-link class="bx--left-nav__section--link">Services</span>
+                <span data-left-nav-section-link class="{{@root.prefix}}--left-nav__section--link">Services</span>
               </a>
             </li>
-            <li data-left-nav-section="infrastructure" class="bx--left-nav__section bx--left-nav__section--infrastructure" tabindex="0">
-              <a href="javascript:void(0)" class="bx--left-nav__section--anchor" tabindex="0">
-                <svg data-left-nav-section-icon="infrastructure" class="bx--left-nav__section--taxonomy-icon">
+            <li data-left-nav-section="infrastructure" class="{{@root.prefix}}--left-nav__section {{@root.prefix}}--left-nav__section--infrastructure" tabindex="0">
+              <a href="javascript:void(0)" class="{{@root.prefix}}--left-nav__section--anchor" tabindex="0">
+                <svg data-left-nav-section-icon="infrastructure" class="{{@root.prefix}}--left-nav__section--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
-                <span data-left-nav-section-link class="bx--left-nav__section--link">Infrastructure</span>
+                <span data-left-nav-section-link class="{{@root.prefix}}--left-nav__section--link">Infrastructure</span>
               </a>
             </li>
           </ul>
           <!-- APPLICATIONS MENU -->
-          <ul role="menubar" class="bx--left-nav__main-nav" data-left-nav-list="apps" aria-hidden="false">
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item data-left-nav-item-with-children tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+          <ul role="menubar" class="{{@root.prefix}}--left-nav__main-nav" data-left-nav-list="apps" aria-hidden="false">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item data-left-nav-item-with-children tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
-                <div class="bx--parent-item__link--down-icon">
+                <div class="{{@root.prefix}}--parent-item__link--down-icon">
                   <svg>
                     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--down"></use>
                   </svg>
                 </div>
               </a>
-              <ul role="menu" class="bx--main-nav__nested-list" aria-hidden="true" data-left-nav-nested-list>
-                <li role="menuitem" class="bx--nested-list__item bx--active-list-item" data-left-nav-nested-item tabindex="-1">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
+              <ul role="menu" class="{{@root.prefix}}--main-nav__nested-list" aria-hidden="true" data-left-nav-nested-list>
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item {{@root.prefix}}--active-list-item" data-left-nav-nested-item tabindex="-1">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
                 </li>
-                <li role="menuitem" class="bx--nested-list__item" data-left-nav-nested-item tabindex="-1">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item" data-left-nav-nested-item tabindex="-1">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
                 </li>
-                <li role="menuitem" class="bx--nested-list__item" data-left-nav-nested-item data-left-nav-has-flyout tabindex="-1" aria-haspopup="true">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item
-                    <div class="bx--nested-list__item--icon">
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item" data-left-nav-nested-item data-left-nav-has-flyout tabindex="-1" aria-haspopup="true">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item
+                    <div class="{{@root.prefix}}--nested-list__item--icon">
                       <svg>
                         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--right"></use>
                       </svg>
                     </div>
                   </a>
-                  <ul role="menu" class="bx--nested-list__flyout-menu" data-left-nav-flyout aria-hidden="true">
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                  <ul role="menu" class="{{@root.prefix}}--nested-list__flyout-menu" data-left-nav-flyout aria-hidden="true">
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
                   </ul>
                 </li>
               </ul>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
               </a>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
               </a>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
@@ -307,70 +307,70 @@
           <!-- END APPLICATIONS MENU -->
 
           <!-- SERVICES MENU -->
-          <ul role="menubar" class="bx--left-nav__main-nav bx--left-nav__main-nav--hidden bx--left-nav__main-nav--top" data-left-nav-list="services" aria-hidden="true">
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item data-left-nav-item-with-children tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+          <ul role="menubar" class="{{@root.prefix}}--left-nav__main-nav {{@root.prefix}}--left-nav__main-nav--hidden {{@root.prefix}}--left-nav__main-nav--top" data-left-nav-list="services" aria-hidden="true">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item data-left-nav-item-with-children tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
-                <div class="bx--parent-item__link--down-icon">
+                <div class="{{@root.prefix}}--parent-item__link--down-icon">
                   <svg>
                     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--down"></use>
                   </svg>
                 </div>
               </a>
-              <ul role="menu" class="bx--main-nav__nested-list" aria-hidden="true" data-left-nav-nested-list>
-                <li role="menuitem" class="bx--nested-list__item bx--active-list-item" data-left-nav-nested-item tabindex="-1">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
+              <ul role="menu" class="{{@root.prefix}}--main-nav__nested-list" aria-hidden="true" data-left-nav-nested-list>
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item {{@root.prefix}}--active-list-item" data-left-nav-nested-item tabindex="-1">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
                 </li>
-                <li role="menuitem" class="bx--nested-list__item" data-left-nav-nested-item tabindex="-1">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item" data-left-nav-nested-item tabindex="-1">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
                 </li>
-                <li role="menuitem" class="bx--nested-list__item" data-left-nav-nested-item data-left-nav-has-flyout tabindex="-1" aria-haspopup="true">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item
-                    <div class="bx--nested-list__item--icon">
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item" data-left-nav-nested-item data-left-nav-has-flyout tabindex="-1" aria-haspopup="true">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item
+                    <div class="{{@root.prefix}}--nested-list__item--icon">
                       <svg>
                         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--right"></use>
                       </svg>
                     </div>
                   </a>
-                  <ul role="menu" class="bx--nested-list__flyout-menu" data-left-nav-flyout aria-hidden="true">
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                  <ul role="menu" class="{{@root.prefix}}--nested-list__flyout-menu" data-left-nav-flyout aria-hidden="true">
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
                   </ul>
                 </li>
               </ul>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" aria-haspopup="true" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" aria-haspopup="true" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
               </a>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
               </a>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
@@ -380,70 +380,70 @@
           <!-- END SERVICES MENU -->
 
           <!-- INFRASTRUCTURE MENU -->
-          <ul role="menubar" class="bx--left-nav__main-nav bx--left-nav__main-nav--hidden bx--left-nav__main-nav--top" data-left-nav-list="infrastructure" aria-hidden="true">
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item data-left-nav-item-with-children tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+          <ul role="menubar" class="{{@root.prefix}}--left-nav__main-nav {{@root.prefix}}--left-nav__main-nav--hidden {{@root.prefix}}--left-nav__main-nav--top" data-left-nav-list="infrastructure" aria-hidden="true">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item data-left-nav-item-with-children tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
-                <div class="bx--parent-item__link--down-icon">
+                <div class="{{@root.prefix}}--parent-item__link--down-icon">
                   <svg>
                     <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--down"></use>
                   </svg>
                 </div>
               </a>
-              <ul role="menu" class="bx--main-nav__nested-list" aria-hidden="true" data-left-nav-nested-list>
-                <li role="menuitem" class="bx--nested-list__item bx--active-list-item" data-left-nav-nested-item tabindex="-1">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
+              <ul role="menu" class="{{@root.prefix}}--main-nav__nested-list" aria-hidden="true" data-left-nav-nested-list>
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item {{@root.prefix}}--active-list-item" data-left-nav-nested-item tabindex="-1">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
                 </li>
-                <li role="menuitem" class="bx--nested-list__item" data-left-nav-nested-item tabindex="-1">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item" data-left-nav-nested-item tabindex="-1">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item</a>
                 </li>
-                <li role="menuitem" class="bx--nested-list__item" data-left-nav-nested-item data-left-nav-has-flyout tabindex="-1" aria-haspopup="true">
-                  <a href="#" class="bx--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item
-                    <div class="bx--nested-list__item--icon">
+                <li role="menuitem" class="{{@root.prefix}}--nested-list__item" data-left-nav-nested-item data-left-nav-has-flyout tabindex="-1" aria-haspopup="true">
+                  <a href="#" class="{{@root.prefix}}--nested-list__item--link" tabindex="-1" data-left-nav-item-link>Example Child Item
+                    <div class="{{@root.prefix}}--nested-list__item--icon">
                       <svg>
                         <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--chevron--right"></use>
                       </svg>
                     </div>
                   </a>
-                  <ul role="menu" class="bx--nested-list__flyout-menu" data-left-nav-flyout aria-hidden="true">
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                  <ul role="menu" class="{{@root.prefix}}--nested-list__flyout-menu" data-left-nav-flyout aria-hidden="true">
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
-                    <li role="menuitem" class="bx--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
-                      <a href="#" class="bx--flyout-menu__item--link">Example Flyout Item</a>
+                    <li role="menuitem" class="{{@root.prefix}}--flyout-menu__item" data-left-nav-flyout-item tabindex="-1">
+                      <a href="#" class="{{@root.prefix}}--flyout-menu__item--link">Example Flyout Item</a>
                     </li>
                   </ul>
                 </li>
               </ul>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" aria-haspopup="true" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" aria-haspopup="true" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
               </a>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
               </a>
             </li>
-            <li role="menuitem" class="bx--main-nav__parent-item" data-left-nav-item tabindex="0">
-              <a class="bx--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
-                <svg class="bx--parent-item__link--taxonomy-icon">
+            <li role="menuitem" class="{{@root.prefix}}--main-nav__parent-item" data-left-nav-item tabindex="0">
+              <a class="{{@root.prefix}}--parent-item__link" href="#" title="Example Item" tabindex="-1" data-left-nav-item-link>
+                <svg class="{{@root.prefix}}--parent-item__link--taxonomy-icon">
                   <use xlink:href="/carbon-icons/bluemix-icons.svg#icon--apps"></use>
                 </svg>
                 Example Parent Item
@@ -456,37 +456,37 @@
       </div>
 
 
-    <div class="bx--global-header__title">
-      <a href="#" class="bx--global-header__title--logo" tabindex="0">
-        <img class="bx--logo__image" src="/globals/assets/bluemix-logo.svg"></img>
-        <h1 class="bx--logo__text">
-          IBM <span class="bx--logo__text--bold">Bluemix</span>
+    <div class="{{@root.prefix}}--global-header__title">
+      <a href="#" class="{{@root.prefix}}--global-header__title--logo" tabindex="0">
+        <img class="{{@root.prefix}}--logo__image" src="/globals/assets/bluemix-logo.svg"></img>
+        <h1 class="{{@root.prefix}}--logo__text">
+          IBM <span class="{{@root.prefix}}--logo__text--bold">Bluemix</span>
         </h1>
       </a>
-      <h4 class="bx--global-header__title--current-page">Apps</h4>
+      <h4 class="{{@root.prefix}}--global-header__title--current-page">Apps</h4>
     </div>
     </div>
 
     <!-- Global Header - Right Nav -->
-    <div class="bx--global-header__right-container">
-    <ul data-global-header-menu role="menubar" class="bx--global-header__menu" aria-hidden="false">
-      <li role="menuitem" class="bx--global-header__menu__item">
-        <a class="bx--global-header__menu__item--link" tabindex="0" href="javascript:void(0)">Catalog</a>
+    <div class="{{@root.prefix}}--global-header__right-container">
+    <ul data-global-header-menu role="menubar" class="{{@root.prefix}}--global-header__menu" aria-hidden="false">
+      <li role="menuitem" class="{{@root.prefix}}--global-header__menu__item">
+        <a class="{{@root.prefix}}--global-header__menu__item--link" tabindex="0" href="javascript:void(0)">Catalog</a>
       </li>
-      <li role="menuitem" class="bx--global-header__menu__item">
-        <a class="bx--global-header__menu__item--link" tabindex="0" href="javascript:void(0)">Support</a>
+      <li role="menuitem" class="{{@root.prefix}}--global-header__menu__item">
+        <a class="{{@root.prefix}}--global-header__menu__item--link" tabindex="0" href="javascript:void(0)">Support</a>
       </li>
-      <li role="menuitem" class="bx--global-header__menu__item">
-        <ul role="menu" data-dropdown data-dropdown-type="navigation" class="bx--dropdown" tabindex="0">
-          <li class="bx--dropdown-text">Account</li>
+      <li role="menuitem" class="{{@root.prefix}}--global-header__menu__item">
+        <ul role="menu" data-dropdown data-dropdown-type="navigation" class="{{@root.prefix}}--dropdown" tabindex="0">
+          <li class="{{@root.prefix}}--dropdown-text">Account</li>
           <li aria-haspopup="true">
-            <ul role="menu" aria-hidden="true" class="bx--dropdown-list">
-              <li role="menuitem" tabindex="0" data-option class="bx--dropdown-item"><a class="bx--dropdown-link" href="javascript:void(0)">Make A Payment</a></li>
-              <li role="menuitem" tabindex="0" data-option class="bx--dropdown-item"><a data-account-link class="bx--dropdown-link" href="javascript:void(0)">Sales</a></li>
-              <li role="menuitem" tabindex="0" data-option class="bx--dropdown-item"><a data-account-link class="bx--dropdown-link" href="javascript:void(0)">Billing</a></li>
-              <li role="menuitem" tabindex="0" data-option class="bx--dropdown-item"><a data-account-link class="bx--dropdown-link" href="javascript:void(0)">Users</a></li>
-              <li role="menuitem" tabindex="0" data-option class="bx--dropdown-item"><a data-account-link class="bx--dropdown-link" href="javascript:void(0)">VPN Access</a></li>
-              <li role="menuitem" tabindex="0" data-option class="bx--dropdown-item"><a data-account-link class="bx--dropdown-link" href="javascript:void(0)">Manage</a></li>
+            <ul role="menu" aria-hidden="true" class="{{@root.prefix}}--dropdown-list">
+              <li role="menuitem" tabindex="0" data-option class="{{@root.prefix}}--dropdown-item"><a class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)">Make A Payment</a></li>
+              <li role="menuitem" tabindex="0" data-option class="{{@root.prefix}}--dropdown-item"><a data-account-link class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)">Sales</a></li>
+              <li role="menuitem" tabindex="0" data-option class="{{@root.prefix}}--dropdown-item"><a data-account-link class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)">Billing</a></li>
+              <li role="menuitem" tabindex="0" data-option class="{{@root.prefix}}--dropdown-item"><a data-account-link class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)">Users</a></li>
+              <li role="menuitem" tabindex="0" data-option class="{{@root.prefix}}--dropdown-item"><a data-account-link class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)">VPN Access</a></li>
+              <li role="menuitem" tabindex="0" data-option class="{{@root.prefix}}--dropdown-item"><a data-account-link class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)">Manage</a></li>
             </ul>
           </li>
         </ul>

--- a/src/globals/js/settings.js
+++ b/src/globals/js/settings.js
@@ -15,4 +15,4 @@
 const settings = {
   prefix: 'bx',
 };
-export default settings;
+module.exports = settings;

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -1,3 +1,5 @@
+/* eslint-disable prettier/prettier */
+
 'use strict';
 
 /* eslint-disable import/no-extraneous-dependencies, global-require */
@@ -69,7 +71,7 @@ module.exports = function(config) {
         rules: [
           {
             test: /\.js?$/,
-            exclude: /node_modules/,
+            exclude: [/node_modules/, /settings\.js$/],
             loader: 'babel-loader',
             query: {
               presets: [
@@ -97,6 +99,39 @@ module.exports = function(config) {
                       ]
                 )
                 .concat(['rewire']),
+            },
+          },
+          {
+            test: /settings\.js?$/,
+            loader: 'babel-loader',
+            query: {
+              presets: [
+                [
+                  'env',
+                  {
+                    modules: false,
+                    targets: {
+                      browsers: ['last 1 version', 'ie >= 11'],
+                    },
+                  },
+                ],
+              ],
+              plugins: [
+                'transform-class-properties',
+                'transform-object-rest-spread',
+                ['transform-runtime', { polyfill: false }],
+              ].concat(
+                cloptions.debug
+                  ? []
+                  : [
+                      [
+                        'istanbul',
+                        {
+                          include: ['src/{components,globals}/**/*.js'],
+                        },
+                      ],
+                    ]
+              ),
             },
           },
           {

--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -31,7 +31,7 @@ module.exports = {
       main: true,
     }),
     commonjs({
-      include: ['node_modules/**', 'demo/feature-flags.js'],
+      include: ['node_modules/**', 'src/globals/js/settings.js', 'demo/feature-flags.js'],
       sourceMap: true,
       namedExports: {
         'node_modules/react/index.js': [

--- a/tools/rollup.config.js
+++ b/tools/rollup.config.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     resolve(),
     commonjs({
-      include: ['node_modules/**', 'src/globals/js/feature-flags.js'],
+      include: ['node_modules/**', 'src/globals/js/settings.js', 'src/globals/js/feature-flags.js'],
       sourceMap: false,
     }),
     babel({


### PR DESCRIPTION
Fixes #1409.

#### Changelog

**New**

- Parameterized CSS class prefix in Handlebars templates.

#### Testing / Reviewing

Testing should make sure:

* No component (demo) is broken
* The emitted HTML by `gulp html:source` task is exactly same as before-change
* Production JavaScript build is not broken