### PR TITLE
fix(structured-list): implement keyboard navigation for new markup

### DIFF
--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -50,7 +50,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
   }
 
   _handleInputChecked(index) {
-    const rows = [...this.element.querySelectorAll(this.options.selectorRow)];
+    const rows = this.element.querySelectorAll(this.options.selectorRow);
     const input = rows[index].querySelector('input');
     input.checked = true;
   }

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -67,11 +67,12 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
 
   // Handle Enter or Space keydown events for selecting <label> rows
   _handleKeydownChecked(evt) {
+    evt.preventDefault(); // prevent spacebar from scrolling page
     const selectedRow = eventMatches(evt, this.options.selectorRow);
     [...this.element.querySelectorAll(this.options.selectorRow)].forEach(row => row.classList.remove(this.options.classActive));
     if (selectedRow) {
       selectedRow.classList.add(this.options.classActive);
-      const input = this.element.querySelector(this.options.selectorListInput(selectedRow.getAttribute('for')));
+      const input = selectedRow.querySelector('input');
       input.checked = true;
     }
   }

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -87,7 +87,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
       const firstIndex = 0;
       const nextIndex = this._nextIndex(rows, selectedRow, direction);
       const lastIndex = rows.length - 1;
-      const getIndex = () => {
+      const getSelectedIndex = () => {
         switch (nextIndex) {
           case -1:
             return lastIndex;
@@ -97,7 +97,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
             return nextIndex;
         }
       };
-      const selectedIndex = getIndex();
+      const selectedIndex = getSelectedIndex();
       rows[selectedIndex].classList.add(this.options.classActive);
       rows[selectedIndex].focus();
       this._handleInputChecked(selectedIndex);

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -49,9 +49,14 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     return array.indexOf(arrayItem) + direction; // returns -1, 0, 1, 2, 3, 4...
   }
 
+  _getInput(index) {
+    const rows = [...this.element.querySelectorAll(this.options.selectorRow)];
+    return this.element.ownerDocument.querySelector(this.options.selectorListInput(rows[index].getAttribute('for')));
+  }
+
   _handleInputChecked(index) {
     const rows = this.element.querySelectorAll(this.options.selectorRow);
-    const input = rows[index].querySelector('input');
+    const input = this.getInput(index) || rows[index].querySelector('input');
     input.checked = true;
   }
 
@@ -70,7 +75,9 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     [...this.element.querySelectorAll(this.options.selectorRow)].forEach(row => row.classList.remove(this.options.classActive));
     if (selectedRow) {
       selectedRow.classList.add(this.options.classActive);
-      const input = selectedRow.querySelector('input');
+      const input =
+        selectedRow.querySelector(this.options.selectorListInput(selectedRow.getAttribute('for'))) ||
+        selectedRow.querySelector('input');
       input.checked = true;
     }
   }

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -21,7 +21,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     super(element, options);
     this.manage(
       on(this.element, 'keydown', evt => {
-        if (evt.which === 38 || evt.which === 40) {
+        if (evt.which === 37 || evt.which === 38 || evt.which === 39 || evt.which === 40) {
           this._handleKeydownArrow(evt);
         }
         if (evt.which === 13 || evt.which === 32) {
@@ -38,7 +38,9 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
 
   _direction(evt) {
     return {
+      37: -1, // backward
       38: -1, // backward
+      39: 1, // forward
       40: 1, // forward
     }[evt.which];
   }

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -47,13 +47,9 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     return array.indexOf(arrayItem) + direction; // returns -1, 0, 1, 2, 3, 4...
   }
 
-  _getInput(index) {
-    const rows = [...this.element.querySelectorAll(this.options.selectorRow)];
-    return this.element.ownerDocument.querySelector(this.options.selectorListInput(rows[index].getAttribute('for')));
-  }
-
   _handleInputChecked(index) {
-    const input = this._getInput(index);
+    const rows = [...this.element.querySelectorAll(this.options.selectorRow)];
+    const input = rows[index].querySelector('input');
     input.checked = true;
   }
 
@@ -79,6 +75,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
 
   // Handle up and down keydown events for selecting <label> rows
   _handleKeydownArrow(evt) {
+    evt.preventDefault(); // prevent arrow keys from scrolling
     const selectedRow = eventMatches(evt, this.options.selectorRow);
     const direction = this._direction(evt);
 
@@ -88,24 +85,20 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
       const firstIndex = 0;
       const nextIndex = this._nextIndex(rows, selectedRow, direction);
       const lastIndex = rows.length - 1;
-
-      switch (nextIndex) {
-        case -1:
-          rows[lastIndex].classList.add(this.options.classActive);
-          rows[lastIndex].focus();
-          this._handleInputChecked(lastIndex);
-          break;
-        case rows.length:
-          rows[firstIndex].classList.add(this.options.classActive);
-          rows[firstIndex].focus();
-          this._handleInputChecked(firstIndex);
-          break;
-        default:
-          rows[nextIndex].classList.add(this.options.classActive);
-          rows[nextIndex].focus();
-          this._handleInputChecked(nextIndex);
-          break;
-      }
+      const getIndex = () => {
+        switch (nextIndex) {
+          case -1:
+            return lastIndex;
+          case rows.length:
+            return firstIndex;
+          default:
+            return nextIndex;
+        }
+      };
+      const selectedIndex = getIndex();
+      rows[selectedIndex].classList.add(this.options.classActive);
+      rows[selectedIndex].focus();
+      this._handleInputChecked(selectedIndex);
     }
   }
 


### PR DESCRIPTION
Closes #1426

This PR will fix the keyboard navigation behavior for structured lists, in accordance to http://w3c.github.io/aria-practices/#radiobutton

> * When a radio group receives focus:
>   * If a radio button is checked, focus is set on the checked button.
>   * If none of the radio buttons are checked, focus is set on the first radio button in the group.
> * `Space`: checks the focused radio button if it is not already checked.
> * `Right Arrow` and `Down Arrow`: move focus to the next radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the last button, focus moves to the first button.
> * `Left Arrow` and `Up Arrow`: move focus to the previous radio button in the group, uncheck the previously focused button, and check the newly focused button. If focus is on the first button, focus moves to the last button.

#### Changelog

**New**

- event handlers for left/right arrow keydown events

**Changed**

The previous `keydown` handlers were looking for `<label>` rows with a `for` attribute for a corresponding labelable element, but the `for` attribute is not required when using a `<label>` due to the implicit association by nesting the corresponding `input` in our templates. The new element selection query will:

- in the case of `Enter` or `Space` keypress: find the nested `input` in the selected row
- in the case of arrow key keypress: find the nested `input` in the row with the correct index that the user is navigating towards

- handle enter or space `keydown` events for selecting `<label>` rows
- handle up arrow and down arrow `keydown` events for selecting `label` rows

#### Testing / Reviewing

1. tab into a structured list
2. navigate the list with tab or arrow keys
3. press Enter or space bar to make new selection

related issues:

https://github.com/IBM/carbon-components-react/issues/1555

https://github.com/IBM/carbon-components-react/pull/1528