### PR TITLE
fix: add min-width back for notification icon to display correctly

### DIFF
--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -54,6 +54,7 @@
   .#{$prefix}--inline-notification__icon {
     height: 16px;
     width: 16px;
+    min-width: 22px;
   }
 
   .#{$prefix}--inline-notification__text-wrapper {


### PR DESCRIPTION
The min-width for the notification icon was removed recently and is causing the icon to display too small with latest version. 

compare 
https://codesandbox.io/s/zlzol1m5l3

to 

http://react.carbondesignsystem.com/?selectedKind=Notifications&selectedStory=inline&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

This PR adds it back in.