### PR TITLE
fix(data-table-v2): fix expandable cell index

### DIFF
--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -285,7 +285,7 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
       selectorCount: '[data-items-selected]',
       selectorActionCancel: `.${prefix}--batch-summary__cancel`,
       selectorCheckbox: `.${prefix}--checkbox`,
-      selectorExpandCells: `.${prefix}--table-expand-v2`,
+      selectorExpandCells: `td.${prefix}--table-expand-v2`,
       selectorExpandableRows: `.${prefix}--expandable-row-v2`,
       selectorParentRows: `.${prefix}--parent-row-v2`,
       selectorChildRow: '[data-child-row]',

--- a/tests/spec/data-table-v2_spec.js
+++ b/tests/spec/data-table-v2_spec.js
@@ -27,7 +27,7 @@ describe('DataTableV2', function() {
         selectorCount: '[data-items-selected]',
         selectorActionCancel: '.bx--batch-summary__cancel',
         selectorCheckbox: '.bx--checkbox',
-        selectorExpandCells: '.bx--table-expand-v2',
+        selectorExpandCells: 'td.bx--table-expand-v2',
         selectorExpandableRows: '.bx--expandable-row-v2',
         selectorParentRows: '.bx--parent-row-v2',
         selectorChildRow: '[data-child-row]',


### PR DESCRIPTION
v10 markup adds `bx--table-expand-v2` class on `<th>` in addition to `<td>` presumably to better align checkbox next to expando (below style rule), but JS code had assumed that that class applied only on `<td>`, causing wrong index in an array to determine where expandable row content should be put to.

```css
th.bx--table-expand-v2 + th.bx--table-column-checkbox {
  padding-left: 0.5rem;
}
```

This was discovered by running unit tests on `v10` markup.

Refs #2209.

#### Changelog

**Changed**

- The CSS selector to find expando cells in data table, coping with `v10` markup change.

#### Testing / Reviewing

Testing should make sure our @jnm2377's data table work is not broken, especially on expandable row support.