### PR TITLE
fix(content-switcher): add divider token

### DIFF
--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -169,7 +169,7 @@
     display: block;
     height: rem(16px);
     width: rem(1px);
-    background-color: $content-switcher-divider;
+    background-color: $ui-03;
     position: absolute;
     z-index: 2;
     right: rem(-1px);

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -169,7 +169,7 @@
     display: block;
     height: rem(16px);
     width: rem(1px);
-    background-color: $ui-03;
+    background-color: $content-switcher-divider;
     position: absolute;
     z-index: 2;
     right: rem(-1px);

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -167,7 +167,7 @@
   // Content Switcher
   $content-switcher-border-radius: 0px !default !global;
   $content-switcher-option-border: 1px solid $brand-01 !default !global;
-  $content-switcher-divider: $ibm-colors__gray-30 !default !global;
+  $content-switcher-divider: $ui-03 !default !global;
 
   // Data Table
   $data-table-heading-transform: uppercase !default !global;


### PR DESCRIPTION
Experimental content switcher divider color values references `$ibm-colors__gray-30` instead of a token role value.

#### Changelog

**Changed**

- Update content switcher divider to use `$ui-03` token
