### PR TITLE
fix(multi-select): use theme tokens for icon fill to make accessible for dark UIs

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -363,7 +363,7 @@ $list-box-menu-width: rem(300px);
   }
 
   .#{$prefix}--list-box__selection--multi > svg {
-    fill: white;
+    fill: $inverse-01;
     margin-left: rem(4px);
     width: rem(20px);
     height: rem(20px);
@@ -373,6 +373,7 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box__selection--multi > svg:hover {
     border-radius: 50%;
     background-color: $hover-secondary;
+    fill: $icon-03;
   }
 
   .#{$prefix}--list-box__selection--multi:focus,


### PR DESCRIPTION
This fixes a slight color theming issue with the multi select component. As it is right now, the fill of the "x" icon is set to `fill: white` which breaks / isn't accessible in dark UIs:

<img width="153" alt="Screen Shot 2019-05-06 at 11 21 53 AM" src="https://user-images.githubusercontent.com/9057921/57239860-b91d8880-6ff2-11e9-8409-1015a6364d56.png">

This change updates the fill color to `$inverse-01`, which will make it so that the icon is visible in a dark UI multi select:

![Screen Shot 2019-05-06 at 11 31 54 AM](https://user-images.githubusercontent.com/9057921/57239923-df432880-6ff2-11e9-91de-891574ebd070.png)

Moreover, I added `fill: $icon-03` for the hover state so that the icon is ALWAYS white on hover. That way this doesn't break existing light UIs and also makes it work for the dark UIs (since the hover color remains dark in this case):

![Screen Shot 2019-05-06 at 11 32 02 AM](https://user-images.githubusercontent.com/9057921/57239964-f8e47000-6ff2-11e9-8305-1a6142d15825.png)


#### Changelog

**Changed**

- use `$inverse-01` for icon fill
- use `$icon-03` for HOVER state of icon fill