### PR TITLE
fix(overflow-menu): use disabled tokens for icons

### DIFF
--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -376,7 +376,7 @@
   }
 
   .#{$prefix}--overflow-menu-options__option--disabled .#{$prefix}--overflow-menu-options__btn {
-    color: $disabled;
+    color: $disabled-02;
     pointer-events: none;
 
     &:hover,
@@ -385,6 +385,10 @@
       @include focus-outline('reset');
       background-color: $ui-01;
     }
+  }
+
+  .#{$prefix}--overflow-menu-options__option--disabled .#{$prefix}--overflow-menu-options__btn svg {
+    fill: $disabled-02;
   }
 
   .#{$prefix}--overflow-menu--flip {

--- a/src/components/overflow-menu/overflow-menu.hbs
+++ b/src/components/overflow-menu/overflow-menu.hbs
@@ -84,11 +84,18 @@
     </li>
     {{/each}}
     {{#if @root.featureFlags.componentsX}}
+    <li class="{{@root.prefix}}--overflow-menu-options__option" role="presentation">
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem">
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          Add
+        </div>
+        {{carbon-icon 'Add16'}}
+      </button>
+    </li>
     <li
-      class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
-      role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
-      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}} title="{{title}}"
-        {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus {{/if}} {{#if disabled}} tabindex="-1" {{/if}}>
+      class="{{@root.prefix}}--overflow-menu-options__option {{@root.prefix}}--overflow-menu-options__option--disabled"
+      role="presentation" aria-disabled="true" }>
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" tabindex="-1">
         <div class="{{@root.prefix}}--overflow-menu-options__option-content">
           Add
         </div>
@@ -132,17 +139,23 @@
     </li>
     {{/each}}
     {{#if @root.featureFlags.componentsX}}
-    <li
-      class="{{@root.prefix}}--overflow-menu-options__option {{#if disabled}} {{@root.prefix}}--overflow-menu-options__option--disabled {{/if}} {{#if danger}} {{@root.prefix}}--overflow-menu-options__option--danger {{/if}}"
-      role="presentation" {{#if disabled}} aria-disabled="true" {{/if}}>
-      <a href="https://www.ibm.com" class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" {{#if title}}
-        title="{{title}}" {{/if}} {{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}{{#if disabled}}
-        tabindex="-1" {{/if}}>
+    <li class="{{@root.prefix}}--overflow-menu-options__option" role="presentation">
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem">
         <div class="{{@root.prefix}}--overflow-menu-options__option-content">
           Add
         </div>
         {{carbon-icon 'Add16'}}
-      </a>
+      </button>
+    </li>
+    <li
+      class="{{@root.prefix}}--overflow-menu-options__option {{@root.prefix}}--overflow-menu-options__option--disabled"
+      role="presentation" aria-disabled="true" }>
+      <button class="{{@root.prefix}}--overflow-menu-options__btn" role="menuitem" tabindex="-1">
+        <div class="{{@root.prefix}}--overflow-menu-options__option-content">
+          Add
+        </div>
+        {{carbon-icon 'Add16'}}
+      </button>
     </li>
     {{/if}}
   </ul>


### PR DESCRIPTION
Closes #2101

Related: IBM/carbon-components-react#2007

This PR adds color rules and documentation examples for disabled overflow menu items with icons