### PR TITLE
style(mixins): reduce jank with grey portion of inline loading

### DIFF
--- a/src/components/loading/_mixins.scss
+++ b/src/components/loading/_mixins.scss
@@ -19,9 +19,9 @@
   animation-iteration-count: infinite;
 
   // Animate the stroke
-  & svg circle {
+  svg circle {
     animation-name: init-stroke;
-    animation-duration: 1000ms;
+    animation-duration: 10ms;
     animation-timing-function: $carbon--standard-easing;
   }
 }


### PR DESCRIPTION
Closes #1803

This PR incorporates feedback from the v1.1 component audit

#### Changelog

**Changed**

- fix the disappearing grey portion of the loading SVG after changing loading state

---

regarding the following points:

> * Loading icon needs update

can I get some more direction on this updated icon?

> * Text should be 8px away from loader

it appears that this is already the case, unless I am looking at the wrong part of the loader. Can I get some guidance on what to look for here?