### PR TITLE
fix(reset): resets components with no box-sizing

### DIFF
--- a/src/components/code-snippet/_code-snippet.scss
+++ b/src/components/code-snippet/_code-snippet.scss
@@ -16,6 +16,10 @@
 /// @access private
 /// @group code-snippet
 @mixin snippet {
+  .#{$prefix}--snippet {
+    @include reset;
+  }
+
   .#{$prefix}--snippet code {
     @include type-style('code-01');
   }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -20,6 +20,7 @@
 /// @group tabs
 @mixin tabs {
   .#{$prefix}--tabs {
+    @include reset;
     @include type-style('body-short-01');
     color: $text-01;
     height: auto;
@@ -135,6 +136,7 @@
   // Item
   //-----------------------------
   .#{$prefix}--tabs__nav-item {
+    @include reset;
     background-color: $ui-01;
     display: flex;
     padding: 0;


### PR DESCRIPTION
Without the global box-sizing property `* { box-sizing: border-box }`, or `$css--reset` set to false, the following components render incorrectly.
- Code snippet
- Tabs

#### Changelog

**New**

- Adds `reset` mixin to components affected components

**Changed**