### PR TITLE
chore(sass): add spacing variables for dynamic generation of classes

### DIFF
--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -56,3 +56,27 @@ $layout-md: $spacing-baseline * 3 !default;
 $layout-lg: $spacing-baseline * 4 !default;
 $layout-xl: $spacing-baseline * 6 !default;
 $layout-2xl: $spacing-baseline * 10 !default;
+
+$carbon-spacing: (
+    spacing: (
+        2xs: $layout-2xs,
+        xs: $layout-xs,
+        sm: $layout-sm,
+        md: $layout-md,
+        lg: $layout-lg,
+        xl: $layout-xl,
+        2xl: $layout-2xl,
+    ),
+    layout: (
+        4xs: $spacing-4xs,
+        3xs: $spacing-3xs,
+        2xs: $spacing-2xs,
+        xs: $spacing-xs,
+        sm: $spacing-sm,
+        md: $spacing-md,
+        lg: $spacing-lg,
+        xl: $spacing-xl,
+        2xl: $spacing-2xl,
+        3xl: $spacing-3xl,
+    )
+);


### PR DESCRIPTION
Adds a variable ($carbon-spacing) that includes all of the Carbon spacing
information so developers can iterate through these and generate classes for all
spacing and layout options. For example:

```scss
@each $spacing-type, $spacing-details in $carbon-spacing {
    @each $size-name, $size in $spacing-details {
        .myapp-padding-top-#{$spacing-type}--#{$size-name} {
            padding-top: $size;
        }
    }
}
```

#### Changelog

**New**

- Variable `$carbon-spacing`

**Changed**

None

**Removed**

None

#### Testing / Reviewing

Try running the example shown above, as a demo of how we could now iterate through the Carbon spacings. I welcome any suggestions for naming this slightly different! Not sure on the spacing vs. layout names that I chose.

I prefixed with `carbon` but noticed that this isn't done anywhere else - not sure of your approach for this.
