### PR TITLE
docs(radio-button): include new vertical radio button group class

### DIFF
--- a/src/components/radio-button/migrate-to-10.x.md
+++ b/src/components/radio-button/migrate-to-10.x.md
@@ -1,0 +1,7 @@
+### SCSS
+
+A new `.bx--radio-button-group--vertical` class has been created for the vertical radio button group variation.
+
+| Class                              | Note | Remarks                                |
+| ---------------------------------- | ---- | -------------------------------------- |
+| `bx--radio-button-group--vertical` | New  | Arranges radio button group vertically |


### PR DESCRIPTION
References https://github.com/IBM/carbon-components/pull/1811#issuecomment-463793693

Closes #1853

This PR adds a note to the radio button v10 migration doc to include the class name for vertical radio button groups