### PR TITLE
chore(devenv): avoid using method shorthand syntax

### DIFF
--- a/demo/polyfills/devenv.js
+++ b/demo/polyfills/devenv.js
@@ -1,14 +1,14 @@
 // Polyfill for dev env UI based on `carbon-components-react`
-/* eslint-disable import/no-extraneous-dependencies, global-require */
 import 'core-js/modules/es6.string.includes';
 import 'core-js/modules/es7.object.values';
 import 'whatwg-fetch';
+import PromisePolyfill from 'promise/lib/es6-extensions';
+import rejectionTracking from 'promise/lib/rejection-tracking';
 
 if (typeof Promise === 'undefined') {
   // Rejection tracking prevents a common issue where React gets into an
   // inconsistent state due to an error, but it gets swallowed by a Promise,
   // and the user has no idea what causes React's erratic future behavior.
-  require('promise/lib/rejection-tracking').enable();
-  window.Promise = require('promise/lib/es6-extensions.js');
+  rejectionTracking.enable();
+  window.Promise = PromisePolyfill;
 }
-/* eslint-enable import/no-extraneous-dependencies, global-require */

--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -32,6 +32,7 @@ module.exports = {
     resolve({
       jsnext: true,
       main: true,
+      browser: true,
     }),
     commonjs({
       include: ['node_modules/**', 'src/globals/js/settings.js', 'demo/feature-flags.js'],

--- a/tools/rollup.config.dev.js
+++ b/tools/rollup.config.dev.js
@@ -15,7 +15,7 @@ module.exports = {
           return `
             function Markdown() {}
             Markdown.prototype = {
-              render() { return '' }
+              render: function () { return '' }
             };
             export default Markdown;
           `;


### PR DESCRIPTION
Refs #2046.

#### Changelog

**Changed**

- Replaced method shorthand syntax in `markdown-it` mock with regular property/function one.
- Fixed a mixed ESM/CJS code so `rollup-plugin-commonjs' is not needed there.
- Fixed a Rollup configuration issue so `package.json`'s `browser` field works.

#### Testing / Reviewing

Test can be done by opening the Netlify link and ensuring that the dev env opens.
