### PR TITLE
fix(list-box): fix icon overlap

### DIFF
--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -124,7 +124,7 @@ $list-box-menu-width: rem(300px);
     display: inline-flex;
     align-items: center;
     height: 100%;
-    padding: 0 1rem;
+    padding: 0 2rem 0 1rem;
     cursor: pointer;
   }
 
@@ -413,7 +413,7 @@ $list-box-menu-width: rem(300px);
     display: inline-flex;
     align-items: center;
     height: rem(40px);
-    padding: 0 1rem;
+    padding: 0 2rem 0 1rem;
     cursor: pointer;
     outline: none;
   }


### PR DESCRIPTION
Fixes #1031.
Refs #1059.

#### Changelog

**Changed**

- List box field style to avoid text overlapping with trigger icon.

#### Testing / Reviewing

Testing should make sure multi select and drop down V2 are not broken.