### PR TITLE
feat: text input and textarea character limit counter

### DIFF
--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -99,14 +99,20 @@
   // -----------------
   // Character counter
   // -----------------
-  .#{$prefix}--text-area-wrapper--character-counter {
-    position: relative;
+  .#{$prefix}--text-area__character-counter-title {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .#{$prefix}--text-area__character-counter-title
+    + .#{$prefix}--form__helper-text {
+    margin-top: rem(-6px);
   }
 
   .#{$prefix}--text-area--character-counter {
+    margin-bottom: $carbon--spacing-03;
     @include type-style('label-01');
-    position: absolute;
-    right: 0;
     color: $text-02;
   }
 

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -105,6 +105,10 @@
     width: 100%;
   }
 
+  .#{$prefix}--text-area__character-counter-title .#{$prefix}--label {
+    margin-right: rem(16px);
+  }
+
   .#{$prefix}--text-area__character-counter-title
     + .#{$prefix}--form__helper-text {
     margin-top: rem(-6px);

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -20,6 +20,10 @@
 /// @access private
 /// @group text-area
 @mixin text-area {
+  .#{$prefix}--text-area__container {
+    position: relative;
+  }
+
   .#{$prefix}--text-area {
     @include reset;
     @include type-style('body-long-01');
@@ -82,6 +86,7 @@
   .#{$prefix}--text-area__wrapper {
     position: relative;
     display: flex;
+    width: 100%;
   }
 
   .#{$prefix}--text-area__invalid-icon {
@@ -89,6 +94,24 @@
     right: $carbon--spacing-05;
     top: $carbon--spacing-04;
     fill: $support-01;
+  }
+
+  // -----------------
+  // Character counter
+  // -----------------
+  .#{$prefix}--text-area-wrapper--character-counter {
+    position: relative;
+  }
+
+  .#{$prefix}--text-area--character-counter {
+    @include type-style('label-01');
+    position: absolute;
+    right: 0;
+    color: $text-02;
+  }
+
+  .#{$prefix}--text-area--character-counter--disabled {
+    color: $disabled-02;
   }
 
   //-----------------------------

--- a/packages/components/src/components/text-area/text-area.config.js
+++ b/packages/components/src/components/text-area/text-area.config.js
@@ -29,5 +29,22 @@ module.exports = {
         light: true,
       },
     },
+    {
+      name: 'character-counter',
+      label: 'Text area with character counter',
+      context: {
+        charCounter: true,
+        maxLength: 3500,
+      },
+    },
+    {
+      name: 'character-counter--light',
+      label: 'Text area with character counter (light)',
+      context: {
+        charCounter: true,
+        maxLength: 3500,
+        light: true,
+      },
+    },
   ],
 };

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -5,47 +5,48 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <label for="text-area-2" class="{{@root.prefix}}--label">Text Area label</label>
-  <div class="{{@root.prefix}}--text-area__wrapper">
+<div class="{{prefix}}--form-item">
+  <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
+  <div class="{{prefix}}--text-area__wrapper">
     <textarea id="text-area-2"
-      class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
-      rows="4" cols="50" placeholder="Placeholder text."></textarea>
+      class="{{prefix}}--text-area {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+      cols="50" placeholder="Placeholder text."></textarea>
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
-  <label for="text-area-3" class="{{@root.prefix}}--label">Text Area label</label>
-  <div class="{{@root.prefix}}--text-area__wrapper" data-invalid>
-    {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--text-area__invalid-icon')}}
+<div class="{{prefix}}--form-item">
+  <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
+  <div class="{{prefix}}--text-area__wrapper" data-invalid>
+    {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-area__invalid-icon')}}
     <textarea id="text-area-3"
-      class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--invalid {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
+      class="{{prefix}}--text-area {{prefix}}--text-area--invalid {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}"
       rows="4" cols="50" placeholder="Placeholder text."></textarea>
   </div>
-  <div class="{{@root.prefix}}--form-requirement">
+  <div class="{{prefix}}--form-requirement">
     Validation message here
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
-  <label for="text-area-4" class="{{@root.prefix}}--label">Text Area label</label>
-  <div class="{{@root.prefix}}--form__helper-text">
+<div class="{{prefix}}--form-item">
+  <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
+  <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
-  <div class="{{@root.prefix}}--text-area__wrapper">
+  <div class="{{prefix}}--text-area__wrapper">
     <textarea id="text-area-4"
-      class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
-      rows="4" cols="50" placeholder="Placeholder text."></textarea>
+      class="{{prefix}}--text-area {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+      cols="50" placeholder="Placeholder text."></textarea>
   </div>
 </div>
 
-<div class="bx--form-item">
-  <label for="text-area-5" class="bx--label bx--label--disabled">Text Area label</label>
-  <div class="{{@root.prefix}}--form__helper-text {{@root.prefix}}--form__helper-text--disabled">
+<div class="{{prefix}}--form-item">
+  <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
+  <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
-  <div class="{{@root.prefix}}--text-area__wrapper">
-    <textarea id="text-area-5" class="bx--text-area bx--text-area--v2{{#if light}} bx--text-area--light{{/if}}" rows="4"
+  <div class="{{prefix}}--text-area__wrapper">
+    <textarea id="text-area-5"
+      class="{{prefix}}--text-area {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
       cols="50" placeholder="Placeholder text." disabled></textarea>
   </div>
 </div>

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -8,8 +8,7 @@
 <div class="{{prefix}}--form-item">
   <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
   <div class="{{prefix}}--text-area__wrapper">
-    <textarea id="text-area-2"
-      class="{{prefix}}--text-area {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+    <textarea id="text-area-2" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
       cols="50" placeholder="Placeholder text."></textarea>
   </div>
 </div>
@@ -19,7 +18,7 @@
   <div class="{{prefix}}--text-area__wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-area__invalid-icon')}}
     <textarea id="text-area-3"
-      class="{{prefix}}--text-area {{prefix}}--text-area--invalid {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}"
+      class="{{prefix}}--text-area {{prefix}}--text-area--invalid {{#if light}} {{prefix}}--text-area--light{{/if}}"
       rows="4" cols="50" placeholder="Placeholder text."></textarea>
   </div>
   <div class="{{prefix}}--form-requirement">
@@ -33,8 +32,7 @@
     Optional helper text goes here
   </div>
   <div class="{{prefix}}--text-area__wrapper">
-    <textarea id="text-area-4"
-      class="{{prefix}}--text-area {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+    <textarea id="text-area-4" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
       cols="50" placeholder="Placeholder text."></textarea>
   </div>
 </div>
@@ -45,8 +43,7 @@
     Optional helper text goes here
   </div>
   <div class="{{prefix}}--text-area__wrapper">
-    <textarea id="text-area-5"
-      class="{{prefix}}--text-area {{prefix}}--text-area--v2{{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+    <textarea id="text-area-5" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
       cols="50" placeholder="Placeholder text." disabled></textarea>
   </div>
 </div>

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -5,45 +5,71 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{prefix}}--form-item">
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
   <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-area--character-counter">
+    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-area__wrapper">
     <textarea id="text-area-2" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
-      cols="50" placeholder="Placeholder text."></textarea>
+      cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}></textarea>
   </div>
 </div>
 
-<div class="{{prefix}}--form-item">
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
   <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-area--character-counter">
+    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-area__wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-area__invalid-icon')}}
     <textarea id="text-area-3"
       class="{{prefix}}--text-area {{prefix}}--text-area--invalid {{#if light}} {{prefix}}--text-area--light{{/if}}"
-      rows="4" cols="50" placeholder="Placeholder text."></textarea>
+      rows="4" cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}"
+      {{/if}}></textarea>
   </div>
   <div class="{{prefix}}--form-requirement">
     Validation message here
   </div>
 </div>
 
-<div class="{{prefix}}--form-item">
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
   <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-area--character-counter">
+    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
   <div class="{{prefix}}--text-area__wrapper">
     <textarea id="text-area-4" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
-      cols="50" placeholder="Placeholder text."></textarea>
+      cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}></textarea>
   </div>
 </div>
 
-<div class="{{prefix}}--form-item">
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
   <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-area--character-counter {{prefix}}--text-area--character-counter--disabled">
+    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
   <div class="{{prefix}}--text-area__wrapper">
     <textarea id="text-area-5" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
-      cols="50" placeholder="Placeholder text." disabled></textarea>
+      cols="50" placeholder="Placeholder text." disabled{{#if charCounter}} maxlength="{{maxLength}}"
+      {{/if}}></textarea>
   </div>
 </div>

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -6,12 +6,16 @@
 -->
 
 <div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
-  <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-area--character-counter">
-    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
-  </span>
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
   {{/if}}
   <div class="{{prefix}}--text-area__wrapper">
     <textarea id="text-area-2" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
@@ -20,12 +24,16 @@
 </div>
 
 <div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
-  <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-area--character-counter">
-    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
-  </span>
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
   {{/if}}
   <div class="{{prefix}}--text-area__wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-area__invalid-icon')}}
@@ -40,12 +48,16 @@
 </div>
 
 <div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
-  <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-area--character-counter">
-    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
-  </span>
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
   {{/if}}
   <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
@@ -57,12 +69,16 @@
 </div>
 
 <div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
-  <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-area--character-counter {{prefix}}--text-area--character-counter--disabled">
-    <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
-  </span>
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter {{prefix}}--text-area--character-counter--disabled">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
   {{/if}}
   <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here

--- a/packages/components/src/components/text-area/text-area.js
+++ b/packages/components/src/components/text-area/text-area.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import settings from '../../globals/js/settings';
+import mixin from '../../globals/js/misc/mixin';
+import createComponent from '../../globals/js/mixins/create-component';
+import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
+
+export default class TextArea extends mixin(
+  createComponent,
+  initComponentBySearch,
+  handles
+) {
+  /**
+   * Text Area.
+   * @extends CreateComponent
+   * @extends InitComponentBySearch
+   * @extends Handles
+   * @param {HTMLElement} element - The textarea element
+   */
+  constructor(element, options) {
+    super(element, options);
+    this.manage(
+      on(this.element, 'input', event => {
+        if (event.target.maxLength < 0) {
+          return;
+        }
+        this._handleInput({ element, length: event.target.value.length });
+      })
+    );
+  }
+
+  /**
+   * Updates the character counter
+   * @param {Object} obj - The elements that can change in the component
+   * @param {HTMLElement} obj.element - The textarea element
+   * @param {HTMLElement} obj.length - The length of the textarea value
+   */
+  _handleInput = ({ element, length }) => {
+    element.querySelector(
+      this.options.selectorCharCounter
+    ).textContent = length;
+  };
+
+  /**
+   * The component options.
+   *
+   * If `options` is specified in the constructor,
+   * {@linkcode TextArea.create .create()},
+   * or {@linkcode TextArea.init .init()},
+   * properties in this object are overriden for the instance being
+   * created and how {@linkcode TextArea.init .init()} works.
+   * @property {string} selectorInit The CSS selector to find textarea UIs.
+   */
+  static get options() {
+    const { prefix } = settings;
+    return {
+      selectorInit: '[data-text-area]',
+      selectorCharCounter: `.${prefix}--text-area--character-counter--length`,
+    };
+  }
+
+  /**
+   * The map associating DOM element and textarea UI instance.
+   * @type {WeakMap}
+   */
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
+}

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -62,14 +62,24 @@
   // -----------------
   // Character counter
   // -----------------
-  .#{$prefix}--text-input-wrapper--character-counter {
-    position: relative;
+  .#{$prefix}--text-input__character-counter-title {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .#{$prefix}--text-input__character-counter-title
+    + .#{$prefix}--form__helper-text {
+    margin-top: rem(-6px);
+  }
+
+  .#{$prefix}--text-input__character-counter-title .#{$prefix}--label {
+    margin-right: rem(16px);
   }
 
   .#{$prefix}--text-input--character-counter {
