### PR TITLE
 feat(scss): add _motion.scss

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -173,7 +173,7 @@
     position: relative;
     width: 100%;
     margin: 0;
-    transition: background-color $transition--base;
+    transition: background-color motion(standard, productive) 100ms;
 
     &:hover:before,
     &:focus:before {
@@ -223,7 +223,8 @@
   }
 
   .#{$prefix}--accordion__content {
-    transition: all $transition--expansion $carbon--ease-out;
+    // Transition property for when the accordion closes
+    transition: all motion(standard, productive) 120ms;
     padding-left: $spacing-md;
     padding-right: 25%;
     height: 0;
@@ -244,7 +245,8 @@
       height: auto;
       visibility: visible;
       opacity: 1;
-      transition: all $transition--expansion $carbon--ease-in;
+      // Transition property for when the accordion opens
+      transition: all motion(entrance, productive) 120ms;
     }
 
     .#{$prefix}--accordion__arrow {

--- a/src/globals/scss/__tests__/motion-test.js
+++ b/src/globals/scss/__tests__/motion-test.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright IBM Corp. 2015, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+const { renderSass } = require('../../../../tools/jest/scss');
+
+const variables = [
+  'carbon--ease-in',
+  'carbon--ease-out',
+  'carbon--standard-easing',
+  'transition--base',
+  'transition--expansion',
+  'bx--ease-in',
+  'bx--ease-out',
+  'bx--standard-easing',
+];
+
+describe('motion', () => {
+  describe.each(variables)('$%s', async name => {
+    // Temporarily test for regression since these variables were initially
+    // under _vars.scss
+    it('should be exported through _vars.scss', async () => {
+      const { calls } = await renderSass(`
+@import './src/globals/scss/motion';
+
+$c: test(global-variable-exists(${name}));
+`);
+      // Check that global-variable-exists returned true
+      expect(calls[0][0].getValue()).toBe(true);
+    });
+
+    // New location
+    it('should be exported through _motion.scss', async () => {
+      const { calls } = await renderSass(`
+@import './src/globals/scss/motion';
+
+$c: test(global-variable-exists(${name}));
+`);
+      // Check that global-variable-exists returned true
+      expect(calls[0][0].getValue()).toBe(true);
+    });
+  });
+
+  describe('motion function', () => {
+    it('should be exported', async () => {
+      const { calls } = await renderSass(`
+@import './src/globals/scss/motion';
+
+$c: test(function-exists(motion));
+$c: test(function-exists(carbon--motion));
+`);
+      // Check that global-variable-exists returned true
+      expect(calls[0][0].getValue()).toBe(true);
+      expect(calls[1][0].getValue()).toBe(true);
+    });
+  });
+
+  describe('motion mixin', () => {
+    it('should be exported', async () => {
+      const { calls } = await renderSass(`
+@import './src/globals/scss/motion';
+
+$c: test(mixin-exists(motion));
+$c: test(mixin-exists(carbon--motion));
+`);
+      // Check that global-variable-exists returned true
+      expect(calls[0][0].getValue()).toBe(true);
+      expect(calls[1][0].getValue()).toBe(true);
+    });
+  });
+});

