### PR TITLE
chore: bump minimatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "lolex": "1.4.0",
     "markdown-it": "^8.4.0",
     "merge-stream": "^1.0.0",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.4",
     "mkdirp": "^0.5.0",
     "mock-raf": "^1.0.0",
     "node-sass": "^4.11.0",


### PR DESCRIPTION
Closes #2021

This PR bumps our `minimatch` version to address a reported security vulnerability