### PR TITLE
fix(form): set max width on helper text on non-mobile screens

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -187,8 +187,13 @@
     color: $text-02;
     z-index: 0;
     opacity: 1;
-    max-width: 75%;
     margin-bottom: $spacing-xs;
+  }
+
+  @media (min-width: breakpoint('sm')) {
+    .#{$prefix}--form__helper-text {
+      max-width: 75%;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #2000

This PR adds a media query to reduce the width of form component helper text only on non-mobile screen sizes only