### PR TITLE
fix(textarea): remove webkit only prefix

### DIFF
--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -136,7 +136,7 @@
     @include focus-outline('outline');
   }
 
-  .#{$prefix}--text-area::-webkit-input-placeholder {
+  .#{$prefix}--text-area::placeholder {
     @include placeholder-colors;
     @include type-style('body-long-01');
   }
@@ -171,8 +171,8 @@
     border-bottom: 1px solid transparent;
   }
 
-  .#{$prefix}--text-area:disabled::-webkit-input-placeholder {
-    color: $disabled;
+  .#{$prefix}--text-area:disabled::placeholder {
+    color: $disabled-02;
   }
 
   // Skeleton State
@@ -180,7 +180,7 @@
     @include skeleton;
     height: rem(100px);
 
-    &::-webkit-input-placeholder {
+    &::placeholder {
       color: transparent;
     }
   }

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -139,6 +139,7 @@
   .#{$prefix}--text-area::placeholder {
     @include placeholder-colors;
     @include type-style('body-long-01');
+    opacity: 1;
   }
 
   .#{$prefix}--text-area--light {


### PR DESCRIPTION
Closes #2152

This PR removes our prefixes on selectors for placeholder text which were only targeting webkit browsers. Also resets browser styles on placeholder text

#### Testing/Reviewing

make sure disabled textarea placeholder is properly styled