### PR TITLE
fix(tab): re-enable elipsis

### DIFF
--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -428,7 +428,6 @@
       width: rem(160px);
       margin: 0;
       line-height: inherit;
-      overflow: visible;
 
       &:focus,
       &:active {


### PR DESCRIPTION
Fixes #2178.

#### Changelog

**Removed**

- Code that had disabled tab's ellipsis somehow.

#### Testing / Reviewing

Testing can be done by the following:

1. Click on "View full render" link in the tabs demo
2. Type the following in Chrome DevTools' console: `document.getElementById('tab-link-1').textContent = 'the long text the long text'`