### PR TITLE
fix(notification): update color tokens for a11y

### DIFF
--- a/src/components/notification/README.md
+++ b/src/components/notification/README.md
@@ -2,10 +2,9 @@
 
 #### Mixins
 
-| Name                         | Params           | Description                               |
-| ---------------------------- | ---------------- | ----------------------------------------- |
-| `inline-notification--color` | `$color`: String | Applies given `$color` to border and icon |
-| `notification--color`        | `$color`: String | Applies given `$color` to left border     |
+| Name                  | Params           | Description                               |
+| --------------------- | ---------------- | ----------------------------------------- |
+| `notification--color` | `$color`: String | Applies given `$color` to border and icon |
 
 #### Modifiers
 

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -33,6 +33,7 @@
     color: $inverse-01;
     margin-top: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-05;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
 
     @include carbon--breakpoint(md) {
       max-width: rem(608px);

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -30,7 +30,7 @@
     min-height: rem(48px);
     min-width: rem(288px);
     max-width: rem(288px);
-    color: $text-01;
+    color: $inverse-01;
     margin-top: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-05;
 
@@ -48,15 +48,15 @@
   }
 
   .#{$prefix}--inline-notification--error {
-    @include notification--experimental($support-01, $notification-error-background-color);
+    @include notification--color($red-50);
   }
 
   .#{$prefix}--inline-notification--success {
-    @include notification--experimental($support-02, $notification-success-background-color);
+    @include notification--color($support-02);
   }
 
   .#{$prefix}--inline-notification--info {
-    @include notification--experimental($support-04, $notification-info-background-color);
+    @include notification--color($interactive-01);
   }
 
   .#{$prefix}--inline-notification--info .bx--inline-notification__icon {
@@ -64,7 +64,7 @@
   }
 
   .#{$prefix}--inline-notification--warning {
-    @include notification--experimental($support-03, $notification-warning-background-color);
+    @include notification--color($support-03);
   }
 
   .#{$prefix}--inline-notification--warning .#{$prefix}--inline-notification__icon path[opacity='0'] {
@@ -121,7 +121,7 @@
     .#{$prefix}--inline-notification__close-icon {
       height: 1rem;
       width: 1rem;
-      fill: $ui-05;
+      fill: $inverse-01;
     }
   }
 }

--- a/src/components/notification/_mixins.scss
+++ b/src/components/notification/_mixins.scss
@@ -5,34 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//----------------------------------------------
-// Inline Notification
-// ---------------------------------------------
-
 /// @access private
 /// @group notification
-@mixin inline-notification--color($color) {
-  border: 1px solid $color;
-  border-left: 6px solid $color;
-
-  .#{$prefix}--inline-notification__icon {
-    fill: $color;
-  }
-}
-
-//----------------------------------------------
-// Toast Notification
-// ---------------------------------------------
-
-/// @access private
-/// @group notification
-@mixin notification--color($color) {
-  border-left: 6px solid $color;
-}
-
-/// @access private
-/// @group notification
-@mixin notification--experimental($color, $background-color) {
+@mixin notification--color($color, $background-color: $inverse-02) {
   border-left: 3px solid $color;
   background: $background-color;
 

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -28,7 +28,7 @@
     width: rem(288px);
     height: auto;
     padding-left: $carbon--spacing-05;
-    color: $text-01;
+    color: $inverse-01;
     margin-top: $carbon--spacing-03;
     margin-bottom: $carbon--spacing-03;
     margin-right: $carbon--spacing-05;
@@ -43,19 +43,19 @@
   }
 
   .#{$prefix}--toast-notification--error {
-    @include notification--experimental($support-01, $notification-error-background-color);
+    @include notification--color($support-01);
   }
 
   .#{$prefix}--toast-notification--success {
-    @include notification--experimental($support-02, $notification-success-background-color);
+    @include notification--color($support-02);
   }
 
   .#{$prefix}--toast-notification--info {
-    @include notification--experimental($support-04, $notification-info-background-color);
+    @include notification--color($interactive-01);
   }
 
   .#{$prefix}--toast-notification--warning {
-    @include notification--experimental($support-03, $notification-warning-background-color);
+    @include notification--color($support-03);
   }
 
   .#{$prefix}--toast-notification--warning .#{$prefix}--toast-notification__icon path[opacity='0'] {
@@ -93,7 +93,7 @@
     .#{$prefix}--toast-notification__close-icon {
       height: 1rem;
       width: 1rem;
-      fill: $ui-05;
+      fill: $inverse-01;
     }
   }
 
@@ -106,16 +106,12 @@
 
   .#{$prefix}--toast-notification__subtitle {
     @include type-style('body-short-01');
-
-    color: $text-01;
     margin-top: 0;
     margin-bottom: $carbon--spacing-06;
   }
 
   .#{$prefix}--toast-notification__caption {
     @include type-style('body-short-01');
-
-    color: $text-01;
     margin-bottom: $carbon--spacing-05;
   }
 }

--- a/src/components/notification/_toast-notification.scss
+++ b/src/components/notification/_toast-notification.scss
@@ -32,6 +32,7 @@
     margin-top: $carbon--spacing-03;
     margin-bottom: $carbon--spacing-03;
     margin-right: $carbon--spacing-05;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
 
     &:first-child {
       margin-top: $carbon--spacing-05;

--- a/src/components/notification/migrate-to-10.x.md
+++ b/src/components/notification/migrate-to-10.x.md
@@ -43,3 +43,11 @@ Updating HTML pertains only to the "close" button SVG icon. Icon from [`carbon-e
 ### SCSS
 
 No new selectors.
+
+#### Mixins
+
+| Name                  | Params           | Description                               |
+| --------------------- | ---------------- | ----------------------------------------- |
+| `notification--color` | `$color`: String | Applies given `$color` to border and icon |
+
+The `inline-notification--color` mixin has been consolidated with the `notification--color` mixin, which determines the border color and icon color for toast and inline notifications.

--- a/src/globals/scss/_theme-tokens.scss
+++ b/src/globals/scss/_theme-tokens.scss
@@ -226,28 +226,6 @@
   /// @group modal
   $modal-footer-background-color: $ui-03 !default !global;
 
-  // Notification
-
-  /// @type Color
-  /// @access public
-  /// @group notification
-  $notification-info-background-color: $ibm-color__blue-10 !default !global;
-
-  /// @type Color
-  /// @access public
-  /// @group notification
-  $notification-error-background-color: $ibm-color__red-10 !default !global;
-
-  /// @type Color
-  /// @access public
-  /// @group notification
-  $notification-warning-background-color: rgba(#fdd13a, 0.15) !default !global;
-
-  /// @type Color
-  /// @access public
-  /// @group notification
-  $notification-success-background-color: $ibm-color__green-10 !default !global;
-
   // Progress Indicator
 
   /// @type Value


### PR DESCRIPTION
Closes #2354
Closes #2263

This PR changes the new color tokens for toast and inline notifications.

#### Changelog

**Changed**

- notification color tokens
- consolidate notification mixins

**Removed**

- unused mixins and dead code

#### Testing / Reviewing

Ensure notifications display properly in all themes