### PR TITLE
chore(styles): deprecate misc features for v10

### DIFF
--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -266,3 +266,9 @@ REASON: #{$reason}';
 .component-example__live .bx--form-item.bx--checkbox-wrapper {
   margin-bottom: 0;
 }
+
+@if feature-flag-enabled('components-x') {
+  .component-variation__name {
+    @include type-style('heading-02');
+  }
+}

--- a/src/globals/scss/_colors.scss
+++ b/src/globals/scss/_colors.scss
@@ -15,58 +15,109 @@
 //--------------------
 
 // UI Color Scheme
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-20: #7cc7ff !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-30: #5aaafa !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-40: #5596e6 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-50: #4178be !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-90: #152935 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-1: #0f212e !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-2: #20343e !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-3: #2d3f49 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-4: #394b54 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-5: #42535c !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-6: #5a6872 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-7: #8c9ba5 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-8: #dfe6eb !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__navy-gray-9: #eff2f5 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__white: #fff !default;
 
 // Light UI Color Scheme
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-51: #3d70b2 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__gray-1: #dfe3e6 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__gray-2: #f0f3f6 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__gray-3: #f5f7fa !default;
 
 // Accent Colors
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-10: #c0e6ff !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__blue-60: #325c80 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__teal-10: #a7fae6 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__teal-20: #6eedd8 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__teal-30: #41d6c3 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__teal-40: #00b4a0 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__teal-50: #008571 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__teal-60: #006d5d !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__green-10: #c8f08f !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__green-20: #b4e051 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__green-30: #8cd211 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__green-40: #5aa700 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__green-50: #4b8400 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__green-60: #2d660a !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__yellow-10: #fde876 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__yellow-20: #fdd600 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__yellow-30: #efc100 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__yellow-60: #735f00 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__orange-10: #ffd4a0 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__orange-20: #ffa573 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__orange-30: #ff7832 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__orange-60: #a53725 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__red-10: #ffd2dd !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__red-30: #ff7d87 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__red-40: #ff5050 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__red-50: #e71d32 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__red-60: #ad1625 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__purple-10: #eed2ff !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__purple-20: #d7aaff !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__purple-30: #ba8ff7 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__purple-40: #af6ee8 !default;
+/// @deprecated (For v10) Use `@include carbon--colors()`
 $color__purple-60: #734098 !default;

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -9,6 +9,7 @@
 @import 'typography';
 @import 'css--reset';
 @import 'import-once';
+@import 'functions';
 
 @mixin css-body {
   body {
@@ -20,8 +21,22 @@
   }
 }
 
+@mixin css-body--x {
+  body {
+    @include reset;
+    @include type-style('body-short-01');
+    color: $text-01;
+    background-color: $ui-background;
+    line-height: 1;
+  }
+}
+
 @include exports('css--body') {
   @if global-variable-exists('css--body') == false or $css--body == true {
-    @include css-body;
+    @if not feature-flag-enabled('components-x') {
+      @include css-body;
+    } @else {
+      @include css-body--x;
+    }
   }
 }

--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -10,6 +10,7 @@ $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !defa
 @import 'helper-mixins';
 @import 'import-once';
 
+/// @deprecated (For v10) Superseded by `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 $unicodes: (
   Pi:
     'U+03C0, U+0E3F, U+2070, U+2074-2079, U+2080-2089, U+2113, U+2116, U+2126, U+212E, U+2150-2151, U+2153-215E, U+2190-2199, U+21A9-21AA, U+21B0-21B3, U+21B6-21B7, U+21BA-21BB, U+21C4, U+21C6, U+2202, U+2206, U+220F, U+2211, U+221A, U+221E, U+222B, U+2248, U+2260, U+2264-2265, U+25CA, U+2713, U+274C, U+2B0E-2B11, U+EBE1, U+EBE3-EBE4, U+EBE6-EBE7, U+ECE0, U+EFCC',
