### PR TITLE
fix: replace invalid `disabled` attribute on list items with CSS classes

### DIFF
--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -259,7 +259,7 @@
   }
 
   //DISABLED STYLING
-  .#{$prefix}--progress-step[disabled] {
+  .#{$prefix}--progress-step--disabled {
     cursor: not-allowed;
 
     svg {

--- a/src/components/progress-indicator/progress-indicator.hbs
+++ b/src/components/progress-indicator/progress-indicator.hbs
@@ -1,6 +1,6 @@
 <ul data-progress data-progress-current class="{{@root.prefix}}--progress">
   {{#each steps}}
-    <li class="{{@root.prefix}}--progress-step {{@root.prefix}}--progress-step--{{state}}" {{#if disabled}} disabled {{/if}} {{#if invalid}} data-invalid {{/if}}>
+    <li class="{{@root.prefix}}--progress-step {{@root.prefix}}--progress-step--{{state}} {{#if disabled}} {{@root.prefix}}--progress-step--disabled {{/if}}" {{#if invalid}} data-invalid {{/if}}>
       {{#is state "complete"}}
         {{carbon-icon 'CheckmarkOutline16'}}
       {{/is}}

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -51,21 +51,21 @@ tabsInstance.setActive(document.getElementById('my-tab-item-1'));
 
 #### Options
 
-| Option                 | Default Selector                      | Description                                                                            |
-| ---------------------- | ------------------------------------- | -------------------------------------------------------------------------------------- |
-| selectorInit           | [data-tabs]                           | The CSS selector to find tab containers                                                |
-| selectorMenu           | .bx--tabs\_\_nav                      | The CSS selector to find the drop down menu used in narrow mode                        |
-| selectorTrigger        | .bx--tabs-trigger                     | The CSS selector to find the button to open the drop down menu used in narrow mode     |
-| selectorTriggerText    | .bx--tabs-trigger-text                | The CSS selector to find the element used in narrow mode showing the selected tab item |
-| selectorButton         | .bx--tabs\_\_nav-item                 | The CSS selector to find tab containers                                                |
-| selectorButtonEnabled  | .bx--tabs\_\_nav-item:not([disabled]) | The CSS selector to find tab containers that are not disabled                          |
-| selectorButtonSelected | .bx--tabs\_\_nav-item--selected       | The CSS selector to find the selected tab                                              |
-| selectorLink           | .bx--tabs\_\_nav-link                 | The CSS selector to find the links in tabs                                             |
-| classActive            | bx--tabs\_\_nav-item--selected        | The CSS class for tab's selected state                                                 |
-| classHidden            | bx--tabs\_\_nav--hidden               | The CSS class for the drop down menu's hidden state used in narrow mode                |
-| classOpen              | bx--tabs-trigger--open                | The CSS class for the drop down menu motion on open and close                          |
-| eventBeforeSelected    | tab-beingselected                     | The name of the custom event fired before a tab is selected                            |
-| eventAfterSelected     | tab-selected                          | The name of the custom event fired after a tab is selected                             |
+| Option                 | Default Selector                                           | Description                                                                            |
+| ---------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| selectorInit           | [data-tabs]                                                | The CSS selector to find tab containers                                                |
+| selectorMenu           | .bx--tabs\_\_nav                                           | The CSS selector to find the drop down menu used in narrow mode                        |
+| selectorTrigger        | .bx--tabs-trigger                                          | The CSS selector to find the button to open the drop down menu used in narrow mode     |
+| selectorTriggerText    | .bx--tabs-trigger-text                                     | The CSS selector to find the element used in narrow mode showing the selected tab item |
+| selectorButton         | .bx--tabs\_\_nav-item                                      | The CSS selector to find tab containers                                                |
+| selectorButtonEnabled  | .bx--tabs\_\_nav-item:not(.bx--tabs\_\_nav-item--disabled) | The CSS selector to find tab containers that are not disabled                          |
+| selectorButtonSelected | .bx--tabs\_\_nav-item--selected                            | The CSS selector to find the selected tab                                              |
+| selectorLink           | .bx--tabs\_\_nav-link                                      | The CSS selector to find the links in tabs                                             |
+| classActive            | bx--tabs\_\_nav-item--selected                             | The CSS class for tab's selected state                                                 |
+| classHidden            | bx--tabs\_\_nav--hidden                                    | The CSS class for the drop down menu's hidden state used in narrow mode                |
+| classOpen              | bx--tabs-trigger--open                                     | The CSS class for the drop down menu motion on open and close                          |
+| eventBeforeSelected    | tab-beingselected                                          | The name of the custom event fired before a tab is selected                            |
+| eventAfterSelected     | tab-selected                                               | The name of the custom event fired after a tab is selected                             |
 
 #### Events
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -359,7 +359,7 @@
     }
   }
 
-  .#{$prefix}--tabs__nav-item:hover:not([disabled]) {
+  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
     @include max-breakpoint(bp--sm--major) {
       background-color: $hover-field;
       box-shadow: 0 -1px 0 $hover-field;
@@ -369,15 +369,15 @@
   //---------------------------------------------
   // Item Disabled
   //---------------------------------------------
-  .#{$prefix}--tabs__nav-item[disabled],
-  .#{$prefix}--tabs__nav-item[disabled]:hover {
+  .#{$prefix}--tabs__nav-item--disabled,
+  .#{$prefix}--tabs__nav-item--disabled:hover {
     cursor: not-allowed;
   }
 
   //-----------------------------
   // Item Selected
   //-----------------------------
-  .#{$prefix}--tabs__nav-item--selected:not([disabled]) {
+  .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
     border: none;
     @include breakpoint(bp--sm--major) {
       .#{$prefix}--tabs__nav-link {
@@ -441,7 +441,8 @@
   //-----------------------------
   //  Link Hover
   //-----------------------------
-  .#{$prefix}--tabs__nav-item:hover:not([disabled]) .#{$prefix}--tabs__nav-link {
+  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled))
+    .#{$prefix}--tabs__nav-link {
     color: $text-01;
     @include breakpoint(bp--sm--major) {
       color: $text-01;
@@ -452,18 +453,18 @@
   //-----------------------------
   //  Link Disabled
   //-----------------------------
-  .#{$prefix}--tabs__nav-item[disabled] .#{$prefix}--tabs__nav-link {
+  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
     color: $tab-text-disabled;
     border-bottom: $tab-underline-disabled;
   }
 
-  .#{$prefix}--tabs__nav-item[disabled]:hover .#{$prefix}--tabs__nav-link {
+  .#{$prefix}--tabs__nav-item--disabled:hover .#{$prefix}--tabs__nav-link {
     cursor: no-drop;
     border-bottom: $tab-underline-disabled;
   }
 
-  .#{$prefix}--tabs__nav-item[disabled] .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs__nav-item[disabled] a.#{$prefix}--tabs__nav-link:active {
+  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:focus,
+  .#{$prefix}--tabs__nav-item--disabled a.#{$prefix}--tabs__nav-link:active {
     outline: none;
     border-bottom: $tab-underline-disabled;
   }
@@ -471,8 +472,10 @@
   //-----------------------------
   //  Link Focus
   //-----------------------------
-  .#{$prefix}--tabs__nav-item:not([disabled]):not(.#{$prefix}--tabs__nav-item--selected) .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs__nav-item:not([disabled]):not(.#{$prefix}--tabs__nav-item--selected) a.#{$prefix}--tabs__nav-link:active {
+  .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)):not(.#{$prefix}--tabs__nav-item--selected)
+    .#{$prefix}--tabs__nav-link:focus,
+  .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled)):not(.#{$prefix}--tabs__nav-item--selected)
+    a.#{$prefix}--tabs__nav-link:active {
     color: $text-02;
   }
 

--- a/src/components/tabs/tabs.hbs
+++ b/src/components/tabs/tabs.hbs
@@ -11,7 +11,7 @@
   </div>
   <ul class="{{@root.prefix}}--tabs__nav {{@root.prefix}}--tabs__nav--hidden" role="tablist">
     {{#each items}}
-      <li class="{{@root.prefix}}--tabs__nav-item{{#if selected}} {{@root.prefix}}--tabs__nav-item--selected{{/if}}" data-target=".{{panelClass}}" role="presentation" {{#if ../featureFlags.componentsX}}{{#if disabled}} disabled {{/if}}{{/if}}>
+      <li class="{{@root.prefix}}--tabs__nav-item{{#if selected}} {{@root.prefix}}--tabs__nav-item--selected{{/if}} {{#if disabled}} {{@root.prefix}}--tabs__nav-item--disabled {{/if}}" data-target=".{{panelClass}}" role="presentation" {{#if ../featureFlags.componentsX}}{{/if}}>
         <a tabindex="0" id="{{linkId}}" class="{{@root.prefix}}--tabs__nav-link" href="javascript:void(0)" role="tab" aria-controls="{{panelId}}"{{#if selected}} aria-selected="true"{{/if}}>{{label}}</a>
       </li>
     {{/each}}

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -65,7 +65,7 @@ class Tab extends ContentSwitcher {
   _handleClick(event) {
     const button = eventMatches(event, this.options.selectorButton);
     const trigger = eventMatches(event, this.options.selectorTrigger);
-    if (button && !button.hasAttribute('disabled')) {
+    if (button && !button.classList.contains(this.options.classButtonDisabled)) {
       super._handleClick(event);
       this._updateMenuState(false);
     }
@@ -182,6 +182,7 @@ class Tab extends ContentSwitcher {
       classActive: `${prefix}--tabs__nav-item--selected`,
       classHidden: `${prefix}--tabs__nav--hidden`,
       classOpen: `${prefix}--tabs-trigger--open`,
+      classButtonDisabled: `${prefix}--tabs__nav-item--disabled`,
       eventBeforeSelected: 'tab-beingselected',
       eventAfterSelected: 'tab-selected',
     });

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -176,7 +176,7 @@ class Tab extends ContentSwitcher {
       selectorTrigger: `.${prefix}--tabs-trigger`,
       selectorTriggerText: `.${prefix}--tabs-trigger-text`,
       selectorButton: `.${prefix}--tabs__nav-item`,
-      selectorButtonEnabled: `.${prefix}--tabs__nav-item:not([disabled])`,
+      selectorButtonEnabled: `.${prefix}--tabs__nav-item:not(.${prefix}--tabs__nav-item--disabled)`,
       selectorButtonSelected: `.${prefix}--tabs__nav-item--selected`,
       selectorLink: `.${prefix}--tabs__nav-link`,
       classActive: `${prefix}--tabs__nav-item--selected`,

--- a/tests/spec/tabs_spec.js
+++ b/tests/spec/tabs_spec.js
@@ -18,6 +18,7 @@ describe('Test tabs', function() {
         classActive: 'bx--tabs__nav-item--selected',
         classHidden: 'bx--tabs__nav--hidden',
         classOpen: 'bx--tabs-trigger--open',
+        classButtonDisabled: `bx--tabs__nav-item--disabled`,
         eventBeforeSelected: 'tab-beingselected',
         eventAfterSelected: 'tab-selected',
       });
@@ -153,7 +154,7 @@ describe('Test tabs', function() {
     });
 
     it('Should avoid activating disabled tab on click', function() {
-      buttonNodes[1].setAttribute('disabled', '');
+      buttonNodes[1].classList.add('bx--tabs__nav-item--disabled');
       buttonNodes[1].dispatchEvent(new CustomEvent('click', { bubbles: true }));
       expect(buttonNodes[0].classList.contains('bx--tabs__nav-item--selected')).toBe(true);
       expect(buttonNodes[1].classList.contains('bx--tabs__nav-item--selected')).toBe(false);

--- a/tests/spec/tabs_spec.js
+++ b/tests/spec/tabs_spec.js
@@ -12,7 +12,7 @@ describe('Test tabs', function() {
         selectorTrigger: '.bx--tabs-trigger',
         selectorTriggerText: '.bx--tabs-trigger-text',
         selectorButton: '.bx--tabs__nav-item',
-        selectorButtonEnabled: '.bx--tabs__nav-item:not([disabled])',
+        selectorButtonEnabled: '.bx--tabs__nav-item:not(.bx--tabs__nav-item--disabled)',
         selectorButtonSelected: '.bx--tabs__nav-item--selected',
         selectorLink: '.bx--tabs__nav-link',
         classActive: 'bx--tabs__nav-item--selected',
@@ -131,7 +131,7 @@ describe('Test tabs', function() {
 
     beforeEach(function() {
       buttonNodes.forEach((buttonNode, i) => {
-        buttonNode.removeAttribute('disabled');
+        buttonNode.classList.remove('bx--tabs__nav-item--disabled');
         buttonNode.classList[i === 0 ? 'add' : 'remove']('bx--tabs__nav-item--selected');
       });
     });
@@ -144,7 +144,7 @@ describe('Test tabs', function() {
     });
 
     it('Should skip disabled tab upon right key', function() {
-      buttonNodes[1].setAttribute('disabled', '');
+      buttonNodes[1].classList.add('bx--tabs__nav-item--disabled');
       const defaultPrevented = element.dispatchEvent(Object.assign(new CustomEvent('keydown'), { which: 39 }));
       expect(defaultPrevented).toBe(true);
       expect(buttonNodes[0].classList.contains('bx--tabs__nav-item--selected')).toBe(false);


### PR DESCRIPTION
Closes #1611

This PR replaces invalid use of the `disabled` attribute on list items with a CSS class instead to provide the same styling and functionality.

#### Changelog

**Changed**

- Progress indicator component markup and disabled style selectors
- Tabs component markup and disabled style selectors

#### Testing / Reviewing

Netlify deploy link below
