### PR TITLE
docs(migration): update link to v10 documentation

### DIFF
--- a/docs/migration/migrate-to-10.x.md
+++ b/docs/migration/migrate-to-10.x.md
@@ -1,6 +1,6 @@
 # 10.x Migration
 
-Refer to the [Carbon X Migration Guide](https://www.carbondesignsystem.com/updates/migration/overview) for more information on migrating from v9 to v10.
+Refer to the [Carbon X Migration Guide](https://www.carbondesignsystem.com/updates/v10-migration/overview) for more information on migrating from v9 to v10.
 
 <!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
Quick update to migration docs for link to v10 migration on main website.