### PR TITLE
feat(number-input): add mobile variant

### DIFF
--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -340,6 +340,7 @@
     input[type='number'] {
       min-width: rem(64px);
       width: auto;
+      margin: 0;
       border-right: 1px solid $ui-03;
       border-left: 1px solid $ui-03;
       padding: 0;

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -317,6 +317,36 @@
     background: $field-02;
   }
 
+  .#{$prefix}--number--mobile {
+    min-width: rem(144px);
+    width: auto;
+
+    .#{$prefix}--number__control-btn {
+      width: rem(40px);
+      height: rem(40px);
+      background-color: $field-01;
+
+      &:hover,
+      &:focus {
+        background-color: $hover-ui;
+      }
+
+      &:focus {
+        outline-width: 2px;
+        outline-offset: -2px;
+      }
+    }
+
+    input[type='number'] {
+      min-width: rem(64px);
+      width: auto;
+      border-right: 1px solid $ui-03;
+      border-left: 1px solid $ui-03;
+      padding: 0;
+      text-align: center;
+    }
+  }
+
   // Skeleton State
   .#{$prefix}--number.#{$prefix}--skeleton {
     @include skeleton;

--- a/src/components/number-input/number-input.config.js
+++ b/src/components/number-input/number-input.config.js
@@ -10,9 +10,10 @@
 const featureFlags = require('../../globals/js/feature-flags');
 const { prefix } = require('../../globals/js/settings');
 
+const { componentsX } = featureFlags;
 module.exports = {
   context: {
-    featureFlags,
+    componentsX,
     prefix,
   },
   variants: [

--- a/src/components/number-input/number-input.config.js
+++ b/src/components/number-input/number-input.config.js
@@ -32,20 +32,24 @@ module.exports = {
         light: true,
       },
     },
-    {
-      name: 'mobile',
-      label: 'Mobile Number Input',
-      context: {
-        mobile: true,
-      },
-    },
-    {
-      name: 'mobile-light',
-      label: 'Mobile Number Input (light)',
-      context: {
-        light: true,
-        mobile: true,
-      },
-    },
+    ...(componentsX
+      ? [
+          {
+            name: 'mobile',
+            label: 'Mobile Number Input',
+            context: {
+              mobile: true,
+            },
+          },
+          {
+            name: 'mobile-light',
+            label: 'Mobile Number Input (light)',
+            context: {
+              light: true,
+              mobile: true,
+            },
+          },
+        ]
+      : []),
   ],
 };

--- a/src/components/number-input/number-input.config.js
+++ b/src/components/number-input/number-input.config.js
@@ -32,5 +32,20 @@ module.exports = {
         light: true,
       },
     },
+    {
+      name: 'mobile',
+      label: 'Mobile Number Input',
+      context: {
+        mobile: true,
+      },
+    },
+    {
+      name: 'mobile-light',
+      label: 'Mobile Number Input (light)',
+      context: {
+        light: true,
+        mobile: true,
+      },
+    },
   ],
 };

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -5,15 +5,15 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <div data-numberinput class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}}">
-    <label for="number-input0" class="{{@root.prefix}}--label">Number input label</label>
-    <div class="{{@root.prefix}}--number__input-wrapper">
+<div class="{{prefix}}--form-item">
+  <div data-numberinput class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}}">
+    <label for="number-input0" class="{{prefix}}--label">Number input label</label>
+    <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input0" type="number" min="0" max="100" value="1">
-      <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+      <div class="{{prefix}}--number__controls">
+        <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
           aria-live="polite" aria-atomic="true">
