### PR TITLE
[Audit] Select fixes

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -61,14 +61,6 @@
       box-shadow: 0 2px 0 0 $support-01;
     }
 
-    &:focus ~ .#{$prefix}--label {
-      color: $brand-01;
-    }
-
-    &[data-invalid]:focus ~ .#{$prefix}--label {
-      color: $support-01;
-    }
-
     &:disabled {
       opacity: 0.5;
       cursor: not-allowed;


### PR DESCRIPTION
Closes #1958

**Changed**

~- [ ]  fix inline Select: should be dynamic width that sizes to content~
PR ready for merge, other issues addressed in https://github.com/IBM/carbon-components/pull/1978

**Removed**

- [x]  removed unused CSS rules in v9 Select that was attempting to style the label color of focused form elements, but was no doing that job (afaik we removed this label color change from the spec, but lemme know if that's a problem!)

