### PR TITLE
feat(globals): add elements font-face to components

### DIFF
--- a/src/globals/scss/__tests__/__snapshots__/css--font-face-test.js.snap
+++ b/src/globals/scss/__tests__/__snapshots__/css--font-face-test.js.snap
@@ -1,0 +1,649 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_css--font-face.scss experimental should output @font-face blocks from elements if components-x flag is enabled 1`] = `
+"/**
+ * Generic \`deprecate\` mixin that is being used to indicate that a component is
+ * no longer going to be present in the next major release of Carbon.
+ */
+@keyframes skeleton {
+  0% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; }
+  20% {
+    width: 100%;
+    left: 0;
+    right: auto;
+    opacity: 1; }
+  28% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  51% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  58% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  82% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  83% {
+    width: 100%;
+    left: 0;
+    right: auto; }
+  96% {
+    width: 0%;
+    left: 0;
+    right: auto; }
+  100% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; } }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light Italic\\"), local(\\"IBMPlexMono-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1gMoW.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono Italic\\"), local(\\"IBMPlexMono-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa1Xdm.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold Italic\\"), local(\\"IBMPlexMono-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1gMoW.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light\\"), local(\\"IBMPlexMono-Light\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwlBFhA.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono\\"), local(\\"IBMPlexMono\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1i8q0Q.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold\\"), local(\\"IBMPlexMono-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlBFhA.woff) format(\\"woff\\"); }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light Italic\\"), local(\\"IBMPlexMono-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1jcoQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light Italic\\"), local(\\"IBMPlexMono-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1hMoQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light Italic\\"), local(\\"IBMPlexMono-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1j8oQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light Italic\\"), local(\\"IBMPlexMono-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1jsoQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light Italic\\"), local(\\"IBMPlexMono-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSflV1gMoQPttozw.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono Italic\\"), local(\\"IBMPlexMono-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa2HdgregdFOFh.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono Italic\\"), local(\\"IBMPlexMono-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa0XdgregdFOFh.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono Italic\\"), local(\\"IBMPlexMono-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa2ndgregdFOFh.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono Italic\\"), local(\\"IBMPlexMono-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa23dgregdFOFh.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono Italic\\"), local(\\"IBMPlexMono-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6pfjptAgt5VM-kVkqdyU8n1ioa1XdgregdFA.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold Italic\\"), local(\\"IBMPlexMono-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1jcoQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold Italic\\"), local(\\"IBMPlexMono-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1hMoQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold Italic\\"), local(\\"IBMPlexMono-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1j8oQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold Italic\\"), local(\\"IBMPlexMono-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1jsoQPttoz6Pz.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold Italic\\"), local(\\"IBMPlexMono-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6sfjptAgt5VM-kVkqdyU8n1ioSClN1gMoQPttozw.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light\\"), local(\\"IBMPlexMono-Light\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwl1FgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light\\"), local(\\"IBMPlexMono-Light\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwlRFgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light\\"), local(\\"IBMPlexMono-Light\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwl9FgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light\\"), local(\\"IBMPlexMono-Light\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwl5FgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Mono Light\\"), local(\\"IBMPlexMono-Light\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3oQIwlBFgsAXHNk.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono\\"), local(\\"IBMPlexMono\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono\\"), local(\\"IBMPlexMono\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono\\"), local(\\"IBMPlexMono\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono\\"), local(\\"IBMPlexMono\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Mono\\"), local(\\"IBMPlexMono\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold\\"), local(\\"IBMPlexMono-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwl1FgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold\\"), local(\\"IBMPlexMono-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlRFgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold\\"), local(\\"IBMPlexMono-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwl9FgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold\\"), local(\\"IBMPlexMono-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwl5FgsAXHNlYzg.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Mono SemiBold\\"), local(\\"IBMPlexMono-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexmono/v4/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlBFgsAXHNk.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light Italic\\"), local(\\"IBMPlexSans-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfo.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans Italic\\"), local(\\"IBMPlexSans-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZP.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold Italic\\"), local(\\"IBMPlexSans-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfo.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light\\"), local(\\"IBMPlexSans-Light\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFscg.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans\\"), local(\\"IBMPlexSans\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdHeEw.woff) format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold\\"), local(\\"IBMPlexSans-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format(\\"woff\\"); }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light Italic\\"), local(\\"IBMPlexSans-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRce_fuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light Italic\\"), local(\\"IBMPlexSans-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRccvfuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light Italic\\"), local(\\"IBMPlexSans-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRceffuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light Italic\\"), local(\\"IBMPlexSans-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcePfuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light Italic\\"), local(\\"IBMPlexSans-LightItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRcdvfuJGl18Q.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans Italic\\"), local(\\"IBMPlexSans-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuGqZJW9XjDlN8.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans Italic\\"), local(\\"IBMPlexSans-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuE6ZJW9XjDlN8.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans Italic\\"), local(\\"IBMPlexSans-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuGKZJW9XjDlN8.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans Italic\\"), local(\\"IBMPlexSans-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuGaZJW9XjDlN8.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans Italic\\"), local(\\"IBMPlexSans-Italic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX-KVElMYYaJe8bpLHnCwDKhdTuF6ZJW9XjDg.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold Italic\\"), local(\\"IBMPlexSans-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJce_fuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold Italic\\"), local(\\"IBMPlexSans-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJccvfuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold Italic\\"), local(\\"IBMPlexSans-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJceffuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold Italic\\"), local(\\"IBMPlexSans-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcePfuJGl18QRY.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold Italic\\"), local(\\"IBMPlexSans-SemiBoldItalic\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJcdvfuJGl18Q.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light\\"), local(\\"IBMPlexSans-Light\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIxsdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light\\"), local(\\"IBMPlexSans-Light\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIVsdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light\\"), local(\\"IBMPlexSans-Light\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI5sdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light\\"), local(\\"IBMPlexSans-Light\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AI9sdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local(\\"IBM Plex Sans Light\\"), local(\\"IBMPlexSans-Light\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjXr8AIFsdP3pBms.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans\\"), local(\\"IBMPlexSans\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdzeFaxOedfTDw.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans\\"), local(\\"IBMPlexSans\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdXeFaxOedfTDw.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans\\"), local(\\"IBMPlexSans\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhd7eFaxOedfTDw.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans\\"), local(\\"IBMPlexSans\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhd_eFaxOedfTDw.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local(\\"IBM Plex Sans\\"), local(\\"IBMPlexSans\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYXgKVElMYYaJe8bpLHnCwDKhdHeFaxOedc.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold\\"), local(\\"IBMPlexSans-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIxsdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+/* cyrillic */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold\\"), local(\\"IBMPlexSans-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIVsdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116; }
+
+/* vietnamese */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold\\"), local(\\"IBMPlexSans-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI5sdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold\\"), local(\\"IBMPlexSans-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AI9sdP3pBmtF8A.woff2) format(\\"woff2\\");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local(\\"IBM Plex Sans SemiBold\\"), local(\\"IBMPlexSans-SemiBold\\"), url(https://fonts.gstatic.com/s/ibmplexsans/v4/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2) format(\\"woff2\\");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+"
+`;
+
+exports[`_css--font-face.scss should not output CSS if $css--font-face is false 1`] = `
+"/**
+ * Generic \`deprecate\` mixin that is being used to indicate that a component is
+ * no longer going to be present in the next major release of Carbon.
+ */
+@keyframes skeleton {
+  0% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; }
+  20% {
+    width: 100%;
+    left: 0;
+    right: auto;
+    opacity: 1; }
+  28% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  51% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  58% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  82% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  83% {
+    width: 100%;
+    left: 0;
+    right: auto; }
+  96% {
+    width: 0%;
+    left: 0;
+    right: auto; }
+  100% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; } }
+"
+`;

