### PR TITLE
fix(search): use correct "clear" button icon

### DIFF
--- a/src/components/search/search.hbs
+++ b/src/components/search/search.hbs
@@ -14,7 +14,7 @@
     <button class="{{@root.prefix}}--search-close {{@root.prefix}}--search-close--hidden" title="Clear search
         input" aria-label="Clear search input">
       {{#if @root.featureFlags.componentsX}}
-        {{ carbon-icon 'Search16' class=(add @root.prefix '--search-magnifier') }}
+        {{ carbon-icon 'Close16' class=(add @root.prefix '--search-clear') }}
       {{else}}
       <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
         <path d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"


### PR DESCRIPTION
Closes #1616

This PR replaces the "clear" button icon in the experimental search component with the correct icon according to the experimental spec