### PR TITLE
fix(ui-shell): remove duplicate variable

### DIFF
--- a/packages/components/src/components/ui-shell/_theme.scss
+++ b/packages/components/src/components/ui-shell/_theme.scss
@@ -115,12 +115,6 @@ $shell-panel-bg-04: $carbon--white-0; //TODO waiting for updated color
 /// @group ui-shell
 $shell-header-text-03: $carbon--gray-50; //TODO waiting for updated color
 
-/// Icons in header panel
-/// @type Color
-/// @access private
-/// @group ui-shell
-$shell-header-icon-02: #252525; //TODO waiting for updated color
-
 /// Header icon selected state background
 /// @type Color
 /// @access private


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/2721

Noticed we had a duplicate `$shell-header-icon-02` which was causing some icons to render black instead of white 