### PR TITLE
refactor(tooltip): avoid magic number positioning

### DIFF
--- a/packages/components/src/components/button/README.md
+++ b/packages/components/src/components/button/README.md
@@ -22,6 +22,8 @@ Use these modifiers with `.bx--btn` class.
 | `.bx--btn--danger`    | Selector for applying danger button styles    |
 | `.bx--btn--sm`        | Selector for applying small button styles     |
 | `.bx--btn—ghost`      | Selector for applying ghost button styles     |
+| `.bx--btn--icon-only` | Selector for applying icon button styles      |
+| `.bx--tooltip--icon`  | Selector for applying icon button styles      |
 
 ### FAQ
 

--- a/packages/components/src/components/button/README.md
+++ b/packages/components/src/components/button/README.md
@@ -23,7 +23,6 @@ Use these modifiers with `.bx--btn` class.
 | `.bx--btn--sm`        | Selector for applying small button styles     |
 | `.bx--btn—ghost`      | Selector for applying ghost button styles     |
 | `.bx--btn--icon-only` | Selector for applying icon button styles      |
-| `.bx--tooltip--icon`  | Selector for applying icon button styles      |
 
 ### FAQ
 

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -163,12 +163,17 @@
     }
   }
 
+  .#{$prefix}--btn--icon-only {
+    @include tooltip--trigger('icon', 'bottom');
+  }
+
   .#{$prefix}--btn--icon-only--top {
     @include tooltip--trigger('icon', 'top');
+    @include tooltip--placement('icon', 'top', 'center');
   }
 
   .#{$prefix}--btn--icon-only--bottom {
-    @include tooltip--trigger('icon', 'bottom');
+    @include tooltip--placement('icon', 'bottom', 'center');
   }
 
   .#{$prefix}--btn--icon-only,

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -163,16 +163,12 @@
     }
   }
 
-  .#{$prefix}--btn--icon-only {
-    @include tooltip--icon;
-  }
-
   .#{$prefix}--btn--icon-only--top {
-    @include tooltip--placement('top');
+    @include tooltip--trigger('icon', 'top');
   }
 
   .#{$prefix}--btn--icon-only--bottom {
-    @include tooltip--placement('bottom');
+    @include tooltip--trigger('icon', 'bottom');
   }
 
   .#{$prefix}--btn--icon-only,

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -186,11 +186,6 @@
     &.#{$prefix}--btn--ghost .#{$prefix}--btn__icon {
       margin: 0;
     }
-
-    &::after {
-      transform: translate(calc(-50% + 8px), calc(100% + 10px));
-      margin: 0;
-    }
   }
 
   .#{$prefix}--btn--danger {

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -168,11 +168,11 @@
   }
 
   .#{$prefix}--btn--icon-only--top {
-    @include tooltip--icon-placement('top');
+    @include tooltip--placement('top');
   }
 
   .#{$prefix}--btn--icon-only--bottom {
-    @include tooltip--icon-placement('bottom');
+    @include tooltip--placement('bottom');
   }
 
   .#{$prefix}--btn--icon-only,