+    margin-bottom: $carbon--spacing-03;
     @include type-style('label-01');
-    position: absolute;
-    right: 0;
     color: $text-02;
   }
 

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -59,6 +59,24 @@
     background-color: $field-02;
   }
 
+  // -----------------
+  // Character counter
+  // -----------------
+  .#{$prefix}--text-input-wrapper--character-counter {
+    position: relative;
+  }
+
+  .#{$prefix}--text-input--character-counter {
+    @include type-style('label-01');
+    position: absolute;
+    right: 0;
+    color: $text-02;
+  }
+
+  .#{$prefix}--text-input--character-counter--disabled {
+    color: $disabled-02;
+  }
+
   //-----------------------------
   // Disabled & Error icon spacing
   //-----------------------------
@@ -100,15 +118,12 @@
       padding-right: rem(64px);
     }
 
-    .#{$prefix}--text-input--invalid
-      + .#{$prefix}--text-input--password__visibility {
+    .#{$prefix}--text-input--invalid+.#{$prefix}--text-input--password__visibility {
       right: rem(40px);
     }
   }
 
-  .#{$prefix}--text-input:disabled
-    + .#{$prefix}--text-input--password__visibility
-    svg {
+  .#{$prefix}--text-input:disabled+.#{$prefix}--text-input--password__visibility svg {
     opacity: 0.5;
     cursor: not-allowed;
   }

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -93,6 +93,7 @@
   .#{$prefix}--text-input__field-wrapper {
     position: relative;
     display: flex;
+    width: 100%;
     align-items: center;
 
     .#{$prefix}--text-input__invalid-icon {

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -118,12 +118,15 @@
       padding-right: rem(64px);
     }
 
-    .#{$prefix}--text-input--invalid+.#{$prefix}--text-input--password__visibility {
+    .#{$prefix}--text-input--invalid
+      + .#{$prefix}--text-input--password__visibility {
       right: rem(40px);
     }
   }
 
-  .#{$prefix}--text-input:disabled+.#{$prefix}--text-input--password__visibility svg {
+  .#{$prefix}--text-input:disabled
+    + .#{$prefix}--text-input--password__visibility
+    svg {
     opacity: 0.5;
     cursor: not-allowed;
   }

