### PR TITLE
chore(sass): remove deprecated sass features

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -232,7 +232,7 @@
     visibility: hidden;
     opacity: 0;
 
-    @include max-breakpoint('bp--xs--major') {
+    @include carbon--breakpoint-down('md') {
       padding-right: $carbon--spacing-09;
     }
 

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -75,9 +75,16 @@
   .#{$prefix}--breadcrumb {
     @include type-style('body-short-01');
     display: inline;
-    @include carbon--breakpoint(md) {
-      display: flex;
-      flex-wrap: wrap;
+    @if feature-flag-enabled('grid') {
+      @include carbon--breakpoint(md) {
+        display: flex;
+        flex-wrap: wrap;
+      }
+    } @else {
+      @include breakpoint(bp--xs--major) {
+        display: flex;
+        flex-wrap: wrap;
+      }
     }
   }
 

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -74,19 +74,10 @@
 @mixin breadcrumb--x {
   .#{$prefix}--breadcrumb {
     @include type-style('body-short-01');
-
     display: inline;
-
-    @if feature-flag-enabled('grid') {
-      @include carbon--breakpoint(md) {
-        display: flex;
-        flex-wrap: wrap;
-      }
-    } @else {
-      @include breakpoint(bp--xs--major) {
-        display: flex;
-        flex-wrap: wrap;
-      }
+    @include carbon--breakpoint(md) {
+      display: flex;
+      flex-wrap: wrap;
     }
   }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -292,7 +292,6 @@
   }
 
   .#{$prefix}--btn--sm {
-    @include letter-spacing;
     min-height: rem(32px);
     padding: $button-padding-sm;
   }

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -300,7 +300,6 @@
 
 @mixin snippet--x {
   .#{$prefix}--snippet code {
-    font-family: $font-family-mono;
     @include type-style('code-01');
   }
 

--- a/src/components/copy-button/_copy-button.scss
+++ b/src/components/copy-button/_copy-button.scss
@@ -34,7 +34,11 @@
 
     &:before {
       @include layer('overlay');
-      @include typescale('omega');
+      @if not feature-flag-enabled('components-x') {
+        @include typescale('omega');
+      } @else {
+        @include type-style('body-short-01');
+      }
       top: 1.1rem;
       padding: $spacing-2xs;
       color: $inverse-01;

--- a/src/components/copy-button/_copy-button.scss
+++ b/src/components/copy-button/_copy-button.scss
@@ -37,7 +37,7 @@
       @if not feature-flag-enabled('components-x') {
         @include typescale('omega');
       } @else {
-        @include type-style('body-short-01');
+        @include type-style('label-01');
       }
       top: 1.1rem;
       padding: $spacing-2xs;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -252,8 +252,6 @@
 
   .#{$prefix}--dropdown {
     @include reset;
-    @include font-family;
-    @include typescale('zeta');
     @include focus-outline('reset');
     position: relative;
     list-style: none;

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -134,7 +134,9 @@
   }
 
   .#{$prefix}--label .#{$prefix}--tooltip__trigger {
-    @include typescale('zeta');
+    // When tooltip trigger is put in form label the trigger button should fit in the size of label
+    // https://github.com/IBM/carbon-components-react/issues/115
+    @include type-style('label-01');
   }
 
   // Skeleton State

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -147,7 +147,7 @@
   }
 
   input[type='number'] {
-    font-family: $font-family-mono;
+    font-family: carbon--font-family('mono');
   }
 
   input[data-invalid],

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -101,7 +101,6 @@
   .#{$prefix}--link--disabled {
     @include reset;
     @include type-style('body-long-01');
-    @include font-smoothing;
     display: inline;
     color: $disabled-02;
     font-weight: 400;

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -434,7 +434,7 @@ $list-box-menu-width: rem(300px);
 
   // Label for a `list-box__field`
   .#{$prefix}--list-box__label {
-    @include typescale('zeta');
+    @include type-style('label-01');
 
     color: $text-01;
     user-select: none;
