### PR TITLE
fix(inline-notification): justifies elements in components-x

### DIFF
--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -116,6 +116,7 @@
     @include font-smoothing;
     @include typescale('zeta');
     display: flex;
+    justify-content: space-between;
     height: auto;
     min-height: rem(48px);
     min-width: rem(288px);


### PR DESCRIPTION
Using an inline notification within a parent element that does not use `display: flex` results in incorrect positioning of the close icon. 

![screenshot 2019-02-18 at 17 59 16](https://user-images.githubusercontent.com/12685163/52969183-60e9c980-33a7-11e9-8afa-4334a1f2eede.png)

This PR re-introduces `justify-content: space-between` which is [used in the current inline notification](https://github.com/IBM/carbon-components/blob/master/src/components/notification/_inline-notification.scss#L28).

#### Changelog

**Changed**

- Adds justify-content property to components-x inline notification