@@ -18,16 +19,19 @@ $unicodes: (
   Latin1: 'U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+20AC, U+2122, U+2212, U+FB01-FB02',
 );
 
+/// @deprecated (For v10) Superseded by `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 $families: (
   'Mono': unquote("'ibm-plex-mono'"),
   'Sans': unquote("'ibm-plex-sans'"),
 );
 
+/// @deprecated (For v10) Superseded by `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 $fallbacks: (
   'Mono': unquote("'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace"),
   'Sans': unquote("'ibm-plex-sans', 'Helvetica Neue', Arial, sans-serif"),
 );
 
+/// @deprecated (For v10) Superseded by `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 $weights: (
   'Light': (
     font-style: normal,
@@ -43,6 +47,7 @@ $weights: (
   ),
 ) !default;
 
+/// @deprecated (For v10) Superseded by `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 @mixin check-default-font-path {
   @if (str-index($font-path, 'https://unpkg.com/') == 1) {
     @warn 'The default font path (#{$font-path}) should be used only for demonstration/evaluation purposes. For production applications, please host fonts in your own CDN and change `$font-path` accordingly.';
@@ -52,6 +57,7 @@ $weights: (
   }
 }
 
+/// @deprecated (For v10) Use `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 @mixin plex-font-face {
   @include deprecate(
     '`@include plex-font-face` has been deprecated. ' + 'It will be removed in the next major release.',

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -135,7 +135,8 @@
 
 @include exports('css--typography') {
   @if global-variable-exists('css--typography') == false or $css--typography == true {
-    // TODO: Use `@include carbon--type-classes` for `components-x`
-    @include typography;
+    @if not feature-flag-enabled('components-x') {
+      @include typography;
+    }
   }
 }

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -9,123 +9,133 @@
 @import 'typography';
 @import 'css--reset';
 @import 'import-once';
+@import 'deprecate';
+@import 'functions';
 
+/// @deprecated (For v10) Use `@include carbon--type-classes`
 @mixin typography {
-  // really big
-  .#{$prefix}--type-giga {
-    @include typescale('giga');
-    @include reset;
-    @include line-height('heading');
-    font-weight: 300;
-  }
+  @include deprecate(
+    '`@include typography` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--type-classes` instead.',
+    feature-flag-enabled('components-x')
+  ) {
+    // really big
+    .#{$prefix}--type-giga {
+      @include typescale('giga');
+      @include reset;
+      @include line-height('heading');
+      font-weight: 300;
+    }
 
-  .#{$prefix}--type-mega {
-    @include typescale('mega');
-    @include reset;
-    @include line-height('heading');
-    font-weight: 300;
-  }
+    .#{$prefix}--type-mega {
+      @include typescale('mega');
+      @include reset;
+      @include line-height('heading');
+      font-weight: 300;
+    }
 
-  // really small
-  .#{$prefix}--type-omega {
-    @include typescale('omega');
-    @include reset;
-    @include line-height('heading');
-    font-weight: 600;
-  }
+    // really small
+    .#{$prefix}--type-omega {
+      @include typescale('omega');
+      @include reset;
+      @include line-height('heading');
+      font-weight: 600;
+    }
 
-  .#{$prefix}--type-caption {
-    @include typescale('caption');
-    @include reset;
-    @include line-height('body');
-    font-weight: 400;
-  }
+    .#{$prefix}--type-caption {
+      @include typescale('caption');
+      @include reset;
+      @include line-height('body');
+      font-weight: 400;
+    }
 
-  .#{$prefix}--type-legal {
-    @include typescale('legal');
-    @include reset;
-    @include line-height('body');
-    font-weight: 400;
-  }
+    .#{$prefix}--type-legal {
+      @include typescale('legal');
+      @include reset;
+      @include line-height('body');
+      font-weight: 400;
+    }
 
