### PR TITLE
chore(styles): mark css-body mixin as private

### DIFF
--- a/docs/migration/migrate-to-10.x.md
+++ b/docs/migration/migrate-to-10.x.md
@@ -18,6 +18,8 @@ Refer to the [Carbon X Migration Guide](https://carbondesignsystem.com/updates/m
 
 ## Components
 
+**IMPORTANT NOTE**: `v9` component styles will be _removed_ soon after the initial `v10` release.
+
 | Component          | v10                                                                   |
 | ------------------ | --------------------------------------------------------------------- |
 | Accordion          | [Migrate](../../src/components/accordion/migrate-to-10.x.md)          |
@@ -69,6 +71,8 @@ Refer to the [Carbon X Migration Guide](https://carbondesignsystem.com/updates/m
 | Unified Header     | Removed                                                               |
 
 ## Styles
+
+**IMPORTANT NOTE**: Most of deprecated variables, mixins and functions will be _removed_ soon after the initial `v10` release.
 
 | `scss` path         | v10                                                                           |
 | ------------------- | ----------------------------------------------------------------------------- |

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -11,6 +11,7 @@
 @import 'functions';
 @import './vendor/@carbon/elements/scss/import-once/import-once';
 
+/// @access private
 @mixin css-body {
   body {
     @include reset;
@@ -21,6 +22,7 @@
   }
 }
 
+/// @access private
 @mixin css-body--x {
   body {
     @include reset;

--- a/src/globals/scss/migrate-to-10.x.md
+++ b/src/globals/scss/migrate-to-10.x.md
@@ -1,5 +1,7 @@
 # `src/globals/scss`
 
+**IMPORTANT NOTE**: Most of deprecated variables, mixins and functions will be _removed_ soon after the initial `v10` release.
+
 <!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -36,7 +38,7 @@
 
 ## `_colors.scss`
 
-Migration table available [here](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-color.md).
+`$color__` variables are deprecated. Migration table available [here](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-color.md).
 
 ## `_css--body.scss`
 


### PR DESCRIPTION
Also added more noticeable notes on our strategy on deprecated Sass features in `v10`.

Refs #1501.

#### Changelog

**New**

- SassDoc annotation for `@mixin css-body` to mark it as private.
- More noticeable notes on our strategy on deprecated Sass features in `v10`.