### PR TITLE
refactor(tooltip): avoid magic number positioning

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -186,11 +186,6 @@
     &.#{$prefix}--btn--ghost .#{$prefix}--btn__icon {
       margin: 0;
     }
-
-    &::after {
-      transform: translate(calc(-50% + 8px), calc(100% + 10px));
-      margin: 0;
-    }
   }
 
   .#{$prefix}--btn--danger {

--- a/packages/components/src/components/tooltip/tooltip--icon.hbs
+++ b/packages/components/src/components/tooltip/tooltip--icon.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -7,6 +7,8 @@
 
 @import 'layer';
 
+$tooltip-caret-spacing: rem(8px);
+
 // Tooltip Icon
 // Icon CSS only tooltip
 /// @access public
@@ -32,17 +34,12 @@
   }
 
   &::before {
-    right: 0;
-    left: 0;
     width: 0;
     height: 0;
-    border-width: 0 rem(4px) rem(5px) rem(4px);
+    border-width: 0 rem(4px) rem(5px) rem(4px); // isoceles triangle w/8px width, 5px height bounding box
     border-style: solid;
     border-color: transparent transparent $inverse-02 transparent;
-    margin: 0 auto;
     content: '';
-    margin-top: 1px;
-    margin-left: 50%;
   }
 
   &::after {
@@ -50,7 +47,6 @@
     min-width: rem(24px);
     max-width: rem(208px);
     height: rem(24px);
-    margin-left: 50%;
     padding: 0 1rem;
     border-radius: rem(2px);
     color: $inverse-01;
@@ -75,14 +71,22 @@
 /// @access public
 /// @group tooltip
 @mixin tooltip--icon--top {
+  &::before,
+  &::after {
+    top: 0;
+    left: 50%;
+  }
+
   &::before {
-    top: 1px;
-    transform: translate(-50%, calc(-100% - 9px)) rotate(180deg);
+    transform: translate(-50%, calc(-100% - #{$tooltip-caret-spacing}))
+      rotate(180deg);
   }
 
   &::after {
-    top: 0;
-    transform: translate(-50%, calc(-100% - 12px));
+    transform: translate(
+      -50%,
+      calc(-100% - #{$tooltip-caret-spacing} - 5px)
+    ); // 5px caret height
   }
 }
 
@@ -90,13 +94,20 @@
 /// @access public
 /// @group tooltip
 @mixin tooltip--icon--bottom {
-  &::before {
+  &::before,
+  &::after {
     bottom: 0;
-    transform: translate(-50%, 10px);
+    left: 50%;
+  }
+
+  &::before {
+    transform: translate(-50%, calc(100% + #{$tooltip-caret-spacing}));
   }
 
   &::after {
-    bottom: 0;
-    transform: translate(-50%, calc(100% + 10px));
+    transform: translate(
+      -50%,
+      calc(100% + #{$tooltip-caret-spacing} + 5px)
+    ); // 5px caret height
   }
 }


### PR DESCRIPTION
Closes #2748

This PR avoids relying on magic numbers to position icon tooltips. Similar logic can be applied for left/right positioning tooltips in #2731

#### Changelog

**New**

- tooltip caret spacing token

**Changed**

- tooltip transform/translate rules

**Removed**

- custom positioning in `button.scss`

#### Testing / Reviewing

Ensure that tooltips render as expected
