### PR TITLE
fix(combo-box): support v10 input controls

### DIFF
--- a/demo/js/components/ComponentExample/component-overrides.scss
+++ b/demo/js/components/ComponentExample/component-overrides.scss
@@ -6,29 +6,29 @@
   width: 100%;
   max-width: 1000px;
 
-  & > .primary-button button,
-  & > .secondary-button button {
+  &>.primary-button button,
+  &>.secondary-button button {
     margin: 0.5rem;
   }
 
-  & > .detail-page-header--no-tabs > .bx--detail-page-header--no-tabs {
+  &>.detail-page-header--no-tabs>.bx--detail-page-header--no-tabs {
     width: 100%;
     left: 0;
     top: 206px;
   }
 
-  & > .detail-page-header--with-tabs > .bx--detail-page-header--with-tabs {
+  &>.detail-page-header--with-tabs>.bx--detail-page-header--with-tabs {
     width: 100%;
     left: 0;
     top: 206px;
   }
 
-  & > .inline-notification .bx--inline-notification {
+  &>.inline-notification .bx--inline-notification {
     display: inline-flex;
     margin-right: 10rem;
   }
 
-  & > .overflow-menu .bx--overflow-menu {
+  &>.overflow-menu .bx--overflow-menu {
     position: absolute;
     left: 3rem;
 
@@ -67,7 +67,7 @@
     margin-bottom: 0.5rem;
   }
 
-  .data-table > div {
+  .data-table>div {
     width: 100%;
   }
 
@@ -90,7 +90,7 @@
     }
   }
 
-  & .notification > div {
+  & .notification>div {
     max-width: 700px;
   }
 
@@ -121,7 +121,7 @@
     }
   }
 
-  & > .dropdown > div {
+  &>.dropdown>div {
     width: 100%;
     max-width: 502px;
   }
@@ -151,7 +151,7 @@
   }
 
   & .tabs {
-    & > div {
+    &>div {
       min-width: 100%;
 
       @include breakpoint(if(not feature-flag-enabled('components-x'), '768px', '42rem')) {
@@ -159,7 +159,7 @@
       }
     }
 
-    .bx--tabs + div {
+    .bx--tabs+div {
       padding: 0 !important;
       margin-top: 2rem;
     }
@@ -174,9 +174,13 @@
       }
     }
   }
+
+  .combo-box .bx--form-item:nth-last-of-type(-n + 3) {
+    margin-bottom: 10rem;
+  }
 }
 
-.page-header + div > .bx--tabs {
+.page-header+div>.bx--tabs {
   background-color: $field-01;
 
   @include breakpoint(if(not feature-flag-enabled('components-x'), '768px', '42rem')) {

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -32,6 +32,10 @@
     }
   }
 
+  .#{$prefix}--combo-box.#{$prefix}--list-box--expanded .#{$prefix}--text-input {
+    border-bottom-color: $ui-03;
+  }
+
   .#{$prefix}--combo-box .#{$prefix}--list-box__field,
   .#{$prefix}--combo-box.#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__field {
     padding: 0;

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -22,8 +22,6 @@
 
 @mixin combo-box--x {
   .#{$prefix}--combo-box .#{$prefix}--text-input {
-    padding-right: $carbon--spacing-09;
-
     &::placeholder {
       color: $text-02;
       opacity: 1;
@@ -32,10 +30,6 @@
     &[disabled]::placeholder {
       color: $disabled-02;
     }
-  }
-
-  .#{$prefix}--combo-box.#{$prefix}--list-box[data-invalid] .#{$prefix}--text-input {
-    padding-right: carbon--mini-units(8);
   }
 
   .#{$prefix}--combo-box .#{$prefix}--list-box__field,

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -27,6 +27,29 @@
 </div>
 
 <div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper{{#if inline}} {{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
+        <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
+          {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
+        </div>
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>
     {{#unless inline}}
@@ -53,6 +76,34 @@
 
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
+      data-invalid>
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
+        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
+        <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
+          {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
+        </div>
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
+      </div>
+    </div>
+    <div class="{{@root.prefix}}--form-requirement">
+      Validation message here
+    </div>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Combo box label</label>
     {{#unless inline}}
     <div class="{{@root.prefix}}--form__helper-text {{@root.prefix}}--form__helper-text--disabled">Optional helper text
@@ -65,6 +116,36 @@
         aria-expanded="false" aria-haspopup="true" disabled>
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
+        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
+        <div class="{{@root.prefix}}--list-box__menu-icon">
+          {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
+        </div>
+      </div>
+    </div>
+    <div class="{{@root.prefix}}--form-requirement">
+      Validation message here
+    </div>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label {{@root.prefix}}--label--disabled">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text {{@root.prefix}}--form__helper-text--disabled">Optional helper text
+      here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
+      data-invalid>
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true" disabled>
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="This is not a value" id="downshift-input-2" placeholder="Filter..." disabled>
+        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
+        <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
+          {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
+        </div>
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
         </div>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -35,11 +35,11 @@
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
       <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
         aria-expanded="false" aria-haspopup="true">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
         </div>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -14,8 +14,8 @@
     {{/unless}}
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
         <div class="{{@root.prefix}}--list-box__menu-icon">
@@ -34,8 +34,8 @@
     {{/unless}}
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
         <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
@@ -58,8 +58,8 @@
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
@@ -83,8 +83,8 @@
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
@@ -112,8 +112,8 @@
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true" disabled>
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="true" disabled>
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
@@ -138,8 +138,8 @@
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true" disabled>
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="true" disabled>
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="This is not a value" id="downshift-input-2" placeholder="Filter..." disabled>
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
@@ -166,8 +166,8 @@
     {{/unless}}
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true" disabled>
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="true" disabled>
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
         <div class="{{@root.prefix}}--list-box__menu-icon">
@@ -188,8 +188,8 @@
     {{/unless}}
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--expanded{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="close menu"
-        aria-expanded="true" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
         <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
@@ -221,8 +221,8 @@
     {{/unless}}
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--expanded{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="close menu"
-        aria-expanded="true" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
         <div role="button" class="{{@root.prefix}}--list-box__selection" tabindex="0" title="Clear selected item">
@@ -256,8 +256,8 @@
     <div
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
-        aria-expanded="false" aria-haspopup="true">
+      <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+        aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
@@ -288,7 +288,7 @@
 {{else}}
 <div
   class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
-  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
+  <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
     aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
       aria-autocomplete="list" aria-expanded="false" autocomplete="off" value="" id="downshift-input-2"
       placeholder="Filter..." {{#if disabled}} disabled{{/if}}>
@@ -302,7 +302,7 @@
 </div>
 <div
   class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">
-  <div role="button" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
+  <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
     aria-haspopup="true" {{#if disabled}} disabled{{/if}}> <input class="{{@root.prefix}}--text-input" role="combobox"
       aria-autocomplete="list" aria-expanded="true" autocomplete="off" value="" id="downshift-input-2"
       placeholder="Filter..." aria-activedescendant="downshift-1-item-2" {{#if disabled}} disabled{{/if}}>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -129,6 +129,81 @@
     </div>
   </div>
 </div>
+<br><br><br><br><br><br><br><br>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text
+      here
+    </div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--expanded{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="close menu"
+        aria-expanded="true" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
+        <div role="button" class="{{@root.prefix}}--list-box__selection" tabindex="0" title="Clear selected item">
+          {{ carbon-icon 'Close16' aria-label="Clear text input" }}
+        </div>
+        <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
+          {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
+        </div>
+      </div>
+      <ul class="{{@root.prefix}}--list-box__menu">
+        {{#each items}}
+        <li
+          class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
+          id="{{id}}">
+          <div class="{{@root.prefix}}--list-box__menu-item__option" tabindex="0">
+            {{label}}
+          </div>
+        </li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+</div>
+<br><br><br><br><br><br><br><br>
+<div class="{{@root.prefix}}--form-item">
+  <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
+    <label class="{{@root.prefix}}--label">Combo box label</label>
+    {{#unless inline}}
+    <div class="{{@root.prefix}}--form__helper-text">Optional helper text here</div>
+    {{/unless}}
+    <div
+      class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
+      data-invalid>
+      <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
+        aria-expanded="false" aria-haspopup="true">
+        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
+          autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
+        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
+        <div role="button" class="{{@root.prefix}}--list-box__selection" tabindex="0" title="Clear selected item">
+          {{ carbon-icon 'Close16' aria-label="Clear text input" }}
+        </div>
+        <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
+          {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
+        </div>
+      </div>
+      <ul class="{{@root.prefix}}--list-box__menu">
+        {{#each items}}
+        <li
+          class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
+          id="{{id}}">
+          <div class="{{@root.prefix}}--list-box__menu-item__option" tabindex="0">
+            {{label}}
+          </div>
+        </li>
+        {{/each}}
+      </ul>
+    </div>
+    <div class="{{@root.prefix}}--form-requirement">
+      Validation message here
+    </div>
+  </div>
+</div>
 {{else}}
 <div
   class="{{@root.prefix}}--form-item {{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if disabled}} {{@root.prefix}}--list-box--disabled{{/if}}">

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -210,7 +210,7 @@
     </div>
   </div>
 </div>
-<br><br><br><br><br><br><br><br>
+
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>
@@ -247,7 +247,7 @@
     </div>
   </div>
 </div>
-<br><br><br><br><br><br><br><br>
+
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -17,7 +17,7 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="" id="downshift-input-2" placeholder="Filter...">
+          value="" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
         </div>
@@ -37,7 +37,7 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="This is not a value." id="downshift-input-2" placeholder="Filter...">
+          value="This is not a value." id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
         </div>
@@ -61,7 +61,7 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="" id="downshift-input-2" placeholder="Filter...">
+          value="" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
@@ -86,7 +86,7 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="This is not a value." id="downshift-input-2" placeholder="Filter...">
+          value="This is not a value." id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
@@ -191,12 +191,12 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="" id="downshift-input-2" placeholder="Filter...">
+          value="" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu" role="listbox">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" aria-label="Filter...">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
@@ -224,7 +224,7 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="Option 3" id="downshift-input-2" placeholder="Filter...">
+          value="Option 3" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
         </div>
@@ -232,7 +232,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu" role="listbox">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" aria-label="Filter...">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
@@ -259,7 +259,7 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="Option 3" id="downshift-input-2" placeholder="Filter...">
+          value="Option 3" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
@@ -268,7 +268,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu" role="listbox">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" aria-label="Filter...">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -191,12 +191,12 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
+          value="" id="downshift-input-2" placeholder="Filter..." aria-label="Filter..." aria-owns="list-box__menu-0">
         <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" aria-label="Filter...">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" id="list-box__menu-0" aria-label="Filter...">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
@@ -224,7 +224,8 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="Option 3" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
+          value="Option 3" id="downshift-input-2" placeholder="Filter..." aria-label="Filter..."
+          aria-owns="list-box__menu-1">
         <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
         </div>
@@ -232,7 +233,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" aria-label="Filter...">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" id="list-box__menu-1" aria-label="Filter...">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
@@ -259,7 +260,8 @@
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
-          value="Option 3" id="downshift-input-2" placeholder="Filter..." aria-label="Filter...">
+          value="Option 3" id="downshift-input-2" placeholder="Filter..." aria-label="Filter..."
+          aria-owns="list-box__menu-2">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
@@ -268,7 +270,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" aria-label="Filter...">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox" id="list-box__menu-2" aria-label="Filter...">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -210,7 +210,7 @@
     </div>
   </div>
 </div>
-<br><br><br><br><br><br><br><br>
+<div style="margin-bottom:10rem"></div>
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>
@@ -247,7 +247,7 @@
     </div>
   </div>
 </div>
-<br><br><br><br><br><br><br><br>
+<div style="margin-bottom:10rem"></div>
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -210,7 +210,7 @@
     </div>
   </div>
 </div>
-<div style="margin-bottom:10rem"></div>
+<br><br><br><br><br><br><br><br>
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>
@@ -247,7 +247,7 @@
     </div>
   </div>
 </div>
-<div style="margin-bottom:10rem"></div>
+<br><br><br><br><br><br><br><br>
 <div class="{{@root.prefix}}--form-item">
   <div class="{{@root.prefix}}--list-box__wrapper {{#if inline}}{{@root.prefix}}--list-box__wrapper--inline{{/if}}">
     <label class="{{@root.prefix}}--label">Combo box label</label>

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -16,8 +16,8 @@
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="" id="downshift-input-2" placeholder="Filter...">
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
         </div>
@@ -36,8 +36,8 @@
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="This is not a value." id="downshift-input-2" placeholder="Filter...">
         <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
         </div>
@@ -60,8 +60,8 @@
       data-invalid>
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="" id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
@@ -85,8 +85,8 @@
       data-invalid>
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="This is not a value." id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
@@ -114,8 +114,8 @@
       data-invalid>
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="true" disabled>
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="" id="downshift-input-2" placeholder="Filter..." disabled>
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
@@ -140,8 +140,8 @@
       data-invalid>
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="true" disabled>
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="This is not a value" id="downshift-input-2" placeholder="Filter..." disabled>
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="This is not a value" id="downshift-input-2" placeholder="Filter..." disabled>
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
@@ -168,8 +168,8 @@
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--disabled{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="true" disabled>
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter..." disabled>
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="" id="downshift-input-2" placeholder="Filter..." disabled>
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}
         </div>
@@ -190,8 +190,8 @@
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--expanded{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="" id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="" id="downshift-input-2" placeholder="Filter...">
         <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
@@ -223,8 +223,8 @@
       class="{{@root.prefix}}--combo-box {{@root.prefix}}--list-box {{@root.prefix}}--list-box--expanded{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}">
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="close menu" aria-expanded="true"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="Option 3" id="downshift-input-2" placeholder="Filter...">
         <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
         </div>
@@ -258,8 +258,8 @@
       data-invalid>
       <div role="combobox" class="{{@root.prefix}}--list-box__field" aria-label="open menu" aria-expanded="false"
         aria-haspopup="listbox">
-        <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
-          autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
+        <input class="{{@root.prefix}}--text-input" aria-autocomplete="list" aria-expanded="false" autocomplete="off"
+          value="Option 3" id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -38,7 +38,7 @@
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
-        <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
+        <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
         </div>
         <div class="{{@root.prefix}}--list-box__menu-icon">
@@ -88,7 +88,7 @@
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="This is not a value." id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
-        <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
+        <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
         </div>
         <div class="{{@root.prefix}}--list-box__menu-icon">
@@ -143,7 +143,7 @@
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="This is not a value" id="downshift-input-2" placeholder="Filter..." disabled>
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
-        <div class="{{@root.prefix}}--list-box__selection" role="button" tabIndex="0">
+        <div class="{{@root.prefix}}--list-box__selection" role="button">
           {{ carbon-icon "Close16" aria-label="Clear all" title="Clear all" }}
         </div>
         <div class="{{@root.prefix}}--list-box__menu-icon">
@@ -225,7 +225,7 @@
         aria-haspopup="listbox">
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
-        <div role="button" class="{{@root.prefix}}--list-box__selection" tabindex="0" title="Clear selected item">
+        <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
         </div>
         <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">
@@ -261,7 +261,7 @@
         <input class="{{@root.prefix}}--text-input" role="combobox" aria-autocomplete="list" aria-expanded="false"
           autocomplete="off" value="Option 3" id="downshift-input-2" placeholder="Filter...">
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
-        <div role="button" class="{{@root.prefix}}--list-box__selection" tabindex="0" title="Clear selected item">
+        <div role="button" class="{{@root.prefix}}--list-box__selection" title="Clear selected item">
           {{ carbon-icon 'Close16' aria-label="Clear text input" }}
         </div>
         <div class="{{@root.prefix}}--list-box__menu-icon {{@root.prefix}}--list-box__menu-icon--open">

--- a/src/components/combo-box/combo-box.hbs
+++ b/src/components/combo-box/combo-box.hbs
@@ -196,7 +196,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
@@ -232,7 +232,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"
@@ -268,7 +268,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu">
+      <ul class="{{@root.prefix}}--list-box__menu" role="listbox">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -62,7 +62,7 @@
   .#{$prefix}--list-box[data-invalid] {
     box-shadow: 0 2px 0px 0px $support-01;
 
-    ~ .#{$prefix}--form-requirement {
+    ~.#{$prefix}--form-requirement {
       max-height: rem(200px);
       display: block;
     }
@@ -152,9 +152,10 @@
 
   input[data-invalid],
   .#{$prefix}--text-input__field-wrapper[data-invalid],
-  .#{$prefix}--text-area__wrapper[data-invalid] > .#{$prefix}--text-area--invalid,
+  .#{$prefix}--text-area__wrapper[data-invalid]>.#{$prefix}--text-area--invalid,
   .#{$prefix}--select-input__wrapper[data-invalid],
-  .#{$prefix}--list-box[data-invalid] {
+  .#{$prefix}--list-box[data-invalid],
+  .#{$prefix}--combo-box[data-invalid] .#{$prefix}--text-input {
     @include focus-outline('invalid');
   }
 
@@ -164,7 +165,7 @@
   .#{$prefix}--select-input__wrapper[data-invalid],
   .#{$prefix}--time-picker[data-invalid],
   .#{$prefix}--list-box[data-invalid] {
-    ~ .#{$prefix}--form-requirement {
+    ~.#{$prefix}--form-requirement {
       max-height: rem(200px);
       display: block;
       color: $support-01;
@@ -186,7 +187,7 @@
     display: none;
   }
 
-  .#{$prefix}--label + .#{$prefix}--form__helper-text {
+  .#{$prefix}--label+.#{$prefix}--form__helper-text {
     margin-top: rem(-6px); // when both helper text and label are rendered
   }
 
@@ -214,7 +215,9 @@
 @include exports('form') {
   @if feature-flag-enabled('components-x') {
     @include form--x;
-  } @else {
+  }
+
+  @else {
     @include form;
   }
 }

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -562,7 +562,7 @@ $list-box-menu-width: rem(300px);
   }
 
   .#{$prefix}--list-box__menu-icon > svg {
-    fill: $icon-02;
+    fill: $icon-01;
     height: 100%;
   }
 

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -472,7 +472,7 @@ $list-box-menu-width: rem(300px);
   }
 
   .#{$prefix}--list-box.#{$prefix}--list-box--inline .#{$prefix}--list-box__menu-icon {
-    padding: 0 $carbon--spacing-03;
+    right: $carbon--spacing-03;
   }
 
   .#{$prefix}--list-box.#{$prefix}--list-box--inline .#{$prefix}--list-box__invalid-icon {
@@ -512,6 +512,38 @@ $list-box-menu-width: rem(300px);
     border-bottom: none; // Use border on list box instead
   }
 
+  // populated input field
+  .#{$prefix}--list-box__field .#{$prefix}--text-input[value] {
+    padding-right: carbon--mini-units(9);
+  }
+
+  // invalid && populated input field
+  .#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__field .#{$prefix}--text-input[value] {
+    padding-right: rem(98px); // to account for clear input button outline
+  }
+
+  .#{$prefix}--list-box[data-invalid]
+    .#{$prefix}--list-box__field
+    .#{$prefix}--text-input[value]
+    + .#{$prefix}--list-box__invalid-icon {
+    right: rem(66px); // to account for clear input button outline
+  }
+
+  // empty input field
+  .#{$prefix}--list-box__field .#{$prefix}--text-input[value=''] {
+    padding-right: $carbon--spacing-09;
+  }
+
+  // invalid && empty input field
+  .#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__field .#{$prefix}--text-input[value=''] {
+    padding-right: carbon--mini-units(9);
+  }
+
+  // disabled && invalid && empty input field
+  .#{$prefix}--list-box--disabled[data-invalid] .#{$prefix}--list-box__field .#{$prefix}--text-input[value=''] {
+    padding-right: $carbon--spacing-09;
+  }
+
   // Label for a `list-box__field`
   .#{$prefix}--list-box__label {
     @include type-style('body-short-01');
@@ -524,13 +556,9 @@ $list-box-menu-width: rem(300px);
 
   // Menu status inside of a `list-box__field`
   .#{$prefix}--list-box__menu-icon {
-    display: inline-block;
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
+    right: $carbon--spacing-05;
     height: 100%;
-    padding: 0 1rem;
     transition: transform $duration--fast-02 motion(standard, productive);
     cursor: pointer;
   }
@@ -546,21 +574,24 @@ $list-box-menu-width: rem(300px);
 
   // Selection indicator for a `list-box__field`
   .#{$prefix}--list-box__selection {
-    display: inline-block;
     position: absolute;
-    top: 0;
-    right: rem(26px);
-    bottom: 0;
-    height: rem(40px);
-    padding: 0 1rem;
+    right: rem(33px); // to preserve .5rem space between icons according to spec
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: rem(30px);
+    width: rem(30px);
     cursor: pointer;
     user-select: none;
     transition: background-color $duration--fast-02 motion(standard, productive);
+
+    &:focus {
+      @include focus-outline('outline');
+    }
   }
 
   .#{$prefix}--list-box__selection > svg {
     fill: $ui-05;
-    height: 100%;
   }
 
   // Modifier for a selection to show that multiple selections have been made
@@ -573,6 +604,7 @@ $list-box-menu-width: rem(300px);
     padding: 0;
     background-color: $inverse-02;
     height: rem(24px);
+    width: auto;
     color: $inverse-01;
     line-height: 0;
     padding: rem(8px);

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -562,7 +562,7 @@ $list-box-menu-width: rem(300px);
   }
 
   .#{$prefix}--list-box__menu-icon > svg {
-    fill: $ui-05;
+    fill: $icon-02;
     height: 100%;
   }
 
@@ -589,7 +589,7 @@ $list-box-menu-width: rem(300px);
   }
 
   .#{$prefix}--list-box__selection > svg {
-    fill: $ui-05;
+    fill: $icon-02;
   }
 
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__selection:focus {

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -508,10 +508,6 @@ $list-box-menu-width: rem(300px);
     color: $disabled-02;
   }
 
-  .#{$prefix}--list-box__field .#{$prefix}--text-input {
-    border-bottom: none; // Use border on list box instead
-  }
-
   // populated input field
   .#{$prefix}--list-box__field .#{$prefix}--text-input[value] {
     padding-right: carbon--mini-units(9);

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -539,6 +539,13 @@ $list-box-menu-width: rem(300px);
     padding-right: carbon--mini-units(9);
   }
 
+  .#{$prefix}--list-box[data-invalid]
+    .#{$prefix}--list-box__field
+    .#{$prefix}--text-input[value='']
+    + .#{$prefix}--list-box__invalid-icon {
+    right: rem(40px); // to account for clear input button outline
+  }
+
   // disabled && invalid && empty input field
   .#{$prefix}--list-box--disabled[data-invalid] .#{$prefix}--list-box__field .#{$prefix}--text-input[value=''] {
     padding-right: $carbon--spacing-09;

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -546,11 +546,6 @@ $list-box-menu-width: rem(300px);
     right: rem(40px); // to account for clear input button outline
   }
 
-  // disabled && invalid && empty input field
-  .#{$prefix}--list-box--disabled[data-invalid] .#{$prefix}--list-box__field .#{$prefix}--text-input[value=''] {
-    padding-right: $carbon--spacing-09;
-  }
-
   // Label for a `list-box__field`
   .#{$prefix}--list-box__label {
     @include type-style('body-short-01');
@@ -599,6 +594,14 @@ $list-box-menu-width: rem(300px);
 
   .#{$prefix}--list-box__selection > svg {
     fill: $ui-05;
+  }
+
+  .#{$prefix}--list-box--disabled .#{$prefix}--list-box__selection:focus {
+    outline: none;
+  }
+
+  .#{$prefix}--list-box--disabled .#{$prefix}--list-box__selection > svg {
+    fill: $disabled-02;
   }
 
   // Modifier for a selection to show that multiple selections have been made

