### PR TITLE
chore: add v9 publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "engines": {
     "node": ">=6.x"
   },
+  "publishConfig": {
+    "tag": "9.x"
+  },
   "dependencies": {
     "carbon-icons": "^7.0.7",
     "flatpickr": "4.5.7",


### PR DESCRIPTION
Closes #2821

This PR adds the `publishConfig` key to the v9 `package.json`

#### Testing / Reviewing

if a reviewer could publish or share the carbon bot GitHub token with me for publishing after approval that would be great :+1:
