### PR TITLE
 refactor(ui-shell): update name and prefix, z-indices, and hbs templates

### DIFF
--- a/src/components/ui-shell/_content.scss
+++ b/src/components/ui-shell/_content.scss
@@ -1,0 +1,29 @@
+@import '../../globals/scss/functions';
+@import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/vars';
+@import 'functions';
+
+@mixin carbon-content {
+  .#{$prefix}--content {
+    transform: translate3d(0, 0, 0);
+    will-change: margin-left;
+  }
+
+  .#{$prefix}--header ~ .#{$prefix}--content {
+    margin-top: mini-units(6);
+  }
+
+  .#{$prefix}--side-nav ~ .#{$prefix}--content {
+    margin-left: mini-units(6);
+  }
+
+  .#{$prefix}--side-nav.#{$prefix}--side-nav--expanded ~ .#{$prefix}--content {
+    margin-left: mini-units(32);
+  }
+}
+
+@include exports('carbon-content') {
+  @if feature-flag-enabled('ui-shell') {
+    @include carbon-content;
+  }
+}

--- a/src/components/ui-shell/_header.scss
+++ b/src/components/ui-shell/_header.scss
@@ -19,6 +19,7 @@
     height: mini-units(6);
     background-color: $shell-header-bg-01;
     color: $shell-header-text-01;
+    z-index: z('header');
   }
 
   .#{$prefix}--header__action {
@@ -58,14 +59,14 @@
     height: 100%;
     padding: 0 mini-units(2);
     text-decoration: none;
-    font-weight: 400;
+    font-weight: 600;
     letter-spacing: 0.1px;
     line-height: 20px;
     user-select: none;
   }
 
-  .#{$prefix}--header__name {
-    font-weight: 600;
+  .#{$prefix}--header__name--prefix {
+    font-weight: 400;
   }
 
   a.#{$prefix}--header__name,

--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -2,6 +2,7 @@
 @import '../../globals/scss/css--helpers';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
+@import '../../globals/scss/layout';
 @import '../../globals/scss/vars';
 @import 'functions';
 @import 'theme';
@@ -84,6 +85,7 @@
     overflow: hidden;
     // Separates out the panel from the header of the same color
     border-top: 1px solid $ibm-colors__gray--80;
+    z-index: z('header');
   }
 
   .#{$prefix}--side-nav:not(.#{$prefix}--side-nav--fixed):hover,
@@ -117,7 +119,12 @@
     display: flex;
     border-bottom: 1px solid $ibm-colors__gray--80;
     width: 100%;
+    height: mini-units(6);
     max-width: 100%;
+
+    @include expanded() {
+      height: auto;
+    }
   }
 
   //----------------------------------------------------------------------------

--- a/src/components/ui-shell/_ui-shell.scss
+++ b/src/components/ui-shell/_ui-shell.scss
@@ -5,3 +5,4 @@
 @import 'product-switcher';
 @import 'side-nav';
 @import 'nav';
+@import 'content';

--- a/src/components/ui-shell/header.hbs
+++ b/src/components/ui-shell/header.hbs
@@ -10,7 +10,11 @@
   {{/if}}
   </button>
   <a class="{{@root.prefix}}--header__name" href="#" title="{{header.name}}">
-    {{header.company}} <span class="{{@root.prefix}}--header__name">{{header.platform}}</span>
+    <span class="bx--header__name--prefix">
+      {{header.company}}
+      &nbsp;
+    </span>
+    {{header.platform}}
   </a>
   {{> header-nav }}
   <div class="{{@root.prefix}}--header__global">

--- a/src/components/ui-shell/side-nav-header.hbs
+++ b/src/components/ui-shell/side-nav-header.hbs
@@ -16,19 +16,19 @@
       title="{{ sidenav.title.text }}">
       {{ sidenav.title.text }}
     </h2>
-    {{#if sidenav.title.subMenu }}
     <div class="{{@root.prefix}}--side-nav__switcher">
       <label for="side-nav-switcher" class="{{@root.prefix}}--assistive-text">
-        {{ sidenav.title.subMenu.label }}
+        Switcher
       </label>
-      <select id="side-nav-switcher" class="{{@root.prefix}}--side-nav__select" name="Switcher">
+      <select id="carbon-side-nav-switcher" class="{{@root.prefix}}--side-nav__select">
         <option
           class="{{@root.prefix}}--side-nav__option"
           disabled=""
           hidden=""
           value=""
-          selected="">
-          {{ sidenav.title.subMenu.label }}
+          selected=""
+        >
+          Switcher
         </option>
         <option class="{{@root.prefix}}--side-nav__option" value="Option 1">
           Option 1
@@ -46,12 +46,12 @@
           width="20"
           height="20"
           xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 32 32">
+          viewBox="0 0 32 32"
+        >
           <path d="M16 22L6 12l1.414-1.414L16 19.172l8.586-8.586L26 12 16 22z" />
         </svg>
       </div>
     </div>
-    {{/if}}
   </div>
 </header>
 {{/if}}

--- a/src/components/ui-shell/ui-shell.config.js
+++ b/src/components/ui-shell/ui-shell.config.js
@@ -231,6 +231,7 @@ module.exports = {
     nav,
     sidenav,
     switcher,
+    content: Array.from({ length: 10 }),
   },
   variants: [
     {

--- a/src/components/ui-shell/ui-shell.hbs
+++ b/src/components/ui-shell/ui-shell.hbs
@@ -6,3 +6,19 @@
 {{/if}}
 {{> product-switcher }}
 {{> nav }}
+<div class="bx--content">
+  <h1>Heading</h1>
+  {{#each content}}
+  <h2>Sub-section</h2>
+  <p>
+    Elit odit veritatis repudiandae laboriosam amet. Dolore doloribus ut obcaecati harum ad Expedita hic atque quas repellat et sed Tempore similique laudantium autem quam commodi, temporibus. Minus voluptates reiciendis adipisci.
+  </p>
+  <p>
+    Elit odit veritatis repudiandae laboriosam amet. Dolore doloribus ut obcaecati harum ad Expedita hic atque quas repellat et sed Tempore similique laudantium autem quam commodi, temporibus. Minus voluptates reiciendis adipisci.
+  </p>
+  <h3>Tertiary section</h3>
+  <p>
+    Adipisicing eius ea est ducimus nihil Sit modi quisquam tempore asperiores at Culpa omnis quasi a rem sapiente, illo Omnis aut maiores magnam perspiciatis at, rerum? Esse ullam veritatis debitis.
+  </p>
+  {{/each}}
+</div>


### PR DESCRIPTION
While working with UI Shell I noticed some things we need to fix/refactor, namely we need to add in z-index properties on our controls and update the content in our hbs templates to make sure we prevent events like arrow up/down or home/end.

#### Changelog

**New**

- `_content.scss` for UI Shell

**Changed**

- Header now uses a prefix as a modifier and the default is just name
- Add in z-index for header and side-nav

**Removed**

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
