### PR TITLE
fix(button): add disabled button class

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -181,6 +181,7 @@
   button.#{$prefix}--btn {
     display: inline-block;
 
+    &--disabled > .#{$prefix}--btn__icon,
     &:disabled > .#{$prefix}--btn__icon {
       fill: $ui-04;
     }
@@ -219,7 +220,10 @@
 
     &:disabled,
     &:hover:disabled,
-    &:focus:disabled {
+    &:focus:disabled,
+    &--disabled,
+    &--disabled:hover,
+    &--disabled:focus {
       background: transparent;
       color: $disabled;
 
@@ -261,7 +265,10 @@
 
     &:disabled,
     &:hover:disabled,
-    &:focus:disabled {
+    &:focus:disabled,
+    &--disabled,
+    &--disabled:hover,
+    &--disabled:focus {
       color: $disabled;
       background: transparent;
       border-color: transparent;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -178,7 +178,7 @@
 
 @mixin button--x {
   // <button> elements cannot be used as flex containers
-  button.#{$prefix}--btn {
+  .#{$prefix}--btn {
     display: inline-block;
 
     &--disabled > .#{$prefix}--btn__icon,
@@ -188,7 +188,7 @@
   }
 
   // Reset intrisic padding in Firefox (see #731)
-  button.#{$prefix}--btn::-moz-focus-inner {
+  .#{$prefix}--btn::-moz-focus-inner {
     padding: 0;
     border: 0;
   }
@@ -237,7 +237,7 @@
     }
   }
 
-  button.#{$prefix}--btn--ghost {
+  .#{$prefix}--btn--ghost {
     @include button-theme--x(transparent, transparent, $interactive-01, $hover-ui, $interactive-01, $active-ui);
     display: inline-flex;
     align-items: center;

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -15,7 +15,7 @@
 </button>
 <button
   class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled"
   {{#if danger}} aria-label="danger" {{/if}}
   type="button" disabled
 >
@@ -38,7 +38,7 @@
 </button>
 <button
   class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled"
   {{#if danger}} aria-label="danger" {{/if}}
   type="button" disabled
 >

--- a/src/components/button/migrate-to-10.x.md
+++ b/src/components/button/migrate-to-10.x.md
@@ -1,3 +1,11 @@
 ### HTML
 
 Icon from [`carbon-elements`](https://github.com/IBM/carbon-elements) package is now used. Vanilla markup should be migrated to one shown in [carbondesignsystem.com](https://next.carbondesignsystem.com/components/button/code) site. React and other framework variants should reflect the change automatically.
+
+### SCSS
+
+A new class has been added to target disabled buttons
+
+| Old Class | New Class         | Note |
+| --------- | ----------------- | ---- |
+| -         | bx--btn--disabled | New  |


### PR DESCRIPTION
Closes #2086

This PR adds disabled button classes to apply disabled button styles to buttonlike elements with different root nodes

Related

https://github.com/IBM/carbon-components-react/pull/1891

https://github.com/IBM/carbon-components-react/pull/1910

https://github.com/IBM/carbon-components-react/issues/2012