### PR TITLE
fix(combo-box): match experimental spec

### DIFF
--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -23,6 +23,14 @@
 @mixin combo-box--x {
   .#{$prefix}--combo-box .#{$prefix}--text-input {
     padding-right: $carbon--spacing-09;
+
+    &::placeholder {
+      color: $text-02;
+    }
+
+    &[disabled]::placeholder {
+      color: $disabled-02;
+    }
   }
 
   .#{$prefix}--combo-box.#{$prefix}--list-box[data-invalid] .#{$prefix}--text-input {

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -26,6 +26,7 @@
 
     &::placeholder {
       color: $text-02;
+      opacity: 1;
     }
 
     &[disabled]::placeholder {

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -38,10 +38,6 @@
   .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon--open {
     display: none;
   }
-
-  .#{$prefix}--combo-box.#{$prefix}--list-box {
-    border-bottom: none;
-  }
 }
 
 @include exports('combo-box') {

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -21,13 +21,22 @@
 }
 
 @mixin combo-box--x {
+  .#{$prefix}--combo-box .#{$prefix}--text-input {
+    padding-right: $carbon--spacing-09;
+  }
+
+  .#{$prefix}--combo-box.#{$prefix}--list-box[data-invalid] .#{$prefix}--text-input {
+    padding-right: carbon--mini-units(8);
+  }
+
+  .#{$prefix}--combo-box .#{$prefix}--list-box__field,
+  .#{$prefix}--combo-box.#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__field {
+    padding: 0;
+  }
+
   .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon,
   .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon--open {
     display: none;
-  }
-
-  .#{$prefix}--combo-box > .#{$prefix}--list-box__field {
-    padding: 0;
   }
 
   .#{$prefix}--combo-box.#{$prefix}--list-box {

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -33,11 +33,6 @@
   .#{$prefix}--combo-box.#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__field {
     padding: 0;
   }
-
-  .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon,
-  .#{$prefix}--combo-box > .#{$prefix}--list-box__field[disabled] > .#{$prefix}--list-box__menu-icon--open {
-    display: none;
-  }
 }
 
 @include exports('combo-box') {

--- a/src/components/combo-box/combo-box.config.js
+++ b/src/components/combo-box/combo-box.config.js
@@ -28,6 +28,10 @@ const items = [
     id: 'downshift-1-item-3',
     label: 'Option 4',
   },
+  {
+    id: 'downshift-1-item-4',
+    label: 'An example option that is really long to show what should be done to handle long text',
+  },
 ];
 
 module.exports = {

--- a/src/components/combo-box/combo-box.config.js
+++ b/src/components/combo-box/combo-box.config.js
@@ -47,13 +47,34 @@ module.exports = {
         items,
       },
     },
-    {
-      name: 'disabled',
-      label: 'Disabled',
-      context: {
-        disabled: true,
-        items,
-      },
-    },
+    ...(featureFlags.componentsX
+      ? [
+          {
+            name: 'light',
+            label: 'Light',
+            context: {
+              light: true,
+              items,
+            },
+          },
+          {
+            name: 'inline',
+            label: 'Inline',
+            context: {
+              inline: true,
+              items,
+            },
+          },
+        ]
+      : [
+          {
+            name: 'disabled',
+            label: 'Disabled',
+            context: {
+              disabled: true,
+              items,
+            },
+          },
+        ]),
   ],
 };

--- a/src/components/combo-box/combo-box.config.js
+++ b/src/components/combo-box/combo-box.config.js
@@ -57,14 +57,16 @@ module.exports = {
               items,
             },
           },