--- a/packages/components/src/components/button/button.hbs
+++ b/packages/components/src/components/button/button.hbs
@@ -25,7 +25,7 @@
 </button>
 {{#if hasIconOnly}}
 <button
-  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}} {{@root.prefix}}--btn--icon-only {{@root.prefix}}--btn--icon-only--bottom {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}} {{@root.prefix}}--btn--icon-only {{@root.prefix}}--tooltip--icon {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   aria-label="Add">
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
 </button>

--- a/packages/components/src/components/button/button.hbs
+++ b/packages/components/src/components/button/button.hbs
@@ -25,7 +25,7 @@
 </button>
 {{#if hasIconOnly}}
 <button
-  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}} {{@root.prefix}}--btn--icon-only {{@root.prefix}}--tooltip--icon {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
+  class="{{@root.prefix}}--btn {{@root.prefix}}--btn--{{variant}} {{@root.prefix}}--btn--icon-only {{@root.prefix}}--btn--icon-only--bottom {{#if small}} {{@root.prefix}}--btn--sm{{/if}}"
   aria-label="Add">
   {{ carbon-icon 'Add16' class=(add @root.prefix '--btn__icon') }}
 </button>

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -13,6 +13,7 @@
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+@import '../../globals/scss/tooltip';
 @import '../form/form';
 
 /// Text input styles

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -99,6 +99,8 @@
     }
 
     .#{$prefix}--text-input--password__visibility {
+      @include tooltip--trigger('icon', 'bottom');
+      @include tooltip--placement('icon', 'bottom', 'center');
       position: absolute;
       height: rem(16px);
       width: rem(16px);

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -29,7 +29,7 @@
       placeholder="Placeholder text" data-toggle-password-visibility{{#if charCounter}} maxlength="{{maxLength}}"
       {{/if}}>
     <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
+      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
@@ -63,7 +63,7 @@
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility>
     <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
+      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
@@ -102,7 +102,7 @@
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility>
     <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
+      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
@@ -139,7 +139,7 @@
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility>
     <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
+      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
@@ -175,7 +175,7 @@
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility disabled>
     <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
+      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -28,9 +28,7 @@
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" data-toggle-password-visibility{{#if charCounter}} maxlength="{{maxLength}}"
       {{/if}}>
-    <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
-      aria-label="Show password">
+    <button class="{{prefix}}--text-input--password__visibility" aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
     </button>
@@ -62,9 +60,7 @@
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility>
-    <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
-      aria-label="Show password">
+    <button class="{{prefix}}--text-input--password__visibility" aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
     </button>
@@ -101,9 +97,7 @@
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility>
-    <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
-      aria-label="Show password">
+    <button class="{{prefix}}--text-input--password__visibility" aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
     </button>
@@ -138,9 +132,7 @@
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility>
-    <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
-      aria-label="Show password">
+    <button class="{{prefix}}--text-input--password__visibility" aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
     </button>
@@ -174,9 +166,7 @@
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
       data-toggle-password-visibility disabled>
-    <button
-      class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--bottom"
-      aria-label="Show password">
+    <button class="{{prefix}}--text-input--password__visibility" aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
       {{ carbon-icon 'View16' class=(add prefix '--icon--visibility-on') }}
     </button>

--- a/packages/components/src/components/tooltip/README.md
+++ b/packages/components/src/components/tooltip/README.md
@@ -170,10 +170,12 @@ does not use any JavaScript. No label should be added to this variation. If
 there are actions a user can take in the tooltip (e.g. a link or a button), use
 interactive tooltip.
 
-| Selector               | Description                                           |
-| ---------------------- | ----------------------------------------------------- |
-| `.bx--tooltip--top`    | A simple tooltip that is displayed above the trigger. |
-| `.bx--tooltip--bottom` | A simple tooltip that is displayed below the trigger. |
+| Selector               | Description                                                     |
+| ---------------------- | --------------------------------------------------------------- |
+| `.bx--tooltip--top`    | A simple tooltip that is displayed above the trigger.           |
+| `.bx--tooltip--right`  | A simple tooltip that is displayed to the right of the trigger. |
+| `.bx--tooltip--bottom` | A simple tooltip that is displayed below the trigger.           |
+| `.bx--tooltip--left`   | A simple tooltip that is displayed to the left of the trigger.  |
 
 ### Links & Resources
 

--- a/packages/components/src/components/tooltip/README.md
+++ b/packages/components/src/components/tooltip/README.md
@@ -170,10 +170,10 @@ does not use any JavaScript. No label should be added to this variation. If
 there are actions a user can take in the tooltip (e.g. a link or a button), use
 interactive tooltip.
 
-| Selector                     | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
-| `.bx--tooltip--icon__top`    | A simple tooltip that is displayed above the trigger. |
-| `.bx--tooltip--icon__bottom` | A simple tooltip that is displayed below the trigger. |
+| Selector               | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `.bx--tooltip--top`    | A simple tooltip that is displayed above the trigger. |
+| `.bx--tooltip--bottom` | A simple tooltip that is displayed below the trigger. |
 
 ### Links & Resources
 

--- a/packages/components/src/components/tooltip/README.md
+++ b/packages/components/src/components/tooltip/README.md
@@ -158,10 +158,10 @@ interactive tooltip can be repetitive when it’s shown several times on a page.
 Definition tooltip does not use any JavaScript. If there are actions a user can
 take in the tooltip (e.g. a link or a button), use interactive tooltip.
 
-| Selector                           | Description                                           |
-| ---------------------------------- | ----------------------------------------------------- |
-| `.bx--tooltip--definition__top`    | A simple tooltip that is displayed above the trigger. |
-| `.bx--tooltip--definition__bottom` | A simple tooltip that is displayed below the trigger. |
+| Selector               | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `.bx--tooltip--top`    | A simple tooltip that is displayed above the trigger. |
+| `.bx--tooltip--bottom` | A simple tooltip that is displayed below the trigger. |
 
 ### Icon tooltip
 

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -156,10 +156,14 @@
 
   .#{$prefix}--tooltip--definition {
     .#{$prefix}--tooltip--top {
-      @include tooltip--trigger('definition', 'top');
+      @include tooltip--trigger('definition', 'top', 'start');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('definition', 'top', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('definition', 'top', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -168,10 +172,14 @@
     }
 
     .#{$prefix}--tooltip--right {
-      @include tooltip--trigger('definition', 'right');
+      @include tooltip--trigger('definition', 'right', 'start');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('definition', 'right', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('definition', 'right', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -180,10 +188,14 @@
     }
 
     .#{$prefix}--tooltip--bottom {
-      @include tooltip--trigger('definition', 'bottom');
+      @include tooltip--trigger('definition', 'bottom', 'start');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('definition', 'bottom', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('definition', 'bottom', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -192,10 +204,14 @@
     }
 
     .#{$prefix}--tooltip--left {
-      @include tooltip--trigger('definition', 'left');
+      @include tooltip--trigger('definition', 'left', 'start');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('definition', 'left', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('definition', 'left', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -225,10 +241,14 @@
 
   .#{$prefix}--tooltip--icon {
     .#{$prefix}--tooltip--top {
-      @include tooltip--trigger('icon', 'top');
+      @include tooltip--trigger('icon', 'top', 'center');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('icon', 'top', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('icon', 'top', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -237,10 +257,14 @@
     }
 
     .#{$prefix}--tooltip--right {
-      @include tooltip--trigger('icon', 'right');
+      @include tooltip--trigger('icon', 'right', 'center');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('icon', 'right', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('icon', 'right', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -249,10 +273,14 @@
     }
 
     .#{$prefix}--tooltip--bottom {
-      @include tooltip--trigger('icon', 'bottom');
+      @include tooltip--trigger('icon', 'bottom', 'center');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('icon', 'bottom', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('icon', 'bottom', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
@@ -261,10 +289,14 @@
     }
 
     .#{$prefix}--tooltip--left {
-      @include tooltip--trigger('icon', 'left');
+      @include tooltip--trigger('icon', 'left', 'center');
 
       &.#{$prefix}--tooltip--align-start {
         @include tooltip--trigger('icon', 'left', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-center {
+        @include tooltip--trigger('icon', 'left', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -12,15 +12,302 @@
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
 
-/// Tooltip styles
+// TODO: deprecate legacy tooltip mixins
+// Tooltip Icon
+// Icon CSS only tooltip
 /// @access private
+/// @deprecated
 /// @group tooltip
-@mixin tooltip {
+@mixin tooltip--icon {
+  @include reset;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  overflow: visible;
+
+  // Tooltip - renders as a combo of ::before and ::after elements
+  &::before,
+  &::after {
+    @include type-style('body-short-01');
+    position: absolute;
+    display: flex;
+    align-items: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity $duration--fast-01 motion(standard, productive);
+  }
+
+  &::before {
+    right: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-width: 0 rem(4px) rem(5px) rem(4px);
+    border-style: solid;
+    border-color: transparent transparent $inverse-02 transparent;
+    margin: 0 auto;
+    content: '';
+    margin-top: 1px;
+    margin-left: 50%;
+  }
+
+  &::after {
+    @include layer('overlay');
+    min-width: rem(24px);
+    max-width: rem(208px);
+    height: rem(24px);
+    margin-left: 50%;
+    padding: 0 1rem;
+    border-radius: rem(2px);
+    color: $inverse-01;
+    font-weight: 400;
+    content: attr(aria-label);
+    transform: translateX(-50%);
+    white-space: nowrap;
+    pointer-events: none;
+    background-color: $inverse-02;
+  }
+
+  &:hover,
+  &:focus {
+    &::before,
+    &::after {
+      opacity: 1;
+    }
+  }
+}
+
+// Tooltip Icon caret - top position
+/// @param {String} $position ['bottom'] - The position, from: `top`, `bottom`
+/// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
+/// @access private
+/// @deprecated
+/// @group tooltip
+@mixin tooltip--icon-placement($position: 'bottom', $align: 'center') {
+  $translate-x: if($align == 'center', -50%, 0);
+  $translate-y-caret: if($position == 'top', calc(-100% - 9px), 10px);
+  $translate-y-body: if(
+    $position == 'top',
+    calc(-100% - 12px),
+    calc(100% + 10px)
+  );
+  $rotate-caret: if($position == 'top', 180deg, 0);
+
+  &::before {
+    @if ($position == 'top') {
+      top: 1px;
+    } @else {
+      bottom: 0;
+    }
+    @if ($align == 'start') {
+      margin-left: 4px;
+    } @else if ($align == 'end') {
+      margin-right: 4px;
+      left: auto;
+      right: 0;
+    }
+    transform: translate($translate-x, $translate-y-caret) rotate($rotate-caret);
+  }
+
+  &::after {
+    @if ($position == 'top') {
+      top: 0;
+    } @else {
+      bottom: 0;
+    }
+    @if ($align != 'center') {
+      margin-left: 0;
+    }
+    @if ($align == 'end') {
+      right: 0;
+    }
+    transform: translate($translate-x, $translate-y-body);
+  }
+}
+
+// legacy definition tooltip mixin
+/// @access private
+/// @deprecated
+/// @group tooltip
+@mixin tooltip--definition--legacy {
+  .#{$prefix}--tooltip--definition {
+    @include reset;
+    position: relative;
+
+    .#{$prefix}--tooltip__trigger {
+      @include type-style('label-01');
+      display: inline-flex;
+      position: relative;
+      border-bottom: 1px dotted $interactive-01;
+      color: $text-01;
+
+      &:hover {
+        cursor: pointer;
+
+        + .#{$prefix}--tooltip--definition__top,
+        + .#{$prefix}--tooltip--definition__bottom {
+          display: block;
+        }
+      }
+
+      &:focus {
+        @include focus-outline('border');
+
+        + .#{$prefix}--tooltip--definition__top,
+        + .#{$prefix}--tooltip--definition__bottom {
+          display: block;
+        }
+      }
+    }
+  }
+
+  .#{$prefix}--tooltip--definition__bottom,
+  .#{$prefix}--tooltip--definition__top {
+    @include layer('overlay');
+    position: absolute;
+    z-index: 1;
+    display: none;
+    background: $inverse-02;
+    width: rem(208px);
+    margin-top: $carbon--spacing-04;
+    padding: $carbon--spacing-03 $carbon--spacing-05;
+    border-radius: rem(2px);
+    pointer-events: none;
+    cursor: pointer;
+
+    p {
+      @include type-style('body-short-01');
+      color: $inverse-01;
+    }
+
+    .#{$prefix}--tooltip__caret {
+      position: absolute;
+      right: 0;
+      left: 0;
+      width: 0.6rem;
+      height: 0.6rem;
+      background: $inverse-02;
+      margin-left: $carbon--spacing-05;
+    }
+  }
+
+  // Tooltip Definition caret - bottom position
+  .#{$prefix}--tooltip--definition__bottom .#{$prefix}--tooltip__caret {
+    top: -0.2rem;
+    transform: rotate(-135deg);
+  }
+
+  // Tooltip Definition caret - top position
+  .#{$prefix}--tooltip--definition__top {
+    transform: translateY(-100%);
+    margin-top: rem(-32px);
+
+    .#{$prefix}--tooltip__caret {
+      bottom: -0.2rem;
+      transform: rotate(45deg);
+    }
+  }
+
+  .#{$prefix}--tooltip--definition__align-end {
+    right: 0;
+  }
+
+  .#{$prefix}--tooltip--definition__align-center {
+    margin-left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .#{$prefix}--tooltip--definition__top.#{$prefix}--tooltip--definition__align-center {
+    margin-left: 50%;
+    transform: translate(-50%, -100%);
+  }
+
+  .#{$prefix}--tooltip--definition__align-center .#{$prefix}--tooltip__caret {
+    left: auto;
+    margin-left: auto;
+    // Adjust by the half of the diagonal of the caret, which sizes 0.6rem
+    margin-right: calc(50% - 6px);
+  }
+
+  .#{$prefix}--tooltip--definition__align-end .#{$prefix}--tooltip__caret {
+    left: auto;
+    margin-left: auto;
+    margin-right: rem(16px);
+  }
+}
+
+// legacy icon tooltip mixin
+/// @access private
+/// @deprecated
+/// @group tooltip
+@mixin tooltip--icon--legacy {
+  // Icon CSS only tooltip
   .#{$prefix}--tooltip--icon {
     display: inline-flex;
     align-items: center;
   }
 
+  .#{$prefix}--tooltip--icon__top,
+  .#{$prefix}--tooltip--icon__bottom {
+    @include tooltip--icon;
+
+    &:hover,
+    &:focus {
+      svg {
+        fill: $icon-02;
+      }
+    }
+
+    &:focus {
+      outline: 1px solid transparent;
+
+      svg {
+        @include focus-outline('border');
+      }
+    }
+  }
+
+  // Tooltip Icon caret - top position
+  .#{$prefix}--tooltip--icon__top {
+    @include tooltip--icon-placement('top');
+  }
+
+  // Tooltip Icon caret - bottom position
+  .#{$prefix}--tooltip--icon__bottom {
+    @include tooltip--icon-placement('bottom');
+  }
+
+  // Tooltip Icon caret - top position, left alignment
+  .#{$prefix}--tooltip--icon__top.#{$prefix}--tooltip--icon__align-start {
+    @include tooltip--icon-placement('top', 'start');
+  }
+
+  // Tooltip Icon caret - top position, right alignment
+  .#{$prefix}--tooltip--icon__top.#{$prefix}--tooltip--icon__align-end {
+    @include tooltip--icon-placement('top', 'end');
+  }
+
+  // Tooltip Icon caret - bottom position, left alignment
+  .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-start {
+    @include tooltip--icon-placement('bottom', 'start');
+  }
+
+  // Tooltip Icon caret - bottom position, right alignment
+  .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-end {
+    @include tooltip--icon-placement('bottom', 'end');
+  }
+
+  // Tooltip position - icon only
+  .#{$prefix}--tooltip--icon .#{$prefix}--tooltip__trigger svg {
+    margin-left: 0;
+  }
+}
+
+/// Tooltip styles
+/// @access private
+/// @group tooltip
+@mixin tooltip {
   .#{$prefix}--tooltip__label {
     @include type-style('label-01');
     display: inline-flex;
@@ -148,178 +435,132 @@
   }
 
   // Tooltip Definition
