### PR TITLE
Add test setup for classic Sass code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -22,3 +22,6 @@ src/**/*.config.js
 
 # TODO: Use more granular ESLint configuration
 tests/es-test.js
+
+# TODO: update so that "jest": true has impact on "env" config
+**/__tests__/**

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-modules-umd": "^7.0.0",
-    "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
@@ -259,6 +259,16 @@
     "testMatch": [
       "<rootDir>/**/__tests__/**/*.js?(x)",
       "<rootDir>/**/?(*-)(spec|test).js?(x)"
-    ]
+    ],
+    "testPathIgnorePatterns": [
+      "/cjs/",
+      "/dist/",
+      "/es/",
+      "/lib/",
+      "/umd/"
+    ],
+    "transform": {
+      "^.+\\.(js|jsx)$": "./tools/jest/jsTransform.js"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "mock-raf": "^1.0.0",
-    "node-sass": "^4.10.0",
+    "node-sass": "^4.11.0",
     "nodemon": "^1.18.7",
     "path-to-regexp": "^2.2.0",
     "portscanner": "^2.2.0",

--- a/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
+++ b/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
@@ -1,0 +1,951 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_grid.scss should support the grid mixin 1`] = `
+"/**
+ * Generic \`deprecate\` mixin that is being used to indicate that a component is
+ * no longer going to be present in the next major release of Carbon.
+ */
+@keyframes skeleton {
+  0% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; }
+  20% {
+    width: 100%;
+    left: 0;
+    right: auto;
+    opacity: 1; }
+  28% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  51% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  58% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  82% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  83% {
+    width: 100%;
+    left: 0;
+    right: auto; }
+  96% {
+    width: 0%;
+    left: 0;
+    right: auto; }
+  100% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; } }
+
+.bx--grid {
+  margin-left: 3%;
+  margin-right: 3%;
+  padding-left: 5px;
+  padding-right: 5px; }
+  @media (min-width: 576px) {
+    .bx--grid {
+      margin-left: 5%;
+      margin-right: 5%;
+      padding-left: 10px;
+      padding-right: 10px; } }
+  @media (min-width: 1600px) {
+    .bx--grid {
+      margin: 0 auto; } }
+  .bx--grid.max {
+    max-width: 1600px; }
+
+.bx--row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -5px; }
+  @media (min-width: 576px) {
+    .bx--row {
+      margin: 0 -10px; } }
+
+[class*='bx--col'] {
+  position: relative;
+  width: 100%;
+  padding: 0 5px; }
+  @media (min-width: 576px) {
+    [class*='bx--col'] {
+      padding: 0 10px; } }
+
+.bx--col-xs-1 {
+  flex: 0 0 8.33333%;
+  max-width: 8.33333%; }
+
+.bx--offset-xs-1 {
+  margin-left: 8.33333%; }
+
+.bx--col-xs-2 {
+  flex: 0 0 16.66667%;
+  max-width: 16.66667%; }
+
+.bx--offset-xs-2 {
+  margin-left: 16.66667%; }
+
+.bx--col-xs-3 {
+  flex: 0 0 25%;
+  max-width: 25%; }
+
+.bx--offset-xs-3 {
+  margin-left: 25%; }
+
+.bx--col-xs-4 {
+  flex: 0 0 33.33333%;
+  max-width: 33.33333%; }
+
+.bx--offset-xs-4 {
+  margin-left: 33.33333%; }
+
+.bx--col-xs-5 {
+  flex: 0 0 41.66667%;
+  max-width: 41.66667%; }
+
+.bx--offset-xs-5 {
+  margin-left: 41.66667%; }
+
+.bx--col-xs-6 {
+  flex: 0 0 50%;
+  max-width: 50%; }
+
+.bx--offset-xs-6 {
+  margin-left: 50%; }
+
+.bx--col-xs-7 {
+  flex: 0 0 58.33333%;
+  max-width: 58.33333%; }
+
+.bx--offset-xs-7 {
+  margin-left: 58.33333%; }
+
+.bx--col-xs-8 {
+  flex: 0 0 66.66667%;
+  max-width: 66.66667%; }
+
+.bx--offset-xs-8 {
+  margin-left: 66.66667%; }
+
+.bx--col-xs-9 {
+  flex: 0 0 75%;
+  max-width: 75%; }
+
+.bx--offset-xs-9 {
+  margin-left: 75%; }
+
+.bx--col-xs-10 {
+  flex: 0 0 83.33333%;
+  max-width: 83.33333%; }
+
+.bx--offset-xs-10 {
+  margin-left: 83.33333%; }
+
+.bx--col-xs-11 {
+  flex: 0 0 91.66667%;
+  max-width: 91.66667%; }
+
+.bx--offset-xs-11 {
+  margin-left: 91.66667%; }
+
+.bx--col-xs-12 {
+  flex: 0 0 100%;
+  max-width: 100%; }
+
+.bx--offset-xs-12 {
+  margin-left: 100%; }
+
+@media (min-width: 576px) {
+  .bx--col-sm-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-sm-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-sm-1 {
+    margin-left: 8.33333%; }
+  .bx--col-sm-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-sm-2 {
+    margin-left: 16.66667%; }
+  .bx--col-sm-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-sm-3 {
+    margin-left: 25%; }
+  .bx--col-sm-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-sm-4 {
+    margin-left: 33.33333%; }
+  .bx--col-sm-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-sm-5 {
+    margin-left: 41.66667%; }
+  .bx--col-sm-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-sm-6 {
+    margin-left: 50%; }
+  .bx--col-sm-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-sm-7 {
+    margin-left: 58.33333%; }
+  .bx--col-sm-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-sm-8 {
+    margin-left: 66.66667%; }
+  .bx--col-sm-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-sm-9 {
+    margin-left: 75%; }
+  .bx--col-sm-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-sm-10 {
+    margin-left: 83.33333%; }
+  .bx--col-sm-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-sm-11 {
+    margin-left: 91.66667%; }
+  .bx--col-sm-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-sm-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 768px) {
+  .bx--col-md-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-md-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-md-1 {
+    margin-left: 8.33333%; }
+  .bx--col-md-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-md-2 {
+    margin-left: 16.66667%; }
+  .bx--col-md-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-md-3 {
+    margin-left: 25%; }
+  .bx--col-md-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-md-4 {
+    margin-left: 33.33333%; }
+  .bx--col-md-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-md-5 {
+    margin-left: 41.66667%; }
+  .bx--col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-md-6 {
+    margin-left: 50%; }
+  .bx--col-md-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-md-7 {
+    margin-left: 58.33333%; }
+  .bx--col-md-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-md-8 {
+    margin-left: 66.66667%; }
+  .bx--col-md-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-md-9 {
+    margin-left: 75%; }
+  .bx--col-md-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-md-10 {
+    margin-left: 83.33333%; }
+  .bx--col-md-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-md-11 {
+    margin-left: 91.66667%; }
+  .bx--col-md-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-md-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 992px) {
+  .bx--col-lg-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-lg-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-lg-1 {
+    margin-left: 8.33333%; }
+  .bx--col-lg-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-lg-2 {
+    margin-left: 16.66667%; }
+  .bx--col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-lg-3 {
+    margin-left: 25%; }
+  .bx--col-lg-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-lg-4 {
+    margin-left: 33.33333%; }
+  .bx--col-lg-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-lg-5 {
+    margin-left: 41.66667%; }
+  .bx--col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-lg-6 {
+    margin-left: 50%; }
+  .bx--col-lg-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-lg-7 {
+    margin-left: 58.33333%; }
+  .bx--col-lg-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-lg-8 {
+    margin-left: 66.66667%; }
+  .bx--col-lg-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-lg-9 {
+    margin-left: 75%; }
+  .bx--col-lg-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-lg-10 {
+    margin-left: 83.33333%; }
+  .bx--col-lg-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-lg-11 {
+    margin-left: 91.66667%; }
+  .bx--col-lg-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-lg-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 1200px) {
+  .bx--col-xl-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-xl-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-xl-1 {
+    margin-left: 8.33333%; }
+  .bx--col-xl-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-xl-2 {
+    margin-left: 16.66667%; }
+  .bx--col-xl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-xl-3 {
+    margin-left: 25%; }
+  .bx--col-xl-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-xl-4 {
+    margin-left: 33.33333%; }
+  .bx--col-xl-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-xl-5 {
+    margin-left: 41.66667%; }
+  .bx--col-xl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-xl-6 {
+    margin-left: 50%; }
+  .bx--col-xl-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-xl-7 {
+    margin-left: 58.33333%; }
+  .bx--col-xl-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-xl-8 {
+    margin-left: 66.66667%; }
+  .bx--col-xl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-xl-9 {
+    margin-left: 75%; }
+  .bx--col-xl-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-xl-10 {
+    margin-left: 83.33333%; }
+  .bx--col-xl-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-xl-11 {
+    margin-left: 91.66667%; }
+  .bx--col-xl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-xl-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 1600px) {
+  .bx--col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-xxl-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-xxl-1 {
+    margin-left: 8.33333%; }
+  .bx--col-xxl-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-xxl-2 {
+    margin-left: 16.66667%; }
+  .bx--col-xxl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-xxl-3 {
+    margin-left: 25%; }
+  .bx--col-xxl-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-xxl-4 {
+    margin-left: 33.33333%; }
+  .bx--col-xxl-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-xxl-5 {
+    margin-left: 41.66667%; }
+  .bx--col-xxl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-xxl-6 {
+    margin-left: 50%; }
+  .bx--col-xxl-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-xxl-7 {
+    margin-left: 58.33333%; }
+  .bx--col-xxl-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-xxl-8 {
+    margin-left: 66.66667%; }
+  .bx--col-xxl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-xxl-9 {
+    margin-left: 75%; }
+  .bx--col-xxl-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-xxl-10 {
+    margin-left: 83.33333%; }
+  .bx--col-xxl-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-xxl-11 {
+    margin-left: 91.66667%; }
+  .bx--col-xxl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-xxl-12 {
+    margin-left: 100%; } }
+
+.bx--col-xs,
+.bx--col-sm,
+.bx--col-md,
+.bx--col-lg {
+  flex-basis: 0;
+  flex: 1;
+  flex-grow: 1;
+  max-width: 100%; }
+
+.bx--grid {
+  margin-left: 3%;
+  margin-right: 3%;
+  padding-left: 5px;
+  padding-right: 5px; }
+  @media (min-width: 576px) {
+    .bx--grid {
+      margin-left: 5%;
+      margin-right: 5%;
+      padding-left: 10px;
+      padding-right: 10px; } }
+  @media (min-width: 1600px) {
+    .bx--grid {
+      margin: 0 auto; } }
+  .bx--grid.max {
+    max-width: 1600px; }
+
+.bx--row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -5px; }
+  @media (min-width: 576px) {
+    .bx--row {
+      margin: 0 -10px; } }
+
+[class*='bx--col'] {
+  position: relative;
+  width: 100%;
+  padding: 0 5px; }
+  @media (min-width: 576px) {
+    [class*='bx--col'] {
+      padding: 0 10px; } }
+
+.bx--col-xs-1 {
+  flex: 0 0 8.33333%;
+  max-width: 8.33333%; }
+
+.bx--offset-xs-1 {
+  margin-left: 8.33333%; }
+
+.bx--col-xs-2 {
+  flex: 0 0 16.66667%;
+  max-width: 16.66667%; }
+
+.bx--offset-xs-2 {
+  margin-left: 16.66667%; }
+
+.bx--col-xs-3 {
+  flex: 0 0 25%;
+  max-width: 25%; }
+
+.bx--offset-xs-3 {
+  margin-left: 25%; }
+
+.bx--col-xs-4 {
+  flex: 0 0 33.33333%;
+  max-width: 33.33333%; }
+
+.bx--offset-xs-4 {
+  margin-left: 33.33333%; }
+
+.bx--col-xs-5 {
+  flex: 0 0 41.66667%;
+  max-width: 41.66667%; }
+
+.bx--offset-xs-5 {
+  margin-left: 41.66667%; }
+
+.bx--col-xs-6 {
+  flex: 0 0 50%;
+  max-width: 50%; }
+
+.bx--offset-xs-6 {
+  margin-left: 50%; }
+
+.bx--col-xs-7 {
+  flex: 0 0 58.33333%;
+  max-width: 58.33333%; }
+
+.bx--offset-xs-7 {
+  margin-left: 58.33333%; }
+
+.bx--col-xs-8 {
+  flex: 0 0 66.66667%;
+  max-width: 66.66667%; }
+
+.bx--offset-xs-8 {
+  margin-left: 66.66667%; }
+
+.bx--col-xs-9 {
+  flex: 0 0 75%;
+  max-width: 75%; }
+
+.bx--offset-xs-9 {
+  margin-left: 75%; }
+
+.bx--col-xs-10 {
+  flex: 0 0 83.33333%;
+  max-width: 83.33333%; }
+
+.bx--offset-xs-10 {
+  margin-left: 83.33333%; }
+
+.bx--col-xs-11 {
+  flex: 0 0 91.66667%;
+  max-width: 91.66667%; }
+
+.bx--offset-xs-11 {
+  margin-left: 91.66667%; }
+
+.bx--col-xs-12 {
+  flex: 0 0 100%;
+  max-width: 100%; }
+
+.bx--offset-xs-12 {
+  margin-left: 100%; }
+
+@media (min-width: 576px) {
+  .bx--col-sm-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-sm-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-sm-1 {
+    margin-left: 8.33333%; }
+  .bx--col-sm-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-sm-2 {
+    margin-left: 16.66667%; }
+  .bx--col-sm-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-sm-3 {
+    margin-left: 25%; }
+  .bx--col-sm-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-sm-4 {
+    margin-left: 33.33333%; }
+  .bx--col-sm-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-sm-5 {
+    margin-left: 41.66667%; }
+  .bx--col-sm-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-sm-6 {
+    margin-left: 50%; }
+  .bx--col-sm-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-sm-7 {
+    margin-left: 58.33333%; }
+  .bx--col-sm-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-sm-8 {
+    margin-left: 66.66667%; }
+  .bx--col-sm-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-sm-9 {
+    margin-left: 75%; }
+  .bx--col-sm-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-sm-10 {
+    margin-left: 83.33333%; }
+  .bx--col-sm-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-sm-11 {
+    margin-left: 91.66667%; }
+  .bx--col-sm-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-sm-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 768px) {
+  .bx--col-md-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-md-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-md-1 {
+    margin-left: 8.33333%; }
+  .bx--col-md-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-md-2 {
+    margin-left: 16.66667%; }
+  .bx--col-md-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-md-3 {
+    margin-left: 25%; }
+  .bx--col-md-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-md-4 {
+    margin-left: 33.33333%; }
+  .bx--col-md-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-md-5 {
+    margin-left: 41.66667%; }
+  .bx--col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-md-6 {
+    margin-left: 50%; }
+  .bx--col-md-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-md-7 {
+    margin-left: 58.33333%; }
+  .bx--col-md-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-md-8 {
+    margin-left: 66.66667%; }
+  .bx--col-md-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-md-9 {
+    margin-left: 75%; }
+  .bx--col-md-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-md-10 {
+    margin-left: 83.33333%; }
+  .bx--col-md-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-md-11 {
+    margin-left: 91.66667%; }
+  .bx--col-md-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-md-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 992px) {
+  .bx--col-lg-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-lg-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-lg-1 {
+    margin-left: 8.33333%; }
+  .bx--col-lg-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-lg-2 {
+    margin-left: 16.66667%; }
+  .bx--col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-lg-3 {
+    margin-left: 25%; }
+  .bx--col-lg-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-lg-4 {
+    margin-left: 33.33333%; }
+  .bx--col-lg-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-lg-5 {
+    margin-left: 41.66667%; }
+  .bx--col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-lg-6 {
+    margin-left: 50%; }
+  .bx--col-lg-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-lg-7 {
+    margin-left: 58.33333%; }
+  .bx--col-lg-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-lg-8 {
+    margin-left: 66.66667%; }
+  .bx--col-lg-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-lg-9 {
+    margin-left: 75%; }
+  .bx--col-lg-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-lg-10 {
+    margin-left: 83.33333%; }
+  .bx--col-lg-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-lg-11 {
+    margin-left: 91.66667%; }
+  .bx--col-lg-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-lg-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 1200px) {
+  .bx--col-xl-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-xl-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-xl-1 {
+    margin-left: 8.33333%; }
+  .bx--col-xl-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-xl-2 {
+    margin-left: 16.66667%; }
+  .bx--col-xl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-xl-3 {
+    margin-left: 25%; }
+  .bx--col-xl-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-xl-4 {
+    margin-left: 33.33333%; }
+  .bx--col-xl-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-xl-5 {
+    margin-left: 41.66667%; }
+  .bx--col-xl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-xl-6 {
+    margin-left: 50%; }
+  .bx--col-xl-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-xl-7 {
+    margin-left: 58.33333%; }
+  .bx--col-xl-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-xl-8 {
+    margin-left: 66.66667%; }
+  .bx--col-xl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-xl-9 {
+    margin-left: 75%; }
+  .bx--col-xl-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-xl-10 {
+    margin-left: 83.33333%; }
+  .bx--col-xl-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-xl-11 {
+    margin-left: 91.66667%; }
+  .bx--col-xl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-xl-12 {
+    margin-left: 100%; } }
+
+@media (min-width: 1600px) {
+  .bx--col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .bx--col-xxl-1 {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .bx--offset-xxl-1 {
+    margin-left: 8.33333%; }
+  .bx--col-xxl-2 {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .bx--offset-xxl-2 {
+    margin-left: 16.66667%; }
+  .bx--col-xxl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .bx--offset-xxl-3 {
+    margin-left: 25%; }
+  .bx--col-xxl-4 {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .bx--offset-xxl-4 {
+    margin-left: 33.33333%; }
+  .bx--col-xxl-5 {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .bx--offset-xxl-5 {
+    margin-left: 41.66667%; }
+  .bx--col-xxl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .bx--offset-xxl-6 {
+    margin-left: 50%; }
+  .bx--col-xxl-7 {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .bx--offset-xxl-7 {
+    margin-left: 58.33333%; }
+  .bx--col-xxl-8 {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .bx--offset-xxl-8 {
+    margin-left: 66.66667%; }
+  .bx--col-xxl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .bx--offset-xxl-9 {
+    margin-left: 75%; }
+  .bx--col-xxl-10 {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .bx--offset-xxl-10 {
+    margin-left: 83.33333%; }
+  .bx--col-xxl-11 {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .bx--offset-xxl-11 {
+    margin-left: 91.66667%; }
+  .bx--col-xxl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .bx--offset-xxl-12 {
+    margin-left: 100%; } }
+
+.bx--col-xs,
+.bx--col-sm,
+.bx--col-md,
+.bx--col-lg {
+  flex-basis: 0;
+  flex: 1;
+  flex-grow: 1;
+  max-width: 100%; }
+"
+`;

--- a/src/globals/grid/__tests__/grid-test.js
+++ b/src/globals/grid/__tests__/grid-test.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+const { types } = require('node-sass');
+const { convert, renderSass } = require('../../../../tools/jest/scss');
+
+describe('_grid.scss', () => {
+  it('should export grid variables', async () => {
+    const { calls } = await renderSass(`
+@import './src/globals/grid/grid';
+
+$variables: (
+  'max-width': $max-width,
+  'columns': $max-width,
+  'grid-breakpoints': $grid-breakpoints,
+  'gutter-breakpoints': $gutter-breakpoints,
+  'grid-gutter-breakpoints': $grid-gutter-breakpoints,
+);
+
+@each $key, $value in $variables {
+  $t: test($key, $value);
+}
+`);
+
+    const variables = calls.reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key.getValue()]: convert(value),
+      }),
+      {}
+    );
+
+    expect(variables).toMatchInlineSnapshot(`
+Object {
+  "columns": "1600px",
+  "grid-breakpoints": Object {
+    "lg": "992px",
+    "md": "768px",
+    "sm": "576px",
+    "xl": "1200px",
+    "xxl": "1600px",
+  },
+  "grid-gutter-breakpoints": Object {
+    "sm": "5%",
+    "xs": "3%",
+  },
+  "gutter-breakpoints": Object {
+    "sm": "10px",
+    "xs": "5px",
+  },
+  "max-width": "1600px",
+}
+`);
+  });
+
+  it('should support the grid mixin', async () => {
+    const { result } = await renderSass(`
+$css--reset: false;
+$css--helpers: false;
+@import './src/globals/grid/grid';
+
+@include grid();
+`);
+
+    expect(result.css.toString()).toMatchSnapshot();
+  });
+
+  it('should support the breakpoint function', async () => {
+    const { calls, error, output } = await renderSass(`
+@import './src/globals/grid/grid';
+
+@each $key, $value in $grid-breakpoints {
+  $t: test($key, breakpoint($key));
+}
+$t: test('unknown', breakpoint('unknown'));
+`);
+
+    // We want to check valid breakpoints up to the last call, which was
+    // unknown
+    for (let i = 0; i < calls.length - 1; i++) {
+      expect(calls[i][0]).toBeInstanceOf(types.String);
+      expect(calls[i][1]).toBeInstanceOf(types.Number);
+    }
+
+    // `breakpoint` is expected to warn on the unknown test case
+    expect(output.warn).toHaveBeenCalledTimes(1);
+
+    // This should fail because `breakpoint('unknown')` does not return a
+    // value
+    expect(error).toBeDefined();
+  });
+});

