### PR TITLE
fix(tag): add filter tag keyboard navigation

### DIFF
--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -96,6 +96,7 @@
     height: rem(20px);
   }
 
+  .#{$prefix}--tag--filter:focus > svg,
   .#{$prefix}--tag--filter > svg:hover {
     border-radius: 50%;
     background-color: $icon-02;

--- a/src/components/tag/tag.hbs
+++ b/src/components/tag/tag.hbs
@@ -10,7 +10,7 @@
 {{/each}}
 
 {{#if filter}}
-<span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--filter" title="Clear filter">
+<span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--filter" title="Clear filter" tabindex="0">
   filter
   {{ carbon-icon 'Close16' aria-label='Clear filter' }}
 </span>


### PR DESCRIPTION
Closes #2348

This PR adds keyboard navigation to the filter tag. When focused, the filter tag will appear as though it is hovered