### PR TITLE
WIP chore(js): include IE11 support in demo JS build

### DIFF
--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -61,6 +61,16 @@ module.exports = {
       exclude: ['node_modules/**'],
     }),
     babel({
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              browsers: ['last 1 version', 'ie >= 11'],
+            },
+          },
+        ],
+      ],
       include: ['node_modules/markdown-it/**'],
     }),
     replace({

--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -48,6 +48,16 @@ module.exports = {
       },
     }),
     babel({
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              browsers: ['last 1 version', 'ie >= 11'],
+            },
+          },
+        ],
+      ],
       exclude: ['node_modules/**'],
     }),
     babel({

--- a/tools/rollup.config.js
+++ b/tools/rollup.config.js
@@ -14,6 +14,16 @@ module.exports = {
       sourceMap: false,
     }),
     babel({
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              browsers: ['last 1 version', 'ie >= 11'],
+            },
+          },
+        ],
+      ],
       exclude: ['node_modules/**'], // only transpile our source code
     }),
     replace({


### PR DESCRIPTION
Closes #2046 

Fixes issue where IE11 is throwing a syntax error because of a `class` keyword when rendering any component from the demo environment.