### PR TITLE
chore(lint): run Prettier to staged Sass files

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
       "yarn lerna run lint:staged --scope carbon-components",
       "git add"
     ],
+    "packages/components/**/*.scss": [
+      "yarn format:staged",
+      "git add"
+    ],
     "packages/react/**/*.js": [
       "yarn format:staged",
       "yarn lerna run lint:staged --scope carbon-components-react",


### PR DESCRIPTION
#### Changelog

**New**

- `lint-staged` setting to lint staged `.scss` files in `carbon-components` package.

#### Testing / Reviewing

Testing should make sure our commit process, especially of `.scss` files, is not broken.