### PR TITLE
fix(tabs): remove disabled item hover state

### DIFF
--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -426,10 +426,6 @@
       border-bottom: 1px solid $ui-03;
       text-overflow: ellipsis;
       overflow: hidden;
-      &:hover {
-        color: $text-01;
-        border-bottom: 1px solid transparent;
-      }
       &:focus,
       &:active {
         width: 100%;


### PR DESCRIPTION
Closes #1921

This PR prevents mobile tab items from reacting on hover, giving the false impression that the items are actionable