### PR TITLE
fix(tabs): adjust focus outline size

### DIFF
--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -133,6 +133,7 @@
   //-----------------------------
   .#{$prefix}--tabs__nav-item {
     background-color: $ui-01;
+    display: flex;
     padding: 0;
     cursor: pointer;
     width: 100%;
@@ -180,7 +181,7 @@
     border: none;
     display: none;
     @include carbon--breakpoint(md) {
-      display: list-item;
+      display: flex;
       .#{$prefix}--tabs__nav-link {
         color: $text-01;
         @include type-style('heading-01');


### PR DESCRIPTION
Fixes #2073.

Note that it's still slightly big, due to usage of `outline-offset` that is not supported by IE.

#### Changelog

**Changed**

- A change to make a tab item a flex box.

#### Testing / Reviewing

Testing should make sure our tab component is not broken.
