### PR TITLE
fix(tile): add styles for selected check mark on accessible tile

### DIFF
--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -154,6 +154,14 @@
     outline: none;
   }
 
+  .#{$prefix}--tile--is-selected .#{$prefix}--tile__checkmark {
+    opacity: 1;
+
+    svg {
+      fill: $brand-01;
+    }
+  }
+
   .#{$prefix}--tile-input:checked {
     & + .#{$prefix}--tile__checkmark {
       opacity: 1;


### PR DESCRIPTION
Closes #1741

Closes https://github.com/IBM/carbon-components-react/issues/1819

This PR adds styles to display the selected check mark for DAP compliant tile markup