### PR TITLE
fix(multi-select): adjust text input left padding

### DIFF
--- a/src/components/multi-select/_multi-select.scss
+++ b/src/components/multi-select/_multi-select.scss
@@ -34,10 +34,6 @@
     color: $text-01;
   }
 
-  .#{$prefix}--multi-select.#{$prefix}--multi-select--selected .#{$prefix}--list-box__field {
-    padding-left: $carbon--spacing-03;
-  }
-
   .#{$prefix}--multi-select--filterable {
     .#{$prefix}--list-box__selection--multi {
       position: absolute;
@@ -52,7 +48,7 @@
     //
     // i.e. the input field needs adjusted padding to account for the width of
     // the number in <ListBox.Selection>
-    padding-left: carbon--mini-units(6);
+    padding-left: carbon--mini-units(7);
   }
 }
 


### PR DESCRIPTION
Closes #2324

This PR adjusts the padding for `<Listbox.Field>` and the text input for filterable multiselect

Related: https://github.com/IBM/carbon-components-react/issues/2109