### PR TITLE
chore(type): deprecate @mixin plex-font-face

### DIFF
--- a/demo/scss/_layout.scss
+++ b/demo/scss/_layout.scss
@@ -3,9 +3,14 @@
 // Includes styles for body, link, wrapper and container.
 //--------------------
 @import 'typography';
+@import '../../src/globals/scss/functions';
 
 body {
-  @include font-family;
+  @if not feature-flag-enabled('components-x') {
+    font-family: 'ibm-plex-sans', Helvetica Neue, Arial, sans serif;
+  } @else {
+    @include type-style('body-short-01');
+  }
   background-color: $color__white;
   color: $color__blue-90;
 

--- a/demo/scss/_layout.scss
+++ b/demo/scss/_layout.scss
@@ -3,10 +3,9 @@
 // Includes styles for body, link, wrapper and container.
 //--------------------
 @import 'typography';
-@include plex-font-face;
 
 body {
-  font-family: 'ibm-plex-sans', Helvetica Neue, Arial, sans serif;
+  @include font-family;
   background-color: $color__white;
   color: $color__blue-90;
 

--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -1,6 +1,13 @@
 // Used for sidebar in dev environment
 @import 'interior-left-nav';
 @import '../../src/globals/scss/styles';
+
+$deprecations--entry: true;
+// Collect all deprecation reasons into this list throughout the import cycle.
+$deprecations--reasons: ();
+// This message will be prepended to any deprecation notice
+$deprecations--message: 'Deprecated code was found, this code will be removed before the next release of Carbon.';
+
 @import '../../src/globals/scss/functions';
 @import './_vars.scss';
 @import './_mixins.scss';
@@ -14,6 +21,18 @@
 @import '../js/components/ComponentExample/component-overrides.scss';
 @import '../js/components/PageHeader/page-header.scss';
 @import '../js/components/SideNavToggle/side-nav-toggle.scss';
+
+// Cycle through all the deprecation reasons, if any exist, that have been
+// accumulated through the @import process.
+@if (length($deprecations--reasons) > 0) {
+  $deprecations--message: '';
+  @each $reason in $deprecations--reasons {
+    $deprecations--message: '#{$deprecations--message}
+REASON: #{$reason}';
+  }
+
+  @warn $deprecations--message;
+}
 
 [data-renderroot] {
   display: block;

--- a/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
+++ b/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`_grid.scss grid--x should generate grid code when the grid feature flag is on 1`] = `
-"/**
- * Generic \`deprecate\` mixin that is being used to indicate that a component is
- * no longer going to be present in the next major release of Carbon.
- */
-@keyframes skeleton {
+"@keyframes skeleton {
   0% {
     width: 0%;
     left: 0;
@@ -1435,11 +1431,7 @@ exports[`_grid.scss grid--x should generate grid code when the grid feature flag
 `;
 
 exports[`_grid.scss should support the grid mixin 1`] = `
-"/**
- * Generic \`deprecate\` mixin that is being used to indicate that a component is
- * no longer going to be present in the next major release of Carbon.
- */
-@keyframes skeleton {
+"@keyframes skeleton {
   0% {
     width: 0%;
     left: 0;

--- a/src/globals/scss/__tests__/__snapshots__/css--font-face-test.js.snap
+++ b/src/globals/scss/__tests__/__snapshots__/css--font-face-test.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`_css--font-face.scss experimental should output @font-face blocks from elements if components-x flag is enabled 1`] = `
-"/**
- * Generic \`deprecate\` mixin that is being used to indicate that a component is
- * no longer going to be present in the next major release of Carbon.
- */
-@keyframes skeleton {
+"@keyframes skeleton {
   0% {
     width: 0%;
     left: 0;
@@ -601,11 +597,7 @@ exports[`_css--font-face.scss experimental should output @font-face blocks from 
 `;
 
 exports[`_css--font-face.scss should not output CSS if $css--font-face is false 1`] = `
-"/**
- * Generic \`deprecate\` mixin that is being used to indicate that a component is
- * no longer going to be present in the next major release of Carbon.
- */
-@keyframes skeleton {
+"@keyframes skeleton {
   0% {
     width: 0%;
     left: 0;

--- a/src/globals/scss/__tests__/__snapshots__/css--plex-core-test.js.snap
+++ b/src/globals/scss/__tests__/__snapshots__/css--plex-core-test.js.snap
@@ -1,7 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`_css--plex-core plex-font-face should output @font-face files based on families, weights, and unicodes 1`] = `
-"@font-face {
+"@keyframes skeleton {
+  0% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; }
+  20% {
+    width: 100%;
+    left: 0;
+    right: auto;
+    opacity: 1; }
+  28% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  51% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  58% {
+    width: 0%;
+    left: auto;
+    right: 0; }
+  82% {
+    width: 100%;
+    left: auto;
+    right: 0; }
+  83% {
+    width: 100%;
+    left: 0;
+    right: auto; }
+  96% {
+    width: 0%;
+    left: 0;
+    right: auto; }
+  100% {
+    width: 0%;
+    left: 0;
+    right: auto;
+    opacity: 0.3; } }
+
+@font-face {
   font-family: 'ibm-plex-mono';
   font-style: normal;
   font-weight: 300;

--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -57,25 +57,23 @@ $weights: (
     '`@include plex-font-face` has been deprecated. ' + 'It will be removed in the next major release.',
     feature-flag-enabled('components-x')
   ) {
-    @if not(feature-flag-enabled('components-x')) {
-      @include check-default-font-path {
-        @each $family, $name in $families {
-          @each $weight, $styles in $weights {
+    @include check-default-font-path {
+      @each $family, $name in $families {
+        @each $weight, $styles in $weights {
+          @font-face {
+            font-family: $name;
+            font-style: map-get($styles, 'font-style');
+            font-weight: map-get($styles, 'font-weight');
+            src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}.woff') format('woff');
+          }
+
+          @each $unicode, $range in $unicodes {
             @font-face {
               font-family: $name;
               font-style: map-get($styles, 'font-style');
               font-weight: map-get($styles, 'font-weight');
-              src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}.woff') format('woff');
-            }
-
-            @each $unicode, $range in $unicodes {
-              @font-face {
-                font-family: $name;
-                font-style: map-get($styles, 'font-style');
-                font-weight: map-get($styles, 'font-weight');
-                src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}-#{$unicode}.woff2') format('woff2');
-                unicode-range: map-get($unicodes, $unicode);
-              }
+              src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}-#{$unicode}.woff2') format('woff2');
+              unicode-range: map-get($unicodes, $unicode);
             }
           }
         }

--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -7,7 +7,7 @@
 
 $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !default;
 
-@import 'functions';
+@import 'helper-mixins';
 @import 'import-once';
 
 $unicodes: (

--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -7,6 +7,7 @@
 
 $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !default;
 
+@import 'functions';
 @import 'import-once';
 
 $unicodes: (
@@ -52,23 +53,30 @@ $weights: (
 }
 
 @mixin plex-font-face {
-  @include check-default-font-path {
-    @each $family, $name in $families {
-      @each $weight, $styles in $weights {
-        @font-face {
-          font-family: $name;
-          font-style: map-get($styles, 'font-style');
-          font-weight: map-get($styles, 'font-weight');
-          src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}.woff') format('woff');
-        }
+  @include deprecate(
+    '`@include plex-font-face` has been deprecated. ' + 'It will be removed in the next major release.',
+    feature-flag-enabled('components-x')
+  ) {
+    @if not(feature-flag-enabled('components-x')) {
+      @include check-default-font-path {
+        @each $family, $name in $families {
+          @each $weight, $styles in $weights {
+            @font-face {
+              font-family: $name;
+              font-style: map-get($styles, 'font-style');
+              font-weight: map-get($styles, 'font-weight');
+              src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}.woff') format('woff');
+            }
 
-        @each $unicode, $range in $unicodes {
-          @font-face {
-            font-family: $name;
-            font-style: map-get($styles, 'font-style');
-            font-weight: map-get($styles, 'font-weight');
-            src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}-#{$unicode}.woff2') format('woff2');
-            unicode-range: map-get($unicodes, $unicode);
+            @each $unicode, $range in $unicodes {
+              @font-face {
+                font-family: $name;
+                font-style: map-get($styles, 'font-style');
+                font-weight: map-get($styles, 'font-weight');
+                src: url('#{$font-path}/IBMPlex#{$family}-#{$weight}-#{$unicode}.woff2') format('woff2');
+                unicode-range: map-get($unicodes, $unicode);
+              }
+            }
           }
         }
       }

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -117,14 +117,19 @@
   }
 }
 
-/**
- * Generic `deprecate` mixin that is being used to indicate that a component is
- * no longer going to be present in the next major release of Carbon.
- */
-@mixin deprecate($reason) {
+/// Generic `deprecate` mixin that is being used to indicate that a component is
+/// no longer going to be present in the next major release of Carbon.
+/// @access public
+/// @param {String} $reason - The message
+/// @param {Bool} $condition [true] - `true` to emits the given deprecation messsage
+/// @require $deprecations--entry
+/// @require $deprecations--reasons
+@mixin deprecate($reason, $condition: true) {
   $deprecations--entry: false !default;
 
-  @if ($deprecations--entry == true) {
+  @if not $condition {
+    @content;
+  } @else if ($deprecations--entry == true) {
     $deprecations--reasons: append($deprecations--reasons, $reason) !global;
     @content;
   } @else {

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -6,6 +6,7 @@
 //
 
 @import 'vars';
+@import './vendor/@carbon/elements/scss/type/font-family';
 
 $font-family-mono: 'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace !default;
 $font-family-sans-serif: 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
@@ -51,7 +52,11 @@ $typescale-map: (
 
 @mixin font-family {
   @if global-variable-exists('css--plex') and $css--plex == true {
-    font-family: $font-family-sans-serif;
+    @if feature-flag-enabled('components-x') {
+      font-family: carbon--font-family('sans');
+    } @else {
+      font-family: $font-family-sans-serif;
+    }
   } @else {
     font-family: $font-family-helvetica;
   }

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -6,7 +6,6 @@
 //
 
 @import 'vars';
-@import './vendor/@carbon/elements/scss/type/font-family';
 
 $font-family-mono: 'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace !default;
 $font-family-sans-serif: 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
@@ -52,11 +51,7 @@ $typescale-map: (
 
 @mixin font-family {
   @if global-variable-exists('css--plex') and $css--plex == true {
-    @if feature-flag-enabled('components-x') {
-      font-family: carbon--font-family('sans');
-    } @else {
-      font-family: $font-family-sans-serif;
-    }
+    font-family: $font-family-sans-serif;
   } @else {
     font-family: $font-family-helvetica;
   }


### PR DESCRIPTION
(Please use Diff settings - Hide whitespace changes for reviewing)

Refs #1626.

#### Changelog

**New**

- An optional parameter to `@mixin deprecate()` to control whether or not to emit the deprecate message (the default is `true`).

**Changed**

- Deprecated `@mixin plex-font-face` and made it no-op for `components-x` mode.
- `@mixin font-family` now refers to `@carbon/type` font definition. (@joshblack Please let me know if this mixin should also be deprecated)

#### Testing / Reviewing

Testing should make sure no component is broken.