### PR TITLE
fix(input): revert experimental inputs back to 40px, remove hover styles

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -302,7 +302,7 @@
   // Checked
   .#{$prefix}--checkbox:checked:focus + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='true'].#{$prefix}--checkbox-label__focus::before,
-  // Indeterminate 
+  // Indeterminate
   .#{$prefix}--checkbox:indeterminate:focus + .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='mixed'].#{$prefix}--checkbox-label__focus::before {
     // We can't use outline here because of the rounded corners so have to increase the width/height to fake an outline.

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -507,7 +507,7 @@
     font-family: $font-family-mono;
     display: block;
     position: relative;
-    height: rem(32px);
+    height: rem(40px);
     max-width: rem(288px);
     padding: 0 $spacing-md;
     background-color: $field-01;
@@ -519,11 +519,6 @@
     &:focus,
     &.#{$prefix}--focused {
       @include focus-outline('outline');
-    }
-
-    &:hover {
-      cursor: pointer;
-      background-color: $hover-field;
     }
 
     &[data-invalid],
@@ -573,11 +568,11 @@
   }
 
   .#{$prefix}--date-picker--single .#{$prefix}--date-picker__icon {
-    top: 2rem;
+    top: 2.25rem;
   }
 
   .#{$prefix}--date-picker--nolabel .#{$prefix}--date-picker__icon {
-    top: rem(8px);
+    top: rem(12px);
   }
 
   .#{$prefix}--date-picker__icon ~ .#{$prefix}--date-picker__input {

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -230,26 +230,22 @@
     @include reset;
     @include font-family;
     @include typescale('zeta');
+    @include focus-outline('reset');
     position: relative;
     list-style: none;
     display: block;
     background-color: $field-01;
     border: none;
-    box-shadow: 0 1px 0 0 $ui-04;
-    order: 1;
+    border-bottom: 1px solid $ui-04;
     width: 100%;
-    height: rem(32px);
+    height: rem(40px);
     cursor: pointer;
     color: $text-01;
     outline: 2px solid transparent;
     transition: $transition--base all;
 
     &:focus {
-      outline: 2px solid $brand-01;
-    }
-
-    &:hover {
-      background-color: $ui-03;
+      @include focus-outline('outline');
     }
   }
 
@@ -274,7 +270,7 @@
     fill: $ui-05;
     position: absolute;
     right: 1rem;
-    top: rem(13px);
+    top: rem(17px);
     width: rem(10px);
     height: rem(5px);
     pointer-events: none;
@@ -287,15 +283,14 @@
   }
 
   .#{$prefix}--dropdown-text {
-    height: rem(32px);
-    padding-top: rem(9px);
-    padding-bottom: rem(9px);
+    height: rem(40px);
+    padding-top: rem(12px);
+    padding-bottom: rem(12px);
     padding-left: rem(15px);
     padding-right: $spacing-2xl;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    border: $input-border;
   }
 
   .#{$prefix}--dropdown-list {
@@ -338,12 +333,13 @@
   }
 
   .#{$prefix}--dropdown-link {
+    @include focus-outline('reset');
     display: block;
     color: currentColor;
     text-decoration: none;
     font-weight: normal;
     line-height: rem(16px);
-    padding: $spacing-xs 0;
+    padding: rem(11px) 0;
     margin: 0 rem(16px);
     border: 1px solid transparent;
     border-bottom: 1px solid $ui-03;
@@ -351,14 +347,18 @@
     overflow: hidden;
 
     &:focus {
-      outline: 2px solid $brand-01;
+      @include focus-outline('outline');
       margin: 0 rem(2px);
-      padding: $spacing-xs rem(14px);
+      padding: rem(11px) rem(14px);
     }
 
     &:hover {
       color: $text-01;
     }
+  }
+
+  .#{$prefix}--dropdown-item:hover .#{$prefix}--dropdown-link {
+    border-bottom-color: $hover-field;
   }
 
   .#{$prefix}--dropdown--selected {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -174,13 +174,12 @@
 
   .#{$prefix}--form__helper-text {
     @include typescale('omega');
+    font-style: italic;
     color: $text-02;
-    order: 1;
     line-height: 1.5;
     z-index: 0;
-    max-height: 3rem;
     opacity: 1;