--- a/src/globals/scss/__tests__/colors-test.js
+++ b/src/globals/scss/__tests__/colors-test.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+const { renderSass } = require('../../../../tools/jest/scss');
+
+const classic = [
+  // UI color scheme
+  'blue-20',
+  'blue-30',
+  'blue-40',
+  'blue-50',
+  'blue-90',
+
+  'navy-gray-1',
+  'navy-gray-2',
+  'navy-gray-3',
+  'navy-gray-4',
+  'navy-gray-5',
+  'navy-gray-6',
+  'navy-gray-7',
+  'navy-gray-8',
+  'navy-gray-9',
+
+  'white',
+
+  // Light UI color scheme
+  'blue-51',
+  'gray-1',
+  'gray-2',
+  'gray-3',
+
+  // Accent colors
+  'blue-10',
+  'blue-60',
+
+  'teal-10',
+  'teal-20',
+  'teal-30',
+  'teal-40',
+  'teal-50',
+  'teal-60',
+
+  'green-10',
+  'green-20',
+  'green-30',
+  'green-40',
+  'green-50',
+  'green-60',
+
+  'yellow-10',
+  'yellow-20',
+  'yellow-30',
+  'yellow-60',
+
+  'orange-10',
+  'orange-20',
+  'orange-30',
+  'orange-60',
+
+  'red-10',
+  'red-30',
+  'red-40',
+  'red-50',
+  'red-60',
+
+  'purple-10',
+  'purple-20',
+  'purple-30',
+  'purple-40',
+  'purple-60',
+];
+
+describe('_colors.scss', () => {
+  describe.each(classic)('%s', name => {
+    it(`should be exported as $color__${name}`, async () => {
+      const { calls } = await renderSass(`
+@import './src/globals/scss/colors';
+$c: test(global-variable-exists(color__${name}));
+`);
+      // Check that global-variable-exists returned true
+      expect(calls[0][0].getValue()).toBe(true);
+    });
+  });
+});