-          {
-            name: 'inline',
-            label: 'Inline',
-            context: {
-              inline: true,
-              items,
-            },
-          },
+          // this variant is not part of our current spec
+          // but it is supported (because of list-box) if needed
+          // {
+          //   name: 'inline',
+          //   label: 'Inline',
+          //   context: {
+          //     inline: true,
+          //     items,
+          //   },
+          // },
         ]
       : [
           {

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -1,44 +1,50 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
-  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false" aria-haspopup="true"
-    {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list"
-    aria-expanded="false" autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." {{#if disabled}}
-    disabled{{/if}}> <div class="{{@root.prefix}}--list-box__menu-icon">
-    {{#if @root.featureFlags.componentsX}}
+<div
+  class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+    aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
+      aria-autocomplete="list" aria-expanded="false" autocomplete="off" value="" id="downshift-input-2"
+      placeholder="Filter..." {{#if disabled}} disabled{{/if}}>
+    <div class="{{@root.prefix}}--list-box__menu-icon">
+      {{#if @root.featureFlags.componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' aria-label='Open menu' }}
-    {{else}}
+      {{else}}
       <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Open menu" name="caret--down" role="img">
         <title>Close menu</title>
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
-    {{/if}}
+      {{/if}}
+    </div>
   </div>
 </div>
-</div>
-<div class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
-  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true" aria-haspopup="true"
-    {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list"
-    aria-expanded="true" autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..."
-    aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}> <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
-    {{#if @root.featureFlags.componentsX}}
+<div
+  class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
+    aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
+      aria-autocomplete="list" aria-expanded="true" autocomplete="off" value="" id="downshift-input-2"
+      placeholder="Filter..." aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}>
+    <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
+      {{#if @root.featureFlags.componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' aria-label='Close menu' }}
-    {{else}}
+      {{else}}
       <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Close menu" name="caret--down" role="img">
         <title>Close menu</title>
         <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
       </svg>
-    {{/if}}
+      {{/if}}
+    </div>
   </div>
-</div>
-<div class="{{@root.prefix}}--list-box__menu">
-  {{#each items}}
-  <div class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}" id="{{id}}">{{label}}</div>
-  {{/each}}
-</div>
+  <div class="{{@root.prefix}}--list-box__menu">
+    {{#each items}}
+    <div
+      class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
+      id="{{id}}">{{label}}</div>
+    {{/each}}
+  </div>
 </div>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -27,13 +27,17 @@
       {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
     </div>
   </div>
-  <div class="{{@root.prefix}}--list-box__menu">
+  <ul class="{{@root.prefix}}--list-box__menu">
     {{#each items}}
-    <div
+    <li
       class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
-      id="{{id}}">{{label}}</div>
+      id="{{id}}">
+      <div class="{{@root.prefix}}--list-box__menu-item__option" tabindex="0">
+        {{label}}
+      </div>
+    </li>
     {{/each}}
-  </div>
+  </ul>
 </div>
 {{else}}
 <div

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -5,6 +5,7 @@
   LICENSE file in the root directory of this source tree.
 -->
 
+{{#if @root.featureFlags.componentsX}}
 <div
   class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
   <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
@@ -12,14 +13,7 @@
       aria-autocomplete="list" aria-expanded="false" autocomplete="off" value="" id="downshift-input-2"
       placeholder="Filter..." {{#if disabled}} disabled{{/if}}>
     <div class="{{@root.prefix}}--list-box__menu-icon">
-      {{#if @root.featureFlags.componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' aria-label='Open menu' }}
-      {{else}}
-      <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Open menu" name="caret--down" role="img">
-        <title>Close menu</title>
-        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-      </svg>
-      {{/if}}
     </div>
   </div>
 </div>
@@ -30,14 +24,7 @@
       aria-autocomplete="list" aria-expanded="true" autocomplete="off" value="" id="downshift-input-2"
       placeholder="Filter..." aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}>
     <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
-      {{#if @root.featureFlags.componentsX}}
       {{ carbon-icon 'ChevronDownGlyph' aria-label='Close menu' }}
-      {{else}}
-      <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Close menu" name="caret--down" role="img">
-        <title>Close menu</title>
-        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-      </svg>
-      {{/if}}
     </div>
   </div>
   <div class="{{@root.prefix}}--list-box__menu">
@@ -48,3 +35,40 @@
     {{/each}}
   </div>
 </div>
+{{else}}
+<div
+  class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+    aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
+      aria-autocomplete="list" aria-expanded="false" autocomplete="off" value="" id="downshift-input-2"
+      placeholder="Filter..." {{#if disabled}} disabled{{/if}}>
+    <div class="{{@root.prefix}}--list-box__menu-icon">
+      <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Open menu" name="caret--down" role="img">
+        <title>Close menu</title>
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+    </div>
+  </div>
+</div>
+<div
+  class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
+  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
+    aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
+      aria-autocomplete="list" aria-expanded="true" autocomplete="off" value="" id="downshift-input-2"
+      placeholder="Filter..." aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}>
+    <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
+      <svg width="10" height="5" viewBox="0 0 10 5" aria-label="Close menu" name="caret--down" role="img">
+        <title>Close menu</title>
+        <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+      </svg>
+    </div>
+  </div>
+  <div class="{{@root.prefix}}--list-box__menu">
+    {{#each items}}
+    <div
+      class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
+      id="{{id}}">{{label}}</div>
+    {{/each}}
+  </div>
+</div>
+{{/if}}

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -6,38 +6,128 @@
 -->
 
 {{#if @root.featureFlags.componentsX}}
-<div
-  class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
-  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
-    aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
-      aria-autocomplete="list" aria-expanded="false" autocomplete="off" value="" id="downshift-input-2"
-      placeholder="Filter..." {{#if disabled}} disabled{{/if}}>
-    <div class="{{@root.prefix}}--list-box__menu-icon">
-      {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper{{#if inline}} {{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
+      </div>
     </div>
   </div>
 </div>
-<div
-  class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
-  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
-    aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
-      aria-autocomplete="list" aria-expanded="true" autocomplete="off" value="" id="downshift-input-2"
-      placeholder="Filter..." aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}>
-    <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
-      {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
+
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
+      data-invalid>
+      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
+      </div>
+    </div>
+    <div class="{{@root.prefix}}--form-requirement">
+      Validation message here
     </div>
   </div>
-  <ul class="{{@root.prefix}}--list-box__menu">
-    {{#each items}}
-    <li
-      class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
-      id="{{id}}">
-      <div class="{{@root.prefix}}--list-box__menu-item__option" tabindex="0">
-        {{label}}
+</div>
+
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text {{@root.prefix}}--form__helper-text--disabled">Optional helper text
+      here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
+      data-invalid>
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true" disabled>
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
       </div>
-    </li>
-    {{/each}}
-  </ul>
+    </div>
+    <div class="{{@root.prefix}}--form-requirement">
+      Validation message here
+    </div>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text {{@root.prefix}}--form__helper-text--disabled">Optional helper text
+      here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true" disabled>
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text
+      here
+    </div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--expanded{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="close menu"
+        aria-expanded="true" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
+          {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
+        </div>
+      </div>
+      <ul class="{{@root.prefix}}--list-box__menu">
+        {{#each items}}
+        <li
+          class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
+          id="{{id}}">
+          <div class="{{@root.prefix}}--list-box__menu-item__option" tabindex="0">
+            {{label}}
+          </div>
+        </li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
 </div>
 {{else}}
 <div

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -13,7 +13,7 @@
       aria-autocomplete="list" aria-expanded="false" autocomplete="off" value="" id="downshift-input-2"
       placeholder="Filter..." {{#if disabled}} disabled{{/if}}>
     <div class="{{@root.prefix}}--list-box__menu-icon">
-      {{ carbon-icon 'ChevronDownGlyph' aria-label='Open menu' }}
+      {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
     </div>
   </div>
 </div>
@@ -24,7 +24,7 @@
       aria-autocomplete="list" aria-expanded="true" autocomplete="off" value="" id="downshift-input-2"
       placeholder="Filter..." aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}>
     <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
-      {{ carbon-icon 'ChevronDownGlyph' aria-label='Close menu' }}
+      {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
     </div>
   </div>
   <div class="{{@root.prefix}}--list-box__menu">

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -341,6 +341,10 @@ $list-box-menu-width: rem(300px);
     }
   }
 
+  .#{$prefix}--list-box--expanded {
+    border-bottom-color: $ui-03;
+  }
+
   .#{$prefix}--list-box--expanded:hover {
     background-color: $field-01;
   }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -722,7 +722,6 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box input[role='combobox'] {
     background-color: inherit;
     font-weight: 600;
-    outline-offset: -1px;
     min-width: 0;
   }
 

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -682,6 +682,7 @@ $list-box-menu-width: rem(300px);
     color: $text-01;
     border-color: transparent;
 
+    > .#{$prefix}--list-box__menu-item__option,
     + .#{$prefix}--list-box__menu-item .#{$prefix}--list-box__menu-item__option {
       border-color: transparent;
     }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -709,29 +709,12 @@ $list-box-menu-width: rem(300px);
   }
 
   // Tweaks for descendants
-
-  // In multi-select scenarios, we need to target checkbox inputs
-  .#{$prefix}--list-box__menu-item > .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
-    margin: 0;
-    width: 100%;
-  }
-
   // When handling input, we need to target nodes that specifically opt-in to
   // the `combobox` role in order to make sure the text input is styled
   // correctly.
   .#{$prefix}--list-box input[role='combobox'] {
     background-color: inherit;
-    font-weight: 600;
     min-width: 0;
-  }
-
-  .#{$prefix}--list-box input[role='combobox']::placeholder {
-    color: $text-01;
-    font-weight: 400;
-  }
-
-  .#{$prefix}--list-box--disabled input[role='combobox'] {
-    opacity: 1;
   }
 }
 

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -228,7 +228,8 @@
     background-color: $field-02;
   }
 
-  .#{$prefix}--text-input:disabled::-webkit-input-placeholder {
+  .#{$prefix}--text-input:disabled::placeholder {
+    opacity: 1;
     color: $disabled-02;
   }
 


### PR DESCRIPTION
Closes #2186

This PR updates the experimental combobox component to align with the v10 spec

related: #2206

#### Changelog

**New**

- incorporate v10 listbox
- add component variants to docs
- add overflow text menu option for testing

**Changed**

- input field spacing and outline offset to match v10

**Removed**

- unused legacy styles