### PR TITLE
fix(number-input): uses updated tokens to work in dark themes

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -270,6 +270,7 @@
 
   .#{$prefix}--number__control-btn {
     @include button-reset;
+    color: $icon-01;
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -277,17 +278,21 @@
     width: rem(20px);
     height: rem(10px);
 
+    svg {
+      fill: currentColor;
+    }
+
     &:focus {
       @include focus-outline;
-      fill: $interactive-01;
+      color: $interactive-01;
     }
 
     &:hover {
       cursor: pointer;
     }
 
-    &:hover svg {
-      fill: $ui-05;
+    &:hover {
+      color: $icon-01;
     }
   }
 

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -122,8 +122,8 @@
   // Global
   $input-border: 1px solid transparent !default !global;
   $input-label-weight: 400 !default !global;
-  $disabled: $ibm-colors__gray-30 !default !global;
-  $disabled-background-color: $ibm-colors__gray-10 !default !global;
+  $disabled: $disabled-02 !default !global;
+  $disabled-background-color: $disabled-01 !default !global;
   $focus: $ibm-colors__blue-60 !default !global;
 
   // Link


### PR DESCRIPTION
Uses the icon token in number input buttons, so that it works with dark themes.

#### Changelog

**Changed**

- Uses color `$icon-01` for buttons  / currentColor fills for SVGs
- Assigns component / global disabled variables to the new disabled color tokens.

