### PR TITLE
chore(build): bring Netlify build back

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,5 +22,6 @@
   </head>
   <body>
     <a class="bx--btn bx--btn--primary" href="./components/">Components</a>
+    <a class="bx--btn bx--btn--primary" href="./react/">React</a>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "prettier --write '**/*.{js,md,scss,ts}' '!**/{build,es,lib,storybook,ts,umd,components}/**'",
     "format:diff": "prettier --list-different '**/*.{js,md,scss,ts}' '!**/{build,es,lib,storybook,ts,umd,components}/**'",
     "format:staged": "prettier --write",
-    "gather-deploy-files": "yarn workspaces run gather-deploy-files",
+    "gather-deploy-files": "yarn workspace carbon-components gather-deploy-files && yarn workspace carbon-components-react gather-deploy-files",
     "lint:styles": "stylelint \"**/*.{css,scss}\" --config ./packages/stylelint-config-elements",
     "sync": "node tasks/sync.js",
     "test": "jest",

--- a/packages/components/tools/rollup.config.dev.js
+++ b/packages/components/tools/rollup.config.dev.js
@@ -42,6 +42,15 @@ module.exports = {
         'react/index.js': ['Children', 'Component', 'PureComponent', 'Fragment', 'PropTypes', 'createElement', 'isValidElement'],
         'react-dom/index.js': ['render'],
         'react-is/index.js': ['isForwardRef'],
+        'downshift/node_modules/react/index.js': [
+          'Children',
+          'Component',
+          'PureComponent',
+          'Fragment',
+          'PropTypes',
+          'createElement',
+          'isValidElement',
+        ],
       },
     }),
     babel({

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,11 +8,12 @@
   "sideEffects": false,
   "scripts": {
     "build": "yarn clean && node scripts/build.js",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -o ../../demo/react",
     "ci-check": "yarn prettier:diff && yarn lint && yarn test --runInBand && yarn test-ssr",
     "clean": "rimraf es lib umd storybook-static",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
+    "gather-deploy-files": "yarn build-storybook",
     "lint": "eslint src",
     "lint:staged": "eslint",
     "prepublish": "yarn build",


### PR DESCRIPTION
GitHub workflow stuffs we are investigating may solve this problem space. This PR is a stop-gap approach until we make the idea in action - Which is, build deploy artifacts for each and collect them into a single directory so the index.html can refer to.

This also enables Netlify build for our React variant.

Refs #2406.

#### Changelog

**New**

- Code to gather Netlify build for React.
- Additional Rollup config for `carbon-components` Netlify build (some recent change may have made it required).

#### Testing / Reviewing

Testing should make sure our Netlify build is back working.

**NOTE**: The build took 7 mins which I hope is safe enough for US time, too.