### PR TITLE
Set unit variable as default

### DIFF
--- a/src/components/ui-shell/_variables.scss
+++ b/src/components/ui-shell/_variables.scss
@@ -8,4 +8,4 @@
 // Use rem here to accomodate zoom behavior
 // Reference:
 // https://github.com/IBM/carbon-components/pull/1032#discussion_r210418579
-$unit: 0.5rem;
+$unit: 0.5rem !default;


### PR DESCRIPTION
#### Changelog

**Changed**

- Set $unit variable (ui-shell) as default - it gives possibility to change menu size

#### Testing / Reviewing

In some test project, add 
`$unit: 12px;`
and after build project, left menu width should be doubled
