### PR TITLE
refactor(tag): deduplicate markup and improve readability

### DIFF
--- a/src/components/tag/tag.hbs
+++ b/src/components/tag/tag.hbs
@@ -1,10 +1,6 @@
-{{#if componentsX}}
 {{#each tags}}
 <span class="bx--tag bx--tag--{{type}}">{{label}}</span>
 {{/each}}
+{{#if componentsX}}
 <span class="bx--tag bx--tag--basic" disabled>Component</span>
-{{else}}
-{{#each tags}}
-<span class="bx--tag bx--tag--{{type}}">{{label}}</span>
-  {{/each}}
 {{/if}}


### PR DESCRIPTION
While working on the experimental React component implementations (e.g. https://github.com/IBM/carbon-components-react/pull/1523), I found it difficult sometimes to diff the handlebars template changes. This PR is a refactor of the current Tag handlebars template to improve readability when comparing experimental markup to non-experimental markup.

I will continue to refactor the handlebars templates for other components as I progress with the experimental React versions

#### Changelog

**Changed**

- `tag.hbs`