### PR TITLE
fix(codesnippet): use theme variables on gradients

### DIFF
--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -95,7 +95,7 @@
     position: absolute;
     top: 0;
     right: rem(56px);
-    background-image: linear-gradient(to right, rgba(243, 243, 243, 0), rgba(243, 243, 243, 1));
+    background-image: linear-gradient(to right, transparent, $ui-01);
   }
 
   // Multi Line Snippet
@@ -140,7 +140,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    background-image: linear-gradient(to right, rgba(243, 243, 243, 0), rgba(243, 243, 243, 1));
+    background-image: linear-gradient(to right, transparent, $ui-01);
   }
 
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre code {


### PR DESCRIPTION
Uses theme variables for code snippet gradients. These colors are currently hardcoded and do not work for different themes.

#### Changelog

**Changed**

- Use theme variables for code snippet gradients.