### PR TITLE
chore(test): fix CLI argument conflict

### DIFF
--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -10,7 +10,7 @@ const flatten = a => a.reduce((result, item) => [...result, ...(Array.isArray(it
 const collect = (v, a) => (a.indexOf(v) < 0 ? [...a, v] : a);
 const defaultFiles = ['demo/polyfills/index.js'];
 const cloptions = commander
-  .option('-b, --browser [browser]', 'Browser to test with (ChromeHeadless or Chrome)', collect, [])
+  .option('--browser [browser]', 'Browser to test with (ChromeHeadless or Chrome)', collect, [])
   .option('-d, --debug', 'Disables collection of code coverage, useful for runinng debugger against specs or sources')
   .option('-f, --file [file]', 'Spec files to run', collect, defaultFiles)
   .option('-r, --random', 'Enable random execution order of tests')

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -4,7 +4,7 @@ set -e
 
 yarn build
 yarn lint
-yarn test:unit -- -b ChromeHeadless_Travis -b Firefox
+yarn test:unit -- --browser ChromeHeadless_Travis --browser Firefox
 yarn test:build
 if [[ -n "$RUN_EACH" ]]; then find tests/spec -name "*.js" ! -name left-nav_spec.js -print0 | xargs -0 -n 1 -P 1 yarn test:unit -- -d -f; fi
 if [[ -n "$AAT_TOKEN" ]]; then yarn test:a11y; fi


### PR DESCRIPTION
Between the flag for breaking change mode and the arg for choosing browser for test.

#### Changelog

**Changed**

- `ci-echeck` script reflecting below change.

**Removed**

- `-b` option for running tests, superseded by `--browser`.

#### Testing / Reviewing

Our tests should not be broken, including CI.