--- a/packages/components/src/components/text-input/text-input.config.js
+++ b/packages/components/src/components/text-input/text-input.config.js
@@ -31,6 +31,23 @@ module.exports = {
       },
     },
     {
+      name: 'character-counter',
+      label: 'Text Input with character counter',
+      context: {
+        charCounter: true,
+        maxLength: 100,
+      },
+    },
+    {
+      name: 'character-counter--light',
+      label: 'Text Input with character counter (light)',
+      context: {
+        charCounter: true,
+        maxLength: 100,
+        light: true,
+      },
+    },
+    {
       name: 'password',
       label: 'Password Input',
       context: {
@@ -41,6 +58,25 @@ module.exports = {
       name: 'password--light',
       label: 'Password Input (Light)',
       context: {
+        light: true,
+        password: true,
+      },
+    },
+    {
+      name: 'password--character-counter',
+      label: 'Password Input with character counter',
+      context: {
+        charCounter: true,
+        maxLength: 100,
+        password: true,
+      },
+    },
+    {
+      name: 'password--light--character-counter',
+      label: 'Password Input with character counter (Light)',
+      context: {
+        charCounter: true,
+        maxLength: 100,
         light: true,
         password: true,
       },

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -5,17 +5,25 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
   <label for="text-input-3" class="{{prefix}}--label">Text Input label</label>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-input--character-counter">
+    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-3" type="text"
-      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
+      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input id="text-input-3" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" data-toggle-password-visibility{{#if charCounter}} maxlength="{{maxLength}}"
+      {{/if}}>
     <button
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
@@ -26,19 +34,26 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
-  <label for="text-input-4" class="{{prefix}}--label">Text Input label</label>
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}} class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}
+  {{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  <label for=" text-input-4" class="{{prefix}}--label">Text Input label</label>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-input--character-counter">
+    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-input__invalid-icon')}}
     {{#unless password}}
     <input id="text-input-4" type="text"
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid {{#if light}} {{prefix}}--text-input--light{{/if}}"
-      placeholder="Placeholder text">
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input data-invalid id="text-input-4" type="password"
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility>
     <button
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
@@ -52,20 +67,28 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
   <label for="text-input-5" class="{{prefix}}--label">Text Input label</label>
   <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-input--character-counter">
+    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-5" type="text"
-      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
+      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input id="text-input-5" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility>
     <button
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
@@ -76,21 +99,29 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}"
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}"
   style="width: 320px">
   <label for="text-input-6" class="{{prefix}}--label">Text Input label</label>
   <div class="{{prefix}}--form__helper-text">
     Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
   </div>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-input--character-counter">
+    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-6" type="text"
-      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
+      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input id="text-input-6" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility>
     <button
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
@@ -101,21 +132,28 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
   <label for="text-input-7" class="{{prefix}}--label {{prefix}}--label--disabled">Text Input label</label>
   <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
+  {{#if charCounter}}
+  <span class="{{prefix}}--text-input--character-counter">
+    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+  </span>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-7" type="text"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
-      disabled>
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}} disabled>
     {{else}}
     <input id="text-input-7" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility disabled>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility disabled>
     <button
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -7,12 +7,16 @@
 
 <div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
   class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
-  <label for="text-input-3" class="{{prefix}}--label">Text Input label</label>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-input--character-counter">
-    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
-  </span>
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-3" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-input-3" class="{{prefix}}--label">Text Input label</label>
   {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
@@ -36,12 +40,16 @@
 
 <div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}} class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}
   {{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
-  <label for=" text-input-4" class="{{prefix}}--label">Text Input label</label>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-input--character-counter">
-    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
-  </span>
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for=" text-input-4" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for=" text-input-4" class="{{prefix}}--label">Text Input label</label>
   {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-input__invalid-icon')}}
@@ -69,16 +77,20 @@
 
 <div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
   class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-5" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-5" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
-  {{#if charCounter}}
-  <span class="{{prefix}}--text-input--character-counter">
-    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
-  </span>
-  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-5" type="text"
@@ -102,16 +114,20 @@
 <div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
   class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}"
   style="width: 320px">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-6" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-6" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text">
     Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
   </div>
-  {{#if charCounter}}
-  <span class="{{prefix}}--text-input--character-counter">
-    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
-  </span>
-  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-6" type="text"
@@ -134,16 +150,20 @@
 
 <div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
   class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter {{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-7" class="{{prefix}}--label {{prefix}}--label--disabled">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter {{prefix}}--text-input--character-counter--disabled">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-7" class="{{prefix}}--label {{prefix}}--label--disabled">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
-  {{#if charCounter}}
-  <span class="{{prefix}}--text-input--character-counter {{prefix}}--text-input--character-counter--disabled">
-    <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
-      class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
-  </span>
-  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-7" type="text"

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -133,13 +133,13 @@
 </div>
 
 <div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter {{/if}}">
   <label for="text-input-7" class="{{prefix}}--label {{prefix}}--label--disabled">Text Input label</label>
   <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
   {{#if charCounter}}
-  <span class="{{prefix}}--text-input--character-counter">
+  <span class="{{prefix}}--text-input--character-counter {{prefix}}--text-input--character-counter--disabled">
     <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
       class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
   </span>

--- a/packages/components/src/components/text-input/text-input.js
+++ b/packages/components/src/components/text-input/text-input.js
@@ -39,13 +39,11 @@ export default class TextInput extends mixin(
       })
     );
     this.manage(
-      on(this.element, 'keydown', event => {
+      on(this.element, 'input', event => {
         if (event.target.maxLength < 0) {
           return;
         }
-        setTimeout(() => {
-          this._handleKeyPress({ element, length: event.target.value.length });
-        }, 0);
+        this._handleInput({ element, length: event.target.value.length });
       })
     );
   }
@@ -56,7 +54,7 @@ export default class TextInput extends mixin(
    * @param {HTMLElement} obj.element - The element functioning as a text field
    * @param {HTMLElement} obj.length - The length of the text field value
    */
-  _handleKeyPress = ({ element, length }) => {
+  _handleInput = ({ element, length }) => {
     element.querySelector(
       this.options.selectorCharCounter
     ).textContent = length;

--- a/packages/components/src/components/text-input/text-input.js
+++ b/packages/components/src/components/text-input/text-input.js
@@ -38,7 +38,29 @@ export default class TextInput extends mixin(
         }
       })
     );
+    this.manage(
+      on(this.element, 'keydown', event => {
+        if (event.target.maxLength < 0) {
+          return;
+        }
+        setTimeout(() => {
+          this._handleKeyPress({ element, length: event.target.value.length });
+        }, 0);
+      })
+    );
   }
+
+  /**
+   * Updates the character counter
+   * @param {Object} obj - The elements that can change in the component
+   * @param {HTMLElement} obj.element - The element functioning as a text field
+   * @param {HTMLElement} obj.length - The length of the text field value
+   */
+  _handleKeyPress = ({ element, length }) => {
+    element.querySelector(
+      `.${this.options.selectorCharCounter}`
+    ).textContent = length;
+  };
 
   /**
    *
@@ -124,6 +146,7 @@ export default class TextInput extends mixin(
       passwordIsVisible: `${prefix}--text-input--password-visible`,
       svgIconVisibilityOn: `svg.${prefix}--icon--visibility-on`,
       svgIconVisibilityOff: `svg.${prefix}--icon--visibility-off`,
+      selectorCharCounter: `${prefix}--text-input--character-counter--length`,
     };
   }
 

--- a/packages/components/src/components/text-input/text-input.js
+++ b/packages/components/src/components/text-input/text-input.js
@@ -58,7 +58,7 @@ export default class TextInput extends mixin(
    */
   _handleKeyPress = ({ element, length }) => {
     element.querySelector(
-      `.${this.options.selectorCharCounter}`
+      this.options.selectorCharCounter
     ).textContent = length;
   };
 
@@ -146,7 +146,7 @@ export default class TextInput extends mixin(
       passwordIsVisible: `${prefix}--text-input--password-visible`,
       svgIconVisibilityOn: `svg.${prefix}--icon--visibility-on`,
       svgIconVisibilityOff: `svg.${prefix}--icon--visibility-off`,
-      selectorCharCounter: `${prefix}--text-input--character-counter--length`,
+      selectorCharCounter: `.${prefix}--text-input--character-counter--length`,
     };
   }
 

--- a/packages/components/src/globals/js/components.js
+++ b/packages/components/src/globals/js/components.js
@@ -57,6 +57,7 @@ export { default as Tile } from '../../components/tile/tile';
 export {
   default as CodeSnippet,
 } from '../../components/code-snippet/code-snippet';
+export { default as TextArea } from '../../components/text-area/text-area';
 export { default as TextInput } from '../../components/text-input/text-input';
 export { default as SideNav } from '../../components/ui-shell/side-nav';
 export {

--- a/packages/components/tests/axe/allHtml/a11y-html.json
+++ b/packages/components/tests/axe/allHtml/a11y-html.json
@@ -4,20 +4,19 @@
       {
         "description": "Ensures every accesskey attribute value is unique",
         "help": "accesskey attribute value must be unique",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/accesskeys?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/accesskeys?application=webdriverjs",
         "id": "accesskeys",
         "impact": null,
         "nodes": [],
         "tags": [
-          "wcag2a",
-          "wcag211",
+          "best-practice",
           "cat.keyboard"
         ]
       },
       {
         "description": "Ensures <area> elements of image maps have alternate text",
         "help": "Active <area> elements must have alternate text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/area-alt?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/area-alt?application=webdriverjs",
         "id": "area-alt",
         "impact": null,
         "nodes": [],
@@ -30,24 +29,35 @@
         ]
       },
       {
-        "description": "Ensures <audio> elements have captions",
-        "help": "<audio> elements must have a captions track",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/audio-caption?application=webdriverjs",
-        "id": "audio-caption",
+        "description": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles",
+        "help": "Unsupported DPUB ARIA roles should be used on elements with implicit fallback roles",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/aria-dpub-role-fallback?application=webdriverjs",
+        "id": "aria-dpub-role-fallback",
         "impact": null,
         "nodes": [],
         "tags": [
-          "cat.time-and-media",
+          "cat.aria",
           "wcag2a",
-          "wcag122",
-          "section508",
-          "section508.22.a"
+          "wcag131"
+        ]
+      },
+      {
+        "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
+        "help": "autocomplete attribute must be used correctly",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/autocomplete-valid?application=webdriverjs",
+        "id": "autocomplete-valid",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.forms",
+          "wcag21aa",
+          "wcag135"
         ]
       },
       {
         "description": "Ensures <blink> elements are not used",
         "help": "<blink> elements are deprecated and must not be used",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/blink?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/blink?application=webdriverjs",
         "id": "blink",
         "impact": null,
         "nodes": [],
@@ -60,9 +70,9 @@
         ]
       },
       {
-        "description": "Ensures related <input type=\"checkbox\"> elements have a group and that that group designation is consistent",
+        "description": "Ensures related <input type=\"checkbox\"> elements have a group and that the group designation is consistent",
         "help": "Checkbox inputs with the same name attribute value must be part of a group",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/checkboxgroup?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/checkboxgroup?application=webdriverjs",
         "id": "checkboxgroup",
         "impact": null,
         "nodes": [],
@@ -74,7 +84,7 @@
       {
         "description": "Ensures <dl> elements are structured correctly",
         "help": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script> or <template> elements",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/definition-list?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/definition-list?application=webdriverjs",
         "id": "definition-list",
         "impact": null,
         "nodes": [],
@@ -87,7 +97,7 @@
       {
         "description": "Ensures <dt> and <dd> elements are contained by a <dl>",
         "help": "<dt> and <dd> elements must be contained by a <dl>",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/dlitem?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/dlitem?application=webdriverjs",
         "id": "dlitem",
         "impact": null,
         "nodes": [],
@@ -98,9 +108,35 @@
         ]
       },
       {
+        "description": "Ensures form field does not have multiple label elements",
+        "help": "Form field must not have multiple label elements",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/form-field-multiple-labels?application=webdriverjs",
+        "id": "form-field-multiple-labels",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.forms",
+          "wcag2a",
+          "wcag332"
+        ]
+      },
+      {
+        "description": "Ensures <iframe> and <frame> elements contain the axe-core script",
+        "help": "Frames must be tested with axe-core",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/frame-tested?application=webdriverjs",
+        "id": "frame-tested",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.structure",
+          "review-item",
+          "best-practice"
+        ]
+      },
+      {
         "description": "Ensures <iframe> and <frame> elements contain a unique title attribute",
         "help": "Frames must have a unique title attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/frame-title-unique?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/frame-title-unique?application=webdriverjs",
         "id": "frame-title-unique",
         "impact": null,
         "nodes": [],
@@ -112,7 +148,7 @@
       {
         "description": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
         "help": "Frames must have title attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/frame-title?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/frame-title?application=webdriverjs",
         "id": "frame-title",
         "impact": null,
         "nodes": [],
@@ -120,14 +156,28 @@
           "cat.text-alternatives",
           "wcag2a",
           "wcag241",
+          "wcag412",
           "section508",
           "section508.22.i"
         ]
       },
       {
+        "description": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page",
+        "help": "HTML elements with lang and xml:lang must have the same base language",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/html-xml-lang-mismatch?application=webdriverjs",
+        "id": "html-xml-lang-mismatch",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.language",
+          "wcag2a",
+          "wcag311"
+        ]
+      },
+      {
         "description": "Ensures <input type=\"image\"> elements have alternate text",
         "help": "Image buttons must have alternate text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/input-image-alt?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/input-image-alt?application=webdriverjs",
         "id": "input-image-alt",
         "impact": null,
         "nodes": [],
@@ -140,9 +190,73 @@
         ]
       },
       {
+        "description": "Ensures that every form element is not solely labeled using the title or aria-describedby attributes",
+        "help": "Form elements should have a visible label",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/label-title-only?application=webdriverjs",
+        "id": "label-title-only",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.forms",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures every form element has a label",
+        "help": "Form elements must have labels",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/label?application=webdriverjs",
+        "id": "label",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.forms",
+          "wcag2a",
+          "wcag332",
+          "wcag131",
+          "section508",
+          "section508.22.n"
+        ]
+      },
+      {
+        "description": "Ensures the banner landmark is at top level",
+        "help": "Banner landmark must not be contained in another landmark",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/landmark-banner-is-top-level?application=webdriverjs",
+        "id": "landmark-banner-is-top-level",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.semantics",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures the complementary landmark or aside is at top level",
+        "help": "Aside must not be contained in another landmark",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/landmark-complementary-is-top-level?application=webdriverjs",
+        "id": "landmark-complementary-is-top-level",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.semantics",
+          "best-practice"
+        ]
+      },
+      {
+        "description": "Ensures the contentinfo landmark is at top level",
+        "help": "Contentinfo landmark must not be contained in another landmark",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/landmark-contentinfo-is-top-level?application=webdriverjs",
+        "id": "landmark-contentinfo-is-top-level",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.semantics",
+          "best-practice"
+        ]
+      },
+      {
         "description": "Ensures presentational <table> elements do not use <th>, <caption> elements or the summary attribute",
         "help": "Layout tables must not use data table elements",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/layout-table?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/layout-table?application=webdriverjs",
         "id": "layout-table",
         "impact": null,
         "nodes": [],
@@ -155,7 +269,7 @@
       {
         "description": "Ensures <marquee> elements are not used",
         "help": "<marquee> elements are deprecated and must not be used",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/marquee?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/marquee?application=webdriverjs",
         "id": "marquee",
         "impact": null,
         "nodes": [],
@@ -168,7 +282,7 @@
       {
         "description": "Ensures <meta http-equiv=\"refresh\"> is not used",
         "help": "Timed refresh must not exist",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/meta-refresh?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/meta-refresh?application=webdriverjs",
         "id": "meta-refresh",
         "impact": null,
         "nodes": [],
@@ -184,7 +298,7 @@
       {
         "description": "Ensures <object> elements have alternate text",
         "help": "<object> elements must have alternate text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/object-alt?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/object-alt?application=webdriverjs",
         "id": "object-alt",
         "impact": null,
         "nodes": [],
@@ -199,7 +313,7 @@
       {
         "description": "Ensures related <input type=\"radio\"> elements have a group and that the group designation is consistent",
         "help": "Radio inputs with the same name attribute value must be part of a group",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/radiogroup?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/radiogroup?application=webdriverjs",
         "id": "radiogroup",
         "impact": null,
         "nodes": [],
@@ -211,7 +325,7 @@
       {
         "description": "Ensures the scope attribute is used correctly on tables",
         "help": "scope attribute should be used correctly",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/scope-attr-valid?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/scope-attr-valid?application=webdriverjs",
         "id": "scope-attr-valid",
         "impact": null,
         "nodes": [],
@@ -223,7 +337,7 @@
       {
         "description": "Ensures that server-side image maps are not used",
         "help": "Server-side image maps must not be used",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/server-side-image-map?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/server-side-image-map?application=webdriverjs",
         "id": "server-side-image-map",
         "impact": null,
         "nodes": [],
@@ -236,9 +350,21 @@
         ]
       },
       {
+        "description": "Ensure all skip links have a focusable target",
+        "help": "The skip-link target should exist and be focusable",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/skip-link?application=webdriverjs",
+        "id": "skip-link",
+        "impact": null,
+        "nodes": [],
+        "tags": [
+          "cat.keyboard",
+          "best-practice"
+        ]
+      },
+      {
         "description": "Ensures lang attributes have valid values",
         "help": "lang attribute must have a valid value",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/valid-lang?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/valid-lang?application=webdriverjs",
         "id": "valid-lang",
         "impact": null,
         "nodes": [],
@@ -251,7 +377,7 @@
       {
         "description": "Ensures <video> elements have captions",
         "help": "<video> elements must have captions",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/video-caption?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/video-caption?application=webdriverjs",
         "id": "video-caption",
         "impact": null,
         "nodes": [],
@@ -259,7 +385,6 @@
           "cat.text-alternatives",
           "wcag2a",
           "wcag122",
-          "wcag123",
           "section508",
           "section508.22.a"
         ]
@@ -267,7 +392,7 @@
       {
         "description": "Ensures <video> elements have audio descriptions",
         "help": "<video> elements must have an audio description track",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/video-description?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/video-description?application=webdriverjs",
         "id": "video-description",
         "impact": null,
         "nodes": [],
@@ -284,7 +409,7 @@
       {
         "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
         "help": "Elements must have sufficient color contrast",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/color-contrast?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=webdriverjs",
         "id": "color-contrast",
         "impact": "serious",
         "nodes": [
@@ -309,7 +434,132 @@
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(4) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(4) > .attr-name.token:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">style</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .style-attr.language-css.token > .attr-name.token > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .style-attr.language-css.token > .punctuation.token:nth-child(2)"
             ]
           },
           {
@@ -330,11 +580,36 @@
                 "relatedNodes": []
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "html": "<span class=\"token attr-value\"><span class=\"token property\">will-change</span><span class=\"token punctuation\">:</span> transform<span class=\"token punctuation\">;</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(5)"
+              ".tag.token:nth-child(5) > .style-attr.language-css.token > .attr-value.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#c92c2c",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token property\">will-change</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .style-attr.language-css.token > .attr-value.token > .property.token"
             ]
           },
           {
@@ -355,11 +630,294 @@
                 "relatedNodes": []
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(5)"
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>true<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(18)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(6) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(18) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(18) > .attr-name.token:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">style</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .style-attr.language-css.token > .attr-name.token > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .style-attr.language-css.token > .punctuation.token:nth-child(2)"
             ]
           },
           {
@@ -380,11 +938,36 @@
                 "relatedNodes": []
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "html": "<span class=\"token attr-value\"><span class=\"token property\">will-change</span><span class=\"token punctuation\">:</span> transform<span class=\"token punctuation\">;</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(5)"
+              ".tag.token:nth-child(19) > .style-attr.language-css.token > .attr-value.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#c92c2c",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token property\">will-change</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .style-attr.language-css.token > .attr-value.token > .property.token"
             ]
           },
           {
@@ -405,11 +988,885 @@
                 "relatedNodes": []
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z<span class=\"token punctuation\">\"</span></span>",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(5)"
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>true<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(18)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(20) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(32) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(32) > .attr-name.token:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">style</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .style-attr.language-css.token > .attr-name.token > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .style-attr.language-css.token > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token property\">will-change</span><span class=\"token punctuation\">:</span> transform<span class=\"token punctuation\">;</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .style-attr.language-css.token > .attr-value.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#c92c2c",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token property\">will-change</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .style-attr.language-css.token > .attr-value.token > .property.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>true<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(18)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(34) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(46) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">aria-controls</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(46) > .attr-name.token:nth-child(6)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-value.token:nth-child(5) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">style</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .style-attr.language-css.token > .attr-name.token > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .style-attr.language-css.token > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token property\">will-change</span><span class=\"token punctuation\">:</span> transform<span class=\"token punctuation\">;</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .style-attr.language-css.token > .attr-value.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#c92c2c",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token property\">will-change</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .style-attr.language-css.token > .attr-value.token > .property.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(10)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>true<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(18)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(18) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(48) > .attr-name.token"
             ]
           },
           {
@@ -432,7 +1889,7 @@
                   {
                     "html": "<button type=\"button\" data-copy-btn=\"true\" class=\"bx--snippet-button code-example__copy-btn\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .bx--snippet-button.code-example__copy-btn[data-copy-btn=\"true\"]"
                     ]
                   }
                 ]
@@ -442,7 +1899,7 @@
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .bx--snippet-button.code-example__copy-btn[data-copy-btn=\"true\"]"
             ]
           },
           {
@@ -466,7 +1923,1103 @@
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(3) > .attr-value.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(3) > .attr-value.token:nth-child(6) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(3) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(6) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(7) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(17) > .attr-value.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(17) > .attr-value.token:nth-child(6) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(17) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(20) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(21) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(31) > .attr-value.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(31) > .attr-value.token:nth-child(6) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(31) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(34) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(35) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(45) > .attr-value.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(45) > .attr-value.token:nth-child(6) > .punctuation.token:nth-child(3)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(45) > .punctuation.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "bgOverlap"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it is overlapped by another element",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-name\">viewBox</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "elmPartiallyObscuring"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element's background color could not be determined because it partially overlaps other elements",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">=</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(1)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">\"</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(9) > .punctuation.token:nth-child(2)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "html": "<span class=\"token attr-name\">d</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(48) > .attr-name.token"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "contrastRatio": 0,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#5f6364",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal",
+                  "missingData": "shortTextContent"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element content is too short to determine if it is actual text content",
+                "relatedNodes": []
+              }
+            ],
+            "html": "<span class=\"token punctuation\">&gt;</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(49) > .punctuation.token"
             ]
           },
           {
@@ -489,7 +3042,7 @@
                   {
                     "html": "<button type=\"button\" data-copy-btn=\"true\" class=\"bx--snippet-button code-example__copy-btn\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .bx--snippet-button.code-example__copy-btn[data-copy-btn=\"true\"]"
                     ]
                   }
                 ]
