### PR TITLE
feat(data-table): add visible overflow menu icon option

### DIFF
--- a/packages/components/src/components/data-table/README.md
+++ b/packages/components/src/components/data-table/README.md
@@ -3,6 +3,16 @@
 The update to tables splits out the `scss` files into multiple partial files
 with specific functionality, with a main index file bringing them together.
 
+By default, overflow menu icons are hidden until the user hovers over a table
+row. To display overflow menu icons by default without requiring the user to
+hover, target the overflow menu icons and set the `opacity` to `1`.
+
+```css
+.bx--data-table .bx--overflow-menu .bx--overflow-menu__icon {
+  opacity: 1;
+}
+```
+
 #### Files
 
 | Name                    | Description                              |

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -171,6 +171,10 @@
     opacity: 0;
   }
 
+  .#{$prefix}--data-table.#{$prefix}--data-table--visible-overflow-menu
+    td.#{$prefix}--table-column-menu
+    .#{$prefix}--overflow-menu
+    .#{$prefix}--overflow-menu__icon,
   .#{$prefix}--data-table
     td.#{$prefix}--table-column-menu
     .#{$prefix}--overflow-menu:hover

--- a/packages/components/src/components/data-table/data-table.config.js
+++ b/packages/components/src/components/data-table/data-table.config.js
@@ -541,5 +541,36 @@ module.exports = {
         sort: true,
       },
     },
+    {
+      name: 'show-overflow-menus',
+      label: 'Data Table (with visible overflow menu triggers)',
+      notes: `
+        Data Tables are used to represent a collection of resources, displaying a
+        subset of their fields in columns, or headers.
+      `,
+      context: {
+        state: 'default',
+        title: 'Table title',
+        optionalHelper: 'Optional Helper Text',
+        batchActions,
+        toolbarActions,
+        toolbarActionsX,
+        columns,
+        rows,
+        selectedItemsCounterLabel: `
+          <span data-items-selected>3</span> items selected
+        `,
+        searchInputId: 'search__input-2',
+        searchLabelId: 'search-input-label-1',
+        searchLabel: 'Search',
+        clearSearchLabel: 'Clear search input',
+        addNewLabel: 'Add new',
+        cancelLabel: 'Cancel',
+        sortLabel: 'Sort rows by this header in descending order',
+        hasToolbar: true,
+        sort: true,
+        displayOverflowMenus: true,
+      },
+    },
   ],
 };

--- a/packages/components/src/components/data-table/data-table.hbs
+++ b/packages/components/src/components/data-table/data-table.hbs
@@ -132,7 +132,7 @@
   <section class="{{@root.prefix}}--data-table_inner-container">
   {{/if}}
   <!-- Table -->
-  <table class="{{@root.prefix}}--data-table {{#if truncate}}{{@root.prefix}}--data-table--overflow-truncate{{/if}} {{#if sticky}}{{@root.prefix}}--data-table--sticky-header{{/if}} {{#if zebra}}{{@root.prefix}}--data-table--zebra{{/if}}{{#if small}} {{@root.prefix}}--data-table--compact{{/if}} {{#if tall}}{{@root.prefix}}--data-table--tall {{/if}}{{#if sort}} {{@root.prefix}}--data-table--sort {{/if}}" >
+  <table class="{{@root.prefix}}--data-table {{#if truncate}}{{@root.prefix}}--data-table--overflow-truncate{{/if}}{{#if sticky}} {{@root.prefix}}--data-table--sticky-header{{/if}}{{#if zebra}} {{@root.prefix}}--data-table--zebra{{/if}}{{#if small}} {{@root.prefix}}--data-table--compact{{/if}}{{#if tall}} {{@root.prefix}}--data-table--tall{{/if}}{{#if sort}} {{@root.prefix}}--data-table--sort{{/if}}{{#if displayOverflowMenus}} {{@root.prefix}}--data-table--visible-overflow-menu{{/if}}" >
     <thead>
       <tr>
         {{#each columns}}


### PR DESCRIPTION
Closes #1156

This PR adds a new selector for overflow menu icons in data table rows to make them visible by default without needing to hover over the table row
