### PR TITLE
fix(ui-shell): remove usage of unset

### DIFF
--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -249,15 +249,15 @@
   }
 
   // Force all of our side navigation items to be the same dimensions. When our
-  // menu expands, we can unset these values.
+  // menu expands, we can reset these values.
   .#{$prefix}--side-nav__item {
     width: mini-units(6);
     height: mini-units(6);
     overflow: hidden;
 
     @include expanded() {
-      width: unset;
-      height: unset;
+      width: initial;
+      height: initial;
     }
   }
 


### PR DESCRIPTION
Closes #1761

Remove usage of unset.

#### Changelog

**New**

**Changed**

- `_side-nav.scss` now uses `inherit` instead of `unset`

**Removed**
