### PR TITLE
IE11 progress indicator

### DIFF
--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -252,7 +252,7 @@
   }
 
   .#{$prefix}--progress--vertical .#{$prefix}--progress-optional {
-    margin-top: initial;
+    margin-top: auto;
     position: initial;
     margin-left: 2.25rem;
   }

--- a/src/components/progress-indicator/_progress-indicator.scss
+++ b/src/components/progress-indicator/_progress-indicator.scss
@@ -38,6 +38,7 @@
 
   .#{$prefix}--progress-line {
     position: absolute;
+    left: 0;
     height: 1px;
     width: rem(128px);
     border: $progress-indicator-bar-width;
@@ -128,6 +129,7 @@
   //OPTIONAL HELPER TEXT STYLING
   .#{$prefix}--progress-optional {
     position: absolute;
+    left: 0;
     margin-left: $carbon--spacing-06;
     margin-top: rem(28px);
     @include type-style('label-01');


### PR DESCRIPTION
Closes #2072 

Fixes progress indicator issues

#### Changelog

**Changed**

- fixed the progress indicator line position and option text
- changed `margin-top: initial` to `margin-top: auto` in vertical optional text
