### PR TITLE
fix(time-picker): vertically center caret

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -155,7 +155,14 @@
   .#{$prefix}--list-box[data-invalid] {
     outline: 2px solid $support-01;
     outline-offset: -2px;
+  }
 
+  input[data-invalid],
+  .#{$prefix}--text-input__field-wrapper[data-invalid],
+  .#{$prefix}--text-area__wrapper[data-invalid],
+  .#{$prefix}--select-input__wrapper[data-invalid],
+  .#{$prefix}--time-picker[data-invalid],
+  .#{$prefix}--list-box[data-invalid] {
     ~ .#{$prefix}--form-requirement {
       max-height: rem(200px);
       display: block;

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -115,8 +115,12 @@
     @include focus-outline('invalid');
   }
 
-  .#{$prefix}--time-picker__select:not(:last-of-type) {
-    margin: 0 $spacing-3xs;
+  .#{$prefix}--time-picker__select {
+    justify-content: center;
+
+    &:not(:last-of-type) {
+      margin: 0 $spacing-3xs;
+    }
   }
 
   .#{$prefix}--time-picker__input {

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -131,6 +131,7 @@
   .#{$prefix}--time-picker .#{$prefix}--select-input {
     min-width: auto;
     width: auto;
+    padding-right: rem(48px);
     line-height: 1;
   }
 

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -109,11 +109,10 @@
   .#{$prefix}--time-picker {
     display: flex;
     align-items: flex-end;
+  }
 
-    .#{$prefix}--label {
-      @include type-style('label-01');
-      order: 1;
-    }
+  .#{$prefix}--time-picker[data-invalid] .#{$prefix}--time-picker__input-field {
+    @include focus-outline('invalid');
   }
 
   .#{$prefix}--time-picker__select:not(:last-of-type) {
@@ -126,72 +125,20 @@
   }
 
   .#{$prefix}--time-picker .#{$prefix}--select-input {
-    padding-right: rem(42px); // 2rem + SVG width
     min-width: auto;
     width: auto;
     line-height: 1;
-    display: flex;
-    align-items: center;
   }
 
   .#{$prefix}--time-picker__input-field {
     @include reset;
-    @include type-style('body-short-01');
     @include focus-outline('reset');
-    font-family: $font-family-mono;
+    @include type-style('code-01');
     display: flex;
     align-items: center;
-    background-color: $field-01;
-    border: none;
-    border-bottom: 1px solid $ui-04;
     width: 4.875rem;
-    color: $text-01;
     height: rem(40px);
-    padding: 0 $spacing-md;
-    order: 2;
     transition: outline $transition--base;
-
-    &:focus {
-      @include focus-outline('outline');
-    }
-
-    &::placeholder {
-      color: $text-03;
-    }
-
-    &[data-invalid],
-    &[data-invalid]:focus {
-      @include focus-outline('invalid');
-    }
-
-    & ~ .#{$prefix}--form-requirement {
-      order: 3;
-      color: $support-01;
-      font-weight: 400;
-      margin-top: 0;
-      max-height: 0;
-
-      &::before {
-        display: none;
-      }
-    }
-
-    &[data-invalid] ~ .#{$prefix}--form-requirement {
-      overflow: visible;
-      max-height: 0;
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-  }
-
-  .#{$prefix}--time-picker--light {
-    .#{$prefix}--time-picker__input-field,
-    .#{$prefix}--select-input {
-      background: $field-02;
-    }
   }
 }
 

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -137,7 +137,7 @@
   .#{$prefix}--time-picker__input-field {
     @include reset;
     @include focus-outline('reset');
-    @include type-style('code-01');
+    @include type-style('code-02');
     display: flex;
     align-items: center;
     width: 4.875rem;

