### PR TITLE
fix: move the current selector to fix scoping issues

### DIFF
--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -27,6 +27,10 @@
     min-width: 7rem;
     transition: $transition--base all $carbon--standard-easing;
     overflow: visible;
+
+    &:first-child .#{$prefix}--progress-line {
+      display: none;
+    }
   }
 
   .#{$prefix}--progress-line {
@@ -36,10 +40,6 @@
     height: 1px;
     width: calc(100% - 24px);
     border: $progress-indicator-bar-width;
-
-    .#{$prefix}--progress-step:first-child & {
-      display: none;
-    }
   }
 
   .#{$prefix}--progress-step svg {

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -26,6 +26,11 @@
 
   .#{$prefix}--structured-list-input {
     display: none;
+
+    &:checked + .#{$prefix}--structured-list-row .#{$prefix}--structured-list-svg,
+    &:checked + .#{$prefix}--structured-list-td .#{$prefix}--structured-list-svg {
+      fill: $brand-02;
+    }
   }
 
   .#{$prefix}--structured-list {
@@ -57,11 +62,6 @@
     border-bottom: 1px solid $ui-03;
     transition: $transition--base $carbon--standard-easing;
 
-    .#{$prefix}--structured-list--selection &:hover:not(.#{$prefix}--structured-list-row--header-row) {
-      background-color: $hover-row;
-      cursor: pointer;
-    }
-
     // Deprecated
     [data-structured-list] &:hover:not(.#{$prefix}--structured-list-row--header-row) {
       background-color: $hover-row;
@@ -80,6 +80,16 @@
     &:focus:not(.#{$prefix}--structured-list-row--header-row) {
       @include focus-outline('border');
     }
+
+    &:hover .#{$prefix}--structured-list-svg {
+      fill: $hover-row;
+    }
+  }
+
+  .#{$prefix}--structured-list--selection
+    .#{$prefix}--structured-list-row:hover:not(.#{$prefix}--structured-list-row--header-row) {
+    background-color: $hover-row;
+    cursor: pointer;
   }
 
   .#{$prefix}--structured-list-thead {
@@ -127,15 +137,6 @@
     fill: transparent;
     vertical-align: middle;
     transition: $transition--base $carbon--standard-easing;
-
-    .#{$prefix}--structured-list-row:hover & {
-      fill: $hover-row;
-    }
-
-    .#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-row &,
-    .#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-td & {
-      fill: $brand-02;
-    }
   }
 
   // Skeleton State

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -129,7 +129,7 @@
       background: transparent;
       padding: $spacing-sm 0 $spacing-sm;
 
-      & + & {
+      & + .#{$prefix}--tabs__nav-item {
         margin-left: rem(48px);
       }
     }
@@ -344,7 +344,7 @@
     width: 100%;
     @include breakpoint(bp--sm--major) {
       background: transparent;
-      & + & {
+      & + .#{$prefix}--tabs__nav-item {
         margin-left: rem(1px);
       }
     }


### PR DESCRIPTION
Closes #1711 for all instances that I'm presently aware of

TL;DR from the issue:

If `&` is used as a second level selector, it inherits the _entire_  first level selector. So `.#{$prefix}--structured-list-row` becomes `.carbon .bx--structured-list-row` and 

```sass
.#{$prefix}--structured-list--selection &:hover:not(.#{$prefix}--structured-list-row--header-row)
``` 

becomes 
```sass
.bx--structured-list--selection .carbon .bx--structured-list-row:hover:not(.bx--structured-list-row--header-row)
```

instead of
```sass
.carbon .bx--structured-list--selection .bx--structured-list-row:hover:not(.bx--structured-list-row--header-row)
```

This PR moves a few of the selectors around. This does result in a few styles moving away from their direct container, but it does express the intent of the selectors better.

As far as I can tell none of the X styles are affected by this.