### PR TITLE
chore(build): upgrade to Babel 7

### DIFF
--- a/demo/.babelrc
+++ b/demo/.babelrc
@@ -1,15 +1,22 @@
 {
   "presets": [
     [
-      "env",
+      "@babel/preset-env",
       {
         "modules": false,
         "targets": {
-          "browsers": ["last 1 version", "ie >= 11"]
+          "browsers": [
+            "last 1 version",
+            "ie >= 11"
+          ]
         }
       }
     ],
-    "react"
+    "@babel/preset-react"
   ],
-  "plugins": ["transform-class-properties", "transform-object-rest-spread", "dev-expression"]
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread",
+    "dev-expression"
+  ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -180,7 +180,7 @@ gulp.task('scripts:umd', () => {
   const babelOpts = {
     presets: [
       [
-        'env',
+        '@babel/preset-env',
         {
           targets: {
             browsers: ['last 1 version', 'ie >= 11'],
@@ -188,12 +188,18 @@ gulp.task('scripts:umd', () => {
         },
       ],
     ],
-    plugins: ['transform-es2015-modules-umd', 'transform-class-properties'],
+    plugins: ['@babel/plugin-transform-modules-umd', ['@babel/plugin-proposal-class-properties', { loose: true }]],
   };
 
   return gulp
     .src(srcFiles)
     .pipe(babel(babelOpts))
+    .pipe(
+      babel({
+        plugins: [require('./tools/babel-plugin-pure-assignment')], // eslint-disable-line global-require
+        babelrc: false,
+      })
+    )
     .pipe(gulp.dest('umd/'));
 });
 
@@ -202,7 +208,7 @@ gulp.task('scripts:es', () => {
   const babelOpts = {
     presets: [
       [
-        'env',
+        '@babel/preset-env',
         {
           modules: false,
           targets: {
@@ -211,7 +217,7 @@ gulp.task('scripts:es', () => {
         },
       ],
     ],
-    plugins: ['transform-class-properties'],
+    plugins: [['@babel/plugin-proposal-class-properties', { loose: true }]],
   };
   const pathsToConvertToESM = new Set([
     path.resolve(__dirname, 'src/globals/js/feature-flags.js'),
@@ -222,6 +228,12 @@ gulp.task('scripts:es', () => {
   return gulp
     .src(srcFiles)
     .pipe(babel(babelOpts))
+    .pipe(
+      babel({
+        plugins: [require('./tools/babel-plugin-pure-assignment')], // eslint-disable-line global-require
+        babelrc: false,
+      })
+    )
     .pipe(
       through.obj((file, enc, callback) => {
         if (!pathsToConvertToESM.has(file.path)) {
@@ -428,7 +440,7 @@ gulp.task('jsdoc', cb => {
     .src('./src/**/*.js')
     .pipe(
       babel({
-        plugins: ['transform-class-properties', 'transform-object-rest-spread'],
+        plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-proposal-object-rest-spread'],
         babelrc: false,
       })
     )

--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
     "warning": "^3.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-modules-umd": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
     "@carbon/colors": "^0.0.1-alpha.16",
     "@carbon/icons-handlebars": "^0.0.1-alpha.16",
     "@carbon/layout": "^0.0.1-alpha.16",
@@ -48,20 +56,12 @@
     "@frctl/fractal": "^1.1.0",
     "adaro": "1.0.4",
     "autoprefixer": "^8.2.0",
-    "babel-core": "^6.22.0",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^7.0.0",
-    "babel-loader": "^7.1.0",
+    "babel-loader": "^8.0.0",
     "babel-plugin-dev-expression": "^0.2.1",
-    "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^3.0.0",
     "babel-plugin-rewire": "^1.1.0",
-    "babel-plugin-transform-class-properties": "^6.22.0",
-    "babel-plugin-transform-es2015-modules-umd": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.22.0",
-    "babel-preset-env": "^1.0.0",
-    "babel-preset-react": "^6.24.0",
-    "babel-runtime": "^6.22.0",
     "bluebird": "~3.1.1",
     "browser-sync": "^2.26.3",
     "carbon-addons-cloud": "^1.8.0",
@@ -91,7 +91,7 @@
     "gulp": "~3.9.0",
     "gulp-autoprefixer": "~3.0.1",
     "gulp-axe-webdriver": "^1.4.0",
-    "gulp-babel": "^6.1.2",
+    "gulp-babel": "^8.0.0",
     "gulp-header": "^2.0.0",
     "gulp-jsdoc3": "^0.2.1",
     "gulp-nodemon": "^2.4.2",
@@ -139,7 +139,7 @@
     "react-dom": "^16.2.0",
     "react-ga": "^2.4.0",
     "rollup": "^0.49.0",
-    "rollup-plugin-babel": "^3.0.0",
+    "rollup-plugin-babel": "^4.0.0",
     "rollup-plugin-commonjs": "^8.2.0",
     "rollup-plugin-filesize": "^1.2.1",
     "rollup-plugin-node-resolve": "^3.0.0",
@@ -158,6 +158,7 @@
     "whatwg-fetch": "^2.0.4"
   },
   "resolutions": {
+    "babel-core": "7.0.0-bridge.0",
     "freshy": ">= 1.0.3"
   },
   "files": [
@@ -206,7 +207,7 @@
   "babel": {
     "presets": [
       [
-        "env",
+        "@babel/preset-env",
         {
           "modules": false,
           "targets": {
@@ -219,8 +220,8 @@
       ]
     ],
     "plugins": [
-      "transform-class-properties",
-      "transform-object-rest-spread",
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-object-rest-spread",
       "dev-expression"
     ]
   },

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -95,7 +95,7 @@ class Accordion extends mixin(createComponent, initComponentBySearch, handles) {
    * The map associating DOM element and accordion UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default Accordion;

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -95,7 +95,7 @@ class Accordion extends mixin(createComponent, initComponentBySearch, handles) {
    * The map associating DOM element and accordion UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default Accordion;

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -73,7 +73,7 @@ class Carousel extends mixin(createComponent, initComponentBySearch) {
    * The map associating DOM element and accordion UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? Carousel : removedComponent('Carousel'));

--- a/src/components/carousel/carousel.js
+++ b/src/components/carousel/carousel.js
@@ -73,7 +73,7 @@ class Carousel extends mixin(createComponent, initComponentBySearch) {
    * The map associating DOM element and accordion UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? Carousel : removedComponent('Carousel'));

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -144,7 +144,7 @@ class Checkbox extends mixin(createComponent, initComponentBySearch, handles) {
    * @member Checkbox.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -174,7 +174,7 @@ class Checkbox extends mixin(createComponent, initComponentBySearch, handles) {
     };
   }
 
-  static stateChangeTypes = stateChangeTypes;
+  static stateChangeTypes /* #__PURE__ */ = stateChangeTypes;
 }
 
 export default Checkbox;

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -144,7 +144,7 @@ class Checkbox extends mixin(createComponent, initComponentBySearch, handles) {
    * @member Checkbox.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -174,7 +174,7 @@ class Checkbox extends mixin(createComponent, initComponentBySearch, handles) {
     };
   }
 
-  static stateChangeTypes /* #__PURE__ */ = stateChangeTypes;
+  static stateChangeTypes /* #__PURE_CLASS_PROPERTY__ */ = stateChangeTypes;
 }
 
 export default Checkbox;

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -49,7 +49,7 @@ class CodeSnippet extends mixin(createComponent, initComponentBySearch, handles)
    * @member CodeSnippet.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -49,7 +49,7 @@ class CodeSnippet extends mixin(createComponent, initComponentBySearch, handles)
    * @member CodeSnippet.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/content-switcher/content-switcher.js
+++ b/src/components/content-switcher/content-switcher.js
@@ -7,6 +7,8 @@ import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class ContentSwitcher extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * Set of content switcher buttons.
@@ -62,7 +64,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
     // `options.selectorLink` is not defined in this class itself, code here primary is for inherited classes
     const itemLink = item.querySelector(this.options.selectorLink);
     if (itemLink) {
-      [...this.element.querySelectorAll(this.options.selectorLink)].forEach(link => {
+      toArray(this.element.querySelectorAll(this.options.selectorLink)).forEach(link => {
         if (link !== itemLink) {
           link.setAttribute('aria-selected', 'false');
         }
@@ -70,13 +72,13 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
       itemLink.setAttribute('aria-selected', 'true');
     }
 
-    const selectorButtons = [...this.element.querySelectorAll(this.options.selectorButton)];
+    const selectorButtons = toArray(this.element.querySelectorAll(this.options.selectorButton));
 
     selectorButtons.forEach(button => {
       if (button !== item) {
         button.setAttribute('aria-selected', false);
         button.classList.toggle(this.options.classActive, false);
-        [...button.ownerDocument.querySelectorAll(button.dataset.target)].forEach(element => {
+        toArray(button.ownerDocument.querySelectorAll(button.dataset.target)).forEach(element => {
           element.setAttribute('hidden', '');
           element.setAttribute('aria-hidden', 'true');
         });
@@ -85,7 +87,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
 
     item.classList.toggle(this.options.classActive, true);
     item.setAttribute('aria-selected', true);
-    [...item.ownerDocument.querySelectorAll(item.dataset.target)].forEach(element => {
+    toArray(item.ownerDocument.querySelectorAll(item.dataset.target)).forEach(element => {
       element.removeAttribute('hidden');
       element.setAttribute('aria-hidden', 'false');
     });
@@ -126,7 +128,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
    * @member ContentSwitcher.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/content-switcher/content-switcher.js
+++ b/src/components/content-switcher/content-switcher.js
@@ -128,7 +128,7 @@ class ContentSwitcher extends mixin(createComponent, initComponentBySearch, even
    * @member ContentSwitcher.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -36,7 +36,7 @@ class CopyButton extends mixin(createComponent, InitComponentBySearch, handles) 
    * @member CopyBtn.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -36,7 +36,7 @@ class CopyButton extends mixin(createComponent, InitComponentBySearch, handles) 
    * @member CopyBtn.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -255,10 +255,10 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
     this.parentRows = newParentRows;
   };
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   // UI Events
-  static eventHandlers /* #__PURE__ */ = {
+  static eventHandlers /* #__PURE_CLASS_PROPERTY__ */ = {
     expand: '_rowExpandToggle',
     sort: '_sortToggle',
     select: '_selectToggle',

--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -5,6 +5,8 @@ import initComponentBySearch from '../../globals/js/mixins/init-component-by-sea
 import eventedState from '../../globals/js/mixins/evented-state';
 import eventMatches from '../../globals/js/misc/event-matches';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedState) {
   /**
    * Data Table
@@ -62,7 +64,7 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
   _sortToggle = detail => {
     const { element, previousValue } = detail;
 
-    [...this.tableHeaders].forEach(header => {
+    toArray(this.tableHeaders).forEach(header => {
       const sortEl = header.querySelector(this.options.selectorTableSort);
 
       if (sortEl !== null && sortEl !== element) {
@@ -101,7 +103,7 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
   _selectAllToggle = detail => {
     const checked = detail.element.checked;
 
-    const inputs = [...this.element.querySelectorAll(this.options.selectorCheckbox)];
+    const inputs = toArray(this.element.querySelectorAll(this.options.selectorCheckbox));
 
     this.state.checkboxCount = checked ? inputs.length - 1 : 0;
 
@@ -124,8 +126,8 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
   };
 
   _actionBarCancel = () => {
-    const inputs = [...this.element.querySelectorAll(this.options.selectorCheckbox)];
-    const row = [...this.element.querySelectorAll(this.options.selectorTableSelected)];
+    const inputs = toArray(this.element.querySelectorAll(this.options.selectorCheckbox));
+    const row = toArray(this.element.querySelectorAll(this.options.selectorTableSelected));
 
     row.forEach(item => {
       item.classList.remove(this.options.classTableSelected);
@@ -229,9 +231,9 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
   }
 
   refreshRows = () => {
-    const newExpandCells = [...this.element.querySelectorAll(this.options.selectorExpandCells)];
-    const newExpandableRows = [...this.element.querySelectorAll(this.options.selectorExpandableRows)];
-    const newParentRows = [...this.element.querySelectorAll(this.options.selectorParentRows)];
+    const newExpandCells = toArray(this.element.querySelectorAll(this.options.selectorExpandCells));
+    const newExpandableRows = toArray(this.element.querySelectorAll(this.options.selectorExpandableRows));
+    const newParentRows = toArray(this.element.querySelectorAll(this.options.selectorParentRows));
 
     // check if this is a refresh or the first time
     if (this.parentRows.length > 0) {
@@ -240,7 +242,7 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
       // check if there are expandable rows
       if (newExpandableRows.length > 0) {
         const diffExpandableRows = diffParentRows.map(newRow => newRow.nextElementSibling);
-        const mergedExpandableRows = [...this.expandableRows, ...diffExpandableRows];
+        const mergedExpandableRows = [...toArray(this.expandableRows), ...toArray(diffExpandableRows)];
         this._expandableRowsInit(diffExpandableRows);
         this.expandableRows = mergedExpandableRows;
       }
@@ -253,10 +255,10 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
     this.parentRows = newParentRows;
   };
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   // UI Events
-  static eventHandlers = {
+  static eventHandlers /* #__PURE__ */ = {
     expand: '_rowExpandToggle',
     sort: '_sortToggle',
     select: '_selectToggle',

--- a/src/components/data-table/data-table.js
+++ b/src/components/data-table/data-table.js
@@ -11,6 +11,7 @@ import on from '../../globals/js/misc/on';
 import removedComponent from '../removed-component';
 
 let didWarnAboutDeprecation;
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
 
 class DataTable extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
@@ -164,7 +165,7 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
    */
   _toggleSelectAll = detail => {
     const { element, previousValue } = detail;
-    const inputs = [...this.element.querySelectorAll(this.options.selectorCheckbox)];
+    const inputs = toArray(this.element.querySelectorAll(this.options.selectorCheckbox));
     if (!previousValue || previousValue === 'toggled') {
       inputs.forEach(item => {
         item.checked = true; // eslint-disable-line no-param-reassign
@@ -182,9 +183,9 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
    * On fire, create the parent child rows + striping
    */
   refreshRows = () => {
-    const newExpandCells = [...this.element.querySelectorAll(this.options.selectorExpandCells)];
-    const newExpandableRows = [...this.element.querySelectorAll(this.options.selectorExpandableRows)];
-    const newParentRows = [...this.element.querySelectorAll(this.options.selectorParentRows)];
+    const newExpandCells = toArray(this.element.querySelectorAll(this.options.selectorExpandCells));
+    const newExpandableRows = toArray(this.element.querySelectorAll(this.options.selectorExpandableRows));
+    const newParentRows = toArray(this.element.querySelectorAll(this.options.selectorParentRows));
 
     // check if this is a refresh or the first time
     if (this.parentRows.length > 0) {
@@ -193,7 +194,7 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
       // check if there are expandable rows
       if (newExpandableRows.length > 0) {
         const diffExpandableRows = diffParentRows.map(newRow => newRow.nextElementSibling);
-        const mergedExpandableRows = [...this.expandableRows, ...diffExpandableRows];
+        const mergedExpandableRows = toArray(this.expandableRows, ...diffExpandableRows);
         this._initExpandableRows(diffExpandableRows);
         this.expandableRows = mergedExpandableRows;
       }
@@ -212,9 +213,9 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
     this.parentRows = newParentRows;
   };
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
-  static eventHandlers = {
+  static eventHandlers /* #__PURE__ */ = {
     expand: '_toggleRowExpand',
     sort: '_toggleSort',
     'select-all': '_toggleSelectAll',

--- a/src/components/data-table/data-table.js
+++ b/src/components/data-table/data-table.js
@@ -213,9 +213,9 @@ class DataTable extends mixin(createComponent, initComponentBySearch, eventedSta
     this.parentRows = newParentRows;
   };
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
-  static eventHandlers /* #__PURE__ */ = {
+  static eventHandlers /* #__PURE_CLASS_PROPERTY__ */ = {
     expand: '_toggleRowExpand',
     sort: '_toggleSort',
     'select-all': '_toggleSelectAll',

--- a/src/components/date-picker/date-picker.js
+++ b/src/components/date-picker/date-picker.js
@@ -331,7 +331,7 @@ class DatePicker extends mixin(createComponent, initComponentBySearch, handles) 
    * The map associating DOM element and date picker UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default DatePicker;

--- a/src/components/date-picker/date-picker.js
+++ b/src/components/date-picker/date-picker.js
@@ -31,6 +31,8 @@ Flatpickr.l10ns.en.weekdays.shorthand.forEach((day, index) => {
   }
 });
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class DatePicker extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * DatePicker.
@@ -252,12 +254,12 @@ class DatePicker extends mixin(createComponent, initComponentBySearch, handles) 
       calendarContainer.querySelector('.flatpickr-month').classList.add(this.options.classMonth);
       calendarContainer.querySelector('.flatpickr-weekdays').classList.add(this.options.classWeekdays);
       calendarContainer.querySelector('.flatpickr-days').classList.add(this.options.classDays);
-      [...calendarContainer.querySelectorAll('.flatpickr-weekday')].forEach(item => {
+      toArray(calendarContainer.querySelectorAll('.flatpickr-weekday')).forEach(item => {
         const currentItem = item;
         currentItem.innerHTML = currentItem.innerHTML.replace(/\s+/g, '');
         currentItem.classList.add(this.options.classWeekday);
       });
-      [...calendarContainer.querySelectorAll('.flatpickr-day')].forEach(item => {
+      toArray(calendarContainer.querySelectorAll('.flatpickr-day')).forEach(item => {
         item.classList.add(this.options.classDay);
         if (item.classList.contains('today') && calendar.selectedDates.length > 0) {
           item.classList.add('no-border');
@@ -329,7 +331,7 @@ class DatePicker extends mixin(createComponent, initComponentBySearch, handles) 
    * The map associating DOM element and date picker UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default DatePicker;

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -6,6 +6,8 @@ import trackBlur from '../../globals/js/mixins/track-blur';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) {
   /**
    * A selector with drop downs.
@@ -94,7 +96,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
           this.element.focus();
         }
       });
-      const listItems = [...this.element.querySelectorAll(this.options.selectorItem)];
+      const listItems = toArray(this.element.querySelectorAll(this.options.selectorItem));
       listItems.forEach(item => {
         if (this.element.classList.contains(this.options.classOpen)) {
           item.tabIndex = 0;
@@ -118,7 +120,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @param {number} direction The direction of navigating.
    */
   navigate(direction) {
-    const items = [...this.element.querySelectorAll(this.options.selectorItem)];
+    const items = toArray(this.element.querySelectorAll(this.options.selectorItem));
     const start = this.getCurrentNavigation() || this.element.querySelector(this.options.selectorItemSelected);
     const getNextItem = old => {
       const handleUnderflow = (i, l) => i + (i >= 0 ? 0 : l);
@@ -165,7 +167,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
       }
       this.element.dataset.value = itemToSelect.parentElement.dataset.value;
 
-      [...this.element.querySelectorAll(this.options.selectorItemSelected)].forEach(item => {
+      toArray(this.element.querySelectorAll(this.options.selectorItemSelected)).forEach(item => {
         if (itemToSelect !== item) {
           item.classList.remove(this.options.classSelected);
         }
@@ -193,7 +195,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @member Dropdown.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -242,7 +244,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE = {
+  static NAVIGATE /* #__PURE__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -195,7 +195,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @member Dropdown.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -244,7 +244,7 @@ class Dropdown extends mixin(createComponent, initComponentBySearch, trackBlur) 
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE /* #__PURE__ */ = {
+  static NAVIGATE /* #__PURE_CLASS_PROPERTY__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/fab/fab.js
+++ b/src/components/fab/fab.js
@@ -70,7 +70,7 @@ class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
    * @member FabButton.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -80,7 +80,7 @@ class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
    * @type {Object}
    * @property {string} selectorInit The CSS selector to find floating action buttons.
    */
-  static options = {
+  static options /* #__PURE__ */ = {
     selectorInit: '[data-fab]',
     initEventNames: ['click'],
   };

--- a/src/components/fab/fab.js
+++ b/src/components/fab/fab.js
@@ -70,7 +70,7 @@ class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
    * @member FabButton.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -80,7 +80,7 @@ class FabButton extends mixin(createComponent, initComponentByEvent, handles) {
    * @type {Object}
    * @property {string} selectorInit The CSS selector to find floating action buttons.
    */
-  static options /* #__PURE__ */ = {
+  static options /* #__PURE_CLASS_PROPERTY__ */ = {
     selectorInit: '[data-fab]',
     initEventNames: ['click'],
   };

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -173,7 +173,7 @@ class FileUploader extends mixin(createComponent, initComponentBySearch, evented
    * @member FileUploader.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -8,6 +8,8 @@ import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class FileUploader extends mixin(createComponent, initComponentBySearch, eventedState, handles) {
   /**
    * File uploader.
@@ -85,7 +87,7 @@ class FileUploader extends mixin(createComponent, initComponentBySearch, evented
   };
 
   _getStateContainers() {
-    const stateContainers = [...this.element.querySelectorAll(`[data-for=${this.inputId}]`)];
+    const stateContainers = toArray(this.element.querySelectorAll(`[data-for=${this.inputId}]`));
 
     if (stateContainers.length === 0) {
       throw new TypeError('State container elements not found; invoke _displayFilenames() first');
@@ -103,7 +105,9 @@ class FileUploader extends mixin(createComponent, initComponentBySearch, evented
    */
   _displayFilenames() {
     const container = this.element.querySelector(this.options.selectorContainer);
-    const HTMLString = [...this.input.files].map(file => this._filenamesHTML(file.name, this.inputId)).join('');
+    const HTMLString = toArray(this.input.files)
+      .map(file => this._filenamesHTML(file.name, this.inputId))
+      .join('');
 
     container.insertAdjacentHTML('afterbegin', HTMLString);
   }
@@ -169,7 +173,7 @@ class FileUploader extends mixin(createComponent, initComponentBySearch, evented
    * @member FileUploader.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -253,7 +253,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlu
     super.release();
   }
 
-  static options = {
+  static options /* #__PURE__ */ = {
     selectorContainer: '[data-floating-menu-container]',
     selectorPrimaryFocus: '[data-floating-menu-primary-focus]',
     attribDirection: 'data-floating-menu-direction',
@@ -271,7 +271,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlu
     },
   };
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default FloatingMenu;

--- a/src/components/floating-menu/floating-menu.js
+++ b/src/components/floating-menu/floating-menu.js
@@ -253,7 +253,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlu
     super.release();
   }
 
-  static options /* #__PURE__ */ = {
+  static options /* #__PURE_CLASS_PROPERTY__ */ = {
     selectorContainer: '[data-floating-menu-container]',
     selectorPrimaryFocus: '[data-floating-menu-primary-focus]',
     attribDirection: 'data-floating-menu-direction',
@@ -271,7 +271,7 @@ class FloatingMenu extends mixin(createComponent, eventedShowHideState, trackBlu
     },
   };
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default FloatingMenu;

--- a/src/components/inline-loading/inline-loading.js
+++ b/src/components/inline-loading/inline-loading.js
@@ -66,7 +66,7 @@ class InlineLoading extends mixin(createComponent, initComponentBySearch, handle
    * The list of states.
    * @type {Object<string, string>}
    */
-  static states = {
+  static states /* #__PURE__ */ = {
     INACTIVE: 'inactive',
     ACTIVE: 'active',
     FINISHED: 'finished',
@@ -77,7 +77,7 @@ class InlineLoading extends mixin(createComponent, initComponentBySearch, handle
    * @member InlineLoading.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/inline-loading/inline-loading.js
+++ b/src/components/inline-loading/inline-loading.js
@@ -66,7 +66,7 @@ class InlineLoading extends mixin(createComponent, initComponentBySearch, handle
    * The list of states.
    * @type {Object<string, string>}
    */
-  static states /* #__PURE__ */ = {
+  static states /* #__PURE_CLASS_PROPERTY__ */ = {
     INACTIVE: 'inactive',
     ACTIVE: 'active',
     FINISHED: 'finished',
@@ -77,7 +77,7 @@ class InlineLoading extends mixin(createComponent, initComponentBySearch, handle
    * @member InlineLoading.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/lightbox/lightbox.js
+++ b/src/components/lightbox/lightbox.js
@@ -77,7 +77,7 @@ class Lightbox extends mixin(createComponent, initComponentBySearch) {
    * @type {WeakMap}
    */
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? Lightbox : removedComponent('Lightbox'));

--- a/src/components/lightbox/lightbox.js
+++ b/src/components/lightbox/lightbox.js
@@ -7,6 +7,7 @@ import initComponentBySearch from '../../globals/js/mixins/init-component-by-sea
 import removedComponent from '../removed-component';
 
 let didWarnAboutDeprecation;
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
 
 class Lightbox extends mixin(createComponent, initComponentBySearch) {
   constructor(element, options) {
@@ -52,7 +53,7 @@ class Lightbox extends mixin(createComponent, initComponentBySearch) {
   };
 
   updateSlide = () => {
-    const items = [...this.element.querySelectorAll(this.options.selectorLightboxItem)];
+    const items = toArray(this.element.querySelectorAll(this.options.selectorLightboxItem));
     if (this.activeIndex < 0 || this.activeIndex >= items.length) {
       throw new RangeError('carouselItemIndex data attribute must be in range of lightbox items length');
     }
@@ -76,7 +77,7 @@ class Lightbox extends mixin(createComponent, initComponentBySearch) {
    * @type {WeakMap}
    */
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? Lightbox : removedComponent('Lightbox'));

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -97,7 +97,7 @@ class Loading extends mixin(createComponent, initComponentBySearch, handles) {
    * @member Loading.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -97,7 +97,7 @@ class Loading extends mixin(createComponent, initComponentBySearch, handles) {
    * @member Loading.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -158,7 +158,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
    * @member Modal.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -158,7 +158,7 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
    * @member Modal.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -43,14 +43,14 @@ class Notification extends mixin(createComponent, initComponentBySearch, evented
    * The map associating DOM element and accordion UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
    * @property {string} selectorInit The CSS selector to find InlineNotification.
    * @property {string} selectorButton The CSS selector to find close button.
    */
-  static options = {
+  static options /* #__PURE__ */ = {
     selectorInit: '[data-notification]',
     selectorButton: '[data-notification-btn]',
     eventBeforeDeleteNotification: 'notification-before-delete',

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -43,14 +43,14 @@ class Notification extends mixin(createComponent, initComponentBySearch, evented
    * The map associating DOM element and accordion UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
    * @property {string} selectorInit The CSS selector to find InlineNotification.
    * @property {string} selectorButton The CSS selector to find close button.
    */
-  static options /* #__PURE__ */ = {
+  static options /* #__PURE_CLASS_PROPERTY__ */ = {
     selectorInit: '[data-notification]',
     selectorButton: '[data-notification-btn]',
     eventBeforeDeleteNotification: 'notification-before-delete',

--- a/src/components/number-input/number-input.js
+++ b/src/components/number-input/number-input.js
@@ -57,7 +57,7 @@ class NumberInput extends mixin(createComponent, initComponentBySearch, handles)
    * @member NumberInput.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/number-input/number-input.js
+++ b/src/components/number-input/number-input.js
@@ -57,7 +57,7 @@ class NumberInput extends mixin(createComponent, initComponentBySearch, handles)
    * @member NumberInput.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -237,7 +237,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     }
   }
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -237,7 +237,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     }
   }
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -90,7 +90,7 @@ class Pagination extends mixin(createComponent, initComponentBySearch, handles) 
    * The map associating DOM element and pagination instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -113,7 +113,7 @@ class Pagination extends mixin(createComponent, initComponentBySearch, handles) 
    *   The name of the custom event fired when a user goes forward or backward a page.
    *   event.detail.direction contains the direction a user wishes to go.
    */
-  static options = {
+  static options /* #__PURE__ */ = {
     selectorInit: '[data-pagination]',
     selectorItemsPerPageInput: '[data-items-per-page]',
     selectorPageNumberInput: '[data-page-number-input]',

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -90,7 +90,7 @@ class Pagination extends mixin(createComponent, initComponentBySearch, handles) 
    * The map associating DOM element and pagination instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -113,7 +113,7 @@ class Pagination extends mixin(createComponent, initComponentBySearch, handles) 
    *   The name of the custom event fired when a user goes forward or backward a page.
    *   event.detail.direction contains the direction a user wishes to go.
    */
-  static options /* #__PURE__ */ = {
+  static options /* #__PURE_CLASS_PROPERTY__ */ = {
     selectorInit: '[data-pagination]',
     selectorItemsPerPageInput: '[data-items-per-page]',
     selectorPageNumberInput: '[data-page-number-input]',

--- a/src/components/progress-indicator/progress-indicator.js
+++ b/src/components/progress-indicator/progress-indicator.js
@@ -3,6 +3,8 @@ import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class ProgressIndicator extends mixin(createComponent, initComponentBySearch) {
   /**
    * ProgressIndicator.
@@ -47,7 +49,7 @@ class ProgressIndicator extends mixin(createComponent, initComponentBySearch) {
    * Returns all steps with details about element and index.
    */
   getSteps() {
-    return [...this.element.querySelectorAll(this.options.selectorStepElement)].map((element, index) => ({
+    return toArray(this.element.querySelectorAll(this.options.selectorStepElement)).map((element, index) => ({
       element,
       index,
     }));
@@ -154,8 +156,8 @@ class ProgressIndicator extends mixin(createComponent, initComponentBySearch) {
   }
 
   addOverflowTooltip() {
-    const stepLabels = [...this.element.querySelectorAll(this.options.selectorLabel)];
-    const tooltips = [...this.element.querySelectorAll(this.options.selectorTooltip)];
+    const stepLabels = toArray(this.element.querySelectorAll(this.options.selectorLabel));
+    const tooltips = toArray(this.element.querySelectorAll(this.options.selectorTooltip));
 
     stepLabels.forEach(step => {
       if (step.scrollWidth > this.options.maxWidth) {
@@ -171,7 +173,7 @@ class ProgressIndicator extends mixin(createComponent, initComponentBySearch) {
     });
   }
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/progress-indicator/progress-indicator.js
+++ b/src/components/progress-indicator/progress-indicator.js
@@ -173,7 +173,7 @@ class ProgressIndicator extends mixin(createComponent, initComponentBySearch) {
     });
   }
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/removed-component.js
+++ b/src/components/removed-component.js
@@ -22,8 +22,8 @@ const removedComponent = name => {
     static init() {
       warn();
     }
-    static components = new WeakMap();
-    static options = {};
+    static components /* #__PURE__ */ = new WeakMap();
+    static options /* #__PURE__ */ = {};
   };
 };
 

--- a/src/components/removed-component.js
+++ b/src/components/removed-component.js
@@ -22,8 +22,8 @@ const removedComponent = name => {
     static init() {
       warn();
     }
-    static components /* #__PURE__ */ = new WeakMap();
-    static options /* #__PURE__ */ = {};
+    static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
+    static options /* #__PURE_CLASS_PROPERTY__ */ = {};
   };
 };
 

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -7,6 +7,8 @@ import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 import svgToggleClass from '../../globals/js/misc/svg-toggle-class';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class Search extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Search with Options.
@@ -64,7 +66,7 @@ class Search extends mixin(createComponent, initComponentBySearch, handles) {
    * @param {HTMLElement} element The element contining the layout toggle.
    */
   toggleLayout(element) {
-    [...element.querySelectorAll(this.options.selectorSearchView)].forEach(item => {
+    toArray(element.querySelectorAll(this.options.selectorSearchView)).forEach(item => {
       item.classList.toggle(this.options.classLayoutHidden);
     });
   }
@@ -116,7 +118,7 @@ class Search extends mixin(createComponent, initComponentBySearch, handles) {
    * @member Search.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default Search;

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -118,7 +118,7 @@ class Search extends mixin(createComponent, initComponentBySearch, handles) {
    * @member Search.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default Search;

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -199,7 +199,7 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState,
    * The map associating DOM element and Slider UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -199,7 +199,7 @@ class Slider extends mixin(createComponent, initComponentBySearch, eventedState,
    * The map associating DOM element and Slider UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -117,7 +117,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     }
   }
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/structured-list/structured-list.js
+++ b/src/components/structured-list/structured-list.js
@@ -6,6 +6,8 @@ import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class StructuredList extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * StructuredList
@@ -50,7 +52,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
   }
 
   _getInput(index) {
-    const rows = [...this.element.querySelectorAll(this.options.selectorRow)];
+    const rows = toArray(this.element.querySelectorAll(this.options.selectorRow));
     return this.element.ownerDocument.querySelector(this.options.selectorListInput(rows[index].getAttribute('for')));
   }
 
@@ -62,7 +64,9 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
 
   _handleClick(evt) {
     const selectedRow = eventMatches(evt, this.options.selectorRow);
-    [...this.element.querySelectorAll(this.options.selectorRow)].forEach(row => row.classList.remove(this.options.classActive));
+    toArray(this.element.querySelectorAll(this.options.selectorRow)).forEach(row =>
+      row.classList.remove(this.options.classActive)
+    );
     if (selectedRow) {
       selectedRow.classList.add(this.options.classActive);
     }
@@ -72,7 +76,9 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
   _handleKeydownChecked(evt) {
     evt.preventDefault(); // prevent spacebar from scrolling page
     const selectedRow = eventMatches(evt, this.options.selectorRow);
-    [...this.element.querySelectorAll(this.options.selectorRow)].forEach(row => row.classList.remove(this.options.classActive));
+    toArray(this.element.querySelectorAll(this.options.selectorRow)).forEach(row =>
+      row.classList.remove(this.options.classActive)
+    );
     if (selectedRow) {
       selectedRow.classList.add(this.options.classActive);
       const input =
@@ -89,7 +95,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     const direction = this._direction(evt);
 
     if (direction && selectedRow !== undefined) {
-      const rows = [...this.element.querySelectorAll(this.options.selectorRow)];
+      const rows = toArray(this.element.querySelectorAll(this.options.selectorRow));
       rows.forEach(row => row.classList.remove(this.options.classActive));
       const firstIndex = 0;
       const nextIndex = this._nextIndex(rows, selectedRow, direction);
@@ -111,7 +117,7 @@ class StructuredList extends mixin(createComponent, initComponentBySearch, handl
     }
   }
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3,6 +3,8 @@ import eventMatches from '../../globals/js/misc/event-matches';
 import ContentSwitcher from '../content-switcher/content-switcher';
 import on from '../../globals/js/misc/on';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class Tab extends ContentSwitcher {
   /**
    * Container of tabs.
@@ -93,7 +95,7 @@ class Tab extends ContentSwitcher {
     }[event.which];
 
     if (direction) {
-      const buttons = [...this.element.querySelectorAll(this.options.selectorButtonEnabled)];
+      const buttons = toArray(this.element.querySelectorAll(this.options.selectorButtonEnabled));
       const button = this.element.querySelector(this.options.selectorButtonSelected);
       const nextIndex = Math.max(buttons.indexOf(button) + direction, -1 /* For `button` not found in `buttons` */);
       const nextIndexLooped =
@@ -143,7 +145,7 @@ class Tab extends ContentSwitcher {
    * @member Tab.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -193,7 +195,7 @@ class Tab extends ContentSwitcher {
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE = {
+  static NAVIGATE /* #__PURE__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -145,7 +145,7 @@ class Tab extends ContentSwitcher {
    * @member Tab.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -195,7 +195,7 @@ class Tab extends ContentSwitcher {
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE /* #__PURE__ */ = {
+  static NAVIGATE /* #__PURE_CLASS_PROPERTY__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/text-input/text-input.js
+++ b/src/components/text-input/text-input.js
@@ -98,5 +98,5 @@ export default class TextInput extends mixin(createComponent, initComponentBySea
    * The map associating DOM element and text input UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }

--- a/src/components/text-input/text-input.js
+++ b/src/components/text-input/text-input.js
@@ -98,5 +98,5 @@ export default class TextInput extends mixin(createComponent, initComponentBySea
    * The map associating DOM element and text input UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }

--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -82,7 +82,7 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
    * The map associating DOM element and Tile UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/tile/tile.js
+++ b/src/components/tile/tile.js
@@ -82,7 +82,7 @@ class Tile extends mixin(createComponent, initComponentBySearch) {
    * The map associating DOM element and Tile UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -6,6 +6,8 @@ import handles from '../../globals/js/mixins/handles';
 import eventMatches from '../../globals/js/misc/event-matches';
 import on from '../../globals/js/misc/on';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class Toolbar extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Toolbar.
@@ -28,7 +30,7 @@ class Toolbar extends mixin(createComponent, initComponentBySearch, handles) {
             this._handleRowHeightChange(event, boundTable);
           })
         );
-        // [...this.element.querySelectorAll(this.options.selectorRowHeight)].forEach((item) => {
+        // toArray(this.element.querySelectorAll(this.options.selectorRowHeight)).forEach((item) => {
         //   item.addEventListener('click', (event) => { this._handleRowHeightChange(event, boundTable); });
         // });
       }
@@ -63,7 +65,7 @@ class Toolbar extends mixin(createComponent, initComponentBySearch, handles) {
     }
 
     const targetComponentElement = eventMatches(event, this.options.selectorInit);
-    [...this.element.ownerDocument.querySelectorAll(this.options.selectorSearch)].forEach(item => {
+    toArray(this.element.ownerDocument.querySelectorAll(this.options.selectorSearch)).forEach(item => {
       if (!targetComponentElement || !targetComponentElement.contains(item)) {
         item.classList.remove(this.options.classSearchActive);
       }
@@ -100,7 +102,7 @@ class Toolbar extends mixin(createComponent, initComponentBySearch, handles) {
    * The map associating DOM element and Toolbar UI instance.
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -102,7 +102,7 @@ class Toolbar extends mixin(createComponent, initComponentBySearch, handles) {
    * The map associating DOM element and Toolbar UI instance.
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -170,7 +170,7 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
     }
   }
 
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -170,7 +170,7 @@ class Tooltip extends mixin(createComponent, initComponentByEvent, eventedShowHi
     }
   }
 
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   static get options() {
     const { prefix } = settings;

--- a/src/components/ui-shell/header-nav.js
+++ b/src/components/ui-shell/header-nav.js
@@ -17,7 +17,7 @@ export default class HeaderNav extends mixin(createComponent, initComponentBySea
    * @member HeaderNav.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * @returns {Element} Currently highlighted element.
@@ -90,7 +90,7 @@ export default class HeaderNav extends mixin(createComponent, initComponentBySea
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE /* #__PURE__ */ = {
+  static NAVIGATE /* #__PURE_CLASS_PROPERTY__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/ui-shell/header-nav.js
+++ b/src/components/ui-shell/header-nav.js
@@ -5,6 +5,8 @@ import handles from '../../globals/js/mixins/handles';
 import on from '../../globals/js/misc/on';
 import settings from '../../globals/js/settings';
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 export default class HeaderNav extends mixin(createComponent, initComponentBySearch, handles) {
   constructor(element, options) {
     super(element, options);
@@ -15,7 +17,7 @@ export default class HeaderNav extends mixin(createComponent, initComponentBySea
    * @member HeaderNav.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * @returns {Element} Currently highlighted element.
@@ -30,7 +32,7 @@ export default class HeaderNav extends mixin(createComponent, initComponentBySea
    * @param {number} direction The direction of navigating.
    */
   navigate = direction => {
-    const items = [...this.element.querySelectorAll(this.options.selectorSubmenuLink)];
+    const items = toArray(this.element.querySelectorAll(this.options.selectorSubmenuLink));
     const start = this.getCurrentNavigation();
     const getNextItem = old => {
       const handleUnderflow = (index, length) => index + (index >= 0 ? 0 : length);
@@ -88,7 +90,7 @@ export default class HeaderNav extends mixin(createComponent, initComponentBySea
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE = {
+  static NAVIGATE /* #__PURE__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/ui-shell/header-submenu.js
+++ b/src/components/ui-shell/header-submenu.js
@@ -7,6 +7,7 @@ import settings from '../../globals/js/settings';
 import eventMatches from '../../globals/js/misc/event-matches';
 
 const forEach = Array.prototype.forEach;
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
 
 export default class HeaderSubmenu extends mixin(createComponent, initComponentBySearch, handles) {
   constructor(element, options) {
@@ -23,14 +24,14 @@ export default class HeaderSubmenu extends mixin(createComponent, initComponentB
    * @member HeaderSubmenu.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * Enum for header submenu actions.
    * @readonly
    * @enum {string}
    */
-  static actions = {
+  static actions /* #__PURE__ */ = {
     CLOSE_SUBMENU: 'CLOSE_SUBMENU',
     OPEN_SUBMENU: 'OPEN_SUBMENU',
     TOGGLE_SUBMENU_WITH_FOCUS: 'TOGGLE_SUBMENU_WITH_FOCUS',
@@ -119,7 +120,7 @@ export default class HeaderSubmenu extends mixin(createComponent, initComponentB
    * @param {number} direction The direction of navigating.
    */
   navigate = direction => {
-    const items = [...this.element.querySelectorAll(this.options.selectorItem)];
+    const items = toArray(this.element.querySelectorAll(this.options.selectorItem));
     const start = this.getCurrentNavigation() || this.element.querySelector(this.options.selectorItemSelected);
     const getNextItem = old => {
       const handleUnderflow = (index, length) => index + (index >= 0 ? 0 : length);
@@ -255,7 +256,7 @@ export default class HeaderSubmenu extends mixin(createComponent, initComponentB
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE = {
+  static NAVIGATE /* #__PURE__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/ui-shell/header-submenu.js
+++ b/src/components/ui-shell/header-submenu.js
@@ -24,14 +24,14 @@ export default class HeaderSubmenu extends mixin(createComponent, initComponentB
    * @member HeaderSubmenu.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * Enum for header submenu actions.
    * @readonly
    * @enum {string}
    */
-  static actions /* #__PURE__ */ = {
+  static actions /* #__PURE_CLASS_PROPERTY__ */ = {
     CLOSE_SUBMENU: 'CLOSE_SUBMENU',
     OPEN_SUBMENU: 'OPEN_SUBMENU',
     TOGGLE_SUBMENU_WITH_FOCUS: 'TOGGLE_SUBMENU_WITH_FOCUS',
@@ -256,7 +256,7 @@ export default class HeaderSubmenu extends mixin(createComponent, initComponentB
    * @property {number} BACKWARD Navigating backward.
    * @property {number} FORWARD Navigating forward.
    */
-  static NAVIGATE /* #__PURE__ */ = {
+  static NAVIGATE /* #__PURE_CLASS_PROPERTY__ */ = {
     BACKWARD: -1,
     FORWARD: 1,
   };

--- a/src/components/ui-shell/side-nav.js
+++ b/src/components/ui-shell/side-nav.js
@@ -8,7 +8,7 @@ class SideNav extends mixin(createComponent, initComponentBySearch) {
    * @member SideNav.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -18,7 +18,7 @@ class SideNav extends mixin(createComponent, initComponentBySearch) {
    * @type {Object}
    * @property {string} selectorInit The data attribute to find side navs.
    */
-  static options = {
+  static options /* #__PURE__ */ = {
     selectorInit: '[data-side-nav]',
   };
 }

--- a/src/components/ui-shell/side-nav.js
+++ b/src/components/ui-shell/side-nav.js
@@ -8,7 +8,7 @@ class SideNav extends mixin(createComponent, initComponentBySearch) {
    * @member SideNav.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 
   /**
    * The component options.
@@ -18,7 +18,7 @@ class SideNav extends mixin(createComponent, initComponentBySearch) {
    * @type {Object}
    * @property {string} selectorInit The data attribute to find side navs.
    */
-  static options /* #__PURE__ */ = {
+  static options /* #__PURE_CLASS_PROPERTY__ */ = {
     selectorInit: '[data-side-nav]',
   };
 }

--- a/src/components/unified-header/left-nav.js
+++ b/src/components/unified-header/left-nav.js
@@ -548,7 +548,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
    * @member LeftNav.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? LeftNav : removedComponent('LeftNav'));

--- a/src/components/unified-header/left-nav.js
+++ b/src/components/unified-header/left-nav.js
@@ -11,6 +11,8 @@ import removedComponent from '../removed-component';
 
 let didWarnAboutDeprecation;
 
+const toArray = arrayLike => Array.prototype.slice.call(arrayLike);
+
 class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
   /**
    * Left Navigation.
@@ -124,8 +126,8 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
       `${this.options.selectorLeftNavList}:not(${this.options.selectorLeftNavMainNavHidden})`
     );
     const newLeftNavList = this.element.querySelector(`[data-left-nav-list=${selectedNavTitle}]`);
-    const currentLeftNavItems = [...currentLeftNavList.querySelectorAll(this.options.selectorLeftNavListItem)].reverse();
-    const newLeftNavItems = [...newLeftNavList.querySelectorAll(this.options.selectorLeftNavListItem)];
+    const currentLeftNavItems = toArray(currentLeftNavList.querySelectorAll(this.options.selectorLeftNavListItem)).reverse();
+    const newLeftNavItems = toArray(newLeftNavList.querySelectorAll(this.options.selectorLeftNavListItem));
 
     const fadeOutTime = 300;
     let counter = 0;
@@ -227,7 +229,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
    * Adds event listeners to list items
    */
   hookListItemsEvents() {
-    const leftNavList = [...this.element.querySelectorAll(this.options.selectorLeftNavList)];
+    const leftNavList = toArray(this.element.querySelectorAll(this.options.selectorLeftNavList));
     leftNavList.forEach(list => {
       this.manage(
         on(list, 'click', evt => {
@@ -287,7 +289,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
         })
       );
     });
-    const flyouts = [...this.element.ownerDocument.querySelectorAll(this.options.selectorLeftNavListItemHasFlyout)];
+    const flyouts = toArray(this.element.ownerDocument.querySelectorAll(this.options.selectorLeftNavListItemHasFlyout));
     flyouts.forEach(flyout => {
       this.manage(
         on(flyout, 'mouseenter', () => {
@@ -314,7 +316,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
    * Hides all flyout menus.
    */
   hideAllFlyoutMenus() {
-    const flyoutMenus = [...this.element.querySelectorAll(this.options.selectorLeftNavFlyoutMenu)];
+    const flyoutMenus = toArray(this.element.querySelectorAll(this.options.selectorLeftNavFlyoutMenu));
     flyoutMenus.forEach(menu => {
       menu.setAttribute('aria-hidden', 'true');
       menu.classList.remove(this.options.classFlyoutDisplayed);
@@ -326,7 +328,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
    * @param {Object} item The active list item.
    */
   addActiveListItem(item) {
-    [...this.element.querySelectorAll(this.options.selectorLeftNavAllListItems)].forEach(currentItem => {
+    toArray(this.element.querySelectorAll(this.options.selectorLeftNavAllListItems)).forEach(currentItem => {
       if (!(item === currentItem)) {
         if (!currentItem.contains(item)) {
           currentItem.classList.remove(this.options.classActiveLeftNavListItem);
@@ -335,7 +337,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
         }
       }
     });
-    [...this.element.querySelectorAll(this.options.selectorLeftNavNestedListItem)].forEach(currentItem => {
+    toArray(this.element.querySelectorAll(this.options.selectorLeftNavNestedListItem)).forEach(currentItem => {
       if (!(item === currentItem)) {
         currentItem.classList.remove(this.options.classActiveLeftNavListItem);
       }
@@ -385,7 +387,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
     const isOpen = listItem.classList.contains(this.options.classExpandedLeftNavListItem);
     this.hideAllFlyoutMenus();
     listItem.classList.toggle(this.options.classExpandedLeftNavListItem, !isOpen);
-    const listItems = [...listItem.querySelectorAll(this.options.selectorLeftNavNestedListItem)];
+    const listItems = toArray(listItem.querySelectorAll(this.options.selectorLeftNavNestedListItem));
     listItems.forEach(item => {
       if (isOpen) {
         listItem.querySelector(this.options.selectorLeftNavNestedList).setAttribute('aria-hidden', 'true');
@@ -546,7 +548,7 @@ class LeftNav extends mixin(createComponent, initComponentBySearch, handles) {
    * @member LeftNav.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? LeftNav : removedComponent('LeftNav'));

--- a/src/components/unified-header/profile-switcher.js
+++ b/src/components/unified-header/profile-switcher.js
@@ -312,7 +312,7 @@ class ProfileSwitcher extends mixin(createComponent, initComponentBySearch, hand
    * @member ProfileSwitcher.components
    * @type {WeakMap}
    */
-  static components = new WeakMap();
+  static components /* #__PURE__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? ProfileSwitcher : removedComponent('ProfileSwitcher'));

--- a/src/components/unified-header/profile-switcher.js
+++ b/src/components/unified-header/profile-switcher.js
@@ -312,7 +312,7 @@ class ProfileSwitcher extends mixin(createComponent, initComponentBySearch, hand
    * @member ProfileSwitcher.components
    * @type {WeakMap}
    */
-  static components /* #__PURE__ */ = new WeakMap();
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
 }
 
 export default (!breakingChangesX ? ProfileSwitcher : removedComponent('ProfileSwitcher'));

--- a/src/globals/js/mixins/init-component-by-event.js
+++ b/src/globals/js/mixins/init-component-by-event.js
@@ -11,7 +11,7 @@ export default function(ToMix) {
      * `true` suggests that this component is lazily initialized upon an action/event, etc.
      * @type {boolean}
      */
-    static forLazyInit = true;
+    static forLazyInit /* #__PURE__ */ = true;
 
     /**
      * Instantiates this component in the given element.

--- a/src/globals/js/mixins/init-component-by-event.js
+++ b/src/globals/js/mixins/init-component-by-event.js
@@ -11,7 +11,7 @@ export default function(ToMix) {
      * `true` suggests that this component is lazily initialized upon an action/event, etc.
      * @type {boolean}
      */
-    static forLazyInit /* #__PURE__ */ = true;
+    static forLazyInit /* #__PURE_CLASS_PROPERTY__ */ = true;
 
     /**
      * Instantiates this component in the given element.

--- a/src/globals/js/mixins/init-component-by-launcher.js
+++ b/src/globals/js/mixins/init-component-by-launcher.js
@@ -11,7 +11,7 @@ export default function(ToMix) {
      * `true` suggests that this component is lazily initialized upon an action/event, etc.
      * @type {boolean}
      */
-    static forLazyInit = true;
+    static forLazyInit /* #__PURE__ */ = true;
 
     /**
      * Instantiates this component in the given element.

--- a/src/globals/js/mixins/init-component-by-launcher.js
+++ b/src/globals/js/mixins/init-component-by-launcher.js
@@ -11,7 +11,7 @@ export default function(ToMix) {
      * `true` suggests that this component is lazily initialized upon an action/event, etc.
      * @type {boolean}
      */
-    static forLazyInit /* #__PURE__ */ = true;
+    static forLazyInit /* #__PURE_CLASS_PROPERTY__ */ = true;
 
     /**
      * Instantiates this component in the given element.

--- a/src/globals/js/mixins/init-component-by-search.js
+++ b/src/globals/js/mixins/init-component-by-search.js
@@ -20,7 +20,9 @@ export default function(ToMix) {
       if (target.nodeType === Node.ELEMENT_NODE && target.matches(effectiveOptions.selectorInit)) {
         this.create(target, options);
       } else {
-        [...target.querySelectorAll(effectiveOptions.selectorInit)].forEach(element => this.create(element, options));
+        Array.prototype.forEach.call(target.querySelectorAll(effectiveOptions.selectorInit), element =>
+          this.create(element, options)
+        );
       }
     }
   }

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -77,7 +77,7 @@ module.exports = function(config) {
             query: {
               presets: [
                 [
-                  'env',
+                  '@babel/preset-env',
                   {
                     modules: false,
                     targets: {
@@ -87,9 +87,9 @@ module.exports = function(config) {
                 ],
               ],
               plugins: [
-                'transform-class-properties',
-                'transform-object-rest-spread',
-                ['transform-runtime', { polyfill: false }],
+                '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-proposal-object-rest-spread',
+                '@babel/plugin-transform-runtime',
                 'dev-expression',
               ]
                 .concat(
@@ -113,7 +113,7 @@ module.exports = function(config) {
             query: {
               presets: [
                 [
-                  'env',
+                  '@babel/preset-env',
                   {
                     modules: false,
                     targets: {
@@ -123,9 +123,9 @@ module.exports = function(config) {
                 ],
               ],
               plugins: [
-                'transform-class-properties',
-                'transform-object-rest-spread',
-                ['transform-runtime', { polyfill: false }],
+                '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-proposal-object-rest-spread',
+                '@babel/plugin-transform-runtime',
               ].concat(
                 cloptions.debug
                   ? []

--- a/tools/babel-plugin-pure-assignment.js
+++ b/tools/babel-plugin-pure-assignment.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const regexPure = /^\s*[#@]__PURE__\s*$/;
+
+/**
+ * @param {Map} map The `Map` instanve.
+ * @param {string} key The key in the given `map`.
+ * @param createFn
+ *   A function that returns the value for the new map item.
+ *   Used when the given `map` does not have the given `key`.
+ * @returns The existing map item or newly created map item.
+ */
+function mapGetOrCreate(map, key, createFn) {
+  const existingItem = map.get(key);
+  if (existingItem) {
+    return existingItem;
+  }
+  const newItem = createFn(key);
+  map.set(key, newItem);
+  return newItem;
+}
+
+// In:
+//
+// ```
+// var MyClass = /*#__PURE__*/ function () {
+//   function TheClass() {}
+//   return TheClass;
+// }();
+// MyClass.prop /* #__PURE__ */ = value;
+// ```
+//
+// Out:
+//
+// ```
+// var Accordion = /*#__PURE__*/ function () {
+//   function TheClass() {}
+//   TheClass.prop = value;
+//   return TheClass;
+// }();
+// ```
+module.exports = function convertPureAssignment(babel) {
+  const t = babel.types;
+
+  const pureAssignmentVisitor = {
+    ExpressionStatement(path) {
+      const { expression } = path.node;
+      if (expression.type === 'AssignmentExpression' && expression.operator === '=') {
+        const { left, computed, optional } = expression;
+        const comment = left.trailingComments && left.trailingComments.find(item => regexPure.test(item.value));
+        if (!computed && !optional && left && left.type === 'MemberExpression' && left.object.type === 'Identifier' && comment) {
+          const binding = path.scope.getBinding(left.object.name);
+          const { init } = binding.path.node;
+          if (
+            binding &&
+            init.type === 'CallExpression' &&
+            init.leadingComments &&
+            init.leadingComments.some(item => regexPure.test(item.value))
+          ) {
+            const list = mapGetOrCreate(this.pureAssignmentsMap, binding, () => []);
+            list.push(path.node);
+            path.remove();
+          }
+        }
+      }
+    },
+  };
+
+  const toplevelVisitor = {
+    Program(path) {
+      this.pureAssignmentsState = {
+        pureAssignmentsMap: new WeakMap(),
+      };
+      path.traverse(pureAssignmentVisitor, this.pureAssignmentsState);
+    },
+
+    VariableDeclarator(path) {
+      const { name } = path.node.id;
+      const binding = path.scope.getBinding(name);
+      const pureAssignments = this.pureAssignmentsState.pureAssignmentsMap.get(binding);
+      if (pureAssignments) {
+        const declarator = t.cloneDeep(path.node);
+        const body = declarator.init.callee.body.body;
+        const index = body.findIndex(item => item.type === 'ReturnStatement');
+        if (index >= 0) {
+          const { argument } = body[index];
+          if (argument.type === 'Identifier') {
+            const assignmentsToInsert = pureAssignments.map(node => {
+              const clone = t.cloneDeep(node);
+              const { left, right } = clone.expression;
+              left.object = t.cloneDeep(argument);
+              left.trailingComments = left.trailingComments.filter(item => !regexPure.test(item.value));
+              right.leadingComments = right.leadingComments.filter(item => !regexPure.test(item.value));
+              return clone;
+            });
+            body.splice(index, 0, ...assignmentsToInsert);
+          }
+        }
+        path.replaceWith(declarator);
+        path.stop();
+      }
+    },
+  };
+
+  return {
+    visitor: toplevelVisitor,
+  };
+};

--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -48,11 +48,9 @@ module.exports = {
     }),
     babel({
       exclude: ['node_modules/**'],
-      plugins: ['external-helpers'],
     }),
     babel({
       include: ['node_modules/markdown-it/**'],
-      plugins: ['external-helpers'],
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),

--- a/tools/rollup.config.js
+++ b/tools/rollup.config.js
@@ -17,7 +17,6 @@ module.exports = {
     }),
     babel({
       exclude: ['node_modules/**'], // only transpile our source code
-      plugins: ['external-helpers'],
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify('production'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,21 +7,604 @@
   resolved "https://registry.yarnpkg.com/@allmarkedup/fang/-/fang-1.0.0.tgz#20aa2ea365c57b0a28e6b563613270f5630d6883"
   integrity sha1-IKouo2XFewoo5rVjYTJw9WMNaIM=
 
-"@babel/code-frame@^7.0.0-beta.35":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
   dependencies:
     "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.0.tgz#08958f1371179f62df6966d8a614003d11faeb04"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/helpers" "^7.1.0"
+    "@babel/parser" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    convert-source-map "^1.1.0"
+    debug "^3.1.0"
+    json5 "^0.5.0"
+    lodash "^4.17.10"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0.tgz#1efd58bffa951dc846449e58ce3a1d7f02d393aa"
+  dependencies:
+    "@babel/types" "^7.0.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f"
+  dependencies:
+    "@babel/helper-explode-assignable-expression" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-builder-react-jsx@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz#fa154cb53eb918cf2a9a7ce928e29eb649c5acdb"
+  dependencies:
+    "@babel/types" "^7.0.0"
+    esutils "^2.0.0"
+
+"@babel/helper-call-delegate@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz#6a957f105f37755e8645343d3038a22e1449cc4a"
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-define-map@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/helper-explode-assignable-expression@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6"
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-hoist-variables@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz#46adc4c5e758645ae7a45deb92bab0918c23bb88"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-member-expression-to-functions@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-transforms@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz#470d4f9676d9fad50b324cdcce5fbabbc3da5787"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/helper-optimise-call-expression@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-plugin-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+
+"@babel/helper-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
+  dependencies:
+    lodash "^4.17.10"
+
+"@babel/helper-remap-async-to-generator@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-wrap-function" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-replace-supers@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz#5fc31de522ec0ef0899dc9b3e7cf6a5dd655f362"
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-simple-access@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
+  dependencies:
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-wrap-function@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz#8cf54e9190706067f016af8f75cb3df829cc8c66"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helpers@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.1.0.tgz#429bf0f0020be56a4242883432084e3d70a8a141"
+  dependencies:
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
-  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.0.tgz#a7cd42cb3c12aec52e24375189a47b39759b783e"
+
+"@babel/plugin-proposal-async-generator-functions@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz#41c1a702e10081456e23a7b74d891922dd1bb6ce"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+    "@babel/plugin-syntax-async-generators" "^7.0.0"
+
+"@babel/plugin-proposal-class-properties@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz#9af01856b1241db60ec8838d84691aa0bd1e8df4"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+
+"@babel/plugin-proposal-json-strings@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-json-strings" "^7.0.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz#9a17b547f64d0676b6c9cecd4edf74a82ab85e7e"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz#b610d928fe551ff7117d42c8bb410eec312a6425"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.0.0"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz#498b39cd72536cd7c4b26177d030226eba08cd33"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.2.0"
+
+"@babel/plugin-syntax-async-generators@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-json-strings@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz#0d259a68090e15b383ce3710e01d5b23f3770cbd"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-jsx@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz#034d5e2b4e14ccaea2e4c137af7e4afb39375ffd"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-object-rest-spread@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz#37d8fbcaf216bd658ea1aebbeb8b75e88ebc549b"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz#886f72008b3a8b185977f7cb70713b45e51ee475"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-arrow-functions@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz#a6c14875848c68a3b4b3163a486535ef25c7e749"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-async-to-generator@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz#109e036496c51dd65857e16acab3bafdf3c57811"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+
+"@babel/plugin-transform-block-scoped-functions@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz#482b3f75103927e37288b3b67b65f848e2aa0d07"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-block-scoping@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz#1745075edffd7cdaf69fab2fb6f9694424b7e9bc"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/plugin-transform-classes@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz#ab3f8a564361800cbc8ab1ca6f21108038432249"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.1.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    globals "^11.1.0"
+
+"@babel/plugin-transform-computed-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz#2fbb8900cd3e8258f2a2ede909b90e7556185e31"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-destructuring@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz#68e911e1935dda2f06b6ccbbf184ffb024e9d43a"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-dotall-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz#73a24da69bc3c370251f43a3d048198546115e58"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-duplicate-keys@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz#a0601e580991e7cace080e4cf919cfd58da74e86"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-exponentiation-operator@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz#9c34c2ee7fd77e02779cfa37e403a2e1003ccc73"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-for-of@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz#f2ba4eadb83bd17dc3c7e9b30f4707365e1c3e39"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz#29c5550d5c46208e7f730516d41eeddd4affadbb"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-literals@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz#2aec1d29cdd24c407359c930cdd89e914ee8ff86"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-amd@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz#f9e0a7072c12e296079b5a59f408ff5b97bf86a8"
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz#0a9d86451cbbfb29bd15186306897c67f6f9a05c"
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0.tgz#8873d876d4fee23209decc4d1feab8f198cf2df4"
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-umd@^7.0.0", "@babel/plugin-transform-modules-umd@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz#a29a7d85d6f28c3561c33964442257cc6a21f2a8"
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-new-target@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-object-super@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz#b1ae194a054b826d8d4ba7ca91486d4ada0f91bb"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+
+"@babel/plugin-transform-parameters@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz#44f492f9d618c9124026e62301c296bf606a7aed"
+  dependencies:
+    "@babel/helper-call-delegate" "^7.1.0"
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-react-display-name@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz#93759e6c023782e52c2da3b75eca60d4f10533ee"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-react-jsx-self@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0.tgz#a84bb70fea302d915ea81d9809e628266bb0bc11"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+
+"@babel/plugin-transform-react-jsx-source@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz#28e00584f9598c0dd279f6280eee213fa0121c3c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+
+"@babel/plugin-transform-react-jsx@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz#524379e4eca5363cd10c4446ba163f093da75f3e"
+  dependencies:
+    "@babel/helper-builder-react-jsx" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+
+"@babel/plugin-transform-regenerator@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz#5b41686b4ed40bef874d7ed6a84bdd849c13e0c1"
+  dependencies:
+    regenerator-transform "^0.13.3"
+
+"@babel/plugin-transform-runtime@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz#9f76920d42551bb577e2dc594df229b5f7624b63"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-shorthand-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz#85f8af592dcc07647541a0350e8c95c7bf419d15"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-spread@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz#93583ce48dd8c85e53f3a46056c856e4af30b49b"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-sticky-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz#30a9d64ac2ab46eec087b8530535becd90e73366"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+
+"@babel/plugin-transform-template-literals@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz#084f1952efe5b153ddae69eb8945f882c7a97c65"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-typeof-symbol@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz#4dcf1e52e943e5267b7313bff347fdbe0f81cec9"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-unicode-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz#c6780e5b1863a76fe792d90eded9fcd5b51d68fc"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.1.3"
+
+"@babel/preset-env@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.1.0.tgz#e67ea5b0441cfeab1d6f41e9b5c79798800e8d11"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.1.0"
+    "@babel/plugin-proposal-json-strings" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.0.0"
+    "@babel/plugin-syntax-async-generators" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.0.0"
+    "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-async-to-generator" "^7.1.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-classes" "^7.1.0"
+    "@babel/plugin-transform-computed-properties" "^7.0.0"
+    "@babel/plugin-transform-destructuring" "^7.0.0"
+    "@babel/plugin-transform-dotall-regex" "^7.0.0"
+    "@babel/plugin-transform-duplicate-keys" "^7.0.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.1.0"
+    "@babel/plugin-transform-for-of" "^7.0.0"
+    "@babel/plugin-transform-function-name" "^7.1.0"
+    "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.1.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.1.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.0.0"
+    "@babel/plugin-transform-modules-umd" "^7.1.0"
+    "@babel/plugin-transform-new-target" "^7.0.0"
+    "@babel/plugin-transform-object-super" "^7.1.0"
+    "@babel/plugin-transform-parameters" "^7.1.0"
+    "@babel/plugin-transform-regenerator" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
+    "@babel/plugin-transform-spread" "^7.0.0"
+    "@babel/plugin-transform-sticky-regex" "^7.0.0"
+    "@babel/plugin-transform-template-literals" "^7.0.0"
+    "@babel/plugin-transform-typeof-symbol" "^7.0.0"
+    "@babel/plugin-transform-unicode-regex" "^7.0.0"
+    browserslist "^4.1.0"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.3.0"
+
+"@babel/preset-react@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.0.0"
+    "@babel/plugin-transform-react-jsx" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+
+"@babel/runtime@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/template@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.0.tgz#58cc9572e1bfe24fe1537fdf99d839d53e517e22"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/traverse@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.0.tgz#503ec6669387efd182c3888c4eec07bcc45d91b2"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
+"@babel/types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
 
 "@carbon/colors@^0.0.1-alpha.16":
   version "0.0.1-alpha.16"
@@ -1425,51 +2008,27 @@ axobject-query@^2.0.1:
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.22.0, babel-core@^6.23.1, babel-core@^6.26.0:
-  version "6.26.3"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
-  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.1"
-    debug "^2.6.9"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.8"
-    slash "^1.0.0"
-    source-map "^0.5.7"
+babel-core@7.0.0-bridge.0, babel-core@^6.0.0, babel-core@^7.0.0-bridge.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
 
 babel-eslint@^7.0.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
-  integrity sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=
   dependencies:
     babel-code-frame "^6.22.0"
     babel-traverse "^6.23.1"
     babel-types "^6.23.0"
     babylon "^6.17.0"
 
-babel-generator@^6.18.0, babel-generator@^6.26.0:
+babel-generator@^6.18.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
-  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
   dependencies:
     babel-messages "^6.23.0"
     babel-runtime "^6.26.0"
@@ -1480,128 +2039,6 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
     source-map "^0.5.7"
     trim-right "^1.0.1"
 
-babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
-  integrity sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=
-  dependencies:
-    babel-helper-explode-assignable-expression "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-helper-builder-react-jsx@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
-  integrity sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    esutils "^2.0.2"
-
-babel-helper-call-delegate@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
-  integrity sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=
-  dependencies:
-    babel-helper-hoist-variables "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-helper-define-map@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
-  integrity sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    lodash "^4.17.4"
-
-babel-helper-explode-assignable-expression@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
-  integrity sha1-8luCz33BBDPFX3BZLVdGQArCLKo=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-helper-function-name@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
-  integrity sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=
-  dependencies:
-    babel-helper-get-function-arity "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-helper-get-function-arity@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
-  integrity sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-helper-hoist-variables@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76"
-  integrity sha1-HssnaJydJVE+rbyZFKc/VAi+enY=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-helper-optimise-call-expression@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
-  integrity sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-helper-regex@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
-  integrity sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    lodash "^4.17.4"
-
-babel-helper-remap-async-to-generator@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
-  integrity sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-helper-replace-supers@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
-  integrity sha1-v22/5Dk40XNpohPKiov3S2qQqxo=
-  dependencies:
-    babel-helper-optimise-call-expression "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-helpers@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
-  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
 babel-jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
@@ -1610,14 +2047,14 @@ babel-jest@^23.6.0:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.2.0"
 
-babel-loader@^7.1.0:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.5.tgz#e3ee0cd7394aa557e013b02d3e492bfd07aa6d68"
-  integrity sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==
+babel-loader@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.2.tgz#2079b8ec1628284a929241da3d90f5b3de2a5ae5"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
+    util.promisify "^1.0.0"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -1626,24 +2063,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-check-es2015-constants@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
-  integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-dev-expression@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz#d4a7beefefbb50e3f2734990a82a2486cf9eb9ee"
   integrity sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=
-
-babel-plugin-external-helpers@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
-  integrity sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-istanbul@^3.0.0:
   version "3.1.2"
@@ -1675,328 +2098,10 @@ babel-plugin-rewire@^1.1.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz#822562d72ed2c84e47c0f95ee232c920853e9d89"
   integrity sha512-JBZxczHw3tScS+djy6JPLMjblchGhLI89ep15H3SyjujIzlxo5nr6Yjo7AXotdeVczeBmWs0tF8PgJWDdgzAkQ==
 
-babel-plugin-syntax-async-functions@^6.8.0:
-  version "6.13.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
-  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
-
-babel-plugin-syntax-class-properties@^6.8.0:
-  version "6.13.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
-  integrity sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=
-
-babel-plugin-syntax-exponentiation-operator@^6.8.0:
-  version "6.13.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
-  integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
-
-babel-plugin-syntax-flow@^6.18.0:
-  version "6.18.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
-  integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
-
-babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
-  version "6.18.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
-  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
-
-babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
-
-babel-plugin-syntax-trailing-function-commas@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
-  integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
-
-babel-plugin-transform-async-to-generator@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
-  integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=
-  dependencies:
-    babel-helper-remap-async-to-generator "^6.24.1"
-    babel-plugin-syntax-async-functions "^6.8.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-class-properties@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
-  integrity sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-plugin-syntax-class-properties "^6.8.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-plugin-transform-es2015-arrow-functions@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
-  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
-  integrity sha1-u8UbSflk1wy42OC5ToICRs46YUE=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-block-scoping@^6.23.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
-  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    lodash "^4.17.4"
-
-babel-plugin-transform-es2015-classes@^6.23.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
-  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
-  dependencies:
-    babel-helper-define-map "^6.24.1"
-    babel-helper-function-name "^6.24.1"
-    babel-helper-optimise-call-expression "^6.24.1"
-    babel-helper-replace-supers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-plugin-transform-es2015-computed-properties@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
-  integrity sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-plugin-transform-es2015-destructuring@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
-  integrity sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
-  integrity sha1-c+s9MQypaePvnskcU3QabxV2Qj4=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-plugin-transform-es2015-for-of@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
-  integrity sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-function-name@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
-  integrity sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-plugin-transform-es2015-literals@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
-  integrity sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
-  integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
-  dependencies:
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
-  version "6.26.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
-  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-types "^6.26.0"
-
-babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
-  integrity sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=
-  dependencies:
-    babel-helper-hoist-variables "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-plugin-transform-es2015-modules-umd@^6.22.0, babel-plugin-transform-es2015-modules-umd@^6.23.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
-  integrity sha1-rJl+YoXNGO1hdq22B9YCNErThGg=
-  dependencies:
-    babel-plugin-transform-es2015-modules-amd "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-plugin-transform-es2015-object-super@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
-  integrity sha1-JM72muIcuDp/hgPa0CH1cusnj40=
-  dependencies:
-    babel-helper-replace-supers "^6.24.1"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-parameters@^6.23.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
-  integrity sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=
-  dependencies:
-    babel-helper-call-delegate "^6.24.1"
-    babel-helper-get-function-arity "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
-  integrity sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-plugin-transform-es2015-spread@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
-  integrity sha1-1taKmfia7cRTbIGlQujdnxdG+NE=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-sticky-regex@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
-  integrity sha1-AMHNsaynERLN8M9hJsLta0V8zbw=
-  dependencies:
-    babel-helper-regex "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
-babel-plugin-transform-es2015-template-literals@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
-  integrity sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
-  integrity sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-unicode-regex@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
-  integrity sha1-04sS9C6nMj9yk4fxinxa4frrNek=
-  dependencies:
-    babel-helper-regex "^6.24.1"
-    babel-runtime "^6.22.0"
-    regexpu-core "^2.0.0"
-
-babel-plugin-transform-exponentiation-operator@^6.22.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
-  integrity sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=
-  dependencies:
-    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
-    babel-plugin-syntax-exponentiation-operator "^6.8.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-flow-strip-types@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
-  integrity sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=
-  dependencies:
-    babel-plugin-syntax-flow "^6.18.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-object-rest-spread@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
-  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
-  dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.8.0"
-    babel-runtime "^6.26.0"
-
-babel-plugin-transform-react-display-name@^6.23.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
-  integrity sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-react-jsx-self@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
-  integrity sha1-322AqdomEqEh5t3XVYvL7PBuY24=
-  dependencies:
-    babel-plugin-syntax-jsx "^6.8.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-react-jsx-source@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
-  integrity sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=
-  dependencies:
-    babel-plugin-syntax-jsx "^6.8.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-react-jsx@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
-  integrity sha1-hAoCjn30YN/DotKfDA2R9jduZqM=
-  dependencies:
-    babel-helper-builder-react-jsx "^6.24.1"
-    babel-plugin-syntax-jsx "^6.8.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-regenerator@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
-  integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
-  dependencies:
-    regenerator-transform "^0.10.0"
-
-babel-plugin-transform-runtime@^6.22.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-strict-mode@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
-  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
 
 babel-polyfill@6.26.0, babel-polyfill@^6.3.14:
   version "6.26.0"
@@ -2007,49 +2112,6 @@ babel-polyfill@6.26.0, babel-polyfill@^6.3.14:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@^1.0.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
-  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
-  dependencies:
-    babel-plugin-check-es2015-constants "^6.22.0"
-    babel-plugin-syntax-trailing-function-commas "^6.22.0"
-    babel-plugin-transform-async-to-generator "^6.22.0"
-    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.23.0"
-    babel-plugin-transform-es2015-classes "^6.23.0"
-    babel-plugin-transform-es2015-computed-properties "^6.22.0"
-    babel-plugin-transform-es2015-destructuring "^6.23.0"
-    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
-    babel-plugin-transform-es2015-for-of "^6.23.0"
-    babel-plugin-transform-es2015-function-name "^6.22.0"
-    babel-plugin-transform-es2015-literals "^6.22.0"
-    babel-plugin-transform-es2015-modules-amd "^6.22.0"
-    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
-    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
-    babel-plugin-transform-es2015-modules-umd "^6.23.0"
-    babel-plugin-transform-es2015-object-super "^6.22.0"
-    babel-plugin-transform-es2015-parameters "^6.23.0"
-    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
-    babel-plugin-transform-es2015-spread "^6.22.0"
-    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
-    babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
-    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
-    babel-plugin-transform-exponentiation-operator "^6.22.0"
-    babel-plugin-transform-regenerator "^6.22.0"
-    browserslist "^3.2.6"
-    invariant "^2.2.2"
-    semver "^5.3.0"
-
-babel-preset-flow@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
-  integrity sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=
-  dependencies:
-    babel-plugin-transform-flow-strip-types "^6.22.0"
-
 babel-preset-jest@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
@@ -2058,32 +2120,7 @@ babel-preset-jest@^23.2.0:
     babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-preset-react@^6.24.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
-  integrity sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=
-  dependencies:
-    babel-plugin-syntax-jsx "^6.3.13"
-    babel-plugin-transform-react-display-name "^6.23.0"
-    babel-plugin-transform-react-jsx "^6.24.1"
-    babel-plugin-transform-react-jsx-self "^6.22.0"
-    babel-plugin-transform-react-jsx-source "^6.22.0"
-    babel-preset-flow "^6.23.0"
-
-babel-register@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
-  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
-  dependencies:
-    babel-core "^6.26.0"
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.15"
-
-babel-runtime@6.26.0, babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.0.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -2091,7 +2128,7 @@ babel-runtime@6.26.0, babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
@@ -2102,7 +2139,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
@@ -2117,7 +2154,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-tra
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
@@ -2569,13 +2606,21 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-browserslist@^3.2.6, browserslist@^3.2.8:
+browserslist@^3.2.8:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
   integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+browserslist@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.1.1.tgz#328eb4ff1215b12df6589e9ab82f8adaa4fc8cd6"
+  dependencies:
+    caniuse-lite "^1.0.30000884"
+    electron-to-chromium "^1.3.62"
+    node-releases "^1.0.0-alpha.11"
 
 bs-recipes@1.3.4:
   version "1.3.4"
@@ -2829,10 +2874,9 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000885.tgz#cdc98dd168ed59678650071f7f6a70910e275bc8"
   integrity sha512-Hy1a+UIXooG+tRlt3WnT9avMf+l999bR9J1MqlQdYKgbsYjKxV4a4rgcmiyMmdCLPBFsiRoDxdl9tnNyaq2RXw==
 
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864:
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864, caniuse-lite@^1.0.30000884:
   version "1.0.30000885"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz#e889e9f8e7e50e769f2a49634c932b8aee622984"
-  integrity sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -3593,12 +3637,15 @@ conventional-commits-parser@^3.0.0:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@^1.1.0, convert-source-map@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
-  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
+
+convert-source-map@^1.1.1, convert-source-map@^1.4.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -4484,10 +4531,9 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.62:
   version "1.3.68"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.68.tgz#bb3ccbadcdd06de2afea8fb73e31a60b6558de1f"
-  integrity sha512-NHs9Xm6+ZUDkRj7t1tFwizzfMO2XZg0nmHNRRTurXHDUcEoz3Kdjs2mxXsd8drpEDfg5aVL0S8aypUCTA0HJ/Q==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -5090,17 +5136,12 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
-estree-walker@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
-  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
-
 estree-walker@^0.5.0, estree-walker@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
   integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
 
-esutils@^2.0.2:
+esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
@@ -6249,6 +6290,10 @@ globals@^11.0.1:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
   integrity sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==
 
+globals@^11.1.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
 globals@^9.18.0, globals@^9.2.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -6452,15 +6497,12 @@ gulp-axe-webdriver@^1.4.0:
     selenium-webdriver "^3.0.0"
     then-request "^2.2.0"
 
-gulp-babel@^6.1.2:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-6.1.3.tgz#5aad8acb0db6b7f2f0be19eeee9528f2064df631"
-  integrity sha512-tm15R3rt4gO59WXCuqrwf4QXJM9VIJC+0J2NPYSC6xZn+cZRD5y5RPGAiHaDxCJq7Rz5BDljlrk3cEjWADF+wQ==
+gulp-babel@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-8.0.0.tgz#e0da96f4f2ec4a88dd3a3030f476e38ab2126d87"
   dependencies:
-    babel-core "^6.23.1"
-    object-assign "^4.0.1"
     plugin-error "^1.0.1"
-    replace-ext "0.0.1"
+    replace-ext "^1.0.0"
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
 
@@ -6864,14 +6906,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-home-or-tmp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
-  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.1"
 
 homedir-polyfill@^1.0.1:
   version "1.0.1"
@@ -8325,6 +8359,10 @@ js-beautify@^1.6.2:
     mkdirp "~0.5.0"
     nopt "~4.0.1"
 
+js-levenshtein@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.3.tgz#3ef627df48ec8cf24bacf05c0f184ff30ef413c5"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8335,7 +8373,14 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.x, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.8.1, js-yaml@^3.9.0, js-yaml@^3.9.1:
+js-yaml@3.x, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.6.1, js-yaml@^3.8.1, js-yaml@^3.9.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
@@ -8423,6 +8468,10 @@ jsesc@^1.3.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -8465,7 +8514,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^0.5.0, json5@^0.5.1:
+json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -10178,6 +10227,12 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-releases@^1.0.0-alpha.11:
+  version "1.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.0-alpha.11.tgz#73c810acc2e5b741a17ddfbb39dfca9ab9359d8a"
+  dependencies:
+    semver "^5.3.0"
+
 node-sass@^3.1.2, node-sass@^3.4.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.13.1.tgz#7240fbbff2396304b4223527ed3020589c004fc2"
@@ -10866,7 +10921,7 @@ os-shim@^0.1.2:
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
   integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -11147,7 +11202,7 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
-path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -11701,7 +11756,7 @@ pretty-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-private@^0.1.6, private@^0.1.8, private@~0.1.5:
+private@^0.1.6, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -12325,7 +12380,13 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
-regenerate@^1.2.1:
+regenerate-unicode-properties@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz#107405afcc4a190ec5ed450ecaa00ed0cafa7a4c"
+  dependencies:
+    regenerate "^1.4.0"
+
+regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
@@ -12340,13 +12401,14 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-transform@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
-  integrity sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-transform@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb"
   dependencies:
-    babel-runtime "^6.18.0"
-    babel-types "^6.19.0"
     private "^0.1.6"
 
 regex-cache@^0.4.2:
@@ -12378,14 +12440,16 @@ regexpu-core@^1.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
-regexpu-core@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
-  integrity sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=
+regexpu-core@^4.1.3, regexpu-core@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.2.0.tgz#a3744fa03806cffe146dea4421a3e73bdcc47b1d"
   dependencies:
-    regenerate "^1.2.1"
-    regjsgen "^0.2.0"
-    regjsparser "^0.1.4"
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^7.0.0"
+    regjsgen "^0.4.0"
+    regjsparser "^0.3.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.0.2"
 
 registry-auth-token@^3.0.1, registry-auth-token@^3.3.1:
   version "3.3.2"
@@ -12407,10 +12471,20 @@ regjsgen@^0.2.0:
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
   integrity sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=
 
+regjsgen@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.4.0.tgz#c1eb4c89a209263f8717c782591523913ede2561"
+
 regjsparser@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   integrity sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.3.0.tgz#3c326da7fcfd69fa0d332575a41c8c0cdf588c96"
   dependencies:
     jsesc "~0.5.0"
 
@@ -12486,7 +12560,6 @@ replace-ext@0.0.1:
 replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 replace-homedir@^1.0.0:
   version "1.0.0"
@@ -12640,7 +12713,7 @@ resolve@1.1.7, resolve@1.1.x:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -12720,12 +12793,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-babel@^3.0.0:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz#5b13611f1ab8922497e9d15197ae5d8a23fe3b1e"
-  integrity sha512-bVe2y0z/V5Ax1qU8NX/0idmzIwJPdUGu8Xx3vXH73h0yGjxfv2gkFI82MBVg49SlsFlLTBadBHb67zy4TWM3hA==
+rollup-plugin-babel@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.0.3.tgz#8282b0e22233160d679e9c7631342e848422fb02"
   dependencies:
-    rollup-pluginutils "^1.5.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.3.0"
 
 rollup-plugin-commonjs@^8.2.0:
   version "8.4.1"
@@ -12774,14 +12847,6 @@ rollup-plugin-uglify@^2.0.0:
   dependencies:
     uglify-js "^3.0.9"
 
-rollup-pluginutils@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
-  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
-  dependencies:
-    estree-walker "^0.2.1"
-    minimatch "^3.0.2"
-
 rollup-pluginutils@^2.0.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
@@ -12789,6 +12854,13 @@ rollup-pluginutils@^2.0.1:
   dependencies:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
+
+rollup-pluginutils@^2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.2.tgz#78d99a0a4baa281c80e23e5d911251ed5ab27d4f"
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^3.1.10"
 
 rollup@^0.49.0:
   version "0.49.3"
@@ -13061,7 +13133,7 @@ semver-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
   integrity sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
   integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
@@ -13499,13 +13571,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
-  dependencies:
-    source-map "^0.5.6"
-
 source-map-support@^0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
@@ -13517,7 +13582,6 @@ source-map-support@^0.5.6:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
-  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
 source-map@^0.1.39:
   version "0.1.43"
@@ -13533,10 +13597,9 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
@@ -14278,6 +14341,10 @@ to-fast-properties@^1.0.3:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
   integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
 to-gfm-code-block@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz#25d045a5fae553189e9637b590900da732d8aa82"
@@ -14561,6 +14628,25 @@ undertaker@^1.0.0:
     object.defaults "^1.0.0"
     object.reduce "^1.0.0"
     undertaker-registry "^1.0.0"
+
+unicode-canonical-property-names-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
+
+unicode-match-property-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^1.0.4"
+    unicode-property-aliases-ecmascript "^1.0.4"
+
+unicode-match-property-value-ecmascript@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz#9f1dc76926d6ccf452310564fd834ace059663d4"
+
+unicode-property-aliases-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Upgrade to Babel7 allows better tree-shaking for ES classes, though we need an extra step for class properties (done by an additional Babel plugin).

Better tree-shaking helps ensure `carbon-components-react` bundle only include `settings.js` in this library.

Refs IBM/carbon-components-react#1620.

#### Changelog

**New**

- A Babel plugin to ensure class properties can be tree-shaked.

**Changed**

- Upgrade to Babel7.
- Stop using spread operator (the Babel helper for array spread operator creates dependency to `Symbol`, breaking IE11)

#### Testing / Reviewing

Testing should make sure no component/build is broken.