### PR TITLE
feat(sidenav): added focused class for sidenav

### DIFF
--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -56,7 +56,8 @@
   // Include the fixed variant here so components can render in both expandable
   // and fixed side navs
   .#{$prefix}--side-nav--fixed &,
-  .#{$prefix}--side-nav--expanded & {
+  .#{$prefix}--side-nav--expanded &
+  .#{$prefix}--side-nav--focused & {
     @if $visibility == true {
       visibility: visible;
     }
@@ -95,7 +96,8 @@
   }
 
   .#{$prefix}--side-nav:not(.#{$prefix}--side-nav--fixed):hover,
-  .#{$prefix}--side-nav--expanded {
+  .#{$prefix}--side-nav--expanded,
+  .#{$prefix}--side-nav--focused {
     width: mini-units(32);
   }
 


### PR DESCRIPTION
Closes  #2260 and https://github.com/IBM/carbon-components-react/issues/2151 
Related to https://github.com/IBM/carbon-components-react/issues/2148

Add focus class name to styles applied for expand and hover on the SideNav menu component.

#### Changelog

**Changed**

- _side-nav.scss


#### Testing / Reviewing

Once [this PR](https://github.com/IBM/carbon-components-react/pull/2150) is merged you should be able to see SideNav expand on hover if it is collapsed. 
