### PR TITLE
fix(combo-box): hide disabled listbox chevron icon

### DIFF
--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -17,6 +17,11 @@
 }
 
 @mixin combo-box--x {
+  .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon,
+  .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon--open {
+    display: none;
+  }
+
   .#{$prefix}--combo-box > .#{$prefix}--list-box__field {
     padding: 0;
   }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -410,6 +410,7 @@ $list-box-menu-width: rem(300px);
     height: rem(40px);
     padding: 0 1rem;
     cursor: pointer;
+    outline: none;
   }
 
   .#{$prefix}--list-box__field:focus,


### PR DESCRIPTION
Closes #1598

Also removes the default outline styles on list box component

related: https://github.com/IBM/carbon-components-react/issues/1712