### PR TITLE
chore(test): remove some params shorthand

### DIFF
--- a/packages/components/tests/karma.conf.js
+++ b/packages/components/tests/karma.conf.js
@@ -25,9 +25,9 @@ const cloptions = commander
     '-d, --debug',
     'Disables collection of code coverage, useful for runinng debugger against specs or sources'
   )
-  .option('-f, --file [file]', 'Spec files to run', collect, defaultFiles)
+  .option('--file [file]', 'Spec files to run', collect, defaultFiles)
   .option('-r, --random', 'Enable random execution order of tests')
-  .option('-v, --verbose', 'Enables verbose output')
+  .option('--verbose', 'Enables verbose output')
   .parse(process.argv);
 const isFilesDefault =
   cloptions.file.length === defaultFiles.length &&


### PR DESCRIPTION
As it conflicts with `gulp-cli` itself: https://github.com/gulpjs/gulp-cli

#### Changelog

**Removed**

- `-f` and `-v` options in `gulp test:unit`. `--file` and `--verbose` can still be used.

#### Testing / Reviewing

Should make sure unit test can be run with a specific test spec file.