### PR TITLE
fix(pagination): apply fill colors to CarbonX next/prev button icons

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -302,11 +302,10 @@ $css--helpers: true;
     display: flex;
     justify-content: center;
     align-items: center;
+    fill: $ui-05;
 
     &:hover {
-      .#{$prefix}--pagination__button-icon {
-        fill: $hover-secondary;
-      }
+      fill: $hover-secondary;
     }
 
     &:focus {

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -314,10 +314,7 @@ $css--helpers: true;
 
     &:disabled:hover {
       cursor: default;
-
-      .#{$prefix}--pagination__button-icon {
-        fill: $ui-05;
-      }
+      fill: $ui-05;
     }
   }
 


### PR DESCRIPTION
Closes #1870 

#### Changelog

**New**

- apply `$ui-05` fill color directly to `.#{$prefix}--pagination__button`

**Changed**

- apply hover & disabled hover fill color to the button instead of the button icon, because `.#{$prefix}--pagination__button-icon` class isn't applied in the React component version for Carbon X -- see https://github.com/IBM/carbon-components-react/blob/master/src/components/PaginationV2/PaginationV2.js#L341

```javascript
{componentsX ? (
  <CaretLeft24 />
) : (
  <Icon
    className={`${prefix}--pagination__button-icon`}
    icon={iconChevronLeft}
    description={backwardText}
  />
)}
```
