### PR TITLE
fix: remove input field hover states

### DIFF
--- a/packages/components/src/components/number-input/_number-input.scss
+++ b/packages/components/src/components/number-input/_number-input.scss
@@ -47,10 +47,6 @@
       @include focus-outline('outline');
     }
 
-    &:hover {
-      background-color: $hover-field;
-    }
-
     &:disabled {
       cursor: not-allowed;
       background-color: $disabled-background-color;

--- a/packages/components/src/components/search/_search.scss
+++ b/packages/components/src/components/search/_search.scss
@@ -46,10 +46,6 @@
       outline $duration--fast-02 motion(standard, productive);
     border-bottom: 1px solid $ui-04;
 
-    &:hover {
-      background-color: $hover-field;
-    }
-
     &:focus {
       @include focus-outline('outline');
     }
@@ -176,10 +172,6 @@
     &::before {
       background-color: $focus;
     }
-  }
-
-  .#{$prefix}--search-input:hover ~ .#{$prefix}--search-close::before {
-    background-color: $hover-field;
   }
 
   .#{$prefix}--search-input:focus ~ .#{$prefix}--search-close:hover {

--- a/packages/components/src/components/slider/_slider.scss
+++ b/packages/components/src/components/slider/_slider.scss
@@ -126,10 +126,6 @@
     &::-webkit-inner-spin-button {
       display: none;
     }
-
-    &:hover {
-      background-color: $hover-field;
-    }
   }
 
   .#{$prefix}--slider__thumb:focus ~ .#{$prefix}--slider__filled-track {

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -60,10 +60,6 @@
     }
   }
 
-  .#{$prefix}--text-area:hover {
-    background-color: $hover-field;
-  }
-
   .#{$prefix}--text-area:focus,
   .#{$prefix}--text-area:active {
     @include focus-outline('outline');

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -33,10 +33,6 @@
     transition: background-color $duration--fast-01 motion(standard, productive),
       outline $duration--fast-01 motion(standard, productive);
 
-    &:hover {
-      background-color: $hover-field;
-    }
-
     &:focus,
     &:active {
       @include focus-outline('outline');


### PR DESCRIPTION
Closes #2717

This PR removes the incorrect hover states on input fields

#### Changelog

**Changed**

- text input hover state
- text area hover state
- number input hover state
- date picker hover state
- slider hover state
- search hover state

#### Testing / Reviewing

Ensure that all input fields match the spec
