### PR TITLE
fix(styles): remove duplicate helper classes

### DIFF
--- a/src/globals/scss/_helper-classes.scss
+++ b/src/globals/scss/_helper-classes.scss
@@ -1,18 +1,21 @@
 @import 'vars';
+@import 'import-once';
 
-.#{$prefix}--text-truncate--end {
-  width: 100%;
-  display: inline-block;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}
+@include exports('helper-classes') {
+  .#{$prefix}--text-truncate--end {
+    width: 100%;
+    display: inline-block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
 
-.#{$prefix}--text-truncate--front {
-  width: 100%;
-  display: inline-block;
-  direction: rtl;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  .#{$prefix}--text-truncate--front {
+    width: 100%;
+    display: inline-block;
+    direction: rtl;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
Fixes #1542.

#### Changelog

**New**

- `import-once` guard in `_helper-classes.scss`.

#### Testing / Reviewing

Testing should make sure no component is broken.