### PR TITLE
fix(number-input): add aria attributes for a11y

### DIFF
--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -11,7 +11,8 @@
     <div class="{{@root.prefix}}--number__input-wrapper">
       <input id="number-input0" type="number" min="0" max="100" value="1">
       <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{#if @root.featureFlags.componentsX}}
           {{ carbon-icon 'CaretUpGlyph' }}
           {{else}}
@@ -20,8 +21,8 @@
           </svg>
           {{/if}}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon"
-          type="button">
+        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{#if @root.featureFlags.componentsX}}
           {{ carbon-icon 'CaretDownGlyph' }}
           {{else}}
@@ -44,11 +45,12 @@
       <input id="number-input1" type="number" min="0" max="100" value="1">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon"
-          type="button">
+        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
       </div>
@@ -56,12 +58,14 @@
     {{else}}
     <input id="number-input1" type="number" min="0" max="100" value="1">
     <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
@@ -82,11 +86,12 @@
       <input id="number-input2" type="number" min="0" max="100" value="1">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon"
-          type="button">
+        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
       </div>
@@ -94,12 +99,14 @@
     {{else}}
     <input id="number-input2" type="number" min="0" max="100" value="1">
     <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
@@ -123,11 +130,12 @@
     <div class="{{@root.prefix}}--number__input-wrapper">
       <input id="number-input3" type="number" min="0" max="100" value="1">
       <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon"
-          type="button">
+        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
       </div>
@@ -135,12 +143,14 @@
     {{else}}
     <input id="number-input3" type="number" min="0" max="100" value="1">
     <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
@@ -167,11 +177,12 @@
       <input id="number-input4" type="number" min="0" max="100" value="1">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon"
-          type="button">
+        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
       </div>
@@ -179,12 +190,14 @@
     {{else}}
     <input id="number-input4" type="number" min="0" max="100" value="1">
     <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>
@@ -214,11 +227,12 @@
       <input id="number-input4" type="number" min="0" max="100" value="1">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon"
-          type="button">
+        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+          aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
       </div>
@@ -226,12 +240,14 @@
     {{else}}
     <input id="number-input4" type="number" min="0" max="100" value="1">
     <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button">
+      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button">
+      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
         </svg>

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -42,7 +42,7 @@
     <label for="number-input1" class="{{@root.prefix}}--label">Number Input label</label>
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--number__input-wrapper">
-      <input id="number-input1" type="number" min="0" max="100" value="1">
+      <input id="number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
         <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
@@ -56,7 +56,7 @@
       </div>
     </div>
     {{else}}
-    <input id="number-input1" type="number" min="0" max="100" value="1">
+    <input id="number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
     <div class="{{@root.prefix}}--number__controls">
       <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
@@ -83,7 +83,7 @@
     class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--nolabel">
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--number__input-wrapper">
-      <input id="number-input2" type="number" min="0" max="100" value="1">
+      <input id="number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
         <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
@@ -97,7 +97,7 @@
       </div>
     </div>
     {{else}}
-    <input id="number-input2" type="number" min="0" max="100" value="1">
+    <input id="number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
     <div class="{{@root.prefix}}--number__controls">
       <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
@@ -174,7 +174,7 @@
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
     <div class="{{@root.prefix}}--number__input-wrapper">
-      <input id="number-input4" type="number" min="0" max="100" value="1">
+      <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
         <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
@@ -188,7 +188,7 @@
       </div>
     </div>
     {{else}}
-    <input id="number-input4" type="number" min="0" max="100" value="1">
+    <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
     <div class="{{@root.prefix}}--number__controls">
       <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
@@ -224,7 +224,7 @@
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
     <div class="{{@root.prefix}}--number__input-wrapper">
-      <input id="number-input4" type="number" min="0" max="100" value="1">
+      <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
         <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
@@ -238,7 +238,7 @@
       </div>
     </div>
     {{else}}
-    <input id="number-input4" type="number" min="0" max="100" value="1">
+    <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
     <div class="{{@root.prefix}}--number__controls">
       <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">


### PR DESCRIPTION
Closes #1743

Related: https://github.com/IBM/carbon-components-react/issues/1658

This PR adds `aria-live` and `aria-atomic` attributes to improve a11y