### PR TITLE
fix(accordion): enlarge focus outline

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -179,18 +179,24 @@
     margin: 0;
     transition: background-color $transition--base;
 
-    &:hover:before {
+    &:hover:before, &:focus:before {
       content: '';
       position: absolute;
       top: -1px;
       left: 0;
       width: 100%;
       height: calc(100% + 2px);
+    }
+
+    &:hover:before {
       background-color: $hover-ui;
     }
 
     &:focus {
       outline: none;
+    }
+
+    &:focus:before {
       @include focus-outline('outline');
     }
   }


### PR DESCRIPTION
Refs #1671.

#### Changelog

**Changed**

- Enlarged focus border in experimental mode so it goes on top of the border.

#### Testing / Reviewing

Testing should make sure accordion is not broken.