### PR TITLE
fix(radio-button): support combinations of group/label

### DIFF
--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -92,8 +92,8 @@
     margin: 0px;
   }
 
-  .#{$prefix}--radio-button-wrapper + .#{$prefix}--radio-button-wrapper {
-    margin-left: 20px;
+  .#{$prefix}--radio-button-wrapper:not(:last-of-type) {
+    margin-right: $spacing-md;
   }
 
   .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-right .#{$prefix}--radio-button__label {
@@ -104,13 +104,18 @@
     flex-direction: row-reverse;
   }
 
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-left .#{$prefix}--radio-button__appearance {
+    margin-right: 0;
+    margin-left: $spacing-xs;
+  }
+
   .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-top .#{$prefix}--radio-button__label {
     flex-direction: column-reverse;
     text-align: center;
   }
 
   .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-top .#{$prefix}--radio-button__appearance {
-    margin: 0;
+    margin-right: 0;
   }
 
   .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-top .#{$prefix}--radio-button__label-text {
@@ -127,7 +132,7 @@
   }
 
   .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-bottom .#{$prefix}--radio-button__appearance {
-    margin: 0;
+    margin-right: 0;
   }
 }
 
@@ -229,6 +234,61 @@
 
   .#{$prefix}--radio-button__label.#{$prefix}--skeleton .#{$prefix}--radio-button__appearance {
     display: none;
+  }
+
+  .#{$prefix}--radio-button-wrapper .#{$prefix}--radio-button__label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0px;
+  }
+
+  .#{$prefix}--radio-button-wrapper:not(:last-of-type) {
+    margin-right: $spacing-md;
+  }
+
+  .#{$prefix}--radio-button-group--vertical .#{$prefix}--radio-button-wrapper:not(:last-of-type) {
+    margin-right: 0;
+    margin-bottom: $spacing-xs;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-right .#{$prefix}--radio-button__label {
+    flex-direction: row;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-left .#{$prefix}--radio-button__label {
+    flex-direction: row-reverse;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-left .#{$prefix}--radio-button__appearance {
+    margin-right: 0;
+    margin-left: $spacing-xs;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-top .#{$prefix}--radio-button__label {
+    flex-direction: column-reverse;
+    text-align: center;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-top .#{$prefix}--radio-button__appearance {
+    margin-right: 0;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-top .#{$prefix}--radio-button__label-text {
+    margin-bottom: 5px;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-bottom .#{$prefix}--radio-button__label {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-bottom .#{$prefix}--radio-button__label-text {
+    margin-top: 5px;
+  }
+
+  .#{$prefix}--radio-button-wrapper.#{$prefix}--radio-button-wrapper--label-bottom .#{$prefix}--radio-button__appearance {
+    margin-right: 0;
   }
 }
 

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -240,7 +240,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: 0px;
+    margin: 0;
   }
 
   .#{$prefix}--radio-button-wrapper:not(:last-of-type) {

