### PR TITLE
chore(sass): remove redundant @imports

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -6,10 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/import-once';
@@ -179,7 +175,8 @@
     margin: 0;
     transition: background-color $transition--base;
 
-    &:hover:before, &:focus:before {
+    &:hover:before,
+    &:focus:before {
       content: '';
       position: absolute;
       top: -1px;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -6,13 +6,9 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/mixins';
-@import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
+@import '../../globals/scss/layout';
 @import '../../globals/scss/css--typography';
 @import '../link/link';
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -6,10 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import 'mixins';

--- a/src/components/carousel/_carousel.scss
+++ b/src/components/carousel/_carousel.scss
@@ -6,9 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/import-once';

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -6,10 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/import-once';

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -6,13 +6,9 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import 'mixins';
 

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -9,12 +9,9 @@
 // ComboBox
 //-----------------------------
 
-@import '../../globals/scss/colors';
-@import '../../globals/scss/css--helpers';
-@import '../../globals/scss/layout';
-@import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
+@import '../../globals/scss/functions';
+@import '../../globals/scss/import-once';
 @import '../list-box/list-box';
 
 @mixin combo-box {

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -6,10 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/import-once';

--- a/src/components/copy-button/_copy-button.scss
+++ b/src/components/copy-button/_copy-button.scss
@@ -6,12 +6,9 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../button/button';
 

--- a/src/components/data-table-v2/_data-table-v2-action.scss
+++ b/src/components/data-table-v2/_data-table-v2-action.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('data-table-v2-action') {
   .#{$prefix}--table-toolbar {

--- a/src/components/data-table-v2/_data-table-v2-core.scss
+++ b/src/components/data-table-v2/_data-table-v2-core.scss
@@ -9,7 +9,6 @@
 @import '../../globals/scss/functions';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('data-table-v2-core') {
   .#{$prefix}--data-table-v2-container {

--- a/src/components/data-table-v2/_data-table-v2-expandable.scss
+++ b/src/components/data-table-v2/_data-table-v2-expandable.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('data-table-v2-expandable') {
   tr.#{$prefix}--expandable-row-v2 {

--- a/src/components/data-table-v2/_data-table-v2-inline-edit-cell.scss
+++ b/src/components/data-table-v2/_data-table-v2-inline-edit-cell.scss
@@ -9,7 +9,7 @@
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/layout';
-@import '../../globals/scss/theme';
+@import '../../globals/scss/vars';
 
 @mixin assistive-text {
   position: absolute;

--- a/src/components/data-table-v2/_data-table-v2-inline-edit.scss
+++ b/src/components/data-table-v2/_data-table-v2-inline-edit.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('data-table-v2-inline-edit') {
   .#{$prefix}--inline-edit-label {

--- a/src/components/data-table-v2/_data-table-v2-skeleton.scss
+++ b/src/components/data-table-v2/_data-table-v2-skeleton.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('data-table-v2-skeleton') {
   .#{$prefix}--data-table-v2.#{$prefix}--skeleton {

--- a/src/components/data-table-v2/_data-table-v2-sort.scss
+++ b/src/components/data-table-v2/_data-table-v2-sort.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('data-table-v2-sort') {
   .#{$prefix}--table-sort-v2--ascending {

--- a/src/components/data-table-v2/_data-table-v2.scss
+++ b/src/components/data-table-v2/_data-table-v2.scss
@@ -5,11 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/spacing';
-@import '../../globals/scss/helper-mixins';
-
 @import 'data-table-v2-action';
 @import 'data-table-v2-core';
 @import 'data-table-v2-expandable';

--- a/src/components/data-table/_data-table.scss
+++ b/src/components/data-table/_data-table.scss
@@ -5,10 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/css--typography';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -6,9 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -9,13 +9,9 @@
 // Dropdown
 //-----------------------------
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';

--- a/src/components/fab/_fab.scss
+++ b/src/components/fab/_fab.scss
@@ -5,9 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';

--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -6,10 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -10,10 +10,6 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
 @import '../button/button';

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -5,10 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
-@import '../../globals/scss/theme';
+@import '../../globals/scss/vars';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/import-once';

--- a/src/components/inline-loading/_inline-loading.scss
+++ b/src/components/inline-loading/_inline-loading.scss
@@ -6,8 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
 @import '../../globals/scss/import-once';

--- a/src/components/interior-left-nav/interior-left-nav.scss
+++ b/src/components/interior-left-nav/interior-left-nav.scss
@@ -9,13 +9,10 @@
 // Interior Left Nav
 //-----------------------------
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/mixins';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';

--- a/src/components/lightbox/_lightbox.scss
+++ b/src/components/lightbox/_lightbox.scss
@@ -6,9 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -12,7 +12,6 @@
 @import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/theme';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -9,14 +9,12 @@
 // List Box
 //-----------------------------
 
-@import '../../globals/scss/colors';
+@import '../../globals/scss/vars';
 @import '../../globals/scss/css--helpers';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 $list-box-width: 100%;
 $list-box-height: rem(40px);

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -10,9 +10,6 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';

--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -6,8 +6,6 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/import-once';
 @import 'keyframes';

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -10,16 +10,13 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 @import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
+@import 'mixins';
 
 @import '../button/button';
 

--- a/src/components/multi-select/_multi-select.scss
+++ b/src/components/multi-select/_multi-select.scss
@@ -9,14 +9,8 @@
 // List Box
 //-----------------------------
 
-@import '../../globals/scss/colors';
-@import '../../globals/scss/css--helpers';
-@import '../../globals/scss/helper-mixins';
-@import '../../globals/scss/layer';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 @import '../list-box/list-box';
 
 @include exports('multi-select') {

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -10,16 +10,13 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/layout';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
+@import 'mixins';
 
 @mixin inline-notifications {
   .#{$prefix}--inline-notification {

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -10,16 +10,13 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/layout';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/mixins';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';
+@import 'mixins';
 
 @mixin toast-notifications {
   .#{$prefix}--toast-notification {

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -6,10 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -10,9 +10,6 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/layer';

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -8,9 +8,6 @@
 $css--helpers: true;
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/layout';

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -6,12 +6,8 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -10,10 +10,7 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../form/form';

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -10,14 +10,9 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
 
 @mixin search {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -9,15 +9,11 @@
 // Select
 //-----------------------------
 
-@import '../../globals/scss/feature-flags';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/import-once';
 @import '../form/form';
 

--- a/src/components/skeleton/_skeleton-icon.scss
+++ b/src/components/skeleton/_skeleton-icon.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('skeleton-icon') {
   .#{$prefix}--icon--skeleton {

--- a/src/components/skeleton/_skeleton-placeholder.scss
+++ b/src/components/skeleton/_skeleton-placeholder.scss
@@ -7,7 +7,6 @@
 
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/theme';
 @import '../../globals/scss/vars';
 
 @include exports('skeleton-placeholder') {

--- a/src/components/skeleton/_skeleton-text.scss
+++ b/src/components/skeleton/_skeleton-text.scss
@@ -8,7 +8,6 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 
 @include exports('skeleton-text') {
   .#{$prefix}--skeleton__text {

--- a/src/components/skeleton/_skeleton.scss
+++ b/src/components/skeleton/_skeleton.scss
@@ -5,11 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/spacing';
-@import '../../globals/scss/helper-mixins';
-
 @import 'skeleton-text';
 @import 'skeleton-icon';
 @import 'skeleton-placeholder';

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -10,13 +10,9 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
 @import '../form/form';
 @import '../text-input/text-input';

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -5,16 +5,12 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/mixins';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
+@import 'mixins';
 
 @mixin structured-list {
   .#{$prefix}--structured-list--selection .#{$prefix}--structured-list-td,

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -10,12 +10,8 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--typography';

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -5,12 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/feature-flags';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -10,10 +10,7 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -9,12 +9,9 @@
 // Text
 //-----------------------------
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/import-once';
 @import '../form/form';
 

--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -10,11 +10,8 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/css--typography';

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -10,9 +10,7 @@
 //-----------------------------
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/import-once';

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -9,9 +9,6 @@
 // Toggle
 //-----------------------------
 
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -8,10 +8,9 @@
 $css--helpers: true;
 
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/colors';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/css--helpers';
 @import '../button/button';
 @import '../checkbox/checkbox';

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -6,11 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/spacing';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';

--- a/src/components/ui-shell/_content.scss
+++ b/src/components/ui-shell/_content.scss
@@ -6,7 +6,6 @@
 //
 
 @import '../../globals/scss/functions';
-@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/vars';
 @import 'functions';
 

--- a/src/components/ui-shell/_header.scss
+++ b/src/components/ui-shell/_header.scss
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/helper-classes';
 @import '../../globals/scss/helper-mixins';

--- a/src/components/ui-shell/_navigation-menu.scss
+++ b/src/components/ui-shell/_navigation-menu.scss
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/css--helpers';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/vars';

--- a/src/components/ui-shell/_product-switcher.scss
+++ b/src/components/ui-shell/_product-switcher.scss
@@ -6,7 +6,6 @@
 //
 
 @import '../../globals/scss/functions';
-@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/vars';
 @import '../../globals/scss/typography';
 @import 'theme';

--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/css--helpers';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';

--- a/src/components/unified-header/_account-switcher.scss
+++ b/src/components/unified-header/_account-switcher.scss
@@ -10,7 +10,7 @@
 @import '../../globals/scss/layer';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/colors';
+@import '../../globals/scss/helper-mixins';
 
 @mixin account-switcher {
   @include deprecate(

--- a/src/components/unified-header/_global-header.scss
+++ b/src/components/unified-header/_global-header.scss
@@ -7,8 +7,6 @@
 
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/theme';
 @import '../../globals/scss/layer';
 @import '../../globals/scss/css--typography';
 @import '../../globals/scss/helper-mixins';

--- a/src/components/unified-header/_left-nav-trigger.scss
+++ b/src/components/unified-header/_left-nav-trigger.scss
@@ -7,10 +7,9 @@
 
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/theme';
-@import '../../globals/scss/mixins';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';
+@import 'mixins';
 
 @mixin left-nav-trigger {
   @include deprecate(

--- a/src/components/unified-header/_left-nav.scss
+++ b/src/components/unified-header/_left-nav.scss
@@ -12,8 +12,7 @@
 @import '../../globals/scss/layer';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/theme';
+@import 'mixins';
 
 @mixin left-nav {
   @include deprecate(

--- a/src/components/unified-header/_topnav.scss
+++ b/src/components/unified-header/_topnav.scss
@@ -6,11 +6,10 @@
 //
 
 @import '../../globals/scss/import-once';
-@import '../../globals/scss/mixins';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/colors';
-@import '../../globals/scss/theme';
+@import '../../globals/scss/helper-mixins';
+@import 'mixins';
 
 @mixin topnav {
   @include deprecate(

--- a/src/components/unified-header/_unified-header.scss
+++ b/src/components/unified-header/_unified-header.scss
@@ -5,17 +5,12 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../globals/scss/colors';
 @import '../../globals/scss/vars';
-@import '../../globals/scss/theme';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/layer';
-@import '../../globals/scss/layout';
-@import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';
-@import '../../globals/scss/css--typography';
 @import 'mixins';
 @import 'left-nav-trigger';
 @import 'global-header';

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -5,10 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import 'colors';
 @import 'vars';
-@import 'theme';
-@import 'mixins';
 @import 'typography';
 @import 'css--reset';
 @import 'import-once';

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -6,7 +6,6 @@
 //
 
 @import 'vars';
-@import 'theme';
 @import 'css--reset';
 @import 'typography';
 @import 'import-once';

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -5,10 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import 'colors';
 @import 'vars';
-@import 'theme';
-@import 'mixins';
 @import 'typography';
 @import 'css--reset';
 @import 'import-once';

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -19,7 +19,6 @@
 // Misc
 // ---------------------------------------------
 
-@import 'feature-flags';
 @import 'vars';
 @import 'css--reset';
 @import 'typography';


### PR DESCRIPTION
Refs carbon-design-system/carbon-website#818. The Sass build time there improves nearly 50%.

#### Changelog

**Changed**/**Removed**

* Replaced `@import`s of `_theme.scss` with `_helper-mixins.scss` where `_vars.scss` is imported, because the last two covers everything in `_theme.scss`
* Removed `@import`s of `_colors.scss` and ones of `_spaces.scss` where `_vars.scss` is imported, as `_vars.scss` imports them
* Removed `@import`s of `_typography.scss` where `_css--typography.scss` is imported, as the latter imports the former
* Replaced `@import`s of `src/globals/scss/_mixins.scss` with one of component-specific `_mixins.scss` to make them more specific
* `_css--typography.scss`: Removed `@import` of `_mixins.scss` as no `@mixin`s in `_mixins.scss` are in use from `_css--typography.scss`
* `_helper-mixins.scss`: Removed `@import` of `_feature-flags.scss` as no feature flag reference is in there
* Removed some other `@import`s that are not in use

#### Testing / Reviewing

Testing should make sure our Sass build is not broken.