### PR TITLE
fix(text-area): consolidate invalid textarea style

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -152,11 +152,10 @@
 
   input[data-invalid],
   .#{$prefix}--text-input__field-wrapper[data-invalid],
-  .#{$prefix}--text-area__wrapper[data-invalid],
+  .#{$prefix}--text-area__wrapper[data-invalid] > .#{$prefix}--text-area--invalid,
   .#{$prefix}--select-input__wrapper[data-invalid],
   .#{$prefix}--list-box[data-invalid] {
-    outline: 2px solid $support-01;
-    outline-offset: -2px;
+    @include focus-outline('invalid');
   }
 
   input[data-invalid],

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -175,14 +175,6 @@
     color: $disabled;
   }
 
-  //-----------------------------
-  // Error
-  //-----------------------------
-  .#{$prefix}--text-area--invalid {
-    @include focus-outline('invalid');
-    box-shadow: none;
-  }
-
   // Skeleton State
   #{$prefix}--text-area.#{$prefix}--skeleton {
     @include skeleton;


### PR DESCRIPTION
Closes #2150

Related: https://github.com/IBM/carbon-components-react/pull/2036 

This PR avoids setting the error state outline twice on different elements in the textarea component