### PR TITLE
chore(devenv): remove the last dependency to deprecated mixin

### DIFF
--- a/demo/js/components/CodeExample/code-example.scss
+++ b/demo/js/components/CodeExample/code-example.scss
@@ -64,7 +64,6 @@ $temp-text: $color__blue-90;
 }
 
 .code-example__expand {
-  @include helvetica;
   position: absolute;
   bottom: rem(2px);
   right: rem(2px);


### PR DESCRIPTION
Refs #1501.

#### Changelog

**Removed**

- `@include helvetica` in dev env, that is no longer needed.