### PR TITLE
fix(select): align inline label and helper text

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -265,12 +265,12 @@
     color: $disabled-02;
   }
 
-  .#{$prefix}--select--invalid {
+  .#{$prefix}--select-input--invalid {
     padding-right: rem(58px); // 1rem + chevron width + invalid icon width
   }
 
-  .#{$prefix}--select--invalid,
-  .#{$prefix}--select--invalid:focus {
+  .#{$prefix}--select-input--invalid,
+  .#{$prefix}--select-input--invalid:focus {
     @include focus-outline('invalid');
   }
 
@@ -297,12 +297,12 @@
   }
 
   .#{$prefix}--select__disabled-icon,
-  .#{$prefix}--select--invalid ~ .#{$prefix}--select__invalid-icon {
+  .#{$prefix}--select-input--invalid ~ .#{$prefix}--select__invalid-icon {
     position: absolute;
     right: rem(34px); // 1.5rem + chevron width
   }
 
-  .#{$prefix}--select--invalid ~ .#{$prefix}--select__invalid-icon {
+  .#{$prefix}--select-input--invalid ~ .#{$prefix}--select__invalid-icon {
     fill: $support-01;
   }
 
@@ -334,6 +334,12 @@
     align-items: center;
   }
 
+  .#{$prefix}--select--inline.#{$prefix}--select--invalid .#{$prefix}--label,
+  .#{$prefix}--select--inline.#{$prefix}--select--invalid .#{$prefix}--form__helper-text {
+    margin-top: rem(13px);
+    align-self: flex-start;
+  }
+
   .#{$prefix}--select--inline .#{$prefix}--form__helper-text {
     margin-bottom: 0;
     margin-left: rem(8px);
@@ -342,7 +348,6 @@
   .#{$prefix}--select--inline .#{$prefix}--label {
     white-space: nowrap;
     margin: 0 $spacing-xs 0 0;
-    align-self: center;
   }
 
   .#{$prefix}--select--inline .#{$prefix}--select-input {
@@ -366,11 +371,11 @@
     right: $spacing-xs;
   }
 
-  .#{$prefix}--select--inline .#{$prefix}--select--invalid ~ .#{$prefix}--select__invalid-icon {
+  .#{$prefix}--select--inline .#{$prefix}--select-input--invalid ~ .#{$prefix}--select__invalid-icon {
     right: rem(24px);
   }
 
-  .#{$prefix}--select--inline .#{$prefix}--select--invalid ~ .#{$prefix}--select__disabled-icon {
+  .#{$prefix}--select--inline .#{$prefix}--select-input--invalid ~ .#{$prefix}--select__disabled-icon {
     right: rem(48px);
   }
 

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -265,12 +265,12 @@
     color: $disabled-02;
   }
 
-  .#{$prefix}--select-input--invalid {
+  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input {
     padding-right: rem(58px); // 1rem + chevron width + invalid icon width
   }
 
-  .#{$prefix}--select-input--invalid,
-  .#{$prefix}--select-input--invalid:focus {
+  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input,
+  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input:focus {
     @include focus-outline('invalid');
   }
 
@@ -297,12 +297,12 @@
   }
 
   .#{$prefix}--select__disabled-icon,
-  .#{$prefix}--select-input--invalid ~ .#{$prefix}--select__invalid-icon {
+  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input ~ .#{$prefix}--select__invalid-icon {
     position: absolute;
     right: rem(34px); // 1.5rem + chevron width
   }
 
-  .#{$prefix}--select-input--invalid ~ .#{$prefix}--select__invalid-icon {
+  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input ~ .#{$prefix}--select__invalid-icon {
     fill: $support-01;
   }
 

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -19,8 +19,7 @@
     <div class="{{@root.prefix}}--select-input--inline__wrapper">
       {{/if}}
       <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
-        <select id="select-id"
-          class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}">
+        <select id="select-id" class="{{@root.prefix}}--select-input">
           {{#each items}}
           {{#if items}}
           <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
@@ -53,8 +52,7 @@
       {{/if}}
     </div>
     {{else}}
-    <select {{#if invalid}}data-invalid{{/if}} id="select-id"
-      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}">
+    <select {{#if invalid}}data-invalid{{/if}} id="select-id" class="{{@root.prefix}}--select-input">
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
@@ -106,8 +104,7 @@
     <div class="{{@root.prefix}}--select-input--inline__wrapper">
       {{/if}}
       <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
-        <select id="select-id-disabled"
-          class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}" disabled>
+        <select id="select-id-disabled" class="{{@root.prefix}}--select-input" disabled>
           {{#each items}}
           {{#if items}}
           <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
@@ -127,8 +124,7 @@
     </div>
     {{/if}}
     {{else}}
-    <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled"
-      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}" disabled>
+    <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled" class="{{@root.prefix}}--select-input" disabled>
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">

--- a/src/components/select/select.hbs
+++ b/src/components/select/select.hbs
@@ -7,7 +7,7 @@
 
 <div class="{{@root.prefix}}--form-item">
   <div
-    class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}}">
+    class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}">
     <label for="select-id" class="{{@root.prefix}}--label">Select label</label>
     {{#unless inline}}
     {{#if helperText}}
@@ -20,7 +20,7 @@
       {{/if}}
       <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
         <select id="select-id"
-          class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}">
+          class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}">
           {{#each items}}
           {{#if items}}
           <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
@@ -54,7 +54,7 @@
     </div>
     {{else}}
     <select {{#if invalid}}data-invalid{{/if}} id="select-id"
-      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}">
+      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}">
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
@@ -94,7 +94,7 @@
 
 <div class="{{@root.prefix}}--form-item">
   <div
-    class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}} {{@root.prefix}}--select--disabled">
+    class="{{@root.prefix}}--select{{#if inline}} {{@root.prefix}}--select--inline{{/if}}{{#if light}} {{@root.prefix}}--select--light{{/if}}{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}} {{@root.prefix}}--select--disabled">
     <label for="select-id-disabled" class="{{@root.prefix}}--label">Select label</label>
     {{#unless inline}}
     {{#if helperText}}
@@ -107,7 +107,7 @@
       {{/if}}
       <div class="{{@root.prefix}}--select-input__wrapper" {{#if invalid}}data-invalid{{/if}}>
         <select id="select-id-disabled"
-          class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}" disabled>
+          class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}" disabled>
           {{#each items}}
           {{#if items}}
           <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">
@@ -128,7 +128,7 @@
     {{/if}}
     {{else}}
     <select {{#if invalid}}data-invalid{{/if}} id="select-id-disabled"
-      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select--invalid{{/if}}" disabled>
+      class="{{@root.prefix}}--select-input{{#if invalid}} {{@root.prefix}}--select-input--invalid{{/if}}" disabled>
       {{#each items}}
       {{#if items}}
       <optgroup class="{{@root.prefix}}--select-optgroup" label="{{label}}">


### PR DESCRIPTION
Closes #2096

This PR fixes the alignment of invalid inline select labels and helper text