### PR TITLE
chore(devenv): minify JS code for dev env for staging

### DIFF
--- a/demo/views/layouts/demo-nav.hbs
+++ b/demo/views/layouts/demo-nav.hbs
@@ -21,6 +21,6 @@
     <div data-renderroot></div>
     <input aria-label="inpute-text-offleft" type="text" class="offleft" />
     {{{yield}}}
-    <script src="/demo.js"></script>
+    <script src="/demo{{#if minify}}.min{{/if}}.js"></script>
   </body>
 </html>

--- a/demo/views/layouts/grid-preview.hbs
+++ b/demo/views/layouts/grid-preview.hbs
@@ -28,7 +28,7 @@
 
     <!-- Scripts -->
     <!-- <script src="/carbon-components.min.js"></script> -->
-    <script src="/demo.js"></script>
+    <script src="/demo{{#if minify}}.min{{/if}}.js"></script>
     <!-- Disable Auto Init with this flag -->
     <!-- true = JavaScript will not initialize automatically -->
     <!-- false = JavaScript will initialize automatically -->

--- a/demo/views/layouts/preview.hbs
+++ b/demo/views/layouts/preview.hbs
@@ -28,7 +28,7 @@
 
     <!-- Scripts -->
     <!-- <script src="/carbon-components.min.js"></script> -->
-    <script src="/demo.js"></script>
+    <script src="/demo{{#if minify}}.min{{/if}}.js"></script>
     <!-- Disable Auto Init with this flag -->
     <!-- true = JavaScript will not initialize automatically -->
     <!-- false = JavaScript will initialize automatically -->

--- a/demo/views/layouts/ui-shell-preview.hbs
+++ b/demo/views/layouts/ui-shell-preview.hbs
@@ -17,7 +17,7 @@
   <input aria-label="inpute-text-offleft" type="text" class="offleft" />
   <!-- Scripts -->
   <!-- <script src="/carbon-components.min.js"></script> -->
-  <script src="/demo.js"></script>
+  <script src="/demo{{#if minify}}.min{{/if}}.js"></script>
   <!-- Disable Auto Init with this flag -->
   <!-- true = JavaScript will not initialize automatically -->
   <!-- false = JavaScript will initialize automatically -->

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -166,6 +166,12 @@ gulp.task('scripts:dev', ['scripts:dev:feature-flags'], () => {
   });
 });
 
+gulp.task('scripts:dev:deploy', ['scripts:dev'], cb => {
+  const srcFile = './demo/demo.js';
+
+  pump([gulp.src(srcFile), terser(), rename('demo.min.js'), gulp.dest('demo')], cb);
+});
+
 gulp.task('scripts:dev:feature-flags', () => {
   const replaceTable = {
     breakingChangesX: useBreakingChanges,
@@ -410,6 +416,7 @@ gulp.task('html:dev', ['scripts:dev:feature-flags'], () =>
               routeWithQueryArgs: true,
               useStaticFullRenderPage: true,
             }),
+            minify: true,
           })
         ),
         ...componentSource
@@ -424,7 +431,7 @@ gulp.task('html:dev', ['scripts:dev:feature-flags'], () =>
           )
           .toArray(),
         templates
-          .render({ layout: 'preview' })
+          .render({ layout: 'preview', layoutContext: { minify: true } })
           .then(table =>
             Promise.all(
               Array.from(table.entries()).map(([{ handle }, value]) =>
@@ -546,6 +553,7 @@ gulp.task('build', ['build:scripts', 'build:styles', 'html:source']);
 
 // For demo environment
 gulp.task('build:dev', ['sass:dev', 'scripts:dev', 'html:dev']);
+gulp.task('build:dev:deploy', ['sass:dev', 'scripts:dev:deploy', 'html:dev']);
 
 gulp.task('default', () => {
   // eslint-disable-next-line no-console

--- a/package.json
+++ b/package.json
@@ -176,8 +176,8 @@
   "scripts": {
     "build": "gulp build",
     "build-dev": "gulp build:dev",
-    "build-dev-rollup": "gulp build:dev --rollup",
-    "build-dev-rollup-experimental": "gulp build:dev --rollup -e",
+    "build-dev-rollup": "gulp build:dev:deploy --rollup",
+    "build-dev-rollup-experimental": "gulp build:dev:deploy --rollup -e",
     "ci-check": "sh ./tools/ci-check.sh",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "dev": "gulp serve",

--- a/tools/templates.js
+++ b/tools/templates.js
@@ -113,13 +113,14 @@ const cache = {
  * @param {Object} [options] The options.
  * @param {string} [options.layout] The default Handlebars template name to lay out stuffs. `false` to force empty layout.
  * @param {boolean} [options.concat] Setting `true` here returns rendered contents all concatenated, instead of returning a map.
+ * @param {Object} [options.layoutContext] Additional Handlebars rendering context for layout template.
  * @param {string} [handle]
  *   The internal component name seen in Fractal.
  *   Can be of a component or of a variant, or left empty.
  *   Leaving `handle` empty renders all components.
  * @returns {string|Map<Variant, string>} The list of rendered template, keyed by Fractal `Variant` object.
  */
-const renderComponent = ({ layout, concat } = {}, handle) =>
+const renderComponent = ({ layout, concat, layoutContext } = {}, handle) =>
   cache.get().then(({ componentSource, contents }) => {
     const renderedItems = new Map();
     if (!componentSource) {
@@ -140,7 +141,10 @@ const renderComponent = ({ layout, concat } = {}, handle) =>
           if (template) {
             const body = template(context);
             const layoutTemplate = layout !== false && (contents.get(item.preview) || contents.get(layout));
-            renderedItems.set(item, !layoutTemplate ? body : layoutTemplate(Object.assign({ yield: body }, context)));
+            renderedItems.set(
+              item,
+              !layoutTemplate ? body : layoutTemplate(Object.assign({ yield: body }, { ...context, ...layoutContext }))
+            );
           }
         });
       }


### PR DESCRIPTION
#### Changelog

**New**

- Code to minify JavaScript code for dev env (`demo.js`) for staging. Not sure how much the difference is in the US, but in Japan the Netlify link (in this PR) is significantly faster.

#### Testing / Reviewing

Testing should make sure our dev env is not broken.