### PR TITLE
docs(migrate): add root migration guide and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you just want to try out `carbon-components`, you can also use [CodeSandbox](
 - See our documentation site [here](http://carbondesignsystem.com/getting-started/developers) for full how-to docs and guidelines
 - [Contributing](/.github/CONTRIBUTING.md): Guidelines for making contributions to this repo.
 - [🏃‍♀️ Migration Guides](./docs/migration)
-  - [v9](./docs/migrate-to-10.x.md)
+  - [v9 to v10](./docs/migrate-to-10.x.md)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
 # carbon-components
 
+[![Carbon Components is released under the Apache-2.0 license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![Build Status](https://travis-ci.org/IBM/carbon-components.svg?branch=master)](https://travis-ci.org/IBM/carbon-components)
+[![PRs welcome!](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./.github/CONTRIBUTING.md)
 
 The Carbon Design System is a series of individual styles and components, that when combined make beautiful, intuitive designs. These designs are systemic and logical, as they all follow the same universal principles.
 
 The component library gives developers a collection of re-usable HTML and SCSS partials for building their products.
 
-# How to install
+## Getting started
 
-Run the following command using [npm](https://www.npmjs.com/):
+To install `carbon-components` in your project, you will need to run the
+following command using [npm](https://www.npmjs.com/):
 
 ```bash
 npm install -S carbon-components
 ```
 
-If you prefer [Yarn](https://yarnpkg.com/en/), use the following command instead:
+If you prefer [Yarn](https://yarnpkg.com/en/), use the following
+command instead:
 
 ```bash
 yarn add carbon-components
 ```
 
-(**Important note**: `src` directory in the package has been deprecated and subject to breaking changes. Please use `es`/`umd`/`scss` directories instead)
-
 If you just want to try out `carbon-components`, you can also use [CodeSandbox](https://codesandbox.io).
 
 [![Edit carbon-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/IBM/carbon-components/tree/master/examples/codesandbox)
+
+(**Important note**: `src` directory in the package has been deprecated and subject to breaking changes. Please use `es`/`umd`/`scss` directories instead)
 
 # :books: Documentation
 
 - See our documentation site [here](http://carbondesignsystem.com/getting-started/developers) for full how-to docs and guidelines
 - [Contributing](/.github/CONTRIBUTING.md): Guidelines for making contributions to this repo.
+- [🏃‍♀️ Migration Guides](./docs/migration)
+  - [v9](./docs/migrate-to-10.x.md)
 
 ## Contributors
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,5 @@
+# Migration Guides
+
+Available guides:
+
+- [v9](./migrate-to-10.x.md)

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -2,4 +2,4 @@
 
 Available guides:
 
-- [v9](./migrate-to-10.x.md)
+- [v9 to v10](./migrate-to-10.x.md)

--- a/docs/migration/migrate-to-10.x.md
+++ b/docs/migration/migrate-to-10.x.md
@@ -56,7 +56,7 @@ Anything in this document is subject to change up until v10 is released._
 | Structured List    | [Migrate](../../src/components/structured-list/migrate-to-10.x.md)    |
 | Tabs               | [Migrate](../../src/components/tabs/migrate-to-10.x.md)               |
 | Tag                | [Migrate](../../src/components/tag/migrate-to-10.x.md)                |
-| Text Area          | No breaking changes                                                   |
+| Text Area          | TODO                                                                  |
 | Text Input         | [Migrate](../../src/components/text-input/migrate-to-10.x.md)         |
 | Tile               | [Migrate](../../src/components/tile/migrate-to-10.x.md)               |
 | Time Picker        | [Migrate](../../src/components/time-picker/migrate-to-10.x.md)        |

--- a/docs/migration/migrate-to-10.x.md
+++ b/docs/migration/migrate-to-10.x.md
@@ -1,0 +1,76 @@
+# 10.x Migration
+
+_Note: this migration guide is for a future, unreleased version of Carbon.
+Anything in this document is subject to change up until v10 is released._
+
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Components](#components)
+- [Styles](#styles)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
+
+## Components
+
+| Component          | v10                                                                   |
+| ------------------ | --------------------------------------------------------------------- |
+| Accordion          | [Migrate](../../src/components/accordion/migrate-to-10.x.md)          |
+| Breadcrumb         | [Migrate](../../src/components/breadcrumb/migrate-to-10.x.md)         |
+| Button             | [Migrate](../../src/components/button/migrate-to-10.x.md)             |
+| Carousel           | Removed                                                               |
+| Checkbox           | No breaking changes                                                   |
+| Code Snippet       | [Migrate](../../src/components/code-snippet/migrate-to-10.x.md)       |
+| Combobox           | No breaking changes                                                   |
+| Content Switcher   | [Migrate](../../src/components/content-switcher/migrate-to-10.x.md)   |
+| Copy Button        | [Migrate](../../src/components/copy-button/migrate-to-10.x.md)        |
+| Data Table V2      | TODO                                                                  |
+| Data Table         | Removed                                                               |
+| Date Picker        | TODO                                                                  |
+| Dropdown           | [Migrate](../../src/components/dropdown/migrate-to-10.x.md)           |
+| Fab                | Removed                                                               |
+| File Uploader      | [Migrate](../../src/components/file-uploader/migrate-to-10.x.md)      |
+| Footer             | Removed                                                               |
+| Form               | [Migrate](../../src/components/form/migrate-to-10.x.md)               |
+| Inline Loading     | [Migrate](../../src/components/inline-loading/migrate-to-10.x.md)     |
+| Interior Left Nav  | Removed                                                               |
+| Lightbox           | Removed                                                               |
+| Link               | No breaking changes                                                   |
+| List Box           | No breaking changes                                                   |
+| List               | No breaking changes                                                   |
+| Loading            | [Migrate](../../src/components/loading/migrate-to-10.x.md)            |
+| Modal              | [Migrate](../../src/components/modal/migrate-to-10.x.md)              |
+| MultiSelect        | No breaking changes                                                   |
+| Notification       | [Migrate](../../src/components/notification/migrate-to-10.x.md)       |
+| Number Input       | [Migrate](../../src/components/number-input/migrate-to-10.x.md)       |
+| Overflow Menu      | [Migrate](../../src/components/overflow-menu/migrate-to-10.x.md)      |
+| Pagination Nav     | Removed                                                               |
+| Pagination         | [Migrate](../../src/components/pagination/migrate-to-10.x.md)         |
+| Progress Indicator | [Migrate](../../src/components/progress-indicator/migrate-to-10.x.md) |
+| Radio Button       | [Migrate](../../src/components/radio-button/migrate-to-10.x.md)       |
+| Search             | [Migrate](../../src/components/search/migrate-to-10.x.md)             |
+| Select             | [Migrate](../../src/components/select/migrate-to-10.x.md)             |
+| Slider             | [Migrate](../../src/components/slider/migrate-to-10.x.md)             |
+| Structured List    | [Migrate](../../src/components/structured-list/migrate-to-10.x.md)    |
+| Tabs               | [Migrate](../../src/components/tabs/migrate-to-10.x.md)               |
+| Tag                | [Migrate](../../src/components/tag/migrate-to-10.x.md)                |
+| Text Area          | No breaking changes                                                   |
+| Text Input         | [Migrate](../../src/components/text-input/migrate-to-10.x.md)         |
+| Tile               | [Migrate](../../src/components/tile/migrate-to-10.x.md)               |
+| Time Picker        | [Migrate](../../src/components/time-picker/migrate-to-10.x.md)        |
+| Toggle             | No breaking changes                                                   |
+| Toolbar            | [Migrate](../../src/components/toolbar/migrate-to-10.x.md)            |
+| Tooltip            | [Migrate](../../src/components/tooltip/migrate-to-10.x.md)            |
+| UI Shell           | New, experimental                                                     |
+| Unified Header     | Removed                                                               |
+
+## Styles
+
+| `scss` path         | v10                                                                           |
+| ------------------- | ----------------------------------------------------------------------------- |
+| `src`               | Deprecated in v10, use `scss` instead [Migrate](../../src/migrate-to-10.x.md) |
+| `scss/globals`      | [Migrate](../../src/globals/scss/migrate-to-10.x.md)                          |
+| `scss/globals/grid` | [Migrate](../../src/globals/scss/grid/migrate-to-10.x.md)                     |

--- a/docs/migration/migrate-to-10.x.md
+++ b/docs/migration/migrate-to-10.x.md
@@ -47,7 +47,6 @@ Anything in this document is subject to change up until v10 is released._
 | Notification       | [Migrate](../../src/components/notification/migrate-to-10.x.md)       |
 | Number Input       | [Migrate](../../src/components/number-input/migrate-to-10.x.md)       |
 | Overflow Menu      | [Migrate](../../src/components/overflow-menu/migrate-to-10.x.md)      |
-| Pagination Nav     | Removed                                                               |
 | Pagination         | [Migrate](../../src/components/pagination/migrate-to-10.x.md)         |
 | Progress Indicator | [Migrate](../../src/components/progress-indicator/migrate-to-10.x.md) |
 | Radio Button       | [Migrate](../../src/components/radio-button/migrate-to-10.x.md)       |


### PR DESCRIPTION
Closes #2034

Add root migration guide doc for v10

#### Changelog

**New**

- `docs/migration/migrate-to-10.x.md` as an index view for all changes

**Changed**

- Update README with migration guide content

**Removed**

