### PR TITLE
fix(button): target disabled classes

### DIFF
--- a/demo/js/components/ComponentExample/component-overrides.scss
+++ b/demo/js/components/ComponentExample/component-overrides.scss
@@ -63,7 +63,7 @@
 .component-example__live {
   position: relative;
 
-  .button button {
+  .button .bx--btn {
     margin-bottom: 0.5rem;
   }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -180,7 +180,7 @@
   .#{$prefix}--btn {
     @include button-base--x;
 
-    &--disabled > .#{$prefix}--btn__icon,
+    &.#{$prefix}--btn--disabled > .#{$prefix}--btn__icon,
     &:disabled > .#{$prefix}--btn__icon {
       fill: $ui-04;
     }
@@ -219,9 +219,9 @@
     &:disabled,
     &:hover:disabled,
     &:focus:disabled,
-    &--disabled,
-    &--disabled:hover,
-    &--disabled:focus {
+    &.#{$prefix}--btn--disabled,
+    &.#{$prefix}--btn--disabled:hover,
+    &.#{$prefix}--btn--disabled:focus {
       background: transparent;
       color: $disabled;
 
@@ -260,9 +260,9 @@
     &:disabled,
     &:hover:disabled,
     &:focus:disabled,
-    &--disabled,
-    &--disabled:hover,
-    &--disabled:focus {
+    &.#{$prefix}--btn--disabled,
+    &.#{$prefix}--btn--disabled:hover,
+    &.#{$prefix}--btn--disabled:focus {
       color: $disabled;
       background: transparent;
       border-color: transparent;

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -94,7 +94,8 @@
   max-width: rem(320px);
   min-width: rem(125px);
 
-  &:disabled {
+  &:disabled,
+  &.#{$prefix}--btn--disabled {
     cursor: not-allowed;
     color: $ui-04;
     background: $ibm-color__gray-30;
@@ -129,7 +130,7 @@
     transition: $duration--fast-01 motion(entrance, productive);
   }
 
-  &::before {
+  &:not(.#{$prefix}--btn--disabled)::before {
     top: calc(-#{$button-border-width} + #{$button-outline-width});
     left: -$button-border-width + $button-outline-width;
     width: calc(100% + (2 * #{$button-border-width}) - (2 * #{$button-outline-width}));
@@ -141,7 +142,7 @@
     border-color: $ui-02;
   }
 
-  &::after {
+  &:not(.#{$prefix}--btn--disabled)::after {
     top: -#{$button-border-width};
     left: -#{$button-border-width};
     height: calc(100% + 2 * #{$button-border-width});
@@ -154,7 +155,9 @@
   }
 
   &:disabled:hover,
-  &:disabled:focus {
+  &:disabled:focus,
+  &:hover.#{$prefix}--btn--disabled,
+  &:focus.#{$prefix}--btn--disabled {
     color: $ui-04;
     background: $ibm-color__gray-30;
     border-color: $ibm-color__gray-30;

--- a/src/components/button/button.hbs
+++ b/src/components/button/button.hbs
@@ -38,12 +38,17 @@
   {{/if}}
 </button>
 <a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button"
   role="button" href="#">
   Link
 </a>
 <a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button" disabled
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled {{@root.prefix}}--disabled"
+  {{#if danger}} aria-label="danger" {{/if}} type="button" role="button" tabindex="-1">
+  Link
+</a>
+<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} type="button"
   role="button" href="#">
   Link with icon
   {{#if @root.featureFlags.componentsX}}
@@ -55,14 +60,44 @@
   </svg>
   {{/if}}
 </a>
+<a class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}} {{@root.prefix}}--btn--disabled{{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  {{#if danger}} aria-label="danger" {{/if}} type="button" role="button" tabindex="-1">
+  Link with icon
+  {{#if @root.featureFlags.componentsX}}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{else}}
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true">
+    <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+  </svg>
+  {{/if}}
+</a>
 <p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} disabled role="button"
-  href="#" tabindex="0">
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} role="button"
+  tabindex="0">
   Alternate root node
 </p>
 <p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
-  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} disabled role="button"
-  href="#" tabindex="0">
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled" {{#if danger}} aria-label="danger"
+  {{/if}} role="button" tabindex="-1">
+  Alternate root node
+</p>
+<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}}" {{#if danger}} aria-label="danger" {{/if}} role="button"
+  tabindex="0">
+  Alternate root node with icon
+  {{#if @root.featureFlags.componentsX}}
+  {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
+  {{else}}
+  <svg class="{{@root.prefix}}--btn__icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true">
+    <path d="M7 7H4v2h3v3h2V9h3V7H9V4H7v3zm1 9A8 8 0 1 1 8 0a8 8 0 0 1 0 16z" fill-rule="evenodd" />
+  </svg>
+  {{/if}}
+</p>
+<p class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}}
+  {{#if small}} {{@root.prefix}}--btn--sm{{/if}} {{@root.prefix}}--btn--disabled" {{#if danger}} aria-label="danger"
+  {{/if}} role="button" tabindex="-1">
   Alternate root node with icon
   {{#if @root.featureFlags.componentsX}}
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}


### PR DESCRIPTION
Closes #2086

Related: https://github.com/IBM/carbon-components-react/issues/2012

We are still targeting the `button` element or `:disabled` pseudoclass for disabled styles, so this PR adds the `.bx--btn--disabled` class and styles it to allow for more flexibility with rendering Carbon buttons

#### Testing / Reviewing

Check that all button variants behave as expected while enabled and disabled
