### PR TITLE
fix(button): set minimum height instead of fixed height

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -290,7 +290,7 @@
 
   .#{$prefix}--btn--sm {
     @include letter-spacing;
-    height: rem(32px);
+    min-height: rem(32px);
     padding: $button-padding-sm;
   }
 

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -19,7 +19,7 @@
   flex-shrink: 0;
   font-size: $button-font-size;
   font-weight: $button-font-weight;
-  height: rem($button-height);
+  min-height: rem($button-height);
   padding: $button-padding;
   border-radius: $button-border-radius;
   text-align: center;
@@ -80,7 +80,7 @@
 
   cursor: pointer;
   flex-shrink: 0;
-  height: rem($button-height);
+  min-height: rem($button-height);
   padding: $button-padding;
   border-radius: $button-border-radius;
   text-align: left;


### PR DESCRIPTION
Closes #1893

This PR will replace the fixed height of our buttons with a minimum height so that it can grow based on its content