### PR TITLE
fix(form): use caption-01 style for validation UI

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -169,7 +169,7 @@
 
   .#{$prefix}--form-requirement {
     @include reset;
-    @include type-style('label-01');
+    @include type-style('caption-01');
     margin: $spacing-2xs 0 0;
     max-height: 0;
     overflow: hidden;


### PR DESCRIPTION
Closes #2058

This PR replaces the `label-01` type styles for validation UI with `caption-01` type styles

#### Testing / Reviewing

check that the validation messages for invalid component examples has the correct type styles
