### PR TITLE
chore(tooltip): merge icon tooltip placement mixins

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -168,11 +168,11 @@
   }
 
   .#{$prefix}--btn--icon-only--top {
-    @include tooltip--icon--top;
+    @include tooltip--icon-placement('top');
   }
 
   .#{$prefix}--btn--icon-only--bottom {
-    @include tooltip--icon--bottom;
+    @include tooltip--icon-placement('bottom');
   }
 
   .#{$prefix}--btn--icon-only,

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -278,12 +278,12 @@
 
   // Tooltip Icon caret - top position
   .#{$prefix}--tooltip--icon__top {
-    @include tooltip--icon--top;
+    @include tooltip--icon-placement('top');
   }
 
   // Tooltip Icon caret - bottom position
   .#{$prefix}--tooltip--icon__bottom {
-    @include tooltip--icon--bottom;
+    @include tooltip--icon-placement('bottom');
   }
 
   // Tooltip position - icon only

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -71,7 +71,7 @@
   }
 }
 
-// Tooltip Icon placement
+/// Tooltip Icon placement
 /// @param {String} $position ['bottom'] - The position from: `top`, `bottom`
 /// @access public
 /// @group tooltip

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -71,32 +71,28 @@
   }
 }
 
-// Tooltip Icon caret - top position
+// Tooltip Icon placement
+/// @param {String} $position ['bottom'] - The position from: `top`, `bottom`
 /// @access public
 /// @group tooltip
-@mixin tooltip--icon--top {
+@mixin tooltip--icon-placement($position: 'bottom') {
   &::before {
-    top: 1px;
-    transform: translate(-50%, calc(-100% - 9px)) rotate(180deg);
+    @if ($position == 'top') {
+      top: 1px;
+      transform: translate(-50%, calc(-100% - 9px)) rotate(180deg);
+    } @else {
+      bottom: 0;
+      transform: translate(-50%, 10px);
+    }
   }
 
   &::after {
-    top: 0;
-    transform: translate(-50%, calc(-100% - 12px));
-  }
-}
-
-// Tooltip Icon caret - bottom position
-/// @access public
-/// @group tooltip
-@mixin tooltip--icon--bottom {
-  &::before {
-    bottom: 0;
-    transform: translate(-50%, 10px);
-  }
-
-  &::after {
-    bottom: 0;
-    transform: translate(-50%, calc(100% + 10px));
+    @if ($position == 'top') {
+      top: 0;
+      transform: translate(-50%, calc(-100% - 12px));
+    } @else {
+      bottom: 0;
+      transform: translate(-50%, calc(100% + 10px));
+    }
   }
 }


### PR DESCRIPTION
Considering that we are adding left/right alignment options to icon tooltip, figured that it'd be better merging two mixins wrt icon tooltip placement.

**Note**: Want this included in next release, given this change breaks the existing/public Sass mixin API.

Refs #2293.

#### Changelog

**Changed**

- Merged `@mixin tooltip--icon--top` and `@mixin tooltip--icon--bottom` to `@mixin tooltip--icon-placement()`.

#### Testing / Reviewing

Testing should make sure icon-only button as well as icon tooltip are not broken.