### PR TITLE
fix(tag): update color usage behind feature flag

### DIFF
--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -133,7 +133,7 @@
   .#{$prefix}--tag.#{$prefix}--skeleton {
     // TODO: replace hexcode with gray 10 hover hover token
     // from @carbon/elements
-    @include tag-theme--x(#e5e5e5, $ibm-color__gray-30);
+    @include tag-theme--x(#e5e5e5, $ibm-colors__gray-30);
     width: rem(60px);
 
     &:after {


### PR DESCRIPTION
Our netlify links are broken because of a bad variable name that causes the build to fail. This replaces it with the correct variable name.

#### Changelog

**New**

**Changed**

- Change `ibm-color__` to `ibm-colors__`

**Removed**

#### Testing / Reviewing

- Run `yarn gulp build:dev --rollup -e` and make sure it passes
