### PR TITLE
fix(bundler): avoid regex replace for dir paths

### DIFF
--- a/packages/icons/src/build.js
+++ b/packages/icons/src/build.js
@@ -266,10 +266,7 @@ async function createDescriptorFromFile(file) {
 }
 
 function getIndexName(basename, prefix) {
-  return prefix
-    .filter(part => isNaN(part))
-    .concat(basename)
-    .join('/');
+  return path.join(...prefix.filter(part => isNaN(part)), basename);
 }
 
 async function findPackageJsonFor(filepath) {

--- a/packages/icons/src/build.js
+++ b/packages/icons/src/build.js
@@ -127,7 +127,10 @@ async function build(source, { cwd } = {}) {
         });
         const outputOptions = {
           format,
-          file: jsFilepath.replace(/es/, directory),
+          file: path.join(
+            path.join(directory, ...formattedPrefix, basename),
+            size ? `${size}.js` : 'index.js'
+          ),
         };
         if (format === 'umd') {
           outputOptions.name = moduleName;

--- a/packages/icons/src/search.js
+++ b/packages/icons/src/search.js
@@ -53,10 +53,7 @@ async function search(directory) {
   const prefixed = files.map(file => {
     const { filepath } = file;
     const dirname = path.dirname(filepath);
-    const prefix = path
-      .relative(directory, dirname)
-      .split('/')
-      .filter(Boolean);
+    const prefix = path.relative(directory, dirname).split(path.sep);
     return {
       ...file,
       prefix,


### PR DESCRIPTION
Closes #2434

This PR avoids regex `.replace` when the bundler is creating output folders

Sassdoc and `icons-angular` issues still need to be resolved (and possibly other packages)

#### Testing / Reviewing

Ensure that the install and build steps complete without failure (esp on Windows)
