### PR TITLE
refactor(accordion) removes repetitive styling

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -258,7 +258,6 @@
         padding-bottom motion(entrance, productive) $duration--fast-02;
 
       p {
-        @include type-style('body-long-01');
         height: auto;
         transition: height motion(entrance, productive) $duration--fast-02;
       }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -238,8 +238,6 @@
 
     p {
       @include type-style('body-long-01');
-      height: 0;
-      transition: height motion(standard, productive) $duration--fast-02;
     }
   }
 
@@ -256,11 +254,6 @@
       transition: height motion(entrance, productive) $duration--fast-02,
         padding-top motion(entrance, productive) $duration--fast-02,
         padding-bottom motion(entrance, productive) $duration--fast-02;
-
-      p {
-        height: auto;
-        transition: height motion(entrance, productive) $duration--fast-02;
-      }
     }
 
     .#{$prefix}--accordion__arrow {


### PR DESCRIPTION
Closes #1974 

This pull request removes some repetitive styling that added a higher specificity to the active content area within the accordion. The issue this pull request closes only addressed the type-style, but in here I also remove height and transitions that appeared to be unnecessary. Let me know if that solved for some sort of edge case and I can revert that commit to only remove the `type-style`.

### Changelog

**Removed**

- `type-style` under `active` class name scope (already defined)
- `..._content p` height and transition (transition happens at the `content` level, this appeared to be redundant. Let me know otherwise.)