--- a/src/components/list-box/list-box.hbs
+++ b/src/components/list-box/list-box.hbs
@@ -112,7 +112,7 @@
           {{ carbon-icon 'ChevronDown16' aria-label='Close menu' }}
         </div>
       </div>
-      <ul class="{{@root.prefix}}--list-box__menu">
+      <ul class="{{@root.prefix}}--list-box__menu" role="combobox">
         {{#each items}}
         <li
           class="{{@root.prefix}}--list-box__menu-item{{#if selected}} {{@root.prefix}}--list-box__menu-item--highlighted{{/if}}"

--- a/src/components/list-box/list-box.hbs
+++ b/src/components/list-box/list-box.hbs
@@ -34,9 +34,9 @@
     <div
       class="{{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
+      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
       <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
         aria-expanded="false" aria-haspopup="true">
-        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <span class="{{@root.prefix}}--list-box__label">List box options</span>
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}

--- a/src/components/list-box/list-box.hbs
+++ b/src/components/list-box/list-box.hbs
@@ -34,9 +34,9 @@
     <div
       class="{{@root.prefix}}--list-box{{#if inline}} {{@root.prefix}}--list-box--inline{{/if}}{{#if light}} {{@root.prefix}}--list-box--light{{/if}}"
       data-invalid>
-      {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
       <div role="button" class="{{@root.prefix}}--list-box__field" tabindex="0" aria-label="open menu"
         aria-expanded="false" aria-haspopup="true">
+        {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--list-box__invalid-icon')}}
         <span class="{{@root.prefix}}--list-box__label">List box options</span>
         <div class="{{@root.prefix}}--list-box__menu-icon">
           {{ carbon-icon 'ChevronDown16' aria-label='Open menu' }}

--- a/src/components/multi-select/multi-select.hbs
+++ b/src/components/multi-select/multi-select.hbs
@@ -44,7 +44,7 @@
           {{ carbon-icon 'ChevronUp16' aria-label='Close menu' }}
         </div>
       </div>
-      <fieldset class="{{@root.prefix}}--list-box__menu">
+      <fieldset class="{{@root.prefix}}--list-box__menu" role="listbox">
         <legend class="{{@root.prefix}}--assistive-text">Description of form elements within the fieldset</legend>
         {{#each items}}
         <div class="{{@root.prefix}}--list-box__menu-item">
@@ -99,7 +99,7 @@
       </svg>
     </div>
   </div>
-  <fieldset class="{{@root.prefix}}--list-box__menu">
+  <fieldset class="{{@root.prefix}}--list-box__menu" role="listbox">
     <legend class="{{@root.prefix}}--assistive-text">Description of form elements within the fieldset</legend>
     {{#each items}}
     <div class="{{@root.prefix}}--list-box__menu-item">


### PR DESCRIPTION
Closes #2240

This PR adds styles for the v10 combo box selection button and refactors multiselect selection button styles

Related:

https://github.com/IBM/carbon-components-react/issues/2109

https://github.com/IBM/carbon-components-react/issues/2113

#### Changelog

**New**

- add styles for v10 combo box input controls

**Changed**

- nest warning icons within list box field

#### Testing / Reviewing

- Ensure listbox is not visually broken
- Ensure multiselect is not visually broken
- Ensure combobox is not visually broken
