### PR TITLE
fix(datepicker): apply top positioning for icon to CarbonX mixin

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -565,6 +565,7 @@
 
   .#{$prefix}--date-picker__icon {
     position: absolute;
+    top: 2.25rem;
     right: 1rem;
     fill: $ui-05;
     cursor: pointer;
@@ -573,10 +574,6 @@
     &:hover {
       fill: $hover-primary;
     }
-  }
-
-  .#{$prefix}--date-picker--single .#{$prefix}--date-picker__icon {
-    top: 2.25rem;
   }
 
   .#{$prefix}--date-picker--nolabel .#{$prefix}--date-picker__icon {


### PR DESCRIPTION
Related to this issue: https://github.com/IBM/carbon-components-react/issues/1904

The Carbon X design kit has an icon for all variations except for the "simple" variation. I opened an issue for that in `carbon-components-react` (see link above) since there is some logic preventing the icon from showing up in anything but a `single` type of `DatePickerInput`.

Here, I propose restoring a style rule that puts a `top: 2.25rem` rule to add `.#{$prefix}--date-picker__icon` elements. It was previously here, in the old/v9 component mixin: https://github.com/IBM/carbon-components/blob/master/src/components/date-picker/_date-picker.scss#L118

Making this change will restore the top positioning of the icons to what is in v9 (and what is currently appled to Carbon X single type `DatePicker`s) and will also help resolve https://github.com/IBM/carbon-components-react/issues/1904

**Changed**

- Moved `top: 2.25rem` to apply to all `.#{$prefix}--date-picker__icon` elements
