### PR TITLE
fix(toggle): update color tokens and add check for mini version

### DIFF
--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -404,6 +404,10 @@
   .#{$prefix}--toggle:disabled:active + .#{$prefix}--toggle__label .#{$prefix}--toggle__appearance:before {
     box-shadow: none;
   }
+
+  .#{$prefix}--toggle:disabled + .#{$prefix}--toggle__label .#{$prefix}--toggle__check {
+    fill: $disabled-02;
+  }
 }
 
 @include exports('toggle') {

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -251,7 +251,7 @@
       position: absolute;
       display: block;
       content: '';
-      background-color: $ui-03;
+      background-color: $ui-04;
       cursor: pointer;
       box-sizing: border-box;
       height: rem(24px);
@@ -270,7 +270,7 @@
       top: 3px;
       width: rem(18px);
       height: rem(18px);
-      background-color: $ui-02;
+      background-color: $ui-03;
       border-radius: 50%;
       content: '';
       transition: $transition--base $carbon--standard-easing;
@@ -295,6 +295,21 @@
       top: 3px;
       left: 3px;
     }
+  }
+
+  .#{$prefix}--toggle__check {
+    fill: $ui-03;
+    position: absolute;
+    left: 6px;
+    top: 6px;
+    z-index: 1;
+    transition: $transition--base $carbon--standard-easing;
+    transform: scale(0.2);
+  }
+
+  .#{$prefix}--toggle--small:checked + .#{$prefix}--toggle__label .#{$prefix}--toggle__check {
+    fill: $support-02;
+    transform: scale(1) translateX(16px);
   }
 
   .#{$prefix}--toggle__text--left,
@@ -325,16 +340,13 @@
 
   .#{$prefix}--toggle:checked + .#{$prefix}--toggle__label .#{$prefix}--toggle__appearance {
     &:before {
-      background-color: $toggle-background-color;
+      background-color: $support-02;
     }
 
     &:after {
+      background-color: $icon-03;
       transform: translateX(24px);
     }
-  }
-
-  .#{$prefix}--toggle__check {
-    @include hidden;
   }
 
   .#{$prefix}--toggle--small:checked + .#{$prefix}--toggle__label .#{$prefix}--toggle__appearance {
@@ -370,12 +382,11 @@
 
   .#{$prefix}--toggle:disabled + .#{$prefix}--toggle__label .#{$prefix}--toggle__appearance {
     &:before {
-      background-color: $ibm-colors__gray-20; // TODO: Replace with role or add new color variable
-      border-color: $ibm-colors__gray-20; // TODO: Replace with role or add new color variable
+      background-color: $disabled-01;
     }
 
     &:after {
-      background-color: $disabled;
+      background-color: $disabled-02;
     }
 
     &:before,

--- a/src/components/toggle/toggle--small.hbs
+++ b/src/components/toggle/toggle--small.hbs
@@ -6,31 +6,28 @@
 -->
 
 <div class="{{@root.prefix}}--form-item">
-  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle4" type="checkbox" aria-label="Label Name">
+  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle4" type="checkbox"
+    aria-label="Label Name">
   <label class="{{@root.prefix}}--toggle__label" for="toggle4">
     <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
     <span class="{{@root.prefix}}--toggle__appearance">
-      {{#unless componentsX}}
       <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
         <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
       </svg>
-      {{/unless}}
     </span>
     <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
   </label>
 </div>
 
 <div class="{{@root.prefix}}--form-item">
-  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle5" type="checkbox" aria-label="Label Name"
-    disabled>
+  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle5" type="checkbox"
+    aria-label="Label Name" disabled>
   <label class="{{@root.prefix}}--toggle__label" for="toggle5">
     <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
     <span class="{{@root.prefix}}--toggle__appearance">
-      {{#unless componentsX}}
       <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
         <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
       </svg>
-      {{/unless}}
     </span>
     <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
   </label>

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -211,9 +211,6 @@
   $tab-text-disabled: $ibm-color__gray-30 !default !global;
   $tab-underline-disabled: 3px solid $ibm-color__gray-10 !default !global;
 
-  // Toggle
-  $toggle-background-color: $ibm-color__green-50 !default !global;
-
   // Skeleton Loading
   $skeleton: rgba($color__blue-51, 0.1) !default !global; //old $field-01 TODO: Define for experimental
 


### PR DESCRIPTION
Closes #1911

Updates toggle to match latest spec for v10

#### Changelog

**New**

- Adds a check mark to mini toggle

**Changed**

- color tokens for various toggle states

**Removed**

- ` $toggle-background-color` variable, it now uses support token

#### Testing / Reviewing

- make sure toggle matches spec