@@ -499,31 +3052,7 @@
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > button.bx--snippet-button.code-example__copy-btn"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "contrastRatio": 0,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#ffffff",
-                  "fontSize": "10.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Unable to determine contrast ratio",
-                "relatedNodes": []
-              }
-            ],
-            "html": "<div id=\"__bs_notify__\" style=\"display: block; padding: 15px; font-family: sans-serif; position: fixed; font-size: 0.9em; z-index: 9999; right: 0px; top: 0px; border-bottom-left-radius: 5px; background-color: rgb(27, 32, 50); margin: 0px; color: white; text-align: center; pointer-events: none;\">",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#__bs_notify__"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .bx--snippet-button.code-example__copy-btn[data-copy-btn=\"true\"]"
             ]
           }
         ],
@@ -536,7 +3065,7 @@
       {
         "description": "Ensure that each table header in a data table refers to data cells",
         "help": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/th-has-data-cells?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/th-has-data-cells?application=webdriverjs",
         "id": "th-has-data-cells",
         "impact": "serious",
         "nodes": [
@@ -551,7 +3080,7 @@
                   {
                     "html": "<th>Params</th>",
                     "target": [
-                      "#maincontent > div:nth-child(2) > .page_md > table:nth-child(7) > thead > tr > th:nth-child(2)"
+                      "table:nth-child(7) > thead > tr > th:nth-child(2)"
                     ]
                   }
                 ]
@@ -562,7 +3091,7 @@
             "impact": "serious",
             "none": [],
             "target": [
-              ".page_md > table:nth-child(7)"
+              "table:nth-child(7)"
             ]
           }
         ],
@@ -575,13 +3104,41 @@
         ]
       }
     ],
