### PR TITLE
docs(progress-indicator): resolve experimental progress indicator DAP violations

### DIFF
--- a/src/components/progress-indicator/progress-indicator.config.js
+++ b/src/components/progress-indicator/progress-indicator.config.js
@@ -22,12 +22,18 @@ const steps = [
     label: 'Second Step',
     overflow: true,
     overflowLabel: 'Overflow Ex. 1',
+    tooltipId: Math.random()
+      .toString(36)
+      .substr(2),
   },
   {
     state: 'incomplete',
     label: 'Third Step',
     overflow: true,
     overflowLabel: 'Overflow Ex. 2 Multi Line',
+    tooltipId: Math.random()
+      .toString(36)
+      .substr(2),
   },
   {
     state: 'incomplete',

--- a/src/components/progress-indicator/progress-indicator.hbs
+++ b/src/components/progress-indicator/progress-indicator.hbs
@@ -36,7 +36,7 @@
           </svg>
         {{/if}}
       {{/is}}
-      <p tabindex="0" class="{{@root.prefix}}--progress-label" {{#if ../componentsX}} aria-describedby="label-tooltip" {{/if}}>
+      <p tabindex="0" class="{{@root.prefix}}--progress-label" {{#if ../componentsX}} {{#if overflow}} aria-describedby="label-tooltip{{tooltipId}}" {{/if}} {{/if}}>
         {{#if ../componentsX}}
           {{#if overflow}}
             {{#if ../vertical}}
@@ -52,7 +52,7 @@
         {{/if}}
       </p>
       {{#if ../componentsX}}
-        <div id="label-tooltip" role="tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip" data-avoid-focus-on-open>
+        <div id="label-tooltip{{tooltipId}}" role="tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip" data-avoid-focus-on-open>
           <span class="{{@root.prefix}}--tooltip__caret"></span>
           <p class="{{@root.prefix}}--tooltip__text">{{overflowLabel}}</p>
         </div>

--- a/src/components/progress-indicator/progress-indicator.hbs
+++ b/src/components/progress-indicator/progress-indicator.hbs
@@ -7,7 +7,7 @@
 
 <ul data-progress data-progress-current class="{{@root.prefix}}--progress {{#if vertical}}{{@root.prefix}}--progress--vertical{{/if}}">
   {{#each steps}}
-    <li class="{{@root.prefix}}--progress-step {{@root.prefix}}--progress-step--{{state}} {{#if disabled}} {{@root.prefix}}--progress-step--disabled {{/if}}" {{#if invalid}} data-invalid {{/if}}>
+    <li class="{{@root.prefix}}--progress-step {{@root.prefix}}--progress-step--{{state}} {{#if disabled}} {{@root.prefix}}--progress-step--disabled {{/if}}" {{#if invalid}} data-invalid {{/if}} {{#if disabled}} aria-disabled="true" {{/if}}>
       {{#is state "complete"}}
         {{carbon-icon 'CheckmarkOutline16'}}
       {{/is}}


### PR DESCRIPTION
Closes #1782

This PR addresses the DAP violations found on the experimental progress indicator examples in the documentation

#### Changelog

**New**

- add `aria-disabled` attribute on disabled progress step

**Changed**

- assign unique IDs to tooltip labels