### PR TITLE
chore(code-snippet): add padding after single line

### DIFF
--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -368,6 +368,7 @@
   .#{$prefix}--snippet--single pre {
     white-space: nowrap;
     @include type-style('code-01');
+    padding-right: $spacing-xs;
   }
 
   .#{$prefix}--snippet--single::after {


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-react/issues/2041

#### Changelog

**Changed**

- added padding to end of single line to avoid putting the fade on end character 


Related https://github.com/IBM/carbon-components-react/pull/2075