### PR TITLE
fix(button): set default button heights

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -305,7 +305,7 @@
 
   .#{$prefix}--btn--sm {
     @include letter-spacing;
-    height: auto;
+    height: rem(32px);
     padding: $button-padding-sm;
   }
 

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -81,7 +81,7 @@
   flex-shrink: 0;
   font-size: $button-font-size;
   font-weight: $button-font-weight;
-  height: rem(48px);
+  height: rem($button-height);
   padding: $button-padding;
   border-radius: $button-border-radius;
   text-align: left;

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -81,7 +81,7 @@
   flex-shrink: 0;
   font-size: $button-font-size;
   font-weight: $button-font-weight;
-  height: auto;
+  height: rem(48px);
   padding: $button-padding;
   border-radius: $button-border-radius;
   text-align: left;


### PR DESCRIPTION
Closes #1691

This PR sets default button heights to avoid collapsing when button content is not rendered