### PR TITLE
fix: allow click on search magnifier to focus on input

### DIFF
--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -98,6 +98,7 @@
     transform: translateY(-50%);
     // Ensure clear icon is rendered in Firefox (#1127)
     fill: $text-02;
+    pointer-events: none;
   }
 
   .#{$prefix}--search--xl .#{$prefix}--search-magnifier {


### PR DESCRIPTION
As a user I would expect that clicking the magnifier icon in the search input would place focus in the search box.

#### Changelog

**Changed**

- src/components/search/_search.scss

#### Testing / Reviewing

Clicking the search magnifier should now place focus in the search input.
