### PR TITLE
fix(toolbar): misc fixes

### DIFF
--- a/src/components/overflow-menu/overflow-menu.js
+++ b/src/components/overflow-menu/overflow-menu.js
@@ -6,6 +6,7 @@
  */
 
 import settings from '../../globals/js/settings';
+import eventMatches from '../../globals/js/misc/event-matches';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
 import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
@@ -189,11 +190,13 @@ class OverflowMenu extends mixin(createComponent, initComponentBySearch, evented
       event.delegateTarget = element; // eslint-disable-line no-param-reassign
     }
 
-    this.changeState(state, getLaunchingDetails(event), () => {
-      if (state === 'hidden' && isOfMenu) {
-        element.focus();
-      }
-    });
+    if (!isOfMenu || eventMatches(event, this.options.selectorItem)) {
+      this.changeState(state, getLaunchingDetails(event), () => {
+        if (state === 'hidden' && isOfMenu) {
+          element.focus();
+        }
+      });
+    }
   }
 
   /**

--- a/src/components/toolbar/toolbar.config.js
+++ b/src/components/toolbar/toolbar.config.js
@@ -15,6 +15,7 @@ const filterOptions = [
     id: 'filter-option-1',
     value: 'filter-option-1',
     label: 'Filter option 1',
+    primaryFocus: true,
   },
   {
     id: 'filter-option-2',
@@ -34,6 +35,7 @@ const rowHeightOptions = [
     value: 'short',
     label: 'Short',
     selected: true,
+    primaryFocus: true,
   },
   {
     id: 'tall-rows',

--- a/src/components/toolbar/toolbar.hbs
+++ b/src/components/toolbar/toolbar.hbs
@@ -46,15 +46,8 @@
       <li class="{{@root.prefix}}--toolbar-menu__title">FILTER BY</li>
       {{#each filterOptions}}
         <li class="{{@root.prefix}}--toolbar-menu__option">
-          <input id="{{id}}" class="{{@root.prefix}}--checkbox" type="checkbox" value="{{value}}" name="checkbox">
-          <label for="{{id}}" class="{{@root.prefix}}--checkbox-label">
-            <span class="{{@root.prefix}}--checkbox-appearance">
-              <svg class="{{@root.prefix}}--checkbox-checkmark" width="12" height="9" viewBox="0 0 12 9" fill-rule="evenodd">
-                <path d="M4.1 6.1L1.4 3.4 0 4.9 4.1 9l7.6-7.6L10.3 0z"></path>
-              </svg>
-            </span>
-            {{label}}
-          </label>
+          <input id="{{id}}" class="{{@root.prefix}}--checkbox" type="checkbox" value="{{value}}" name="checkbox"{{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}>
+          <label for="{{id}}" class="{{@root.prefix}}--checkbox-label">{{label}}</label>
         </li>
       {{/each}}
     </ul>
@@ -79,7 +72,7 @@
         <legend class="{{@root.prefix}}--visually-hidden">Select table row height</legend>
         {{#each rowHeightOptions}}
           <li class="{{@root.prefix}}--toolbar-menu__option">
-            <input id="{{id}}" class="{{@root.prefix}}--radio-button" type="radio" value="{{value}}" name="radio"{{#if selected}} checked{{/if}}>
+            <input id="{{id}}" class="{{@root.prefix}}--radio-button" type="radio" value="{{value}}" name="radio"{{#if selected}} checked{{/if}}{{#if primaryFocus}} data-floating-menu-primary-focus{{/if}}>
             <label for="{{id}}" class="{{@root.prefix}}--radio-button__label">
               <span class="{{@root.prefix}}--radio-button__appearance"></span>
               {{label}}


### PR DESCRIPTION
Fixes #2108.

#### Changelog

**Changed**

* Prevented overflow menu from being closed when non-menu-item content in menu body is clicked on
* Aligned checkbox markup with `checkbox.hbs` by removing redaundant checkmark icon
* Ensured checkbox/radiobutton gets focus when overflow menu gets open

#### Testing / Reviewing

Testing should make sure toolbar and overflow menu are not broken.