### PR TITLE
fix(form): remove overflow and max-height rules

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -149,7 +149,7 @@
   }
 
   input[data-invalid],
-  textarea[data-invalid],
+  .#{$prefix}--text-area__wrapper[data-invalid],
   .#{$prefix}--select-input__wrapper[data-invalid],
   .#{$prefix}--list-box[data-invalid] {
     outline: 2px solid $support-01;

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -149,6 +149,7 @@
   }
 
   input[data-invalid],
+  .#{$prefix}--text-input__field-wrapper[data-invalid],
   .#{$prefix}--text-area__wrapper[data-invalid],
   .#{$prefix}--select-input__wrapper[data-invalid],
   .#{$prefix}--list-box[data-invalid] {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -150,7 +150,7 @@
 
   input[data-invalid],
   textarea[data-invalid],
-  select[data-invalid],
+  .#{$prefix}--select-input__wrapper[data-invalid],
   .#{$prefix}--list-box[data-invalid] {
     outline: 2px solid $support-01;
     outline-offset: -2px;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -370,10 +370,6 @@
     right: rem(48px);
   }
 
-  .#{$prefix}--select--inline[data-invalid] {
-    @include focus-outline('invalid');
-  }
-
   .#{$prefix}--select--inline .#{$prefix}--select-input:disabled {
     color: $disabled;
     cursor: not-allowed;