@@ -486,7 +486,7 @@ $list-box-menu-width: rem(300px);
 
   // Modifier for a selection to show that multiple selections have been made
   .#{$prefix}--list-box__selection--multi {
-    @include typescale('omega');
+    @include type-style('label-01');
 
     position: static;
     display: flex;
@@ -542,7 +542,7 @@ $list-box-menu-width: rem(300px);
 
   // Descendant of a `list-box__menu` that represents a selection for a control
   .#{$prefix}--list-box__menu-item {
-    @include typescale('zeta');
+    @include type-style('body-short-01');
 
     display: flex;
     align-items: center;

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -434,7 +434,7 @@ $list-box-menu-width: rem(300px);
 
   // Label for a `list-box__field`
   .#{$prefix}--list-box__label {
-    @include type-style('label-01');
+    @include type-style('body-short-01');
 
     color: $text-01;
     user-select: none;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -196,14 +196,14 @@
     max-height: 100%;
     height: 100%;
 
-    @include breakpoint(md) {
+    @include carbon--breakpoint(md) {
       height: auto;
       width: 50%;
       max-width: 768px;
       max-height: 90%;
     }
 
-    @include breakpoint(lg) {
+    @include carbon--breakpoint(lg) {
       max-height: 80%;
     }
   }

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -123,15 +123,15 @@
     margin-top: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-05;
 
-    @include breakpoint(md) {
+    @include carbon--breakpoint(md) {
       max-width: rem(608px);
     }
 
-    @include breakpoint(lg) {
+    @include carbon--breakpoint(lg) {
       max-width: rem(736px);
     }
 
-    @include breakpoint(max) {
+    @include carbon--breakpoint(max) {
       max-width: rem(832px);
     }
   }

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -121,7 +121,7 @@
       margin-top: $carbon--spacing-05;
     }
 
-    @include breakpoint(max) {
+    @include carbon--breakpoint(max) {
       width: rem(352px);
     }
   }

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -194,7 +194,7 @@
   .#{$prefix}--number input[type='number'] {
     @include type-style('body-short-01');
     @include focus-outline('reset');
-    font-family: $font-family-mono;
+    font-family: carbon--font-family('mono');
     box-sizing: border-box;
     display: inline-flex;
     width: 100%;

--- a/src/components/pagination-nav/_pagination-nav.scss
+++ b/src/components/pagination-nav/_pagination-nav.scss
@@ -59,9 +59,13 @@
 ) {
   .#{$prefix}--pagination-nav {
     @include reset;
-    @include font-family;
-    @include font-smoothing;
-    @include typescale('zeta');
+    @if not feature-flag-enabled('components-x') {
+      @include font-family;
+      @include font-smoothing;
+      @include typescale('zeta');
+    } @else {
+      @include type-style('body-short-01');
+    }
     line-height: 0;
   }
 
@@ -84,7 +88,11 @@
   }
 
   .#{$prefix}--pagination-nav__page {
-    @include typescale('zeta');
+    @if not feature-flag-enabled('components-x') {
+      @include typescale('zeta');
+    } @else {
+      @include type-style('body-short-01');
+    }
     @include button-reset($width: false);
     border-radius: 0;
     color: $text-color;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -171,8 +171,7 @@
   }
 
   .#{$prefix}--slider__range-label {
-    @include typescale('zeta');
-    font-family: $font-family-mono;
+    @include type-style('code-02');
     color: $text-01;
 
     &:last-of-type {

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -270,7 +270,6 @@
   .#{$prefix}--structured-list-td {
     @include reset;
     @include type-style('body-long-01');
-    @include line-height('body');
     @include padding-td--x;
     position: relative;
     display: table-cell;

--- a/src/components/structured-list/_structured-list.scss
+++ b/src/components/structured-list/_structured-list.scss
@@ -271,6 +271,7 @@
     @include reset;
     @include type-style('body-long-01');
     @include padding-td--x;
+    line-height: carbon--rem(21px);
     position: relative;
     display: table-cell;
     max-width: 36rem;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -222,7 +222,7 @@
     height: auto;
     width: 100%;
     position: relative;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       background: none;
       min-height: rem(48px);
     }