-  .#{$prefix}--type-caps {
-    text-transform: uppercase;
-  }
+    .#{$prefix}--type-caps {
+      text-transform: uppercase;
+    }
 
-  strong,
-  .#{$prefix}--type-strong {
-    @include reset;
-    font-weight: 700;
-  }
+    strong,
+    .#{$prefix}--type-strong {
+      @include reset;
+      font-weight: 700;
+    }
 
-  p {
-    @include reset;
-    @include typescale('p');
-    @include line-height('body');
-    font-weight: 400;
-  }
+    p {
+      @include reset;
+      @include typescale('p');
+      @include line-height('body');
+      font-weight: 400;
+    }
 
-  em {
-    @include reset;
-    font-style: italic;
-  }
+    em {
+      @include reset;
+      font-style: italic;
+    }
 
-  a {
-    @include reset;
-    color: $brand-01;
-  }
+    a {
+      @include reset;
+      color: $brand-01;
+    }
 
-  h1,
-  .#{$prefix}--type-alpha {
-    @include reset;
-    @include typescale('alpha');
-    @include line-height('heading');
-    font-weight: 300;
-  }
+    h1,
+    .#{$prefix}--type-alpha {
+      @include reset;
+      @include typescale('alpha');
+      @include line-height('heading');
+      font-weight: 300;
+    }
 
-  h2,
-  .#{$prefix}--type-beta {
-    @include reset;
-    @include typescale('beta');
-    @include line-height('heading');
-    font-weight: 300;
-  }
+    h2,
+    .#{$prefix}--type-beta {
+      @include reset;
+      @include typescale('beta');
+      @include line-height('heading');
+      font-weight: 300;
+    }
 
-  h3,
-  .#{$prefix}--type-gamma {
-    @include reset;
-    @include typescale('gamma');
-    @include line-height('heading');
-    font-weight: 300;
-  }
+    h3,
+    .#{$prefix}--type-gamma {
+      @include reset;
+      @include typescale('gamma');
+      @include line-height('heading');
+      font-weight: 300;
+    }
 
-  h4,
-  .#{$prefix}--type-delta {
-    @include reset;
-    @include typescale('delta');
-    @include line-height('heading');
-    font-weight: 600;
-  }
+    h4,
+    .#{$prefix}--type-delta {
+      @include reset;
+      @include typescale('delta');
+      @include line-height('heading');
+      font-weight: 600;
+    }
 
-  h5,
-  .#{$prefix}--type-epsilon {
-    @include reset;
-    @include typescale('epsilon');
-    @include line-height('heading');
-    font-weight: 600;
-  }
+    h5,
+    .#{$prefix}--type-epsilon {
+      @include reset;
+      @include typescale('epsilon');
+      @include line-height('heading');
+      font-weight: 600;
+    }
 
-  h6,
-  .#{$prefix}--type-zeta {
-    @include reset;
-    @include typescale('zeta');
-    @include line-height('heading');
-    font-weight: 600;
+    h6,
+    .#{$prefix}--type-zeta {
+      @include reset;
+      @include typescale('zeta');
+      @include line-height('heading');
+      font-weight: 600;
+    }
   }
 }
 
 @include exports('css--typography') {
   @if global-variable-exists('css--typography') == false or $css--typography == true {
+    // TODO: Use `@include carbon--type-classes` for `components-x`
     @include typography;
   }
 }

--- a/src/globals/scss/_deprecate.scss
+++ b/src/globals/scss/_deprecate.scss
@@ -1,0 +1,20 @@
+/// Generic `deprecate` mixin that is being used to indicate that a component is
+/// no longer going to be present in the next major release of Carbon.
+/// @access public
+/// @param {String} $reason - The message
+/// @param {Bool} $condition [true] - `true` to emits the given deprecation messsage
+/// @require {Bool} $deprecations--entry
+/// @require {Map} $deprecations--reasons
+@mixin deprecate($reason, $condition: true) {
+  $deprecations--entry: false !default;
+
+  @if not $condition {
+    @content;
+  } @else if ($deprecations--entry == true) {
+    $deprecations--reasons: append($deprecations--reasons, $reason) !global;
+    @content;
+  } @else {
+    @warn 'Deprecated code was found, this code will be removed before the next release of Carbon. REASON: #{$reason}';
+    @content;
+  }
+}

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -23,6 +23,8 @@
 @import 'css--reset';
 @import 'typography';
 @import 'import-once';
