### PR TITLE
fix(time-picker): move label before input it's labelling

### DIFF
--- a/src/components/time-picker/time-picker.hbs
+++ b/src/components/time-picker/time-picker.hbs
@@ -1,9 +1,9 @@
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--time-picker">
     <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
       <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
         placeholder="hh:mm" maxlength="5" />
-      <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
       <div class="{{@root.prefix}}--form-requirement">
         Invalid time.
       </div>


### PR DESCRIPTION
Closes #1345

The input's label was placed after the form element instead of before. Just a quick fix ✊ 