### PR TITLE
chore(devenv): use transpiled code as markdown-it mock

### DIFF
--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -13,9 +13,11 @@ module.exports = {
       load(id) {
         if (id === require.resolve('markdown-it')) {
           return `
-            export default class Markdown {
+            function Markdown() {}
+            Markdown.prototype = {
               render() { return '' }
-            }
+            };
+            export default Markdown;
           `;
         }
         if (id === path.resolve(__dirname, '../src/globals/js/feature-flags.js')) {
@@ -49,9 +51,6 @@ module.exports = {
     }),
     babel({
       exclude: ['node_modules/**'],
-    }),
-    babel({
-      include: ['node_modules/markdown-it/**'],
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),


### PR DESCRIPTION
So we don't have to run `rollup-plugin-babel` for that mock. `rollup-plugin-babel` for that mock wasn't applied to that mock anyway in recent code, which broke IE.

Fixes #2046.

#### Changelog

**Changed**

- `markdown-it` mock in `rollup.config.dev.js` now is a transpiled version of a JavaScript class.

**Removed**

- `rollup-plugin-babel` usage for `markdown-it` in `rollup.config.dev.js` (One used for deployed version of dev env build)

#### Testing / Reviewing

Testing should make sure our dev env, especially the deployed version, is not broken.