### PR TITLE
feat(breadcrumb): add support for current page, update text styles

### DIFF
--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -1,3 +1,13 @@
+### SCSS
+
+| Selector                                    | Description                                                                                                        |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `bx--breadcrumb`                            | Used on the containing `<nav>` or equivalent node                                                                  |
+| `bx--breadcrumb-item`                       | Used on each individual breadcrumb item                                                                            |
+| `bx--breadcrumb-item--current`              | Used to specify which breadcrumb item is the current page                                                          |
+| `bx--breadcrumb-item [aria-current='page']` | Alternative to `bx--breadcrumb-item--current`, automatically applied if a descending `<a>` tag uses `aria-current` |
+| `bx--breadcrumb--no-trailing-slash`         | Used to specify that no trailing slash should be added                                                             |
+
 ### FAQ
 
 #### How to remove a breadcrumb-item slash

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -11,6 +11,7 @@
 @import '../../globals/scss/layout';
 @import '../../globals/scss/css--typography';
 @import '../link/link';
+@import '../../globals/scss/functions';
 
 @mixin breadcrumb {
   .#{$prefix}--breadcrumb {
@@ -70,45 +71,54 @@
   }
 }
 
-@mixin breadcrumb-experimental {
+@mixin breadcrumb--x {
   .#{$prefix}--breadcrumb {
-    @include typescale('zeta');
-    @include font-family;
+    @include type-style('body-short-01');
+
     display: inline;
 
-    @include breakpoint(bp--xs--major) {
-      display: flex;
-      flex-wrap: wrap;
+    @if feature-flag-enabled('grid') {
+      @include carbon--breakpoint(md) {
+        display: flex;
+        flex-wrap: wrap;
+      }
+    } @else {
+      @include breakpoint(bp--xs--major) {
+        display: flex;
+        flex-wrap: wrap;
+      }
     }
   }
 
   .#{$prefix}--breadcrumb-item {
-    margin-right: $spacing-xs;
+    position: relative;
     display: flex;
     align-items: center;
-    line-height: 1.25; //needed for correct spacing for underline hover
+    margin-right: $spacing-xs;
   }
 
   .#{$prefix}--breadcrumb-item::after {
     content: '/';
+    color: $text-01;
     margin-left: $spacing-xs;
-    color: $text-02;
   }
 
   .#{$prefix}--breadcrumb--no-trailing-slash .#{$prefix}--breadcrumb-item:last-child::after {
     content: '';
   }
 
-  .#{$prefix}--breadcrumb-item:last-child {
+  .#{$prefix}--breadcrumb-item:last-child,
+  .#{$prefix}--breadcrumb-item:last-child::after {
     margin-right: 0;
-
-    &::after {
-      margin-right: 0;
-    }
   }
 
   .#{$prefix}--breadcrumb .#{$prefix}--link {
     white-space: nowrap;
+  }
+
+  .#{$prefix}--breadcrumb-item [aria-current='page'],
+  .#{$prefix}--breadcrumb-item.#{$prefix}--breadcrumb-item--current .#{$prefix}--link {
+    color: $text-01;
   }
 
   // Skeleton State
