### PR TITLE
fix(button): temporarily hard code danger button bgc

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -195,7 +195,8 @@
 
   .#{$prefix}--btn--danger {
     @include button-theme(
-      $support-01,
+      // $support-01, TODO: replace with updated token
+        #dc222b,
       $support-01,
       $text-04,
       $hover-danger,


### PR DESCRIPTION
Temporary fix for #2364 (ref https://github.com/carbon-design-system/carbon/issues/2364#issuecomment-495716649)

This PR changes the danger button background color with a hard coded value `#DC222B` until the new color token is finalized

#### Testing / Reviewing

Ensure the danger button color contrast is sufficient across all themes
