### PR TITLE
fix(overflow-menu): use correct tokens for item icons

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -342,6 +342,14 @@
     }
   }
 
+  .#{$prefix}--overflow-menu-options__btn svg {
+    fill: $icon-02;
+  }
+
+  .#{$prefix}--overflow-menu-options__btn:hover svg {
+    fill: $icon-01;
+  }
+
   .#{$prefix}--overflow-menu-options__option-content {
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
Closes #2051

This PR adds style rules to keep menu item button icon colors consistent with menu item text colors

Depends on #2053