### PR TITLE
fix(radio-button): remove unset usage

### DIFF
--- a/src/components/radio-button/_radio-button.scss
+++ b/src/components/radio-button/_radio-button.scss
@@ -41,7 +41,7 @@
 
   .#{$prefix}--radio-button {
     @include hidden;
-    visibility: unset;
+    visibility: inherit;
   }
 
   .#{$prefix}--radio-button__label {


### PR DESCRIPTION
Fixes #1761.

#### Changelog

**Removed**

- `unset` usage in radio button.

#### Testing / Reviewing

Testing should make sure our radio button is not broken.