### PR TITLE
fix(dropdown): add inline display rule to inline dropdown

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -432,11 +432,12 @@
   }
 
   .#{$prefix}--dropdown--inline {
+    display: inline-block;
     border-bottom-color: transparent;
     background-color: transparent;
     box-shadow: none;
     transition-property: none;
-    width: initial;
+    width: auto;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
Closes #2017

This PR sets the display rule of inline dropdowns to be `inline-block`