### PR TITLE
fix(file-uploader): fixes multiple tabbable elements bug and adds keyboard navigation to label

### DIFF
--- a/src/components/file-uploader/addKeyboardNavigation.js
+++ b/src/components/file-uploader/addKeyboardNavigation.js
@@ -1,0 +1,22 @@
+/**
+ * We're using a pattern where we style an input's label to look like a button.
+ * Consequently we need to add proper keyboard accessibility to the label in
+ * order to mimic if it were an input button -- also worth noting is we hide the
+ * actual input from tab order in the markup.
+ */
+function addKeyboardNavigation() {
+  const uploadLabel = document.getElementById('input-button');
+  const uploadInput = document.getElementById('your-file-importer-id-here');
+  if (uploadLabel != null) {
+    uploadLabel.addEventListener('keydown', event => {
+      // Stop propagation of the event so we don't throw open the dialog more than once.
+      event.stopPropagation();
+      // if the user presses the enter key or the spacebar click the upload button.
+      if (event.keyCode === 32 || event.keyCode === 13) {
+        uploadInput.click();
+      }
+    });
+  }
+}
+
+export default addKeyboardNavigation;

--- a/src/components/file-uploader/file-uploader.hbs
+++ b/src/components/file-uploader/file-uploader.hbs
@@ -1,13 +1,14 @@
 <div class="bx--form-item">
   <strong class="bx--label">Account photo</strong>
   <p class="bx--label-description">only .jpg and .png files. 500kb max file size.</p>
-  <div class="bx--file" data-file>
+  <form class="bx--file" data-file>
     <label
-      for="your-file-importer-id-here"
-      class="bx--file-btn bx--btn bx--btn--secondary"
-      role="button"
-      tabindex="0">Add files</label>
+      for="your-file-importer-id-here" 
+      id="input-button"
+      tabindex="0"
+      class="bx--file-btn bx--btn bx--btn--secondary">Add files</label>
     <input
+      tabindex="-1"
       type="file"
       class="bx--file-input"
       id="your-file-importer-id-here"
@@ -15,6 +16,6 @@
       data-target="[data-file-container]"
       multiple
     />
-    <div data-file-container class="bx--file-container"></div>
-  </div>
+    <div id="dog" data-file-container class="bx--file-container"></div>
+  </form>
 </div>

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -13,10 +13,10 @@ import on from '../../globals/js/misc/on';
  * order to mimic if it were an input button -- also worth noting is we hide the
  * actual input from tab order in the markup.
  */
-document.addEventListener('DOMContentLoaded', () => {
-  const uploadLabel = document.getElementById('input-button');
-  const uploadInput = document.getElementById('your-file-importer-id-here');
-  if (uploadLabel !== null) {
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const uploadLabel = document.getElementById('input-button');
+    const uploadInput = document.getElementById('your-file-importer-id-here');
     uploadLabel.addEventListener('keydown', event => {
       // Stop propagation of the event so we don't throw open the dialog more than once.
       event.stopPropagation();
@@ -25,8 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
         uploadInput.click();
       }
     });
-  }
-});
+  });
+}
 
 class FileUploader extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -7,6 +7,27 @@ import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
+/**
+ * We're using a pattern where we style an input's label to look like a button.
+ * Consequently we need to add proper keyboard accessibility to the label in
+ * order to mimic if it were an input button -- also worth noting is we hide the
+ * actual input from tab order in the markup.
+ */
+document.onreadystatechange(() => {
+  if (document.readyState === 'complete') {
+    const uploadLabel = document.getElementById('input-button');
+    const uploadInput = document.getElementById('your-file-importer-id-here');
+    uploadLabel.addEventListener('keydown', event => {
+      // Stop propagation of the event so we don't throw open the dialog more than once.
+      event.stopPropagation();
+      // if the user presses the enter key or the spacebar click the upload button.
+      if (event.keyCode === 32 || event.keyCode === 13) {
+        uploadInput.click();
+      }
+    });
+  }
+});
+
 class FileUploader extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * File uploader.

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -13,19 +13,17 @@ import on from '../../globals/js/misc/on';
  * order to mimic if it were an input button -- also worth noting is we hide the
  * actual input from tab order in the markup.
  */
