### PR TITLE
fix(checkbox-x): make background transparent

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -245,7 +245,7 @@
     position: absolute;
     left: 0;
     top: rem(2px);
-    background-color: $ui-02;
+    background-color: transparent;
     border: 1px solid $ui-05;
     border-radius: 2px;
   }

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -245,6 +245,8 @@
     position: absolute;
     left: 0;
     top: rem(2px);
+
+    // Checkboxes with a background color look visually off against a parent container.
     background-color: transparent;
     border: 1px solid $ui-05;
     border-radius: 2px;


### PR DESCRIPTION
Experimental checkboxes currently use `$ui-02` as a background color - The implications of this are that they look visually off on different container background colors.

This PR proposes to make the background color transparent to align with that of the parent container.

#### Changelog

**Changed**

- Make experimental checkbox background color transparent
