### PR TITLE
fix(modal): prevent modal content overflow from shifting footer

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -78,6 +78,11 @@
     margin-bottom: $spacing-lg;
   }
 
+  .#{$prefix}--modal-header,
+  .#{$prefix}--modal-footer {
+    flex-shrink: 0;
+  }
+
   .#{$prefix}--modal-header__label {
     @include reset;
     @include typescale('omega');


### PR DESCRIPTION
Closes #1000 

Closes #663

This PR will prevent overflow content in a modal from shifting the modal footer elements past the modal container's dimensions

#### Changelog

**Changed**

- prevent `flex-shrink` in non-`modal-content` elements