--- a/src/components/time-picker/migrate-to-10.x.md
+++ b/src/components/time-picker/migrate-to-10.x.md
@@ -1,3 +1,11 @@
 ### HTML
 
 Icon from [`carbon-elements`](https://github.com/IBM/carbon-elements) package is now used. Also design change around the select box involves changing the list of CSS classes applied to the markup. Vanilla markup should be migrated to one shown in [carbondesignsystem.com](https://next.carbondesignsystem.com/components/date-picker/code) site. React and other framework variants should reflect the change automatically.
+
+### SCSS
+
+The `data-invalid` attribute has been placed on the time picker wrapper div
+
+| Old Class | New Class                     | Note    |
+| --------- | ----------------------------- | ------- |
+| -         | bx--time-picker[data-invalid] | Changed |

--- a/src/components/time-picker/time-picker--light.hbs
+++ b/src/components/time-picker/time-picker--light.hbs
@@ -5,190 +5,190 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}">
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-5" class="{{@root.prefix}}--label">Select a time</label>
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker{{#if light}} {{prefix}}--time-picker--light{{/if}}">
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-5" class="{{prefix}}--label">Select a time</label>
       <input id="time-picker-5" type="text"
-        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-9" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-9" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-9" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-9" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-10" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-10" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-10" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-10" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
 </div>
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}" data-invalid>
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-6" class="{{@root.prefix}}--label">Select a time</label>
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker{{#if light}} {{prefix}}--time-picker--light{{/if}}" data-invalid>
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-6" class="{{prefix}}--label">Select a time</label>
       <input id="time-picker-6" type="text"
-        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
       {{#unless componentsX}}
-      <div class="{{@root.prefix}}--form-requirement">
+      <div class="{{prefix}}--form-requirement">
         Invalid time.
       </div>
       {{/unless}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-11" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-11" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-11" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-11" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-12" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-12" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-12" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-12" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
   {{#if componentsX}}
-  <div class="{{@root.prefix}}--form-requirement">
+  <div class="{{prefix}}--form-requirement">
     Invalid time.
   </div>
   {{/if}}
 </div>
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}">
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-7" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker{{#if light}} {{prefix}}--time-picker--light{{/if}}">
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-7" class="{{prefix}}--label {{prefix}}--label--disabled">Select a time</label>
       <input id="time-picker-7" type="text"
-        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-13" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-13" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-13" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-13" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-14" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-14" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-14" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-14" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
 </div>
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}" data-invalid>
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-8" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker{{#if light}} {{prefix}}--time-picker--light{{/if}}" data-invalid>
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-8" class="{{prefix}}--label {{prefix}}--label--disabled">Select a time</label>
       <input id="time-picker-8" type="text"
-        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
       {{#unless componentsX}}
-      <div class="{{@root.prefix}}--form-requirement">
+      <div class="{{prefix}}--form-requirement">
         Invalid time.
       </div>
       {{/unless}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-15" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-15" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-15" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-15" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-16" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#if light}} {{prefix}}--select--light{{/if}}{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-16" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-16" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-16" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
+      {{#if componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
   {{#if componentsX}}
-  <div class="{{@root.prefix}}--form-requirement">
+  <div class="{{prefix}}--form-requirement">
     Invalid time.
   </div>
   {{/if}}

--- a/src/components/time-picker/time-picker--light.hbs
+++ b/src/components/time-picker/time-picker--light.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -6,43 +6,190 @@
 -->
 
 <div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker {{@root.prefix}}--time-picker--light">
+  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}">
     <div class="{{@root.prefix}}--time-picker__input">
-      <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
-        placeholder="hh:mm" maxlength="5" />
-      <div class="{{@root.prefix}}--form-requirement">
-        Invalid time.
-      </div>
-      <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
+      <label for="time-picker-5" class="{{@root.prefix}}--label">Select a time</label>
+      <input id="time-picker-5" type="text"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
     </div>
-    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
-      <label for="select-id-1" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-1" class="{{@root.prefix}}--select-input">
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-9" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-9" class="{{@root.prefix}}--select-input">
         <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
         <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if @root.componentsX}}
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
-          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-        </svg>
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
       {{/if}}
     </div>
-    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
-      <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time zone</label>
-      <select id="select-id-2" class="{{@root.prefix}}--select-input">
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-10" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-10" class="{{@root.prefix}}--select-input">
         <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
         <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
         <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if @root.componentsX}}
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
-          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-        </svg>
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
       {{/if}}
     </div>
   </div>
+</div>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}" data-invalid>
+    <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-6" class="{{@root.prefix}}--label">Select a time</label>
+      <input id="time-picker-6" type="text"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
+      {{#unless componentsX}}
+      <div class="{{@root.prefix}}--form-requirement">
+        Invalid time.
+      </div>
+      {{/unless}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-11" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-11" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-12" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-12" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+  </div>
+  {{#if componentsX}}
+  <div class="{{@root.prefix}}--form-requirement">
+    Invalid time.
+  </div>
+  {{/if}}
+</div>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}">
+    <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-7" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
+      <input id="time-picker-7" type="text"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-13" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-13" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-14" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-14" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+  </div>
+</div>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker{{#if light}} {{@root.prefix}}--time-picker--light{{/if}}" data-invalid>
+    <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-8" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
+      <input id="time-picker-8" type="text"
+        class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}} {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
+      {{#unless componentsX}}
+      <div class="{{@root.prefix}}--form-requirement">
+        Invalid time.
+      </div>
+      {{/unless}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-15" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-15" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-16" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-16" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+  </div>
+  {{#if componentsX}}
+  <div class="{{@root.prefix}}--form-requirement">
+    Invalid time.
+  </div>
+  {{/if}}
 </div>

--- a/src/components/time-picker/time-picker--light.hbs
+++ b/src/components/time-picker/time-picker--light.hbs
@@ -21,7 +21,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -38,7 +38,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -68,7 +68,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -85,7 +85,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -115,7 +115,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -132,7 +132,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -162,7 +162,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -179,7 +179,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />

--- a/src/components/time-picker/time-picker.hbs
+++ b/src/components/time-picker/time-picker.hbs
@@ -5,186 +5,186 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker">
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
-      <input id="time-picker-1" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker">
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-1" class="{{prefix}}--label">Select a time</label>
+      <input id="time-picker-1" type="text" class="{{prefix}}--text-input {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-1" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-1" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-1" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-1" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-2" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-2" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-2" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
 </div>
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker" data-invalid>
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-2" class="{{@root.prefix}}--label">Select a time</label>
-      <input id="time-picker-2" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker" data-invalid>
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-2" class="{{prefix}}--label">Select a time</label>
+      <input id="time-picker-2" type="text" class="{{prefix}}--text-input {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
       {{#unless componentsX}}
-      <div class="{{@root.prefix}}--form-requirement">
+      <div class="{{prefix}}--form-requirement">
         Invalid time.
       </div>
       {{/unless}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-3" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-3" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-3" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-3" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-4" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-4" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-4" class="{{@root.prefix}}--select-input">
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-4" class="{{prefix}}--select-input">
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
   {{#if componentsX}}
-  <div class="{{@root.prefix}}--form-requirement">
+  <div class="{{prefix}}--form-requirement">
     Invalid time.
   </div>
   {{/if}}
 </div>
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker">
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-3" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
-      <input id="time-picker-3" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker">
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-3" class="{{prefix}}--label {{prefix}}--label--disabled">Select a time</label>
+      <input id="time-picker-3" type="text" class="{{prefix}}--text-input {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-5" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-5" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-5" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-5" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-6" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-6" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-6" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-6" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
 </div>
-<div class="{{@root.prefix}}--form-item">
-  <div class="{{@root.prefix}}--time-picker" data-invalid>
-    <div class="{{@root.prefix}}--time-picker__input">
-      <label for="time-picker-4" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
-      <input id="time-picker-4" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+<div class="{{prefix}}--form-item">
+  <div class="{{prefix}}--time-picker" data-invalid>
+    <div class="{{prefix}}--time-picker__input">
+      <label for="time-picker-4" class="{{prefix}}--label {{prefix}}--label--disabled">Select a time</label>
+      <input id="time-picker-4" type="text" class="{{prefix}}--text-input {{prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
       {{#unless componentsX}}
-      <div class="{{@root.prefix}}--form-requirement">
+      <div class="{{prefix}}--form-requirement">
         Invalid time.
       </div>
       {{/unless}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-7" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
-      <select id="select-id-7" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
-        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-7" class="{{prefix}}--label {{prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-7" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="AM">AM</option>
+        <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
-      <label for="select-id-8" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+      class="{{prefix}}--time-picker__select {{prefix}}--select{{#unless componentsX}} {{prefix}}--select--inline{{/unless}}">
+      <label for="select-id-8" class="{{prefix}}--label {{prefix}}--visually-hidden">Select time
         zone</label>
-      <select id="select-id-8" class="{{@root.prefix}}--select-input" disabled>
-        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
-        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
-        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      <select id="select-id-8" class="{{prefix}}--select-input" disabled>
+        <option class="{{prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
-      {{#if @root.componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{#if componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
       {{else}}
-      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+      <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
       {{/if}}
     </div>
   </div>
   {{#if componentsX}}
-  <div class="{{@root.prefix}}--form-requirement">
+  <div class="{{prefix}}--form-requirement">
     Invalid time.
   </div>
   {{/if}}

--- a/src/components/time-picker/time-picker.hbs
+++ b/src/components/time-picker/time-picker.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -9,39 +9,42 @@
   <div class="{{@root.prefix}}--time-picker">
     <div class="{{@root.prefix}}--time-picker__input">
       <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
-      <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field" pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)"
-        placeholder="hh:mm" maxlength="5" />
+      <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
       <div class="{{@root.prefix}}--form-requirement">
         Invalid time.
       </div>
     </div>
-    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
       <label for="select-id-1" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
       <select id="select-id-1" class="{{@root.prefix}}--select-input">
         <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
         <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if @root.componentsX}}
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
-          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-        </svg>
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
       {{/if}}
     </div>
-    <div class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
-      <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time zone</label>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
       <select id="select-id-2" class="{{@root.prefix}}--select-input">
         <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
         <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
         <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if @root.componentsX}}
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
       {{else}}
-        <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
-          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-        </svg>
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
       {{/if}}
     </div>
   </div>

--- a/src/components/time-picker/time-picker.hbs
+++ b/src/components/time-picker/time-picker.hbs
@@ -20,7 +20,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -37,7 +37,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -66,7 +66,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -83,7 +83,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -112,7 +112,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -129,7 +129,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -158,7 +158,7 @@
         <option class="{{prefix}}--select-option" value="PM">PM</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
@@ -175,7 +175,7 @@
         <option class="{{prefix}}--select-option" value="option-3">Time zone 3</option>
       </select>
       {{#if componentsX}}
-      {{ carbon-icon 'ChevronDownGlyph' class=(add prefix '--select__arrow') }}
+      {{ carbon-icon 'ChevronDown16' class=(add prefix '--select__arrow') }}
       {{else}}
       <svg class="{{prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />

--- a/src/components/time-picker/time-picker.hbs
+++ b/src/components/time-picker/time-picker.hbs
@@ -9,14 +9,11 @@
   <div class="{{@root.prefix}}--time-picker">
     <div class="{{@root.prefix}}--time-picker__input">
       <label for="time-picker-1" class="{{@root.prefix}}--label">Select a time</label>
-      <input id="time-picker-1" type="text" class="{{@root.prefix}}--time-picker__input-field"
+      <input id="time-picker-1" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
         pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
-      <div class="{{@root.prefix}}--form-requirement">
-        Invalid time.
-      </div>
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
       <label for="select-id-1" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
       <select id="select-id-1" class="{{@root.prefix}}--select-input">
         <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
@@ -31,7 +28,7 @@
       {{/if}}
     </div>
     <div
-      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select {{#if componentsX}}{{else}}{{@root.prefix}}--select--inline{{/if}}">
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
       <label for="select-id-2" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
         zone</label>
       <select id="select-id-2" class="{{@root.prefix}}--select-input">
@@ -48,4 +45,147 @@
       {{/if}}
     </div>
   </div>
+</div>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker" data-invalid>
+    <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-2" class="{{@root.prefix}}--label">Select a time</label>
+      <input id="time-picker-2" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" />
+      {{#unless componentsX}}
+      <div class="{{@root.prefix}}--form-requirement">
+        Invalid time.
+      </div>
+      {{/unless}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-3" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-3" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-4" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-4" class="{{@root.prefix}}--select-input">
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+  </div>
+  {{#if componentsX}}
+  <div class="{{@root.prefix}}--form-requirement">
+    Invalid time.
+  </div>
+  {{/if}}
+</div>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker">
+    <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-3" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
+      <input id="time-picker-3" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-5" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-5" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-6" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-6" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+  </div>
+</div>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--time-picker" data-invalid>
+    <div class="{{@root.prefix}}--time-picker__input">
+      <label for="time-picker-4" class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Select a time</label>
+      <input id="time-picker-4" type="text" class="{{prefix}}--text-input {{@root.prefix}}--time-picker__input-field"
+        pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?(?i)" placeholder="hh:mm" maxlength="5" disabled />
+      {{#unless componentsX}}
+      <div class="{{@root.prefix}}--form-requirement">
+        Invalid time.
+      </div>
+      {{/unless}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-7" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select AM/PM</label>
+      <select id="select-id-7" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="AM">AM</option>
+        <option class="{{@root.prefix}}--select-option" value="PM">PM</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+    <div
+      class="{{@root.prefix}}--time-picker__select {{@root.prefix}}--select{{#unless componentsX}} {{@root.prefix}}--select--inline{{/unless}}">
+      <label for="select-id-8" class="{{@root.prefix}}--label {{@root.prefix}}--visually-hidden">Select time
+        zone</label>
+      <select id="select-id-8" class="{{@root.prefix}}--select-input" disabled>
+        <option class="{{@root.prefix}}--select-option" value="option-1">Time zone 1</option>
+        <option class="{{@root.prefix}}--select-option" value="option-2">Time zone 2</option>
+        <option class="{{@root.prefix}}--select-option" value="option-3">Time zone 3</option>
+      </select>
+      {{#if @root.componentsX}}
+      {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+      {{else}}
+      <svg class="{{@root.prefix}}--select__arrow" width="10" height="5" viewBox="0 0 10 5">
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+      {{/if}}
+    </div>
+  </div>
+  {{#if componentsX}}
+  <div class="{{@root.prefix}}--form-requirement">
+    Invalid time.
+  </div>
+  {{/if}}
 </div>


### PR DESCRIPTION
Closes #2094

Closes #2098

This PR adds style rules to position the time picker `<select>` carets properly after https://github.com/IBM/carbon-components/pull/1978

#### Changelog

**New**

- documentation examples for invalid and disabled states

**Changed**

- Carbon classes for text input and `<select>`s to share styling
- type styles

**Removed**

- redundant and unused styles

#### Testing / Reviewing

Ensure the component is not broken
