### PR TITLE
fix(Accordion) added layout dependency to Accordion

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -7,6 +7,7 @@
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/layout';
 @import '../../globals/scss/functions';
 @import '../../globals/scss/import-once';
 @import '../../globals/scss/css--reset';


### PR DESCRIPTION
Closes #1899 

This pull requests help solves #1899 by adding the global `layout` sass file as a dependency to the accordion component.

#### Changelog

**New**

- added `globals/scss/layout` to accordion
