### PR TITLE
fix: bug where MS edge doesn't update disabled state

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -318,6 +318,12 @@
   // Disabled
   // ---------------------------------------------
 
+  .#{$prefix}--checkbox:disabled + .#{$prefix}--checkbox-label {
+    [disabled] ~ _ {
+      font-size: inherit;
+    }
+  }
+    
   .#{$prefix}--checkbox:disabled + .#{$prefix}--checkbox-label,
   .#{$prefix}--checkbox-label[data-contained-checkbox-disabled='true'] {
     cursor: not-allowed;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -317,13 +317,12 @@
   //----------------------------------------------
   // Disabled
   // ---------------------------------------------
-
-  .#{$prefix}--checkbox:disabled + .#{$prefix}--checkbox-label {
-    [disabled] ~ _ {
-      font-size: inherit;
-    }
+  
+  // Bugfix: https://github.com/IBM/carbon-components/issues/1536
+  [disabled] ~ _ {
+    font-size: inherit;
   }
-    
+  
   .#{$prefix}--checkbox:disabled + .#{$prefix}--checkbox-label,
   .#{$prefix}--checkbox-label[data-contained-checkbox-disabled='true'] {
     cursor: not-allowed;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -318,7 +318,7 @@
   // Disabled
   // ---------------------------------------------
   
-  // Bugfix: https://github.com/IBM/carbon-components/issues/1536
+  // Workaround for: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231
   [disabled] ~ _ {
     font-size: inherit;
   }

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -133,10 +133,9 @@
 
   // Disabled
 
-  .#{$prefix}--radio-button:disabled + .#{$prefix}--radio-button__label {
-    [disabled] ~ _ {
-      font-size: inherit;
-    }
+  // Bugfix: https://github.com/IBM/carbon-components/issues/1536
+  [disabled] ~ _ {
+    font-size: inherit;
   }
 
   .#{$prefix}--radio-button:disabled + .#{$prefix}--radio-button__label {

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -133,7 +133,7 @@
 
   // Disabled
 
-  // Bugfix: https://github.com/IBM/carbon-components/issues/1536
+  // Workaround for: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231
   [disabled] ~ _ {
     font-size: inherit;
   }

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -134,6 +134,12 @@
   // Disabled
 
   .#{$prefix}--radio-button:disabled + .#{$prefix}--radio-button__label {
+    [disabled] ~ _ {
+      font-size: inherit;
+    }
+  }
+
+  .#{$prefix}--radio-button:disabled + .#{$prefix}--radio-button__label {
     color: $disabled;
     cursor: not-allowed;
   }


### PR DESCRIPTION
Closes #1536 

Implements the workaround mentioned in the GitHub issue that is required to make sure that MS Edge correctly updates styles between disabled and not disabled.

#### Changelog

**New**

- Adds a "do nothing" CSS rule as mentioned in the GitHub issue

**Changed**

- Nothing

**Removed**

- Nothing

#### Testing / Reviewing

See the GitHub issue.
