### PR TITLE
chore(styles): update focus-outline for v10

### DIFF
--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -55,7 +55,7 @@
 
 @mixin focus-outline($type: 'border') {
   @if ($type == 'border') {
-    outline: 1px solid $brand-01;
+    outline: 1px solid if(not feature-flag-enabled('components-x'), $brand-01, $focus);
   }
 
   @if ($type == 'blurred') {
@@ -64,7 +64,7 @@
   }
 
   @if ($type == 'outline') {
-    outline: 2px solid $brand-01;
+    outline: 2px solid if(not feature-flag-enabled('components-x'), $brand-01, $focus);
     outline-offset: -2px;
   }
 


### PR DESCRIPTION
Fixes #1887.

#### Changelog

**Changed**

- `@mixin focus-outline` to use `$focus` token instead of `$brand-01`.

#### Testing / Reviewing

Testing should make sure focus outline is good, e.g. experimental accordion, definition/icon tooltip.