### PR TITLE
fix(accordion): left align non-experimental accordion titles

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -75,6 +75,7 @@
     @include line-height('body');
     margin: $accordion-title-margin;
     font-weight: 400;
+    text-align: left;
   }
 
   .#{$prefix}--accordion__content {


### PR DESCRIPTION
Closes #1403 

This PR overrides browser styles and left-aligns non-experimental accordion titles

#### Changelog

**Changed**

- left align non-experimental accordion titles