### PR TITLE
fix(components): update type styles

### DIFF
--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -437,7 +437,7 @@
   }
 
   .#{$prefix}--btn--copy__feedback {
-    @include font-family;
+    @include type-style('body-short-01');
     z-index: z('overlay');
     font-weight: 400;
     left: inherit;

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -650,7 +650,7 @@
 
   .#{$prefix}--date-picker__month .flatpickr-current-month,
   .flatpickr-month .flatpickr-current-month {
-    @include typescale('zeta');
+    @include type-style('heading-01');
     padding: 0;
   }
 
@@ -714,15 +714,14 @@
 
   span.#{$prefix}--date-picker__weekday,
   span.flatpickr-weekday {
-    @include typescale('zeta');
+    @include type-style('body-short-01');
     color: $text-01;
     font-weight: 400;
   }
 
   .#{$prefix}--date-picker__day,
   .flatpickr-day {
-    @include typescale('zeta');
-    @include focus-outline('reset');
+    @include type-style('body-short-01');
     height: rem(40px);
     width: rem(40px);
     display: flex;

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -113,7 +113,7 @@
   }
 
   .#{$prefix}--form-item {
-    @include font-family;
+    @include type-style('body-short-01');
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -182,7 +182,7 @@
   }
 
   .#{$prefix}--form__helper-text {
-    @include typescale('omega');
+    @include type-style('helper-text-01');
     font-style: italic;
     color: $text-02;
     line-height: 1.5;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -154,7 +154,6 @@
 
 @mixin modal--x {
   .#{$prefix}--modal {
-    @include font-family;
     position: fixed;
     top: 0;
     right: 0;

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -158,7 +158,6 @@
 @mixin progress-indicator--x {
   .#{$prefix}--progress {
     @include reset;
-    @include font-family;
     display: flex;
     list-style: none;
   }
@@ -202,7 +201,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    @include font-size('14');
+    @include type-style('body-short-01');
 
     &::before {
       content: '';
@@ -266,8 +265,7 @@
     position: absolute;
     margin-left: $spacing-lg;
     margin-top: rem(28px);
-    @include font-size('12');
-    color: $text-02;
+    @include type-style('label-01') color: $text-02;
   }
 
   //CURRENT STYLING

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -265,7 +265,8 @@
     position: absolute;
     margin-left: $spacing-lg;
     margin-top: rem(28px);
-    @include type-style('label-01') color: $text-02;
+    @include type-style('label-01');
+    color: $text-02;
   }
 
   //CURRENT STYLING

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -162,8 +162,7 @@
   }
 
   .#{$prefix}--radio-button__label {
-    @include typescale('zeta');
-    @include font-family;
+    @include type-style('body-short-01');
     display: flex;
     align-items: center;
     cursor: pointer;

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -182,7 +182,7 @@
 
   .#{$prefix}--search-input {
     @include reset;
-    @include font-family;
+    @include type-style('body-short-02');
     @include focus-outline('reset');
     appearance: none;
     border: none;
@@ -234,17 +234,17 @@
   }
 
   .#{$prefix}--search--sm .#{$prefix}--search-input {
-    @include typescale('zeta');
+    @include type-style('body-short-01');
     height: rem(32px);
   }
 
   .#{$prefix}--search--lg .#{$prefix}--search-input {
-    @include typescale('epsilon');
     height: rem(40px);
   }
 
   .#{$prefix}--search--xl .#{$prefix}--search-input {
-    @include typescale('epsilon');
+    @include type-style('body-short-02');
+    font-size: carbon--type-scale(4);
     height: rem(48px);
     padding: 0 rem(64px) 0 rem(48px);
   }

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -191,7 +191,6 @@
 
   .#{$prefix}--structured-list {
     @include reset;
-    @include font-family;
     display: table;
     overflow-x: auto;
     overflow-y: hidden;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -217,8 +217,7 @@
 
 @mixin tabs--x {
   .#{$prefix}--tabs {
-    @include typescale('zeta');
-    @include font-family;
+    @include type-style('body-short-01');
     color: $text-01;
     height: auto;
     width: 100%;
@@ -302,7 +301,6 @@
     z-index: z('dropdown');
     background: $ui-01;
     @include breakpoint(bp--sm--major) {
-      @include typescale('epsilon');
       flex-direction: row;
       margin-right: $spacing-md;
       margin-left: $spacing-md;
@@ -337,7 +335,6 @@
   // Item
   //-----------------------------
   .#{$prefix}--tabs__nav-item {
-    @include typescale('zeta');
     background-color: $ui-01;
     padding: 0;
     cursor: pointer;
@@ -385,14 +382,13 @@
     @include breakpoint(bp--sm--major) {
       .#{$prefix}--tabs__nav-link {
         color: $text-01;
-        font-weight: 600;
+        @include type-style('heading-01');
         border-bottom: 3px solid $interactive-01;
       }
 
       .#{$prefix}--tabs__nav-link:focus,
       .#{$prefix}--tabs__nav-link:active {
         color: $text-01;
-        font-weight: 600;
       }
     }
     @include max-breakpoint(bp--sm--major) {

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -74,8 +74,7 @@
 
 @mixin tags--x {
   .#{$prefix}--tag {
-    @include font-family;
-    @include typescale('omega');
+    @include type-style('label-01');
     display: inline-flex;
     align-items: center;
     padding: 0 $spacing-xs;

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -137,7 +137,7 @@
 
   .#{$prefix}--text-area::-webkit-input-placeholder {
     @include placeholder-colors;
-    @include font-family;
+    @include type-style('body-long-01');
   }
 
   .#{$prefix}--text-area--light {

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -314,7 +314,7 @@
 
   .#{$prefix}--toggle__text--left,
   .#{$prefix}--toggle__text--right {
-    @include typescale('zeta');
+    @include type-style('body-short-01');
     position: relative;
     margin-left: $spacing-xs;
   }

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -98,7 +98,7 @@
 
 @mixin button-reset($width: true) {
   @include reset;
-  @include font-family;
+  @include type-style('body-short-01');
   @include font-smoothing;
   @include letter-spacing;
   display: inline-block;


### PR DESCRIPTION
Refs #1945.

#### Changelog

**Changed**

- Type styles of various components, details below.

#### Testing / Reviewing

@IBM/carbon-designers: It'd be great if you can review focusing (only) on type tokens of the following components:

* Feedback text of code snippet (Couldn't find a spec for that in #1888)
* Date picker (#1927 is closed as fixed but still found usages of deprecated type tokens)
* Helper text for various form components
* Modal (#1843 does not cover type tokens)
* Progress indicator (In "needs review" state)
* Radio button (#1926/#1962 do not cover type tokens)
* Search (In "needs review" state)
* Structured list (Just removed a usage of deprecated type token which seems not needed)
* Tabs (In "needs review" state)
* Tag (In "stable" state, but still found usages of deprecated type tokens)
* Text area (#1946 does not cover type tokens)
* Toggle (#1911 does not cover type tokens)

Thanks!

BTW did _not_ touch the following components:

* Dropdown (Covered by #1955)
* Number input (Covered by #1939)
* Pagination (Covered by #1957)
* Select (Covered by #1958)
* Tooltip (Covered by #1954)