### PR TITLE
fix(data-table-v2): fix unit test failure

### DIFF
--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { componentsX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -183,8 +184,10 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
 
   _expandableRowsInit = expandableRows => {
     expandableRows.forEach(item => {
-      item.classList.remove(this.options.classExpandableRowHidden);
-      this.tableBody.removeChild(item);
+      if (!componentsX) {
+        item.classList.remove(this.options.classExpandableRowHidden);
+        this.tableBody.removeChild(item);
+      }
     });
   };
 
@@ -195,10 +198,14 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
     if (element.dataset.previousValue === undefined || element.dataset.previousValue === 'expanded') {
       element.dataset.previousValue = 'collapsed';
       parent.classList.add(this.options.classExpandableRow);
-      this.tableBody.insertBefore(this.expandableRows[index], this.parentRows[index + 1]);
+      if (!componentsX) {
+        this.tableBody.insertBefore(this.expandableRows[index], this.parentRows[index + 1]);
+      }
     } else {
       parent.classList.remove(this.options.classExpandableRow);
-      this.tableBody.removeChild(parent.nextElementSibling);
+      if (!componentsX) {
+        this.tableBody.removeChild(parent.nextElementSibling);
+      }
       element.dataset.previousValue = 'expanded';
     }
   };

--- a/src/components/data-table-v2/data-table-v2.js
+++ b/src/components/data-table-v2/data-table-v2.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { componentsX } from '../../globals/js/feature-flags';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -184,10 +183,8 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
 
   _expandableRowsInit = expandableRows => {
     expandableRows.forEach(item => {
-      if (!componentsX) {
-        item.classList.remove(this.options.classExpandableRowHidden);
-        this.tableBody.removeChild(item);
-      }
+      item.classList.remove(this.options.classExpandableRowHidden);
+      this.tableBody.removeChild(item);
     });
   };
 
@@ -198,14 +195,10 @@ class DataTableV2 extends mixin(createComponent, initComponentBySearch, eventedS
     if (element.dataset.previousValue === undefined || element.dataset.previousValue === 'expanded') {
       element.dataset.previousValue = 'collapsed';
       parent.classList.add(this.options.classExpandableRow);
-      if (!componentsX) {
-        this.tableBody.insertBefore(this.expandableRows[index], this.parentRows[index + 1]);
-      }
+      this.tableBody.insertBefore(this.expandableRows[index], this.parentRows[index + 1]);
     } else {
       parent.classList.remove(this.options.classExpandableRow);
-      if (!componentsX) {
-        this.tableBody.removeChild(parent.nextElementSibling);
-      }
+      this.tableBody.removeChild(parent.nextElementSibling);
       element.dataset.previousValue = 'expanded';
     }
   };

--- a/tests/spec/data-table-v2_spec.js
+++ b/tests/spec/data-table-v2_spec.js
@@ -3,6 +3,7 @@ import flattenOptions from '../utils/flatten-options';
 import DataTableV2 from '../../src/components/data-table-v2/data-table-v2';
 import HTML from '../../html/data-table-v2/data-table-v2.html';
 import ExpandableHTML from '../../html/data-table-v2/data-table-v2--expandable.html';
+import { componentsX } from '../../src/globals/js/feature-flags';
 
 describe('DataTableV2', function() {
   describe('Constructor', function() {
@@ -95,9 +96,21 @@ describe('DataTableV2', function() {
     it('Should toggle the row on click', function() {
       const firstRowExpand = document.querySelector('[data-event="expand"]');
       firstRowExpand.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(document.querySelector('[data-child-row]')).toBeTruthy();
+      if (!componentsX) {
+        expect(document.querySelector('[data-child-row]')).toBeTruthy();
+      } else {
+        expect(
+          document.querySelector('[data-child-row]').previousElementSibling.classList.contains('bx--expandable-row-v2')
+        ).toBeTruthy();
+      }
       firstRowExpand.dispatchEvent(new CustomEvent('click', { bubbles: true }));
-      expect(document.querySelector('[data-child-row]')).toBeFalsy();
+      if (!componentsX) {
+        expect(document.querySelector('[data-child-row]')).toBeFalsy();
+      } else {
+        expect(
+          document.querySelector('[data-child-row]').previousElementSibling.classList.contains('bx--expandable-row-v2')
+        ).toBeFalsy();
+      }
     });
 
     it('Should emit an event on row expansion click', function() {


### PR DESCRIPTION
(Please review the change with whitespace ignored)

A change that was no longer needed seems to have got into `master`, which caused unit test failures with feature flags flipped. This PR reverts such change.

#### Changelog

**Removed**

- Code that got stale by #2220.

#### Testing / Reviewing

Testing should make sure data table is not broken.