### PR TITLE
fix(dropdown): avoid invalid dropdown icons overlapping with option text

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -259,6 +259,10 @@
   .#{$prefix}--dropdown[data-invalid] {
     @include focus-outline('invalid');
 
+    .#{$prefix}--dropdown-text {
+      padding-right: rem(58px); // 2rem + 2xSVG width
+    }
+
     + .#{$prefix}--form-requirement {
       display: inline-block;
       max-height: rem(200px);

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -256,7 +256,7 @@
     }
   }
 
-  .#{$prefix}--dropdown[data-invalid] {
+  .#{$prefix}--dropdown--invalid {
     @include focus-outline('invalid');
 
     .#{$prefix}--dropdown-text {

--- a/src/components/dropdown/migrate-to-10.x.md
+++ b/src/components/dropdown/migrate-to-10.x.md
@@ -1,3 +1,11 @@
 ### HTML
 
 Icon from [`carbon-elements`](https://github.com/IBM/carbon-elements) package is now used. Vanilla markup should be migrated to one shown in [carbondesignsystem.com](https://next.carbondesignsystem.com/components/dropdown/code) site. React and other framework variants should reflect the change automatically.
+
+### SCSS
+
+The selector for the invalid state has changed to avoid selecting data attributes
+
+| Old Class                  | New Class             | Note    |
+| -------------------------- | --------------------- | ------- |
+| bx--dropdown[data-invalid] | bx--dropdown--invalid | Changed |


### PR DESCRIPTION
Closes #1897

#### Changelog

**Changed**

- increase right padding of invalid state dropdown options
- avoid data attribute selectors