### PR TITLE
fix(button): hide button icons from assistive technology

### DIFF
--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -8,7 +8,7 @@
   {{#if @root.featureFlags.componentsX}}
     {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
-    <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
       <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
     </svg>
   {{/if}}


### PR DESCRIPTION
Closes #1630

This PR adds the `aria-hidden` attribute on the icons within legacy buttons.