### PR TITLE
fix(dropdown): add overflow styles to menu options

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -389,13 +389,13 @@
 
   .#{$prefix}--dropdown-link {
     @include focus-outline('reset');
-    display: flex;
-    align-items: center;
+    display: block;
     height: rem(40px);
     color: $text-02;
     text-decoration: none;
     font-weight: normal;
     line-height: rem(16px);
+    padding: rem(11px) 0;
     margin: 0 $carbon--spacing-05;
     border: 1px solid transparent;
     border-top-color: $ui-03;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -389,17 +389,19 @@
 
   .#{$prefix}--dropdown-link {
     @include focus-outline('reset');
-    display: block;
+    display: flex;
+    align-items: center;
+    height: rem(40px);
     color: $text-02;
     text-decoration: none;
     font-weight: normal;
     line-height: rem(16px);
-    padding: rem(11px) 0;
-    margin: 0 rem(16px);
+    margin: 0 $carbon--spacing-05;
     border: 1px solid transparent;
     border-top-color: $ui-03;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
 
     &:focus {
       @include focus-outline('outline');

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -333,8 +333,7 @@
 
   .#{$prefix}--dropdown-text {
     @include type-style('body-short-01');
-    display: flex;
-    align-items: center;
+    display: block;
     height: rem(40px);
     padding-top: $carbon--spacing-04;
     padding-bottom: $carbon--spacing-04;

--- a/src/components/dropdown/dropdown.config.js
+++ b/src/components/dropdown/dropdown.config.js
@@ -31,6 +31,10 @@ const items = [
     label: 'Option 5',
     value: 'router',
   },
+  {
+    label: 'An example option that is really long to show what should be done to handle long text',
+    value: 'loremipsum',
+  },
 ];
 
 module.exports = {

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -647,17 +647,19 @@ $list-box-menu-width: rem(300px);
 
   .#{$prefix}--list-box__menu-item__option {
     @include focus-outline('reset');
-    display: block;
+    display: flex;
+    align-items: center;
+    height: rem(40px);
     color: $text-02;
     text-decoration: none;
     font-weight: normal;
     line-height: rem(16px);
-    padding: rem(11px) 0;
-    margin: 0 rem(16px);
+    margin: 0 $carbon--spacing-05;
     border: 1px solid transparent;
     border-top-color: $ui-03;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
 
     &:focus {
       @include focus-outline('outline');
@@ -670,6 +672,10 @@ $list-box-menu-width: rem(300px);
       color: $text-01;
       border-color: transparent;
     }
+  }
+
+  .#{$prefix}--list-box.#{$prefix}--list-box--inline .#{$prefix}--list-box__menu-item__option {
+    margin: 0 $carbon--spacing-03;
   }
 
   .#{$prefix}--list-box__menu-item--highlighted {

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -679,6 +679,12 @@ $list-box-menu-width: rem(300px);
 
   .#{$prefix}--list-box.#{$prefix}--list-box--inline .#{$prefix}--list-box__menu-item__option {
     margin: 0 $carbon--spacing-03;
+
+    &:focus {
+      margin: 0;
+      padding-left: $carbon--spacing-03;
+      padding-right: $carbon--spacing-03;
+    }
   }
 
   .#{$prefix}--list-box__menu-item--highlighted {

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -485,6 +485,7 @@ $list-box-menu-width: rem(300px);
     position: relative;
     display: inline-flex;
     align-items: center;
+    vertical-align: top;
     height: rem(40px);
     padding: 0 $carbon--spacing-09 0 $carbon--spacing-05;
     cursor: pointer;
@@ -561,7 +562,6 @@ $list-box-menu-width: rem(300px);
   // Modifier for a selection to show that multiple selections have been made
   .#{$prefix}--list-box__selection--multi {
     @include type-style('label-01');
-
     position: static;
     display: flex;
     align-items: center;

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -489,14 +489,9 @@ $list-box-menu-width: rem(300px);
     padding: 0 $carbon--spacing-09 0 $carbon--spacing-05;
     cursor: pointer;
     outline: none;
-    border-bottom: 1px solid $ui-04;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .#{$prefix}--list-box--inline .#{$prefix}--list-box__field {
-    border: none;
   }
 
   .#{$prefix}--list-box__field:focus {

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -517,6 +517,9 @@ $list-box-menu-width: rem(300px);
     @include type-style('body-short-01');
     color: $text-01;
     user-select: none;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 
   // Menu status inside of a `list-box__field`

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -647,13 +647,13 @@ $list-box-menu-width: rem(300px);
 
   .#{$prefix}--list-box__menu-item__option {
     @include focus-outline('reset');
-    display: flex;
-    align-items: center;
+    display: block;
     height: rem(40px);
     color: $text-02;
     text-decoration: none;
     font-weight: normal;
     line-height: rem(16px);
+    padding: rem(11px) 0;
     margin: 0 $carbon--spacing-05;
     border: 1px solid transparent;
     border-top-color: $ui-03;

--- a/src/components/list-box/list-box.config.js
+++ b/src/components/list-box/list-box.config.js
@@ -28,6 +28,10 @@ const items = [
     id: 'downshift-1-item-3',
     label: 'Option 4',
   },
+  {
+    id: 'downshift-1-item-4',
+    label: 'An example option that is really long to show what should be done to handle long text',
+  },
 ];
 
 module.exports = {


### PR DESCRIPTION
Closes #2205

This PR adds overflow styles to dropdown menu options to match the changes to the trigger button changes in #2203

#### Changelog

**New**

- text overflow styles for dropdown menu options
- docs examples to show text overflow behavior in dropdowns and listboxes

**Changed**

- reduce inline listbox menu side margins to match 
- revert flex item menu options to block display for text-overflow styles

#### Testing / Reviewing

check dropdown and listbox menus for regressions
