### PR TITLE
fix(date-picker): restrict label max-width for single and date range picker

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -579,14 +579,6 @@
     }
   }
 
-  .#{$prefix}--date-picker--single .#{$prefix}--date-picker__icon {
-    top: 2.25rem;
-  }
-
-  .#{$prefix}--date-picker--nolabel .#{$prefix}--date-picker__icon {
-    top: rem(12px);
-  }
-
   .#{$prefix}--date-picker__icon ~ .#{$prefix}--date-picker__input {
     padding-right: $spacing-3xl;
   }

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -468,7 +468,6 @@
 @mixin date-picker--x {
   .#{$prefix}--date-picker {
     display: flex;
-    align-items: flex-start;
   }
 
   .#{$prefix}--date-picker--light .#{$prefix}--date-picker__input {
@@ -483,6 +482,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
   }
 
   .#{$prefix}--date-picker-input__wrapper {
@@ -587,15 +587,11 @@
     padding-right: $spacing-3xl;
   }
 
-  .#{$prefix}--date-picker--range {
-    display: flex;
-    position: relative;
-  }
-
   .#{$prefix}--date-picker--range > .#{$prefix}--date-picker-container:first-child {
     margin-right: rem(1px);
   }
 
+  .#{$prefix}--date-picker--range .#{$prefix}--date-picker-container,
   .#{$prefix}--date-picker--range .#{$prefix}--date-picker__input {
     width: rem(143.5px);
   }

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -17,7 +17,6 @@
 @mixin date-picker {
   .#{$prefix}--date-picker {
     display: flex;
-    align-items: flex-start;
   }
 
   .#{$prefix}--date-picker--light .#{$prefix}--date-picker__input {
@@ -32,6 +31,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
   }
 
   .#{$prefix}--date-picker.#{$prefix}--date-picker--simple {
@@ -144,10 +144,13 @@
   }
 
   .#{$prefix}--date-picker--range .#{$prefix}--date-picker__icon {
+    top: initial;
     right: -1.75rem;
+    bottom: 0.6rem;
     left: auto;
   }
 
+  .#{$prefix}--date-picker--range .#{$prefix}--label,
   .#{$prefix}--date-picker--range .#{$prefix}--date-picker__input {
     width: 7.075rem;
   }

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -516,6 +516,10 @@
   }
 
   .#{$prefix}--date-picker.#{$prefix}--date-picker--single {
+    .#{$prefix}--date-picker-container {
+      max-width: rem(288px);
+    }
+
     .#{$prefix}--date-picker__input {
       width: rem(288px);
     }


### PR DESCRIPTION
Closes #1877 

Related https://github.com/IBM/carbon-components/pull/1622

This PR sets max-width rules on the label for single date picker and date range pickers so that the calendar icons are not incorrectly positioned

#### Changelog

**New**

- width and max-width rules on date picker input containers

**Removed**

- redundant positioning rules

#### Testing / Reviewing

Modify the length of the date picker labels to see how the component behaves

screenshot for reference

![localhost_3000_demo_date-picker](https://user-images.githubusercontent.com/8265238/53193334-54978380-35d6-11e9-84ef-fcf7cb74c5d2.png)

