### PR TITLE
refactor(button): convert to flex container

### DIFF
--- a/demo/js/components/ComponentExample/component-overrides.scss
+++ b/demo/js/components/ComponentExample/component-overrides.scss
@@ -64,7 +64,7 @@
   position: relative;
 
   .button button {
-    margin: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
   .data-table > div {
@@ -84,6 +84,7 @@
     left: 2rem;
     top: 2rem;
     width: calc(100% - 4rem);
+
     .bx--overflow-menu--flip {
       left: auto;
     }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -240,6 +240,10 @@
     min-width: auto;
     padding: rem(14px) rem(16px);
 
+    .#{$prefix}--btn__icon {
+      margin-left: $carbon--spacing-03;
+    }
+
     &:hover,
     &:active {
       color: $ibm-color__blue-70;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -177,9 +177,8 @@
 }
 
 @mixin button--x {
-  // <button> elements cannot be used as flex containers
   .#{$prefix}--btn {
-    display: inline-block;
+    @include button-base--x;
 
     &--disabled > .#{$prefix}--btn__icon,
     &:disabled > .#{$prefix}--btn__icon {
@@ -193,12 +192,12 @@
     border: 0;
   }
 
-  .#{$prefix}--btn {
-    @include button-base--x;
-  }
-
   .#{$prefix}--btn--primary {
     @include button-theme--x($interactive-01, transparent, $text-04, $hover-primary, $text-04, $active-primary);
+
+    &:hover {
+      color: $text-04;
+    }
   }
 
   .#{$prefix}--btn--secondary {
@@ -212,7 +211,6 @@
 
   .#{$prefix}--btn--tertiary {
     @include button-theme--x(transparent, $interactive-03, $interactive-03, $hover-tertiary, $interactive-03, $active-tertiary);
-    position: relative;
 
     &:hover {
       color: $inverse-01;
@@ -239,8 +237,6 @@
 
   .#{$prefix}--btn--ghost {
     @include button-theme--x(transparent, transparent, $interactive-01, $hover-ui, $interactive-01, $active-ui);
-    display: inline-flex;
-    align-items: center;
     min-width: auto;
     padding: rem(14px) rem(16px);
 
@@ -255,12 +251,6 @@
 
     &:active {
       background-color: $active-ui;
-    }
-
-    .#{$prefix}--btn__icon {
-      position: static;
-      margin-left: $spacing-xs;
-      transform: none;
     }
 
     &:disabled,
@@ -287,6 +277,7 @@
     @include button-theme--x($support-01, $support-01, $text-04, $hover-danger, $icon-03, $active-danger);
 
     &:hover {
+      color: $text-04;
       border: $button-border-width solid transparent;
     }
   }
@@ -295,11 +286,6 @@
     @include letter-spacing;
     min-height: rem(32px);
     padding: $button-padding-sm;
-  }
-
-  .#{$prefix}--btn--secondary + .#{$prefix}--btn--primary,
-  .#{$prefix}--btn--tertiary + .#{$prefix}--btn--danger {
-    margin-left: $carbon--spacing-05;
   }
 
   // Skeleton State

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -79,6 +79,9 @@
   @include type-style('body-short-01');
 
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
   flex-shrink: 0;
   min-height: rem($button-height);
   padding: $button-padding;
@@ -89,7 +92,7 @@
   outline: $button-outline-width solid transparent;
   position: relative;
   max-width: rem(320px);
-  min-width: rem(80px);
+  min-width: rem(125px);
 
   &:disabled {
     cursor: not-allowed;
@@ -98,14 +101,15 @@
     border-color: $ibm-color__gray-30;
   }
 
+  .#{$prefix}--btn__content {
+    flex: 1;
+  }
+
   .#{$prefix}--btn__icon {
     width: rem(16px);
     height: rem(16px);
+    margin-left: $spacing-md;
     transition: $duration--fast-01 motion(entrance, productive);
-    position: absolute;
-    right: rem(16px);
-    top: 50%;
-    transform: translateY(-50%);
   }
 }
 

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -101,11 +101,8 @@
     border-color: $ibm-color__gray-30;
   }
 
-  .#{$prefix}--btn__content {
-    flex: 1;
-  }
-
   .#{$prefix}--btn__icon {
+    flex-shrink: 0;
     width: rem(16px);
     height: rem(16px);
     margin-left: $spacing-md;

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -56,13 +56,13 @@
   {{/if}}
 </a>
 <p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
-  type="button" role="button" href="#">
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} disabled role="button"
+  href="#" tabindex="0">
   Alternate root node
 </p>
 <p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
