### PR TITLE
fix(tile): avoid `display: none` rule on input for a11y

### DIFF
--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -179,7 +179,7 @@
   }
 
   .#{$prefix}--tile-input {
-    display: none;
+    @include hidden();
   }
 }
 


### PR DESCRIPTION
Closes #1940

Related: https://github.com/IBM/carbon-components-react/issues/1114, https://github.com/IBM/carbon-components/pull/1670

This PR replaces the `display: none` rule on selectable tiles with our a11y-friendly mixin