### PR TITLE
fix(button--x): update primary, secondary text and icon color token

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -197,16 +197,16 @@
   }
 
   .#{$prefix}--btn--primary {
-    @include button-theme--x($interactive-01, transparent, $inverse-01, #0353e9, $ui-01, $interactive-02);
+    @include button-theme--x($interactive-01, transparent, $text-04, #0353e9, $text-04, $interactive-02);
   }
 
   .#{$prefix}--btn--secondary {
     @include button-theme--x(
       $ibm-colors__gray-80,
       $ibm-colors__gray-80,
-      $inverse-01,
+      $text-04,
       $ibm-colors__gray-70,
-      $inverse-01,
+      $text-04,
       $ibm-colors__gray-60
     );
 


### PR DESCRIPTION
Closes #1706 

#### Changelog

**Changed**

- Update color token for text and icon colors in Carbon X primary & secondary buttons to `$text-04`, which is `#ffffff` for the white, g10, g90, and g100 themes. (See: https://carbon-elements.netlify.com/themes/examples/preview/)