### PR TITLE
fix(pagination): style form wrapper for React `<Select />`

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -256,6 +256,11 @@ $css--helpers: true;
     align-items: center;
   }
 
+  .#{$prefix}--pagination__left > .#{$prefix}--form-item,
+  .#{$prefix}--pagination__right > .#{$prefix}--form-item {
+    height: 100%;
+  }
+
   .#{$prefix}--pagination__left .#{$prefix}--pagination__text {
     margin-right: rem(1px);
   }


### PR DESCRIPTION
Closes #1696

This PR will add a style rule to target the wrapper div that is included with React `<Select />` components by default in `carbon-components-react` (more details: https://github.com/IBM/carbon-components-react/issues/1681)

affects https://github.com/IBM/carbon-components-react/pull/1800