### PR TITLE
fix(dropdown): prevent chevrons from disappearing on option select

### DIFF
--- a/src/components/dropdown/dropdown.hbs
+++ b/src/components/dropdown/dropdown.hbs
@@ -12,6 +12,8 @@
     {{#unless inline}} Dropdown label {{else}}
     <span class="{{@root.prefix}}--dropdown-text__inner">Inline Dropdown label</span>
     {{/unless}}
+  </li>
+  <li class="{{@root.prefix}}--dropdown__arrow-container">
     {{#if featureFlags.componentsX}}
     {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--dropdown__arrow') }}
     {{else}}
@@ -41,6 +43,8 @@
       {{#unless inline}} Dropdown label {{else}}
       <span class="{{@root.prefix}}--dropdown-text__inner">Inline Dropdown label</span>
       {{/unless}}
+    </li>
+    <li class="{{@root.prefix}}--dropdown__arrow-container">
       {{#if featureFlags.componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--dropdown__arrow') }}
       {{else}}


### PR DESCRIPTION
Closes #1895

Related #1765 #1846

This PR prevents the dropdown logic from erasing the chevron from the list item when a new option is selected.

To the reviewers: is there a more elegant way to get around this issue aside from appending the raw SVG string each time?