### PR TITLE
fix(modal): prevent bubbling on ESC on inactive

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -137,7 +137,8 @@ class Modal extends mixin(createComponent, initComponentByLauncher, eventedShowH
 
     this._handleKeydownListener = this.manage(
       on(this.element.ownerDocument.body, 'keydown', evt => {
-        if (evt.which === 27) {
+        // Avoid running `evt.stopPropagation()` only when modal is shown
+        if (evt.which === 27 && this.shouldStateBeChanged('hidden')) {
           evt.stopPropagation();
           this.hide(evt);
         }


### PR DESCRIPTION
Fixes #2312.

#### Changelog

**Changed**

- A change to prevent `event.stopPropagation()` from running upon ESC key when modal is not open.

#### Testing / Reviewing

Testing should make sure our modal is not broken.