-          {{#if @root.featureFlags.componentsX}}
+          {{#if componentsX}}
           {{ carbon-icon 'CaretUpGlyph' }}
           {{else}}
           <svg width="10" height="5" viewBox="0 0 10 5">
@@ -21,9 +21,9 @@
           </svg>
           {{/if}}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
           aria-live="polite" aria-atomic="true">
-          {{#if @root.featureFlags.componentsX}}
+          {{#if componentsX}}
           {{ carbon-icon 'CaretDownGlyph' }}
           {{else}}
           <svg width="10" height="5" viewBox="0 0 10 5">
@@ -36,20 +36,19 @@
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
-  <div data-invalid data-numberinput
-    class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}}">
-    <label for="number-input1" class="{{@root.prefix}}--label">Number input label</label>
-    {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--number__input-wrapper">
+<div class="{{prefix}}--form-item">
+  <div data-invalid data-numberinput class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}}">
+    <label for="number-input1" class="{{prefix}}--label">Number input label</label>
+    {{#if componentsX}}
+    <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
-      <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+      {{ carbon-icon 'WarningFilled16' class=(add prefix '--number__invalid')}}
+      <div class="{{prefix}}--number__controls">
+        <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
@@ -57,14 +56,14 @@
     </div>
     {{else}}
     <input id="number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-    <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+    <div class="{{prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -72,25 +71,25 @@
       </button>
     </div>
     {{/if}}
-    <div class="{{@root.prefix}}--form-requirement">
+    <div class="{{prefix}}--form-requirement">
       Invalid number
     </div>
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
+<div class="{{prefix}}--form-item">
   <div data-invalid data-numberinput
-    class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--nolabel">
-    {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--number__input-wrapper">
+    class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}} {{prefix}}--number--nolabel">
+    {{#if componentsX}}
+    <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
-      <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+      {{ carbon-icon 'WarningFilled16' class=(add prefix '--number__invalid')}}
+      <div class="{{prefix}}--number__controls">
+        <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
@@ -98,14 +97,14 @@
     </div>
     {{else}}
     <input id="number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-    <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+    <div class="{{prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -113,28 +112,28 @@
       </button>
     </div>
     {{/if}}
-    <div class="{{@root.prefix}}--form-requirement">
+    <div class="{{prefix}}--form-requirement">
       Invalid number
     </div>
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
+<div class="{{prefix}}--form-item">
   <div data-numberinput
-    class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
-    <label for="number-input3" class="{{@root.prefix}}--label">Number input label</label>
-    {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--form__helper-text">
+    class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}} {{prefix}}--number--helpertext">
+    <label for="number-input3" class="{{prefix}}--label">Number input label</label>
+    {{#if componentsX}}
+    <div class="{{prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
-    <div class="{{@root.prefix}}--number__input-wrapper">
+    <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input3" type="number" min="0" max="100" value="1">
-      <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+      <div class="{{prefix}}--number__controls">
+        <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
@@ -142,14 +141,14 @@
     </div>
     {{else}}
     <input id="number-input3" type="number" min="0" max="100" value="1">
-    <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+    <div class="{{prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -157,31 +156,31 @@
       </button>
     </div>
     {{/if}}
-    {{#unless @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--form__helper-text">
+    {{#unless componentsX}}
+    <div class="{{prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
     {{/unless}}
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
+<div class="{{prefix}}--form-item">
   <div data-invalid data-numberinput
-    class="{{@root.prefix}}--number {{#if light}}{{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
-    <label for="number-input4" class="{{@root.prefix}}--label">Number input label</label>
-    {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--form__helper-text">
+    class="{{prefix}}--number {{#if light}}{{prefix}}--number--light{{/if}} {{prefix}}--number--helpertext">
+    <label for="number-input4" class="{{prefix}}--label">Number input label</label>
+    {{#if componentsX}}
+    <div class="{{prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
-    <div class="{{@root.prefix}}--number__input-wrapper">
+    <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
-      <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+      {{ carbon-icon 'WarningFilled16' class=(add prefix '--number__invalid')}}
+      <div class="{{prefix}}--number__controls">
+        <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
@@ -189,14 +188,14 @@
     </div>
     {{else}}
     <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-    <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+    <div class="{{prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -204,34 +203,34 @@
       </button>
     </div>
     {{/if}}
-    <div class="{{@root.prefix}}--form-requirement">
+    <div class="{{prefix}}--form-requirement">
       Invalid number
     </div>
-    {{#unless @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--form__helper-text">
+    {{#unless componentsX}}
+    <div class="{{prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
     {{/unless}}
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
+<div class="{{prefix}}--form-item">
   <div data-invalid data-numberinput
-    class="{{@root.prefix}}--number {{#if light}}{{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
-    <label for="number-input5" class="{{@root.prefix}}--label">Number input label</label>
-    {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--form__helper-text">
+    class="{{prefix}}--number {{#if light}}{{prefix}}--number--light{{/if}} {{prefix}}--number--helpertext">
+    <label for="number-input5" class="{{prefix}}--label">Number input label</label>
+    {{#if componentsX}}
+    <div class="{{prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
-    <div class="{{@root.prefix}}--number__input-wrapper">
+    <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input5" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
-      <div class="{{@root.prefix}}--number__controls">
-        <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+      {{ carbon-icon 'WarningFilled16' class=(add prefix '--number__invalid')}}
+      <div class="{{prefix}}--number__controls">
+        <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretUpGlyph' }}
         </button>
-        <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+        <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
           aria-live="polite" aria-atomic="true">
           {{ carbon-icon 'CaretDownGlyph' }}
         </button>
@@ -239,14 +238,14 @@
     </div>
     {{else}}
     <input id="number-input5" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
-    <div class="{{@root.prefix}}--number__controls">
-      <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
+    <div class="{{prefix}}--number__controls">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
         </svg>
       </button>
-      <button aria-label="decrease number input" class="{{@root.prefix}}--number__control-btn down-icon" type="button"
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
         aria-live="polite" aria-atomic="true">
         <svg width="10" height="5" viewBox="0 0 10 5">
           <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -254,11 +253,11 @@
       </button>
     </div>
     {{/if}}
-    {{#unless @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--form-requirement">
+    {{#unless componentsX}}
+    <div class="{{prefix}}--form-requirement">
       Invalid number
     </div>
-    <div class="{{@root.prefix}}--form__helper-text">
+    <div class="{{prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
     {{/unless}}

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -5,6 +5,7 @@
   LICENSE file in the root directory of this source tree.
 -->
 
+{{#unless mobile}}
 <div class="{{prefix}}--form-item">
   <div data-numberinput class="
     {{prefix}}--number
@@ -281,3 +282,153 @@
     {{/unless}}
   </div>
 </div>
+{{else}}
+{{#if componentsX}}
+<div class="{{prefix}}--form-item">
+  <div data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+    {{#if mobile}} {{prefix}}--number--mobile {{/if}}
+    ">
+    <label for="mobile-number-input0" class="{{prefix}}--label">Number input label</label>
+    <div class="{{prefix}}--number__input-wrapper">
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretDownGlyph' }}
+      </button>
+      <input id="mobile-number-input0" type="number" min="0" max="100" value="1">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretUpGlyph' }}
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+    {{#if mobile}} {{prefix}}--number--mobile {{/if}}
+  ">
+    <label for="mobile-number-input1" class="{{prefix}}--label">Number input label</label>
+    <div class="{{prefix}}--number__input-wrapper">
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretDownGlyph' }}
+      </button>
+      <input id="mobile-number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretUpGlyph' }}
+      </button>
+    </div>
+    <div class="{{prefix}}--form-requirement">
+      Invalid number
+    </div>
+  </div>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <div data-invalid data-numberinput class="
+      {{prefix}}--number
+      {{#if light}} {{prefix}}--number--light {{/if}}
+      {{#if mobile}} {{prefix}}--number--mobile {{/if}}
+      {{prefix}}--number--nolabel
+    ">
+    <div class="{{prefix}}--number__input-wrapper">
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretDownGlyph' }}
+      </button>
+      <input id="mobile-number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretUpGlyph' }}
+      </button>
+    </div>
+    <div class="{{prefix}}--form-requirement">
+      Invalid number
+    </div>
+  </div>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <div data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light{{/if}}
+    {{#if mobile}} {{prefix}}--number--mobile {{/if}}
+    {{prefix}}--number--helpertext
+  ">
+    <label for="mobile-number-input3" class="{{prefix}}--label">Number input label</label>
+    <div class="{{prefix}}--form__helper-text">
+      Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
+    </div>
+    <div class="{{prefix}}--number__input-wrapper">
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretDownGlyph' }}
+      </button>
+      <input id="mobile-number-input3" type="number" min="0" max="100" value="1">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretUpGlyph' }}
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+    {{#if mobile}} {{prefix}}--number--mobile {{/if}}
+    {{prefix}}--number--helpertext
+  ">
+    <label for="mobile-number-input4" class="{{prefix}}--label">Number input label</label>
+    <div class="{{prefix}}--form__helper-text">
+      Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
+    </div>
+    <div class="{{prefix}}--number__input-wrapper">
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretDownGlyph' }}
+      </button>
+      <input id="mobile-number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretUpGlyph' }}
+      </button>
+    </div>
+    <div class="{{prefix}}--form-requirement">
+      Invalid number
+    </div>
+  </div>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light{{/if}}
+    {{#if mobile}} {{prefix}}--number--mobile{{/if}}
+    {{prefix}}--number--helpertext
+  ">
+    <label for="mobile-number-input5" class="{{prefix}}--label">Number input label</label>
+    <div class="{{prefix}}--form__helper-text">
+      Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
+    </div>
+    <div class="{{prefix}}--number__input-wrapper">
+      <button aria-label="decrease number input" class="{{prefix}}--number__control-btn down-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretDownGlyph' }}
+      </button>
+      <input id="mobile-number-input5" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
+        aria-live="polite" aria-atomic="true">
+        {{ carbon-icon 'CaretUpGlyph' }}
+      </button>
+    </div>
+  </div>
+</div>
+{{/if}}
+{{/unless}}

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -296,7 +296,7 @@
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretDownGlyph' }}
       </button>
-      <input id="mobile-number-input0" type="number" min="0" max="100" value="1">
+      <input id="mobile-number-input0" type="number" pattern="\d*" min="0" max="100" value="1">
       <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretUpGlyph' }}
@@ -317,7 +317,8 @@
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretDownGlyph' }}
       </button>
-      <input id="mobile-number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <input id="mobile-number-input1" type="number" pattern="\d*" min="0" max="100" value="1" role="alert"
+        aria-atomic="true">
       <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretUpGlyph' }}
@@ -341,7 +342,8 @@
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretDownGlyph' }}
       </button>
-      <input id="mobile-number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <input id="mobile-number-input2" type="number" pattern="\d*" min="0" max="100" value="1" role="alert"
+        aria-atomic="true">
       <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretUpGlyph' }}
@@ -369,7 +371,7 @@
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretDownGlyph' }}
       </button>
-      <input id="mobile-number-input3" type="number" min="0" max="100" value="1">
+      <input id="mobile-number-input3" type="number" pattern="\d*" min="0" max="100" value="1">
       <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretUpGlyph' }}
@@ -394,7 +396,8 @@
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretDownGlyph' }}
       </button>
-      <input id="mobile-number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <input id="mobile-number-input4" type="number" pattern="\d*" min="0" max="100" value="1" role="alert"
+        aria-atomic="true">
       <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretUpGlyph' }}
@@ -422,7 +425,8 @@
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretDownGlyph' }}
       </button>
-      <input id="mobile-number-input5" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <input id="mobile-number-input5" type="number" pattern="\d*" min="0" max="100" value="1" role="alert"
+        aria-atomic="true">
       <button aria-label="increase number input" class="{{prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">
         {{ carbon-icon 'CaretUpGlyph' }}

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -6,7 +6,10 @@
 -->
 
 <div class="{{prefix}}--form-item">
-  <div data-numberinput class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}}">
+  <div data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+  ">
     <label for="number-input0" class="{{prefix}}--label">Number input label</label>
     <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input0" type="number" min="0" max="100" value="1">
@@ -37,7 +40,10 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <div data-invalid data-numberinput class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}}">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+  ">
     <label for="number-input1" class="{{prefix}}--label">Number input label</label>
     {{#if componentsX}}
     <div class="{{prefix}}--number__input-wrapper">
@@ -78,8 +84,11 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <div data-invalid data-numberinput
-    class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}} {{prefix}}--number--nolabel">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light{{/if}}
+    {{prefix}}--number--nolabel
+  ">
     {{#if componentsX}}
     <div class="{{prefix}}--number__input-wrapper">
       <input id="number-input2" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
@@ -119,8 +128,11 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <div data-numberinput
-    class="{{prefix}}--number{{#if light}} {{prefix}}--number--light{{/if}} {{prefix}}--number--helpertext">
+  <div data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+    {{prefix}}--number--helpertext
+  ">
     <label for="number-input3" class="{{prefix}}--label">Number input label</label>
     {{#if componentsX}}
     <div class="{{prefix}}--form__helper-text">
@@ -165,8 +177,11 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <div data-invalid data-numberinput
-    class="{{prefix}}--number {{#if light}}{{prefix}}--number--light{{/if}} {{prefix}}--number--helpertext">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+    {{prefix}}--number--helpertext
+  ">
     <label for="number-input4" class="{{prefix}}--label">Number input label</label>
     {{#if componentsX}}
     <div class="{{prefix}}--form__helper-text">
@@ -215,8 +230,11 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <div data-invalid data-numberinput
-    class="{{prefix}}--number {{#if light}}{{prefix}}--number--light{{/if}} {{prefix}}--number--helpertext">
+  <div data-invalid data-numberinput class="
+    {{prefix}}--number
+    {{#if light}} {{prefix}}--number--light {{/if}}
+    {{prefix}}--number--helpertext
+  ">
     <label for="number-input5" class="{{prefix}}--label">Number input label</label>
     {{#if componentsX}}
     <div class="{{prefix}}--form__helper-text">

--- a/src/components/number-input/number-input.hbs
+++ b/src/components/number-input/number-input.hbs
@@ -7,7 +7,7 @@
 
 <div class="{{@root.prefix}}--form-item">
   <div data-numberinput class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}}">
-    <label for="number-input0" class="{{@root.prefix}}--label">Number Input label</label>
+    <label for="number-input0" class="{{@root.prefix}}--label">Number input label</label>
     <div class="{{@root.prefix}}--number__input-wrapper">
       <input id="number-input0" type="number" min="0" max="100" value="1">
       <div class="{{@root.prefix}}--number__controls">
@@ -39,7 +39,7 @@
 <div class="{{@root.prefix}}--form-item">
   <div data-invalid data-numberinput
     class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}}">
-    <label for="number-input1" class="{{@root.prefix}}--label">Number Input label</label>
+    <label for="number-input1" class="{{@root.prefix}}--label">Number input label</label>
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--number__input-wrapper">
       <input id="number-input1" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
@@ -122,7 +122,7 @@
 <div class="{{@root.prefix}}--form-item">
   <div data-numberinput
     class="{{@root.prefix}}--number{{#if light}} {{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
-    <label for="number-input3" class="{{@root.prefix}}--label">Number Input label</label>
+    <label for="number-input3" class="{{@root.prefix}}--label">Number input label</label>
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
@@ -168,7 +168,7 @@
 <div class="{{@root.prefix}}--form-item">
   <div data-invalid data-numberinput
     class="{{@root.prefix}}--number {{#if light}}{{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
-    <label for="number-input4" class="{{@root.prefix}}--label">Number Input label</label>
+    <label for="number-input4" class="{{@root.prefix}}--label">Number input label</label>
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
@@ -218,13 +218,13 @@
 <div class="{{@root.prefix}}--form-item">
   <div data-invalid data-numberinput
     class="{{@root.prefix}}--number {{#if light}}{{@root.prefix}}--number--light{{/if}} {{@root.prefix}}--number--helpertext">
-    <label for="number-input4" class="{{@root.prefix}}--label">Number Input label</label>
+    <label for="number-input5" class="{{@root.prefix}}--label">Number input label</label>
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--form__helper-text">
       Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
     </div>
     <div class="{{@root.prefix}}--number__input-wrapper">
-      <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+      <input id="number-input5" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--number__invalid')}}
       <div class="{{@root.prefix}}--number__controls">
         <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
@@ -238,7 +238,7 @@
       </div>
     </div>
     {{else}}
-    <input id="number-input4" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
+    <input id="number-input5" type="number" min="0" max="100" value="1" role="alert" aria-atomic="true">
     <div class="{{@root.prefix}}--number__controls">
       <button aria-label="increase number input" class="{{@root.prefix}}--number__control-btn up-icon" type="button"
         aria-live="polite" aria-atomic="true">


### PR DESCRIPTION
Closes #1837

Related: https://github.com/carbon-design-system/carbon-contribution/issues/3

This PR adds support for a mobile number input variant and updates the documentation to include examples

#### Testing / Reviewing

Ensure the mobile number input looks correct and functions properly