### PR TITLE
fix(radio button) Selected disabled state with $disabled token

### DIFF
--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -210,6 +210,10 @@
   .#{$prefix}--radio-button:disabled + .#{$prefix}--radio-button__label .#{$prefix}--radio-button__appearance,
   .#{$prefix}--radio-button:disabled:checked + .#{$prefix}--radio-button__label .#{$prefix}--radio-button__appearance {
     border-color: $disabled;
+
+    &::before {
+      background-color: $disabled;
+    }
   }
 
   // Focus


### PR DESCRIPTION
Closes #2194 

This pull request quickly adds the `$disabled` token to the radio button's inner circle to correct its color when selected and disabled.

#### Changelog

**New**
- added `$disable` token to `::before`
