### PR TITLE
fix(modal): fix JavaScript error in IE11

### DIFF
--- a/src/globals/js/mixins/init-component-by-launcher.js
+++ b/src/globals/js/mixins/init-component-by-launcher.js
@@ -45,9 +45,7 @@ export default function(ToMix) {
 
             if (launcher) {
               event.delegateTarget = launcher; // eslint-disable-line no-param-reassign
-              const elements = [
-                ...launcher.ownerDocument.querySelectorAll(launcher.getAttribute(effectiveOptions.attribInitTarget)),
-              ];
+              const elements = launcher.ownerDocument.querySelectorAll(launcher.getAttribute(effectiveOptions.attribInitTarget));
               if (elements.length > 1) {
                 throw new Error('Target widget must be unique.');
               }


### PR DESCRIPTION
We hit babel/babel#7597 with our logic turning `NodeList` to an array, but turned out it's not needed there.

Fixes #2068.

#### Changelog

**Removed**

- Logic converting `NodeList` to an array in modal instantiation logic.

#### Testing / Reviewing

Testing should make sure modal is not broken. The fix to the bug can be verified by (successfully) opening modal in our dev env with IE11.