### PR TITLE
feat(list-box): add disabled styles for listbox selection component

### DIFF
--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -219,6 +219,10 @@ $list-box-menu-width: rem(300px);
     outline: none;
   }
 
+  .#{$prefix}--list-box__selection--disabled:hover {
+    cursor: not-allowed;
+  }
+
   // Descendant of a `list-box` that displays a list of options to select
   .#{$prefix}--list-box__menu {
     @include box-shadow();

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -219,10 +219,6 @@ $list-box-menu-width: rem(300px);
     outline: none;
   }
 
-  .#{$prefix}--list-box__selection--disabled:hover {
-    cursor: not-allowed;
-  }
-
   // Descendant of a `list-box` that displays a list of options to select
   .#{$prefix}--list-box__menu {
     @include box-shadow();
@@ -362,6 +358,10 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__menu-item--highlighted {
     background-color: transparent;
     text-decoration: none;
+  }
+
+  .#{$prefix}--list-box--disabled .#{$prefix}--list-box__selection:hover {
+    cursor: not-allowed;
   }
 
   // Inline variant for a `list-box`


### PR DESCRIPTION
This PR adds disabled styles to the listbox selection component

#### Changelog

**New**

- disabled styles on hover of listbox selection component

Related:

https://github.com/IBM/carbon-components-react/issues/1596

https://github.com/IBM/carbon-components-react/pull/1597

