### PR TITLE
chore(test): update assertions for classic styles

### DIFF
--- a/src/globals/grid/__tests__/grid-test.js
+++ b/src/globals/grid/__tests__/grid-test.js
@@ -28,14 +28,6 @@ $feature-flags: (components-x: false, breaking-changes-x: false, grid: false);
 ${content}
 `);
 
-const isClassic = async () => {
-  const { calls } = await renderClassic(`
-@import '../../scss/functions';
-$t: test(feature-flag-enabled('breaking-changes-x'));
-`);
-  return !convert(calls[0][0]);
-};
-
 describe('_grid.scss', () => {
   it('should export grid variables', async () => {
     const { calls } = await renderClassic(`
@@ -113,8 +105,7 @@ $t: test('unknown', breakpoint('unknown'));
     }
 
     // `breakpoint` is expected to warn on the unknown test case
-    // Should be called twice now since feature flags have diverged in v10
-    expect(output.warn).toHaveBeenCalledTimes((await isClassic()) ? 1 : 2);
+    expect(output.warn).toHaveBeenCalledTimes(1);
 
     // This should fail because `breakpoint('unknown')` does not return a
     // value

--- a/src/globals/scss/__tests__/css--plex-core-test.js
+++ b/src/globals/scss/__tests__/css--plex-core-test.js
@@ -18,14 +18,6 @@ $feature-flags: (components-x: false, breaking-changes-x: false);
 ${content}
 `);
 
-const isClassic = async () => {
-  const { calls } = await renderClassic(`
-@import '../../scss/functions';
-$t: test(feature-flag-enabled('breaking-changes-x'));
-`);
-  return !convert(calls[0][0]);
-};
-
 describe('_css--plex-core', () => {
   it.each(variables)('should export the variable $%s', async name => {
     const { calls } = await renderClassic(`
@@ -49,8 +41,7 @@ $value: test($${name});
 };
 `);
 
-      // This should be called twice now that feature flags have diverged in v10
-      expect(output.warn).toHaveBeenCalledTimes((await isClassic()) ? 1 : 2);
+      expect(output.warn).toHaveBeenCalledTimes(1);
     });
 
     it('should not warn if $font-path is set and does not contain unpkg', async () => {
@@ -62,8 +53,7 @@ $font-path: 'https://my-custom-cdn.com';
   $test: true;
 };
 `);
-      // In v10, one call comes from feature flag divergence
-      expect(output.warn).toHaveBeenCalledTimes((await isClassic()) ? 0 : 1);
+      expect(output.warn).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/src/globals/scss/__tests__/typography-test.js
+++ b/src/globals/scss/__tests__/typography-test.js
@@ -26,14 +26,6 @@ $feature-flags: (components-x: false, breaking-changes-x: false);
 ${content}
 `);
 
-const isClassic = async () => {
-  const { calls } = await renderClassic(`
-@import '../../scss/functions';
-$t: test(feature-flag-enabled('breaking-changes-x'));
-`);
-  return !convert(calls[0][0]);
-};
-
 describe('_typography.scss', () => {
   describe.each(variables)('$%s', name => {
     it('should be exported', async () => {
@@ -78,9 +70,7 @@ ${tests.join('\n')}
   @include typescale('<unknown>');
 }
 `);
-      // `output.warn` is called twice now since feature flags have diverged in
-      // v10
-      expect(output.warn).toHaveBeenCalledTimes((await isClassic()) ? 1 : 2);
+      expect(output.warn).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
Quickfix for our `renderClassic` assertions.