### PR TITLE
chore(styles): remove deprecated color tokens

### DIFF
--- a/src/components/data-table/_data-table-core.scss
+++ b/src/components/data-table/_data-table-core.scss
@@ -214,13 +214,13 @@
     color: $text-01;
     background-color: $ui-03;
     border-top: 1px solid $ui-03;
-    border-bottom: 1px solid $active-01; //bottom border acts as separator from other rows
+    border-bottom: 1px solid $active-ui; //bottom border acts as separator from other rows
   }
 
   // first row
   .#{$prefix}--data-table--zebra tbody tr:first-of-type:nth-child(odd).#{$prefix}--data-table--selected td,
   tr.#{$prefix}--data-table--selected:first-of-type td {
-    border-top: 1px solid $active-01; //top border acts as separator from thead
+    border-top: 1px solid $active-ui; //top border acts as separator from thead
   }
 
   // last row + zebra select last
@@ -233,7 +233,7 @@
 
   // zebra select - odd child
   .#{$prefix}--data-table--zebra tbody tr:nth-child(even).#{$prefix}--data-table--selected td {
-    border-bottom: 1px solid $active-01;
+    border-bottom: 1px solid $active-ui;
   }
 
   .#{$prefix}--data-table--zebra tbody tr:nth-child(even).#{$prefix}--data-table--selected:hover td {

--- a/src/components/data-table/_data-table-expandable.scss
+++ b/src/components/data-table/_data-table-expandable.scss
@@ -203,16 +203,16 @@
   // parent collapsed
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:first-of-type td {
     background: $ui-03;
-    border-top: 1px solid $active-01;
+    border-top: 1px solid $active-ui;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $active-01;
+    box-shadow: 0 1px $active-ui;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected td {
     background: $ui-03;
     color: $text-01;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $active-01;
+    box-shadow: 0 1px $active-ui;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:last-of-type td {
@@ -252,12 +252,12 @@
     color: $text-01;
     background-color: $hover-field;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $active-01;
+    box-shadow: 0 1px $active-ui;
     border-top: 1px solid $active-ui;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row + tr[data-child-row]:last-of-type td {
-    box-shadow: inset 0 -1px $active-01;
+    box-shadow: inset 0 -1px $active-ui;
     padding-bottom: rem(24px);
   }
 

--- a/src/globals/scss/__tests__/themes-test.js
+++ b/src/globals/scss/__tests__/themes-test.js
@@ -35,15 +35,6 @@ const classic = [
   'support-03',
   'support-04',
 
-  'nav-01',
-  'nav-02',
-  'nav-03',
-  'nav-04',
-  'nav-05',
-  'nav-06',
-  'nav-07',
-  'nav-08',
-
   'hover-primary',
   'hover-primary-text',
   'hover-danger',

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -324,68 +324,6 @@
   /// @access public
   /// @group skeleton
   $skeleton: rgba(#3d70b2, 0.1) !default !global; //old $color__blue-51/$field-01 TODO: Define for experimental
-
-  // ⚠️ Deprecated
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $hover-field: $hover-ui !default !global;
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $active-01: $active-ui !default !global;
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-01: #0f212e !default !global; // Old $color__navy-gray-1
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group
-  $nav-02: #152935 !default !global; // Old $color__blue-90
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-03: #ba8ff7 !default !global; // Old $color__purple-30
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-04: #734098 !default !global; // Old $color__purple-60
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-05: #00b4a0 !default !global; // Old $color__teal-40
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-06: #008571 !default !global; // Old $color__teal-50
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-07: #5aaafa !default !global; // Old $color__blue-30
-
-  /// @deprecated
-  /// @type Color
-  /// @access public
-  /// @group global
-  $nav-08: #3d70b2 !default !global; // Old $color__blue-51
 }
 
 @include exports('theme') {


### PR DESCRIPTION
Refs #2308.

#### Changelog

**Changed**

- Migrate some color tokens to `v10` ones, in data table styles.

**Removed**

- Several deprecated color tokens.

#### Testing / Reviewing

Testing should make sure no component is broken.