@@ -239,7 +239,7 @@
     outline: 2px solid transparent;
     border-bottom: 1px solid $ui-04;
     background-color: $field-01;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       display: none;
     }
   }
@@ -300,7 +300,7 @@
     flex-direction: column;
     z-index: z('dropdown');
     background: $ui-01;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       flex-direction: row;
       margin-right: $carbon--spacing-05;
       margin-left: $carbon--spacing-05;
@@ -308,11 +308,11 @@
       box-shadow: none;
       z-index: auto;
     }
-    @include breakpoint(bp--lg--major) {
+    @include carbon--breakpoint(xlg) {
       margin-left: 0;
     }
 
-    @include max-breakpoint(bp--sm--major) {
+    @include carbon--breakpoint-down(md) {
       transition: max-height $duration--moderate-01 motion(standard, productive);
       max-height: 600px;
       width: 100%;
@@ -321,10 +321,10 @@
   }
 
   .#{$prefix}--tabs__nav--hidden {
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       display: flex;
     }
-    @include max-breakpoint(bp--sm--major) {
+    @include carbon--breakpoint-down(md) {
       transition: max-height $duration--moderate-01 motion(standard, productive);
       overflow: hidden;
       max-height: 0;
@@ -339,13 +339,13 @@
     padding: 0;
     cursor: pointer;
     width: 100%;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       background: transparent;
       & + .#{$prefix}--tabs__nav-item {
         margin-left: rem(2px);
       }
     }
-    @include max-breakpoint(bp--sm--major) {
+    @include carbon--breakpoint-down(md) {
       height: rem(40px);
     }
   }
@@ -354,13 +354,13 @@
   // Item Hover
   //-----------------------------
   .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected) {
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       background: transparent;
     }
   }
 
   .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
-    @include max-breakpoint(bp--sm--major) {
+    @include carbon--breakpoint-down(md) {
       background-color: $hover-ui;
       box-shadow: 0 -1px 0 $hover-ui;
     }
@@ -379,7 +379,7 @@
   //-----------------------------
   .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
     border: none;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       .#{$prefix}--tabs__nav-link {
         color: $text-01;
         @include type-style('heading-01');
@@ -392,7 +392,7 @@
         border-bottom: 2px;
       }
     }
-    @include max-breakpoint(bp--sm--major) {
+    @include carbon--breakpoint-down(md) {
       display: none;
     }
   }
@@ -409,11 +409,11 @@
     width: rem(160px);
     white-space: nowrap;
     text-overflow: ellipsis;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       border-bottom: $tab-underline-color;
       padding: $carbon--spacing-03 $carbon--spacing-05;
     }
