### PR TITLE
fix(date-picker): increase width of input field

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -508,7 +508,7 @@
 
   .#{$prefix}--date-picker.#{$prefix}--date-picker--simple {
     .#{$prefix}--date-picker__input {
-      width: 7.25rem;
+      width: rem(120px);
     }
   }
 


### PR DESCRIPTION
Closes #1980

Related https://github.com/IBM/carbon-components-react/issues/1965

This PR increases the width of the default date picker input