--- a/src/globals/scss/__tests__/motion-test.js
+++ b/src/globals/scss/__tests__/motion-test.js
@@ -26,7 +26,7 @@ describe('motion', () => {
     // under _vars.scss
     it('should be exported through _vars.scss', async () => {
       const { calls } = await renderSass(`
-@import './src/globals/scss/motion';
+@import './src/globals/scss/vars';
 
 $c: test(global-variable-exists(${name}));
 `);

--- a/src/globals/scss/_motion.scss
+++ b/src/globals/scss/_motion.scss
@@ -1,0 +1,75 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import './vendor/@carbon/elements/scss/motion/motion';
+
+/// Used primarily for removing elements from the screen.
+/// @access public
+$carbon--ease-in: cubic-bezier(0.25, 0, 1, 1);
+
+/// Used for adding elements to the screen or changing on-screen states at a users's input.
+/// @access public
+$carbon--ease-out: cubic-bezier(0, 0, 0.25, 1);
+
+/// Used for the majority of animations.
+/// @access public
+$carbon--standard-easing: cubic-bezier(0.5, 0, 0.1, 1);
+
+/// Base transition duration
+/// @access public
+$transition--base: 250ms;
+
+/// Expansion duration
+/// @access public
+$transition--expansion: 300ms;
+
+// ☠️ Deprecated
+
+/// Default ease-in for components
+/// @access public
+/// @deprecated Updated to `$carbon--ease-in`
+$bx--ease-in: $carbon--ease-in;
+
+/// Default ease-out for components
+/// @access public
+/// @deprecated Updated to `$carbon--ease-out`
+$bx--ease-out: $carbon--ease-out;
+
+/// Standard easing for components
+/// @access public
+/// @deprecated Updated to `$carbon--standard-easing`
+$bx--standard-easing: $carbon--standard-easing;
+
+@if feature-flag-enabled('components-x') {
+  $carbon--ease-in: cubic-bezier(0.2, 0, 1, 0.9);
+  $carbon--ease-out: cubic-bezier(0, 0, 0.38, 0.9);
+  $carbon--standard-easing: cubic-bezier(0.2, 0.2, 0.38, 0.9);
+  $transition--base: 100ms;
+  $transition--expansion: 150ms;
+}
+
+/// Get the transition-timing-function for a given easing and motion mode.
+/// Easings that are currently supported include: standard, entrance, and exit.
+/// We also offer two modes: productive and expressive.
+/// @access public
+/// @param {String} $name - the name of the easing curve to apply
+/// @param {String} $mode - the mode for the easing curve to use
+/// @return {cubic-bezier}
+@function motion($name, $mode: productive, $easings: $carbon--easings) {
+  @return carbon--motion($name, $mode, $easings);
+}
+
+/// Get the transition-timing-function for a given easing and motion mode.
+/// Easings that are currently supported include: standard, entrance, and exit.
+/// We also offer two modes: productive and expressive.
+/// @access public
+/// @param {String} $name - the name of the easing curve to apply
+/// @param {String} $mode - the mode for the easing curve to use
+/// @return {cubic-bezier}
+@mixin motion($name, $mode) {
+  @include carbon--motion($name, $mode);
+}

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -8,50 +8,7 @@
 @import 'colors';
 @import 'spacing';
 @import 'theme-tokens';
-
 @import 'functions';
+@import 'motion';
 
 $prefix: 'bx' !default;
-
-// TODO: Remove `null`-initialization once `components-x`/`breaking-changes-x` feature flags are removed
-$carbon--ease-in: null;
-$carbon--ease-out: null;
-$carbon--standard-easing: null;
-$transition--base: null;
-$transition--expansion: null;
-$bx--ease-in: null;
-$bx--ease-out: null;
-$bx--standard-easing: null;
-
-@if feature-flag-enabled('components-x') {
-  $carbon--ease-in: cubic-bezier(0.2, 0, 1, 0.9); // Used primarily for removing elements from the screen.
-  $carbon--ease-out: cubic-bezier(
-    0,
-    0,
-    0.38,
-    0.9
-  ); // Used for adding elements to the screen or changing on-screen states at a users's input.
-  $carbon--standard-easing: cubic-bezier(0.2, 0.2, 0.38, 0.9); // Used for the majority of animations.
-
-  $transition--base: 100ms;
-  $transition--expansion: 150ms;
-} @else {
-  $carbon--ease-in: cubic-bezier(0.25, 0, 1, 1); // Used primarily for removing elements from the screen.
-  $carbon--ease-out: cubic-bezier(
-    0,
-    0,
-    0.25,
-    1
-  ); // Used for adding elements to the screen or changing on-screen states at a users's input.
-  $carbon--standard-easing: cubic-bezier(0.5, 0, 0.1, 1); // Used for the majority of animations.
-
-  $transition--base: 250ms;
-  $transition--expansion: 300ms;
-}
-
-@if not feature-flag-enabled('breaking-changes-x') {
-  // For back-ward compatibility
-  $bx--ease-in: $carbon--ease-in;
-  $bx--ease-out: $carbon--ease-out;
-  $bx--standard-easing: $carbon--standard-easing;
-}


### PR DESCRIPTION
Partially addresses #1433 by including motion from elements, adding tests, and showing reference implementation in accordion. Work will need to be done to add to each component outside of this PR.

#### Changelog

**New**

- Add `_motion.scss` entrypoint with SassDoc for public motion variables, functions, and mixins
- Add test for `_motion.scss`

**Changed**

- Update `_vars.scss` to include `_motion.scss`

**Removed**