### PR TITLE
refactor(dropdown): avoid SVG child in `ul`

### DIFF
--- a/src/components/dropdown/dropdown.hbs
+++ b/src/components/dropdown/dropdown.hbs
@@ -11,6 +11,7 @@
   <li class="{{@root.prefix}}--dropdown-text">
     {{#unless inline}} Dropdown label {{else}}
     <span class="{{@root.prefix}}--dropdown-text__inner">Inline Dropdown label</span>
+    {{/unless}}
     {{#if featureFlags.componentsX}}
     {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--dropdown__arrow') }}
     {{else}}
@@ -18,17 +19,7 @@
       <path d="M10 0L5 5 0 0z"></path>
     </svg>
     {{/if}}
-    {{/unless}}
   </li>
-  {{#unless inline}}
-  {{#if featureFlags.componentsX}}
-  {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--dropdown__arrow') }}
-  {{else}}
-  <svg class="{{@root.prefix}}--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
-    <path d="M10 0L5 5 0 0z"></path>
-  </svg>
-  {{/if}}
-  {{/unless}}
   <li>
     <ul class="{{@root.prefix}}--dropdown-list">
       {{#each items}}
@@ -41,24 +32,15 @@
 </ul>
 <br>
 {{#if featureFlags.componentsX}}
-  <div class="{{@root.prefix}}--form-item">
-    <ul data-dropdown{{#if inline}} data-dropdown-type="inline" {{/if}} data-value
-      class="{{@root.prefix}}--dropdown {{@root.prefix}}--dropdown--invalid {{#if up}} {{@root.prefix}}--dropdown--up{{/if}}{{#if light}} {{@root.prefix}}--dropdown--light{{/if}}{{#if inline}} {{@root.prefix}}--dropdown--inline{{/if}}"
-      tabindex="0" data-invalid>
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--dropdown__invalid')}}
-      <li class="{{@root.prefix}}--dropdown-text">
-        {{#unless inline}} Dropdown label {{else}}
-        <span class="{{@root.prefix}}--dropdown-text__inner">Inline Dropdown label</span>
-        {{#if featureFlags.componentsX}}
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--dropdown__arrow') }}
-        {{else}}
-        <svg class="{{@root.prefix}}--dropdown__arrow" width="10" height="5" viewBox="0 0 10 5" fill-rule="evenodd">
-          <path d="M10 0L5 5 0 0z"></path>
-        </svg>
-        {{/if}}
-        {{/unless}}
-      </li>
-      {{#unless inline}}
+<div class="{{@root.prefix}}--form-item">
+  <ul data-dropdown{{#if inline}} data-dropdown-type="inline" {{/if}} data-value
+    class="{{@root.prefix}}--dropdown {{@root.prefix}}--dropdown--invalid {{#if up}} {{@root.prefix}}--dropdown--up{{/if}}{{#if light}} {{@root.prefix}}--dropdown--light{{/if}}{{#if inline}} {{@root.prefix}}--dropdown--inline{{/if}}"
+    tabindex="0" data-invalid>
+    {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--dropdown__invalid')}}
+    <li class="{{@root.prefix}}--dropdown-text">
+      {{#unless inline}} Dropdown label {{else}}
+      <span class="{{@root.prefix}}--dropdown-text__inner">Inline Dropdown label</span>
+      {{/unless}}
       {{#if featureFlags.componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--dropdown__arrow') }}
       {{else}}
@@ -66,19 +48,19 @@
         <path d="M10 0L5 5 0 0z"></path>
       </svg>
       {{/if}}
-      {{/unless}}
-      <li>
-        <ul class="{{@root.prefix}}--dropdown-list">
-          {{#each items}}
-          <li data-option data-value="{{value}}" class="{{@root.prefix}}--dropdown-item">
-            <a class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="-1">{{label}}</a>
-          </li>
-          {{/each}}
-        </ul>
-      </li>
-    </ul>
-    <div class="{{@root.prefix}}--form-requirement">
-      This is not a validation message
-    </div>
+    </li>
+    <li>
+      <ul class="{{@root.prefix}}--dropdown-list">
+        {{#each items}}
+        <li data-option data-value="{{value}}" class="{{@root.prefix}}--dropdown-item">
+          <a class="{{@root.prefix}}--dropdown-link" href="javascript:void(0)" tabindex="-1">{{label}}</a>
+        </li>
+        {{/each}}
+      </ul>
+    </li>
+  </ul>
+  <div class="{{@root.prefix}}--form-requirement">
+    This is not a validation message
   </div>
+</div>
 {{/if}}


### PR DESCRIPTION
Closes #1765

This PR refactors the dropdown component examples to avoid placing SVG icons as children of `ul` elements. Since the icons are already positioned absolutely, no CSS fixes are required