### PR TITLE
fix(button): match experimental spec for danger button

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -281,25 +281,10 @@
   }
 
   .#{$prefix}--btn--danger {
-    @include button-theme--x(transparent, $support-01, $support-01, $support-01, $support-01, $ibm-colors__red-80);
+    @include button-theme--x($support-01, $support-01, $text-04, $hover-danger, $text-04, $active-danger);
 
     &:hover {
-      color: $inverse-01;
       border: $button-border-width solid transparent;
-    }
-
-    &:hover > .#{$prefix}--btn__icon {
-      fill: $inverse-01;
-    }
-  }
-
-  .#{$prefix}--btn--danger--primary {
-    @include button-theme--x($support-01, transparent, $inverse-01, #ba1b23, $ui-01, $ibm-colors__red-80);
-
-    &:hover:disabled,
-    &:focus:disabled {
-      color: $ui-04;
-      border: $button-border-width solid $disabled;
     }
   }
 
@@ -310,7 +295,7 @@
   }
 
   .#{$prefix}--btn--secondary + .#{$prefix}--btn--primary,
-  .#{$prefix}--btn--tertiary + .#{$prefix}--btn--danger--primary {
+  .#{$prefix}--btn--tertiary + .#{$prefix}--btn--danger {
     margin-left: $spacing-md;
   }
 


### PR DESCRIPTION
Closes #1851 

#### Changelog

**Changed**

- Update danger button color theme to match spec (NOTE: using `$text-04` instead of `$inverse-01` because the former stays white in all themes: https://carbon-elements.netlify.com/themes/examples/preview)
![image](https://user-images.githubusercontent.com/9057921/52965286-1302a080-336a-11e9-8331-d6aa64fd1855.png)

**Removed**

- Remove `danger--primary` button variation from Carbon X