--- a/src/globals/scss/__tests__/themes-test.js
+++ b/src/globals/scss/__tests__/themes-test.js
@@ -114,7 +114,7 @@ const classic = [
 ];
 
 describe('_theme.scss', () => {
-  test.each(classic)('$%s should be exported', async name => {
+  it.each(classic)('$%s should be exported', async name => {
     const { calls } = await renderSass(`
 @import './src/globals/scss/theme';
 

--- a/src/globals/scss/__tests__/themes-test.js
+++ b/src/globals/scss/__tests__/themes-test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+const { types } = require('node-sass');
+const { renderSass } = require('../../../../tools/jest/scss');
+
+const classic = [
+  'brand-01',
+  'brand-02',
+  'brand-03',
+
+  'inverse-01',
+  'inverse-02',
+
+  'ui-01',
+  'ui-02',
+  'ui-03',
+  'ui-04',
+  'ui-05',
+
+  'text-01',
+  'text-02',
+  'text-03',
+
+  'field-01',
+  'field-02',
+
+  'support-01',
+  'support-02',
+  'support-03',
+  'support-04',
+
+  'nav-01',
+  'nav-02',
+  'nav-03',
+  'nav-04',
+  'nav-05',
+  'nav-06',
+  'nav-07',
+  'nav-08',
+
+  'hover-primary',
+  'hover-primary-text',
+  'hover-danger',
+  'hover-secondary',
+  'hover-row',
+
+  // Global
+  'input-border',
+  'input-label-weight',
+  'focus',
+
+  // Button
+  'button-font-weight',
+  'button-font-size',
+  'button-border-radius',
+  'button-height',
+  'button-padding',
+  'button-padding-sm',
+  'button-border-width',
+  'button-outline-width',
+
+  // Accordion (Reverse)
+  'accordion-flex-direction',
+  'accordion-justify-content',
+  'accordion-arrow-margin',
+  'accordion-title-margin',
+  'accordion-content-padding',
+
+  // Card
+  'card-text-align',
+  'card-flex-align',
+
+  // Checkbox
+  'checkbox-border-width',
+
+  // Code Snippet
+  'snippet-background-color',
+  'snippet-border-color',
+
+  // Content Switcher
+  'content-switcher-border-radius',
+  'content-switcher-option-border',
+
+  // Data Table
+  'data-table-heading-transform',
+  'data-table-heading-border-bottom',
+  'data-table-row-height',
+
+  // Modal
+  'modal-border-top',
+  'modal-footer-background-color',
+
+  // Progress Indicator
+  'progress-indicator-bar-width',
+  'progress-indicator-stroke-width',
+  'progress-indicator-line-offset',
+
+  // Radio Button
+  'radio-border-width',
+
+  // Structured Theme Variables
+  'structured-list-padding',
+  'structured-list-text-transform',
+
+  // Skeleton Loading
+  'skeleton',
+];
+
+describe('_theme.scss', () => {
+  test.each(classic)('$%s should be exported', async name => {
+    const { calls } = await renderSass(`
+@import './src/globals/scss/theme';
+
+$c: test(global-variable-exists(${name}));
+`);
+    // Check that global-variable-exists returned true
+    expect(calls[0][0].getValue()).toBe(true);
+  });
+});

--- a/tests/pure-modules-test.js
+++ b/tests/pure-modules-test.js
@@ -28,6 +28,9 @@ const files = glob.sync('**/*.js', {
     '**/*.config.js',
     // TODO: Make Flatpickr tree-shakable
     '**/date-picker.js',
+    // Ignore tests
+    '**/__tests__/**',
+    '**/__mocks__/**',
   ],
 });
 

--- a/tools/jest/jsTransform.js
+++ b/tools/jest/jsTransform.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { createTransformer } = require('babel-jest');
+
+const babelOptions = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: ['last 1 version', 'ie >= 11', 'Firefox ESR'],
+        },
+      },
+    ],
+    '@babel/preset-react',
+  ],
+  plugins: [
+    [
+      '@babel/plugin-transform-runtime',
+      {
+        regenerator: true,
+      },
+    ],
+  ],
+};
+
+module.exports = createTransformer(babelOptions);

--- a/tools/jest/scss.js
+++ b/tools/jest/scss.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* global jest */
+
+'use strict';
+
+const fs = require('fs');
+const { render, types } = require('node-sass');
+const path = require('path');
+
+function sassAsync(options) {
+  return new Promise((resolve, reject) => {
+    render(options, (error, result) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+const root = path.resolve(__dirname, '../..');
+
+function importer(url, prev, done) {
+  const baseDirectory = prev !== 'stdin' ? path.dirname(prev) : root;
+  const partialFilepath = path.resolve(baseDirectory, path.dirname(url), `_${path.basename(url)}.scss`);
+  const filepath = path.resolve(baseDirectory, path.dirname(url), `${path.basename(url)}.scss`);
+
+  if (fs.existsSync(partialFilepath)) {
+    done({ file: partialFilepath });
+    return;
+  }
+
+  if (fs.existsSync(filepath)) {
+    done({ file: filepath });
+    return;
+  }
+
+  done();
+}
+
+async function renderSass(data) {
+  const calls = [];
+  const warn = jest.fn(() => types.Null());
+  const mockError = jest.fn(() => types.Null());
+  const log = jest.fn(() => types.Null());
+  let result;
+  let renderError;
+
+  try {
+    result = await sassAsync({
+      data,
+      importer,
+      functions: {
+        '@error': mockError,
+        '@log': log,
+        '@warn': warn,
+        test(...args) {
+          // Remove the `done()` argument at the end
+          calls.push(args.slice(0, -1));
+          // return types.String('test');
+          return types.Null();
+        },
+      },
+    });
+  } catch (error) {
+    if (!error.message.includes('Function breakpoint finished without @return')) {
+      throw error;
+    }
+    renderError = error;
+  }
+
+  return {
+    calls,
+    result,
+    error: renderError,
+    output: {
+      warn,
+      error: mockError,
+      log,
+    },
+  };
+}
+
+function convert(value) {
+  if (value instanceof types.Boolean || value instanceof types.String) {
+    return value.getValue();
+  }
+
+  if (value instanceof types.Number) {
+    return `${value.getValue()}${value.getUnit()}`;
+  }
+
+  if (value instanceof types.List) {
+    const length = value.getLength();
+    const list = [];
+
+    for (let i = 0; i < length; i++) {
+      list.push(convert(value.getValue(i)));
+    }
+
+    return list;
+  }
+
+  if (value instanceof types.Map) {
+    const length = value.getLength();
+    const map = {};
+
+    for (let i = 0; i < length; i++) {
+      const key = value.getKey(i).getValue();
+      map[key] = convert(value.getValue(i));
+    }
+
+    return map;
+  }
+
+  if (value instanceof types.Null) {
+    return null;
+  }
+
+  throw new Error(`Unknown value type: ${value}`);
+}
+
+module.exports = {
+  convert,
+  renderSass,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,9 +464,10 @@
   dependencies:
     regenerator-transform "^0.13.3"
 
-"@babel/plugin-transform-runtime@^7.0.0":
+"@babel/plugin-transform-runtime@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
+  integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9093,9 +9093,10 @@ node-sass@^3.1.2, node-sass@^3.4.2:
     request "^2.61.0"
     sass-graph "^2.1.1"
 
-node-sass@^4.10.0:
+node-sass@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
+  integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
Second part of this RFC: https://github.com/IBM/carbon-components/pull/1795

This PR adds a testing strategy with `node-sass` for verifying our public API. It also includes some updates to Jest to get it working again 👍 

#### Changelog

**New**

- Add `tools/jest` for rendering sass partials inline
- Add tests for colors, grid, and themes
- Update eslint config and pure-modules-test ignore settings

**Changed**

- `package.json`
  - Update config for jest
  - Add babel plugin for runtime

**Removed**