@@ -121,7 +131,7 @@
 
 @include exports('breadcrumb') {
   @if feature-flag-enabled('components-x') {
-    @include breadcrumb-experimental;
+    @include breadcrumb--x;
   } @else {
     @include breadcrumb;
   }

--- a/src/components/breadcrumb/breadcrumb--current-page.hbs
+++ b/src/components/breadcrumb/breadcrumb--current-page.hbs
@@ -1,0 +1,27 @@
+<nav class="{{@root.prefix}}--breadcrumb {{@root.prefix}}--breadcrumb--no-trailing-slash" aria-label="breadcrumb">
+  {{#each items}}
+    <div class="{{@root.prefix}}--breadcrumb-item">
+      {{#if label}}
+        <a
+          href="#"
+          class="{{@root.prefix}}--link"
+          {{#if current}}aria-current="page"{{/if}}
+        >
+            {{label}}
+        </a>
+      {{/if}}
+    </div>
+  {{/each}}
+</nav>
+
+<nav class="{{@root.prefix}}--breadcrumb {{@root.prefix}}--breadcrumb--no-trailing-slash" aria-label="breadcrumb">
+  {{#each items}}
+    <div class="{{@root.prefix}}--breadcrumb-item {{#if current}}{{@root.prefix}}--breadcrumb-item--current{{/if}}">
+      {{#if label}}
+        <a href="#" class="{{@root.prefix}}--link">
+          {{label}}
+        </a>
+      {{/if}}
+    </div>
+  {{/each}}
+</nav>

--- a/src/components/breadcrumb/breadcrumb--enabled.hbs
+++ b/src/components/breadcrumb/breadcrumb--enabled.hbs
@@ -1,0 +1,5 @@
+<nav class="{{@root.prefix}}--breadcrumb" aria-label="breadcrumb">
+  <div class="{{@root.prefix}}--breadcrumb-item">
+    <a href="#" class="{{@root.prefix}}--link">Breadcrumb 1</a>
+  </div>
+</nav>

--- a/src/components/breadcrumb/breadcrumb.config.js
+++ b/src/components/breadcrumb/breadcrumb.config.js
@@ -8,10 +8,25 @@
 'use strict';
 
 const { prefix } = require('../../globals/js/settings');
+const featureFlags = require('../../globals/js/feature-flags');
+
+const items = [
+  {
+    label: 'Breadcrumb 1',
+  },
+  {
+    label: 'Breadcrumb 2',
+  },
+  {
+    label: 'Breadcrumb 3',
+  },
+];
 
 module.exports = {
   context: {
+    featureFlags,
     prefix,
+    items,
   },
   variants: [
     {
@@ -21,18 +36,20 @@ module.exports = {
         Breadcrumb enables users to quickly see their location within a path of navigation
         and move up to a parent level if desired.
       `,
+    },
+    {
+      name: 'current-page',
+      label: 'with current page',
       context: {
-        items: [
-          {
-            label: 'Breadcrumb 1',
-          },
-          {
-            label: 'Breadcrumb 2',
-          },
-          {
-            label: 'Breadcrumb 3',
-          },
-        ],
+        items: items.map((item, i) => {
+          if (i !== items.length - 1) {
+            return item;
+          }
+          return {
+            ...item,
+            current: true,
+          };
+        }),
       },
     },
   ],

--- a/src/components/breadcrumb/breadcrumb.hbs
+++ b/src/components/breadcrumb/breadcrumb.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the

--- a/src/components/breadcrumb/migrate-to-10.x.md
+++ b/src/components/breadcrumb/migrate-to-10.x.md
@@ -1,0 +1,21 @@
+## Changes
+
+### SCSS
+
+#### Usage
+
+The import path remains unchanged at:
+
+```scss
+@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
+```
+
+#### Selectors
+
+| v9                                          | v10       |
+| ------------------------------------------- | --------- |
+| `bx--breadcrumb`                            | No change |
+| `bx--breadcrumb-item`                       | No change |
+| `bx--breadcrumb-item--current`              | ✨ New    |
+| `bx--breadcrumb-item [aria-current='page']` | ✨ New    |
+| `bx--breadcrumb--no-trailing-slash`         | No change |


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1910

Work done for component audit. Add support for current page use-case, update text styles.

#### Changelog

**New**

- Breadcrumb now supports current page through `.bx--breadcrumb-item--current` and `[aria-current='page']`
- New variants, docs, and migration guide for breadcrumb

**Changed**

- Text styles in Breadcrumb

**Removed**

#### Testing / Reviewing

We are testing the following permutations:

![image](https://user-images.githubusercontent.com/3901764/53364636-dd7b2b80-3904-11e9-9e3f-ff55a9c06eef.png)

Link styles (for underlines) will be handled under the Link component.
