### PR TITLE
chore(components): remove deprecated JavaScript components

### DIFF
--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -1,7 +1,12 @@
+import warning from 'warning';
+import { breakingChangesX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import removedComponent from '../removed-component';
+
+let didWarnAboutDeprecation;
 
 class Carousel extends mixin(createComponent, initComponentBySearch) {
   /**
@@ -12,6 +17,13 @@ class Carousel extends mixin(createComponent, initComponentBySearch) {
    */
   constructor(element, options) {
     super(element, options);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `Carousel` component in `carbon-components` has been deprecated. It will be removed in the next major release.'
+      );
+      didWarnAboutDeprecation = true;
+    }
     this.filmstrip = this.element.querySelector(this.options.selectorFilmstrip);
     this.carouselItem = this.element.querySelector(this.options.selectorCarouselItem);
 
@@ -64,4 +76,4 @@ class Carousel extends mixin(createComponent, initComponentBySearch) {
   static components = new WeakMap();
 }
 
-export default Carousel;
+export default (!breakingChangesX ? Carousel : removedComponent('Carousel'));

--- a/src/components/data-table/data-table.config.js
+++ b/src/components/data-table/data-table.config.js
@@ -252,6 +252,7 @@ const rows = [
 ];
 
 module.exports = {
+  hidden: true,
   context: {
     prefix,
   },

--- a/src/components/data-table/data-table.js
+++ b/src/components/data-table/data-table.js
@@ -1,3 +1,5 @@
+import warning from 'warning';
+import { breakingChangesX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -6,6 +8,9 @@ import eventedState from '../../globals/js/mixins/evented-state';
 import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
+import removedComponent from '../removed-component';
+
+let didWarnAboutDeprecation;
 
 class DataTable extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
@@ -26,6 +31,15 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
    */
   constructor(element, options) {
     super(element, options);
+
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `DataTable` component in `carbon-components` has been deprecated. It will be removed in the next major release. ' +
+          'If you still need this component, please use the `DataTableV2` component.'
+      );
+      didWarnAboutDeprecation = true;
+    }
 
     this.container = element.parentNode; // requires the immediate parent to be the container
     this.tableBody = this.element.querySelector(this.options.selectorTableBody);
@@ -232,4 +246,4 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
   }
 }
 
-export default DataTable;
+export default (!breakingChangesX ? DataTable : removedComponent('DataTable'));

--- a/src/components/fab/fab.js
+++ b/src/components/fab/fab.js
@@ -1,8 +1,13 @@
+import warning from 'warning';
+import { breakingChangesX } from '../../globals/js/feature-flags';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentByEvent from '../../globals/js/mixins/init-component-by-event';
 import handles from '../../globals/js/mixins/handles';
 import on from '../../globals/js/misc/on';