+  /* begin legacy definition tooltip TODO: deprecate */
+  @include tooltip--definition--legacy;
+  /* end legacy definition tooltip */
+
   // Definition CSS only tooltip
-  .#{$prefix}--tooltip--definition .#{$prefix}--tooltip__trigger {
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition {
     @include type-style('label-01');
     border-bottom: rem(1px) dotted $interactive-01;
   }
 
-  .#{$prefix}--tooltip--definition {
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition.#{$prefix}--tooltip--top {
+    @include tooltip--trigger('definition', 'top');
+    @include tooltip--placement('definition', 'top', 'start');
+
+    &.#{$prefix}--tooltip--align-start {
+      @include tooltip--placement('definition', 'top', 'start');
+    }
+
+    &.#{$prefix}--tooltip--align-center {
+      @include tooltip--placement('definition', 'top', 'center');
+    }
+
+    &.#{$prefix}--tooltip--align-end {
+      @include tooltip--placement('definition', 'top', 'end');
+    }
+  }
+
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition.#{$prefix}--tooltip--bottom {
+    @include tooltip--trigger('definition', 'bottom');
     @include tooltip--placement('definition', 'bottom', 'start');
 
-    .#{$prefix}--tooltip--top {
-      @include tooltip--trigger('definition', 'top');
-      @include tooltip--placement('definition', 'top', 'start');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('definition', 'top', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('definition', 'top', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('definition', 'top', 'end');
-      }
-    }
-
-    .#{$prefix}--tooltip--right {
-      @include tooltip--trigger('definition', 'right');
-      @include tooltip--placement('definition', 'right', 'start');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('definition', 'right', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('definition', 'right', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('definition', 'right', 'end');
-      }
-    }
-
-    .#{$prefix}--tooltip--bottom {
-      @include tooltip--trigger('definition', 'bottom');
+    &.#{$prefix}--tooltip--align-start {
       @include tooltip--placement('definition', 'bottom', 'start');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('definition', 'bottom', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('definition', 'bottom', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('definition', 'bottom', 'end');
-      }
     }
 
-    .#{$prefix}--tooltip--left {
-      @include tooltip--trigger('definition', 'left');
-      @include tooltip--placement('definition', 'left', 'start');
+    &.#{$prefix}--tooltip--align-center {
+      @include tooltip--placement('definition', 'bottom', 'center');
+    }
 
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('definition', 'left', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('definition', 'left', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('definition', 'left', 'end');
-      }
+    &.#{$prefix}--tooltip--align-end {
+      @include tooltip--placement('definition', 'bottom', 'end');
     }
   }
 
   // Tooltip Icon
+
+  /* begin tooltip icon (TODO: deprecate) */
+  @include tooltip--icon--legacy;
+  /* end legacy tooltip icon */
+
   // Icon CSS only tooltip
-  .#{$prefix}--tooltip--icon .#{$prefix}--tooltip__trigger {
+  .#{$prefix}--tooltip__trigger {
     &:hover,
     &:focus {
       svg {
         fill: $icon-02;
       }
     }
+  }
 
-    &:focus {
-      outline: 1px solid transparent;
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip--top {
+    @include tooltip--trigger('icon', 'top');
+    @include tooltip--placement('icon', 'top', 'center');
 
-      svg {
-        @include focus-outline('border');
-      }
+    &.#{$prefix}--tooltip--align-start {
+      @include tooltip--placement('icon', 'top', 'start');
+    }
+
+    &.#{$prefix}--tooltip--align-center {
+      @include tooltip--placement('icon', 'top', 'center');
+    }
+
+    &.#{$prefix}--tooltip--align-end {
+      @include tooltip--placement('icon', 'top', 'end');
     }
   }
 
-  .#{$prefix}--tooltip--icon {
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip--right {
+    @include tooltip--trigger('icon', 'right');
+    @include tooltip--placement('icon', 'right', 'center');
+
+    &.#{$prefix}--tooltip--align-start {
+      @include tooltip--placement('icon', 'right', 'start');
+    }
+
+    &.#{$prefix}--tooltip--align-center {
+      @include tooltip--placement('icon', 'right', 'center');
+    }
+
+    &.#{$prefix}--tooltip--align-end {
+      @include tooltip--placement('icon', 'right', 'end');
+    }
+  }
+
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip--bottom {
+    @include tooltip--trigger('icon', 'bottom');
     @include tooltip--placement('icon', 'bottom', 'center');
 
-    .#{$prefix}--tooltip--top {
-      @include tooltip--trigger('icon', 'top');
-      @include tooltip--placement('icon', 'top', 'center');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('icon', 'top', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('icon', 'top', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('icon', 'top', 'end');
-      }
+    &.#{$prefix}--tooltip--align-start {
+      @include tooltip--placement('icon', 'bottom', 'start');
     }
 
-    .#{$prefix}--tooltip--right {
-      @include tooltip--trigger('icon', 'right');
-      @include tooltip--placement('icon', 'right', 'center');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('icon', 'right', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('icon', 'right', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('icon', 'right', 'end');
-      }
-    }
-
-    .#{$prefix}--tooltip--bottom {
-      @include tooltip--trigger('icon', 'bottom');
+    &.#{$prefix}--tooltip--align-center {
       @include tooltip--placement('icon', 'bottom', 'center');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('icon', 'bottom', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('icon', 'bottom', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('icon', 'bottom', 'end');
-      }
     }
 
-    .#{$prefix}--tooltip--left {
-      @include tooltip--trigger('icon', 'left');
-      @include tooltip--placement('icon', 'left', 'center');
-
-      &.#{$prefix}--tooltip--align-start {
-        @include tooltip--placement('icon', 'left', 'start');
-      }
-
-      &.#{$prefix}--tooltip--align-center {
-        @include tooltip--placement('icon', 'left', 'center');
-      }
-
-      &.#{$prefix}--tooltip--align-end {
-        @include tooltip--placement('icon', 'left', 'end');
-      }
+    &.#{$prefix}--tooltip--align-end {
+      @include tooltip--placement('icon', 'bottom', 'end');
     }
   }
 
-  // Tooltip position - icon only
-  .#{$prefix}--tooltip--icon .#{$prefix}--tooltip__trigger svg {
-    margin-left: 0;
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip--left {
+    @include tooltip--trigger('icon', 'left');
+    @include tooltip--placement('icon', 'left', 'center');
+
+    &.#{$prefix}--tooltip--align-start {
+      @include tooltip--placement('icon', 'left', 'start');
+    }
+
+    &.#{$prefix}--tooltip--align-center {
+      @include tooltip--placement('icon', 'left', 'center');
+    }
+
+    &.#{$prefix}--tooltip--align-end {
+      @include tooltip--placement('icon', 'left', 'end');
+    }
   }
 }
 

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -155,67 +155,73 @@
   }
 
   .#{$prefix}--tooltip--definition {
+    @include tooltip--placement('definition', 'bottom', 'start');
+
     .#{$prefix}--tooltip--top {
-      @include tooltip--trigger('definition', 'top', 'start');
+      @include tooltip--trigger('definition', 'top');
+      @include tooltip--placement('definition', 'top', 'start');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('definition', 'top', 'start');
+        @include tooltip--placement('definition', 'top', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('definition', 'top', 'center');
+        @include tooltip--placement('definition', 'top', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('definition', 'top', 'end');
+        @include tooltip--placement('definition', 'top', 'end');
       }
     }
 
     .#{$prefix}--tooltip--right {
-      @include tooltip--trigger('definition', 'right', 'start');
+      @include tooltip--trigger('definition', 'right');
+      @include tooltip--placement('definition', 'right', 'start');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('definition', 'right', 'start');
+        @include tooltip--placement('definition', 'right', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('definition', 'right', 'center');
+        @include tooltip--placement('definition', 'right', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('definition', 'right', 'end');
+        @include tooltip--placement('definition', 'right', 'end');
       }
     }
 
     .#{$prefix}--tooltip--bottom {
-      @include tooltip--trigger('definition', 'bottom', 'start');
+      @include tooltip--trigger('definition', 'bottom');
+      @include tooltip--placement('definition', 'bottom', 'start');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('definition', 'bottom', 'start');
+        @include tooltip--placement('definition', 'bottom', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('definition', 'bottom', 'center');
+        @include tooltip--placement('definition', 'bottom', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('definition', 'bottom', 'end');
+        @include tooltip--placement('definition', 'bottom', 'end');
       }
     }
 
     .#{$prefix}--tooltip--left {
-      @include tooltip--trigger('definition', 'left', 'start');
+      @include tooltip--trigger('definition', 'left');
+      @include tooltip--placement('definition', 'left', 'start');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('definition', 'left', 'start');
+        @include tooltip--placement('definition', 'left', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('definition', 'left', 'center');
+        @include tooltip--placement('definition', 'left', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('definition', 'left', 'end');
+        @include tooltip--placement('definition', 'left', 'end');
       }
     }
   }
@@ -240,67 +246,73 @@
   }
 
   .#{$prefix}--tooltip--icon {
+    @include tooltip--placement('icon', 'bottom', 'center');
+
     .#{$prefix}--tooltip--top {
-      @include tooltip--trigger('icon', 'top', 'center');
+      @include tooltip--trigger('icon', 'top');
+      @include tooltip--placement('icon', 'top', 'center');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('icon', 'top', 'start');
+        @include tooltip--placement('icon', 'top', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('icon', 'top', 'center');
+        @include tooltip--placement('icon', 'top', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('icon', 'top', 'end');
+        @include tooltip--placement('icon', 'top', 'end');
       }
     }
 
     .#{$prefix}--tooltip--right {
