### PR TITLE
fix(link): color adjustments

### DIFF
--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -54,28 +54,24 @@
   .#{$prefix}--link {
     @include reset;
     @include type-style('body-long-01');
-    color: $interactive-01;
+    color: $link-01;
     text-decoration: none;
     outline: none;
     transition: $duration--fast-01 motion(standard, productive);
 
     &:hover {
-      color: $interactive-01;
-      box-shadow: 0 1px $interactive-01;
+      color: $link-01;
+      box-shadow: 0 1px currentColor;
     }
 
     &:active,
     &:active:visited {
       color: $text-01;
-      box-shadow: 0 1px $text-01;
+      box-shadow: 0 1px currentColor;
     }
 
     &:focus {
-      box-shadow: 0 3px $interactive-01;
-    }
-
-    &:focus:active {
-      box-shadow: 0 1px $text-01;
+      box-shadow: 0 3px $link-01;
     }
 
     &:not([href]) {
@@ -90,7 +86,7 @@
     }
 
     &:visited {
-      color: $interactive-01;
+      color: $link-01;
     }
   }
 


### PR DESCRIPTION
Refs IBM/carbon-components-react#2061.

> Tooltip's link's hover underline color should be $link-01, same as link. Also wrong is link's `active` state
![image](https://user-images.githubusercontent.com/15144993/54657828-03759500-4a99-11e9-93f9-bf5908247ea6.png)

@shixiedesign My finding is this; I saw `box-shadow: 0 1px #0062ff` on the link in question which seems to match `$link-01` color in white theme. The code was using `$interactive-01`, though, so I replaced `$interactive-01` with `$link-01`. Tried to get an idea on what your feedback means further by digging the history of issues/PRs for link and found [this](https://github.com/IBM/carbon-components/pull/1960#issuecomment-469357884) saying that the underlines should be `currentColor`, which made me start guessing your feedback came from this and went ahead with ensuring text/underline colors are in sync. Hoping the changes matches your intent, but please don't hesitate to speak up anything - Thanks!

#### Changelog

**Changed**

- Replaced `$interactive-01` with `$link-01`.
- Ensured underline color matches text color regardless of the link state

#### Testing / Reviewing

Testing should make sure our link component (experimental) is not broken, especially its colors.