-    margin-top: $spacing-2xs;
+    max-width: 75%;
     margin-bottom: $spacing-xs;
   }
 }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -298,8 +298,8 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box {
     position: relative;
     width: $list-box-width;
-    height: rem(32px);
-    max-height: rem(32px);
+    height: rem(40px);
+    max-height: rem(40px);
     background-color: $field-01;
     border: none;
     border-bottom: 1px solid $ui-04;
@@ -403,7 +403,7 @@ $list-box-menu-width: rem(300px);
     position: relative;
     display: inline-flex;
     align-items: center;
-    height: rem(32px);
+    height: rem(40px);
     padding: 0 1rem;
     cursor: pointer;
   }
@@ -510,7 +510,7 @@ $list-box-menu-width: rem(300px);
     position: absolute;
     left: 0;
     right: 0;
-    top: rem(32px);
+    top: rem(40px);
     width: $list-box-width;
     background-color: $ui-01;
     max-height: rem(120px);
@@ -524,7 +524,7 @@ $list-box-menu-width: rem(300px);
 
     display: flex;
     align-items: center;
-    height: rem(32px);
+    height: rem(40px);
     margin-top: -1px;
     padding: 0 1rem;
     cursor: pointer;

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -200,7 +200,7 @@
     padding-left: $spacing-md;
     padding-right: $spacing-xl;
     font-weight: 300;
-    height: rem(32px);
+    height: rem(40px);
     color: $text-01;
     background-color: $field-01;
     border: none;
@@ -215,10 +215,6 @@
 
     &:focus {
       @include focus-outline('outline');
-    }
-
-    &:hover {
-      background-color: $hover-field;
     }
 
     &:disabled {
@@ -272,7 +268,7 @@
     align-items: center;
     left: auto;
     right: 0.4rem;
-    top: 1.875rem;
+    top: 2.125rem;
   }
 
   .#{$prefix}--number__control-btn {
@@ -310,16 +306,16 @@
   }
 
   .#{$prefix}--number--nolabel .#{$prefix}--number__controls {
-    top: 0.375rem;
+    top: 0.625rem;
   }
 
   .#{$prefix}--number--helpertext .#{$prefix}--number__controls {
-    top: 2.25rem;
+    top: 1.75rem;
   }
 
   .#{$prefix}--number--helpertext:not([data-invalid]) .#{$prefix}--number__controls {
     top: auto;
-    bottom: 0.375rem;
+    bottom: 0.625rem;
   }
 
   .#{$prefix}--number--helpertext[data-invalid] .#{$prefix}--number__controls {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -209,7 +209,7 @@
     @include font-family;
     @include typescale('zeta');
     @include focus-outline('reset');
-    height: rem(32px);
+    height: rem(40px);
     appearance: none;
     display: block;
     width: rem(224px);
@@ -236,10 +236,6 @@
 
     &:focus {
       @include focus-outline('outline');
-    }
-
-    &:hover {
-      background-color: $hover-field;
     }
 
     &[data-invalid],
@@ -274,14 +270,14 @@
     fill: $ui-05;
     position: absolute;
     right: 1rem;
-    bottom: 0.75rem;
+    bottom: 1rem;
     width: rem(10px);
     height: rem(5px);
     pointer-events: none;
   }
 
   &[data-invalid] ~ .#{$prefix}--select__arrow {
-    bottom: 2.125rem;
+    bottom: 2.5rem;
   }
 
   .#{$prefix}--select-optgroup,
@@ -347,7 +343,7 @@
 
   .#{$prefix}--select--inline .#{$prefix}--select__arrow {
     bottom: auto;
-    top: 0.875rem;
+    top: 1.125rem;
     right: $spacing-xs;
   }
 

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -287,7 +287,7 @@
   .#{$prefix}--slider-text-input,
   .#{$prefix}-slider-text-input {
     width: rem(64px);
-    height: 2rem;
+    height: rem(40px);
     padding: 0;
     text-align: center;
     -moz-appearance: textfield;

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -120,28 +120,24 @@
   }
 }
 
-@mixin text-input--experimental {
+@mixin text-input--x {
   .#{$prefix}--text-input {
     @include reset;
     @include typescale('zeta');
     @include focus-outline('reset');
     background-color: $field-01;
     width: 100%;
-    height: rem(32px);
+    height: rem(40px);
     padding: 0 $spacing-xl 0 $spacing-md;
     color: $text-01;
     border: none;
     border-bottom: 1px solid $ui-04;
     transition: $transition--base all;
-  }
 
-  .#{$prefix}--text-input:hover {
-    background-color: $hover-field;
-  }
-
-  .#{$prefix}--text-input:focus,
-  .#{$prefix}--text-input:active {
-    @include focus-outline('outline');
+    &:focus,
+    &:active {
+      @include focus-outline('outline');
+    }
   }
 
   .#{$prefix}--text-input::-webkit-input-placeholder {
