### PR TITLE
fix(overflow-menu): allow keyboard actions in menu items

### DIFF
--- a/src/components/data-table-v2/data-table-v2.hbs
+++ b/src/components/data-table-v2/data-table-v2.hbs
@@ -115,7 +115,7 @@
                   <ul class="{{@root.prefix}}--overflow-menu-options{{#if data.flip}} {{@root.prefix}}--overflow-menu--flip{{/if}}">
                     {{#each data.items}}
                       <li class="{{@root.prefix}}--overflow-menu-options__option{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}">
-                        <button class="{{@root.prefix}}--overflow-menu-options__btn">{{label}}</button>
+                        <button class="{{@root.prefix}}--overflow-menu-options__btn" onclick="console.log('keyboard action')">{{label}}</button>
                       </li>
                     {{/each}}
                   </ul>

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -263,6 +263,7 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
         const state = shouldBeOpen ? 'shown' : 'hidden';
 
         if (isOfSelf) {
+          event.delegateTarget = element; // eslint-disable-line no-param-reassign
           event.preventDefault(); // prevent scrolling
           this.changeState(state, getLaunchingDetails(event), () => {
             if (state === 'hidden' && isOfMenu) {

--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -258,20 +258,18 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
         if (!isExpanded && this.element.ownerDocument.activeElement !== this.element) {
           return;
         }
-        event.preventDefault(); // prevent scrolling
         const isOfSelf = element.contains(event.target);
         const shouldBeOpen = isOfSelf && !element.classList.contains(options.classShown);
         const state = shouldBeOpen ? 'shown' : 'hidden';
 
         if (isOfSelf) {
-          event.delegateTarget = element; // eslint-disable-line no-param-reassign
+          event.preventDefault(); // prevent scrolling
+          this.changeState(state, getLaunchingDetails(event), () => {
+            if (state === 'hidden' && isOfMenu) {
+              element.focus();
+            }
+          });
         }
-
-        this.changeState(state, getLaunchingDetails(event), () => {
-          if (state === 'hidden' && isOfMenu) {
-            element.focus();
-          }
-        });
         break;
       }
       case 38: // up arrow

--- a/tests/axe/allHtml/a11y-html.json
+++ b/tests/axe/allHtml/a11y-html.json
@@ -30,103 +30,6 @@
         ]
       },
       {
-        "description": "Ensures ARIA attributes are allowed for an element's role",
-        "help": "Elements must only use allowed ARIA attributes",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-allowed-attr?application=webdriverjs",
-        "id": "aria-allowed-attr",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag411",
-          "wcag412"
-        ]
-      },
-      {
-        "description": "Ensures elements with ARIA roles have all required ARIA attributes",
-        "help": "Required ARIA attributes must be provided",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-required-attr?application=webdriverjs",
-        "id": "aria-required-attr",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag411",
-          "wcag412"
-        ]
-      },
-      {
-        "description": "Ensures elements with an ARIA role that require child roles contain them",
-        "help": "Certain ARIA roles must contain particular children",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-required-children?application=webdriverjs",
-        "id": "aria-required-children",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag131"
-        ]
-      },
-      {
-        "description": "Ensures elements with an ARIA role that require parent roles are contained by them",
-        "help": "Certain ARIA roles must be contained by particular parents",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-required-parent?application=webdriverjs",
-        "id": "aria-required-parent",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag131"
-        ]
-      },
-      {
-        "description": "Ensures all elements with a role attribute use a valid value",
-        "help": "ARIA roles used must conform to valid values",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-roles?application=webdriverjs",
-        "id": "aria-roles",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag131",
-          "wcag411",
-          "wcag412"
-        ]
-      },
-      {
-        "description": "Ensures all ARIA attributes have valid values",
-        "help": "ARIA attributes must conform to valid values",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-valid-attr-value?application=webdriverjs",
-        "id": "aria-valid-attr-value",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag131",
-          "wcag411",
-          "wcag412"
-        ]
-      },
-      {
-        "description": "Ensures attributes that begin with aria- are valid ARIA attributes",
-        "help": "ARIA attributes must conform to valid names",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/aria-valid-attr?application=webdriverjs",
-        "id": "aria-valid-attr",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag411"
-        ]
-      },
-      {
         "description": "Ensures <audio> elements have captions",
         "help": "<audio> elements must have a captions track",
         "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/audio-caption?application=webdriverjs",
@@ -237,33 +140,6 @@
         ]
       },
       {
-        "description": "Ensures every form element has a label",
-        "help": "Form elements must have labels",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/label?application=webdriverjs",
-        "id": "label",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.forms",
-          "wcag2a",
-          "wcag332",
-          "wcag131",
-          "section508",
-          "section508.22.n"
-        ]
-      },
-      {
-        "description": "The main landmark should not be contained in another landmark",
-        "help": "Main landmark is not at top level",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/landmark-main-is-top-level?application=webdriverjs",
-        "id": "landmark-main-is-top-level",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "best-practice"
-        ]
-      },
-      {
         "description": "Ensures presentational <table> elements do not use <th>, <caption> elements or the summary attribute",
         "help": "Layout tables must not use data table elements",
         "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/layout-table?application=webdriverjs",
@@ -360,60 +236,6 @@
         ]
       },
       {
-        "description": "Ensures tabindex attribute values are not greater than 0",
-        "help": "Elements should not have tabindex greater than zero",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/tabindex?application=webdriverjs",
-        "id": "tabindex",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.keyboard",
-          "best-practice"
-        ]
-      },
-      {
-        "description": "Ensure that tables do not have the same summary and caption",
-        "help": "The <caption> element should not contain the same text as the summary attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/table-duplicate-name?application=webdriverjs",
-        "id": "table-duplicate-name",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.tables",
-          "best-practice"
-        ]
-      },
-      {
-        "description": "Ensure that each cell in a table using the headers refers to another cell in that table",
-        "help": "All cells in a table element that use the headers attribute must only refer to other cells of that same table",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/td-headers-attr?application=webdriverjs",
-        "id": "td-headers-attr",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.tables",
-          "wcag2a",
-          "wcag131",
-          "section508",
-          "section508.22.g"
-        ]
-      },
-      {
-        "description": "Ensure that each table header in a data table refers to data cells",
-        "help": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/th-has-data-cells?application=webdriverjs",
-        "id": "th-has-data-cells",
-        "impact": null,
-        "nodes": [],
-        "tags": [
-          "cat.tables",
-          "wcag2a",
-          "wcag131",
-          "section508",
-          "section508.22.g"
-        ]
-      },
-      {
         "description": "Ensures lang attributes have valid values",
         "help": "lang attribute must have a valid value",
         "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/valid-lang?application=webdriverjs",
@@ -458,74 +280,6848 @@
         ]
       }
     ],