-      @include tooltip--trigger('icon', 'right', 'center');
+      @include tooltip--trigger('icon', 'right');
+      @include tooltip--placement('icon', 'right', 'center');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('icon', 'right', 'start');
+        @include tooltip--placement('icon', 'right', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('icon', 'right', 'center');
+        @include tooltip--placement('icon', 'right', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('icon', 'right', 'end');
+        @include tooltip--placement('icon', 'right', 'end');
       }
     }
 
     .#{$prefix}--tooltip--bottom {
-      @include tooltip--trigger('icon', 'bottom', 'center');
+      @include tooltip--trigger('icon', 'bottom');
+      @include tooltip--placement('icon', 'bottom', 'center');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('icon', 'bottom', 'start');
+        @include tooltip--placement('icon', 'bottom', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('icon', 'bottom', 'center');
+        @include tooltip--placement('icon', 'bottom', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('icon', 'bottom', 'end');
+        @include tooltip--placement('icon', 'bottom', 'end');
       }
     }
 
     .#{$prefix}--tooltip--left {
-      @include tooltip--trigger('icon', 'left', 'center');
+      @include tooltip--trigger('icon', 'left');
+      @include tooltip--placement('icon', 'left', 'center');
 
       &.#{$prefix}--tooltip--align-start {
-        @include tooltip--trigger('icon', 'left', 'start');
+        @include tooltip--placement('icon', 'left', 'start');
       }
 
       &.#{$prefix}--tooltip--align-center {
-        @include tooltip--trigger('icon', 'left', 'center');
+        @include tooltip--placement('icon', 'left', 'center');
       }
 
       &.#{$prefix}--tooltip--align-end {
-        @include tooltip--trigger('icon', 'left', 'end');
+        @include tooltip--placement('icon', 'left', 'end');
       }
     }
   }

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -256,10 +256,10 @@
 
   // Tooltip Icon
   // Icon CSS only tooltip
-  .#{$prefix}--tooltip--icon__top,
-  .#{$prefix}--tooltip--icon__right,
-  .#{$prefix}--tooltip--icon__bottom,
-  .#{$prefix}--tooltip--icon__left {
+  .#{$prefix}--tooltip--top,
+  .#{$prefix}--tooltip--right,
+  .#{$prefix}--tooltip--bottom,
+  .#{$prefix}--tooltip--left {
     @include tooltip--icon;
 
     &:hover,
@@ -279,62 +279,62 @@
   }
 
   // Tooltip Icon caret - top position
-  .#{$prefix}--tooltip--icon__top {
+  .#{$prefix}--tooltip--top {
     @include tooltip--placement('top');
   }
 
   // Tooltip Icon caret - right position
-  .#{$prefix}--tooltip--icon__right {
+  .#{$prefix}--tooltip--right {
     @include tooltip--placement('right');
   }
 
   // Tooltip Icon caret - bottom position
-  .#{$prefix}--tooltip--icon__bottom {
+  .#{$prefix}--tooltip--bottom {
     @include tooltip--placement('bottom');
   }
 
   // Tooltip Icon caret - left position
-  .#{$prefix}--tooltip--icon__left {
+  .#{$prefix}--tooltip--left {
     @include tooltip--placement('left');
   }
 
   // Tooltip Icon caret - top position, left alignment
-  .#{$prefix}--tooltip--icon__top.#{$prefix}--tooltip--icon__align-start {
+  .#{$prefix}--tooltip--top.#{$prefix}--tooltip--align-start {
     @include tooltip--placement('top', 'start');
   }
 
   // Tooltip Icon caret - top position, right alignment
-  .#{$prefix}--tooltip--icon__top.#{$prefix}--tooltip--icon__align-end {
+  .#{$prefix}--tooltip--top.#{$prefix}--tooltip--align-end {
     @include tooltip--placement('top', 'end');
   }
 
   // Tooltip Icon caret - right position, left alignment
-  .#{$prefix}--tooltip--icon__right.#{$prefix}--tooltip--icon__align-start {
+  .#{$prefix}--tooltip--right.#{$prefix}--tooltip--align-start {
     @include tooltip--placement('right', 'start');
   }
 
   // Tooltip Icon caret - right position, right alignment
-  .#{$prefix}--tooltip--icon__right.#{$prefix}--tooltip--icon__align-end {
+  .#{$prefix}--tooltip--right.#{$prefix}--tooltip--align-end {
     @include tooltip--placement('right', 'end');
   }
 
   // Tooltip Icon caret - bottom position, left alignment
-  .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-start {
+  .#{$prefix}--tooltip--bottom.#{$prefix}--tooltip--align-start {
     @include tooltip--placement('bottom', 'start');
   }
 
   // Tooltip Icon caret - bottom position, right alignment
-  .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-end {
+  .#{$prefix}--tooltip--bottom.#{$prefix}--tooltip--align-end {
     @include tooltip--placement('bottom', 'end');
   }
 
   // Tooltip Icon caret - left position, left alignment
-  .#{$prefix}--tooltip--icon__left.#{$prefix}--tooltip--icon__align-start {
+  .#{$prefix}--tooltip--left.#{$prefix}--tooltip--align-start {
     @include tooltip--placement('left', 'start');
   }
 
   // Tooltip Icon caret - left position, right alignment
-  .#{$prefix}--tooltip--icon__left.#{$prefix}--tooltip--icon__align-end {
+  .#{$prefix}--tooltip--left.#{$prefix}--tooltip--align-end {
     @include tooltip--placement('left', 'end');
   }
 

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -257,7 +257,9 @@
   // Tooltip Icon
   // Icon CSS only tooltip
   .#{$prefix}--tooltip--icon__top,
-  .#{$prefix}--tooltip--icon__bottom {
+  .#{$prefix}--tooltip--icon__right,
+  .#{$prefix}--tooltip--icon__bottom,
+  .#{$prefix}--tooltip--icon__left {
     @include tooltip--icon;
 
     &:hover,
@@ -281,9 +283,19 @@
     @include tooltip--icon-placement('top');
   }
 
+  // Tooltip Icon caret - right position
+  .#{$prefix}--tooltip--icon__right {
+    @include tooltip--icon-placement('right');
+  }
+
   // Tooltip Icon caret - bottom position
   .#{$prefix}--tooltip--icon__bottom {
     @include tooltip--icon-placement('bottom');
+  }
+
+  // Tooltip Icon caret - left position
+  .#{$prefix}--tooltip--icon__left {
+    @include tooltip--icon-placement('left');
   }
 
   // Tooltip Icon caret - top position, left alignment
@@ -296,6 +308,16 @@
     @include tooltip--icon-placement('top', 'end');
   }
 
+  // Tooltip Icon caret - right position, left alignment
+  .#{$prefix}--tooltip--icon__right.#{$prefix}--tooltip--icon__align-start {
+    @include tooltip--icon-placement('right', 'start');
+  }
+
+  // Tooltip Icon caret - right position, right alignment
+  .#{$prefix}--tooltip--icon__right.#{$prefix}--tooltip--icon__align-end {
+    @include tooltip--icon-placement('right', 'end');
+  }
+
   // Tooltip Icon caret - bottom position, left alignment
   .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-start {
     @include tooltip--icon-placement('bottom', 'start');
@@ -304,6 +326,16 @@
   // Tooltip Icon caret - bottom position, right alignment
   .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-end {
     @include tooltip--icon-placement('bottom', 'end');
+  }
+
+  // Tooltip Icon caret - left position, left alignment
+  .#{$prefix}--tooltip--icon__left.#{$prefix}--tooltip--icon__align-start {
+    @include tooltip--icon-placement('left', 'start');
+  }
+
+  // Tooltip Icon caret - left position, right alignment
+  .#{$prefix}--tooltip--icon__left.#{$prefix}--tooltip--icon__align-end {
+    @include tooltip--icon-placement('left', 'end');
   }
 
   // Tooltip position - icon only

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -149,119 +149,64 @@
 
   // Tooltip Definition
   // Definition CSS only tooltip
+  .#{$prefix}--tooltip--definition .#{$prefix}--tooltip__trigger {
+    @include type-style('label-01');
+    border-bottom: rem(1px) dotted $interactive-01;
+  }
+
   .#{$prefix}--tooltip--definition {
-    @include reset;
-    position: relative;
+    .#{$prefix}--tooltip--top {
+      @include tooltip--trigger('definition', 'top');
 
-    .#{$prefix}--tooltip__trigger {
-      @include type-style('label-01');
-      display: inline-flex;
-      position: relative;
-      border-bottom: 1px dotted $interactive-01;
-      color: $text-01;
-
-      &:hover {
-        cursor: pointer;
-
-        + .#{$prefix}--tooltip--definition__top,
-        + .#{$prefix}--tooltip--definition__bottom {
-          display: block;
-        }
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('definition', 'top', 'start');
       }
 
-      &:focus {
-        @include focus-outline('border');
-
-        + .#{$prefix}--tooltip--definition__top,
-        + .#{$prefix}--tooltip--definition__bottom {
-          display: block;
-        }
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('definition', 'top', 'end');
       }
     }
-  }
 
-  .#{$prefix}--tooltip--definition__bottom,
-  .#{$prefix}--tooltip--definition__top {
-    @include layer('overlay');
-    position: absolute;
-    z-index: 1;
-    display: none;
-    background: $inverse-02;
-    width: rem(208px);
-    margin-top: $carbon--spacing-04;
-    padding: $carbon--spacing-03 $carbon--spacing-05;
-    border-radius: rem(2px);
-    pointer-events: none;
-    cursor: pointer;
+    .#{$prefix}--tooltip--right {
+      @include tooltip--trigger('definition', 'right');
 
