### PR TITLE
fix(text-area): modify spacing tokens for invalid icon

### DIFF
--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -157,8 +157,8 @@
 
   .#{$prefix}--text-area__invalid-icon {
     position: absolute;
-    right: rem(16px);
-    top: rem(16px);
+    right: $carbon--spacing-05;
+    top: $carbon--spacing-04;
     fill: $support-01;
   }
 


### PR DESCRIPTION
Closes #2157

This PR repositions the invalid icon for v10 textareas