### PR TITLE
feat(NumberInput): controlled upon onChange prop

### DIFF
--- a/packages/react/.storybook/webpack.config.js
+++ b/packages/react/.storybook/webpack.config.js
@@ -9,7 +9,13 @@ const useExternalCss =
 const useStyleSourceMap =
   process.env.CARBON_REACT_STORYBOOK_USE_STYLE_SOURCEMAP === 'true';
 
+const useControlledStateWithEventListener =
+  process.env.CARBON_REACT_USE_CONTROLLED_STATE_WITH_EVENT_LISTENER === 'true';
 const useRtl = process.env.CARBON_REACT_STORYBOOK_USE_RTL === 'true';
+
+const replaceTable = {
+  useControlledStateWithEventListener,
+};
 
 const styleLoaders = [
   {
@@ -77,6 +83,18 @@ module.exports = (baseConfig, env, defaultConfig) => {
       }),
     ],
   };
+
+  defaultConfig.module.rules.push({
+    test: /(\/|\\)FeatureFlags\.js$/,
+    loader: 'string-replace-loader',
+    options: {
+      multiple: Object.keys(replaceTable).map(key => ({
+        search: `export\\s+const\\s+${key}\\s*=\\s*false`,
+        replace: `export const ${key} = ${replaceTable[key]}`,
+        flags: 'i',
+      })),
+    },
+  });
 
   defaultConfig.module.rules.push({
     test: /-story\.jsx?$/,

--- a/packages/react/src/internal/FeatureFlags.js
+++ b/packages/react/src/internal/FeatureFlags.js
@@ -17,4 +17,4 @@
  * const MyComponent = props => (<div {...props}>{aFeatureFlag ? 'foo' : 'bar'}</div>);
  */
 
-/* Currently no feature flag is in use, but keeping this file as a placeholder */
+export const useControlledStateWithEventListener = false;


### PR DESCRIPTION
This change turns `<NumberInput>` to "controlled mode", if `onChange` prop exists.

Refs #2489.

#### Changelog

**New**

- A mechanism to turn `<NumberInput>` to "controlled mode", if `onChange` prop exists.

#### Testing / Reviewing

Testing should make sure `<NumberInput>` is not broken.