### PR TITLE
fix(link): add `aria-disabled` to disabled example

### DIFF
--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -6,7 +6,7 @@
 -->
 
 <a href="#" class="{{@root.prefix}}--link">Link</a>
-<a class="{{@root.prefix}}--link">Placeholder link</a>
+<a class="{{@root.prefix}}--link" aria-disabled="true">Placeholder link</a>
 <p class="{{@root.prefix}}--link--disabled">Disabled Link</p>
 <a href="#" class="{{@root.prefix}}--link">Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti explicabo
   nobis consequatur quod qui quam laboriosam placeat repudiandae. Ducimus ea aut omnis asperiores mollitia

--- a/src/components/link/link.hbs
+++ b/src/components/link/link.hbs
@@ -8,6 +8,6 @@
 <a href="#" class="{{@root.prefix}}--link">Link</a>
 <a class="{{@root.prefix}}--link" aria-disabled="true">Placeholder link</a>
 <p class="{{@root.prefix}}--link--disabled">Disabled Link</p>
-<a href="#" class="{{@root.prefix}}--link">Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti explicabo
-  nobis consequatur quod qui quam laboriosam placeat repudiandae. Ducimus ea aut omnis asperiores mollitia
-  necessitatibus architecto temporibus provident quo? Repellat!</a>
+<div style="width:200px">
+  <a href="#" class="{{@root.prefix}}--link">Text wrap example for hover, focus, and active state testing.</a>
+</div>


### PR DESCRIPTION
Closes #2188

This PR adds `aria-disabled` to our disabled link example in the docs, as well as placing the word-wrap example in a shortened div rather than rendering an excessively long link example.