### PR TITLE
fix(modal): use overlay token for modal overlay

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -166,7 +166,7 @@
     justify-content: center;
     content: '';
     opacity: 0;
-    background-color: rgba($ui-05, 0.7);
+    background-color: $overlay-01;
     transition: opacity 200ms, z-index 0s 200ms, visibility 0s 200ms;
     visibility: hidden;
 


### PR DESCRIPTION
Closes #1798

Adds the overlay color variable to modal overlay `background-color`. This allows the the overlay to render correctly using different themes.

**Changed**

- Uses new color variable