### PR TITLE
docs(sassdoc): add access and group annotations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,13 +9,12 @@ Set up your SSH Key GitHub Enterprise account and install node.js 4 or higher.
 
 Contributing to carbon-components requires that you can run this repo locally on your computer.
 
-## Coding Style
+## Coding style
 
 ### Class names
 
 Prefix all class names with `#{$prefix}--` in SCSS, which is replaced with `bx--` by default,
-and design systems inheriting Carbon can override.
-This prefix prevents potential conflicts with class names from the user.
+and design systems inheriting Carbon can override. This prefix prevents potential conflicts with class names from the user.
 
 **HTML**
 
@@ -48,7 +47,7 @@ Follow BEM naming convention for classes. Again, the only thing we do differentl
 Avoid nesting selectors, this will make it easier to maintain in the future.
 
 ```scss
-<-- Don't do this -->
+// Don't do this
 .#{$prefix}--inline-notification {
   .#{$prefix}--btn {
     &:hover {
@@ -59,12 +58,69 @@ Avoid nesting selectors, this will make it easier to maintain in the future.
   }
 }
 
-<!-- Do this instead -->
+// Do this instead
 .#{$prefix}--inline-notification .#{$prefix}--btn {
     &:hover svg {
       ...
     }
   }
+}
+```
+
+### Sass documentation
+
+[SassDoc](http://sassdoc.com) is used to document the Carbon Sass source. SassDoc annotations start each line with `///`; do not use `///` in non-SassDoc comments.
+
+For consistency, capitalize types (used in `@type`, `@param`, `@return`) and descriptions (used in `@param`, `@return`, `@deprecated`, `@example`, `@link`).
+
+The following annotations are used:
+
+**Required annotations**
+
+- [Description](http://sassdoc.com/annotations/#description) - can be one line or multiple lines
+- [`@access`](http://sassdoc.com/annotations/#access) - `public` or `private`, where public items make up our public API
+- [`@group`](http://sassdoc.com/annotations/#group) - typically a package or component name
+- [`@type`](http://sassdoc.com/annotations/#type) - allowed on **variables**, (e.g. `Map`, `Color`, `Number`)
+- [`@param`](http://sassdoc.com/annotations/#parameter) - allowed on **functions** and **mixins**, include the type, name, and description, with a default value if there is one (e.g. `@param {Map} $breakpoints [$carbon--grid-breakpoints] - A map of breakpoints where the key is the name`)
+- [`@return`](http://sassdoc.com/annotations/#return) - allowed on **functions**, include the type and description (e.g. `@return {Number} In px`)
+- [`@alias`](http://sassdoc.com/annotations/#alias) - do not include the `$` if aliasing a variable
+- [`@content`](http://sassdoc.com/annotations/#content) - allowed on **mixins**, describe the usage of content
+- [`@deprecated`](http://sassdoc.com/annotations/#deprecated) - context around possible replacements or when the item will no longer be available
+
+  **Optional annotations**
+
+- [`@example`](http://sassdoc.com/annotations/#example) - if the usage isn't straight forward or there are multiple use cases
+- [`@link`](http://sassdoc.com/annotations/#link) - if there's a related link to reference
+
+  **Examples**
+
+```scss
+// Variable example
+
+/// Primary interactive color; Primary buttons
+/// @type Color
+/// @access public
+/// @group @carbon/themes
+$interactive-01: map-get($carbon--theme, interactive-01) !default;
+
+// Mixin example
+
+/// Create the container for a grid. Will cause full-bleed for the grid unless
+/// max-width properties are added with `make-container-max-widths`
+/// @param {Map} $breakpoints [$carbon--grid-breakpoints] - A map of breakpoints where the key is the name
+/// @access private
+/// @group @carbon/grid
+@mixin carbon--make-container($breakpoints: $carbon--grid-breakpoints) {
+}
+
+// Function example
+
+/// Compute the type size for the given type scale step
+/// @param {Number} $step - Type scale step
+/// @return {Number} In px
+/// @access public
+/// @group @carbon/type
+@function carbon--get-type-size($step) {
 }
 ```
 
@@ -79,7 +135,7 @@ A nested element can use a new block name as long as the styles are independent 
 :point_up: The `#{$prefix}--component-button` class implies that this button has independent styles from its parent.
 Generally, it's preferred to start a new block.
 
-### Red Flags
+### Red flags
 
 Avoid names with multiple `__element` names:
 
@@ -206,13 +262,13 @@ To avoid such overhead, you can point NPM dependency of `carbon-components` righ
 
 Then edits of `.scss` files in `/path/to/carbon-components/src` will be reflected to the development environment of your framework variant repository. You don't need to do anything in `carbon-components` side.
 
-## Start Contributing
+## Start contributing
 
-### 1. Fork The Repo:
+### 1. Fork the repo:
 
 Go to [carbon-components](https://github.com/IBM/carbon-components) and click the `Fork` button in the top-right corner.
 
-### 2. Clone Your Fork:
+### 2. Clone your fork:
 
 1.  Go to your [GitHub Repositories](https://github.com/settings/repositories).
 1.  Click on `[your_github_username]/carbon-components`.
@@ -227,7 +283,7 @@ cd carbon-components
 
 See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more details.
 
-### 3. Add Upstream Remotes
+### 3. Add upstream remotes
 
 When you clone your forked repo, doing a `git remote -v` will show that the `origin` remote is set up for you already by default. This should be pointing to your forked repo.
 
@@ -246,7 +302,7 @@ When you do `git remote -v`, you'll see these remotes:
 - `origin`: connection to your fork
 - `upstream`: connection to the original repo.
 
-### 4. Work in a Branch
+### 4. Work in a branch
 
 - Always work in a branch.
 - Submit pull requests from a branch.
@@ -319,13 +375,13 @@ gulp test:a11y --name dropdown
 
 The a11y test may report potential issues that should be handled in application-level, not in carbon-components code. In such case, you can ignore those issues by adding an item to `shouldIssueBeIgnoredForRule` table in [tests/a11y/global-ignore-aat-issues.js](https://github.com/IBM/carbon-components/blob/master/tests/a11y/global-ignore-aat-issues.js). The table is keyed by something like `wcag20.tech.h59.linkValid` which helps identifying what RPT rule to ignore. You can specify `true` to the value which ignores all violations of the rule, or a function which takes the DOM element violating the rule and returns `true` if such violation should be ignored.
 
-### 8. Make a Pull Request
+### 8. Make a pull request
 
 **Note:** Before you make a pull request, [search](https://github.com/IBM/carbon-components/issues) the issues to see if a similar issue has already been submitted. If a similar issue has been submitted, assign yourself or ask to be assigned to the issue by posting a comment. If the issue does not exist, create a new issue.
 
 When you're at a good stopping place and you're ready for feedback from other contributors and maintainers, **push your commits to your fork**:
 
-#### Commit Tip
+#### Commit tip
 
 > **Writing commit messages**
 >
@@ -382,7 +438,7 @@ Write a title and description then click `Create pull request`
 
 - [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
 
-### 9. Updating a Pull Request
+### 9. Updating a pull request
 
 Stay up to date with the activity in your pull request. Maintainers from the Design System team will be reviewing your work and making comments, asking questions and suggesting changes to be made before they merge your code.
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ demo/scss/_prism.scss
 demo/hot
 !demo/index.js
 dist
+docs/api/sass.md
 examples/codesandbox
 src/globals/fonts/LICENSE.md
 tests/a11y-results

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
 
+/// Accordion styles
+/// @access private
+/// @group accordion
 @mixin accordion {
   .#{$prefix}--accordion {
     @include reset;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/layout';
 @import '../link/link';
 
+/// Breadcrumb styles
+/// @access private
+/// @group breadcrumb
 @mixin breadcrumb {
   .#{$prefix}--breadcrumb {
     @include type-style('body-short-01');

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -12,6 +12,9 @@
 @import 'mixins';
 @import '../../globals/scss/css--reset';
 
+/// Button styles
+/// @access private
+/// @group button
 @mixin button {
   // button set styles
   .#{$prefix}--btn-set {

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -7,6 +7,9 @@
 
 @import '../../globals/scss/typography';
 
+/// Button base styles
+/// @access private
+/// @group button
 @mixin button-base {
   @include reset;
   @include type-style('body-short-01');
@@ -44,6 +47,9 @@
   }
 }
 
+/// Button variant styles
+/// @access private
+/// @group button
 @mixin button-theme($bg-color, $border-color, $font-color, $hover-bg-color, $icon-color, $active-color) {
   background-color: $bg-color;
   border-width: $button-border-width;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -12,6 +12,9 @@
 @import '../form/form';
 @import '../../globals/scss/css--reset';
 
+/// Checkbox styles
+/// @access private
+/// @group checkbox
 @mixin checkbox {
   // Spacing between checkboxes
   .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {

--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -12,6 +12,9 @@
 @import '../../globals/scss/css--reset';
 @import 'mixins';
 
+/// Code snippet styles
+/// @access private
+/// @group code-snippet
 @mixin snippet {
   .#{$prefix}--snippet code {
     @include type-style('code-01');

--- a/src/components/code-snippet/_mixins.scss
+++ b/src/components/code-snippet/_mixins.scss
@@ -7,6 +7,9 @@
 
 @import '../../globals/scss/typography';
 
+/// Code snippet base styles
+/// @access private
+/// @group code-snippet
 @mixin bx--snippet {
   @include type-style('code-01');
   background: $snippet-background-color;

--- a/src/components/combo-box/_combo-box.scss
+++ b/src/components/combo-box/_combo-box.scss
@@ -13,6 +13,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../list-box/list-box';
 
+/// Combo box styles
+/// @access private
+/// @group combo-box
 @mixin combo-box {
   .#{$prefix}--combo-box .#{$prefix}--text-input {
     &::placeholder {

--- a/src/components/content-switcher/_content-switcher.scss
+++ b/src/components/content-switcher/_content-switcher.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Content switcher styles
+/// @access private
+/// @group content-switcher
 @mixin content-switcher {
   .#{$prefix}--content-switcher {
     display: flex;

--- a/src/components/data-table/_data-table-action.scss
+++ b/src/components/data-table/_data-table-action.scss
@@ -9,6 +9,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/vars';
 
+/// Data table action styles
+/// @access private
+/// @group data-table
 @mixin data-table-v2-action {
   //-------------------------------------------------
   //TOOLBAR

--- a/src/components/data-table/_data-table-core.scss
+++ b/src/components/data-table/_data-table-core.scss
@@ -9,6 +9,9 @@
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
 
+/// Data table core styles
+/// @access private
+/// @group data-table
 @mixin data-table-core {
   //----------------------------------------------------------------------------
   // Container

--- a/src/components/data-table/_data-table-expandable.scss
+++ b/src/components/data-table/_data-table-expandable.scss
@@ -9,6 +9,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/vars';
 
+/// Data table expandable styles
+/// @access private
+/// @group data-table
 @mixin data-table-expandable {
   //----------------------------------------------------------------------------
   // Parent row

--- a/src/components/data-table/_data-table-inline-edit-cell.scss
+++ b/src/components/data-table/_data-table-inline-edit-cell.scss
@@ -11,6 +11,8 @@
 @import '../../globals/scss/layout';
 @import '../../globals/scss/vars';
 
+/// @access private
+/// @group data-table
 @mixin assistive-text {
   position: absolute;
   width: 1px;
@@ -25,14 +27,25 @@
 }
 
 @include exports('data-table-inline-edit-cell') {
-  // Spacing for cells that are the first in their row
+  /// Spacing for cells that are the first in their row
+  /// @access private
+  /// @group data-table
   $spacing--columns--first: 1.5rem;
-  // Spacing before columns in cell
+
+  /// Spacing before columns in cell
+  /// @access private
+  /// @group data-table
   $spacing--columns--before: 0.75rem;
-  // Spacing for activity areas in a cell, namely status and actions
+
+  /// Spacing for activity areas in a cell, namely status and actions
+  /// @access private
+  /// @group data-table
   $spacing--cell--activity: 3.5rem;
-  // Offset used on input nodes to offer space to activity indicators such that
-  // the input doesn't overlap with the status
+
+  /// Offset used on input nodes to offer space to activity indicators such that
+  /// the input doesn't overlap with the status
+  /// @access private
+  /// @group data-table
   $spacing--cell--status: 2rem;
 
   //----------------------------------------------------------------------------
@@ -180,9 +193,13 @@
   // Cell Edit - Actions
   //----------------------------------------------------------------------------
 
-  // Spacing that should exist around, and in-between, elements in the action
-  // bar
+  /// Spacing that should exist around, and in-between, elements in the action bar
+  /// @access private
+  /// @group data-table
   $spacing--cell-actions: 0.5rem;
+
+  /// @access private
+  /// @group data-table
   $size--edit-actions--height: 3rem;
 
   .#{$prefix}--data-table__edit-actions {

--- a/src/components/data-table/_data-table-sort.scss
+++ b/src/components/data-table/_data-table-sort.scss
@@ -9,6 +9,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/vars';
 
+/// Data table sort styles
+/// @access private
+/// @group data-table
 @mixin data-table-sort {
   // -------------------------------------
   // Sortable table

--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -14,6 +14,9 @@
 @import '../form/form';
 @import 'flatpickr.scss';
 
+/// Date picker styles
+/// @access private
+/// @group date-picker
 @mixin date-picker {
   .#{$prefix}--date-picker {
     display: flex;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -16,6 +16,9 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/layout';
 
+/// Dropdown styles
+/// @access private
+/// @group dropdown
 @mixin dropdown {
   .#{$prefix}--dropdown__wrapper--inline {
     display: inline-grid;

--- a/src/components/file-uploader/_file-uploader.scss
+++ b/src/components/file-uploader/_file-uploader.scss
@@ -14,6 +14,9 @@
 @import '../loading/loading';
 @import '../../globals/scss/vendor/@carbon/elements/scss/type/styles';
 
+/// File uploader styles
+/// @access private
+/// @group file-uploader
 @mixin file-uploader {
   .#{$prefix}--file {
     width: 100%;

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Form styles
+/// @access private
+/// @group form
 @mixin form {
   .#{$prefix}--fieldset {
     @include reset;

--- a/src/components/inline-loading/_inline-loading.scss
+++ b/src/components/inline-loading/_inline-loading.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import 'keyframes';
 
+/// Inline loading styles
+/// @access private
+/// @group inline-loading
 @mixin inline-loading {
   .#{$prefix}--inline-loading {
     display: flex;

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -17,6 +17,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
 
+/// Link styles
+/// @access private
+/// @group link
 @mixin link {
   .#{$prefix}--link {
     @include reset;

--- a/src/components/list-box/_list-box.scss
+++ b/src/components/list-box/_list-box.scss
@@ -16,11 +16,29 @@
 @import '../../globals/scss/layer';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// @type Number
+/// @access private
+/// @group list-box
 $list-box-width: 100%;
+
+/// @type Number
+/// @access private
+/// @group list-box
 $list-box-height: rem(40px);
+
+/// @type Number
+/// @access private
+/// @group list-box
 $list-box-inline-height: $list-box-height;
+
+/// @type Number
+/// @access private
+/// @group list-box
 $list-box-menu-width: rem(300px);
 
+/// List box styles
+/// @access private
+/// @group list-box
 @mixin listbox {
   // The overall container element for a `list-box`. Has two variants,
   // `disabled` and `inline`.

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -14,6 +14,9 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// List styles
+/// @access private
+/// @group list
 @mixin lists {
   .#{$prefix}--list--nested,
   .#{$prefix}--list--unordered,

--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -12,6 +12,9 @@
 @import 'mixins';
 @import 'vars';
 
+/// Loading styles
+/// @access private
+/// @group loading
 @mixin loading {
   .#{$prefix}--loading {
     @include reset;

--- a/src/components/loading/_mixins.scss
+++ b/src/components/loading/_mixins.scss
@@ -10,6 +10,8 @@
 //-------------------------
 @import '../../globals/scss/vars';
 
+/// @access private
+/// @group loading
 @mixin animation__loading--spin {
   // Animate the container
   animation-name: rotate;
@@ -26,6 +28,8 @@
   }
 }
 
+/// @access private
+/// @group loading
 @mixin animation__loading--stop {
   // Animate the container
   animation: rotate-end-p1 700ms $carbon--ease-out forwards, rotate-end-p2 700ms $carbon--ease-out 700ms forwards;

--- a/src/components/loading/_vars.scss
+++ b/src/components/loading/_vars.scss
@@ -5,5 +5,12 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+/// @type Number
+/// @access private
+/// @group loading
 $loading__gap: 40;
+
+/// @type Number
+/// @access private
+/// @group loading
 $loading__size: 10.5rem;

--- a/src/components/modal/_mixins.scss
+++ b/src/components/modal/_mixins.scss
@@ -9,6 +9,8 @@
 // Modal
 // ---------------------------------------------
 
+/// @access private
+/// @group modal
 @mixin modal--color($color) {
   .#{$prefix}--modal-container {
     border-top-color: $color;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -19,6 +19,9 @@
 
 @import '../button/button';
 
+/// Modal styles
+/// @access private
+/// @group modal
 @mixin modal {
   .#{$prefix}--modal {
     position: fixed;

--- a/src/components/multi-select/_multi-select.scss
+++ b/src/components/multi-select/_multi-select.scss
@@ -13,6 +13,9 @@
 @import '../../globals/scss/vars';
 @import '../list-box/list-box';
 
+/// Multi select styles
+/// @access private
+/// @group multi-select
 @mixin multiselect {
   .#{$prefix}--multi-select .#{$prefix}--list-box__menu {
     min-width: auto;

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -17,6 +17,9 @@
 @import '../../globals/scss/css--reset';
 @import 'mixins';
 
+/// Inline notification styles
+/// @access private
+/// @group notification
 @mixin inline-notifications {
   .#{$prefix}--inline-notification {
     @include reset;

--- a/src/components/notification/_mixins.scss
+++ b/src/components/notification/_mixins.scss
@@ -9,6 +9,8 @@
 // Inline Notification
 // ---------------------------------------------
 
+/// @access private
+/// @group notification
 @mixin inline-notification--color($color) {
   border: 1px solid $color;
   border-left: 6px solid $color;
@@ -22,10 +24,14 @@
 // Toast Notification
 // ---------------------------------------------
 
+/// @access private
+/// @group notification
 @mixin notification--color($color) {
   border-left: 6px solid $color;
 }
 
+/// @access private
+/// @group notification
 @mixin notification--experimental($color, $background-color) {
   border-left: 3px solid $color;
   background: $background-color;

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -17,6 +17,9 @@
 @import '../../globals/scss/css--reset';
 @import 'mixins';
 
+/// Toast notification styles
+/// @access private
+/// @group notification
 @mixin toast-notifications {
   .#{$prefix}--toast-notification {
     @include reset;

--- a/src/components/number-input/_number-input.scss
+++ b/src/components/number-input/_number-input.scss
@@ -12,6 +12,9 @@
 @import '../../globals/scss/css--reset';
 @import '../form/form';
 
+/// Number input styles
+/// @access private
+/// @group number-input
 @mixin number-input {
   .#{$prefix}--number {
     @include reset;

--- a/src/components/overflow-menu/_overflow-menu.scss
+++ b/src/components/overflow-menu/_overflow-menu.scss
@@ -17,6 +17,9 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Overflow menu styles
+/// @access private
+/// @group overflow-menu
 @mixin overflow-menu {
   .#{$prefix}--overflow-menu {
     @include reset;

--- a/src/components/pagination-nav/_pagination-nav.scss
+++ b/src/components/pagination-nav/_pagination-nav.scss
@@ -17,6 +17,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
 
+/// Pseudo underline
+/// @access private
+/// @group pagination-nav
 @mixin pseudo-underline() {
   &:not(.#{$prefix}--pagination-nav__page--direction) {
     &::after {
@@ -41,6 +44,20 @@
   }
 }
 
+/// Pagination nav base styles
+/// @access private
+/// @group pagination-nav
+/// @param {Color} $text-color [$text-02]
+/// @param {Color} $text-color-active [$text-02]
+/// @param {Color} $background-color-hover [$hover-ui]
+/// @param {Color} $background-color-active [initial]
+/// @param {Number} $font-weight [400]
+/// @param {Number} $item-padding [0]
+/// @param {Number} $button-min-width [$carbon--spacing-09]
+/// @param {Value} $button-padding [1.0625rem $carbon--spacing-02]
+/// @param {Number} $button-direction-size [$carbon--spacing-09]
+/// @param {Number} $select-icon-top-position [$carbon--spacing-05]
+/// @param {Number} $select-icon-left-position [$carbon--spacing-05]
 @mixin pagination-nav(
   $text-color: $text-02,
   $text-color-active: $text-02,

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -16,6 +16,9 @@ $css--helpers: true;
 @import '../select/select';
 @import '../text-input/text-input';
 
+/// Pagination styles
+/// @access private
+/// @group pagination
 @mixin pagination {
   .#{$prefix}--data-table-container + .#{$prefix}--pagination {
     border-top: 0;

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Progress indicator styles
+/// @access private
+/// @group progress-indicator
 @mixin progress-indicator {
   .#{$prefix}--progress {
     @include reset;

--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -16,6 +16,9 @@
 @import '../form/form';
 @import '../../globals/scss/css--reset';
 
+/// Radio button styles
+/// @access private
+/// @group radio-button
 @mixin radio-button {
   .#{$prefix}--radio-button-group {
     display: flex;

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -15,6 +15,9 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/import-once';
 
+/// Search styles
+/// @access private
+/// @group search
 @mixin search {
   .#{$prefix}--search {
     display: flex;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -16,6 +16,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../form/form';
 
+/// Select styles
+/// @access private
+/// @group select
 @mixin select {
   .#{$prefix}--select {
     @include reset;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -17,6 +17,9 @@
 @import '../form/form';
 @import '../text-input/text-input';
 
+/// Slider styles
+/// @access private
+/// @group slider
 @mixin slider {
   .#{$prefix}--slider-container {
     display: flex;

--- a/src/components/structured-list/_mixins.scss
+++ b/src/components/structured-list/_mixins.scss
@@ -5,13 +5,19 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// Used only for .#{prefix}--structured-list--condensed
+/// Used only for `.#{prefix}--structured-list--condensed`
+/// @access private
+/// @group structured-list
+/// @param {Number} $padding [$structured-list-padding]
 @mixin padding-td--condensed($padding: $structured-list-padding) {
   padding: $padding / 4;
   padding-left: 0;
 }
 
-// Used only for [data-structured-list]
+/// Used only for [data-structured-list]
+/// @access private
+/// @group structured-list
+/// @param {Number} $padding [$structured-list-padding]
 @mixin padding--data-structured-list($padding: $structured-list-padding) {
   padding-left: $padding / 2;
   padding-right: $padding / 2;
@@ -23,7 +29,10 @@
   }
 }
 
-// Used only for normal structured-list
+/// Used only for normal structured-list
+/// @access private
+/// @group structured-list
+/// @param {Number} $padding [$structured-list-padding]
 @mixin padding-th($padding: $structured-list-padding) {
   padding-left: $carbon--spacing-05;
   padding-right: $carbon--spacing-05;
@@ -31,7 +40,10 @@
   padding-bottom: $carbon--spacing-03;
 }
 
-// Used only for normal structured-list
+/// Used only for normal structured-list
+/// @access private
+/// @group structured-list
+/// @param {Number} $padding [$structured-list-padding]
 @mixin padding-td($padding: $structured-list-padding) {
   padding-top: $carbon--spacing-05;
   padding-right: $carbon--spacing-05;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -15,6 +15,9 @@
 @import '../../globals/scss/layout';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Tabs styles
+/// @access private
+/// @group tabs
 @mixin tabs {
   .#{$prefix}--tabs {
     @include type-style('body-short-01');

--- a/src/components/tag/_mixins.scss
+++ b/src/components/tag/_mixins.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+/// @access private
+/// @group tag
 @mixin tag-theme($bg-color, $text-color) {
   background-color: $bg-color;
   color: $text-color;

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import 'mixins';
 
+/// Tag styles
+/// @access private
+/// @group tag
 @mixin tags {
   .#{$prefix}--tag {
     @include type-style('label-01');

--- a/src/components/text-area/_text-area.scss
+++ b/src/components/text-area/_text-area.scss
@@ -16,6 +16,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../form/form';
 
+/// Text area styles
+/// @access private
+/// @group text-area
 @mixin text-area {
   .#{$prefix}--text-area {
     @include reset;

--- a/src/components/text-input/_text-input.scss
+++ b/src/components/text-input/_text-input.scss
@@ -15,6 +15,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../form/form';
 
+/// Text input styles
+/// @access private
+/// @group text-input
 @mixin text-input {
   .#{$prefix}--text-input {
     @include reset;

--- a/src/components/tile/_tile.scss
+++ b/src/components/tile/_tile.scss
@@ -15,6 +15,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
 
+/// Tile styles
+/// @access private
+/// @group tile
 @mixin tile {
   .#{$prefix}--tile {
     display: block;

--- a/src/components/time-picker/_time-picker.scss
+++ b/src/components/time-picker/_time-picker.scss
@@ -15,6 +15,9 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Time picker styles
+/// @access private
+/// @group time-picker
 @mixin time-picker {
   .#{$prefix}--time-picker {
     display: flex;

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -15,6 +15,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../form/form';
 
+/// Toggle styles
+/// @access private
+/// @group toggle
 @mixin toggle {
   .#{$prefix}--toggle {
     @include hidden;

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -19,6 +19,9 @@ $css--helpers: true;
 @import '../overflow-menu/overflow-menu';
 @import '../search/search';
 
+/// Toolbar styles
+/// @access private
+/// @group toolbar
 @mixin toolbar {
   .#{$prefix}--toolbar {
     display: flex;

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -11,6 +11,9 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
 
+/// Tooltip styles
+/// @access private
+/// @group tooltip
 @mixin tooltip {
   .#{$prefix}--tooltip--icon {
     display: flex;

--- a/src/components/ui-shell/_content.scss
+++ b/src/components/ui-shell/_content.scss
@@ -9,6 +9,9 @@
 @import '../../globals/scss/vars';
 @import 'functions';
 
+/// UI shell content
+/// @access private
+/// @group ui-shell
 @mixin carbon-content {
   .#{$prefix}--content {
     transform: translate3d(0, 0, 0);

--- a/src/components/ui-shell/_functions.scss
+++ b/src/components/ui-shell/_functions.scss
@@ -8,8 +8,9 @@
 @import 'variables';
 
 /// Get a `rem` value based for a number of mini-units.
-/// @param {number} $count
-/// @returns {rem}
+/// @param {Number} $count
+/// @returns {Number} In rem
+/// @group ui-shell
 @function mini-units($count) {
   @return $unit * $count;
 }

--- a/src/components/ui-shell/_header.scss
+++ b/src/components/ui-shell/_header.scss
@@ -14,6 +14,9 @@
 @import 'theme';
 @import 'functions';
 
+/// UI shell header
+/// @access private
+/// @group ui-shell
 @mixin carbon-header {
   .#{$prefix}--header {
     display: flex;

--- a/src/components/ui-shell/_navigation-menu.scss
+++ b/src/components/ui-shell/_navigation-menu.scss
@@ -10,6 +10,9 @@
 @import '../../globals/scss/vars';
 @import 'functions';
 
+/// UI shell navigation
+/// @access private
+/// @group ui-shell
 @mixin carbon-navigation {
   //----------------------------------------------------------------------------
   // Navigation

--- a/src/components/ui-shell/_product-switcher.scss
+++ b/src/components/ui-shell/_product-switcher.scss
@@ -11,6 +11,9 @@
 @import 'theme';
 @import 'functions';
 
+/// UI shell product switcher
+/// @access private
+/// @group ui-shell
 @mixin product-switcher {
   //--------------------------------------------------------------------------
   // Global Panel

--- a/src/components/ui-shell/_side-nav.scss
+++ b/src/components/ui-shell/_side-nav.scss
@@ -14,10 +14,12 @@
 @import 'theme';
 
 /// Adds experimental focus styles to a particular selector.
+/// @access private
+/// @group ui-shell
 /// @example
-///    .my-custom-selector:focus {
-///      @include experimental-focus();
-///    }
+///   .my-custom-selector:focus {
+///     @include experimental-focus();
+///   }
 @mixin experimental-focus() {
   outline: 4px solid $shell-side-nav-accent-01;
   outline-offset: -4px;
@@ -25,10 +27,12 @@
 
 /// Helper to add in text overflow styles to a particular node. Useful if we
 /// don't want to have display-inline: block from the text helper classes
+/// @access private
+/// @group ui-shell
 /// @example
-///    .my-custom-selector {
-///      @include text-overflow();
-///    }
+///   .my-custom-selector {
+///     @include text-overflow();
+///   }
 @mixin text-overflow {
   white-space: nowrap;
   overflow: hidden;
@@ -40,8 +44,10 @@
 /// to whether the side-nav is open, or closed. For convenience, we also
 /// optionally set properties for opacity and visibility to help with the
 /// transition animation.
-/// @param {boolean} $opacity
-/// @param {boolean} $visibility
+/// @access private
+/// @group ui-shell
+/// @param {Bool} $opacity [false]
+/// @param {Bool} $visibility [false]
 /// @content
 @mixin expanded($opacity: false, $visibility: false) {
   @if $opacity == true {
@@ -67,6 +73,9 @@
   }
 }
 
+/// UI shell side nav
+/// @access private
+/// @group ui-shell
 @mixin carbon-side-nav {
   //----------------------------------------------------------------------------
   // Side-nav > Panel

--- a/src/components/ui-shell/_theme.scss
+++ b/src/components/ui-shell/_theme.scss
@@ -7,74 +7,147 @@
 
 @import '../../globals/scss/colors';
 
-// Header bar background
+/// Header bar background
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-bg-01: #252525;
 
-// Header-panel background
+/// Header-panel background
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-bg-02: #f3f3f3;
 
-// Panel item hover
+/// Panel item hover
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-bg-03: #dcdcdc;
 
-// Panel overflow hover
+/// Panel overflow hover
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-bg-04: #bebebe;
 
-// Panel input background
+/// Panel input background
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-bg-05: #fff;
 
-// Header Nav Link hober
+/// Header Nav Link hober
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-bg-06: #4c4c4c;
 
-// Primary text in header-panel, Item text
+/// Primary text in header-panel, Item text
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-text-01: #f3f3f3;
 
-// Secondary text in header-panel, Item text
+/// Secondary text in header-panel, Item text
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-text-02: #171717;
 
-// Secondary text in header-panel, Category label
+/// Secondary text in header-panel, Category label
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-text-03: #8c8c8c;
 
-// Header bar icons
+/// Header bar icons
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-icon-01: #f3f3f3;
 
-// Icons in header panel
+/// Icons in header panel
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-icon-02: #252525;
 
-// Item link
+/// Item link
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-link: #0062ff;
 
-// Header icon selected state background
+/// Header icon selected state background
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-header-icon-selected: #0062ff;
 
-// Side-nav panel background
+/// Side-nav panel background
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-bg-01: $ibm-color__gray-90;
 
-// Selected category background
-// Select L2 flatted item background
-// Item hover background
-// Footer-bar background
+/// Selected category background
+/// Select L2 flatted item background
+/// Item hover background
+/// Footer-bar background
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-bg-02: $ibm-color__gray-80;
 
-// Selected L2 nested item
+/// Selected L2 nested item
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-bg-03: $ibm-color__gray-70;
 
-// Primary text in side-nav
-// L2 Flatten item text
-// L2 Nested item text
-// L1 title text
+/// Primary text in side-nav
+/// L2 Flatten item text
+/// L2 Nested item text
+/// L1 title text
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-text-01: $ibm-color__gray-10;
 
-// Secondary text in side nav
-// L2 Category label
+/// Secondary text in side nav
+/// L2 Category label
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-text-02: $ibm-color__gray-30;
 
-// side-nav icon color
+/// Side-nav icon color
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-icon-01: $ibm-color__gray-10;
 
-// item highlight bar
+/// Item highlight bar
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-side-nav-accent-01: $ibm-color__blue-60;
 
-// Temporary token
+/// Temporary token
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-brand-01: #0062ff;
+
+/// Temporary token
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-ui-02: #3d3d3d;
+
+/// Temporary token
+/// @type Color
+/// @access private
+/// @group ui-shell
 $shell-ui-03: #000;

--- a/src/components/ui-shell/_variables.scss
+++ b/src/components/ui-shell/_variables.scss
@@ -5,7 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// Use rem here to accomodate zoom behavior
-// Reference:
-// https://github.com/IBM/carbon-components/pull/1032#discussion_r210418579
+/// Use rem here to accomodate zoom behavior
+/// @link https://github.com/IBM/carbon-components/pull/1032#discussion_r210418579
+/// @access private
+/// @group ui-shell
 $unit: 0.5rem;

--- a/src/globals/scss/__tests__/themes-test.js
+++ b/src/globals/scss/__tests__/themes-test.js
@@ -72,10 +72,6 @@ const classic = [
   'accordion-title-margin',
   'accordion-content-padding',
 
-  // Card
-  'card-text-align',
-  'card-flex-align',
-
   // Checkbox
   'checkbox-border-width',
 

--- a/src/globals/scss/_colors.scss
+++ b/src/globals/scss/_colors.scss
@@ -8,4 +8,4 @@
 //-----------
 // v10 COLORS
 //-----------
-@import './vendor/@carbon/colors/scss/colors';
+@import './vendor/@carbon/elements/scss/colors/colors';

--- a/src/globals/scss/_css--body.scss
+++ b/src/globals/scss/_css--body.scss
@@ -10,7 +10,9 @@
 @import 'css--reset';
 @import './vendor/@carbon/elements/scss/import-once/import-once';
 
+/// Body styles
 /// @access private
+/// @group global-body
 @mixin css-body {
   body {
     @include reset;

--- a/src/globals/scss/_css--font-face.scss
+++ b/src/globals/scss/_css--font-face.scss
@@ -14,6 +14,8 @@ $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !defa
 @import './vendor/@carbon/elements/scss/type/font-face/sans';
 
 /// @deprecated (For v10) Superseded by `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
+/// @access private
+/// @group global-font-face
 @mixin check-default-font-path {
   @if (str-index($font-path, 'https://unpkg.com/') == 1) {
     @warn 'The default font path (#{$font-path}) should be used only for demonstration/evaluation purposes. For production applications, please host fonts in your own CDN and change `$font-path` accordingly.';
@@ -23,8 +25,10 @@ $font-path: 'https://unpkg.com/carbon-components@latest/src/globals/fonts' !defa
   }
 }
 
+/// Helvetica Neue font face declarations
 /// @access public
 /// @deprecated (For v10) Use `@include carbon--font-face-sans()`, `@include carbon--font-face-mono()`, etc.
+/// @group global-font-face
 @mixin helvetica-font-face {
   // Default font directory, `!default` flag allows user override.
   // (font files are configured to be served as static assets from server.js)

--- a/src/globals/scss/_css--helpers.scss
+++ b/src/globals/scss/_css--helpers.scss
@@ -12,6 +12,7 @@
 
 /// Include styles for screen reader/assistive text
 /// @access public
+/// @group global-helpers
 @mixin css-helpers {
   .#{$prefix}--assistive-text,
   .#{$prefix}--visually-hidden {

--- a/src/globals/scss/_css--reset.scss
+++ b/src/globals/scss/_css--reset.scss
@@ -10,8 +10,9 @@
 
 /// Resets default browser styling
 /// @access public
+/// @group global-reset
 @mixin reset {
-  @if global-variable-exists(css--reset) ==false or $css--reset==false {
+  @if global-variable-exists(css--reset) == false or $css--reset == false {
     box-sizing: border-box;
     margin: 0;
     padding: 0;
@@ -30,8 +31,6 @@
 
 @include exports('css--reset') {
   @if global-variable-exists(css--reset) ==false or $css--reset==true {
-    @include carbon--type-reset;
-
     // http://cssreset.com/scripts/eric-meyer-reset-css/
     html,
     body,
@@ -191,5 +190,7 @@
     * {
       box-sizing: border-box;
     }
+
+    @include carbon--type-reset;
   }
 }

--- a/src/globals/scss/_deprecate.scss
+++ b/src/globals/scss/_deprecate.scss
@@ -4,8 +4,7 @@
 /// @param {String} $reason - The message
 /// @param {Bool} $condition [true] - `true` to emit the given deprecation messsage
 /// @param {Bool} $remove-deprecated [false] - `true` to omit the content if $condition is `true`
-/// @require {Bool} $deprecations--entry
-/// @require {Map} $deprecations--reasons
+/// @group global-deprecate
 @mixin deprecate($reason, $condition: true, $remove-deprecated: false) {
   $deprecations--entry: false !default;
 

--- a/src/globals/scss/_feature-flags.scss
+++ b/src/globals/scss/_feature-flags.scss
@@ -9,16 +9,24 @@
 // 🎌 Feature Flags
 //-------------------------
 
-/// Initialize our feature flag map with default values, user can override default values ($default-feature-flags) here
+/// Initialize the feature flag map with default values.
 /// @access public
 /// @type Map
+/// @group feature-flags
 /// @example
-/// $feature-flags: (ui-shell: true); // overrides default values for ui-shell
+/// @example scss - Overriding defaults from the `$default-feature-flags` map
+///   $feature-flags: (
+///     ui-shell: false,
+///     grid: true,
+///     grid-columns-16: false,
+///     grid--fallback: false,
+///   );
 $feature-flags: () !default;
 
 /// Default feature flag values
 /// @access private
 /// @type Map
+/// @group feature-flags
 $default-feature-flags: (
   ui-shell: false,
   grid: true,
@@ -28,14 +36,17 @@ $default-feature-flags: (
 
 /// @access private
 /// @type Bool
+/// @group feature-flags
 $did-warn-diverged-feature-flags: false !default !global;
 
 /// Look for user-defined feature flags that are different from default ones, and warn them before merging them.
 /// @access private
-/// @param {Map} $dst - The feature flags to merge to (default feature flags).
-/// @param {Map} $src - The feature flags to merge from (user-defined feature flags).
-/// @returns {Map} - The result of `map-merge($dst, $src)`.
-/// @example - $feature-flags: merge-feature-flags($default-feature-flags, $feature-flags);
+/// @param {Map} $dst - The feature flags to merge to (default feature flags)
+/// @param {Map} $src - The feature flags to merge from (user-defined feature flags)
+/// @returns {Map} - The result of `map-merge($dst, $src)`
+/// @example scss
+///   $feature-flags: merge-feature-flags($default-feature-flags, $feature-flags);
+/// @group feature-flags
 @function merge-feature-flags($dst, $src) {
   @if (not $did-warn-diverged-feature-flags) {
     $diverged: ();

--- a/src/globals/scss/_functions.scss
+++ b/src/globals/scss/_functions.scss
@@ -9,8 +9,12 @@
 
 /// Used for enabling features
 /// @access public
-/// @param {String} $feature - feature from $default-feature-flags
-/// @example @if feature-flag-enabled('ui-shell') { ... } will include code inside of { } only if ui-shell is true
+/// @param {String} $feature - Feature from `$default-feature-flags`
+/// @return {Bool}
+/// @example scss
+///   // Will include code inside of { } only if `components-x` is true
+///   @if feature-flag-enabled('components-x') { ... }
+/// @group feature-flags
 @function feature-flag-enabled($feature) {
   @if global-variable-exists(feature-flags) == true and map-get($feature-flags, $feature) == true {
     @return true;

--- a/src/globals/scss/_helper-mixins.scss
+++ b/src/globals/scss/_helper-mixins.scss
@@ -26,8 +26,9 @@
 
 /// Adds text overflow styling
 /// @access public
-/// @param {Value} $width [false] - value of width if you want to set width, else nothing
+/// @param {Number} $width [false] - Value of width if you want to set width, else nothing
 /// @example @include text-overflow(300px);
+/// @group global-helpers
 @mixin text-overflow($width: false) {
   display: block;
   overflow-x: hidden;
@@ -42,7 +43,9 @@
 
 /// Adds placeholder text color
 /// @access public
+/// @param {String} $size ['small'] - Size of box shadow
 /// @example @include placeholder-colors;
+/// @group global-helpers
 @mixin placeholder-colors {
   color: $text-03;
 }
@@ -51,6 +54,7 @@
 /// @access public
 /// @param {String} $size ['small'] - size of box shadow
 /// @example @include box-shadow(); @include box-shadow('large');
+/// @group global-helpers
 @mixin box-shadow($size: 'small') {
   // Large - For dropdowns
   @if ($size == 'large') {
@@ -64,8 +68,9 @@
 
 /// Adds outline styles depending on specific type
 /// @access public
-/// @param {String} $type ['border'] - type of outline from: border, blurred, outline, invalid, reset
+/// @param {String} $type ['border'] - Type of outline from: `border`, `blurred`, `outline`, `invalid`, `reset`
 /// @example @include focus-outline('outline');
+/// @group global-helpers
 @mixin focus-outline($type: 'border') {
   @if ($type == 'border') {
     outline: 1px solid $focus;
@@ -94,10 +99,11 @@
 
 /// Adds rotational transformation
 /// @access public
-/// @param {Value} $deg - how many degrees to rotate
-/// @param {Value} $speed - speed of rotation
-/// @param {Value} $origin [center] - transform-origin
+/// @param {Number} $deg - How many degrees to rotate
+/// @param {Number} $speed - Speed of rotation
+/// @param {Value} $origin [center] - `transform-origin`
 /// @example @include rotate(90deg, 300ms);
+/// @group global-helpers
 @mixin rotate($deg, $speed, $origin: center) {
   transform: rotate($deg);
   transition: transform $speed;
@@ -106,6 +112,7 @@
 
 /// Adds styles to hide content
 /// @access public
+/// @group global-helpers
 @mixin hidden {
   position: absolute;
   width: 1px;
@@ -121,8 +128,9 @@
 
 /// Resets button styles
 /// @access public
-/// @param {Bool} $width [true] - sets width to 100% if true
+/// @param {Bool} $width [true] - Sets width to 100% if true
 /// @example @include button-reset($width: false);
+/// @group global-helpers
 @mixin button-reset($width: true) {
   @include reset;
   display: inline-block;
@@ -141,9 +149,10 @@
   }
 }
 
-/// 💀 Skeleton loading animation
+/// Skeleton loading animation
 /// @access public
 /// @example @include skeleton;
+/// @group global-helpers
 @mixin skeleton {
   position: relative;
   border: none;

--- a/src/globals/scss/_layer.scss
+++ b/src/globals/scss/_layer.scss
@@ -22,21 +22,50 @@
 //
 
 // Box shadow variables
+
+/// Box shadow color
 /// @access private
 /// @type Value
-/// @group layer
+/// @group global-layer
 /// @example box-shadow: 0px 3px 3px 0 $box-shadow;
 $box-shadow: rgba(0, 0, 0, 0.1);
+
+/// Raised box shadow
+/// @access private
+/// @type Value
+/// @group global-layer
 $box-shadow--raised: 0 1px 2px 0 $box-shadow;
+
+/// Overlay box shadow
+/// @access private
+/// @type Value
+/// @group global-layer
 $box-shadow--overlay: 0 4px 8px 0 $box-shadow;
+
+/// Sticky nav box shadow
+/// @access private
+/// @type Value
+/// @group global-layer
 $box-shadow--sticky-nav: 0 6px 12px 0 $box-shadow;
+
+/// Temporary nav box shadow
+/// @access private
+/// @type Value
+/// @group global-layer
 $box-shadow--temporary-nav: 0 8px 16px 0 $box-shadow;
+
+/// Pop out box shadow
+/// @access private
+/// @type Value
+/// @group global-layer
 $box-shadow--pop-out: 0 12px 24px 0 $box-shadow;
 
 // Layer box-shadow map
+
+/// Map of box shadows used in the `layer()` mixin
 /// @access private
 /// @type Map
-/// @group layer
+/// @group global-layer
 /// @example - @include layer('raised');
 $layer-shadows: (
   base: none,
@@ -48,10 +77,10 @@ $layer-shadows: (
   sticky-nav: $box-shadow--sticky-nav,
 );
 
-// Layer mixin
+/// Layer mixin to set `box-shadow`
 /// @access public
-/// @param {String} $layer - a value from the $layer-shadows map
-/// @group layer
+/// @param {String} $layer - A value from the `$layer-shadows` map
+/// @group global-layer
 /// @example - @include layer('raised');
 @mixin layer($layer) {
   @if global-variable-exists('css--use-layer') == false or $css--use-layer == true {

--- a/src/globals/scss/_layout.scss
+++ b/src/globals/scss/_layout.scss
@@ -9,7 +9,7 @@
 
 /// @access private
 /// @type Map
-/// @group @function z();
+/// @group global-layout
 $z-indexes: (
   modal: 9000,
   overlay: 8000,
@@ -21,16 +21,13 @@ $z-indexes: (
   floating: 10000,
 );
 
-//-------------------------------------
-// @function: z($layer)
-//-------------------------------------
 /// @access public
-/// @param {String} $layer value from $z-indexes map (See line 139)
-/// @group $z-indexes
-/// @example
-//    .modal {
-//       z-index: z('modal');
-//    }
+/// @param {String} $layer - Value from `$z-indexes` map
+/// @group global-layout
+/// @example - scss
+///   .modal {
+///     z-index: z('modal');
+///   }
 @function z($layer) {
   @if not map-has-key($z-indexes, $layer) {
     @warn 'No layer found for `#{$layer}` in $z-indexes map. Property omitted.';

--- a/src/globals/scss/_motion.scss
+++ b/src/globals/scss/_motion.scss
@@ -7,48 +7,111 @@
 
 @import './vendor/@carbon/elements/scss/motion/motion';
 
-/// Used primarily for removing elements from the screen.
+/// Used primarily for removing elements from the screen
+/// @type Function
 /// @access public
+/// @group global-motion
 $carbon--ease-in: cubic-bezier(0.25, 0, 1, 1);
 
-/// Used for adding elements to the screen or changing on-screen states at a users's input.
+/// Used for adding elements to the screen or changing on-screen states at a users's input
+/// @type Function
 /// @access public
+/// @group global-motion
 $carbon--ease-out: cubic-bezier(0, 0, 0.25, 1);
 
-/// Used for the majority of animations.
+/// Used for the majority of animations
+/// @type Function
 /// @access public
+/// @group global-motion
 $carbon--standard-easing: cubic-bezier(0.5, 0, 0.1, 1);
 
 /// Base transition duration
+/// @type Number
 /// @access public
+/// @group global-motion
 $transition--base: 250ms;
 
 /// Expansion duration
+/// @type Number
 /// @access public
+/// @group global-motion
 $transition--expansion: 300ms;
 
 /// New easing durations
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
 $duration--fast-01: 70ms;
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
 $duration--fast-02: 110ms;
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
 $duration--moderate-01: 150ms;
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
 $duration--moderate-02: 240ms;
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
 $duration--slow-01: 400ms;
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
 $duration--slow-02: 720ms;
 
+/// Default ease-in for components
+/// @access public
+/// @type Function
+/// @group global-motion
 $carbon--ease-in: cubic-bezier(0, 0, 0.38, 0.9);
+
+/// Default ease-out for components
+/// @access public
+/// @type Function
+/// @group global-motion
 $carbon--ease-out: cubic-bezier(0.2, 0, 1, 0.9);
+
+/// Default easing for components
+/// @access public
+/// @type Function
+/// @group global-motion
 $carbon--standard-easing: cubic-bezier(0.2, 0, 0.38, 0.9);
 
+/// @access public
+/// @group global-motion
+/// @alias duration--fast-02
 $transition--base: $duration--fast-02;
+
+/// @access public
+/// @group global-motion
+/// @alias duration--moderate-02
 $transition--expansion: $duration--moderate-02;
 
 /// Get the transition-timing-function for a given easing and motion mode.
-/// Easings that are currently supported include: standard, entrance, and exit.
-/// We also offer two modes: productive and expressive.
+/// Easings that are currently supported include: `standard`, `entrance`, and `exit`.
+/// We also offer two modes: `productive` and `expressive`.
 /// @access public
-/// @param {String} $name - the name of the easing curve to apply
-/// @param {String} $mode - the mode for the easing curve to use
-/// @return {cubic-bezier}
+/// @param {String} $name - The name of the easing curve to apply
+/// @param {String} $mode [productive] - The mode for the easing curve to use
+/// @param {Map} $easings [$carbon--easings] - Map of component easings
+/// @return {Function} A CSS cubic-bezier function
+/// @group global-motion
 @function motion($name, $mode: productive, $easings: $carbon--easings) {
   @return carbon--motion($name, $mode, $easings);
 }
@@ -57,9 +120,10 @@ $transition--expansion: $duration--moderate-02;
 /// Easings that are currently supported include: standard, entrance, and exit.
 /// We also offer two modes: productive and expressive.
 /// @access public
-/// @param {String} $name - the name of the easing curve to apply
-/// @param {String} $mode - the mode for the easing curve to use
-/// @return {cubic-bezier}
+/// @param {String} $name - The name of the easing curve to apply
+/// @param {String} $mode - The mode for the easing curve to use
+/// @group global-motion
+/// @alias carbon--motion
 @mixin motion($name, $mode) {
   @include carbon--motion($name, $mode);
 }

--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -39,34 +39,110 @@
 //   2xl  ||  160px
 //   ==========================================
 
+/// 1rem baseline spacing
 /// @access public
-/// @returns 1 rem
-/// @group spacing/layout tokens
+/// @type Number
+/// @group global-spacing
 $spacing-baseline: 1rem !default;
 
+/// 1px spacing in rem units
 /// @access public
-/// @returns - spacing values in rem, see scale above
-/// @example
-//    .box {
-//      padding-left: $spacing-md;
-//    }
+/// @type Number
+/// @group global-spacing
 $spacing-4xs: $spacing-baseline * 0.0625 !default;
+
+/// 2px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-3xs: $spacing-baseline * 0.125 !default;
+
+/// 4px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-2xs: $spacing-baseline * 0.25 !default;
+
+/// 8px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-xs: $spacing-baseline * 0.5 !default;
+
+/// 12px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-sm: $spacing-baseline * 0.75 !default;
+
+/// 16px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-md: $spacing-baseline !default;
+
+/// 24px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-lg: $spacing-baseline * 1.5 !default;
+
+/// 32px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-xl: $spacing-baseline * 2 !default;
+
+/// 40px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-2xl: $spacing-baseline * 2.5 !default;
+
+/// 48px spacing in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $spacing-3xl: $spacing-baseline * 3 !default;
 
+/// 16px layout in rem units
 /// @access public
-/// @returns - layout values in rem, see scale above
+/// @type Number
+/// @group global-spacing
 $layout-2xs: $spacing-baseline !default;
+
+/// 24px layout in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $layout-xs: $spacing-baseline * 1.5 !default;
+
+/// 32px layout in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $layout-sm: $spacing-baseline * 2 !default;
+
+/// 48px layout in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $layout-md: $spacing-baseline * 3 !default;
+
+/// 64px layout in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $layout-lg: $spacing-baseline * 4 !default;
+
+/// 96px layout in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $layout-xl: $spacing-baseline * 6 !default;
+
+/// 160px layout in rem units
+/// @access public
+/// @type Number
+/// @group global-spacing
 $layout-2xl: $spacing-baseline * 10 !default;

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -10,140 +10,381 @@
 @import 'spacing';
 @import './vendor/@carbon/elements/scss/themes/themes';
 
-// Light Experimental Theme
+/// Theme variables
+/// @access private
+/// @group global-themes
 @mixin theme() {
-  /// @access public
-  $edited: true !default !global;
-  $use-layer: true !default !global;
-
   // Global
+
+  /// @type Value
   /// @access public
+  /// @group global
   $input-border: 1px solid transparent !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group global
   $input-label-weight: 400 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group global
   $disabled: $disabled-02 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group global
   $disabled-background-color: $disabled-01 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group global
   $focus: $ibm-color__blue-60 !default !global;
 
   // Link
+
+  /// @type Color
   /// @access public
+  /// @group link
   $link-visited: $ibm-color__purple-60 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group link
   $link-inverse-color: #6ea6ff !default !global;
 
   // Tooltip
+
+  /// @type Color
   /// @access public
+  /// @group tooltip
   $tooltip-background-color: $inverse-02 !default !global;
 
-  // Button Theme Variables
+  // Button
+
+  /// @type Number
   /// @access public
+  /// @group button
   $button-font-weight: 400 !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group button
   $button-font-size: 0.875rem !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group
   $button-border-radius: 0 !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group
   $button-height: 48px !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group button
   $button-padding: 0.875rem 63px 0.875rem 15px !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group button
   $button-padding-sm: 0.375rem 63px 0.375rem 15px !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group button
   $button-padding-lg: $carbon--spacing-04 !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group button
   $button-border-width: 1px !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group button
   $button-outline-width: 3px !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group button
   $button-outline-offset: -5px !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group button
   $button-outline: 1px solid $ibm-color__white-0 !default !global;
 
-  // Accordion (Reverse)
+  // Accordion
+
+  /// @type Value
   /// @access public
+  /// @group accordion
   $accordion-flex-direction: row-reverse !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group accordion
   $accordion-justify-content: flex-start !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group accordion
   $accordion-arrow-margin: 0 $carbon--spacing-05 0 0 !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group accordion
   $accordion-title-margin: 0 0 0 $carbon--spacing-05 !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group accordion
   $accordion-content-padding: 0 0 0 $carbon--spacing-05 !default !global;
 
-  // Card
-  /// @access public
-  $card-text-align: center !default !global;
-  $card-flex-align: center !default !global;
-
   // Checkbox
+
+  /// @type Number
   /// @access public
+  /// @group checkbox
   $checkbox-border-width: 2px !default !global;
 
   // Code Snippet
+
+  /// @type Color
   /// @access public
+  /// @group code-snippet
   $snippet-background-color: $ui-01 !default !global; // TODO: Define for experimental
+
+  /// @type Color
+  /// @access public
+  /// @group code-snippet
   $snippet-border-color: $ui-03 !default !global; // TODO: Define for experimental
 
   // Content Switcher
+
+  /// @type Number
   /// @access public
+  /// @group content-switcher
   $content-switcher-border-radius: 0px !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group content-switcher
   $content-switcher-option-border: 1px solid $brand-01 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group content-switcher
   $content-switcher-divider: $ui-03 !default !global;
 
   // Data Table
+
+  /// @type Value
   /// @access public
+  /// @group data-table
   $data-table-heading-transform: uppercase !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group data-table
   $data-table-heading-border-bottom: 1px solid $brand-01 !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group data-table
   $data-table-row-height: 2rem !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group data-table
   $data-table-zebra-color: #fcfcfc !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group data-table
   $data-table-column-hover: $hover-selected-ui !default !global;
 
   // Date Picker
+
+  /// @type Color
   /// @access public
+  /// @group data-table
   $date-picker-in-range-background-color: $ibm-color__blue-20 !default !global;
 
   // Modal
+
+  /// @type Color
   /// @access public
+  /// @group modal
   $modal-border-top: $brand-01 4px solid !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group modal
   $modal-footer-background-color: $ui-03 !default !global;
 
   // Notification
+
+  /// @type Color
   /// @access public
+  /// @group notification
   $notification-info-background-color: $ibm-color__blue-10 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group notification
   $notification-error-background-color: $ibm-color__red-10 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group notification
   $notification-warning-background-color: rgba(#fdd13a, 0.15) !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group notification
   $notification-success-background-color: $ibm-color__green-10 !default !global;
 
   // Progress Indicator
+
+  /// @type Value
   /// @access public
+  /// @group progress-indicator
   $progress-indicator-bar-width: 1px inset transparent !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group progress-indicator
   $progress-indicator-stroke-width: 5 !default !global;
+
+  /// @type Number
+  /// @access public
+  /// @group progress-indicator
   $progress-indicator-line-offset: 0.625rem !default !global;
 
-  //Code Snippet
+  // Copy Button
+
+  /// @type Color
   /// @access public
+  /// @group copy-button
   $copy-active: $active-ui !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group copy-button
   $copy-btn-feedback: $ibm-color__gray-80 !default !global;
 
   // Radio Button
+
+  /// @type Number
   /// @access public
+  /// @group radio-button
   $radio-border-width: 1px !default !global;
 
-  // Structured Theme Variables
+  // Structured List
+
+  /// @type Number
   /// @access public
+  /// @group structured-list
   $structured-list-padding: 2rem !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group structured-list
   $structured-list-text-transform: none !default !global;
 
-  // Slider
+  // Tabs
 
-  //Tab
+  /// @type Value
   /// @access public
+  /// @group tabs
   $tab-underline-color: 3px solid $ibm-color__gray-30 !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group tabs
   $tab-underline-color-hover: 3px solid $ibm-color__gray-60 !default !global;
+
+  /// @type Color
+  /// @access public
+  /// @group tabs
   $tab-text-disabled: $ibm-color__gray-30 !default !global;
+
+  /// @type Value
+  /// @access public
+  /// @group tabs
   $tab-underline-disabled: 3px solid $ibm-color__gray-10 !default !global;
 
   // Skeleton Loading
+
+  /// @type Color
   /// @access public
+  /// @group skeleton
   $skeleton: rgba(#3d70b2, 0.1) !default !global; //old $color__blue-51/$field-01 TODO: Define for experimental
 
-  // ☠️ Deprecated
+  // ⚠️ Deprecated
+
   /// @deprecated
+  /// @type Color
   /// @access public
+  /// @group global
   $hover-field: $hover-ui !default !global;
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $active-01: $active-ui !default !global;
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-01: #0f212e !default !global; // Old $color__navy-gray-1
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group
   $nav-02: #152935 !default !global; // Old $color__blue-90
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-03: #ba8ff7 !default !global; // Old $color__purple-30
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-04: #734098 !default !global; // Old $color__purple-60
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-05: #00b4a0 !default !global; // Old $color__teal-40
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-06: #008571 !default !global; // Old $color__teal-50
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-07: #5aaafa !default !global; // Old $color__blue-30
+
+  /// @deprecated
+  /// @type Color
+  /// @access public
+  /// @group global
   $nav-08: #3d70b2 !default !global; // Old $color__blue-51
 }
 

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -7,25 +7,30 @@
 
 @import 'vars';
 
+/// Base font size in px
 /// @access public
-/// @group typography
-/// @returns 16px font size
+/// @group global-typography
+/// @type Number
 /// @deprecated (For v10) Superseded by `$carbon--base-font-size`
-$base-font-size: 16px !default; // Default, Use with em() and rem() functions
+$base-font-size: 16px !default;
 
+/// Convert px to rem
 /// @access public
-/// @param {Value} $px - value of type in pixels
-/// @returns type size converted to rem
-/// @example - rem(48px);
+/// @param {Number} $px - Value of type in pixels
+/// @returns {Number} In rem
+/// @example rem(48px);
+/// @group global-typography
 /// @deprecated (For v10) Use `carbon--rem()`
 @function rem($px) {
   @return ($px / $base-font-size) * 1rem;
 }
 
+/// Convert px to em
 /// @access public
-/// @param {Value} $px - value of type in pixels
-/// @returns type size converted to em
-/// @example - em(48px);
+/// @param {Number} $px - Value of type in pixels
+/// @returns {Number} In em
+/// @example em(48px);
+/// @group global-typography
 /// @deprecated (For v10) Use `carbon--em()`
 @function em($px) {
   @return ($px / $base-font-size) * 1em;
@@ -34,12 +39,12 @@ $base-font-size: 16px !default; // Default, Use with em() and rem() functions
 // 🔬 Experimental
 @import '../../globals/scss/vendor/@carbon/elements/scss/type/styles';
 
+/// Different type styles per token
 /// @access public
-/// @returns different type styles per token.
-/// @see $tokens Map in src/globals/scss/vendor/@carbon/type/scss/_styles.scss
-/// @param {String} $name - the name of the token to get the styles for
-/// @param {Boolean} $fluid [false] - specify whether to include fluid styles
-/// @example -  @include type-style('body-short-01');
+/// @param {String} $name - The name of the token to get the styles for
+/// @param {Bool} $fluid [false] - Specify whether to include fluid styles
+/// @example @include type-style('body-short-01');
+/// @group global-typography
 @mixin type-style($name, $fluid: false) {
   @include carbon--type-style($name, $fluid);
 }

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -13,5 +13,6 @@
 
 /// Sets the prefix for all classes
 /// @access public
+/// @type String
 /// @example .bx--batch-actions
 $prefix: 'bx' !default;

--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -9,21 +9,55 @@
 // 🌍 Global
 //-------------------------
 
+/// If true, includes font face mixins in `_css--font-face.scss` depending on the `css--plex` feature flag
 /// @access public
 /// @type Bool
+/// @group feature-flags
 $css--font-face: true !default;
+
+/// If true, includes the `css-helpers()` mixin
+/// @access public
+/// @type Bool
+/// @group feature-flags
 $css--helpers: true !default;
+
+/// If true, includes the `css-body()` mixin
+/// @access public
+/// @type Bool
+/// @group feature-flags
 $css--body: true !default;
+
+/// If true, the `layer()` mixin sets `box-shadow` values
+/// @access public
+/// @type Bool
+/// @group feature-flags
 $css--use-layer: true !default;
+
+/// If true, include reset CSS
+/// @access public
+/// @type Bool
+/// @group feature-flags
 $css--reset: true !default;
+
+/// Used with `css--font-face` feature flag, if true, uses Plex font families instead of Helvetica
+/// @access public
+/// @type Bool
+/// @group feature-flags
 $css--plex: true !default;
 
-// TODO: remove in next major release. Synced in `feature-flags` as an adapter
-// in the interim
+/// This feature flag was used during development of the v10 experimental grid.
+/// TODO: remove in next major release. Synced in `feature-flags` as an adapter in the interim
 /// @deprecated (For v10) v10 always uses `@carbon/grid`
 /// @access public
 /// @type Bool
+/// @group feature-flags
 $css--use-experimental-grid: false !default;
+
+/// This feature flag was used during development of the v10 experimental grid.
+/// TODO: remove in next major release. Synced in `feature-flags` as an adapter in the interim.
+/// @access public
+/// @type Bool
+/// @group feature-flags
 /// @deprecated (For v10) v10 always uses `@carbon/grid`
 $css--use-experimental-grid-fallback: false !default;
 
@@ -44,23 +78,31 @@ $css--use-experimental-grid-fallback: false !default;
 @import '../grid/grid';
 
 //-------------------------
-// ☠️  Manage deprecations
+// ⚠️ Manage deprecations
 //-------------------------
 
-/**
- * We flag this variable as true if someone uses the globals/scss/styles.scss
- * entry-point. This allows us to collect all the messages and display them at
- * the end of the file instead of bringing it up per-component.
- *
- * If a consumer instead gets the components by importing the partial directly,
- * this variable _will not_ be set to true, so the deprecation message will be
- * displayed after the @import.
- */
+/// We flag this variable as true if someone uses the globals/scss/styles.scss
+/// entry-point. This allows us to collect all the messages and display them at
+/// the end of the file instead of bringing it up per-component.
+///
+/// If a consumer instead gets the components by importing the partial directly,
+/// this variable _will not_ be set to true, so the deprecation message will be
+/// displayed after the @import.
 /// @access private
+/// @type Bool
+/// @group global-deprecate
 $deprecations--entry: true;
-// Collect all deprecation reasons into this list throughout the import cycle.
+
+/// Collect all deprecation reasons into this list throughout the import cycle.
+/// @access private
+/// @type Map
+/// @group global-deprecate
 $deprecations--reasons: ();
-// This message will be prepended to any deprecation notice
+
+/// This message will be prepended to any deprecation notice.
+/// @access private
+/// @type String
+/// @group global-deprecate
 $deprecations--message: 'Deprecated code was found, this code will be removed before the next release of Carbon.';
 
 //-------------------------


### PR DESCRIPTION
Closes #2266

Replaces draft PR #2306 

Adds SassDoc annotations to all functions, mixins and variables. Will do follow-up PR to generate SassDoc markdown when next point release of Carbon Elements is available.

#### Changelog

**New**

- SassDoc annotations
- Contribution guidance on how to consistently use SassDoc

**Changed**

- In `_css--reset.scss` move `$carbon--type-reset` below reset declaration blocks for when we pull in the latest `carbon-elements`

**Removed**

- Unused variables $edited $use-layer $card-text-align and $card-flex-align
