### PR TITLE
fix(button): use correct icon color for disabled buttons with icons

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -183,6 +183,10 @@
   // <button> elements cannot be used as flex containers
   button.#{$prefix}--btn {
     display: inline-block;
+
+    &:disabled > .#{$prefix}--btn__icon {
+      fill: $ui-04;
+    }
   }
 
   // Reset intrisic padding in Firefox (see #731)

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -5,12 +5,43 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
-  type="button">Button</button>
-<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
-  type="button" disabled>Button</button>
-<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}}
-  type="button">
+<button
+  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}}
+  type="button"
+>
+  Button
+</button>
+<button
+  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}}
+  type="button" disabled
+>
+  Button
+</button>
+<button
+  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}}
+  type="button"
+>
+  With icon
+  {{#if @root.featureFlags.componentsX}}
+    {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{else}}
+    <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+    </svg>
+  {{/if}}
+</button>
+<button
+  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}}
+  type="button" disabled
+>
   With icon
   {{#if @root.featureFlags.componentsX}}
     {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}


### PR DESCRIPTION
Closes #1698

This PR will fix the colors for disabled buttons with icons and add examples to the documentation