### PR TITLE
chore(build): stop shipping deprecated html

### DIFF
--- a/server.js
+++ b/server.js
@@ -105,9 +105,10 @@ function componentRoute(req, res, next) {
         if (rendered == null) {
           res.writeHead(404);
           res.end();
+        } else {
+          res.setHeader('Content-Type', 'text/html');
+          res.end(rendered);
         }
-        res.setHeader('Content-Type', 'text/html');
-        res.end(rendered);
       })
       .catch(error => {
         console.error(error.stack); // eslint-disable-line no-console

--- a/src/components/carousel/carousel.config.js
+++ b/src/components/carousel/carousel.config.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const { prefix } = require('../../globals/js/settings');
+const { breakingChangesX } = require('../../globals/js/feature-flags');
 
 module.exports = {
   hidden: true,
+  meta: {
+    removed: breakingChangesX,
+  },
   context: {
     prefix,
   },

--- a/src/components/data-table/data-table.config.js
+++ b/src/components/data-table/data-table.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { prefix } = require('../../globals/js/settings');
+const { breakingChangesX } = require('../../globals/js/feature-flags');
 
 const menuItems = [
   {
@@ -253,6 +254,9 @@ const rows = [
 
 module.exports = {
   hidden: true,
+  meta: {
+    removed: breakingChangesX,
+  },
   context: {
     prefix,
   },

--- a/src/components/fab/fab.config.js
+++ b/src/components/fab/fab.config.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const { prefix } = require('../../globals/js/settings');
+const { breakingChangesX } = require('../../globals/js/feature-flags');
 
 module.exports = {
   hidden: true,
+  meta: {
+    removed: breakingChangesX,
+  },
   context: {
     prefix,
   },

--- a/src/components/interior-left-nav/interior-left-nav.config.js
+++ b/src/components/interior-left-nav/interior-left-nav.config.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const { breakingChangesX } = require('../../globals/js/feature-flags');
+
 module.exports = {
+  meta: {
+    removed: breakingChangesX,
+  },
   hidden: true,
 };

--- a/src/components/lightbox/lightbox.config.js
+++ b/src/components/lightbox/lightbox.config.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const { prefix } = require('../../globals/js/settings');
+const { breakingChangesX } = require('../../globals/js/feature-flags');
 
 module.exports = {
   hidden: true,
+  meta: {
+    removed: breakingChangesX,
+  },
   context: {
     prefix,
   },

--- a/src/components/unified-header/unified-header.config.js
+++ b/src/components/unified-header/unified-header.config.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const { prefix } = require('../../globals/js/settings');
+const { breakingChangesX } = require('../../globals/js/feature-flags');
 
 module.exports = {
   hidden: true,
   meta: {
+    removed: breakingChangesX,
     useIframe: true,
   },
   context: {

--- a/tools/templates.js
+++ b/tools/templates.js
@@ -129,12 +129,14 @@ const renderComponent = ({ layout, concat } = {}, handle) =>
       );
     }
     componentSource.forEach(metadata => {
-      const items = metadata.isCollection ? metadata : !metadata.isCollated && metadata.variants && metadata.variants();
+      const items = metadata.isCollection
+        ? metadata
+        : !metadata.meta.removed && !metadata.isCollated && metadata.variants && metadata.variants();
       if (items) {
         const filteredItems = !handle || handle === metadata.handle ? items : items.filter(item => handle === item.handle);
         filteredItems.forEach(item => {
-          const { handle: itemHandle, baseHandle, context } = item;
-          const template = contents.get(item.view) || contents.get(itemHandle) || contents.get(baseHandle);
+          const { handle: itemHandle, baseHandle, context, meta } = item;
+          const template = !meta.removed && (contents.get(item.view) || contents.get(itemHandle) || contents.get(baseHandle));
           if (template) {
             const body = template(context);
             const layoutTemplate = layout !== false && (contents.get(item.preview) || contents.get(layout));


### PR DESCRIPTION
This change prevents HTML files for deprecated components from being shipped for next release.

Refs #1501.

#### Changelog

**New**

- A mechanism to prevent HTML files for deprecated components from being shipped, if the build is done in "breaking change" mode (e.g. `gulp html:source -b`).

#### Testing / Reviewing

Testing should make sure our build or our dev env is not broken.