### PR TITLE
fix(notification): make warning notification a11y changes

### DIFF
--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -33,6 +33,7 @@
     color: $text-01;
     margin-top: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-05;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
 
     @include carbon--breakpoint(md) {
       max-width: rem(608px);

--- a/packages/components/src/components/notification/_toast-notification.scss
+++ b/packages/components/src/components/notification/_toast-notification.scss
@@ -32,6 +32,7 @@
     margin-top: $carbon--spacing-03;
     margin-bottom: $carbon--spacing-03;
     margin-right: $carbon--spacing-05;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
 
     &:first-child {
       margin-top: $carbon--spacing-05;

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -251,7 +251,7 @@
   /// @type Color
   /// @access public
   /// @group notification
-  $notification-warning-background-color: #fff8e2 !default !global;
+  $notification-warning-background-color: mix($ibm-color__yellow-20, $ibm-color__white-0, 15%) !default !global;
 
   /// @type Color
   /// @access public

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -251,7 +251,7 @@
   /// @type Color
   /// @access public
   /// @group notification
-  $notification-warning-background-color: rgba(#fdd13a, 0.15) !default !global;
+  $notification-warning-background-color: #fff8e2 !default !global;
 
   /// @type Color
   /// @access public

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -251,7 +251,11 @@
   /// @type Color
   /// @access public
   /// @group notification
-  $notification-warning-background-color: mix($ibm-color__yellow-20, $ibm-color__white-0, 15%) !default !global;
+  $notification-warning-background-color: mix(
+    $ibm-color__yellow-20,
+    $ibm-color__white-0,
+    15%
+  ) !default !global;
 
   /// @type Color
   /// @access public


### PR DESCRIPTION
Temp fix for https://github.com/carbon-design-system/carbon/issues/2354

Instead of using `opacity`, just use the hardcoded value so that it shows up on dark backgrounds. We were not using `opacity` to achieve any of the other colors

Also adds in a `box-shadow` on the `inline-notification` variant
