### PR TITLE
fix(ie11): file uploader ie11 bugs

### DIFF
--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -61,7 +61,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    min-height: rem(40px);
+    height: rem(40px);
     max-width: rem(300px);
     margin-bottom: $carbon--spacing-03;
     padding: 0 $carbon--spacing-03 0 $carbon--spacing-05;
@@ -101,6 +101,7 @@
     align-items: center;
     color: $text-01;
     margin-right: $carbon--spacing-05;
+    padding: 1px 0;
     /*rtl:ignore*/
     direction: ltr;
     justify-content: flex-start; /*rtl:{flex-end}*/


### PR DESCRIPTION
Closes #2062 

Fixes height alignment and remove vertical scroll bar appearing in box IE11 and Edge

#### Changelog

**New**

- added a 1px padding that doesn't have any effect on height or look of the component. The padding makes the overflow scroll bar go away for the Microsoft browsers but doesn't actually do anything to the appearance. 

**Changed**

- changed `min-height` to `height`. `min-height` causes issues with vertical alignment with flexbox in IE and must have a set height to it. 


cc @dakahn because you added the 'min-height' idk if you had added it for a reason. If needed we can discuss how to add it back.