### PR TITLE
chore(test): fix testMatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
   "jest": {
     "testMatch": [
       "<rootDir>/**/__tests__/**/*.js?(x)",
-      "<rootDir>/**/es-test.js?(x)"
+      "<rootDir>/**/?(*-)(spec|test).js?(x)"
     ]
   }
 }


### PR DESCRIPTION
An earlier commit inadvertently contained a temporary code, that made `style-test` skipped. This PR is for fixing that problem.

#### Changelog

**Changed**

- Fixed `testMatch` Jest configration.