--- a/src/globals/scss/__tests__/__snapshots__/css--plex-core-test.js.snap
+++ b/src/globals/scss/__tests__/__snapshots__/css--plex-core-test.js.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_css--plex-core plex-font-face should output @font-face files based on families, weights, and unicodes 1`] = `
+"@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Light.woff\\") format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Light-Pi.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Light-Latin3.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0102-0103, U+1EA0-1EF9, U+20AB\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Light-Latin2.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Light-Latin1.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Regular.woff\\") format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Regular-Pi.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Regular-Latin3.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0102-0103, U+1EA0-1EF9, U+20AB\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Regular-Latin2.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-Regular-Latin1.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-SemiBold.woff\\") format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-SemiBold-Pi.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-SemiBold-Latin3.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0102-0103, U+1EA0-1EF9, U+20AB\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-SemiBold-Latin2.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-mono';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexMono-SemiBold-Latin1.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Light.woff\\") format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Light-Pi.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Light-Latin3.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0102-0103, U+1EA0-1EF9, U+20AB\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Light-Latin2.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 300;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Light-Latin1.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Regular.woff\\") format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Regular-Pi.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Regular-Latin3.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0102-0103, U+1EA0-1EF9, U+20AB\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Regular-Latin2.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-Regular-Latin1.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-SemiBold.woff\\") format(\\"woff\\"); }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-SemiBold-Pi.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-SemiBold-Latin3.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0102-0103, U+1EA0-1EF9, U+20AB\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-SemiBold-Latin2.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02\\"; }
+
+@font-face {
+  font-family: 'ibm-plex-sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url(\\"https://unpkg.com/carbon-components@latest/src/globals/fonts/IBMPlexSans-SemiBold-Latin1.woff2\\") format(\\"woff2\\");
+  unicode-range: \\"U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02\\"; }
+"
+`;
+
+exports[`_css--plex-core should export the variable $fallbacks 1`] = `
+Object {
+  "Mono": "'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace",
+  "Sans": "'ibm-plex-sans', 'Helvetica Neue', Arial, sans-serif",
+}
+`;
+
+exports[`_css--plex-core should export the variable $families 1`] = `
+Object {
+  "Mono": "'ibm-plex-mono'",
+  "Sans": "'ibm-plex-sans'",
+}
+`;
+
+exports[`_css--plex-core should export the variable $font-path 1`] = `"https://unpkg.com/carbon-components@latest/src/globals/fonts"`;
+
+exports[`_css--plex-core should export the variable $unicodes 1`] = `
+Object {
+  "Latin1": "U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02",
+  "Latin2": "U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF, U+FB01-FB02",
+  "Latin3": "U+0102-0103, U+1EA0-1EF9, U+20AB",
+  "Pi": "U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC",
+}
+`;
+
+exports[`_css--plex-core should export the variable $weights 1`] = `
+Object {
+  "Light": Object {
+    "font-style": "normal",
+    "font-weight": "300",
+  },
+  "Regular": Object {
+    "font-style": "normal",
+    "font-weight": "400",
+  },
+  "SemiBold": Object {
+    "font-style": "normal",
+    "font-weight": "600",
+  },
+}
+`;

--- a/src/globals/scss/__tests__/css--font-face-test.js
+++ b/src/globals/scss/__tests__/css--font-face-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+const { renderSass } = require('../../../../tools/jest/scss');
+
+describe('_css--font-face.scss', () => {
+  it('should not output CSS if $css--font-face is false', async () => {
+    const { result } = await renderSass(`
+$css--font-face: false;
+@import './src/globals/scss/css--font-face';
+`);
+
+    // Should be an empty string, currently will output only @keyframes that are
+    // not wrapped around a css flag
+    expect(result.css.toString()).toMatchSnapshot();
+  });
+
+  it('should output helvetica if $css--font-face is true and $css--plex is false', async () => {
+    const { result } = await renderSass(`
+$css--font-face: true;
+$css--plex: false;
+@import './src/globals/scss/css--font-face';
+`);
+
+    expect(result.css.toString()).toEqual(expect.stringContaining('@font-face'));
+    expect(result.css.toString()).toEqual(expect.stringContaining(`font-family: 'IBM Helvetica'`));
+  });
+
+  it('should output plex if $css--font-face and $css--plex are true', async () => {
+    const { result } = await renderSass(`
+$css--font-face: true;
+$css--plex: true;
+@import './src/globals/scss/css--font-face';
+`);
+
+    expect(result.css.toString()).toEqual(expect.stringContaining('@font-face'));
+    expect(result.css.toString()).toEqual(expect.stringContaining(`font-family: 'ibm-plex-sans'`));
+  });
+
+  describe('experimental', () => {
+    it('should output @font-face blocks from elements if components-x flag is enabled', async () => {
+      const { result } = await renderSass(`
+$css--font-face: true;
+$css--plex: true;
+$feature-flags: (components-x: true);
+@import './src/globals/scss/css--font-face';
+`);
+
+      expect(result.css.toString()).toMatchSnapshot();
+      expect(result.css.toString()).toEqual(expect.stringContaining('@font-face'));
+      expect(result.css.toString()).toEqual(expect.stringContaining(`font-family: 'IBM Plex Mono'`));
+      expect(result.css.toString()).toEqual(expect.stringContaining(`font-family: 'IBM Plex Sans'`));
+    });
+  });
+});

--- a/src/globals/scss/__tests__/css--plex-core-test.js
+++ b/src/globals/scss/__tests__/css--plex-core-test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+const { convert, renderSass } = require('../../../../tools/jest/scss');
+
+const variables = ['font-path', 'unicodes', 'families', 'fallbacks', 'weights'];
+
+describe('_css--plex-core', () => {
+  it.each(variables)('should export the variable $%s', async name => {
+    const { calls } = await renderSass(`
+@import './src/globals/scss/css--plex-core';
+
+$c: test(global-variable-exists(${name}));
+$value: test($${name});
+`);
+    // Check that global-variable-exists returned true
+    expect(calls[0][0].getValue()).toBe(true);
+    expect(convert(calls[1][0])).toMatchSnapshot();
+  });
+
+  describe('check-default-font-path', () => {
+    it('should warn if the default $font-path uses unpkg', async () => {
+      const { output } = await renderSass(`
+@import './src/globals/scss/css--plex-core';
+
+@include check-default-font-path() {
+  $test: true;
+};
+`);
+      expect(output.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not warn if $font-path is set and does not contain unpkg', async () => {
+      const { output } = await renderSass(`
+$font-path: 'https://my-custom-cdn.com';
+@import './src/globals/scss/css--plex-core';
+
+@include check-default-font-path() {
+  $test: true;
+};
+`);
+      expect(output.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('plex-font-face', () => {
+    it('should output @font-face files based on families, weights, and unicodes', async () => {
+      const { result } = await renderSass(`
+@import './src/globals/scss/css--plex-core';
+
+@include plex-font-face();
+`);
+      expect(result.css.toString()).toMatchSnapshot();
+    });
+  });
+});

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -10,6 +10,9 @@ $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !defa
 @import 'import-once';
 @import 'css--plex-core';
 @import 'helper-mixins';
+@import 'feature-flags';
+@import './vendor/@carbon/elements/scss/type/font-face/mono';
+@import './vendor/@carbon/elements/scss/type/font-face/sans';
 
 @mixin helvetica-font-face {
   // Default font directory, `!default` flag allows user override.
@@ -70,7 +73,12 @@ $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !defa
 @include exports('css--font-face') {
   @if not global-variable-exists('css--font-face') or $css--font-face == true {
     @if global-variable-exists('css--plex') and $css--plex == true {
-      @include plex-font-face;
+      @if feature-flag-enabled('components-x') {
+        @include carbon--font-face-mono();
+        @include carbon--font-face-sans();
+      } @else {
+        @include plex-font-face;
+      }
     } @else {
       @include helvetica-font-face;
     }

--- a/src/globals/scss/migrate-to-10.x.md
+++ b/src/globals/scss/migrate-to-10.x.md
@@ -28,6 +28,9 @@ Toggle on feature flag for `font-family` mixin
 
 ## `_css--font-face.scss`
 
+File now relies on `@carbon/elements` for bringing in font files for IBM Plex.
+It is still recommended to use a CDN for serving IBM Plex.
+
 ### Helvetica Neue
 
 Usage of `helvetica-font-face` is deprecated. Please set `$css--plex: true`
@@ -38,16 +41,27 @@ No longer shipping font files for Helvetica Neue
 
 ## `_css--plex-core.scss`
 
+Notable changes:
+
+- IBM Plex fonts now come from Carbon Elements
+- The CDN for IBM Plex font files is now Google Fonts, we still recommend using
+  your own for production (NOTE: how would one do this?)
+
 | v9                        | v10                                                    |
 | ------------------------- | ------------------------------------------------------ |
+| `$font-path`              | ☠️ Deprecated                                          |
 | `$unicodes`               | ☠️ Deprecated                                          |
 | `$families`               | ☠️ Deprecated, use `font-families` from `@carbon/type` |
 | `$fallbacks`              | ☠️ Deprecated, use `font-families` from `@carbon/type` |
 | `$weights`                | ☠️ Deprecated, use `font-weight` from `@carbon/type`   |
-| `check-default-font-path` | TODO: might want to remove?                            |
+| `check-default-font-path` | ☠️ Deprecated                                          |
+| `plex-font-face`          | ☠️ Deprecated                                          |
 
-- `@font-face` declarations now come from `@carbon/type`
-- Font files come from `@ibm/plex`
+TODO:
+
+- How do we warn if using google fonts CDN? Should we?
+- What guidance do we give for folks wanting to use their own type?
+- What guidance do we give for folks wanting to use a CDN for their fonts?
 
 ## `_css--reset.scss`
 


### PR DESCRIPTION
Closes #1857 

#### Changelog

**New**

- Tests for `_css--font-face.scss` and `_css--plex-core`

**Changed**

- `_css--font-face.scss` now calls `carbon--font-face-*` mixins if `components-x` flag is enabled

**Removed**

