### PR TITLE
chore(docs/tests): update tabs docs, fix wrong function name in test

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -4,10 +4,10 @@
 
 Modifiers are used with various classes for Tabs.
 
-| Name                            | Description                                                              | 
-|---------------------------------|--------------------------------------------------------------------------|
-| .bx--tabs__nav--hidden          | Applies specific styles to hide the narrow tab menu options              |
-| .bx--tabs__nav-item--selected   | Applies specific styles to the currently selected tab item               |
+| Name                            | Description                                                              |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| .bx--tabs\_\_nav--hidden        | Applies specific styles to hide the narrow tab menu options              |
+| .bx--tabs\_\_nav-item--selected | Applies specific styles to the currently selected tab item               |
 | .bx--tabs--light                | Selector for applying light dropdown styles when tabs are in mobile view |
 
 ### JavaScript
@@ -35,10 +35,10 @@ Tabs.create(document.getElementById('my-tabs'));
 
 #### Public Methods
 
-| Name      | Params                        | Description                                                                                                           |
-|-----------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| Name      | Params                                    | Description                                                                                                                                                                                                       |
+| --------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | setActive | item: `HTMLElement`, callback: `Function` | Uses `data-target` attribute to show a content panel using the given CSS selector. Non-active targets will be hidden. You can also pass in an optional callback function, see FAQ in Content Switcher for details |
-| release   |                               | Deletes the instance and removes document event listeners                                                             |
+| release   |                                           | Deletes the instance and removes document event listeners                                                                                                                                                         |
 
 ##### Example - Changing the active item
 
@@ -51,31 +51,33 @@ tabsInstance.setActive(document.getElementById('my-tab-item-1'));
 
 #### Options
 
-| Option                 | Default Selector              | Description                                                                            |
-|------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| selectorInit           | [data-tabs]                   | The CSS selector to find tab containers                                                |
-| selectorMenu           | .bx--tabs__nav                | The CSS selector to find the drop down menu used in narrow mode                        |
-| selectorTrigger        | .bx--tabs-trigger             | The CSS selector to find the button to open the drop down menu used in narrow mode     |
-| selectorTriggerText    | .bx--tabs-trigger-text        | The CSS selector to find the element used in narrow mode showing the selected tab item |
-| selectorButton         | .bx--tabs__nav-item           | The CSS selector to find tab containers                                                |
-| selectorButtonSelected | .bx--tabs__nav-item--selected | The CSS selector to find the selected tab                                              |
-| selectorLink           | .bx--tabs__nav-link           | The CSS selector to find the links in tabs                                             |
-| classActive            | bx--tabs__nav-item--selected  | The CSS class for tab's selected state                                                 |
-| classHidden            | bx--tabs__nav--hidden         | The CSS class for the drop down menu's hidden state used in narrow mode                |
-| eventBeforeSelected    | tab-beingselected             | The name of the custom event fired before a tab is selected                            |
-| eventAfterSelected     | tab-selected                  | The name of the custom event fired after a tab is selected                             |
+| Option                 | Default Selector                      | Description                                                                            |
+| ---------------------- | ------------------------------------- | -------------------------------------------------------------------------------------- |
+| selectorInit           | [data-tabs]                           | The CSS selector to find tab containers                                                |
+| selectorMenu           | .bx--tabs\_\_nav                      | The CSS selector to find the drop down menu used in narrow mode                        |
+| selectorTrigger        | .bx--tabs-trigger                     | The CSS selector to find the button to open the drop down menu used in narrow mode     |
+| selectorTriggerText    | .bx--tabs-trigger-text                | The CSS selector to find the element used in narrow mode showing the selected tab item |
+| selectorButton         | .bx--tabs\_\_nav-item                 | The CSS selector to find tab containers                                                |
+| selectorButtonEnabled  | .bx--tabs\_\_nav-item:not([disabled]) | The CSS selector to find tab containers that are not disabled                          |
+| selectorButtonSelected | .bx--tabs\_\_nav-item--selected       | The CSS selector to find the selected tab                                              |
+| selectorLink           | .bx--tabs\_\_nav-link                 | The CSS selector to find the links in tabs                                             |
+| classActive            | bx--tabs\_\_nav-item--selected        | The CSS class for tab's selected state                                                 |
+| classHidden            | bx--tabs\_\_nav--hidden               | The CSS class for the drop down menu's hidden state used in narrow mode                |
+| classOpen              | bx--tabs-trigger--open                | The CSS class for the drop down menu motion on open and close                          |
+| eventBeforeSelected    | tab-beingselected                     | The name of the custom event fired before a tab is selected                            |
+| eventAfterSelected     | tab-selected                          | The name of the custom event fired after a tab is selected                             |
 
 #### Events
 