-    @include max-breakpoint(bp--sm--major) {
+    @include carbon--breakpoint-down(md) {
       height: rem(40px);
       width: calc(100% - 32px);
       margin: 0 $carbon--spacing-05;
@@ -440,7 +440,7 @@
   .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
     .#{$prefix}--tabs__nav-link {
     color: $text-01;
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       color: $text-01;
       border-bottom: $tab-underline-color-hover;
     }
@@ -477,7 +477,7 @@
 
   .#{$prefix}--tabs__nav-link:focus,
   .#{$prefix}--tabs__nav-link:active {
-    @include breakpoint(bp--sm--major) {
+    @include carbon--breakpoint(md) {
       outline: 2px solid $interactive-01;
       outline-offset: -2px;
       border-bottom: 2px;

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -21,7 +21,9 @@ $css--helpers: true;
 
 @mixin toolbar {
   .#{$prefix}--toolbar {
-    @include font-family;
+    @if not feature-flag-enabled('components-x') {
+      @include font-family;
+    }
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
@@ -111,8 +113,12 @@ $css--helpers: true;
   }
 
   .#{$prefix}--toolbar-menu__title {
-    @include typescale('omega');
-    @include letter-spacing;
+    @if not feature-flag-enabled('components-x') {
+      @include typescale('omega');
+      @include letter-spacing;
+    } @else {
+      @include type-style('caption-01');
+    }
     font-weight: 600;
     padding: 0.5rem 1.25rem;
   }

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -464,7 +464,6 @@
   // Tooltip Definition
   // Definition CSS only tooltip
   .#{$prefix}--tooltip--definition {
-    @include font-family;
     @include reset;
     position: relative;
 

--- a/src/components/ui-shell/_header.scss
+++ b/src/components/ui-shell/_header.scss
@@ -76,7 +76,7 @@
   // Header - Name
   //--------------------------------------------------------------------------
   a.#{$prefix}--header__name {
-    @include typescale('zeta');
+    @include type-style('body-short-01');
     display: flex;
     align-items: center;
     height: 100%;

--- a/src/components/ui-shell/_product-switcher.scss
+++ b/src/components/ui-shell/_product-switcher.scss
@@ -54,7 +54,7 @@
   //--------------------------------------------------------------------------
   .#{$prefix}--product-switcher__subheader,
   .#{$prefix}--product-switcher__all-btn {
-    @include typescale('omega');
+    @include type-style('body-short-01');
     padding: mini-units(1);
     color: $shell-header-text-03;
   }
@@ -92,7 +92,7 @@
   .#{$prefix}--product-switcher__back-btn {
     display: flex;
     align-items: center;
-    @include typescale('omega');
+    @include type-style('body-short-01');
     padding: mini-units(1) mini-units(2);
   }
 
@@ -134,7 +134,7 @@
   }
 
   .#{$prefix}--product-link__name {
-    @include typescale('zeta');
+    @include type-style('body-short-01');
     margin-left: 0.25rem;
     font-weight: 400;
     color: $shell-header-text-02;

--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -187,7 +187,6 @@
   }
 
   .#{$prefix}--side-nav__select {
-    @include font-family();
     appearance: none;
     flex: 1 1 0%;
     background-color: $shell-header-bg-01;

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -27,7 +27,11 @@
 
   .#{$prefix}--body {
     @include reset;
-    @include font-family;
+    @if not feature-flag-enabled('components-x') {
+      @include font-family;
+    } @else {
+      @include type-style('body-short-01');
+    }
     color: $text-01;
     background-color: $ui-02;
     line-height: 1;

--- a/src/globals/scss/_css--plex-core.scss
+++ b/src/globals/scss/_css--plex-core.scss
@@ -7,6 +7,7 @@
 
 $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !default;
 
+@import 'functions';
 @import 'helper-mixins';
 @import './vendor/@carbon/elements/scss/import-once/import-once';
 
