### PR TITLE
fix(link): restyle to match spec

### DIFF
--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -54,28 +54,24 @@
   .#{$prefix}--link {
     @include reset;
     @include type-style('body-short-01');
-
     color: $interactive-01;
-
-    // There is currently no way to set the thinkness of an underline so we'll rely on the box shadow property to achieve this
-    // effect.
     text-decoration: none;
 
-    &:hover,
-    &:focus {
+    &:hover {
       color: $interactive-01;
       box-shadow: 0 1px currentColor;
     }
 
     &:active,
     &:active:visited {
-      color: $text-01;
+      color: $link-visited;
       box-shadow: 0 1px currentColor;
     }
 
     &:focus {
-      outline: none;
-      box-shadow: 0 3px currentColor;
+      color: $interactive-01;
+      outline: 3px solid currentColor;
+      outline-offset: 2px;
     }
 
     &[aria-disabled='true'][tabindex='-1'] {
@@ -87,7 +83,7 @@
     }
 
     &:visited {
-      color: $interactive-01;
+      color: $link-visited;
     }
   }
 }

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -94,7 +94,7 @@
     color: $visited-link;
   }
 
-  .#{$prefix}--disabled {
+  .#{$prefix}--link--disabled {
     @include font-smoothing;
     display: inline;
     color: $disabled-02;

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -70,7 +70,7 @@
 
     &:focus {
       color: $interactive-01;
-      outline: 3px solid currentColor;
+      outline: 2px solid currentColor;
       outline-offset: 2px;
     }
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -64,7 +64,7 @@
 
     &:active,
     &:active:visited {
-      color: $link-visited;
+      color: $text-01;
       box-shadow: 0 1px currentColor;
     }
 
@@ -86,7 +86,7 @@
     }
 
     &:visited {
-      color: $link-visited;
+      color: $interactive-01;
     }
   }
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -74,9 +74,12 @@
       outline-offset: 2px;
     }
 
-    &[aria-disabled='true'][tabindex='-1'] {
-      color: $disabled;
+    &:not([href]) {
+      color: $disabled-02;
       cursor: not-allowed;
+      pointer-events: none;
+      touch-action: none;
+
       &:hover {
         box-shadow: none;
       }
@@ -88,7 +91,10 @@
   }
 
   .#{$prefix}--disabled {
+    @include font-smoothing;
+    display: inline;
     color: $disabled-02;
+    font-weight: 400;
   }
 }
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -90,6 +90,10 @@
     }
   }
 
+  .#{$prefix}--link--visited {
+    color: $visited-link;
+  }
+
   .#{$prefix}--disabled {
     @include font-smoothing;
     display: inline;

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -95,6 +95,8 @@
   }
 
   .#{$prefix}--link--disabled {
+    @include reset;
+    @include type-style('body-short-01');
     @include font-smoothing;
     display: inline;
     color: $disabled-02;

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -86,6 +86,10 @@
       color: $link-visited;
     }
   }
+
+  .#{$prefix}--disabled {
+    color: $disabled-02;
+  }
 }
 
 @include exports('link') {

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -6,5 +6,5 @@
 -->
 
 <a href="#" class="{{@root.prefix}}--link">Link</a>
-<a class="{{@root.prefix}}--link" tabindex="-1" aria-disabled="true">Link</a>
+<a class="{{@root.prefix}}--link">Placeholder link</a>
 <p class="{{@root.prefix}}--disabled">Disabled Link</p>

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -6,4 +6,4 @@
 -->
 
 <a href="#" class="{{@root.prefix}}--link">Link</a>
-<a href="#" class="{{@root.prefix}}--link" tabindex="-1" aria-disabled="true">Link</a>
+<a class="{{@root.prefix}}--link" tabindex="-1" aria-disabled="true">Link</a>

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -7,3 +7,4 @@
 
 <a href="#" class="{{@root.prefix}}--link">Link</a>
 <a class="{{@root.prefix}}--link" tabindex="-1" aria-disabled="true">Link</a>
+<p class="{{@root.prefix}}--disabled">Disabled Link</p>

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -8,3 +8,7 @@
 <a href="#" class="{{@root.prefix}}--link">Link</a>
 <a class="{{@root.prefix}}--link">Placeholder link</a>
 <p class="{{@root.prefix}}--link--disabled">Disabled Link</p>
+<br>
+<a href="#" class="{{@root.prefix}}--link">Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti explicabo
+  nobis consequatur quod qui quam laboriosam placeat repudiandae. Ducimus ea aut omnis asperiores mollitia
+  necessitatibus architecto temporibus provident quo? Repellat!</a>

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -7,4 +7,4 @@
 
 <a href="#" class="{{@root.prefix}}--link">Link</a>
 <a class="{{@root.prefix}}--link">Placeholder link</a>
-<p class="{{@root.prefix}}--disabled">Disabled Link</p>
+<p class="{{@root.prefix}}--link--disabled">Disabled Link</p>


### PR DESCRIPTION
Closes #1801
Closes #1263

This PR incorporates the feedback from the v1.1 component audit

#### Changelog

**Changed**

- use new color tokens
- match spec for `focus` styles. There was a comment about using `box-shadow` to set a border on the focused link state, but this only allowed the border to appear on the bottom of the element. Switching to `outline` allows us to match the spec which calls for a border around the entire element

**Removed**

- `href` attribute from disabled link example (in order to achieve the cursor CSS changes in addition to disabling page navigation)