+@import 'deprecate';
+@import 'functions';
 
 @mixin text-overflow($width: false) {
   display: block;
@@ -117,29 +119,7 @@
   }
 }
 
-/// Generic `deprecate` mixin that is being used to indicate that a component is
-/// no longer going to be present in the next major release of Carbon.
-/// @access public
-/// @param {String} $reason - The message
-/// @param {Bool} $condition [true] - `true` to emits the given deprecation messsage
-/// @require $deprecations--entry
-/// @require $deprecations--reasons
-@mixin deprecate($reason, $condition: true) {
-  $deprecations--entry: false !default;
-
-  @if not $condition {
-    @content;
-  } @else if ($deprecations--entry == true) {
-    $deprecations--reasons: append($deprecations--reasons, $reason) !global;
-    @content;
-  } @else {
-    @warn 'Deprecated code was found, this code will be removed before the next release of Carbon. REASON: #{$reason}';
-    @content;
-  }
-}
-
 // 💀 Skeleton loading animation
-
 @mixin skeleton {
   position: relative;
   border: none;
@@ -222,12 +202,14 @@
   }
 }
 
-//----------------------------------------------
-// Deprecated
-// ---------------------------------------------
-
+/// @deprecated A legacy class used for our older way of dark/light theme switch
 @mixin light-ui {
-  .#{$prefix}--global-light-ui & {
-    @content;
+  @include deprecate(
+    '`@include light-ui` has been deprecated. ' + 'It will be removed in the next major release.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    .#{$prefix}--global-light-ui & {
+      @content;
+    }
   }
 }

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -6,7 +6,10 @@
 //
 
 @import 'helper-classes';
+@import 'deprecate';
+@import 'functions';
 
