### PR TITLE
fix(button): inset button border on focus

### DIFF
--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -148,7 +148,7 @@
   }
 
   &:focus::after {
-    border-color: $brand-01;
+    border-color: $focus;
   }
 
   &:disabled:hover,

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -118,9 +118,37 @@
     background-color: $hover-bg-color;
   }
 
-  &:focus {
-    border: $button-border-width solid $ui-02;
-    outline: $button-outline-width solid $brand-01;
+  &::before,
+  &::after {
+    box-sizing: border-box;
+    position: absolute;
+    content: '';
+    transition-duration: $transition--base;
+    transition-timing-function: ease-in;
+  }
+
+  &::before {
+    top: calc(-#{$button-border-width} + #{$button-outline-width});
+    left: -$button-border-width + $button-outline-width;
+    width: calc(100% + (2 * #{$button-border-width}) - (2 * #{$button-outline-width}));
+    height: calc(100% + (2 * #{$button-border-width}) - (2 * #{$button-outline-width}));
+    border: 1px solid transparent;
+  }
+
+  &:focus::before {
+    border-color: $ui-02;
+  }
+
+  &::after {
+    top: -#{$button-border-width};
+    left: -#{$button-border-width};
+    height: calc(100% + 2 * #{$button-border-width});
+    width: calc(100% + 2 * #{$button-border-width});
+    border: $button-outline-width solid transparent;
+  }
+
+  &:focus::after {
+    border-color: $brand-01;
   }
 
   &:disabled:hover,


### PR DESCRIPTION
Closes #1463 

This PR modifies the existing experimental button mixin styles to inset the border on focus. Instead of changing the values of `border` and `outline`, pseudo-elements are used to create the inset border effect.

**New**

- add experimental button pseudo-elements

**Changed**

- experimental button mixin `:focus` styles