+import removedComponent from '../removed-component';
+
+let didWarnAboutDeprecation;
 
 class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
   /**
@@ -14,6 +19,13 @@ class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
    */
   constructor(element) {
     super(element);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `FabButton` component in `carbon-components` has been deprecated. It will be removed in the next major release.'
+      );
+      didWarnAboutDeprecation = true;
+    }
     this.manage(
       on(element, 'click', event => {
         this.toggle(event);
@@ -74,4 +86,4 @@ class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
   };
 }
 
-export default FabButton;
+export default (!breakingChangesX ? FabButton : removedComponent('FabButton'));

--- a/src/components/lightbox/lightbox.js
+++ b/src/components/lightbox/lightbox.js
@@ -1,11 +1,23 @@
+import warning from 'warning';
+import { breakingChangesX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import removedComponent from '../removed-component';
+
+let didWarnAboutDeprecation;
 
 class Lightbox extends mixin(createComponent, initComponentBySearch) {
   constructor(element, options) {
     super(element, options);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `Lightbox` component in `carbon-components` has been deprecated. It will be removed in the next major release.'
+      );
+      didWarnAboutDeprecation = true;
+    }
     this.activeIndex = this.element.dataset.lightboxIndex;
     this.totalSlides = this.element.querySelectorAll(this.options.selectorLightboxItem).length - 1;
 
@@ -67,4 +79,4 @@ class Lightbox extends mixin(createComponent, initComponentBySearch) {
   static components = new WeakMap();
 }
 
-export default Lightbox;
+export default (!breakingChangesX ? Lightbox : removedComponent('Lightbox'));

--- a/src/components/removed-component.js
+++ b/src/components/removed-component.js
@@ -1,0 +1,30 @@
+import warning from 'warning';
+
+/**
+ * @param {string} name The component name.
+ * @returns {Function} A stub of removed component.
+ */
+const removedComponent = name => {
+  let didWarnAboutRemoval = false;
+  const warn = () => {
+    if (__DEV__) {
+      warning(didWarnAboutRemoval, `The \`${name}\` component has been removed.`);
+      didWarnAboutRemoval = true;
+    }
+  };
+  return class {
+    constructor() {
+      warn();
+    }
+    static create() {
+      warn();
+    }
+    static init() {
+      warn();
+    }
+    static components = new WeakMap();
+    static options = {};
+  };
+};
+
+export default removedComponent;

--- a/src/components/unified-header/left-nav.js
+++ b/src/components/unified-header/left-nav.js
@@ -1,3 +1,5 @@
+import warning from 'warning';
+import { breakingChangesX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -5,6 +7,9 @@ import initComponentBySearch from '../../globals/js/mixins/init-component-by-sea
 import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
+import removedComponent from '../removed-component';
+
+let didWarnAboutDeprecation;
 
 class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
   /**
@@ -40,6 +45,13 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
    */
   constructor(element, options) {
     super(element, options);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `LeftNav` component in `carbon-components` has been deprecated. It will be removed in the next major release.'
+      );
+      didWarnAboutDeprecation = true;
+    }
     this.leftNavSectionActive = false;
     this.hookOpenActions();
     this.hookListSectionEvents();
@@ -537,4 +549,4 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
   static components = new WeakMap();
 }
 
-export default LeftNav;
+export default (!breakingChangesX ? LeftNav : removedComponent('LeftNav'));

--- a/src/components/unified-header/profile-switcher.js
+++ b/src/components/unified-header/profile-switcher.js
@@ -1,3 +1,5 @@
+import warning from 'warning';
+import { breakingChangesX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -5,6 +7,9 @@ import initComponentBySearch from '../../globals/js/mixins/init-component-by-sea
 import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
+import removedComponent from '../removed-component';
+
+let didWarnAboutDeprecation;
 
 class ProfileSwitcher extends mixin(createComponent, initComponentBySearch, handles) {
   /**
@@ -30,6 +35,15 @@ class ProfileSwitcher extends mixin(createComponent, initComponentBySearch, hand
    */
   constructor(element, options) {
     super(element, options);
+
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `ProfileSwitcher` component in `carbon-components` has been deprecated. ' +
+          'It will be removed in the next major release.'
+      );
+      didWarnAboutDeprecation = true;
+    }
 
     this.manage(
       on(this.element.ownerDocument, 'click', evt => {
@@ -301,4 +315,4 @@ class ProfileSwitcher extends mixin(createComponent, initComponentBySearch, hand
   static components = new WeakMap();
 }
 
-export default ProfileSwitcher;
+export default (!breakingChangesX ? ProfileSwitcher : removedComponent('ProfileSwitcher'));

--- a/src/globals/js/feature-flags.js
+++ b/src/globals/js/feature-flags.js
@@ -53,3 +53,4 @@
  */
 
 exports.componentsX = false;
+exports.breakingChangesX = false;

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -85,7 +85,12 @@ module.exports = function(config) {
                   },
                 ],
               ],
-              plugins: ['transform-class-properties', 'transform-object-rest-spread', ['transform-runtime', { polyfill: false }]]
+              plugins: [
+                'transform-class-properties',
+                'transform-object-rest-spread',
+                ['transform-runtime', { polyfill: false }],
+                'dev-expression',
+              ]
                 .concat(
                   cloptions.debug
                     ? []
@@ -185,6 +190,7 @@ module.exports = function(config) {
                   // - Not meeting the code coverage standard set here, which shouldn't have happened
                   // - Very browser dependent code that wouldn't get code coverage unless we run the suite with Sauce Labs
                   // That said, new files should never be added, except for misc code that is very broser-specific
+                  'src/components/removed-component.js',
                   'src/components/code-snippet/code-snippet.js',
                   'src/components/copy-button/copy-button.js',
                   'src/components/detail-page-header/detail-page-header.js',


### PR DESCRIPTION
Refs #1501.

#### Changelog

**New**

- `breakingChangesX` feature flag
- A pseudo component that represents a removed component (does nothing but emitting a warning)

**Changed**

- Exports of deprecated components to above pseudo component

#### Testing / Reviewing

Testing should make sure:

* Our dev env is not broken
* Our build is not broken