### PR TITLE
fix(slider): remove unused and unclosed div

### DIFF
--- a/src/components/slider/slider.hbs
+++ b/src/components/slider/slider.hbs
@@ -1,5 +1,4 @@
 <div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--slider-test">
   <label class="{{@root.prefix}}--label">Slider label</label>
   <div class="{{@root.prefix}}--slider-container">
     <div class="{{@root.prefix}}--slider" data-slider data-slider-input-box="#{{inputId}}">


### PR DESCRIPTION
While working on https://github.com/IBM/carbon-components-react/pull/1683 I found a `div` tag that was unclosed and appeared unused in our stylesheet as well. After looking through the commit history it appears to have been dropped during the v9 migration when the HTML templates were converted to handlebars