### PR TITLE
fix(tooltip): position and focus outline fixes

### DIFF
--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -350,6 +350,10 @@
     }
   }
 
+  .#{$prefix}--tooltip__label:focus {
+    @include focus-outline('border');
+  }
+
   .#{$prefix}--tooltip__trigger {
     @include button-reset($width: false);
     display: inline-flex;
@@ -434,7 +438,7 @@
       .#{$prefix}--tooltip__caret {
         left: auto;
         top: 50%;
-        right: rem(-5px);
+        right: rem(-4px);
         transform: rotate(-45deg) translate(50%, -50%);
       }
     }
@@ -442,14 +446,14 @@
     &[data-floating-menu-direction='top'] {
       .#{$prefix}--tooltip__caret {
         top: auto;
-        bottom: rem(-6px);
+        bottom: rem(-4px);
         transform: rotate(45deg);
       }
     }
 
     &[data-floating-menu-direction='right'] {
       .#{$prefix}--tooltip__caret {
-        left: rem(-5px);
+        left: rem(-4px);
         top: 50%;
         right: auto;
         transform: rotate(135deg) translate(-50%, 50%);

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -43,13 +43,19 @@ const getMenuOffset = (menuBody, menuDirection) => {
     }),
     {}
   );
+  let margin = 0;
+  if (menuDirection !== DIRECTION_BOTTOM) {
+    const style = menuBody.ownerDocument.defaultView.getComputedStyle(menuBody);
+    margin = Number((/^([\d-.]+)px$/.exec(style.getPropertyValue('margin-top')) || [])[1]);
+  }
   values[arrowPositionProp] = values[arrowPositionProp] || -6; // IE, etc.
   if (Object.keys(values).every(name => !isNaN(values[name]))) {
     const { [arrowPositionProp]: arrowPosition, 'border-bottom-width': borderBottomWidth } = values;
     return {
       left: 0,
       top: 0,
-      [menuPositionAdjustmentProp]: Math.sqrt(borderBottomWidth ** 2 * 2) - arrowPosition,
+      [menuPositionAdjustmentProp]:
+        Math.sqrt(borderBottomWidth ** 2 * 2) - arrowPosition + margin * (menuDirection === DIRECTION_TOP ? 2 : 1),
     };
   }
   return undefined;


### PR DESCRIPTION
Fixes #2142.
Fixes IBM/carbon-components-react#2048.
Refs IBM/carbon-components-react#2061.

#### Changelog

**Changed**

- Fix for tooltip positioning in left/top/right positioning.
- Fix for focus outline color in "no icon" option.

#### Testing / Reviewing

Testing requires the following (both can be done in Netlify link):

* For positioning:
  1. Follow "view full render" link in tooltip demo
  2. Do the following in Chrome DevTools' console: `document.querySelector('[data-floating-menu-direction]').setAttribute('data-floating-menu-direction', 'top')`
  3. Click on the trigger icon
* For focus outline color in "no icon" option:
  1. Follow "view full render" link in tooltip demo
  2. Do the following in Chrome DevTools' console: `document.querySelector('.bx--tooltip__label').setAttribute('tabindex', '0')`
  3. Click on the tooltip label