@@ -60,8 +61,10 @@ $weights: (
 /// @deprecated (For v10) Use `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
 @mixin plex-font-face {
   @include deprecate(
-    '`@include plex-font-face` has been deprecated. ' + 'It will be removed in the next major release.',
-    feature-flag-enabled('components-x')
+    '`@include plex-font-face` has been removed. ' +
+      'Use `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc. instead.',
+    feature-flag-enabled('components-x'),
+    true
   ) {
     @include check-default-font-path {
       @each $family, $name in $families {

--- a/src/globals/scss/_css--typography.scss
+++ b/src/globals/scss/_css--typography.scss
@@ -15,9 +15,9 @@
 /// @deprecated (For v10) Use `@include carbon--type-classes`
 @mixin typography {
   @include deprecate(
-    '`@include typography` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--type-classes` instead.',
-    feature-flag-enabled('components-x')
+    '`@include typography` has been removed. ' + 'Use `@include carbon--type-classes` instead.',
+    feature-flag-enabled('components-x'),
+    true
   ) {
     // really big
     .#{$prefix}--type-giga {

--- a/src/globals/scss/_deprecate.scss
+++ b/src/globals/scss/_deprecate.scss
@@ -2,19 +2,23 @@
 /// no longer going to be present in the next major release of Carbon.
 /// @access public
 /// @param {String} $reason - The message
-/// @param {Bool} $condition [true] - `true` to emits the given deprecation messsage
+/// @param {Bool} $condition [true] - `true` to emit the given deprecation messsage
+/// @param {Bool} $remove-deprecated [false] - `true` to omit the content if $condition is `true`
 /// @require {Bool} $deprecations--entry
 /// @require {Map} $deprecations--reasons
-@mixin deprecate($reason, $condition: true) {
+@mixin deprecate($reason, $condition: true, $remove-deprecated: false) {
   $deprecations--entry: false !default;
 
   @if not $condition {
     @content;
-  } @else if ($deprecations--entry == true) {
-    $deprecations--reasons: append($deprecations--reasons, $reason) !global;
-    @content;
   } @else {
-    @warn 'Deprecated code was found, this code will be removed before the next release of Carbon. REASON: #{$reason}';
-    @content;
+    @if ($deprecations--entry == true) {
+      $deprecations--reasons: append($deprecations--reasons, $reason) !global;
+    } @else {
+      @warn 'Deprecated code was found, this code will be removed before the next release of Carbon. REASON: #{$reason}';
+    }
+    @if not $remove-deprecated {
+      @content;
+    }
   }
 }

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -100,9 +100,11 @@
 
 @mixin button-reset($width: true) {
   @include reset;
-  @include type-style('body-short-01');
-  @include font-smoothing;
-  @include letter-spacing;
+  @if not feature-flag-enabled('components-x') {
+    @include font-family;
+    @include font-smoothing;
+    @include letter-spacing;
+  }
   display: inline-block;
   background: none;
   appearance: none;
@@ -204,10 +206,7 @@
 
 /// @deprecated A legacy class used for our older way of dark/light theme switch
 @mixin light-ui {
-  @include deprecate(
-    '`@include light-ui` has been deprecated. ' + 'It will be removed in the next major release.',
-    feature-flag-enabled('breaking-changes-x')
-  ) {
+  @include deprecate('`@include light-ui` has been removed.', feature-flag-enabled('breaking-changes-x'), true) {
     .#{$prefix}--global-light-ui & {
       @content;
     }

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -30,10 +30,14 @@ $padding: (
 
 /// @deprecated (For v10) Was used primary for older grid
 @function padding($value) {
-  @if map-has-key($padding, $value) {
-    @return map-get($padding, $value);
+  @if feature-flag-enabled('breaking-changes-x') {
+    @warn ('`@function padding()` has been removed.');
   } @else {
-    @warn 'padding: could not find #{$value} in $padding map. Please make sure it is defined';
+    @if map-has-key($padding, $value) {
+      @return map-get($padding, $value);
+    } @else {
+      @warn 'padding: could not find #{$value} in $padding map. Please make sure it is defined';
+    }
   }
 }
 
@@ -49,9 +53,9 @@ $padding: (
 /// @deprecated (For v10) Use `@include carbon--breakpoint()`
 @mixin breakpoint($size) {
   @include deprecate(
-    '`@include breakpoint()` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--breakpoint()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include breakpoint()` has been removed. ' + 'Use `@include carbon--breakpoint()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     @if map-has-key($breakpoints, $size) {
       @media screen and (min-width: map-get($breakpoints, $size)) {
@@ -68,9 +72,9 @@ $padding: (
 /// @deprecated (For v10) Use `@include carbon--breakpoint-down()`
 @mixin max-breakpoint($size) {
   @include deprecate(
-    '`@include max-breakpoint()` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--breakpoint-down()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include max-breakpoint()` has been removed. ' + 'Use `@include carbon--breakpoint-down()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     @if map-has-key($breakpoints, $size) {
       @media screen and (max-width: map-get($breakpoints, $size)) {
@@ -91,9 +95,9 @@ $padding: (
 /// @deprecated (For v10) Use `@include carbon--make-container()`
 @mixin grid-container {
   @include deprecate(
-    '`@include grid-container` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--make-container()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include grid-container` has been removed. ' + 'Use `@include carbon--make-container()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     width: 100%;
     padding-right: padding(mobile);

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -40,9 +40,9 @@ $typescale-map: (
 /// @deprecated (For v10) Use `@include carbon--type-scale()`
 @mixin typescale($size) {
   @include deprecate(
-    '`@include typescale()` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--type-scale()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include typescale()` has been removed. ' + 'Use `@include carbon--type-scale()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     @if map-has-key($typescale-map, $size) {
       font-size: map-get($typescale-map, $size);
@@ -70,9 +70,9 @@ $typescale-map: (
 /// @deprecated (For v10) Use `@include carbon--font-family()`
 @mixin font-family {
   @include deprecate(
-    '`@include font-family` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--font-family()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include font-family` has been removed. ' + 'Use `@include carbon--font-family()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     @if global-variable-exists('css--plex') and $css--plex == true {
       font-family: $font-family-sans-serif;
@@ -86,9 +86,9 @@ $typescale-map: (
 /// @deprecated (For v10) Use `@include carbon--type-style()`
 @mixin line-height($el) {
   @include deprecate(
-    '`@include line-height()` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--type-style()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include line-height()` has been removed. ' + 'Use `@include carbon--type-style()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     @if $el == 'heading' {
       line-height: 1.25;
@@ -103,10 +103,7 @@ $typescale-map: (
 // Only applied to bold weight text
 /// @deprecated (For v10) The new type styles doesn't use this
 @mixin font-smoothing {
-  @include deprecate(
-    '`@include font-smoothing` has been deprecated. ' + 'It will be removed in the next major release.',
-    feature-flag-enabled('breaking-changes-x')
-  ) {
+  @include deprecate('`@include font-smoothing` has been removed.', feature-flag-enabled('breaking-changes-x'), true) {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -114,10 +111,7 @@ $typescale-map: (
 
 /// @deprecated (For v10) The new type styles doesn't use this
 @mixin letter-spacing {
-  @include deprecate(
-    '`@include letter-spacing` has been deprecated. ' + 'It will be removed in the next major release.',
-    feature-flag-enabled('breaking-changes-x')
-  ) {
+  @include deprecate('`@include letter-spacing` has been removed.', feature-flag-enabled('breaking-changes-x'), true) {
     letter-spacing: 0;
   }
 }
@@ -139,9 +133,9 @@ $font-size-map: (
 /// @deprecated (For v10) Use `@include carbon--type-scale()`
 @mixin font-size($size) {
   @include deprecate(
-    '`@include font-size()` has been deprecated. ' + 'It will be removed in the next major release. ' +
-      'Use `@include carbon--type-scale()` instead.',
-    feature-flag-enabled('breaking-changes-x')
+    '`@include font-size()` has been removed. ' + 'Use `@include carbon--type-scale()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
   ) {
     @if map-has-key($font-size-map, $size) {
       font-size: map-get($font-size-map, $size);


### PR DESCRIPTION
Refs #1501.
Fixes #1945.

This PR attempts to complete the transition away from deprecated `v9` Sass APIs. ~~Want to wait for data table to complete as this PR makes most of those APIs no-op and I don't want to block data table work by this.~~

#### Changelog

**New**

- 3rd argument in `@mixin deprecate()`, which omits the content if `true` is specified. This effectively removes the mix-in when `true` is given for the 2nd argument.

**Changed**

- Changes to replace below API usage with the corresponding `v10` API.

**Removed**

- The following for `v10`:
  - `@function padding()`
  - `@mixin breakpoint()`
  - `@mixin font-family()`
  - `@mixin font-size()`
  - `@mixin font-smoothing()`
  - `@mixin grid-container()`
  - `@mixin letter-spacing()`
  - `@mixin line-height()`
  - `@mixin max -breakpoint()`
  - `@mixin light-ui`
  - `@mixin plex-font-face`
  - `@mixin typescale()`
  - `@mixin typography`

#### Testing / Reviewing

Testing should make sure no component is broken. Review focus is can be seen in the following comment.