@@ -190,7 +186,7 @@
 
 @include exports('text-input') {
   @if feature-flag-enabled('components-x') {
-    @include text-input--experimental;
+    @include text-input--x;
   } @else {
     @include text-input;
   }

--- a/src/components/text-input/text-input.hbs
+++ b/src/components/text-input/text-input.hbs
@@ -42,6 +42,9 @@
 
 <div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper">
   <label for="text-input-5" class="bx--label">Text Input label</label>
+  <div class="bx--form__helper-text">
+    Optional helper text goes here
+  </div>
   {{#unless password}}
   <input id="text-input-5" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Placeholder text">
   {{else}}
@@ -57,13 +60,13 @@
     </svg>
   </button>
   {{/unless}}
-  <div class="bx--form__helper-text">
-    Optional helper text goes here
-  </div>
 </div>
 
 <div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper" style="width: 320px">
   <label for="text-input-6" class="bx--label">Text Input label</label>
+  <div class="bx--form__helper-text">
+    Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
+  </div>
   {{#unless password}}
   <input id="text-input-6" type="text" class="bx--text-input{{#if light}} bx--text-input--light{{/if}}" placeholder="Placeholder text">
   {{else}}
@@ -79,9 +82,6 @@
     </svg>
   </button>
   {{/unless}}
-  <div class="bx--form__helper-text">
-    Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
-  </div>
 </div>
 
 <div {{#if password}} data-text-input {{/if}} class="bx--form-item bx--text-input-wrapper">

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -142,7 +142,7 @@
     border-bottom: 1px solid $ui-04;
     width: 4.875rem;
     color: $text-01;
-    height: rem(32px);
+    height: rem(40px);
     padding: 0 $spacing-md;
     order: 2;
     transition: outline $transition--base;

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -1,7 +1,7 @@
 @import 'vars';
 
 $font-family-mono: 'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace !default;
-$font-family-sans-serif: 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
+$font-family-sans-serif: 'IBM Plex Sans', 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
 $font-family-serif: 'ibm-plex-serif', 'Georgia', Times, serif !default;
 $font-family-helvetica: 'IBM Helvetica', Helvetica Neue, HelveticaNeue, Helvetica, sans-serif !default;
 
@@ -19,7 +19,7 @@ $typescale-map: (
   'omega': 0.75rem,
   'caption': 0.75rem,
   'legal': 0.6875rem,
-  'p': 1rem
+  'p': 1rem,
 );
 
 @mixin typescale($size) {
@@ -81,7 +81,7 @@ $font-size-map: (
   '16': 1rem,
   '14': 0.875rem,
   '12': 0.75rem,
-  '11': 0.6875rem
+  '11': 0.6875rem,
 );
 
 @mixin font-size($size) {

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -1,7 +1,7 @@
 @import 'vars';
 
 $font-family-mono: 'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace !default;
-$font-family-sans-serif: 'IBM Plex Sans', 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
+$font-family-sans-serif: 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
 $font-family-serif: 'ibm-plex-serif', 'Georgia', Times, serif !default;
 $font-family-helvetica: 'IBM Helvetica', Helvetica Neue, HelveticaNeue, Helvetica, sans-serif !default;
 


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1424

Updates the following form items:
- Date Picker
- Dropdown
- List Box
- Number Input
- Select
- Slider
- Text Input
- Time Picker

I did not touch TextArea. @jnm2377, I would just include these updates in your TextArea PR

#### Changelog

**New**

- ~Added `'IBM Plex Sans'` to `$font-family-sans-serif`, as italic styles were not rendering properly without it.~ After talking with @asudoh, a change like this should be discussed in more detail in a separate PR 
- `bx--form__helper-text` now uses italics

**Changed**

- All inputs are now 40px by default
- Optional text now comes directly after the label
- The positioning of arrows/chevrons due to new sizes 

**Removed**

- Hover styles from input elements

#### Testing / Reviewing

[Staging Link](http://carbon-dev-environment-field-update-fluent-gelada.mybluemix.net/?nav=text-input)
