### PR TITLE
Set global variable css font face to false

### DIFF
--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -2,7 +2,7 @@
 // 🌍 Global
 //-------------------------
 
-$css--font-face: true !default;
+$css--font-face: false !default;
 $css--helpers: true !default;
 $css--body: true !default;
 $css--use-layer: true !default;


### PR DESCRIPTION
Closes #1524

The docs state that all variables are set to false except for css-font-face but in the styles.scss it is set to true. The docs can be found [here](http://www.carbondesignsystem.com/getting-started/developers/vanilla#scss)
> These variables are used to configure which parts of the SCSS get compiled, where each variable controls a SCSS file of the same name. All variables are set to true by default, except for _css--font-face.scss

#### Changelog

**Changed**

- Set global of css--font-face to false to align with the docs. 