--- a/src/components/select/migrate-to-10.x.md
+++ b/src/components/select/migrate-to-10.x.md
@@ -1,3 +1,11 @@
 ### HTML
 
 Icon from [`carbon-elements`](https://github.com/IBM/carbon-elements) package is now used. Vanilla markup should be migrated to one shown in [carbondesignsystem.com](https://next.carbondesignsystem.com/components/select/code) site. React and other framework variants should reflect the change automatically.
+
+### SCSS
+
+The `data-invalid` attribute has moved to account for the new markup
+
+| Old Class            | New Class                                 | Note    |
+| -------------------- | ----------------------------------------- | ------- |
+| select[data-invalid] | bx--select-input\_\_wrapper[data-invalid] | Changed |

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -7,7 +7,7 @@
 
 <div class="{{@root.prefix}}--form-item">
   <div
-    class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}}">
+    class="{{@root.prefix}}--select {{#if inline}}{{@root.prefix}}--select--inline{{/if}} {{#if light}}{{@root.prefix}}--select--light{{/if}}">
     <label for="select-id" class="{{@root.prefix}}--label">Select label</label>
     {{#unless inline}}
     {{#if helperText}}
@@ -16,30 +16,52 @@
     {{/unless}}
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--select-input__wrapper">
-      <select {{#if invalid}} data-invalid{{/if}} id="select-id" class="{{@root.prefix}}--select-input {{#if invalid}} {{@root.prefix}}--select--invalid {{/if}}">
+      <select {{#if invalid}}data-invalid{{/if}} id="select-id"
+        class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}">
         {{#each items}}
         {{#if items}}
         <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
           {{#each items}}
-          <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-            selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}}
-        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-            selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/if}} {{/each}} </select>
+          <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}}
+            {{#if selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+            {{label}}
+          </option>
+          {{/each}}
+        </optgroup>
+        {{else}}
+        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}}
+          {{#if selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+          {{label}}
+        </option>
+        {{/if}}
+        {{/each}}
+      </select>
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{#if invalid}}
       {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--select__invalid-icon')}}
       {{/if}}
     </div>
     {{else}}
-    <select {{#if invalid}} data-invalid{{/if}} id="select-id" class="{{@root.prefix}}--select-input {{#if invalid}} {{@root.prefix}}--select--invalid {{/if}}">
+    <select {{#if invalid}}data-invalid{{/if}} id="select-id"
+      class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}">
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
         {{#each items}}
-        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-          selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}}
-      <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-          selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/if}} {{/each}} </select>
+        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}} {{#if
+          selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+          {{label}}
+        </option>
+        {{/each}}
+      </optgroup>
+      {{else}}
+      <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}} {{#if
+          selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+        {{label}}
+      </option>
+      {{/if}}
+      {{/each}}
+    </select>
     <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>
@@ -68,27 +90,48 @@
     {{/unless}}
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--select-input__wrapper">
-      <select {{#if invalid}} data-invalid{{/if}} id="select-id-disabled" class="{{@root.prefix}}--select-input {{#if invalid}} {{@root.prefix}}--select--invalid {{/if}}" disabled>
+      <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled"
+        class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}" disabled>
         {{#each items}}
         {{#if items}}
         <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
           {{#each items}}
-          <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-            selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}}
-        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-            selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/if}} {{/each}} </select>
+          <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}}
+            {{#if selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+            {{label}}
+          </option>
+          {{/each}}
+        </optgroup>
+        {{else}}
+        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}}
+          {{#if selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+          {{label}}
+        </option>
+        {{/if}}
+        {{/each}}
+      </select>
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
     </div>
     {{else}}
-    <select {{#if invalid}} data-invalid{{/if}} id="select-id-disabled" class="{{@root.prefix}}--select-input {{#if invalid}} {{@root.prefix}}--select--invalid {{/if}}" disabled>
+    <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled"
+      class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid {{/if}}" disabled>
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
         {{#each items}}
-        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-          selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}}
-      <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
-          selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/if}} {{/each}} </select>
+        <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}}
+          {{#if selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+          {{label}}
+        </option>
+        {{/each}}
+      </optgroup>
+      {{else}}
+      <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}}disabled{{/if}}
+        {{#if selected}}selected{{/if}} {{#if hidden}}hidden{{/if}}>
+        {{label}}
+      </option>{{/if}}
+      {{/each}}
+    </select>
     <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
       <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
     </svg>

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -15,8 +15,8 @@
     {{/if}}
     {{/unless}}
     {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--select-input__wrapper">
-      <select {{#if invalid}}data-invalid{{/if}} id="select-id"
+    <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
+      <select id="select-id"
         class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}">
         {{#each items}}
         {{#if items}}
@@ -89,8 +89,8 @@
     {{/if}}
     {{/unless}}
     {{#if @root.featureFlags.componentsX}}
-    <div class="{{@root.prefix}}--select-input__wrapper">
-      <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled"
+    <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
+      <select id="select-id-disabled"
         class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}" disabled>
         {{#each items}}
         {{#if items}}

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -114,7 +114,7 @@
     </div>
     {{else}}
     <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled"
-      class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid {{/if}}" disabled>
+      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}" disabled>
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -43,7 +43,7 @@
     </div>
     {{else}}
     <select {{#if invalid}}data-invalid{{/if}} id="select-id"
-      class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}">
+      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}">
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -91,7 +91,7 @@
     {{#if @root.featureFlags.componentsX}}
     <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
       <select id="select-id-disabled"
-        class="{{@root.prefix}}--select-input {{#if invalid}}{{@root.prefix}}--select--invalid{{/if}}" disabled>
+        class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}" disabled>
         {{#each items}}
         {{#if items}}
         <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -7,7 +7,7 @@
 
 <div class="{{@root.prefix}}--form-item">
   <div
-    class="{{@root.prefix}}--select {{#if inline}}{{@root.prefix}}--select--inline{{/if}} {{#if light}}{{@root.prefix}}--select--light{{/if}}">
+    class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}}">
     <label for="select-id" class="{{@root.prefix}}--label">Select label</label>
     {{#unless inline}}
     {{#if helperText}}

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -178,9 +178,7 @@
   //-----------------------------
   // Error
   //-----------------------------
-  .#{$prefix}--text-area[data-invalid],
-  .#{$prefix}--text-area--invalid,
-  .#{$prefix}--text-area:invalid {
+  .#{$prefix}--text-area--invalid {
     @include focus-outline('invalid');
     box-shadow: none;
   }

--- a/src/components/text-area/migrate-to-10.x.md
+++ b/src/components/text-area/migrate-to-10.x.md
@@ -1,0 +1,7 @@
+### SCSS
+
+The `data-invalid` attribute has moved to account for the new markup
+
+| Old Class              | New Class                              | Note    |
+| ---------------------- | -------------------------------------- | ------- |
+| textarea[data-invalid] | bx--text-area\_\_wrapper[data-invalid] | Changed |

--- a/src/components/text-area/text-area.hbs
+++ b/src/components/text-area/text-area.hbs
@@ -23,9 +23,9 @@
 <div class="{{@root.prefix}}--form-item">
   <label for="text-area-3" class="{{@root.prefix}}--label">Text Area label</label>
   {{#if componentsX}}
-  <div class="{{@root.prefix}}--text-area__wrapper">
+  <div class="{{@root.prefix}}--text-area__wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--text-area__invalid-icon')}}
-    <textarea data-invalid id="text-area-3"
+    <textarea id="text-area-3"
       class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--invalid {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
       rows="4" cols="50" placeholder="Placeholder text."></textarea>
   </div>

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -235,8 +235,7 @@
   //-----------------------------
   // Error
   //-----------------------------
-  .#{$prefix}--text-input[data-invalid],
-  .#{$prefix}--text-input:invalid {
+  .#{$prefix}--text-input--invalid {
     @include focus-outline('invalid');
     box-shadow: none;
 

--- a/src/components/text-input/migrate-to-10.x.md
+++ b/src/components/text-input/migrate-to-10.x.md
@@ -1,3 +1,11 @@
 ### HTML
 
 Icon from [`carbon-elements`](https://github.com/IBM/carbon-elements) package is now used. Vanilla markup should be migrated to one shown in [carbondesignsystem.com](https://next.carbondesignsystem.com/components/text-input/code) site. React and other framework variants should reflect the change automatically.
+
+### SCSS
+
+The `data-invalid` attribute has moved to account for the new markup
+
+| Old Class           | New Class                                     | Note    |
+| ------------------- | --------------------------------------------- | ------- |
+| input[data-invalid] | bx--text-input\_\_field-wrapper[data-invalid] | Changed |

--- a/src/components/text-input/text-input.hbs
+++ b/src/components/text-input/text-input.hbs
@@ -57,10 +57,10 @@
   class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
   <label for="text-input-4" class="{{prefix}}--label">Text Input label</label>
   {{#if componentsX}}
-  <div class="{{prefix}}--text-input__field-wrapper">
+  <div class="{{prefix}}--text-input__field-wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-input__invalid-icon')}}
     {{#unless password}}
-    <input data-invalid id="text-input-4" type="text"
+    <input id="text-input-4" type="text"
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid {{#if light}} {{prefix}}--text-input--light{{/if}}"
       placeholder="Placeholder text">
     {{else}}


### PR DESCRIPTION
Closes #2023

This PR addresses the overlap between validation messages and form item labels. Some redundant style rules are also removed (`overflow: hidden`) since they are already accounted for by other style rules