### PR TITLE
fix(date-picker): update datepicker based on audit

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -530,7 +530,7 @@
 
   .#{$prefix}--date-picker__input {
     @include reset;
-    @include type-style('body-short-01');
+    @include type-style('code-02');
     @include focus-outline('reset');
 
     display: block;
@@ -573,7 +573,7 @@
   .#{$prefix}--date-picker__icon {
     position: absolute;
     right: 1rem;
-    fill: $ui-05;
+    fill: $icon-01;
     cursor: pointer;
     z-index: 1;
   }
@@ -628,8 +628,8 @@
 
   .#{$prefix}--date-picker__month .flatpickr-prev-month,
   .#{$prefix}--date-picker__month .flatpickr-next-month,
-  .flatpickr-month .flatpickr-prev-month,
-  .flatpickr-month .flatpickr-next-month {
+  .flatpickr-months .flatpickr-prev-month,
+  .flatpickr-months .flatpickr-next-month {
     display: flex !important;
     align-items: center;
     justify-content: center;
@@ -691,14 +691,14 @@
       background: none;
 
       &:after {
-        border-bottom-color: $interactive-02;
-        border-top-color: $interactive-02;
+        border-bottom-color: $interactive-01;
+        border-top-color: $interactive-01;
       }
     }
 
     &:after {
-      border-bottom-color: $interactive-01;
-      border-top-color: $interactive-01;
+      border-bottom-color: $icon-01;
+      border-top-color: $icon-01;
     }
   }
 
@@ -751,6 +751,7 @@
   .flatpickr-day.today {
     position: relative;
     color: $interactive-01;
+    font-weight: 600;
 
     &::after {
       content: '';
@@ -798,12 +799,24 @@
   .flatpickr-day.selected {
     color: $inverse-01;
     background: $interactive-01;
+
+    &:hover {
+      color: $text-01;
+    }
   }
 
   .#{$prefix}--date-picker__day.startRange.selected,
   .flatpickr-day.startRange.selected {
     box-shadow: none;
     z-index: 2;
+  }
+
+  .#{$prefix}--date-picker__day.endRange,
+  .flatpickr-day.endRange {
+    &:hover {
+      background: $ui-01;
+      @include focus-outline('outline');
+    }
   }
 
   .#{$prefix}--date-picker__day.endRange.inRange,


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components/issues/1927

- [x] use Plex mono `$code-02` for input fields
- [x] `.#{$prefix}--date-picker__icon` should have `fill: $icon-01`
- [x] `span.flatpickr-next-month` and `previous-month` need background on hover `$hover-ui`
![image](https://user-images.githubusercontent.com/11670886/53444061-cefb4580-39d2-11e9-90e2-921d7d80207c.png)
- [x] year arrows should be `$icon-01` by default and then `interactive-01` on hover
![image](https://user-images.githubusercontent.com/11670886/53444147-ffdb7a80-39d2-11e9-98dd-17ccba9397fb.png)
- [x] `bx--date-picker__day endRange` should have 2px  `$interactive-01` border
As-is:
![image](https://user-images.githubusercontent.com/11670886/53444331-7d06ef80-39d3-11e9-83ef-c92de9a15450.png)
To-be: 
![image](https://user-images.githubusercontent.com/11670886/53444376-9c058180-39d3-11e9-8a1e-316f791d18e1.png)
- [x] `today` should be using `font-weight: 600`


@aagonzales I was unsure what we should do when the selected day is hovered, is this okay? 

![screen shot 2019-02-26 at 3 25 41 pm](https://user-images.githubusercontent.com/11928039/53447482-cf97da00-39da-11e9-9908-e356d1edbc3d.png)