--- a/src/components/radio-button/radio-button.config.js
+++ b/src/components/radio-button/radio-button.config.js
@@ -43,9 +43,84 @@ module.exports = {
       },
     },
     {
+      name: 'horizontal-bottom',
+      label: 'Radio button group (Label at bottom)',
+      context: {
+        direction: 'bottom',
+        selectedValue: 'red',
+        group: 'radio-button',
+        items,
+      },
+    },
+    {
+      name: 'horizontal-left',
+      label: 'Radio button group (Label at left)',
+      context: {
+        direction: 'left',
+        selectedValue: 'red',
+        group: 'radio-button',
+        items,
+      },
+    },
+    {
+      name: 'horizontal-top',
+      label: 'Radio button group (Label at top)',
+      context: {
+        direction: 'top',
+        selectedValue: 'red',
+        group: 'radio-button',
+        items,
+      },
+    },
+    {
       name: 'vertical',
       label: 'Vertical radio button group',
+      meta: {
+        xVersionOnly: true,
+      },
       context: {
+        selectedValue: 'red',
+        group: 'radio-button--vertical',
+        vertical: true,
+        items,
+      },
+    },
+    {
+      name: 'vertical-bottom',
+      label: 'Vertical radio button group (Label at bottom)',
+      meta: {
+        xVersionOnly: true,
+      },
+      context: {
+        direction: 'bottom',
+        selectedValue: 'red',
+        group: 'radio-button--vertical',
+        vertical: true,
+        items,
+      },
+    },
+    {
+      name: 'vertical-left',
+      label: 'Vertical radio button group (Label at left)',
+      meta: {
+        xVersionOnly: true,
+      },
+      context: {
+        direction: 'left',
+        selectedValue: 'red',
+        group: 'radio-button--vertical',
+        vertical: true,
+        items,
+      },
+    },
+    {
+      name: 'vertical-top',
+      label: 'Vertical radio button group (Label at top)',
+      meta: {
+        xVersionOnly: true,
+      },
+      context: {
+        direction: 'top',
         selectedValue: 'red',
         group: 'radio-button--vertical',
         vertical: true,

--- a/src/components/radio-button/radio-button.config.js
+++ b/src/components/radio-button/radio-button.config.js
@@ -9,24 +9,29 @@
 
 const { prefix } = require('../../globals/js/settings');
 
-const items = [
-  {
-    id: 'radio-button-1',
-    value: 'red',
-    label: 'Radio Button label',
-  },
-  {
-    id: 'radio-button-2',
-    value: 'green',
-    label: 'Radio Button label',
-  },
-  {
-    id: 'radio-button-3',
-    value: 'blue',
-    label: 'Radio Button label',
-    disabled: true,
-  },
-];
+const items = () => {
+  const groupId = Math.random()
+    .toString(36)
+    .substr(2);
+  return [
+    {
+      id: `radio-button-${groupId}-1`,
+      value: 'red',
+      label: 'Radio Button label',
+    },
+    {
+      id: `radio-button-${groupId}-2`,
+      value: 'green',
+      label: 'Radio Button label',
+    },
+    {
+      id: `radio-button-${groupId}-3`,
+      value: 'blue',
+      label: 'Radio Button label',
+      disabled: true,
+    },
+  ];
+};
 
 module.exports = {
   context: {
@@ -39,7 +44,7 @@ module.exports = {
       context: {
         selectedValue: 'red',
         group: 'radio-button',
-        items,
+        items: items(),
       },
     },
     {
@@ -49,7 +54,7 @@ module.exports = {
         direction: 'bottom',
         selectedValue: 'red',
         group: 'radio-button',
-        items,
+        items: items(),
       },
     },
     {
@@ -59,7 +64,7 @@ module.exports = {
         direction: 'left',
         selectedValue: 'red',
         group: 'radio-button',
-        items,
+        items: items(),
       },
     },
     {
@@ -69,7 +74,7 @@ module.exports = {
         direction: 'top',
         selectedValue: 'red',
         group: 'radio-button',
-        items,
+        items: items(),
       },
     },
     {
@@ -82,7 +87,7 @@ module.exports = {
         selectedValue: 'red',
         group: 'radio-button--vertical',
         vertical: true,
-        items,
+        items: items(),
       },
     },
     {
@@ -96,7 +101,7 @@ module.exports = {
         selectedValue: 'red',
         group: 'radio-button--vertical',
         vertical: true,
-        items,
+        items: items(),
       },
     },
     {
@@ -110,7 +115,7 @@ module.exports = {
         selectedValue: 'red',
         group: 'radio-button--vertical',
         vertical: true,
-        items,
+        items: items(),
       },
     },
     {
@@ -124,7 +129,7 @@ module.exports = {
         selectedValue: 'red',
         group: 'radio-button--vertical',
         vertical: true,
-        items,
+        items: items(),
       },
     },
   ],

--- a/src/components/radio-button/radio-button.hbs
+++ b/src/components/radio-button/radio-button.hbs
@@ -10,24 +10,9 @@
   <div class="{{@root.prefix}}--form-item">
     <div class="{{@root.prefix}}--radio-button-group {{#if vertical}} {{@root.prefix}}--radio-button-group--vertical {{/if}}">
       {{#each items}}
+        <div class="{{@root.prefix}}--radio-button-wrapper{{#if ../direction}} {{@root.prefix}}--radio-button-wrapper--label-{{../direction}}{{/if}}">
           <input id="{{id}}" class="{{@root.prefix}}--radio-button" type="radio" value="{{value}}" name="{{../group}}" tabindex="0"{{#is value ../selectedValue}} checked{{/is}}{{#if disabled}} disabled{{/if}}>
           <label for="{{id}}" class="{{@root.prefix}}--radio-button__label">
-            <span class="{{@root.prefix}}--radio-button__appearance"></span>
-            {{label}}
-          </label>
-      {{/each}}
-    </div>
-  </div>
-</fieldset>
-
-<fieldset class="{{@root.prefix}}--fieldset">
-  <legend class="{{@root.prefix}}--label">Radio Button heading</legend>
-  <div class="{{@root.prefix}}--form-item">
-    <div class="{{@root.prefix}}--radio-button-group">
-      {{#each items}}
-        <div class="{{@root.prefix}}--radio-button-wrapper {{@root.prefix}}--radio-button-wrapper--label-top">
-          <input id="{{id}}x" class="{{@root.prefix}}--radio-button" type="radio" value="{{value}}" name="{{../group}}" tabindex="0"{{#is value ../selectedValue}} checked{{/is}}{{#if disabled}} disabled{{/if}}>
-          <label for="{{id}}x" class="{{@root.prefix}}--radio-button__label">
             <span class="{{@root.prefix}}--radio-button__appearance"></span>
             <span class="{{@root.prefix}}--radio-button__label-text">{{label}}</span>
           </label>


### PR DESCRIPTION
The earlier commit (#1722) had styling problems with:

* Label positioned at left
* `.bx--radio-button-wrapper` used with the vertical radio group feature we introduced in `v10`

Also:

* Introduced a corresponding set of style definitions for `v10`
* Given `v9` doesn't have a support for vertical radio group, added a change to hide vertical radio group in `v9` dev env

Refs #1721.

#### Changelog

**New**

- `v10` support for #1722.
- Defined the radio group orientation and label positioning matrix as Fractal component variant configs.
- A setting to hide vertical radio group in `v9` dev env.

**Changed**

- Fixes for various radio group orientation and label positioning matrix.
- Merged the markup alternate label positioning to the main markup.
- Applied the same spacing token for the horizontal space between adjacent radio buttons to `.bx--radio-button-wrapper` usage.

#### Testing / Reviewing

Testing should make sure radio button is not broken, even with older markup.