### PR TITLE
fix(date-picker): fix incorrect hover color

### DIFF
--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -367,8 +367,9 @@
   .#{$prefix}--date-picker__day.endRange,
   .flatpickr-day.endRange {
     &:hover {
-      background: $ui-01;
       @include focus-outline('outline');
+      background: $ui-01;
+      color: $text-01;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components/issues/2397

Ensure selected day end range text stays `$text-01` when hovered (Range Calendar)