### PR TITLE
fix(overflow-menu): support flip mode in experimental

### DIFF
--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -153,7 +153,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlu
     return getFloatingPosition({
       menuSize: element.getBoundingClientRect(),
       refPosition: refNode.getBoundingClientRect(),
-      offset: typeof offset !== 'function' ? offset : offset(element, direction),
+      offset: typeof offset !== 'function' ? offset : offset(element, direction, refNode),
       direction,
       scrollX: refNode.ownerDocument.defaultView.pageXOffset,
       scrollY: refNode.ownerDocument.defaultView.pageYOffset,

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -270,6 +270,18 @@
     width: rem(6px);
   }
 
+  .#{$prefix}--overflow-menu--flip.#{$prefix}--overflow-menu-options[data-floating-menu-direction='top']::after,
+  .#{$prefix}--overflow-menu--flip.#{$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+    left: auto;
+    right: 0;
+  }
+
+  .#{$prefix}--overflow-menu--flip.#{$prefix}--overflow-menu-options[data-floating-menu-direction='left']::after,
+  .#{$prefix}--overflow-menu--flip.#{$prefix}--overflow-menu-options[data-floating-menu-direction='right']::after {
+    top: auto;
+    bottom: 0;
+  }
+
   .#{$prefix}--overflow-menu-options--open {
     display: flex;
   }

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -34,10 +34,11 @@ const triggerButtonPositionFactors = {
 /**
  * @param {Element} menuBody The menu body with the menu arrow.
  * @param {string} direction The floating menu direction.
+ * @param {Element} trigger The trigger button.
  * @returns {FloatingMenu~offset} The adjustment of the floating menu position, upon the position of the menu arrow.
  * @private
  */
-export const getMenuOffset = (menuBody, direction) => {
+export const getMenuOffset = (menuBody, direction, trigger) => {
   const triggerButtonPositionProp = triggerButtonPositionProps[direction];
   const triggerButtonPositionFactor = triggerButtonPositionFactors[direction];
   if (!triggerButtonPositionProp || !triggerButtonPositionFactor) {
@@ -63,17 +64,21 @@ export const getMenuOffset = (menuBody, direction) => {
   }
 
   if (componentsX) {
+    const flip = menuBody.classList.contains(`${settings.prefix}--overflow-menu--flip`);
+
     if (triggerButtonPositionProp === 'top' || triggerButtonPositionProp === 'bottom') {
+      const triggerWidth = trigger.offsetWidth;
       return {
-        left: menuWidth / 2 - 16,
+        left: (!flip ? 1 : -1) * (menuWidth / 2 - triggerWidth / 2),
         top: 0,
       };
     }
 
     if (triggerButtonPositionProp === 'left' || triggerButtonPositionProp === 'right') {
+      const triggerHeight = trigger.offsetHeight;
       return {
         left: 0,
-        top: menuHeight / 2 - 16,
+        top: (!flip ? 1 : -1) * (menuHeight / 2 - triggerHeight / 2),
       };
     }
   }

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -64,7 +64,12 @@ export const getMenuOffset = (menuBody, direction, trigger) => {
   }
 
   if (componentsX) {
-    const flip = menuBody.classList.contains(`${settings.prefix}--overflow-menu--flip`);
+    // eslint-disable-next-line no-use-before-define
+    const menu = OverflowMenu.components.get(trigger);
+    if (!menu) {
+      throw new TypeError('Overflow menu instance cannot be found.');
+    }
+    const flip = menuBody.classList.contains(menu.options.classMenuFlip);
 
     if (triggerButtonPositionProp === 'top' || triggerButtonPositionProp === 'bottom') {
       const triggerWidth = trigger.offsetWidth;


### PR DESCRIPTION
Fixes #1481.

#### Changelog

**New**

- Add 3rd argument to `objOffset`/`objOffsetFlip` callbacks, which is, the trigger button
- Logic to support flip mode in experimental

#### Testing / Reviewing

Testing should make sure overflow menu, especially in experimental mode, is not broken.