### PR TITLE
fix(data-table-skeleton): vertical align middle for th

### DIFF
--- a/src/components/data-table/_data-table-skeleton.scss
+++ b/src/components/data-table/_data-table-skeleton.scss
@@ -13,6 +13,7 @@
   .#{$prefix}--data-table.#{$prefix}--skeleton {
     th {
       border-bottom: 1px solid $brand-01;
+      vertical-align: middle;
 
       &:nth-child(3n + 1) {
         width: 10%;


### PR DESCRIPTION
**New**

- add `vertical-align: middle` to `th` so that header text isn't pushed to top