### PR TITLE
feat(combobox): add itemToElement to render items as custom components

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-story.js
+++ b/packages/react/src/components/ComboBox/ComboBox-story.js
@@ -49,6 +49,16 @@ const props = () => ({
   onChange: action('onChange'),
 });
 
+const itemToElement = item => {
+  const itemAsArray = item.text.split(' ');
+  return (
+    <div>
+      <span>{itemAsArray[0]}</span>
+      <span style={{ color: 'red' }}> {itemAsArray[1]}</span>
+    </div>
+  );
+};
+
 storiesOf('ComboBox', module)
   .addDecorator(withKnobs)
   .add(
@@ -58,6 +68,24 @@ storiesOf('ComboBox', module)
         <ComboBox
           items={items}
           itemToString={item => (item ? item.text : '')}
+          {...props()}
+        />
+      </div>
+    ),
+    {
+      info: {
+        text: 'ComboBox',
+      },
+    }
+  )
+  .add(
+    'items as components',
+    () => (
+      <div style={{ width: 300 }}>
+        <ComboBox
+          items={items}
+          itemToString={item => (item ? item.text : '')}
+          itemToElement={itemToElement}
           {...props()}
         />
       </div>

--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -82,6 +82,16 @@ describe('ComboBox', () => {
     expect(onInputChange).toHaveBeenCalledWith('something');
   });
 
+  it('should render custom item components', () => {
+    const wrapper = mount(<ComboBox {...mockProps} />);
+    wrapper.setProps({
+      itemToElement: item => <div className="mock-item">{item.text}</div>,
+    });
+    openMenu(wrapper);
+
+    expect(wrapper.find(`.mock-item`).length).toBe(mockProps.items.length);
+  });
+
   describe('should display initially selected item found in `initialSelectedItem`', () => {
     it('using an object type for the `initialSelectedItem` prop', () => {
       const wrapper = mount(

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -95,6 +95,12 @@ export default class ComboBox extends React.Component {
     itemToString: PropTypes.func,
 
     /**
+     * Optional function to render items as custom components instead of strings.
+     * Defaults to null and is overriden by a getter
+     */
+    itemToElement: PropTypes.func,
+
+    /**
      * `onChange` is a utility for this controlled component to communicate to a
      * consuming component when a specific dropdown item is selected.
      * @param {{ selectedItem }}
@@ -156,6 +162,7 @@ export default class ComboBox extends React.Component {
   static defaultProps = {
     disabled: false,
     itemToString: defaultItemToString,
+    itemToElement: null,
     shouldFilterItem: defaultShouldFilterItem,
     type: 'default',
     ariaLabel: 'Choose an item',
@@ -229,6 +236,7 @@ export default class ComboBox extends React.Component {
       id,
       items,
       itemToString,
+      itemToElement,
       titleText,
       helperText,
       placeholder,
@@ -261,6 +269,9 @@ export default class ComboBox extends React.Component {
       <div className={helperClasses}>{helperText}</div>
     ) : null;
     const wrapperClasses = cx(`${prefix}--list-box__wrapper`);
+
+    // needs to be Capitalized for react to render it correctly
+    const ItemToElement = itemToElement;
     const input = (
       <Downshift
         {...downshiftProps}
@@ -337,7 +348,11 @@ export default class ComboBox extends React.Component {
                         false
                       }
                       {...getItemProps({ item, index })}>
-                      {itemToString(item)}
+                      {itemToElement ? (
+                        <ItemToElement key={itemToString(item)} {...item} />
+                      ) : (
+                        itemToString(item)
+                      )}
                     </ListBox.MenuItem>
                   )
                 )}


### PR DESCRIPTION
Refs #2527

This adds in `itemToElement` functionality that is present in some other components (`Dropdown`, for example). 

I believe #2527 requires custom elements for both the list and input field of `Combobox`, and this feature only applies to list items, so this doesn't close it out. 

All changes were based off of the `itemToElement` feature of `Dropdown`. 

An example of using components as list items can be found in the storybook under
    
    `Combobox -> items as components`

#### Changelog

**New**

- Adds optional `itemToElement` prop to `<Combobox>`.

#### Testing / Reviewing

Ensure that there are no regressions with `Combobox`. 