-document.onreadystatechange(() => {
-  if (document.readyState === 'complete') {
-    const uploadLabel = document.getElementById('input-button');
-    const uploadInput = document.getElementById('your-file-importer-id-here');
-    uploadLabel.addEventListener('keydown', event => {
-      // Stop propagation of the event so we don't throw open the dialog more than once.
-      event.stopPropagation();
-      // if the user presses the enter key or the spacebar click the upload button.
-      if (event.keyCode === 32 || event.keyCode === 13) {
-        uploadInput.click();
-      }
-    });
-  }
+document.addEventListener('DOMContentLoaded', () => {
+  const uploadLabel = document.getElementById('input-button');
+  const uploadInput = document.getElementById('your-file-importer-id-here');
+  uploadLabel.addEventListener('keydown', event => {
+    // Stop propagation of the event so we don't throw open the dialog more than once.
+    event.stopPropagation();
+    // if the user presses the enter key or the spacebar click the upload button.
+    if (event.keyCode === 32 || event.keyCode === 13) {
+      uploadInput.click();
+    }
+  });
 });
 
 class FileUploader extends mixin(createComponent, initComponentBySearch, eventedState, handles) {

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -1,5 +1,6 @@
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
+import addKeyboardNavigation from './addKeyboardNavigation';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 import eventedState from '../../globals/js/mixins/evented-state';
@@ -7,26 +8,9 @@ import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
-/**
- * We're using a pattern where we style an input's label to look like a button.
- * Consequently we need to add proper keyboard accessibility to the label in
- * order to mimic if it were an input button -- also worth noting is we hide the
- * actual input from tab order in the markup.
- */
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
-    const uploadLabel = document.getElementById('input-button');
-    const uploadInput = document.getElementById('your-file-importer-id-here');
-    if (uploadLabel != null) {
-      uploadLabel.addEventListener('keydown', event => {
-        // Stop propagation of the event so we don't throw open the dialog more than once.
-        event.stopPropagation();
-        // if the user presses the enter key or the spacebar click the upload button.
-        if (event.keyCode === 32 || event.keyCode === 13) {
-          uploadInput.click();
-        }
-      });
-    }
+    addKeyboardNavigation();
   });
 }
 

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -17,14 +17,16 @@ if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
     const uploadLabel = document.getElementById('input-button');
     const uploadInput = document.getElementById('your-file-importer-id-here');
-    uploadLabel.addEventListener('keydown', event => {
-      // Stop propagation of the event so we don't throw open the dialog more than once.
-      event.stopPropagation();
-      // if the user presses the enter key or the spacebar click the upload button.
-      if (event.keyCode === 32 || event.keyCode === 13) {
-        uploadInput.click();
-      }
-    });
+    if (uploadLabel != null) {
+      uploadLabel.addEventListener('keydown', event => {
+        // Stop propagation of the event so we don't throw open the dialog more than once.
+        event.stopPropagation();
+        // if the user presses the enter key or the spacebar click the upload button.
+        if (event.keyCode === 32 || event.keyCode === 13) {
+          uploadInput.click();
+        }
+      });
+    }
   });
 }
 

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -16,14 +16,16 @@ import on from '../../globals/js/misc/on';
 document.addEventListener('DOMContentLoaded', () => {
   const uploadLabel = document.getElementById('input-button');
   const uploadInput = document.getElementById('your-file-importer-id-here');
-  uploadLabel.addEventListener('keydown', event => {
-    // Stop propagation of the event so we don't throw open the dialog more than once.
-    event.stopPropagation();
-    // if the user presses the enter key or the spacebar click the upload button.
-    if (event.keyCode === 32 || event.keyCode === 13) {
-      uploadInput.click();
-    }
-  });
+  if (uploadLabel !== null) {
+    uploadLabel.addEventListener('keydown', event => {
+      // Stop propagation of the event so we don't throw open the dialog more than once.
+      event.stopPropagation();
+      // if the user presses the enter key or the spacebar click the upload button.
+      if (event.keyCode === 32 || event.keyCode === 13) {
+        uploadInput.click();
+      }
+    });
+  }
 });
 
 class FileUploader extends mixin(createComponent, initComponentBySearch, eventedState, handles) {

--- a/tests/axe/allHtml/a11y-html.json
+++ b/tests/axe/allHtml/a11y-html.json
@@ -459,7 +459,7 @@
       }
     ],
     "incomplete": [],
