### PR TITLE
fix(data-table): update zebra color token

### DIFF
--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -200,7 +200,7 @@
   /// @type Color
   /// @access public
   /// @group data-table
-  $data-table-zebra-color: #fcfcfc !default !global;
+  $data-table-zebra-color: $ui-02 !default !global;
 
   /// @type Color
   /// @access public


### PR DESCRIPTION
Closes #2351 

I'm making an assumption here about using `$ui-02` but it seemed right! Let me know if you'd like me to change it. 👍 

#### Changelog

**Changed**

- change `$data-table-zebra-color` to use `$ui-02` instead of hard-coded hex value
