### PR TITLE
refactor(overflow-menu): convert item to flex item

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -319,16 +319,14 @@
     width: 100%;
     height: 100%;
     border: none;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     background-color: transparent;
     text-align: left;
     padding: 0 $spacing-md;
     cursor: pointer;
     color: $text-02;
     max-width: 11.25rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     transition: outline $transition--base, background-color $transition--base, color $transition--base;
 
     &:hover {
@@ -342,6 +340,12 @@
     &::-moz-focus-inner {
       border: none;
     }
+  }
+
+  .#{$prefix}--overflow-menu-options__option-content {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .#{$prefix}--overflow-menu-options__option:hover {

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -25,10 +25,24 @@
       class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
       <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
-        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1"
-        {{/if}}>{{label}}</button>
+        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          {{label}}
+        </div>
+      </button>
     </li>
     {{/each}}
+    <li
+      class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
+      role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
+        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          Add
+        </div>
+        {{carbon-icon 'Add16'}}
+      </button>
+    </li>
   </ul>
 </div>
 
@@ -52,10 +66,24 @@
       class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
       <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
-        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1"
-        {{/if}}>{{label}}</button>
+        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          {{label}}
+        </div>
+      </button>
     </li>
     {{/each}}
+    <li
+      class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
+      role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
+        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          Add
+        </div>
+        {{carbon-icon 'Add16'}}
+      </button>
+    </li>
   </ul>
 </div>
 
@@ -80,8 +108,24 @@
       role="presentation">
       <a href="https://www.ibm.com" class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}}
         title="{{title}}" {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}}
-        tabindex="-1" {{/if}}>{{label}}</a>
+        tabindex="-1" {{/if}}>
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          {{label}}
+        </div>
+      </a>
     </li>
     {{/each}}
+    <li
+      class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
+      role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
+      <a href="https://www.ibm.com" class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}}
+        title="{{title}}" {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}}
+        tabindex="-1" {{/if}}>
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          Add
+        </div>
+        {{carbon-icon 'Add16'}}
+      </a>
+    </li>
   </ul>
 </div>

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -59,26 +59,28 @@
   </ul>
 </div>
 
-<div data-overflow-menu tabindex="0" aria-label="Overflow" class="{{@root.prefix}}--overflow-menu" role="button" aria-haspopup="true"
-  aria-expanded="false">
+<div data-overflow-menu tabindex="0" aria-label="Overflow" class="{{@root.prefix}}--overflow-menu" role="button"
+  aria-haspopup="true" aria-expanded="false">
   {{#if @root.featureFlags.componentsX}}
-    {{ carbon-icon 'OverflowMenuVertical16' class=(add @root.prefix '--overflow-menu__icon') }}
+  {{ carbon-icon 'OverflowMenuVertical16' class=(add @root.prefix '--overflow-menu__icon') }}
   {{else}}
-    <svg aria-hidden="true" class="{{@root.prefix}}--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
-      <g fill-rule="evenodd">
-        <circle cx="1.5" cy="1.5" r="1.5" />
-        <circle cx="1.5" cy="7.5" r="1.5" />
-        <circle cx="1.5" cy="13.5" r="1.5" />
-      </g>
-    </svg>
+  <svg aria-hidden="true" class="{{@root.prefix}}--overflow-menu__icon" width="3" height="15" viewBox="0 0 3 15">
+    <g fill-rule="evenodd">
+      <circle cx="1.5" cy="1.5" r="1.5" />
+      <circle cx="1.5" cy="7.5" r="1.5" />
+      <circle cx="1.5" cy="13.5" r="1.5" />
+    </g>
+  </svg>
   {{/if}}
-  <ul class="{{@root.prefix}}--overflow-menu-options {{@root.prefix}}--overflow-menu--flip" tabindex="-1" data-floating-menu-direction="{{direction}}"
-    role="menu" aria-label="Overflow">
+  <ul class="{{@root.prefix}}--overflow-menu-options {{@root.prefix}}--overflow-menu--flip" tabindex="-1"
+    data-floating-menu-direction="{{direction}}" role="menu" aria-label="Overflow">
     {{#each items}}
-    <li class="{{@root.prefix}}--overflow-menu-options__option{{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled{{/if}}{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}"
+    <li
+      class="{{@root.prefix}}--overflow-menu-options__option{{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled{{/if}}{{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger{{/if}}"
       role="presentation">
-      <a href="https://www.ibm.com"  class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}" {{/if}}
-        {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}} tabindex="-1" {{/if}}>{{label}}</a>
+      <a href="https://www.ibm.com" class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}}
+        title="{{title}}" {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}}
+        tabindex="-1" {{/if}}>{{label}}</a>
     </li>
     {{/each}}
   </ul>

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -26,12 +26,17 @@
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
       <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
         {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+        {{#if @root.featureFlags.componentsX}}
         <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          {{/if}}
           {{label}}
+          {{#if @root.featureFlags.componentsX}}
         </div>
+        {{/if}}
       </button>
     </li>
     {{/each}}
+    {{#if @root.featureFlags.componentsX}}
     <li
       class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
@@ -43,6 +48,7 @@
         {{carbon-icon 'Add16'}}
       </button>
     </li>
+    {{/if}}
   </ul>
 </div>
 
@@ -67,12 +73,17 @@
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
       <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
         {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+        {{#if @root.featureFlags.componentsX}}
         <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          {{/if}}
           {{label}}
+          {{#if @root.featureFlags.componentsX}}
         </div>
+        {{/if}}
       </button>
     </li>
     {{/each}}
+    {{#if @root.featureFlags.componentsX}}
     <li
       class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
@@ -84,6 +95,7 @@
         {{carbon-icon 'Add16'}}
       </button>
     </li>
+    {{/if}}
   </ul>
 </div>
 
@@ -109,12 +121,17 @@
       <a href="https://www.ibm.com" class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}}
         title="{{title}}" {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}}
         tabindex="-1" {{/if}}>
+        {{#if @root.featureFlags.componentsX}}
         <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          {{/if}}
           {{label}}
+          {{#if @root.featureFlags.componentsX}}
         </div>
+        {{/if}}
       </a>
     </li>
     {{/each}}
+    {{#if @root.featureFlags.componentsX}}
     <li
       class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
       role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
@@ -127,5 +144,6 @@
         {{carbon-icon 'Add16'}}
       </a>
     </li>
+    {{/if}}
   </ul>
 </div>


### PR DESCRIPTION
Closes #2052

This PR converts overflow menu items to flex containers and wraps its content to still enable ellipsis overflow as a flex child