### PR TITLE
fix(toolbar): hide collapsed search input bottom border

### DIFF
--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -13,7 +13,7 @@ $css--helpers: true;
 @import '../overflow-menu/overflow-menu';
 @import '../search/search';
 
-@include exports('toolbar') {
+@mixin toolbar {
   .#{$prefix}--toolbar {
     @include font-family;
     display: flex;
@@ -123,5 +123,20 @@ $css--helpers: true;
 
   .#{$prefix}--radio-button-group {
     border: none;
+  }
+}
+
+@mixin toolbar--x {
+  @include toolbar;
+  .#{$prefix}--toolbar-search:not(.#{$prefix}--toolbar-search--active) .#{$prefix}--search-input {
+    border-bottom: none;
+  }
+}
+
+@include exports('toolbar') {
+  @if feature-flag-enabled('components-x') {
+    @include toolbar--x;
+  } @else {
+    @include toolbar;
   }
 }


### PR DESCRIPTION
Closes #1583 

This PR hides the search input bottom border when it is collapsed within a toolbar