### PR TITLE
chore(styles): deprecate helvetica mixin

### DIFF
--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -64,7 +64,13 @@ $typescale-map: (
 
 /// @deprecated (For v10) Use Plex fonts
 @mixin helvetica {
-  font-family: $font-family-helvetica;
+  @include deprecate(
+    '`@include helvetica` has been removed. ' + 'Use `@include carbon--font-family()` instead.',
+    feature-flag-enabled('breaking-changes-x'),
+    true
+  ) {
+    font-family: $font-family-helvetica;
+  }
 }
 
 /// @deprecated (For v10) Use `@include carbon--font-family()`


### PR DESCRIPTION
Refs #1626.

#### Changelog

**Removed**

- `@mixin helvetica` for `v10`.

#### Testing / Reviewing

Testing should make sure no component is broken.