-    "timestamp": 1550767500764,
+    "testEngine": {
+      "name": "axe-core",
+      "version": "3.2.2"
+    },
+    "testEnvironment": {
+      "orientationAngle": 0,
+      "orientationType": "landscape-primary",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36",
+      "windowHeight": 710,
+      "windowWidth": 1200
+    },
+    "testRunner": {
+      "name": "axe"
+    },
+    "timestamp": 1557872754319,
+    "toolOptions": {
+      "reporter": "v1",
+      "rules": {
+        "bypass": {
+          "enabled": false
+        },
+        "html-has-lang": {
+          "enabled": false
+        },
+        "image-alt": {
+          "enabled": false
+        }
+      }
+    },
     "url": "http://localhost:3000",
     "violations": [
       {
         "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
         "help": "Elements must have sufficient color contrast",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/2.6/color-contrast?application=webdriverjs",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=webdriverjs",
         "id": "color-contrast",
         "impact": "serious",
         "nodes": [
@@ -604,17 +3161,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.48 (foreground color: #7d8b99, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token comment\" spellcheck=\"true\">&lt;!-- \n  Copyright IBM Corp. 2016, 2018\n\n  This source code is licensed under the Apache-2.0 license found in the\n  LICENSE file in the root directory of this source tree.\n--&gt;</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span.comment"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .comment.token[spellcheck=\"true\"]"
             ]
           },
           {
@@ -636,17 +3194,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(2) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -668,17 +3227,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(2) > .attr-name.token:nth-child(3)"
             ]
           },
           {
@@ -700,17 +3260,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(2) > .attr-value.token"
             ]
           },
           {
@@ -732,17 +3293,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(3) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -764,17 +3326,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(3)"
+              ".tag.token:nth-child(3) > .attr-name.token:nth-child(3)"
             ]
           },
           {
@@ -796,17 +3359,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(3) > .attr-value.token"
             ]
           },
           {
@@ -828,17 +3392,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(4) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -860,17 +3425,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(4) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -892,17 +3458,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">aria-expanded</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(4)"
+              ".tag.token:nth-child(4) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -924,49 +3491,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(5)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">aria-controls</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(6)"
+              ".tag.token:nth-child(4) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -988,17 +3524,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane1<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span:nth-child(7)"
+              ".tag.token:nth-child(4) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -1020,17 +3557,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">class</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">focusable</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -1052,17 +3590,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -1084,17 +3623,183 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">preserveAspectRatio</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-name.token:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>xMidYMid meet<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">xmlns</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>http://www.w3.org/2000/svg<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(4)"
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(11)"
             ]
           },
           {
@@ -1116,17 +3821,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(5)"
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(12)"
             ]
           },
           {
@@ -1148,17 +3854,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(6)"
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(13)"
             ]
           },
           {
@@ -1180,17 +3887,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(7)"
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(14)"
             ]
           },
           {
@@ -1212,17 +3920,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">viewBox</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(8)"
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(15)"
             ]
           },
           {
@@ -1244,17 +3953,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 16 16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(9)"
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(16)"
             ]
           },
           {
@@ -1276,17 +3986,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">aria-hidden</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(2)"
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(17)"
             ]
           },
           {
@@ -1308,17 +4019,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(6) > .attr-value.token"
             ]
           },
           {
@@ -1340,49 +4052,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(8) > span.attr-name"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(9) > .attr-name.token"
             ]
           },
           {
@@ -1404,17 +4085,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(8) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(9) > .attr-value.token"
             ]
           },
           {
@@ -1436,17 +4118,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">id</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(12) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -1468,17 +4151,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane1<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(12) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -1500,17 +4184,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(4)"
+              ".tag.token:nth-child(12) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -1532,17 +4217,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(11) > span:nth-child(5)"
+              ".tag.token:nth-child(12) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -1564,17 +4250,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(16) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(17) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -1596,17 +4283,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(16) > span:nth-child(3)"
+              ".tag.token:nth-child(17) > .attr-name.token:nth-child(3)"
             ]
           },
           {
@@ -1628,17 +4316,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(16) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(17) > .attr-value.token"
             ]
           },
           {
@@ -1660,17 +4349,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(18) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -1692,17 +4382,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(18) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -1724,17 +4415,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">aria-expanded</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(4)"
+              ".tag.token:nth-child(18) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -1756,49 +4448,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(5)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">aria-controls</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(6)"
+              ".tag.token:nth-child(18) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -1820,17 +4481,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane2<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(7)"
+              ".tag.token:nth-child(18) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -1852,17 +4514,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">class</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">focusable</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -1884,17 +4547,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -1916,17 +4580,183 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">preserveAspectRatio</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-name.token:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>xMidYMid meet<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">xmlns</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>http://www.w3.org/2000/svg<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(4)"
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(11)"
             ]
           },
           {
@@ -1948,17 +4778,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(5)"
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(12)"
             ]
           },
           {
@@ -1980,17 +4811,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(6)"
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(13)"
             ]
           },
           {
@@ -2012,17 +4844,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(7)"
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(14)"
             ]
           },
           {
@@ -2044,17 +4877,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">viewBox</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(8)"
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(15)"
             ]
           },
           {
@@ -2076,17 +4910,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 16 16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span:nth-child(9)"
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(16)"
             ]
           },
           {
@@ -2108,17 +4943,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">aria-hidden</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(2)"
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(17)"
             ]
           },
           {
@@ -2140,17 +4976,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(20) > .attr-value.token"
             ]
           },
           {
@@ -2172,49 +5009,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(21) > span.attr-name"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(23) > .attr-name.token"
             ]
           },
           {
@@ -2236,17 +5042,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(21) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(23) > .attr-value.token"
             ]
           },
           {
@@ -2268,17 +5075,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">id</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(26) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -2300,17 +5108,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane2<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(26) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -2332,17 +5141,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(4)"
+              ".tag.token:nth-child(26) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -2364,17 +5174,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(24) > span:nth-child(5)"
+              ".tag.token:nth-child(26) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -2396,17 +5207,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(29) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(31) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -2428,17 +5240,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(29) > span:nth-child(3)"
+              ".tag.token:nth-child(31) > .attr-name.token:nth-child(3)"
             ]
           },
           {
@@ -2460,17 +5273,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(29) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(31) > .attr-value.token"
             ]
           },
           {
@@ -2492,17 +5306,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(32) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -2524,17 +5339,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(32) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -2556,17 +5372,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">aria-expanded</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(4)"
+              ".tag.token:nth-child(32) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -2588,49 +5405,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(5)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">aria-controls</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(6)"
+              ".tag.token:nth-child(32) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -2652,17 +5438,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane3<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(30) > span:nth-child(7)"
+              ".tag.token:nth-child(32) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -2684,17 +5471,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">class</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">focusable</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -2716,17 +5504,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -2748,17 +5537,183 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">preserveAspectRatio</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-name.token:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>xMidYMid meet<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">xmlns</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>http://www.w3.org/2000/svg<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(4)"
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(11)"
             ]
           },
           {
@@ -2780,17 +5735,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(5)"
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(12)"
             ]
           },
           {
@@ -2812,17 +5768,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(6)"
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(13)"
             ]
           },
           {
@@ -2844,17 +5801,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(7)"
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(14)"
             ]
           },
           {
@@ -2876,17 +5834,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">viewBox</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(8)"
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(15)"
             ]
           },
           {
@@ -2908,17 +5867,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 16 16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(9)"
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(16)"
             ]
           },
           {
@@ -2940,17 +5900,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">aria-hidden</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(2)"
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(17)"
             ]
           },
           {
@@ -2972,17 +5933,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(34) > .attr-value.token"
             ]
           },
           {
@@ -3004,49 +5966,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-name"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(37) > .attr-name.token"
             ]
           },
           {
@@ -3068,17 +5999,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(37) > .attr-value.token"
             ]
           },
           {
@@ -3100,17 +6032,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">id</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(40) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -3132,17 +6065,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane3<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(40) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -3164,17 +6098,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(4)"
+              ".tag.token:nth-child(40) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -3196,17 +6131,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span:nth-child(5)"
+              ".tag.token:nth-child(40) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -3228,17 +6164,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(42) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(45) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -3260,17 +6197,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(42) > span:nth-child(3)"
+              ".tag.token:nth-child(45) > .attr-name.token:nth-child(3)"
             ]
           },
           {
@@ -3292,17 +6230,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(42) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(45) > .attr-value.token"
             ]
           },
           {
@@ -3324,17 +6263,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(46) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -3356,17 +6296,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(46) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -3388,17 +6329,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">aria-expanded</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(4)"
+              ".tag.token:nth-child(46) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -3420,49 +6362,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(5)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">aria-controls</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(6)"
+              ".tag.token:nth-child(46) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -3484,17 +6395,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane4<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(43) > span:nth-child(7)"
+              ".tag.token:nth-child(46) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -3516,17 +6428,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">class</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">focusable</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -3548,17 +6461,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>false<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -3580,17 +6494,183 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">preserveAspectRatio</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-name.token:nth-child(4)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>xMidYMid meet<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-value.token:nth-child(5)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">xmlns</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(7)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.66,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#1990b8",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>http://www.w3.org/2000/svg<span class=\"token punctuation\">\"</span></span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(8)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">class</span>",
+            "impact": "serious",
+            "none": [],
+            "target": [
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(9)"
+            ]
+          },
+          {
+            "all": [],
+            "any": [
+              {
+                "data": {
+                  "bgColor": "#ffffff",
+                  "contrastRatio": 3.57,
+                  "expectedContrastRatio": "4.5:1",
+                  "fgColor": "#2f9c0a",
+                  "fontSize": "9.8pt",
+                  "fontWeight": "normal"
+                },
+                "id": "color-contrast",
+                "impact": "serious",
+                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                "relatedNodes": [
+                  {
+                    "html": "<code class=\"  language-html\">",
+                    "target": [
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(4)"
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(11)"
             ]
           },
           {
@@ -3612,17 +6692,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>7<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(5)"
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(12)"
             ]
           },
           {
@@ -3644,17 +6725,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(6)"
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(13)"
             ]
           },
           {
@@ -3676,17 +6758,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(7)"
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(14)"
             ]
           },
           {
@@ -3708,17 +6791,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">viewBox</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(8)"
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(15)"
             ]
           },
           {
@@ -3740,17 +6824,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 7 12<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 16 16<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(44) > span:nth-child(9)"
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(16)"
             ]
           },
           {
@@ -3772,17 +6857,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">fill-rule</span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-name\">aria-hidden</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(2)"
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(17)"
             ]
           },
           {
@@ -3804,17 +6890,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>nonzero<span class=\"token punctuation\">\"</span></span>",
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
+            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(48) > .attr-value.token"
             ]
           },
           {
@@ -3836,49 +6923,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span.attr-name"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(51) > .attr-name.token"
             ]
           },
           {
@@ -3900,17 +6956,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span.attr-value"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(51) > .attr-value.token"
             ]
           },
           {
@@ -3932,17 +6989,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">id</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(2)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(54) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -3964,17 +7022,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>pane4<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(3)"
+              ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(54) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -3996,17 +7055,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(4)"
+              ".tag.token:nth-child(54) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -4028,17 +7088,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(1) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(50) > span:nth-child(5)"
+              ".tag.token:nth-child(54) > .attr-value.token:nth-child(5)"
             ]
           },
           {
@@ -4060,17 +7121,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.48 (foreground color: #7d8b99, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token comment\" spellcheck=\"true\">&lt;!-- \n  Copyright IBM Corp. 2016, 2018\n\n  This source code is licensed under the Apache-2.0 license found in the\n  LICENSE file in the root directory of this source tree.\n--&gt;</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span.comment"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .comment.token[spellcheck=\"true\"]"
             ]
           },
           {
@@ -4092,17 +7154,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(2)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(2) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -4124,17 +7187,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(2) > .attr-name.token:nth-child(3)"
             ]
           },
           {
@@ -4156,17 +7220,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(2) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(2) > .attr-value.token"
             ]
           },
           {
@@ -4188,49 +7253,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">tabindex</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(2)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(3) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -4252,17 +7286,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(4)"
+              ".tag.token:nth-child(3) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -4284,17 +7319,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(5)"
+              ".tag.token:nth-child(3) > .attr-name.token:nth-child(5)"
             ]
           },
           {
@@ -4316,17 +7352,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(3) > span:nth-child(6)"
+              ".tag.token:nth-child(3) > .attr-value.token:nth-child(6)"
             ]
           },
           {
@@ -4348,17 +7385,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(4) > .attr-name.token"
             ]
           },
           {
@@ -4380,17 +7418,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(4) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(4) > .attr-value.token"
             ]
           },
           {
@@ -4412,17 +7451,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(2)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -4444,17 +7484,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -4476,49 +7517,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(5)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(5) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -4540,17 +7550,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(6)"
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(6)"
             ]
           },
           {
@@ -4572,17 +7583,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(7)"
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -4604,81 +7616,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">viewBox</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(8)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(9)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">fill-rule</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(10)"
+              ".tag.token:nth-child(5) > .attr-name.token:nth-child(10)"
             ]
           },
           {
@@ -4700,49 +7649,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(5) > span:nth-child(11)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span.attr-name"
+              ".tag.token:nth-child(5) > .attr-value.token:nth-child(11)"
             ]
           },
           {
@@ -4764,17 +7682,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(6) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(6) > .attr-value.token"
             ]
           },
           {
@@ -4796,17 +7715,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(9) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(9) > .attr-name.token"
             ]
           },
           {
@@ -4828,17 +7748,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(9) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(9) > .attr-value.token"
             ]
           },
           {
@@ -4860,17 +7781,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(12) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(12) > .attr-name.token"
             ]
           },
           {
@@ -4892,17 +7814,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(12) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(12) > .attr-value.token"
             ]
           },
           {
@@ -4924,49 +7847,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">tabindex</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(2)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(17) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -4988,17 +7880,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(4)"
+              ".tag.token:nth-child(17) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -5020,17 +7913,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(5)"
+              ".tag.token:nth-child(17) > .attr-name.token:nth-child(5)"
             ]
           },
           {
@@ -5052,17 +7946,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(17) > span:nth-child(6)"
+              ".tag.token:nth-child(17) > .attr-value.token:nth-child(6)"
             ]
           },
           {
@@ -5084,17 +7979,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(18) > .attr-name.token"
             ]
           },
           {
@@ -5116,17 +8012,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(18) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(18) > .attr-value.token"
             ]
           },
           {
@@ -5148,17 +8045,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(2)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -5180,17 +8078,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -5212,49 +8111,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(5)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(19) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -5276,17 +8144,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(6)"
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(6)"
             ]
           },
           {
@@ -5308,17 +8177,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(7)"
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -5340,81 +8210,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">viewBox</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(8)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(9)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">fill-rule</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(10)"
+              ".tag.token:nth-child(19) > .attr-name.token:nth-child(10)"
             ]
           },
           {
@@ -5436,49 +8243,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(19) > span:nth-child(11)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(20) > span.attr-name"
+              ".tag.token:nth-child(19) > .attr-value.token:nth-child(11)"
             ]
           },
           {
@@ -5500,17 +8276,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(20) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(20) > .attr-value.token"
             ]
           },
           {
@@ -5532,17 +8309,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(23) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(23) > .attr-name.token"
             ]
           },
           {
@@ -5564,17 +8342,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(23) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(23) > .attr-value.token"
             ]
           },
           {
@@ -5596,17 +8375,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(26) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(26) > .attr-name.token"
             ]
           },
           {
@@ -5628,17 +8408,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(26) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(26) > .attr-value.token"
             ]
           },
           {
@@ -5660,49 +8441,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">tabindex</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(2)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(31) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -5724,17 +8474,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(4)"
+              ".tag.token:nth-child(31) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -5756,17 +8507,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(5)"
+              ".tag.token:nth-child(31) > .attr-name.token:nth-child(5)"
             ]
           },
           {
@@ -5788,17 +8540,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(31) > span:nth-child(6)"
+              ".tag.token:nth-child(31) > .attr-value.token:nth-child(6)"
             ]
           },
           {
@@ -5820,17 +8573,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(32) > .attr-name.token"
             ]
           },
           {
@@ -5852,17 +8606,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(32) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(32) > .attr-value.token"
             ]
           },
           {
@@ -5884,17 +8639,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(2)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -5916,17 +8672,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -5948,49 +8705,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(5)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(33) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -6012,17 +8738,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(6)"
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(6)"
             ]
           },
           {
@@ -6044,17 +8771,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(7)"
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -6076,81 +8804,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">viewBox</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(8)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(9)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">fill-rule</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(10)"
+              ".tag.token:nth-child(33) > .attr-name.token:nth-child(10)"
             ]
           },
           {
@@ -6172,49 +8837,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(33) > span:nth-child(11)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-name"
+              ".tag.token:nth-child(33) > .attr-value.token:nth-child(11)"
             ]
           },
           {
@@ -6236,17 +8870,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(34) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(34) > .attr-value.token"
             ]
           },
           {
@@ -6268,17 +8903,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(37) > .attr-name.token"
             ]
           },
           {
@@ -6300,17 +8936,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(37) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(37) > .attr-value.token"
             ]
           },
           {
@@ -6332,17 +8969,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(40) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(40) > .attr-name.token"
             ]
           },
           {
@@ -6364,17 +9002,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(40) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(40) > .attr-value.token"
             ]
           },
           {
@@ -6396,49 +9035,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">tabindex</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(2)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(45) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -6460,17 +9068,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">data-accordion-item</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(4)"
+              ".tag.token:nth-child(45) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -6492,17 +9101,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(5)"
+              ".tag.token:nth-child(45) > .attr-name.token:nth-child(5)"
             ]
           },
           {
@@ -6524,17 +9134,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__item<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(45) > span:nth-child(6)"
+              ".tag.token:nth-child(45) > .attr-value.token:nth-child(6)"
             ]
           },
           {
@@ -6556,17 +9167,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(46) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(46) > .attr-name.token"
             ]
           },
           {
@@ -6588,17 +9200,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__heading<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(46) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(46) > .attr-value.token"
             ]
           },
           {
@@ -6620,17 +9233,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(2)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-name.token:nth-child(2)"
             ]
           },
           {
@@ -6652,17 +9266,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__arrow<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(3)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-value.token:nth-child(3)"
             ]
           },
           {
@@ -6684,49 +9299,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">width</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(4)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>8<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(5)"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(47) > .attr-name.token:nth-child(4)"
             ]
           },
           {
@@ -6748,17 +9332,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">height</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(6)"
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(6)"
             ]
           },
           {
@@ -6780,17 +9365,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>12<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(7)"
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(7)"
             ]
           },
           {
@@ -6812,81 +9398,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
-            "html": "<span class=\"token attr-name\">viewBox</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(8)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.66,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#1990b8",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>0 0 8 12<span class=\"token punctuation\">\"</span></span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(9)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">fill-rule</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(10)"
+              ".tag.token:nth-child(47) > .attr-name.token:nth-child(10)"
             ]
           },
           {
@@ -6908,49 +9431,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>evenodd<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(47) > span:nth-child(11)"
-            ]
-          },
-          {
-            "all": [],
-            "any": [
-              {
-                "data": {
-                  "bgColor": "#ffffff",
-                  "contrastRatio": 3.57,
-                  "expectedContrastRatio": "4.5:1",
-                  "fgColor": "#2f9c0a",
-                  "fontSize": "9.8pt",
-                  "fontWeight": "normal"
-                },
-                "id": "color-contrast",
-                "impact": "serious",
-                "message": "Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
-                "relatedNodes": [
-                  {
-                    "html": "<code class=\"  language-html\">",
-                    "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "html": "<span class=\"token attr-name\">d</span>",
-            "impact": "serious",
-            "none": [],
-            "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(48) > span.attr-name"
+              ".tag.token:nth-child(47) > .attr-value.token:nth-child(11)"
             ]
           },
           {
@@ -6972,17 +9464,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>M0 10.6L4.7 6 0 1.4 1.4 0l6.1 6-6.1 6z<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(48) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(48) > .attr-value.token"
             ]
           },
           {
@@ -7004,17 +9497,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(51) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(51) > .attr-name.token"
             ]
           },
           {
@@ -7036,17 +9530,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__title<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(51) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(51) > .attr-value.token"
             ]
           },
           {
@@ -7068,17 +9563,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.57 (foreground color: #2f9c0a, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-name\">class</span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(54) > span.attr-name"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(54) > .attr-name.token"
             ]
           },
           {
@@ -7100,17 +9596,18 @@
                   {
                     "html": "<code class=\"  language-html\">",
                     "target": [
-                      "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code.language-html"
+                      ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html"
                     ]
                   }
                 ]
               }
             ],