-    "timestamp": 1541803936690,
+    "timestamp": 1541805884452,
     "url": "http://localhost:3000",
     "violations": [
       {
@@ -525,7 +525,7 @@
         ]
       }
     ],
-    "time": 5694,
+    "time": 5883,
     "status": 404
   }
 ]

--- a/tests/axe/allHtml/a11y-html.json
+++ b/tests/axe/allHtml/a11y-html.json
@@ -459,55 +459,9 @@
       }
     ],
     "incomplete": [],
-    "timestamp": 1538076704912,
+    "timestamp": 1541803936690,
     "url": "http://localhost:3000",
     "violations": [
-      {
-        "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
-        "help": "Elements must have sufficient color contrast",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/color-contrast?application=webdriverjs",
-        "id": "color-contrast",
-        "impact": "serious",
-        "nodes": [
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#4285f4",
-                  "contrastRatio": 3.56,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#ffffff",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.56 (foreground color: #ffffff, background color: #4285f4, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<button id=\"reload-button\" class=\"blue-button text-button\" onclick=\"trackClick(this.trackingId);\n                     reloadButtonClick(this.url);\" jsselect=\"reloadButton\" jsvalues=\".url:reloadUrl; .trackingId:reloadTrackingId\" jscontent=\"msg\" jstcache=\"8\">Reload</button>",
-                    "target": [
-                      "#reload-button"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<button id=\"reload-button\" class=\"blue-button text-button\" onclick=\"trackClick(this.trackingId);\n                     reloadButtonClick(this.url);\" jsselect=\"reloadButton\" jsvalues=\".url:reloadUrl; .trackingId:reloadTrackingId\" jscontent=\"msg\" jstcache=\"8\">Reload</button>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#reload-button"
-            ]
-          }
-        ],
-        "tags": [
-          "cat.color",
-          "wcag2aa",
-          "wcag143"
-        ]
-      },
       {
         "description": "Ensures a navigation point to the primary content of the page. If the page contains iframes, each iframe should contain either no main landmarks or just one.",
         "help": "Page must contain one main landmark.",
@@ -571,7 +525,7 @@
         ]
       }
     ],
-    "time": 8052,
+    "time": 5694,
     "status": 404
   }
 ]

--- a/tests/spec/file-uploader_spec.js
+++ b/tests/spec/file-uploader_spec.js
@@ -1,8 +1,15 @@
 import FileUploader from '../../src/components/file-uploader/file-uploader';
+import addKeyboardNavigation from '../../src/components/file-uploader/addKeyboardNavigation';
 import HTML from '../../html/file-uploader/file-uploader.html';
 import flattenOptions from '../utils/flatten-options';
 
 describe('File Uploader', function() {
+  describe('addKeyboardNavigation', () => {
+    expect(function() {
+      addKeyboardNavigation();
+    }).not.toThrow();
+  });
+
   describe('Constructor', function() {
     let instance;
     let element;


### PR DESCRIPTION
Closes #1351

- adds semantic form wrapper to file-uploader 
- removes button role from label since a label can't be a button aria wise
- fixes a bug where there were two tabbable elements in the file-uploader button (label, input)
- adds keyboard navigation to label element