### PR TITLE
fix(data-table): update batch action button icon and text color

### DIFF
--- a/src/components/data-table/_data-table-action.scss
+++ b/src/components/data-table/_data-table-action.scss
@@ -282,11 +282,11 @@
   }
 
   .#{$prefix}--action-list .#{$prefix}--btn {
-    color: $ui-01;
+    color: $text-04;
   }
 
   .#{$prefix}--action-list .#{$prefix}--btn .#{$prefix}--btn__icon {
-    fill: $ui-01;
+    fill: $icon-03;
     margin-left: $spacing-03;
   }
 

--- a/src/components/data-table/_data-table-action.scss
+++ b/src/components/data-table/_data-table-action.scss
@@ -338,7 +338,7 @@
     height: $layout-01;
     width: rem(1px);
     content: '';
-    background-color: $ui-01;
+    background-color: $text-04;
     border: none;
     transition: opacity $duration--fast-02 motion(standard, productive);
   }

--- a/src/components/data-table/_data-table-action.scss
+++ b/src/components/data-table/_data-table-action.scss
@@ -360,7 +360,7 @@
     margin-left: $spacing-05;
     display: flex;
     align-items: center;
-    color: $ui-01;
+    color: $text-04;
   }
 
   .#{$prefix}--batch-summary__para {

--- a/src/components/data-table/_data-table-action.scss
+++ b/src/components/data-table/_data-table-action.scss
@@ -184,7 +184,7 @@
     height: $layout-01;
     width: auto;
     max-width: $layout-01;
-    fill: $ui-05;
+    fill: $icon-01;
   }
 
   //-------------------------------------------------


### PR DESCRIPTION
Closes #2371 

#### Changelog

**Changed**

- use `$text-04` (white, all themes) for batch action cancel button `:before` color
- use `$text-04`  (white, all themes) for batch action text color
- use `$text-04`  (white, all themes) for batch action summary text color
- use `$icon-03` (white, all themes) for batch action icon fill color
- use `$icon-01` (gray10 for dark themes, gray100 for light themes) for toolbar icon fill color
