### PR TITLE
Hide border around accordion arrow in Chrome

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -29,7 +29,7 @@
       outline: none;
 
       .#{$prefix}--accordion__arrow {
-        @include focus-outline('border');
+        outline:none; // chrome fix
         overflow: visible; // safari fix
         outline-offset: -0.5px; // safari fix
       }


### PR DESCRIPTION
Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- Hide border around Accordion's arrow in Chrome

**Removed**

- {{removed thing}}

#### Testing / Reviewing

Run sass or 'npm run-script build' to create a new carbon-components.css. Create an HTML snippet with Accordion and test in Chrome. 
