### PR TITLE
fix(link): reduce :focus:active underline width

### DIFF
--- a/demo/scss/demo.scss
+++ b/demo/scss/demo.scss
@@ -68,12 +68,6 @@ REASON: #{$reason}';
     .bx--interior-left-nav.bx--interior-left-nav--collapsed {
       width: 3rem;
     }
-
-    &.link div {
-      display: flex;
-      flex-direction: column;
-      grid-gap: 32px;
-    }
   }
 }
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -104,6 +104,7 @@
     display: inline;
     color: $disabled-02;
     font-weight: 400;
+    cursor: not-allowed;
   }
 }
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -74,7 +74,7 @@
     }
 
     &:focus:active {
-      box-shadow: 0 3px $text-01;
+      box-shadow: 0 1px $text-01;
     }
 
     &:not([href]) {


### PR DESCRIPTION
Closes #1995

This PR reduces the `.bx--link:focus:active` underline width according to the updated spec. I had to remove the flexbox rules on the demo link container because they were forcing the links to become block level