### PR TITLE
fix(link): fix active/focus/visited underline color

### DIFF
--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -71,7 +71,7 @@
     }
 
     &:focus {
-      box-shadow: 0 3px $link-01;
+      box-shadow: 0 3px currentColor;
     }
 
     &:not([href]) {


### PR DESCRIPTION
Refs IBM/carbon-components-react#2061.

From @emyarod at https://github.com/IBM/carbon-components/pull/2144#issuecomment-474956071:

> just wanted to confirm if the focus+active link underline should be different from the text color

![image](https://user-images.githubusercontent.com/8265238/54707372-eed3e400-4b0e-11e9-9004-ef45c91be8df.png)

Found that `.bx--link:focus` still has non-`currentColor` reference. I'm guessing @shixiedesign would want it to match text/underline colors there, too. This PR does that, but anybody don't hesitate to speak up if it's wrong. Thanks!

#### Changelog

**Changed**

- Focus style of link, ensuring the underline color matches the text color

#### Testing / Reviewing

Testing requires selecting a link in DOM inspector (in Chrome DevTools), clicking on `:hov` icon and checking off `:active` and `:focus`. Need to ensure the color is good.