+/// @deprecated (For v10) Superseded by `$carbon--grid-breakpoints`
 $breakpoints: (
   bp--xs--major: 500px,
   bp--sm--major: 768px,
@@ -41,26 +44,40 @@ $padding: (
 // }
 //-------------------------------------
 
+/// @deprecated (For v10) Use `@include carbon--breakpoint()`
 @mixin breakpoint($size) {
-  @if map-has-key($breakpoints, $size) {
-    @media screen and (min-width: map-get($breakpoints, $size)) {
-      @content;
-    }
-  } @else {
-    @media (min-width: $size) {
-      @content;
+  @include deprecate(
+    '`@include breakpoint()` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--breakpoint()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    @if map-has-key($breakpoints, $size) {
+      @media screen and (min-width: map-get($breakpoints, $size)) {
+        @content;
+      }
+    } @else {
+      @media (min-width: $size) {
+        @content;
+      }
     }
   }
 }
 
+/// @deprecated (For v10) Use `@include carbon--breakpoint-down()`
 @mixin max-breakpoint($size) {
-  @if map-has-key($breakpoints, $size) {
-    @media screen and (max-width: map-get($breakpoints, $size)) {
-      @content;
-    }
-  } @else {
-    @media (max-width: $size) {
-      @content;
+  @include deprecate(
+    '`@include max-breakpoint()` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--breakpoint-down()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    @if map-has-key($breakpoints, $size) {
+      @media screen and (max-width: map-get($breakpoints, $size)) {
+        @content;
+      }
+    } @else {
+      @media (max-width: $size) {
+        @content;
+      }
     }
   }
 }

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -22,11 +22,13 @@ $breakpoints: (
   max: 1584px,
 );
 
+/// @deprecated (For v10) Was used primary for older grid
 $padding: (
   'mobile': 3%,
   'xs': 5%,
 );
 
+/// @deprecated (For v10) Was used primary for older grid
 @function padding($value) {
   @if map-has-key($padding, $value) {
     @return map-get($padding, $value);
@@ -82,23 +84,25 @@ $padding: (
   }
 }
 
-//-------------------------------------
-// @mixin: grid-container
-//-------------------------------------
-// usage:
-// .some-container {
-//   @include grid-container;
-// }
-//-------------------------------------
-
+/// @example
+///   .some-container {
+///     @include grid-container;
+///   }
+/// @deprecated (For v10) Use `@include carbon--make-container()`
 @mixin grid-container {
-  width: 100%;
-  padding-right: padding(mobile);
-  padding-left: padding(mobile);
+  @include deprecate(
+    '`@include grid-container` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--make-container()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    width: 100%;
+    padding-right: padding(mobile);
+    padding-left: padding(mobile);
 
-  @include breakpoint(bp--xs--major) {
-    padding-right: padding(xs);
-    padding-left: padding(xs);
+    @include breakpoint(bp--xs--major) {
+      padding-right: padding(xs);
+      padding-left: padding(xs);
+    }
   }
 }
 

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -101,13 +101,25 @@ $typescale-map: (
 }
 
 // Only applied to bold weight text
+/// @deprecated (For v10) The new type styles doesn't use this
 @mixin font-smoothing {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  @include deprecate(
+    '`@include font-smoothing` has been deprecated. ' + 'It will be removed in the next major release.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }
 
+/// @deprecated (For v10) The new type styles doesn't use this
 @mixin letter-spacing {
-  letter-spacing: 0;
+  @include deprecate(
+    '`@include letter-spacing` has been deprecated. ' + 'It will be removed in the next major release.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    letter-spacing: 0;
+  }
 }
 
 /// @deprecated (For v10) Superseded by `$carbon--type-scale`

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -6,14 +6,22 @@
 //
 
 @import 'vars';
+@import 'deprecate';
+@import 'functions';
 
+/// @deprecated (For v10) Use `$carbon--font-families`
 $font-family-mono: 'ibm-plex-mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace !default;
+/// @deprecated (For v10) Use `$carbon--font-families`
 $font-family-sans-serif: 'ibm-plex-sans', Helvetica Neue, Arial, sans-serif !default;
+/// @deprecated (For v10) Use `$carbon--font-families`
 $font-family-serif: 'ibm-plex-serif', 'Georgia', Times, serif !default;
+/// @deprecated (For v10) Use Plex fonts
 $font-family-helvetica: 'IBM Helvetica', Helvetica Neue, HelveticaNeue, Helvetica, sans-serif !default;
 
+/// @deprecated (For v10) Superseded by `$carbon--base-font-size`
 $base-font-size: 16px !default; // Default, Use with em() and rem() functions
 
+/// @deprecated (For v10) Superseded by `$carbon--type-scale`
 $typescale-map: (
   'giga': 4.75rem,
   'mega': 3.375rem,
@@ -29,42 +37,66 @@ $typescale-map: (
   'p': 1rem,
 );
 
+/// @deprecated (For v10) Use `@include carbon--type-scale()`
 @mixin typescale($size) {
-  @if map-has-key($typescale-map, $size) {
-    font-size: map-get($typescale-map, $size);
-  } @else {
-    @warn 'This is not a step of the Carbon Type Scale!';
+  @include deprecate(
+    '`@include typescale()` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--type-scale()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    @if map-has-key($typescale-map, $size) {
+      font-size: map-get($typescale-map, $size);
+    } @else {
+      @warn 'This is not a step of the Carbon Type Scale!';
+    }
   }
 }
 
+/// @deprecated (For v10) Use `carbon--rem()`
 @function rem($px) {
   @return ($px / $base-font-size) * 1rem;
 }
 
+/// @deprecated (For v10) Use `carbon--em()`
 @function em($px) {
   @return ($px / $base-font-size) * 1em;
 }
 
+/// @deprecated (For v10) Use Plex fonts
 @mixin helvetica {
   font-family: $font-family-helvetica;
 }
 
+/// @deprecated (For v10) Use `@include carbon--font-family()`
 @mixin font-family {
-  @if global-variable-exists('css--plex') and $css--plex == true {
-    font-family: $font-family-sans-serif;
-  } @else {
-    font-family: $font-family-helvetica;
+  @include deprecate(
+    '`@include font-family` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--font-family()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    @if global-variable-exists('css--plex') and $css--plex == true {
+      font-family: $font-family-sans-serif;
+    } @else {
+      font-family: $font-family-helvetica;
+    }
   }
 }
 
 // There are two line heights to choose from. One for headings and one for body text
+/// @deprecated (For v10) Use `@include carbon--type-style()`
 @mixin line-height($el) {
-  @if $el == 'heading' {
-    line-height: 1.25;
-  } @else if $el == 'body' {
-    line-height: 1.5;
-  } @else {
-    @warn 'Invalid argument used for @mixin line-height($el) . Please use 'heading' or 'body'.';
+  @include deprecate(
+    '`@include line-height()` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--type-style()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    @if $el == 'heading' {
+      line-height: 1.25;
+    } @else if $el == 'body' {
+      line-height: 1.5;
+    } @else {
+      @warn 'Invalid argument used for @mixin line-height($el) . Please use 'heading' or 'body'.';
+    }
   }
 }
 
@@ -78,6 +110,7 @@ $typescale-map: (
   letter-spacing: 0;
 }
 
+/// @deprecated (For v10) Superseded by `$carbon--type-scale`
 $font-size-map: (
   '76': 4.75rem,
   '54': 3.375rem,
@@ -91,11 +124,18 @@ $font-size-map: (
   '11': 0.6875rem,
 );
 
+/// @deprecated (For v10) Use `@include carbon--type-scale()`
 @mixin font-size($size) {
-  @if map-has-key($font-size-map, $size) {
-    font-size: map-get($font-size-map, $size);
-  } @else {
-    @warn 'This is not a step of the Carbon Type Scale! Valid sizes are 11, 12, 14, 16, 18, 20, 28, 36, 54, and 76';
+  @include deprecate(
+    '`@include font-size()` has been deprecated. ' + 'It will be removed in the next major release. ' +
+      'Use `@include carbon--type-scale()` instead.',
+    feature-flag-enabled('breaking-changes-x')
+  ) {
+    @if map-has-key($font-size-map, $size) {
+      font-size: map-get($font-size-map, $size);
+    } @else {
+      @warn 'This is not a step of the Carbon Type Scale! Valid sizes are 11, 12, 14, 16, 18, 20, 28, 36, 54, and 76';
+    }
   }
 }
 

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -18,7 +18,9 @@ $css--typography: true !default;
 $css--plex: true !default;
 // TODO: remove in next major release. Synced in `feature-flags` as an adapter
 // in the interim
+/// @deprecated (For v10) v10 always uses `@carbon/grid`
 $css--use-experimental-grid: false !default;
+/// @deprecated (For v10) v10 always uses `@carbon/grid`
 $css--use-experimental-grid-fallback: false !default;
 
 @import 'feature-flags';


### PR DESCRIPTION
Refs #1626.

#### Changelog

**New**

- `_deprecate.scss` file to contain only `@mixin deprecate` - Having it in `_helper-mixin.scss` has caused import loop.
- `@deprecated` annotations for several variables/mixins/functions
- Deprecate message for deprecated mixins

#### Testing / Reviewing

Testing should make sure no component is broken.