### PR TITLE
fix(tooltip): apply styles directly to footer

### DIFF
--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -82,7 +82,7 @@
       @include typescale('zeta');
     }
 
-    div {
+    .#{$prefix}--tooltip__footer {
       display: flex;
       justify-content: space-between;
       align-items: flex-end;


### PR DESCRIPTION
Closes #1567 

#### Changelog

**Changed**

- changed styles to apply directly to `--tooltip__footer` instead of `div` as to not override custom tooltip divs

#### Testing / Reviewing

check environment is not broken
