### PR TITLE
fix(text-input): add missing disabled color token

### DIFF
--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -208,6 +208,7 @@
     outline: none;
     background-color: $disabled-01;
     border-bottom: 1px solid transparent;
+    color: $disabled-02;
   }
 
   .#{$prefix}--text-input--light:disabled {


### PR DESCRIPTION
Closes #2028 

Related: https://github.com/IBM/carbon-components-react/issues/1989

This PR adds the disabled color value to text contained within disabled text input fields