### PR TITLE
fix(tooltip): wrap icon tooltip content

### DIFF
--- a/packages/components/src/components/tooltip/tooltip--icon.hbs
+++ b/packages/components/src/components/tooltip/tooltip--icon.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -56,6 +56,7 @@
     color: $inverse-01;
     font-weight: 400;
     content: attr(aria-label);
+    text-align: left;
     transform: translateX(-50%);
     pointer-events: none;
     background-color: $inverse-02;

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -49,15 +49,14 @@
     @include layer('overlay');
     min-width: rem(24px);
     max-width: rem(208px);
-    height: rem(24px);
+    height: auto;
     margin-left: 50%;
-    padding: 0 1rem;
+    padding: 0.125rem 1rem;
     border-radius: rem(2px);
     color: $inverse-01;
     font-weight: 400;
     content: attr(aria-label);
     transform: translateX(-50%);
-    white-space: nowrap;
     pointer-events: none;
     background-color: $inverse-02;
   }


### PR DESCRIPTION
Closes #2767

This PR modifies icon tooltip content so that it wraps when the tooltip max length has been reached