### PR TITLE
feat(button): support experimental button sets

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -177,6 +177,21 @@
 }
 
 @mixin button--x {
+  // button set styles
+  .#{$prefix}--btn-set {
+    display: flex;
+  }
+
+  .#{$prefix}--btn-set > .#{$prefix}--btn {
+    max-width: rem(196px); // taken from design kit
+    width: 100%;
+  }
+
+  .#{$prefix}--btn--secondary.#{$prefix}--btn--disabled + .#{$prefix}--btn--primary.#{$prefix}--btn--disabled,
+  .#{$prefix}--btn--tertiary.#{$prefix}--btn--disabled + .#{$prefix}--btn--danger.#{$prefix}--btn--disabled {
+    border-left: rem(1px) solid $disabled-03;
+  }
+
   .#{$prefix}--btn {
     @include button-base--x;
 

--- a/src/components/button/button--set.hbs
+++ b/src/components/button/button--set.hbs
@@ -1,0 +1,24 @@
+<!--
+  Copyright IBM Corp. 2016, 2018
+
+  This source code is licensed under the Apache-2.0 license found in the
+  LICENSE file in the root directory of this source tree.
+-->
+
+<div class="{{@root.prefix}}--btn-set">
+  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--secondary">
+    Secondary Button
+  </button>
+  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary">
+    Primary Button
+  </button>
+</div>
+
+<div class="{{@root.prefix}}--btn-set">
+  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--secondary {{@root.prefix}}--btn--disabled" disabled>
+    Secondary Button
+  </button>
+  <button class="{{@root.prefix}}--btn {{@root.prefix}}--btn--primary {{@root.prefix}}--btn--disabled" disabled>
+    Primary Button
+  </button>
+</div>


### PR DESCRIPTION
Closes #2159

This PR adds support for v10 button sets

#### Changelog

**New**

- v10 button sets
- button set docs examples
- disabled button set styles

**Changed**

- style button sets within wrapper div rather than sibling combinator like v9
- add set width for buttons in a set (alternative is to dynamically calculate width and set both buttons to be the same width, but this is probably not preferable and requires JS). users can modify our width rule in CSS as needed