### PR TITLE
chore(devenv): direct ref of src style from Storybook

### DIFF
--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -2,4 +2,8 @@ $css--font-face: true;
 $css--reset: true;
 
 $prefix: 'bx';
-@import '~carbon-components/src/globals/scss/styles.scss';
+
+// IMPORTANT: This import path should _not_ be used outside our source tree
+// as `src` directory is _not_ meant to be shipped in our NPM package.
+// Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
+@import '~carbon-components/src/globals/scss/styles.scss'; // SEE THE NOTE ABOVE


### PR DESCRIPTION
#### Changelog

**Changed**

- A change to make our React Storybook code to directly refer to the style (source) in `packages/components`, so change in `packages/components` will update Storybook live.

#### Testing / Reviewing

Testing should make sure our React dev env (Storybook) is not broken.