### PR TITLE
Update Contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Set up your SSH Key GitHub Enterprise account and install node.js 4 or higher.
+Set up your SSH Key GitHub account and install node.js 4 or higher.
 
 - [Generating SSH Keys - GitHub](https://help.github.com/articles/generating-ssh-keys/)
 - [`nvm` (Node Version Manager)](https://github.com/creationix/nvm) to use the `Node 6`.


### PR DESCRIPTION
#### Description

Since Carbon declare open-source, I am doubt if description in **Requirements** "Set up your SSH Key GitHub ~~Enterprise~~ account" is supposed to "Set up your SSH Key GitHub account"?  General account is sufficient instead of Enterprise ones.

#### Changelog

**Changed**

- {{"Set up your SSH Key GitHub ~~Enterprise~~ account"}}


#### Testing / Reviewing

Please see the **Description** above, thanks.
