### PR TITLE
test(header-submenu): reset submenu attributes before each test

### DIFF
--- a/tests/spec/header-submenu_spec.js
+++ b/tests/spec/header-submenu_spec.js
@@ -345,10 +345,12 @@ describe('Header Submenu', function() {
       headerSubmenu = new HeaderSubmenu(element);
       document.body.appendChild(element);
       unknownEvent = new CustomEvent('unknown', { bubbles: true });
+      Object.defineProperty(unknownEvent, 'target', { value: {}, writable: true });
+      Object.defineProperty(unknownEvent, 'currentTarget', { value: {}, writable: true });
     });
 
     beforeEach(function() {
-      triggerNode.dispatchEvent(unknownEvent);
+      triggerNode.setAttribute('aria-expanded', 'false');
     });
 
     it('should gracefully ignore unknown events', function() {


### PR DESCRIPTION
Related #1491

This PR fixes header submenu tests for handling unknown events

#### Changelog

**Changed**

- reset `aria-expanded` attribute before each unknown event handler test