+            "failureSummary": "Fix any of the following:\n  Element has insufficient color contrast of 3.66 (foreground color: #1990b8, background color: #ffffff, font size: 9.8pt, font weight: normal). Expected contrast ratio of 4.5:1",
             "html": "<span class=\"token attr-value\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>bx--accordion__content<span class=\"token punctuation\">\"</span></span>",
             "impact": "serious",
             "none": [],
             "target": [
-              "#maincontent > div:nth-child(2) > div:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > code > span:nth-child(54) > span.attr-value"
+              ".component-variation:nth-child(2) > .component-example > .code-example > .code-example__raw-html > pre > .language-html > .tag.token:nth-child(54) > .attr-value.token"
             ]
           }
         ],
@@ -7119,9 +9616,48 @@
           "wcag2aa",
           "wcag143"
         ]
+      },
+      {
+        "description": "Ensures all page content is contained by landmarks",
+        "help": "All page content must be contained by landmarks",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/region?application=webdriverjs",
+        "id": "region",
+        "impact": "moderate",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "region",
+                "impact": "moderate",
+                "message": "Some page content is not contained by landmarks",
+                "relatedNodes": [
+                  {
+                    "html": "<input aria-label=\"inpute-text-offleft\" type=\"text\" class=\"offleft\">",
+                    "target": [
+                      ".offleft"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  Some page content is not contained by landmarks",
+            "html": "<html lang=\"en\">",
+            "impact": "moderate",
+            "none": [],
+            "target": [
+              "html"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.keyboard",
+          "best-practice"
+        ]
       }
     ],
-    "time": 1871,
+    "time": 6851,
     "status": 200
   }
 ]

--- a/packages/components/tests/spec/text-area_spec.js
+++ b/packages/components/tests/spec/text-area_spec.js
@@ -58,6 +58,9 @@ describe('Test textarea', () => {
       bubbles: true,
       data: 'a',
     });
