### PR TITLE
fix(overflow-menu): support arrow key navigation

### DIFF
--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -246,7 +246,6 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     switch (key) {
       // Esc
       case 27:
-        this.element.removeAttribute('aria-expanded');
         this.changeState('hidden', getLaunchingDetails(event), () => {
           if (isOfMenu) {
             element.focus();

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -241,7 +241,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     const key = event.which;
     const { element, optionMenu, options } = this;
     const isOfMenu = optionMenu && optionMenu.element.contains(event.target);
-    const isExpanded = this.element.getAttribute('aria-expanded') === 'true';
+    const isExpanded = this.element.classList.contains(this.options.classShown);
 
     switch (key) {
       // Esc

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -210,7 +210,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
    * @param {number} direction The direction of navigating.
    */
   navigate = direction => {
-    const items = [...document.querySelectorAll(this.options.selectorItem)];
+    const items = [...this.element.ownerDocument.querySelectorAll(this.options.selectorItem)];
     const start = this.getCurrentNavigation() || this.element.querySelector(this.options.selectorItemSelected);
     const getNextItem = old => {
       const handleUnderflow = (index, length) => index + (index >= 0 ? 0 : length);
@@ -256,7 +256,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
       // Enter || Space bar
       case 13:
       case 32: {
-        if (!isExpanded && document.activeElement !== this.element) {
+        if (!isExpanded && this.element.ownerDocument.activeElement !== this.element) {
           return;
         }
         event.preventDefault(); // prevent scrolling

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -123,16 +123,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     );
     this.manage(
       on(this.element.ownerDocument, 'keydown', event => {
-        if (event.which === 27) {
-          this._handleKeyPress(event);
-        }
-      })
-    );
-    this.manage(
-      on(this.element.ownerDocument, 'keypress', event => {
-        if (event.which !== 27) {
-          this._handleKeyPress(event);
-        }
+        this._handleKeyPress(event);
       })
     );
     this.manage(
@@ -206,6 +197,42 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
   }
 
   /**
+   * Provides the element to move focus from
+   * @returns {Element} Currently highlighted element.
+   */
+  getCurrentNavigation = () => {
+    const focused = this.element.ownerDocument.activeElement;
+    return focused.nodeType === Node.ELEMENT_NODE && focused.matches(this.options.selectorItem) ? focused : null;
+  };
+
+  /**
+   * Moves the focus up/down.
+   * @param {number} direction The direction of navigating.
+   */
+  navigate = direction => {
+    const items = [...document.querySelectorAll(this.options.selectorItem)];
+    const start = this.getCurrentNavigation() || this.element.querySelector(this.options.selectorItemSelected);
+    const getNextItem = old => {
+      const handleUnderflow = (index, length) => index + (index >= 0 ? 0 : length);
+      const handleOverflow = (index, length) => index - (index < length ? 0 : length);
+
+      // `items.indexOf(old)` may be -1 (Scenario of no previous focus)
+      const index = Math.max(items.indexOf(old) + direction, -1);
+      return items[handleUnderflow(handleOverflow(index, items.length), items.length)];
+    };
+    for (let current = getNextItem(start); current && current !== start; current = getNextItem(current)) {
+      if (
+        !current.matches(this.options.selectorItemHidden) &&
+        !current.parentNode.matches(this.options.selectorItemHidden) &&
+        !current.matches(this.options.selectorItemSelected)
+      ) {
+        current.focus();
+        break;
+      }
+    }
+  };
+
+  /**
    * Handles key press on document.
    * @param {Event} event The triggering event.
    * @private
@@ -214,33 +241,56 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     const key = event.which;
     const { element, optionMenu, options } = this;
     const isOfMenu = optionMenu && optionMenu.element.contains(event.target);
+    const isExpanded = this.element.getAttribute('aria-expanded') === 'true';
 
-    if (key === 27) {
-      this.changeState('hidden', getLaunchingDetails(event), () => {
-        if (isOfMenu) {
-          element.focus();
+    switch (key) {
+      // Esc
+      case 27:
+        this.element.removeAttribute('aria-expanded');
+        this.changeState('hidden', getLaunchingDetails(event), () => {
+          if (isOfMenu) {
+            element.focus();
+          }
+        });
+        break;
+      // Enter || Space bar
+      case 13:
+      case 32: {
+        if (!isExpanded && document.activeElement !== this.element) {
+          return;
         }
-      });
-    }
+        event.preventDefault(); // prevent scrolling
+        const isOfSelf = element.contains(event.target);
+        const shouldBeOpen = isOfSelf && !element.classList.contains(options.classShown);
+        const state = shouldBeOpen ? 'shown' : 'hidden';
 
-    if (key === 13 || key === 32) {
-      const isOfSelf = element.contains(event.target);
-      const shouldBeOpen = isOfSelf && !element.classList.contains(options.classShown);
-      const state = shouldBeOpen ? 'shown' : 'hidden';
-
-      if (isOfSelf) {
-        // 32 is to prevent screen from jumping when menu is opened with spacebar
-        if (element.tagName === 'A' || key === 32) {
-          event.preventDefault();
+        if (isOfSelf) {
+          event.delegateTarget = element; // eslint-disable-line no-param-reassign
         }
-        event.delegateTarget = element; // eslint-disable-line no-param-reassign
+
+        this.changeState(state, getLaunchingDetails(event), () => {
+          if (state === 'hidden' && isOfMenu) {
+            element.focus();
+          }
+        });
+        break;
       }
-
-      this.changeState(state, getLaunchingDetails(event), () => {
-        if (state === 'hidden' && isOfMenu) {
-          element.focus();
+      case 38: // up arrow
+      case 40: // down arrow
+        {
+          if (!isExpanded) {
+            return;
+          }
+          event.preventDefault(); // prevent scrolling
+          const direction = {
+            38: -1,
+            40: 1,
+          }[event.which];
+          this.navigate(direction);
         }
-      });
+        break;
+      default:
+        break;
     }
   }
 
@@ -251,6 +301,11 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
     return {
       selectorInit: '[data-overflow-menu]',
       selectorOptionMenu: `.${prefix}--overflow-menu-options`,
+      selectorItem: `
+        .${prefix}--overflow-menu-options--open >
+        .${prefix}--overflow-menu-options__option:not(.${prefix}--overflow-menu-options__option--disabled) >
+        .${prefix}--overflow-menu-options__btn
+      `,
       classShown: `${prefix}--overflow-menu--open`,
       classMenuShown: `${prefix}--overflow-menu-options--open`,
       classMenuFlip: `${prefix}--overflow-menu--flip`,

--- a/tests/spec/overflow-menu_spec.js
+++ b/tests/spec/overflow-menu_spec.js
@@ -77,6 +77,58 @@ describe('Test Overflow menu', function() {
       expect(element.classList.contains('bx--overflow-menu--open'), 'State of root element').toBe(false);
     });
 
+    describe('Arrow key navigation', function() {
+      const upArrowKeydown = new KeyboardEvent('keydown', { bubbles: true });
+      Object.defineProperty(upArrowKeydown, 'which', { value: 38, writable: true });
+      const downArrowKeydown = new KeyboardEvent('keydown', { bubbles: true });
+      Object.defineProperty(downArrowKeydown, 'which', { value: 40, writable: true });
+      let items;
+
+      beforeEach(() => {
+        optionsElement.classList.add('bx--overflow-menu-options--open');
+        items = document.querySelectorAll(`
+          .bx--overflow-menu-options--open >
+          .bx--overflow-menu-options__option:not(.bx--overflow-menu-options__option--disabled)
+          > .bx--overflow-menu-options__btn
+        `);
+        items[0].focus();
+      });
+
+      describe('Up/Down arrow keys', function() {
+        it('should move focus from currently focused item to previous menu item', function() {
+          spyOn(items[0], 'focus');
+          items[1].focus();
+          element.dispatchEvent(upArrowKeydown);
+          expect(items[0].focus).toHaveBeenCalled();
+          expect(items[0].focus).toHaveBeenCalledTimes(1);
+        });
+
+        it('should wrap focus from first menu item to last menu item', function() {
+          spyOn(items[items.length - 1], 'focus');
+          element.dispatchEvent(upArrowKeydown);
+          expect(items[items.length - 1].focus).toHaveBeenCalled();
+          expect(items[items.length - 1].focus).toHaveBeenCalledTimes(1);
+        });
+
+        it('should move focus from currently focused item to next menu item', function() {
+          spyOn(items[1], 'focus');
+          optionsElement.dispatchEvent(downArrowKeydown);
+          expect(items[1].focus).toHaveBeenCalledTimes(1);
+        });
+
+        it('should wrap focus from last menu item to first menu item', function() {
+          spyOn(items[0], 'focus');
+          items[items.length - 1].focus();
+          optionsElement.dispatchEvent(downArrowKeydown);
+          expect(items[0].focus).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      afterEach(() => {
+        optionsElement.classList.remove('bx--overflow-menu-options--open');
+      });
+    });
+
     it('Should emit an event after showing', function() {
       const spyOverflowEvent = jasmine.createSpy();
       events.on(document, 'floating-menu-shown', spyOverflowEvent);

--- a/tests/spec/overflow-menu_spec.js
+++ b/tests/spec/overflow-menu_spec.js
@@ -85,6 +85,7 @@ describe('Test Overflow menu', function() {
       let items;
 
       beforeEach(() => {
+        element.classList.add('bx--overflow-menu--open');
         optionsElement.classList.add('bx--overflow-menu-options--open');
         items = document.querySelectorAll(`
           .bx--overflow-menu-options--open >
@@ -125,6 +126,7 @@ describe('Test Overflow menu', function() {
       });
 
       afterEach(() => {
+        element.classList.remove('bx--overflow-menu--open');
         optionsElement.classList.remove('bx--overflow-menu-options--open');
       });
     });


### PR DESCRIPTION
Closes #1233

This PR adds up/down arrow key support for navigating the overflow menu component

#### Changelog

**New**

- arrow key navigation support

**Removed**

- event listener for deprecated `keypress` event