### PR TITLE
fix(inline-loading): inline-loading component should have aria-live

### DIFF
--- a/src/components/inline-loading/inline-loading.hbs
+++ b/src/components/inline-loading/inline-loading.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -6,7 +6,7 @@
 -->
 
 <!-- Loading Success State -->
-<div data-inline-loading class="{{@root.prefix}}--inline-loading">
+<div data-inline-loading class="{{@root.prefix}}--inline-loading" role="alert" aria-live="assertive">
   <div class="{{@root.prefix}}--inline-loading__animation">
     <div data-inline-loading-spinner class="{{@root.prefix}}--loading {{@root.prefix}}--loading--small">
       <svg class="{{@root.prefix}}--loading__svg" viewBox="-75 -75 150 150">


### PR DESCRIPTION
Fixes #[1444](https://github.com/IBM/carbon-components/issues/1444)

By adding the attributes `role="alert"` and `aria-live="assertive"` and creating some affordances for changing that markup in our JS visually impaired users with screen reading software can have the full intended experience.

Currently the users with screen readers have no announcements of status read to them.

#### Changelog

**Changed**

- src/components/inline-loading/inline-loading.hbs

#### Testing / Reviewing

- Go to the inline-loading component.
- Turn on screen reader. (I have tested VoiceOver on Mac)
- Click on the toggle button and it tells whether the data is loaded or not.

