### PR TITLE
fix(data-table-v2): revert change from header to title-container

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-core.scss
+++ b/src/components/data-table-v2/_data-table-v2-core.scss
@@ -185,18 +185,18 @@
   //----------------------------------------------------------------------------
   // Table title text
   //----------------------------------------------------------------------------
-  .#{$prefix}--data-table-v2-title-container {
+  .#{$prefix}--data-table-v2-header {
     background: $ui-01;
     height: rem(88px);
     padding: rem(22px) 0 0 $spacing-05;
   }
 
-  .#{$prefix}--data-table-v2-header {
+  .#{$prefix}--data-table-v2-header__title {
     @include type-style('productive-heading-03');
     color: $text-01;
   }
 
-  .#{$prefix}--data-table-v2-optional {
+  .#{$prefix}--data-table-v2-header__description {
     @include type-style('body-short-01');
     color: $text-02;
   }

--- a/src/components/data-table-v2/data-table-v2.hbs
+++ b/src/components/data-table-v2/data-table-v2.hbs
@@ -211,9 +211,9 @@
 {{#if componentsX}}
   {{#if hasToolbar}}
   <div class="{{@root.prefix}}--data-table-v2-container {{#if sticky}}{{@root.prefix}}--data-table-v2--max-width{{/if}}" data-table-v2>
-    <div class="{{@root.prefix}}--data-table-v2-title-container">
-      <h4 class="{{@root.prefix}}--data-table-v2-header">{{title}}</h4>
-      <p class="{{@root.prefix}}--data-table-v2-optional">{{optionalHelper}}</p>
+    <div class="{{@root.prefix}}--data-table-v2-header">
+      <h4 class="{{@root.prefix}}--data-table-v2-header__title">{{title}}</h4>
+      <p class="{{@root.prefix}}--data-table-v2-header__description">{{optionalHelper}}</p>
     </div>
     <!-- Toolbar Content -->
     <section class="{{@root.prefix}}--table-toolbar {{#if small}} {{@root.prefix}}--table-toolbar--small {{/if}}">


### PR DESCRIPTION
Revert change for header to title-container in Data Table

#### Changelog

**New**

**Changed**

- `title-container` goes to `header`, also updates to `header__title` and `header__description`

**Removed**

#### Testing / Reviewing