-  type="button" role="button" href="#">
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} disabled role="button"
+  href="#" tabindex="0">
   Alternate root node with icon
   {{#if @root.featureFlags.componentsX}}
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -1,53 +1,39 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
   LICENSE file in the root directory of this source tree.
 -->
 
-<button
-  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
-  {{#if danger}} aria-label="danger" {{/if}}
-  type="button"
->
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}} type="button">
   Button
 </button>
-<button
-  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled"
-  {{#if danger}} aria-label="danger" {{/if}}
-  type="button" disabled
->
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}} type="button" disabled>
   Button
 </button>
-<button
-  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
-  {{#if danger}} aria-label="danger" {{/if}}
-  type="button"
->
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}} type="button">
   With icon
   {{#if @root.featureFlags.componentsX}}
-    {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
-    <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
-    </svg>
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true">
+    <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+  </svg>
   {{/if}}
 </button>
-<button
-  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled"
-  {{#if danger}} aria-label="danger" {{/if}}
-  type="button" disabled
->
+<button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}} type="button" disabled>
   With icon
   {{#if @root.featureFlags.componentsX}}
-    {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
-    <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-      <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
-    </svg>
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true">
+    <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+  </svg>
   {{/if}}
 </button>

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -37,3 +37,39 @@
   </svg>
   {{/if}}
 </button>
+<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  role="button" href="#">
+  Link
+</a>
+<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  role="button" href="#">
+  Link with icon
+  {{#if @root.featureFlags.componentsX}}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{else}}
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true">
+    <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+  </svg>
+  {{/if}}
+</a>
+<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  type="button" role="button" href="#">
+  Alternate root node
+</p>
+<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  type="button" role="button" href="#">
+  Alternate root node with icon
+  {{#if @root.featureFlags.componentsX}}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{else}}
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true">
+    <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+  </svg>
+  {{/if}}
+</p>

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -7,33 +7,15 @@
 
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button">
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    Button
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
+  Button
 </button>
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button" disabled>
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    Button
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
+  Button
 </button>
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button">
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    With icon
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
+  With icon
   {{#if @root.featureFlags.componentsX}}
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
@@ -45,13 +27,7 @@
 </button>
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button" disabled>
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    With icon
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
+  With icon
   {{#if @root.featureFlags.componentsX}}
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
@@ -61,49 +37,3 @@
   </svg>
   {{/if}}
 </button>
-<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
-  role="button" href="#">
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    Link
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
-</a>
-<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
-  role="button" href="#">
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    Link with icon
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
-  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
-</a>
-<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
-  type="button" role="button" href="#">
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    Alternate root node
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
-</p>
-<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
-  type="button" role="button" href="#">
-  {{#if @root.featureFlags.componentsX}}
-  <span class="{{@root.prefix}}--btn__content">
-    {{/if}}
-    Alternate root node with icon
-    {{#if @root.featureFlags.componentsX}}
-  </span>
-  {{/if}}
-  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
-</p>

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -7,15 +7,33 @@
 
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button">
-  Button
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    Button
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
 </button>
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button" disabled>
-  Button
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    Button
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
 </button>
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button">
-  With icon
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    With icon
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
   {{#if @root.featureFlags.componentsX}}
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
@@ -27,7 +45,13 @@
 </button>
 <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   {{#if danger}} aria-label="danger" {{/if}} type="button" disabled>
-  With icon
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    With icon
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
   {{#if @root.featureFlags.componentsX}}
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
   {{else}}
@@ -37,3 +61,49 @@
   </svg>
   {{/if}}
 </button>
+<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  role="button" href="#">
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    Link
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
+</a>
+<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  role="button" href="#">
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    Link with icon
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+</a>
+<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  type="button" role="button" href="#">
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    Alternate root node
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
+</p>
+<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  type="button" role="button" href="#">
+  {{#if @root.featureFlags.componentsX}}
+  <span class="{{@root.prefix}}--btn__content">
+    {{/if}}
+    Alternate root node with icon
+    {{#if @root.featureFlags.componentsX}}
+  </span>
+  {{/if}}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+</p>

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -138,8 +138,8 @@
   $button-font-size: 0.875rem !default !global;
   $button-border-radius: 0 !default !global;
   $button-height: 48px !default !global;
-  $button-padding: 0.875rem 4rem 0.875rem 1rem !default !global;
-  $button-padding-sm: 0.375rem 4rem 0.375rem 1rem !default !global;
+  $button-padding: 0.875rem 1rem !default !global;
+  $button-padding-sm: 0.375rem 1rem !default !global;
   $button-padding-lg: $carbon--spacing-04 !default !global;
   $button-border-width: 1px !default !global;
   $button-outline-width: 3px !default !global;

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -138,8 +138,8 @@
   $button-font-size: 0.875rem !default !global;
   $button-border-radius: 0 !default !global;
   $button-height: 48px !default !global;
-  $button-padding: 0.875rem 1rem !default !global;
-  $button-padding-sm: 0.375rem 1rem !default !global;
+  $button-padding: 0.875rem 15px !default !global;
+  $button-padding-sm: 0.375rem 15px !default !global;
   $button-padding-lg: $carbon--spacing-04 !default !global;
   $button-border-width: 1px !default !global;
   $button-outline-width: 3px !default !global;


### PR DESCRIPTION
Closes #2103

This PR converts our button classes to display as flex containers and adds additional documentation examples related to https://github.com/IBM/carbon-components-react/pull/1891

#### Changelog

**New**

- component examples with different root nodes using button classes

**Changed**

- convert button classes to display as flex containers
- spacing rules

**Removed**

- absolute positioning rules

#### Testing / Reviewing

Ensure any components consuming buttons or button classes are not broken
