### PR TITLE
fix(tabs): collapse dropdown on document click in mobile variant

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -40,6 +40,11 @@ class Tab extends ContentSwitcher {
         this._handleKeyDown(event);
       })
     );
+    this.manage(
+      on(this.element.ownerDocument, 'click', event => {
+        this._handleDocumentClick(event);
+      })
+    );
 
     const selected = this.element.querySelector(this.options.selectorButtonSelected);
     if (selected) {
@@ -79,6 +84,20 @@ class Tab extends ContentSwitcher {
     if (trigger) {
       this._updateMenuState();
     }
+  }
+
+  /**
+   * Handles click on document.
+   * @param {Event} event The triggering event.
+   * @private
+   */
+  _handleDocumentClick(event) {
+    const { element } = this;
+    const isOfSelf = element.contains(event.target);
+    if (isOfSelf) {
+      return;
+    }
+    this._updateMenuState(false);
   }
 
   /**


### PR DESCRIPTION
Closes #1919

This PR adds a click event handler to collapse the mobile tabs dropdown on "blur"

#### Changelog

**New**

- click event handler to listen to document clicks