-| Event Name          | Description                                                                                                     |
-|---------------------|-----------------------------------------------------------------------------------------------------------------|
-| tab-beingselected   | The name of the custom event fired before a tab is selected. Cancellation of this event stops selection of tab. |
-| tab-selected        | The name of the custom event fired after a tab is selected                                                      |
+| Event Name        | Description                                                                                                     |
+| ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| tab-beingselected | The name of the custom event fired before a tab is selected. Cancellation of this event stops selection of tab. |
+| tab-selected      | The name of the custom event fired after a tab is selected                                                      |
 
 ##### Example - Preventing a tab from being selected in a certain condition
 
 ```javascript
-document.addEventListener('tab-beingselected', function (evt) {
+document.addEventListener('tab-beingselected', function(evt) {
   if (!myApplication.shouldTabItemBeSelected(evt.target)) {
     evt.preventDefault();
   }
@@ -85,7 +87,7 @@ document.addEventListener('tab-beingselected', function (evt) {
 ##### Example - Notifying events of all tab items being selected to an analytics library
 
 ```javascript
-document.addEventListener('tab-selected', function (evt) {
+document.addEventListener('tab-selected', function(evt) {
   myAnalyticsLibrary.send({
     action: 'Tab selected',
     id: evt.target.id,

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -6,8 +6,8 @@ Modifiers are used with various classes for Tabs.
 
 | Name                            | Description                                                              |
 | ------------------------------- | ------------------------------------------------------------------------ |
-| .bx--tabs\_\_nav--hidden        | Applies specific styles to hide the narrow tab menu options              |
-| .bx--tabs\_\_nav-item--selected | Applies specific styles to the currently selected tab item               |
+| .bx--tabs__nav--hidden        | Applies specific styles to hide the narrow tab menu options              |
+| .bx--tabs__nav-item--selected | Applies specific styles to the currently selected tab item               |
 | .bx--tabs--light                | Selector for applying light dropdown styles when tabs are in mobile view |
 
 ### JavaScript
@@ -54,15 +54,15 @@ tabsInstance.setActive(document.getElementById('my-tab-item-1'));
 | Option                 | Default Selector                      | Description                                                                            |
 | ---------------------- | ------------------------------------- | -------------------------------------------------------------------------------------- |
 | selectorInit           | [data-tabs]                           | The CSS selector to find tab containers                                                |
-| selectorMenu           | .bx--tabs\_\_nav                      | The CSS selector to find the drop down menu used in narrow mode                        |
+| selectorMenu           | .bx--tabs__nav                      | The CSS selector to find the drop down menu used in narrow mode                        |
 | selectorTrigger        | .bx--tabs-trigger                     | The CSS selector to find the button to open the drop down menu used in narrow mode     |
 | selectorTriggerText    | .bx--tabs-trigger-text                | The CSS selector to find the element used in narrow mode showing the selected tab item |
-| selectorButton         | .bx--tabs\_\_nav-item                 | The CSS selector to find tab containers                                                |
-| selectorButtonEnabled  | .bx--tabs\_\_nav-item:not([disabled]) | The CSS selector to find tab containers that are not disabled                          |
-| selectorButtonSelected | .bx--tabs\_\_nav-item--selected       | The CSS selector to find the selected tab                                              |
-| selectorLink           | .bx--tabs\_\_nav-link                 | The CSS selector to find the links in tabs                                             |
-| classActive            | bx--tabs\_\_nav-item--selected        | The CSS class for tab's selected state                                                 |
-| classHidden            | bx--tabs\_\_nav--hidden               | The CSS class for the drop down menu's hidden state used in narrow mode                |
+| selectorButton         | .bx--tabs__nav-item                 | The CSS selector to find tab containers                                                |
+| selectorButtonEnabled  | .bx--tabs__nav-item:not([disabled]) | The CSS selector to find tab containers that are not disabled                          |
+| selectorButtonSelected | .bx--tabs__nav-item--selected       | The CSS selector to find the selected tab                                              |
+| selectorLink           | .bx--tabs__nav-link                 | The CSS selector to find the links in tabs                                             |
+| classActive            | bx--tabs__nav-item--selected        | The CSS class for tab's selected state                                                 |
+| classHidden            | bx--tabs__nav--hidden               | The CSS class for the drop down menu's hidden state used in narrow mode                |
 | classOpen              | bx--tabs-trigger--open                | The CSS class for the drop down menu motion on open and close                          |
 | eventBeforeSelected    | tab-beingselected                     | The name of the custom event fired before a tab is selected                            |
 | eventAfterSelected     | tab-selected                          | The name of the custom event fired after a tab is selected                             |

--- a/tests/spec/progress-indicator_spec.js
+++ b/tests/spec/progress-indicator_spec.js
@@ -99,7 +99,7 @@ describe('ProgressIndicator', function() {
     });
   });
 
-  describe('_addOverflowTooltip', function() {
+  describe('addOverflowTooltip', function() {
     let element;
     let instance;
     let stepLabel;


### PR DESCRIPTION
Closes #1503 

- Turns out I had already updated tabs testing but forgot, so this just updates tabs documentation with new selectors and classes. Also fixes a discrepancy in the progress bar test Akira and I wrote last week (removes _ before the name so it matches changes in the `progress-indicator.js` file)

#### Changes
- Adds new options in tabs documentation
- fixes discrepancy in progress indicator test name 