+    if (!aKeyInput.data) {
+      aKeyInput.data = 'a';
+    }
     const deleteKeyInput = new InputEvent('input', {
       inputType: 'deleteContentBackward',
       type: 'input',

--- a/packages/components/tests/spec/text-area_spec.js
+++ b/packages/components/tests/spec/text-area_spec.js
@@ -1,0 +1,100 @@
+import TextArea from '../../src/components/text-area/text-area';
+import TextAreaHTML from '../../html/text-area/text-area.html';
+import CharacterCounterHTML from '../../html/text-area/text-area--character-counter.html';
+import flattenOptions from '../utils/flatten-options';
+import { prefix } from '../../src/globals/js/settings';
+
+describe('Test textarea', () => {
+  describe('Constructor', () => {
+    let instance;
+    const container = document.createElement('div');
+    container.innerHTML = TextAreaHTML;
+
+    beforeAll(() => {
+      document.body.appendChild(container);
+      instance = new TextArea(document.querySelector('[data-text-area]'));
+    });
+
+    it('Should throw if root element is not given', () => {
+      expect(() => {
+        new TextArea();
+      }).toThrowError(
+        TypeError,
+        'DOM element should be given to initialize this widget.'
+      );
+    });
+
+    it('Should throw if root element is not a DOM element', () => {
+      expect(() => {
+        new TextArea(document.createTextNode(''));
+      }).toThrowError(
+        TypeError,
+        'DOM element should be given to initialize this widget.'
+      );
+    });
+
+    it('Should set default options', () => {
+      expect(flattenOptions(instance.options)).toEqual({
+        selectorInit: '[data-text-area]',
+        selectorCharCounter: `.${prefix}--text-area--character-counter--length`,
+      });
+    });
+
+    afterAll(() => {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+
+  describe('Character counter', () => {
+    let textArea;
+    let charCounter;
+    const container = document.createElement('div');
+    container.innerHTML = CharacterCounterHTML;
+    const aKeyInput = new InputEvent('input', {
+      inputType: 'insertText',
+      type: 'input',
+      bubbles: true,
+      data: 'a',
+    });
+    const deleteKeyInput = new InputEvent('input', {
+      inputType: 'deleteContentBackward',
+      type: 'input',
+      bubbles: true,
+      data: null,
+    });
+
+    beforeAll(() => {
+      document.body.appendChild(container);
+      new TextArea(document.querySelector('[data-text-area]'));
+      textArea = document.querySelector('[data-text-area] textarea');
+      charCounter = document.querySelector(
+        `.${prefix}--text-area--character-counter--length`
+      );
+    });
+
+    beforeEach(() => {
+      textArea.value = '';
+    });
+
+    it('Should increment character counter on input value length increase', () => {
+      textArea.value += aKeyInput.data;
+      textArea.dispatchEvent(aKeyInput);
+      expect(textArea.value).toBe('a');
+      expect(charCounter.textContent).toBe('1');
+    });
+
+    it('Should decrement character counter on input value length decrease', () => {
+      textArea.dispatchEvent(deleteKeyInput);
+      expect(textArea.value).toBe('');
+      expect(charCounter.textContent).toBe('0');
+    });
+
+    afterAll(() => {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+});

--- a/packages/components/tests/spec/text-input_spec.js
+++ b/packages/components/tests/spec/text-input_spec.js
@@ -115,6 +115,9 @@ describe('Test text input', () => {
       bubbles: true,
       data: null,
     });
+    if (!aKeyInput.data) {
+      aKeyInput.data = 'a';
+    }
 
     beforeAll(() => {
       document.body.appendChild(container);

--- a/packages/components/tests/spec/text-input_spec.js
+++ b/packages/components/tests/spec/text-input_spec.js
@@ -1,6 +1,7 @@
 // only test JS class since it is only instantiated with password fields
 import TextInput from '../../src/components/text-input/text-input';
 import PasswordVisibilityHTML from '../../html/text-input/text-input--password.html';
+import CharacterCounterHTML from '../../html/text-input/text-input--character-counter.html';
 import flattenOptions from '../utils/flatten-options';
 import { prefix } from '../../src/globals/js/settings';
 
@@ -88,6 +89,57 @@ describe('Test text input', () => {
       expect(
         textInput.classList.contains(`${prefix}--text-input--password-visible`)
       ).toBe(false);
+    });
+
+    afterAll(() => {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+
+  describe('Character counter', () => {
+    let textInput;
+    let charCounter;
+    const container = document.createElement('div');
+    container.innerHTML = CharacterCounterHTML;
+    const aKeyInput = new InputEvent('input', {
+      inputType: 'insertText',
+      type: 'input',
+      bubbles: true,
+      data: 'a',
+    });
+    const deleteKeyInput = new InputEvent('input', {
+      inputType: 'deleteContentBackward',
+      type: 'input',
+      bubbles: true,
+      data: null,
+    });
+
+    beforeAll(() => {
+      document.body.appendChild(container);
+      new TextInput(document.querySelector('[data-text-input]'));
+      textInput = document.querySelector('[data-text-input] input');
+      charCounter = document.querySelector(
+        `.${prefix}--text-input--character-counter--length`
+      );
+    });
+
+    beforeEach(() => {
+      textInput.value = '';
+    });
+
+    it('Should increment character counter on input value length increase', () => {
+      textInput.value += aKeyInput.data;
+      textInput.dispatchEvent(aKeyInput);
+      expect(textInput.value).toBe('a');
+      expect(charCounter.textContent).toBe('1');
+    });
+
+    it('Should decrement character counter on input value length decrease', () => {
+      textInput.dispatchEvent(deleteKeyInput);
+      expect(textInput.value).toBe('');
+      expect(charCounter.textContent).toBe('0');
     });
 
     afterAll(() => {

--- a/packages/components/tests/spec/text-input_spec.js
+++ b/packages/components/tests/spec/text-input_spec.js
@@ -2,6 +2,7 @@
 import TextInput from '../../src/components/text-input/text-input';
 import PasswordVisibilityHTML from '../../html/text-input/text-input--password.html';
 import flattenOptions from '../utils/flatten-options';
+import { prefix } from '../../src/globals/js/settings';
 
 describe('Test text input', () => {
   describe('Constructor', () => {
@@ -35,11 +36,12 @@ describe('Test text input', () => {
     it('Should set default options', () => {
       expect(flattenOptions(instance.options)).toEqual({
         selectorInit: '[data-text-input]',
-        selectorPasswordField: `.bx--text-input[data-toggle-password-visibility]`,
-        selectorPasswordVisibilityButton: `.bx--text-input--password__visibility`,
-        passwordIsVisible: `bx--text-input--password-visible`,
-        svgIconVisibilityOn: 'svg.bx--icon--visibility-on',
-        svgIconVisibilityOff: 'svg.bx--icon--visibility-off',
+        selectorPasswordField: `.${prefix}--text-input[data-toggle-password-visibility]`,
+        selectorPasswordVisibilityButton: `.${prefix}--text-input--password__visibility`,
+        passwordIsVisible: `${prefix}--text-input--password-visible`,
+        svgIconVisibilityOn: `svg.${prefix}--icon--visibility-on`,
+        svgIconVisibilityOff: `svg.${prefix}--icon--visibility-off`,
+        selectorCharCounter: `.${prefix}--text-input--character-counter--length`,
       });
     });
 
@@ -61,12 +63,12 @@ describe('Test text input', () => {
       new TextInput(document.querySelector('[data-text-input]'));
       textInput = document.querySelector('[data-text-input]');
       passwordVisibilityButton = document.querySelector(
-        '.bx--text-input--password__visibility'
+        `.${prefix}--text-input--password__visibility`
       );
     });
 
     beforeEach(() => {
-      textInput.classList.remove('bx--text-input--password-visible');
+      textInput.classList.remove(`${prefix}--text-input--password-visible`);
     });
 
     it('Should set password visibility state on 2n+1 clicks', () => {
@@ -74,17 +76,17 @@ describe('Test text input', () => {
         new CustomEvent('click', { bubbles: true })
       );
       expect(
-        textInput.classList.contains('bx--text-input--password-visible')
+        textInput.classList.contains(`${prefix}--text-input--password-visible`)
       ).toBe(true);
     });
 
     it('Should remove password visibility state on 2n clicks', () => {
-      textInput.classList.add('bx--text-input--password-visible');
+      textInput.classList.add(`${prefix}--text-input--password-visible`);
       passwordVisibilityButton.dispatchEvent(
         new CustomEvent('click', { bubbles: true })
       );
       expect(
-        textInput.classList.contains('bx--text-input--password-visible')
+        textInput.classList.contains(`${prefix}--text-input--password-visible`)
       ).toBe(false);
     });
 

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -63,12 +63,30 @@ describe('TextArea', () => {
 
       it('should set value as expected', () => {
         wrapper.setProps({ value: 'value set' });
-        expect(textarea().props().value).toEqual('value set');
+        expect(wrapper.props().value).toEqual('value set');
       });
 
       it('should set defaultValue as expected', () => {
         wrapper.setProps({ defaultValue: 'default value' });
         expect(textarea().props().defaultValue).toEqual('default value');
+      });
+
+      it('should count length increases in textarea value', () => {
+        const event = { target: { value: 'z' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textarea().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-area--character-counter`).text()
+        ).toBe('1/10');
+      });
+
+      it('should count length decreases in textarea value', () => {
+        const event = { target: { value: '' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textarea().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-area--character-counter`).text()
+        ).toBe('0/10');
       });
 
       it('should specify light version as expected', () => {

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -210,6 +210,16 @@ TextArea.propTypes = {
    * Specify whether you want the light version of this control
    */
   light: PropTypes.bool,
+
+  /**
+   * Specify whether the character counter is shown
+   */
+  charCount: PropTypes.bool,
+
+  /**
+   * The maximum allowed input value length
+   */
+  maxLength: PropTypes.number,
 };
 
 TextArea.defaultProps = {

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -13,6 +13,26 @@ import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
 
 const { prefix } = settings;
 
+const DefaultCharCounter = ({ disabled, count, maxLength }) => {
+  const charCounterClasses = classNames(
+    `${prefix}--text-area--character-counter`,
+    {
+      [`${prefix}--text-area--character-counter--disabled`]: disabled,
+    }
+  );
+  return (
+    <span className={charCounterClasses}>
+      <span className={`${prefix}--text-area--character-counter--length`}>
+        {count}
+      </span>
+      /
+      <span className={`${prefix}--text-area--character-counter--maxlength`}>
+        {maxLength}
+      </span>
+    </span>
+  );
+};
+
 const TextArea = ({
   className,
   id,
@@ -26,6 +46,7 @@ const TextArea = ({
   light,
   charCount,
   maxLength,
+  renderCharCounter: CharCounter = DefaultCharCounter,
   ...other
 }) => {
   const [textareaVal, setInput] = useState('');
@@ -54,25 +75,6 @@ const TextArea = ({
       {labelText}
     </label>
   ) : null;
-
-  const charCounterClasses = classNames(
-    `${prefix}--text-area--character-counter`,
-    {
-      [`${prefix}--text-area--character-counter--disabled`]: other.disabled,
-    }
-  );
-
-  const charCounter = (
-    <span className={charCounterClasses}>
-      <span className={`${prefix}--text-area--character-counter--length`}>
-        {textareaVal.length}
-      </span>
-      /
-      <span className={`${prefix}--text-area--character-counter--maxlength`}>
-        {maxLength}
-      </span>
-    </span>
-  );
 
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
@@ -111,7 +113,13 @@ const TextArea = ({
   return (
     <div className={`${prefix}--form-item`}>
       {label}
-      {charCount && charCounter}
+      {charCount && (
+        <CharCounter
+          disabled={other.disabled}
+          count={textareaVal.length}
+          maxLength={maxLength}
+        />
+      )}
       {helper}
       <div
         className={`${prefix}--text-area__wrapper`}

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -70,11 +70,26 @@ const TextArea = ({
     [`${prefix}--label--disabled`]: other.disabled,
   });
 
-  const label = labelText ? (
-    <label htmlFor={id} className={labelClasses}>
-      {labelText}
-    </label>
-  ) : null;
+  const label = (() => {
+    const labelContent = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
+    if (charCount) {
+      return (
+        <div className={`${prefix}--text-input__character-counter-title`}>
+          {labelContent}
+          <CharCounter
+            disabled={other.disabled}
+            count={textareaVal.length}
+            maxLength={maxLength}
+          />
+        </div>
+      );
+    }
+    return labelContent;
+  })();
 
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
@@ -113,13 +128,6 @@ const TextArea = ({
   return (
     <div className={`${prefix}--form-item`}>
       {label}
-      {charCount && (
-        <CharCounter
-          disabled={other.disabled}
-          count={textareaVal.length}
-          maxLength={maxLength}
-        />
-      )}
       {helper}
       <div
         className={`${prefix}--text-area__wrapper`}

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
@@ -24,8 +24,11 @@ const TextArea = ({
   invalidText,
   helperText,
   light,
+  charCount,
+  maxLength,
   ...other
 }) => {
+  const [textareaVal, setInput] = useState('');
   const textareaProps = {
     id,
     onChange: evt => {
@@ -38,6 +41,7 @@ const TextArea = ({
         onClick(evt);
       }
     },
+    maxLength: maxLength || null,
   };
 
   const labelClasses = classNames(`${prefix}--label`, {
@@ -50,6 +54,25 @@ const TextArea = ({
       {labelText}
     </label>
   ) : null;
+
+  const charCounterClasses = classNames(
+    `${prefix}--text-area--character-counter`,
+    {
+      [`${prefix}--text-area--character-counter--disabled`]: other.disabled,
+    }
+  );
+
+  const charCounter = (
+    <span className={charCounterClasses}>
+      <span className={`${prefix}--text-area--character-counter--length`}>
+        {textareaVal.length}
+      </span>
+      /
+      <span className={`${prefix}--text-area--character-counter--maxlength`}>
+        {maxLength}
+      </span>
+    </span>
+  );
 
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
@@ -80,12 +103,15 @@ const TextArea = ({
       aria-invalid={invalid || null}
       aria-describedby={invalid ? errorId : null}
       disabled={other.disabled}
+      value={textareaVal}
+      onInput={e => setInput(e.target.value)}
     />
   );
 
   return (
     <div className={`${prefix}--form-item`}>
       {label}
+      {charCount && charCounter}
       {helper}
       <div
         className={`${prefix}--text-area__wrapper`}

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -76,9 +76,9 @@ const TextArea = ({
         {labelText}
       </label>
     ) : null;
-    if (charCount) {
+    if (labelContent && charCount) {
       return (
-        <div className={`${prefix}--text-input__character-counter-title`}>
+        <div className={`${prefix}--text-area__character-counter-title`}>
           {labelContent}
           <CharCounter
             disabled={other.disabled}
@@ -95,9 +95,25 @@ const TextArea = ({
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
 
-  const helper = helperText ? (
-    <div className={helperTextClasses}>{helperText}</div>
-  ) : null;
+  const helper = (() => {
+    const helperContent = helperText ? (
+      <div className={helperTextClasses}>{helperText}</div>
+    ) : null;
+    if (!labelText && charCount) {
+      return (
+        <div className={`${prefix}--text-area__character-counter-title`}>
+          {helperContent}
+          <CharCounter
+            disabled={other.disabled}
+            count={textareaVal.length}
+            maxLength={maxLength}
+          />
+        </div>
+      );
+    }
+
+    return helperContent;
+  })();
 
   const errorId = id + '-error-msg';
 

--- a/packages/react/src/components/TextArea/Textarea-story.js
+++ b/packages/react/src/components/TextArea/Textarea-story.js
@@ -20,6 +20,8 @@ const TextAreaProps = () => ({
   hideLabel: boolean('No label (hideLabel)', false),
   labelText: text('Label text (labelText)', 'Text Area label'),
   invalid: boolean('Show form validation UI (invalid)', false),
+  charCount: boolean('Add character counter (charCount)', false),
+  maxLength: number('Input length limit (maxLength)', 100),
   invalidText: text(
     'Content of form validation UI (invalidText)',
     'A valid value is required'

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -8,7 +8,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  boolean,
+  select,
+  text,
+  number,
+} from '@storybook/addon-knobs';
 import TextInput from '../TextInput';
 import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
 
@@ -54,6 +60,8 @@ const TextInputProps = () => ({
   disabled: boolean('Disabled (disabled)', false),
   hideLabel: boolean('No label (hideLabel)', false),
   invalid: boolean('Show form validation UI (invalid)', false),
+  charCount: boolean('Add character counter (charCount)', false),
+  maxLength: number('Input length limit (maxLength)', 100),
   invalidText: text(
     'Form validation UI content (invalidText)',
     'A valid value is required'

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -25,6 +25,54 @@ const types = {
   'For password (password)': 'password',
 };
 
+const props = {
+  textInput: () => ({
+    className: 'some-class',
+    id: 'test2',
+    defaultValue: text(
+      'Default value (defaultValue)',
+      'This is not a default value'
+    ),
+    labelText: text('Label text (labelText)', 'Text Input label'),
+    placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
+    light: boolean('Light variant (light)', false),
+    disabled: boolean('Disabled (disabled)', false),
+    hideLabel: boolean('No label (hideLabel)', false),
+    invalid: boolean('Show form validation UI (invalid)', false),
+    charCount: boolean('Add character counter (charCount)', false),
+    maxLength: number('Input length limit (maxLength)', 100),
+    invalidText: text(
+      'Form validation UI content (invalidText)',
+      'A valid value is required'
+    ),
+    helperText: text('Helper text (helperText)', 'Optional helper text.'),
+    onClick: action('onClick'),
+    onChange: action('onChange'),
+  }),
+  passwordInput: () => ({
+    className: 'some-class',
+    id: 'test2',
+    defaultValue: text(
+      'Default value (defaultValue)',
+      'This is not a default value'
+    ),
+    labelText: text('Label text (labelText)', 'Text Input label'),
+    placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
+    light: boolean('Light variant (light)', false),
+    disabled: boolean('Disabled (disabled)', false),
+    hideLabel: boolean('No label (hideLabel)', false),
+    invalid: boolean('Show form validation UI (invalid)', false),
+    maxLength: number('Input length limit (maxLength)', 100),
+    invalidText: text(
+      'Form validation UI content (invalidText)',
+      'A valid value is required'
+    ),
+    helperText: text('Helper text (helperText)', 'Optional helper text.'),
+    onClick: action('onClick'),
+    onChange: action('onChange'),
+  }),
+};
+
 class ControlledPasswordInputApp extends React.Component {
   state = {
     type: 'password',
@@ -41,35 +89,11 @@ class ControlledPasswordInputApp extends React.Component {
       <TextInput.ControlledPasswordInput
         type={this.state.type}
         togglePasswordVisibility={this.togglePasswordVisibility}
-        {...TextInputProps()}
+        {...props.passwordInput()}
       />
     );
   }
 }
-
-const TextInputProps = () => ({
-  className: 'some-class',
-  id: 'test2',
-  defaultValue: text(
-    'Default value (defaultValue)',
-    'This is not a default value'
-  ),
-  labelText: text('Label text (labelText)', 'Text Input label'),
-  placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
-  light: boolean('Light variant (light)', false),
-  disabled: boolean('Disabled (disabled)', false),
-  hideLabel: boolean('No label (hideLabel)', false),
-  invalid: boolean('Show form validation UI (invalid)', false),
-  charCount: boolean('Add character counter (charCount)', false),
-  maxLength: number('Input length limit (maxLength)', 100),
-  invalidText: text(
-    'Form validation UI content (invalidText)',
-    'A valid value is required'
-  ),
-  helperText: text('Helper text (helperText)', 'Optional helper text.'),
-  onClick: action('onClick'),
-  onChange: action('onChange'),
-});
 
 storiesOf('TextInput', module)
   .addDecorator(withKnobs)
@@ -78,7 +102,7 @@ storiesOf('TextInput', module)
     () => (
       <TextInput
         type={select('Form control type (type)', types, 'text')}
-        {...TextInputProps()}
+        {...props.textInput()}
       />
     ),
     {
@@ -94,7 +118,7 @@ storiesOf('TextInput', module)
   )
   .add(
     'Toggle password visibility',
-    () => <TextInput.PasswordInput {...TextInputProps()} />,
+    () => <TextInput.PasswordInput {...props.passwordInput()} />,
     {
       info: {
         text: `

--- a/packages/react/src/components/TextInput/TextInput-test.js
+++ b/packages/react/src/components/TextInput/TextInput-test.js
@@ -80,6 +80,24 @@ describe('TextInput', () => {
         expect(textInput().props().defaultValue).toEqual('test');
       });
 
+      it('should count length increases in text input value', () => {
+        const event = { target: { value: 'z' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textInput().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-input--character-counter`).text()
+        ).toBe('1/10');
+      });
+
+      it('should count length decreases in text input value', () => {
+        const event = { target: { value: '' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textInput().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-input--character-counter`).text()
+        ).toBe('0/10');
+      });
+
       it('should set disabled as expected', () => {
         expect(textInput().props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
@@ -29,10 +29,13 @@ const TextInput = React.forwardRef(function TextInput(
     invalidText,
     helperText,
     light,
+    charCount,
+    maxLength,
     ...other
   },
   ref
 ) {
+  const [inputVal, setInput] = useState('');
   const errorId = id + '-error-msg';
   const textInputClasses = classNames(`${prefix}--text-input`, className, {
     [`${prefix}--text-input--light`]: light,
@@ -54,12 +57,19 @@ const TextInput = React.forwardRef(function TextInput(
     type,
     ref,
     className: textInputClasses,
+    maxLength: maxLength || null,
     ...other,
   };
   const labelClasses = classNames(`${prefix}--label`, {
     [`${prefix}--visually-hidden`]: hideLabel,
     [`${prefix}--label--disabled`]: other.disabled,
   });
+  const charCounterClasses = classNames(
+    `${prefix}--text-input--character-counter`,
+    {
+      [`${prefix}--text-input--character-counter--disabled`]: other.disabled,
+    }
+  );
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
@@ -68,13 +78,28 @@ const TextInput = React.forwardRef(function TextInput(
       {labelText}
     </label>
   ) : null;
+  const charCounter = (
+    <span className={charCounterClasses}>
+      <span className={`${prefix}--text-input--character-counter--length`}>
+        {inputVal.length}
+      </span>
+      /
+      <span className={`${prefix}--text-input--character-counter--maxlength`}>
+        {maxLength}
+      </span>
+    </span>
+  );
   const error = invalid ? (
     <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
     </div>
   ) : null;
   const input = (
-    <input {...textInputProps({ invalid, sharedTextInputProps, errorId })} />
+    <input
+      {...textInputProps({ invalid, sharedTextInputProps, errorId })}
+      value={inputVal}
+      onInput={e => setInput(e.target.value)}
+    />
   );
   const helper = helperText ? (
     <div className={helperTextClasses}>{helperText}</div>
@@ -83,6 +108,7 @@ const TextInput = React.forwardRef(function TextInput(
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>
       {label}
+      {charCount && charCounter}
       {helper}
       <div
         className={`${prefix}--text-input__field-wrapper`}

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -87,11 +87,26 @@ const TextInput = React.forwardRef(function TextInput(
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
-  const label = labelText ? (
-    <label htmlFor={id} className={labelClasses}>
-      {labelText}
-    </label>
-  ) : null;
+  const label = (() => {
+    const labelContent = labelText && (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    );
+    if (charCount) {
+      return (
+        <div className={`${prefix}--text-input__character-counter-title`}>
+          {labelContent}
+          <CharCounter
+            disabled={other.disabled}
+            count={inputVal.length}
+            maxLength={maxLength}
+          />
+        </div>
+      );
+    }
+    return labelContent;
+  })();
   const error = invalid ? (
     <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
@@ -111,13 +126,6 @@ const TextInput = React.forwardRef(function TextInput(
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>
       {label}
-      {charCount && (
-        <CharCounter
-          disabled={other.disabled}
-          count={inputVal.length}
-          maxLength={maxLength}
-        />
-      )}
       {helper}
       <div
         className={`${prefix}--text-input__field-wrapper`}

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -15,6 +15,25 @@ import ControlledPasswordInput from './ControlledPasswordInput';
 import { textInputProps } from './util';
 
 const { prefix } = settings;
+const DefaultCharCounter = ({ disabled, count, maxLength }) => {
+  const charCounterClasses = classNames(
+    `${prefix}--text-input--character-counter`,
+    {
+      [`${prefix}--text-input--character-counter--disabled`]: disabled,
+    }
+  );
+  return (
+    <span className={charCounterClasses}>
+      <span className={`${prefix}--text-input--character-counter--length`}>
+        {count}
+      </span>
+      /
+      <span className={`${prefix}--text-input--character-counter--maxlength`}>
+        {maxLength}
+      </span>
+    </span>
+  );
+};
 const TextInput = React.forwardRef(function TextInput(
   {
     labelText,
@@ -30,6 +49,7 @@ const TextInput = React.forwardRef(function TextInput(
     helperText,
     light,
     charCount,
+    renderCharCounter: CharCounter = DefaultCharCounter,
     maxLength,
     ...other
   },
@@ -64,12 +84,6 @@ const TextInput = React.forwardRef(function TextInput(
     [`${prefix}--visually-hidden`]: hideLabel,
     [`${prefix}--label--disabled`]: other.disabled,
   });
-  const charCounterClasses = classNames(
-    `${prefix}--text-input--character-counter`,
-    {
-      [`${prefix}--text-input--character-counter--disabled`]: other.disabled,
-    }
-  );
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
@@ -78,17 +92,6 @@ const TextInput = React.forwardRef(function TextInput(
       {labelText}
     </label>
   ) : null;
-  const charCounter = (
-    <span className={charCounterClasses}>
-      <span className={`${prefix}--text-input--character-counter--length`}>
-        {inputVal.length}
-      </span>
-      /
-      <span className={`${prefix}--text-input--character-counter--maxlength`}>
-        {maxLength}
-      </span>
-    </span>
-  );
   const error = invalid ? (
     <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
@@ -108,7 +111,13 @@ const TextInput = React.forwardRef(function TextInput(
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>
       {label}
-      {charCount && charCounter}
+      {charCount && (
+        <CharCounter
+          disabled={other.disabled}
+          count={inputVal.length}
+          maxLength={maxLength}
+        />
+      )}
       {helper}
       <div
         className={`${prefix}--text-input__field-wrapper`}

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -93,7 +93,7 @@ const TextInput = React.forwardRef(function TextInput(
         {labelText}
       </label>
     );
-    if (charCount) {
+    if (labelContent && charCount) {
       return (
         <div className={`${prefix}--text-input__character-counter-title`}>
           {labelContent}
@@ -119,9 +119,25 @@ const TextInput = React.forwardRef(function TextInput(
       onInput={e => setInput(e.target.value)}
     />
   );
-  const helper = helperText ? (
-    <div className={helperTextClasses}>{helperText}</div>
-  ) : null;
+  const helper = (() => {
+    const helperContent = helperText ? (
+      <div className={helperTextClasses}>{helperText}</div>
+    ) : null;
+    if (!labelText && charCount) {
+      return (
+        <div className={`${prefix}--text-input__character-counter-title`}>
+          {helperContent}
+          <CharCounter
+            disabled={other.disabled}
+            count={inputVal.length}
+            maxLength={maxLength}
+          />
+        </div>
+      );
+    }
+
+    return helperContent;
+  })();
 
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -203,6 +203,16 @@ TextInput.propTypes = {
    * `true` to use the light version.
    */
   light: PropTypes.bool,
+
+  /**
+   * Specify whether the character counter is shown
+   */
+  charCount: PropTypes.bool,
+
+  /**
+   * The maximum allowed input value length
+   */
+  maxLength: PropTypes.number,
 };
 
 TextInput.defaultProps = {


### PR DESCRIPTION
Closes #1672 

This PR adds a character counter for `<TextInput>` and `<TextArea>` components in both React and vanilla Carbon. The character counter markup can be customized with the `renderCharCount` render prop

#### Changelog

**New**

- `<TextInput>` and `<TextArea>` character counter

#### Testing / Reviewing

Ensure the text inputs and textareas function as expected without any regressions (with and without character counters)
