### PR TITLE
fix(inline-loading): update SVG styles

### DIFF
--- a/src/components/inline-loading/_inline-loading.scss
+++ b/src/components/inline-loading/_inline-loading.scss
@@ -71,6 +71,14 @@
     display: flex;
     width: 100%;
     align-items: center;
+
+    .#{$prefix}--loading__svg circle {
+      stroke-width: 10;
+    }
+
+    .#{$prefix}--loading__stroke {
+      stroke-dashoffset: 75;
+    }
   }
 
   .#{$prefix}--inline-loading__text {

--- a/src/components/loading/_mixins.scss
+++ b/src/components/loading/_mixins.scss
@@ -6,7 +6,7 @@
 @mixin animation__loading--spin {
   // Animate the container
   animation-name: rotate;
-  animation-duration: 500ms;
+  animation-duration: 690ms;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
   animation-iteration-count: infinite;


### PR DESCRIPTION
Related: https://github.com/IBM/carbon-components-react/pull/1642

Closes #1632

During the review of the experimental `<Loading />` component, it was determined that the inline loading spinner SVG needed some adjustment. More context can be found in the related PR above

