### PR TITLE
 docs: close unclosed `<link>` tag

### DIFF
--- a/examples/codesandbox/index.html
+++ b/examples/codesandbox/index.html
@@ -1,40 +1,43 @@
 <html>
+
 <head>
-	<title>Carbon Design System Sandbox</title>
-	<meta charset="UTF-8" />
-	<link rel="stylesheet" href="//unpkg.com/carbon-components@latest/css/carbon-components.min.css">
-	<link rel="stylesheet" href="src/styles.css"
+  <title>Carbon Design System Sandbox</title>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="//unpkg.com/carbon-components@latest/css/carbon-components.min.css">
+  <link rel="stylesheet" href="src/styles.css">
 </head>
+
 <body>
-	<h1>Hello World! 👋</h1>
-	<div id="app">
-		<ul id="my-dropdown" data-dropdown data-value class="bx--dropdown" tabindex="0">
-			<li class="bx--dropdown-text">
-				Dropdown label </li>
-			<svg class="bx--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
-				<path d="M10 0L5 5 0 0z"></path>
-			</svg>
-			<li>
-				<ul class="bx--dropdown-list">
-					<li data-option data-value="all" class="bx--dropdown-item">
-						<a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 1</a>
-					</li>
-					<li data-option data-value="cloudFoundry" class="bx--dropdown-item">
-						<a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 2</a>
-					</li>
-					<li data-option data-value="staging" class="bx--dropdown-item">
-						<a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 3</a>
-					</li>
-					<li data-option data-value="dea" class="bx--dropdown-item">
-						<a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 4</a>
-					</li>
-					<li data-option data-value="router" class="bx--dropdown-item">
-						<a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 5</a>
-					</li>
-				</ul>
-			</li>
-		</ul>
-	</div>
-	<script src="src/index.js"></script>
+  <h1>Hello World! 👋</h1>
+  <div id="app">
+    <ul id="my-dropdown" data-dropdown data-value class="bx--dropdown" tabindex="0">
+      <li class="bx--dropdown-text">
+        Dropdown label </li>
+      <svg class="bx--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
+        <path d="M10 0L5 5 0 0z"></path>
+      </svg>
+      <li>
+        <ul class="bx--dropdown-list">
+          <li data-option data-value="all" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 1</a>
+          </li>
+          <li data-option data-value="cloudFoundry" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 2</a>
+          </li>
+          <li data-option data-value="staging" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 3</a>
+          </li>
+          <li data-option data-value="dea" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 4</a>
+          </li>
+          <li data-option data-value="router" class="bx--dropdown-item">
+            <a class="bx--dropdown-link" href="javascript:void(0)" tabindex="-1">Option 5</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <script src="src/index.js"></script>
 </body>
+
 </html>

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -9,7 +9,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "carbon-components": "^9.59.0"
+    "carbon-components": "latest"
   },
   "devDependencies": {
     "parcel-bundler": "^1.10.0"


### PR DESCRIPTION
Closes #1726

This PR fixes an unclosed `<link>` tag in the Code Sandbox example code. This PR also defaults to the latest `carbon-components` version when creating using the sandbox