### PR TITLE
fix(list-box): hide top border of first menu option

### DIFF
--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -630,6 +630,10 @@ $list-box-menu-width: rem(300px);
     }
   }
 
+  .#{$prefix}--list-box__menu-item:first-of-type .#{$prefix}--list-box__menu-item__option {
+    border-top-color: transparent;
+  }
+
   .#{$prefix}--list-box__menu-item:hover .#{$prefix}--list-box__menu-item__option {
     color: $text-01;
   }


### PR DESCRIPTION
Closes #2211

This PR hides the top border of the first menu item in listbox drawers per component audit feedback