### PR TITLE
fix(password-input): remove toggle error outline

### DIFF
--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -184,7 +184,6 @@
       border: 0;
       background: none;
       cursor: pointer;
-      outline: inherit;
 
       svg {
         fill: $brand-01;


### PR DESCRIPTION
Closes #2095

This PR removes the red outline from the password visibility toggle SVG on the invalid state