-    p {
-      @include type-style('body-short-01');
-      color: $inverse-01;
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('definition', 'right', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('definition', 'right', 'end');
+      }
     }
 
-    .#{$prefix}--tooltip__caret {
-      position: absolute;
-      right: 0;
-      left: 0;
-      width: 0.6rem;
-      height: 0.6rem;
-      background: $inverse-02;
-      margin-left: $carbon--spacing-05;
+    .#{$prefix}--tooltip--bottom {
+      @include tooltip--trigger('definition', 'bottom');
+
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('definition', 'bottom', 'start');
+      }
+
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('definition', 'bottom', 'end');
+      }
     }
-  }
 
-  // Tooltip Definition caret - bottom position
-  .#{$prefix}--tooltip--definition__bottom .#{$prefix}--tooltip__caret {
-    top: -0.2rem;
-    transform: rotate(-135deg);
-  }
+    .#{$prefix}--tooltip--left {
+      @include tooltip--trigger('definition', 'left');
 
-  // Tooltip Definition caret - top position
-  .#{$prefix}--tooltip--definition__top {
-    transform: translateY(-100%);
-    margin-top: rem(-32px);
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('definition', 'left', 'start');
+      }
 
-    .#{$prefix}--tooltip__caret {
-      bottom: -0.2rem;
-      transform: rotate(45deg);
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('definition', 'left', 'end');
+      }
     }
-  }
-
-  .#{$prefix}--tooltip--definition__align-end {
-    right: 0;
-  }
-
-  .#{$prefix}--tooltip--definition__align-center {
-    margin-left: 50%;
-    transform: translateX(-50%);
-  }
-
-  .#{$prefix}--tooltip--definition__top.#{$prefix}--tooltip--definition__align-center {
-    margin-left: 50%;
-    transform: translate(-50%, -100%);
-  }
-
-  .#{$prefix}--tooltip--definition__align-center .#{$prefix}--tooltip__caret {
-    left: auto;
-    margin-left: auto;
-    // Adjust by the half of the diagonal of the caret, which sizes 0.6rem
-    margin-right: calc(50% - 6px);
-  }
-
-  .#{$prefix}--tooltip--definition__align-end .#{$prefix}--tooltip__caret {
-    left: auto;
-    margin-left: auto;
-    margin-right: rem(16px);
   }
 
   // Tooltip Icon
   // Icon CSS only tooltip
-  .#{$prefix}--tooltip--top,
-  .#{$prefix}--tooltip--right,
-  .#{$prefix}--tooltip--bottom,
-  .#{$prefix}--tooltip--left {
-    @include tooltip--icon;
-
+  .#{$prefix}--tooltip--icon .#{$prefix}--tooltip__trigger {
     &:hover,
     &:focus {
       svg {
@@ -278,64 +223,54 @@
     }
   }
 
-  // Tooltip Icon caret - top position
-  .#{$prefix}--tooltip--top {
-    @include tooltip--placement('top');
-  }
+  .#{$prefix}--tooltip--icon {
+    .#{$prefix}--tooltip--top {
+      @include tooltip--trigger('icon', 'top');
 
-  // Tooltip Icon caret - right position
-  .#{$prefix}--tooltip--right {
-    @include tooltip--placement('right');
-  }
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('icon', 'top', 'start');
+      }
 
-  // Tooltip Icon caret - bottom position
-  .#{$prefix}--tooltip--bottom {
-    @include tooltip--placement('bottom');
-  }
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('icon', 'top', 'end');
+      }
+    }
 
-  // Tooltip Icon caret - left position
-  .#{$prefix}--tooltip--left {
-    @include tooltip--placement('left');
-  }
+    .#{$prefix}--tooltip--right {
+      @include tooltip--trigger('icon', 'right');
 
-  // Tooltip Icon caret - top position, left alignment
-  .#{$prefix}--tooltip--top.#{$prefix}--tooltip--align-start {
-    @include tooltip--placement('top', 'start');
-  }
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('icon', 'right', 'start');
+      }
 
-  // Tooltip Icon caret - top position, right alignment
-  .#{$prefix}--tooltip--top.#{$prefix}--tooltip--align-end {
-    @include tooltip--placement('top', 'end');
-  }
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('icon', 'right', 'end');
+      }
+    }
 
-  // Tooltip Icon caret - right position, left alignment
-  .#{$prefix}--tooltip--right.#{$prefix}--tooltip--align-start {
-    @include tooltip--placement('right', 'start');
-  }
+    .#{$prefix}--tooltip--bottom {
+      @include tooltip--trigger('icon', 'bottom');
 
-  // Tooltip Icon caret - right position, right alignment
-  .#{$prefix}--tooltip--right.#{$prefix}--tooltip--align-end {
-    @include tooltip--placement('right', 'end');
-  }
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('icon', 'bottom', 'start');
+      }
 
-  // Tooltip Icon caret - bottom position, left alignment
-  .#{$prefix}--tooltip--bottom.#{$prefix}--tooltip--align-start {
-    @include tooltip--placement('bottom', 'start');
-  }
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('icon', 'bottom', 'end');
+      }
+    }
 
-  // Tooltip Icon caret - bottom position, right alignment
-  .#{$prefix}--tooltip--bottom.#{$prefix}--tooltip--align-end {
-    @include tooltip--placement('bottom', 'end');
-  }
+    .#{$prefix}--tooltip--left {
+      @include tooltip--trigger('icon', 'left');
 
-  // Tooltip Icon caret - left position, left alignment
-  .#{$prefix}--tooltip--left.#{$prefix}--tooltip--align-start {
-    @include tooltip--placement('left', 'start');
-  }
+      &.#{$prefix}--tooltip--align-start {
+        @include tooltip--trigger('icon', 'left', 'start');
+      }
 
-  // Tooltip Icon caret - left position, right alignment
-  .#{$prefix}--tooltip--left.#{$prefix}--tooltip--align-end {
-    @include tooltip--placement('left', 'end');
+      &.#{$prefix}--tooltip--align-end {
+        @include tooltip--trigger('icon', 'left', 'end');
+      }
+    }
   }
 
   // Tooltip position - icon only

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -280,62 +280,62 @@
 
   // Tooltip Icon caret - top position
   .#{$prefix}--tooltip--icon__top {
-    @include tooltip--icon-placement('top');
+    @include tooltip--placement('top');
   }
 
   // Tooltip Icon caret - right position
   .#{$prefix}--tooltip--icon__right {
-    @include tooltip--icon-placement('right');
+    @include tooltip--placement('right');
   }
 
   // Tooltip Icon caret - bottom position
   .#{$prefix}--tooltip--icon__bottom {
-    @include tooltip--icon-placement('bottom');
+    @include tooltip--placement('bottom');
   }
 
   // Tooltip Icon caret - left position
   .#{$prefix}--tooltip--icon__left {
-    @include tooltip--icon-placement('left');
+    @include tooltip--placement('left');
   }
 
   // Tooltip Icon caret - top position, left alignment
   .#{$prefix}--tooltip--icon__top.#{$prefix}--tooltip--icon__align-start {
-    @include tooltip--icon-placement('top', 'start');
+    @include tooltip--placement('top', 'start');
   }
 
   // Tooltip Icon caret - top position, right alignment
   .#{$prefix}--tooltip--icon__top.#{$prefix}--tooltip--icon__align-end {
-    @include tooltip--icon-placement('top', 'end');
+    @include tooltip--placement('top', 'end');
   }
 
   // Tooltip Icon caret - right position, left alignment
   .#{$prefix}--tooltip--icon__right.#{$prefix}--tooltip--icon__align-start {
-    @include tooltip--icon-placement('right', 'start');
+    @include tooltip--placement('right', 'start');
   }
 
   // Tooltip Icon caret - right position, right alignment
   .#{$prefix}--tooltip--icon__right.#{$prefix}--tooltip--icon__align-end {
-    @include tooltip--icon-placement('right', 'end');
+    @include tooltip--placement('right', 'end');
   }
 
   // Tooltip Icon caret - bottom position, left alignment
   .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-start {
-    @include tooltip--icon-placement('bottom', 'start');
+    @include tooltip--placement('bottom', 'start');
   }
 
   // Tooltip Icon caret - bottom position, right alignment
   .#{$prefix}--tooltip--icon__bottom.#{$prefix}--tooltip--icon__align-end {
-    @include tooltip--icon-placement('bottom', 'end');
+    @include tooltip--placement('bottom', 'end');
   }
 
   // Tooltip Icon caret - left position, left alignment
   .#{$prefix}--tooltip--icon__left.#{$prefix}--tooltip--icon__align-start {
-    @include tooltip--icon-placement('left', 'start');
+    @include tooltip--placement('left', 'start');
   }
 
   // Tooltip Icon caret - left position, right alignment
   .#{$prefix}--tooltip--icon__left.#{$prefix}--tooltip--icon__align-end {
-    @include tooltip--icon-placement('left', 'end');
+    @include tooltip--placement('left', 'end');
   }
 
   // Tooltip position - icon only

--- a/packages/components/src/components/tooltip/tooltip--definition.hbs
+++ b/packages/components/src/components/tooltip/tooltip--definition.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -7,9 +7,31 @@
 
 <div class="{{@root.prefix}}--tooltip--definition">
   <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
-    Definition Tooltip
+    Definition Tooltip (default, start aligned)
   </button>
   <div id="definition-tooltip" role="tooltip" class="{{@root.prefix}}--tooltip--definition__bottom">
