### PR TITLE
fix(Modal): require `aria-labelledby`

### DIFF
--- a/packages/react/src/components/Modal/Modal-story.js
+++ b/packages/react/src/components/Modal/Modal-story.js
@@ -27,7 +27,7 @@ const props = () => ({
   modalHeading: text('Modal heading (modalHeading)', 'Modal heading'),
   modalLabel: text('Optional label (modalLabel)', 'Label'),
   modalAriaLabel: text(
-    'ARIA label (modalAriaLabel)',
+    'ARIA label, used only if modalLabel not provided (modalAriaLabel)',
     'A label to be read by screen readers on the modal root node'
   ),
   primaryButtonText: text(

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -317,13 +317,8 @@ export default class Modal extends Component {
         ref={this.innerModal}
         role="dialog"
         className={`${prefix}--modal-container`}
-        aria-label={this.props[`aria-label`] || modalAriaLabel}
-        aria-labelledby={
-          this.props[`aria-labelledby`] ||
-          modalLabel ||
-          modalHeading ||
-          modalAriaLabel
-        }
+        aria-label={this.props['aria-label'] || modalAriaLabel}
+        aria-labelledby={this.props.id || null}
         aria-modal="true">
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -80,6 +80,9 @@ export default class Modal extends Component {
      */
     onRequestSubmit: PropTypes.func,
 
+    /**
+     * Specify a handler for keypresses.
+     */
     onKeyDown: PropTypes.func,
 
     /**

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -8,11 +8,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import Button from '../Button';
 import { settings } from 'carbon-components';
 import { Close20 } from '@carbon/icons-react';
 import FocusTrap from 'focus-trap-react';
 import toggleClass from '../../tools/toggleClass';
+import Button from '../Button';
+import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 
 const { prefix } = settings;
 
@@ -128,6 +129,11 @@ export default class Modal extends Component {
      * NOTE: by default this is true.
      */
     focusTrap: PropTypes.bool,
+
+    /**
+     * Required props for the accessibility label of the header
+     */
+    ...AriaLabelPropType,
   };
 
   static defaultProps = {
@@ -311,7 +317,13 @@ export default class Modal extends Component {
         ref={this.innerModal}
         role="dialog"
         className={`${prefix}--modal-container`}
-        aria-label={modalAriaLabel}
+        aria-label={this.props[`aria-label`] || modalAriaLabel}
+        aria-labelledby={
+          this.props[`aria-labelledby`] ||
+          modalLabel ||
+          modalHeading ||
+          modalAriaLabel
+        }
         aria-modal="true">
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -318,7 +318,6 @@ export default class Modal extends Component {
         role="dialog"
         className={`${prefix}--modal-container`}
         aria-label={this.props['aria-label'] || modalAriaLabel}
-        aria-labelledby={this.props.id || null}
         aria-modal="true">
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -312,12 +312,28 @@ export default class Modal extends Component {
       </button>
     );
 
+    const getAriaLabelledBy = (() => {
+      const ariaLabelledBy = [];
+      if (modalLabel) {
+        ariaLabelledBy.push(
+          `${prefix}--modal-header__label`,
+          `${prefix}--modal-header__heading`
+        );
+      }
+      return ariaLabelledBy.length ? ariaLabelledBy.join(' ') : null;
+    })();
+
     const modalBody = (
       <div
         ref={this.innerModal}
         role="dialog"
         className={`${prefix}--modal-container`}
-        aria-label={this.props['aria-label'] || modalAriaLabel}
+        aria-label={
+          modalLabel
+            ? null
+            : this.props['aria-label'] || modalAriaLabel || modalHeading
+        }
+        aria-labelledby={getAriaLabelledBy}
         aria-modal="true">
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -77,6 +77,8 @@ exports[`ModalWrapper should render 1`] = `
           tabIndex={-1}
         >
           <div
+            aria-label={null}
+            aria-labelledby="bx--modal-header__label bx--modal-header__heading"
             aria-modal="true"
             className="bx--modal-container"
             role="dialog"

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -77,6 +77,7 @@ exports[`ModalWrapper should render 1`] = `
           tabIndex={-1}
         >
           <div
+            aria-labelledby="Test Modal Label"
             aria-modal="true"
             className="bx--modal-container"
             role="dialog"

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -77,7 +77,6 @@ exports[`ModalWrapper should render 1`] = `
           tabIndex={-1}
         >
           <div
-            aria-labelledby="Test Modal Label"
             aria-modal="true"
             className="bx--modal-container"
             role="dialog"


### PR DESCRIPTION
Closes #2270

This PR makes the `modalAriaLabel` prop required and sets values for `aria-labelledby` depending on the value of the `modalLabel`, `modalHeading`, or `modalAriaLabel` props

cc @carmacleod for testing

#### Testing / Reviewing

Ensure the modal is marked up for a11y