-    "incomplete": [],
-    "timestamp": 1549037585897,
-    "url": "http://localhost:3000",
-    "violations": [
+    "incomplete": [
       {
-        "description": "Ensures a navigation point to the primary content of the page. If the page contains iframes, each iframe should contain either no main landmarks or just one.",
-        "help": "Page must contain one main landmark.",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/landmark-one-main?application=webdriverjs",
-        "id": "landmark-one-main",
-        "impact": "moderate",
-        "nodes": [
-          {
-            "all": [
-              {
-                "data": false,
-                "id": "has-at-least-one-main",
-                "impact": "moderate",
-                "message": "Document has no main landmarks",
-                "relatedNodes": []
-              }
-            ],
-            "any": [],
-            "html": "<html dir=\"ltr\" lang=\"en\" i18n-processed=\"\">",
-            "impact": "moderate",
-            "none": [],
-            "target": [
-              "html"
-            ]
-          }
-        ],
-        "tags": [
-          "best-practice"
-        ]
-      },
-      {
-        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
-        "help": "Zooming and scaling must not be disabled",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/meta-viewport?application=webdriverjs",
-        "id": "meta-viewport",
-        "impact": "critical",
+        "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
+        "help": "Elements must have sufficient color contrast",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/color-contrast?application=webdriverjs",
+        "id": "color-contrast",
+        "impact": "serious",
         "nodes": [
           {
             "all": [],
             "any": [
               {
-                "data": null,
-                "id": "meta-viewport",
-                "impact": "critical",
-                "message": "<meta> tag disables zooming on mobile devices",
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#000000",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Unable to determine contrast ratio",
                 "relatedNodes": []
               }
             ],
-            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
-            "impact": "critical",
+            "html": "<code class=\"  language-html\">",
+            "impact": "serious",
             "none": [],
             "target": [
-              "head > meta[name=\"viewport\"]"
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 1,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#ffffff",
+                  "fontSize": "8.3pt",
+                  "fontWeight": "normal",
+                  "missingData": "equalRatio"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has a 1:1 contrast ratio with the background",
+                "relatedNodes": [
+                  {
+                    "html": "<button type=\"button\" data-copy-btn=\"true\" class=\"bx--snippet-button code-example__copy-btn\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<button type=\"button\" data-copy-btn=\"true\" class=\"bx--snippet-button code-example__copy-btn\">",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#000000",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Unable to determine contrast ratio",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<code class=\"  language-html\">",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 1,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#ffffff",
+                  "fontSize": "8.3pt",
+                  "fontWeight": "normal",
+                  "missingData": "equalRatio"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has a 1:1 contrast ratio with the background",
+                "relatedNodes": [
+                  {
+                    "html": "<button type=\"button\" data-copy-btn=\"true\" class=\"bx--snippet-button code-example__copy-btn\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<button type=\"button\" data-copy-btn=\"true\" class=\"bx--snippet-button code-example__copy-btn\">",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#ffffff",
+                  "fontSize": "10.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Unable to determine contrast ratio",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<div id=\"__bs_notify__\" style=\"display: block; padding: 15px; font-family: sans-serif; position: fixed; font-size: 0.9em; z-index: 9999; right: 0px; top: 0px; border-bottom-left-radius: 5px; background-color: rgb(27, 32, 50); margin: 0px; color: white; text-align: center; pointer-events: none;\">",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#__bs_notify__"
             ]
           }
         ],
         "tags": [
-          "cat.sensory-and-visual-cues",
+          "cat.color",
           "wcag2aa",
-          "wcag144"
+          "wcag143"
+        ]
+      },
+      {
+        "description": "Ensure that each table header in a data table refers to data cells",
+        "help": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/th-has-data-cells?application=webdriverjs",
+        "id": "th-has-data-cells",
+        "impact": "serious",
+        "nodes": [
+          {
+            "all": [
+              {
+                "data": null,
+                "id": "th-has-data-cells",
+                "impact": "serious",
+                "message": "Table data cells are missing or empty",
+                "relatedNodes": [
+                  {
+                    "html": "<th>Params</th>",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > .page_md > table:nth-child(7) > thead > tr > th:nth-child(2)"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "any": [],
+            "html": "<table>\n<thead>\n<tr>\n<th>Name</th>\n<th>Params</th>\n<th>Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><code>release</code></td>\n<td></td>\n<td>Deletes the instance</td>\n</tr>\n</tbody>\n</table>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".page_md > table:nth-child(7)"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.tables",
+          "wcag2a",
+          "wcag131",
+          "section508",
+          "section508.22.g"
         ]
       }
     ],
-    "time": 264,
-    "status": 404
+    "timestamp": 1550767500764,
+    "url": "http://localhost:3000",
+    "violations": [
+      {
+        "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
+        "help": "Elements must have sufficient color contrast",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/color-contrast?application=webdriverjs",
+        "id": "color-contrast",
+        "impact": "serious",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.48,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#7d8b99",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.48 (foreground color: #7d8b99, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token comment\" spellcheck=\"true\">&lt;!-- \n  Copyright IBM Corp. 2016, 2018\n\n  This source code is licensed under the Apache-2.0 license found in the\n  LICENSE file in the root directory of this source tree.\n--&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span.comment"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-expanded</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane1<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(8) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(8) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">id</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane1<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(16) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(16) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(16) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-expanded</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane2<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(21) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(21) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">id</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane2<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(29) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(29) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(29) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-expanded</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane3<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">id</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane3<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(42) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(42) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(42) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-expanded</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane4<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">id</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane4<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.48,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#7d8b99",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.48 (foreground color: #7d8b99, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token comment\" spellcheck=\"true\">&lt;!-- \n  Copyright IBM Corp. 2016, 2018\n\n  This source code is licensed under the Apache-2.0 license found in the\n  LICENSE file in the root directory of this source tree.\n--&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span.comment"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">tabindex</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(11)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(9) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(9) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(12) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(12) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">tabindex</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(11)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(20) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(20) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(23) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(23) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(26) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(26) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">tabindex</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(11)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(40) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(40) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">tabindex</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">data-accordion-item</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(46) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(46) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">width</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">height</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(11)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(48) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(48) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(51) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(51) > span.attr-value"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(54) > span.attr-name"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(54) > span.attr-value"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.color",
+          "wcag2aa",
+          "wcag143"
+        ]
+      }
+    ],
+    "time": 1871,
+    "status": 200
   }
 ]


### PR DESCRIPTION
Closes #1470

Closes #1860

This PR fixes the behavior where an overflow menu would collapse before a keyboard event would be captured by the nested overflow menu item.

#### Changelog

**New**

- `onclick` attribute on data table overflow menu items in docs examples

**Changed**

- prevent default behavior on overflow menu space bar and enter key keypresses only when the event origin is the menu itself (as opposed to originating from menu items)

#### Testing / Reviewing

use the keyboard to navigate overflow menus (including overflow menus found in other components such as data table v2), and ensure that keyboard events are captured by overflow menu items before the overflow menu collapses
