### PR TITLE
docs(readme): deprecate src in the NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you prefer [Yarn](https://yarnpkg.com/en/), use the following command instead
 yarn add carbon-components
 ```
 
+(**Important note**: `src` directory in the package has been deprecated and subject to breaking changes. Please use `es`/`umd`/`scss` directories instead)
+
 If you just want to try out `carbon-components`, you can also use [CodeSandbox](https://codesandbox.io).
 
 [![Edit carbon-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/IBM/carbon-components/tree/master/examples/codesandbox)

--- a/src/migrate-to-10.x.md
+++ b/src/migrate-to-10.x.md
@@ -1,0 +1,6 @@
+# `src`
+
+This directory in `carbon-components` NPM package has been deprecated, and subject to breaking changes. Please use:
+
+- [`es`](https://unpkg.com/carbon-components@latest/es/) or [`umd`](https://unpkg.com/carbon-components@latest/umd/) directory for JavaScript code
+- [`scss`](https://unpkg.com/carbon-components@latest/scss/) directory for Sass code


### PR DESCRIPTION
Fixes #1890.

#### Changelog

**New**

- Deprecation note for `src` directory in the NPM package. The NPM package historically included `src` directory. This technically locks the list of Babel plugins used against our source code, which is unfortunate because we'd want to use some newer specs like [optional catch binding](https://babeljs.io/docs/en/next/babel-plugin-proposal-optional-catch-binding.html).