### PR TITLE
fix(checkbox): match experimental spec

### DIFF
--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -226,3 +226,7 @@
 .component-example__live .bx--form-item {
   margin-bottom: 2rem;
 }
+
+.component-example__live .bx--form-item.bx--checkbox-wrapper {
+  margin-bottom: 0;
+}

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -297,7 +297,7 @@
   .#{$prefix}--checkbox-label[data-contained-checkbox-state='mixed']::after {
     transform: scale(1) rotate(0deg);
     border-left: 0 solid $inverse-01;
-    border-bottom: 1.5px solid $inverse-01;
+    border-bottom: 2px solid $inverse-01;
     width: rem(8px);
     top: rem(11px);
   }

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -190,7 +190,7 @@
 @mixin checkbox--x {
   // Spacing between checkboxes
   .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
-    margin-bottom: rem(6px);
+    margin-bottom: rem(8px);
   }
 
   // Spacing above collection of checkboxes

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -198,6 +198,11 @@
     margin-top: rem(3px);
   }
 
+  // Remove spacing above collection of checkboxes if label is present
+  .#{$prefix}--label + .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
+    margin-top: 0;
+  }
+
   // Spacing below collection of checkboxes
   .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper:last-of-type {
     margin-bottom: rem(3px);

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -253,7 +253,7 @@
     // Checkboxes with a background color look visually off against a parent container.
     background-color: transparent;
     border: 1px solid $ui-05;
-    border-radius: 2px;
+    border-radius: 1px;
   }
 
   // Create the appearance of the check in the `after` pseudo-element


### PR DESCRIPTION
Closes #1841

This PR incorporates feedback from the v1.2 component design audit

Some points for discussion and open questions:

do we want to convert our checkboxes to our icon SVGs? and if so, in order to use our icon SVGs for the checkboxes, do we still want to keep everything contained in pseudoelements?