### PR TITLE
Allowing keyboard accessibility for overflow menu options -- fix for issue 1860

### DIFF
--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -262,6 +262,13 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
         const isOfSelf = element.contains(event.target);
         const shouldBeOpen = isOfSelf && !element.classList.contains(options.classShown);
         const state = shouldBeOpen ? 'shown' : 'hidden';
+        
+        if(isExpanded && !isOfSelf  ){//to perform click on options of overflow menu when it is expanded
+                if(event && event.target && typeof event.target.click === 'function'){
+                  event.target.click();
+                  return;
+                }                
+        }
 
         if (isOfSelf) {
           event.delegateTarget = element; // eslint-disable-line no-param-reassign


### PR DESCRIPTION
Closes #

Issue 1860

#### Changelog

**New**

Added an additional condition to allow clicking of the option when the overflow menu is expanded and focus is on any one of the options of expanded overflow menu with keyboard.



#### Testing / Reviewing

Just made this change in our env it works well with both mouse and keyboard