+    <span class="{{@root.prefix}}--tooltip__caret"></span>
+    <p>Brief description of the dotted, underlined word above.</p>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--tooltip--definition">
+  <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
+    Definition Tooltip (center aligned)
+  </button>
+  <div id="definition-tooltip" role="tooltip"
+    class="{{@root.prefix}}--tooltip--definition__bottom {{@root.prefix}}--tooltip--definition__align-center">
+    <span class="{{@root.prefix}}--tooltip__caret"></span>
+    <p>Brief description of the dotted, underlined word above.</p>
+  </div>
+</div>
+
+<div class="{{@root.prefix}}--tooltip--definition">
+  <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
+    Definition Tooltip (end aligned)
+  </button>
+  <div id="definition-tooltip" role="tooltip"
+    class="{{@root.prefix}}--tooltip--definition__bottom {{@root.prefix}}--tooltip--definition__align-end">
     <span class="{{@root.prefix}}--tooltip__caret"></span>
     <p>Brief description of the dotted, underlined word above.</p>
   </div>

--- a/packages/components/src/components/tooltip/tooltip--definition.hbs
+++ b/packages/components/src/components/tooltip/tooltip--definition.hbs
@@ -7,21 +7,21 @@
 
 <div class="{{@root.prefix}}--tooltip--definition">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-start"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--definition {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-start"
     aria-label="Brief description of the dotted, underlined word above.">
     Definition Tooltip (start aligned)
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--definition">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--definition {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center"
     aria-label="Brief description of the dotted, underlined word above.">
     Definition Tooltip (center aligned)
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--definition">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-end"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--definition {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-end"
     aria-label="Brief description of the dotted, underlined word above.">
     Definition Tooltip (end aligned)
   </button>

--- a/packages/components/src/components/tooltip/tooltip--definition.hbs
+++ b/packages/components/src/components/tooltip/tooltip--definition.hbs
@@ -6,33 +6,22 @@
 -->
 
 <div class="{{@root.prefix}}--tooltip--definition">
-  <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
-    Definition Tooltip (default, start aligned)
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-start"
+    aria-label="Brief description of the dotted, underlined word above.">
+    Definition Tooltip (start aligned)
   </button>
-  <div id="definition-tooltip" role="tooltip" class="{{@root.prefix}}--tooltip--definition__bottom">
-    <span class="{{@root.prefix}}--tooltip__caret"></span>
-    <p>Brief description of the dotted, underlined word above.</p>
-  </div>
 </div>
-
 <div class="{{@root.prefix}}--tooltip--definition">
-  <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom"
+    aria-label="Brief description of the dotted, underlined word above.">
     Definition Tooltip (center aligned)
   </button>
-  <div id="definition-tooltip" role="tooltip"
-    class="{{@root.prefix}}--tooltip--definition__bottom {{@root.prefix}}--tooltip--definition__align-center">
-    <span class="{{@root.prefix}}--tooltip__caret"></span>
-    <p>Brief description of the dotted, underlined word above.</p>
-  </div>
 </div>
-
 <div class="{{@root.prefix}}--tooltip--definition">
-  <button class="{{@root.prefix}}--tooltip__trigger" type="button" aria-describedby="definition-tooltip">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-end"
+    aria-label="Brief description of the dotted, underlined word above.">
     Definition Tooltip (end aligned)
   </button>
-  <div id="definition-tooltip" role="tooltip"
-    class="{{@root.prefix}}--tooltip--definition__bottom {{@root.prefix}}--tooltip--definition__align-end">
-    <span class="{{@root.prefix}}--tooltip__caret"></span>
-    <p>Brief description of the dotted, underlined word above.</p>
-  </div>
 </div>

--- a/packages/components/src/components/tooltip/tooltip--definition.hbs
+++ b/packages/components/src/components/tooltip/tooltip--definition.hbs
@@ -13,7 +13,8 @@
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--definition">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom"
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center"
     aria-label="Brief description of the dotted, underlined word above.">
     Definition Tooltip (center aligned)
   </button>

--- a/packages/components/src/components/tooltip/tooltip--icon.hbs
+++ b/packages/components/src/components/tooltip/tooltip--icon.hbs
@@ -7,86 +7,71 @@
 
 <p>start</p>
 <br>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-start"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--top {{@root.prefix}}--tooltip--align-start"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-start"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--right {{@root.prefix}}--tooltip--align-start"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-start"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--top {{@root.prefix}}--tooltip--align-start"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-start"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--right {{@root.prefix}}--tooltip--align-start"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
 <br>
 <br>
 <p>center</p>
 <br>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--left" aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--top" aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom" aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--right" aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--left"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--top"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--bottom"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--right"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
 <br>
 <br>
 <p>end</p>
 <br>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-end"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--top {{@root.prefix}}--tooltip--align-end"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-end"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--right {{@root.prefix}}--tooltip--align-end"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-end"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--top {{@root.prefix}}--tooltip--align-end"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-end"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>
+<button
+  class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip__trigger--icon {{@root.prefix}}--tooltip--right {{@root.prefix}}--tooltip--align-end"
+  aria-label="Filter">
+  {{ carbon-icon 'Filter16' }}
+</button>

--- a/packages/components/src/components/tooltip/tooltip--icon.hbs
+++ b/packages/components/src/components/tooltip/tooltip--icon.hbs
@@ -5,8 +5,89 @@
   LICENSE file in the root directory of this source tree.
 -->
 
+<p>start</p>
+<br>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__left {{@root.prefix}}--tooltip--icon__align-start"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top {{@root.prefix}}--tooltip--icon__align-start"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom {{@root.prefix}}--tooltip--icon__align-start"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__right {{@root.prefix}}--tooltip--icon__align-start"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<br>
+<br>
+<p>center</p>
+<br>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__left" aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top" aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__right" aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<br>
+<br>
+<p>end</p>
+<br>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__left {{@root.prefix}}--tooltip--icon__align-end"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top {{@root.prefix}}--tooltip--icon__align-end"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom {{@root.prefix}}--tooltip--icon__align-end"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__right {{@root.prefix}}--tooltip--icon__align-end"
+    aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>

--- a/packages/components/src/components/tooltip/tooltip--icon.hbs
+++ b/packages/components/src/components/tooltip/tooltip--icon.hbs
@@ -9,28 +9,28 @@
 <br>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__left {{@root.prefix}}--tooltip--icon__align-start"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-start"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top {{@root.prefix}}--tooltip--icon__align-start"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--top {{@root.prefix}}--tooltip--align-start"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom {{@root.prefix}}--tooltip--icon__align-start"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-start"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__right {{@root.prefix}}--tooltip--icon__align-start"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--right {{@root.prefix}}--tooltip--align-start"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
@@ -40,22 +40,22 @@
 <p>center</p>
 <br>
 <div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__left" aria-label="Filter">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--left" aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top" aria-label="Filter">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--top" aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom" aria-label="Filter">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom" aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
-  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__right" aria-label="Filter">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--right" aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
@@ -65,28 +65,27 @@
 <br>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__left {{@root.prefix}}--tooltip--icon__align-end"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-end"
+    aria-label="Filter">
+    {{ carbon-icon 'Filter16' }}
+  </button>
+</div>
+<div class="{{@root.prefix}}--tooltip--icon">
+  <button class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--top {{@root.prefix}}--tooltip--align-end"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__top {{@root.prefix}}--tooltip--icon__align-end"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-end"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>
 </div>
 <div class="{{@root.prefix}}--tooltip--icon">
   <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__bottom {{@root.prefix}}--tooltip--icon__align-end"
-    aria-label="Filter">
-    {{ carbon-icon 'Filter16' }}
-  </button>
-</div>
-<div class="{{@root.prefix}}--tooltip--icon">
-  <button
-    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--icon__right {{@root.prefix}}--tooltip--icon__align-end"
+    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--right {{@root.prefix}}--tooltip--align-end"
     aria-label="Filter">
     {{ carbon-icon 'Filter16' }}
   </button>

--- a/packages/components/src/components/tooltip/tooltip.config.js
+++ b/packages/components/src/components/tooltip/tooltip.config.js
@@ -35,7 +35,7 @@ module.exports = {
         If there are actions a user can take in the tooltip (e.g. a link or a button), use interactive tooltip.
 
         For top positioning, replace bx--tooltip--definition__bottom class with bx--tooltip--definition__top.
-        For center/right alignment, add bx--tooltip--definition__align-center/bx--tooltip--definition__align-right class
+        For center/right alignment, add bx--tooltip--definition__align-center/bx--tooltip--definition__align-end class
         to the DOM element with bx--tooltip--definition__bottom/bx--tooltip--definition__top.
       `,
     },

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -52,6 +52,9 @@
     @include layer('overlay');
     min-width: rem(24px);
     max-width: rem(208px);
+    @if ($tooltip-type == 'definition') {
+      width: 100%;
+    }
     height: auto;
     padding: if(
       $tooltip-type == 'definition',

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -21,6 +21,16 @@
   cursor: pointer;
   overflow: visible;
 
+  @if $tooltip-type == 'icon' {
+    &:focus {
+      outline: 1px solid transparent;
+
+      svg {
+        @include focus-outline('border');
+      }
+    }
+  }
+
   // Tooltip - renders as a combo of ::before and ::after elements
   &::before,
   &::after {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -32,17 +32,10 @@
   }
 
   &::before {
-    right: 0;
-    left: 0;
     width: 0;
     height: 0;
-    border-width: 0 rem(4px) rem(5px) rem(4px);
     border-style: solid;
-    border-color: transparent transparent $inverse-02 transparent;
-    margin: 0 auto;
     content: '';
-    margin-top: 1px;
-    margin-left: 50%;
   }
 
   &::after {
@@ -50,7 +43,6 @@
     min-width: rem(24px);
     max-width: rem(208px);
     height: auto;
-    margin-left: 50%;
     padding: 0.125rem 1rem;
     border-radius: rem(2px);
     color: $inverse-01;
@@ -77,43 +69,83 @@
 /// @access public
 /// @group tooltip
 @mixin tooltip--icon-placement($position: 'bottom', $align: 'center') {
-  $translate-x: if($align == 'center', -50%, 0);
-  $translate-y-caret: if($position == 'top', calc(-100% - 9px), 10px);
-  $translate-y-body: if(
-    $position == 'top',
-    calc(-100% - 12px),
-    calc(100% + 10px)
-  );
-  $rotate-caret: if($position == 'top', 180deg, 0);
+  $caret-spacing: rem(8px); // space between caret and trigger button
+  $caret-height: rem(5px);
+  $caret-width: rem(8px);
+  $translate-caret: #{$caret-height} + #{$caret-spacing};
+  $translate-body: 100% + #{$caret-spacing} + #{$caret-height};
+  $rotate-caret: set-caret-rotation($position);
+
+  &::before,
+  &::after {
+    @if ($position == 'top') {
+      top: 0;
+      left: 50%;
+    }
+    @if ($position == 'right') {
+      top: 50%;
+      right: 0;
+    }
+    @if ($position == 'bottom') {
+      bottom: 0;
+      left: 50%;
+    }
+    @if ($position == 'left') {
+      top: 50%;
+      left: 0;
+    }
+  }
 
   &::before {
     @if ($position == 'top') {
-      top: 1px;
-    } @else {
-      bottom: 0;
+      border-width: rem(5px) rem(4px) 0 rem(4px);
+      border-color: $inverse-02 transparent transparent transparent;
+      transform: translate(-50%, calc(-1 * (#{$translate-caret})));
     }
-    @if ($align == 'start') {
-      margin-left: 4px;
-    } @else if ($align == 'end') {
-      margin-right: 4px;
-      left: auto;
-      right: 0;
+    @if ($position == 'right') {
+      border-width: rem(4px) rem(5px) rem(4px) 0;
+      border-color: transparent $inverse-02 transparent transparent;
+      transform: translate(calc(#{$translate-caret}), -50%);
     }
-    transform: translate($translate-x, $translate-y-caret) rotate($rotate-caret);
+    @if ($position == 'bottom') {
+      border-width: 0 rem(4px) rem(5px) rem(4px);
+      border-color: transparent transparent $inverse-02 transparent;
+      transform: translate(-50%, calc(#{$translate-caret}));
+    }
+    @if ($position == 'left') {
+      border-width: rem(4px) 0 rem(4px) rem(5px);
+      border-color: transparent transparent transparent $inverse-02;
+      transform: translate(calc(-1 * (#{$translate-caret})), -50%);
+    }
   }
 
   &::after {
     @if ($position == 'top') {
-      top: 0;
-    } @else {
-      bottom: 0;
+      @if ($align == 'start') {
+        transform: translate(-1rem, calc(-1 * (#{$translate-body})));
+      } @else if ($align == 'end') {
+        transform: translate(
+          calc(-100% + 1rem),
+          calc(-1 * (#{$translate-body}))
+        );
+      } @else {
+        transform: translate(-50%, calc(-1 * (#{$translate-body})));
+      }
     }
-    @if ($align != 'center') {
-      margin-left: 0;
+    @if ($position == 'right') {
+      transform: translate(calc(#{$translate-body}), -50%);
     }
-    @if ($align == 'end') {
-      right: 0;
+    @if ($position == 'bottom') {
+      @if ($align == 'start') {
+        transform: translate(-1rem, calc(#{$translate-body}));
+      } @else if ($align == 'end') {
+        transform: translate(calc(-100% + 1rem), calc(#{$translate-body}));
+      } @else {
+        transform: translate(-50%, calc(#{$translate-body}));
+      }
     }
-    transform: translate($translate-x, $translate-y-body);
+    @if ($position == 'left') {
+      transform: translate(calc(-1 * (#{$translate-body})), -50%);
+    }
   }
 }

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -9,9 +9,16 @@
 
 // Tooltip Icon
 // Icon CSS only tooltip
+/// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
+/// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
+/// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
 /// @access public
 /// @group tooltip
-@mixin tooltip--icon {
+@mixin tooltip--trigger(
+  $tooltip-type: 'icon',
+  $position: 'bottom',
+  $align: 'center'
+) {
   @include reset;
   position: relative;
   display: inline-flex;
@@ -24,6 +31,7 @@
   &::after {
     @include type-style('body-short-01');
     position: absolute;
+    z-index: z('floating');
     display: flex;
     align-items: center;
     opacity: 0;
@@ -31,6 +39,7 @@
     transition: opacity $duration--fast-01 motion(standard, productive);
   }
 
+  // caret
   &::before {
     width: 0;
     height: 0;
@@ -38,12 +47,17 @@
     content: '';
   }
 
+  // content box
   &::after {
     @include layer('overlay');
     min-width: rem(24px);
     max-width: rem(208px);
     height: auto;
-    padding: 0.125rem 1rem;
+    padding: if(
+      $tooltip-type == 'definition',
+      rem(8px) rem(16px),
+      rem(2px) rem(16px)
+    );
     border-radius: rem(2px);
     color: $inverse-01;
     font-weight: 400;
@@ -61,15 +75,13 @@
       opacity: 1;
     }
   }
-}
 
-// Tooltip Icon caret - top position
-/// @param {String} $position ['bottom'] - The position, from: `top`, `bottom`
-/// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
-/// @access public
-/// @group tooltip
-@mixin tooltip--placement($position: 'bottom', $align: 'center') {
-  $caret-spacing: rem(8px); // space between caret and trigger button
+  // position and alignment
+  $caret-spacing: if(
+    $tooltip-type == 'definition',
+    rem(4px),
+    rem(8px)
+  ); // space between caret and trigger button
   $caret-height: rem(5px);
   $caret-width: rem(8px);
   $translate-caret: #{$caret-height} + #{$caret-spacing};
@@ -119,6 +131,7 @@
     }
   }
 
+  // alignment options available only for top and bottom tooltip position
   &::after {
     @if ($position == 'top') {
       @if ($align == 'start') {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -138,13 +138,14 @@
   &::after {
     @if ($position == 'top') {
       @if ($align == 'start') {
-        transform: translate(-1rem, calc(-1 * (#{$translate-body})));
+        left: 0;
+        transform: translate(0, calc(-1 * (#{$translate-body})));
       } @else if ($align == 'end') {
-        transform: translate(
-          calc(-100% + 1rem),
-          calc(-1 * (#{$translate-body}))
-        );
+        right: 0;
+        left: initial;
+        transform: translate(0, calc(-1 * (#{$translate-body})));
       } @else {
+        left: 50%;
         transform: translate(-50%, calc(-1 * (#{$translate-body})));
       }
     }
@@ -153,9 +154,12 @@
     }
     @if ($position == 'bottom') {
       @if ($align == 'start') {
-        transform: translate(-1rem, calc(#{$translate-body}));
+        left: 0;
+        transform: translate(0, calc(#{$translate-body}));
       } @else if ($align == 'end') {
-        transform: translate(calc(-100% + 1rem), calc(#{$translate-body}));
+        right: 0;
+        left: initial;
+        transform: translate(0, calc(#{$translate-body}));
       } @else {
         transform: translate(-50%, calc(#{$translate-body}));
       }

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -68,7 +68,7 @@
 /// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
 /// @access public
 /// @group tooltip
-@mixin tooltip--icon-placement($position: 'bottom', $align: 'center') {
+@mixin tooltip--placement($position: 'bottom', $align: 'center') {
   $caret-spacing: rem(8px); // space between caret and trigger button
   $caret-height: rem(5px);
   $caret-width: rem(8px);

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -7,18 +7,13 @@
 
 @import 'layer';
 
-// Tooltip Icon
-// Icon CSS only tooltip
+// Tooltip
+// Definition and Icon CSS only tooltip
 /// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
 /// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
-/// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
 /// @access public
 /// @group tooltip
-@mixin tooltip--trigger(
-  $tooltip-type: 'icon',
-  $position: 'bottom',
-  $align: 'center'
-) {
+@mixin tooltip--trigger($tooltip-type: 'icon', $position: 'bottom') {
   @include reset;
   position: relative;
   display: inline-flex;
@@ -78,7 +73,20 @@
       opacity: 1;
     }
   }
+}
 
+// Tooltip
+// Definition and Icon CSS only tooltip
+/// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
+/// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
+/// @param {String} $align ['center'] - The alignment, from: `start`, `center`, `end`
+/// @access public
+/// @group tooltip
+@mixin tooltip--placement(
+  $tooltip-type: 'icon',
+  $position: 'bottom',
+  $align: 'center'
+) {
   // position and alignment
   $caret-spacing: if(
     $tooltip-type == 'definition',

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -12,9 +12,7 @@ import { settings } from 'carbon-components';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
-
 const getInstanceId = setupGetInstanceId();
-
 const TooltipDefinition = ({
   id,
   className,
@@ -25,29 +23,19 @@ const TooltipDefinition = ({
   ...rest
 }) => {
   const tooltipId = id || `definition-tooltip-${getInstanceId()}`;
-  const definitionClassName = cx({
-    [className]: !!className,
-    [`${prefix}--tooltip--definition`]: true,
-  });
-  const directionClassName = cx({
-    [`${prefix}--tooltip--definition__${direction}`]: direction,
-    [`${prefix}--tooltip--definition__align-${align}`]: align,
+  const tooltipClassName = cx(`${prefix}--tooltip--definition`, className);
+  const tooltipTriggerClasses = cx(`${prefix}--tooltip__trigger`, {
+    [`${prefix}--tooltip--${direction}`]: direction,
+    [`${prefix}--tooltip--align-${align}`]: align,
   });
   return (
-    <div {...rest} className={definitionClassName}>
+    <div {...rest} className={tooltipClassName}>
       <button
-        className={`${prefix}--tooltip__trigger`}
-        aria-describedby={tooltipId}>
+        className={tooltipTriggerClasses}
+        aria-describedby={tooltipId}
+        aria-label={tooltipText}>
         {children}
       </button>
-      <div
-        id={tooltipId}
-        className={directionClassName}
-        role="tooltip"
-        aria-label={tooltipText}>
-        <span className={`${prefix}--tooltip__caret`} />
-        <p>{tooltipText}</p>
-      </div>
     </div>
   );
 };
@@ -60,12 +48,13 @@ TooltipDefinition.propTypes = {
   children: PropTypes.string.isRequired,
 
   /**
-   * Specify the direction of the tooltip. Can be either bottom or top.
+   * Specify the direction of the tooltip. Can be either top or bottom.
    */
   direction: PropTypes.oneOf(['top', 'bottom']),
 
   /**
-   * Specify the alignment (to the trigger button) of the tooltip. Can be one of: start, center or end.
+   * Specify the alignment (to the trigger button) of the tooltip.
+   * Can be one of: start, center, or end.
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
 
@@ -78,7 +67,7 @@ TooltipDefinition.propTypes = {
   /**
    * Provide the text that will be displayed in the tooltip when it is rendered.
    */
-  tooltipText: PropTypes.node.isRequired,
+  tooltipText: PropTypes.string.isRequired,
 };
 
 TooltipDefinition.defaultProps = {

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -24,10 +24,14 @@ const TooltipDefinition = ({
 }) => {
   const tooltipId = id || `definition-tooltip-${getInstanceId()}`;
   const tooltipClassName = cx(`${prefix}--tooltip--definition`, className);
-  const tooltipTriggerClasses = cx(`${prefix}--tooltip__trigger`, {
-    [`${prefix}--tooltip--${direction}`]: direction,
-    [`${prefix}--tooltip--align-${align}`]: align,
-  });
+  const tooltipTriggerClasses = cx(
+    `${prefix}--tooltip__trigger`,
+    `${prefix}--tooltip__trigger--definition`,
+    {
+      [`${prefix}--tooltip--${direction}`]: direction,
+      [`${prefix}--tooltip--align-${align}`]: align,
+    }
+  );
   return (
     <div {...rest} className={tooltipClassName}>
       <button

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -13,7 +13,7 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
     <button
       aria-describedby="definition-tooltip-2"
       aria-label="tooltip text"
-      className="bx--tooltip__trigger bx--tooltip--top bx--tooltip--align-start"
+      className="bx--tooltip__trigger bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
     >
       tooltip trigger
     </button>
@@ -34,7 +34,7 @@ exports[`TooltipDefinition should render 1`] = `
     <button
       aria-describedby="definition-tooltip-1"
       aria-label="tooltip text"
-      className="bx--tooltip__trigger bx--tooltip--bottom bx--tooltip--align-start"
+      className="bx--tooltip__trigger bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
     >
       tooltip trigger
     </button>

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -8,27 +8,15 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
   tooltipText="tooltip text"
 >
   <div
-    className="custom-class bx--tooltip--definition"
+    className="bx--tooltip--definition custom-class"
   >
     <button
       aria-describedby="definition-tooltip-2"
-      className="bx--tooltip__trigger"
+      aria-label="tooltip text"
+      className="bx--tooltip__trigger bx--tooltip--top bx--tooltip--align-start"
     >
       tooltip trigger
     </button>
-    <div
-      aria-label="tooltip text"
-      className="bx--tooltip--definition__top bx--tooltip--definition__align-start"
-      id="definition-tooltip-2"
-      role="tooltip"
-    >
-      <span
-        className="bx--tooltip__caret"
-      />
-      <p>
-        tooltip text
-      </p>
-    </div>
   </div>
 </TooltipDefinition>
 `;
@@ -41,27 +29,15 @@ exports[`TooltipDefinition should render 1`] = `
   tooltipText="tooltip text"
 >
   <div
-    className="custom-class bx--tooltip--definition"
+    className="bx--tooltip--definition custom-class"
   >
     <button
       aria-describedby="definition-tooltip-1"
-      className="bx--tooltip__trigger"
+      aria-label="tooltip text"
+      className="bx--tooltip__trigger bx--tooltip--bottom bx--tooltip--align-start"
     >
       tooltip trigger
     </button>
-    <div
-      aria-label="tooltip text"
-      className="bx--tooltip--definition__bottom bx--tooltip--definition__align-start"
-      id="definition-tooltip-1"
-      role="tooltip"
-    >
-      <span
-        className="bx--tooltip__caret"
-      />
-      <p>
-        tooltip text
-      </p>
-    </div>
   </div>
 </TooltipDefinition>
 `;

--- a/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
@@ -12,8 +12,10 @@ import { withKnobs, select, text } from '@storybook/addon-knobs';
 import TooltipIcon from '../TooltipIcon';
 
 const directions = {
-  'Bottom (bottom)': 'bottom',
   'Top (top)': 'top',
+  'Right (right)': 'right',
+  'Bottom (bottom)': 'bottom',
+  'Left (left)': 'left',
 };
 
 const alignments = {

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -9,10 +9,12 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
+import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
-
+const getInstanceId = setupGetInstanceId();
 const TooltipIcon = ({
+  id,
   className,
   children,
   direction,
@@ -20,18 +22,18 @@ const TooltipIcon = ({
   tooltipText,
   ...rest
 }) => {
-  const tooltipClassName = cx({
-    [className]: !!className,
-    [`${prefix}--tooltip-icon`]: true,
-  });
-  const triggerClassName = cx({
-    [`${prefix}--tooltip__trigger`]: true,
-    [`${prefix}--tooltip--icon__${direction}`]: direction,
-    [`${prefix}--tooltip--icon__align-${align}`]: align,
+  const tooltipId = id || `definition-tooltip-${getInstanceId()}`;
+  const tooltipClassName = cx(`${prefix}--tooltip--icon`, className);
+  const tooltipTriggerClasses = cx(`${prefix}--tooltip__trigger`, {
+    [`${prefix}--tooltip--${direction}`]: direction,
+    [`${prefix}--tooltip--align-${align}`]: align,
   });
   return (
     <div {...rest} className={tooltipClassName}>
-      <button className={triggerClassName} aria-label={tooltipText}>
+      <button
+        className={tooltipTriggerClasses}
+        aria-describedby={tooltipId}
+        aria-label={tooltipText}>
         {children}
       </button>
     </div>
@@ -46,19 +48,27 @@ TooltipIcon.propTypes = {
   children: PropTypes.node.isRequired,
 
   /**
-   * Specify the direction of the tooltip. Can be either bottom or top.
+   * Specify the direction of the tooltip. Can be either top or bottom.
    */
-  direction: PropTypes.oneOf(['bottom', 'top']),
+  direction: PropTypes.oneOf(['top', 'bottom']),
 
   /**
-   * Specify the alignment (to the trigger button) of the tooltip. Can be one of: start, center or end.
+   * Specify the alignment (to the trigger button) of the tooltip.
+   * Can be one of: start, center, or end.
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
 
   /**
-   * Provide the text that will be displayed in the tooltip when it is rendered.
+   * Optionally specify a custom id for the tooltip. If one is not provided, we
+   * generate a unique id for you.
    */
-  tooltipText: PropTypes.node.isRequired,
+  id: PropTypes.string,
+
+  /**
+   * Provide the ARIA label for the tooltip.
+   * TODO: rename this prop (will be a breaking change)
+   */
+  tooltipText: PropTypes.string.isRequired,
 };
 
 TooltipIcon.defaultProps = {

--- a/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
+++ b/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
@@ -8,11 +8,12 @@ exports[`TooltipIcon should allow the user to specify the direction 1`] = `
   tooltipText="tooltip text"
 >
   <div
-    className="custom-class bx--tooltip-icon"
+    className="bx--tooltip--icon custom-class"
   >
     <button
+      aria-describedby="definition-tooltip-2"
       aria-label="tooltip text"
-      className="bx--tooltip__trigger bx--tooltip--icon__top bx--tooltip--icon__align-center"
+      className="bx--tooltip__trigger bx--tooltip--top bx--tooltip--align-center"
     >
       <svg />
     </button>
@@ -28,11 +29,12 @@ exports[`TooltipIcon should render 1`] = `
   tooltipText="tooltip text"
 >
   <div
-    className="custom-class bx--tooltip-icon"
+    className="bx--tooltip--icon custom-class"
   >
     <button
+      aria-describedby="definition-tooltip-1"
       aria-label="tooltip text"
-      className="bx--tooltip__trigger bx--tooltip--icon__bottom bx--tooltip--icon__align-center"
+      className="bx--tooltip__trigger bx--tooltip--bottom bx--tooltip--align-center"
     >
       <svg />
     </button>


### PR DESCRIPTION
Closes #2748

This PR avoids relying on magic numbers to position icon tooltips. Similar logic can be applied for left/right positioning tooltips in #2731

depends on https://github.com/carbon-design-system/carbon/pull/2783

#### Changelog

**New**

- tooltip trigger mixin which controls base tooltip trigger styles as well as tooltip positioning and alignment
- tooltip caret spacing tokens

**Changed**

- tooltip transform/translate rules
- combine definition and icon tooltips
- rename icon tooltip specific classes to be more generic

**Removed**

- custom positioning in `button.scss`

#### Testing / Reviewing

Ensure that tooltips render as expected
