### PR TITLE
fix(data-table-v2): fix skeleton style suffix

### DIFF
--- a/src/components/data-table-v2/_data-table-v2-skeleton.scss
+++ b/src/components/data-table-v2/_data-table-v2-skeleton.scss
@@ -11,7 +11,7 @@
 
 @include exports('data-table-v2-skeleton') {
   /// @access private
-  $data-table-suffix: if(feature-flag-enabled('components-x'), '-v2', '');
+  $data-table-suffix: if(feature-flag-enabled('components-x'), '', '-v2');
 
   .#{$prefix}--data-table#{$data-table-suffix}.#{$prefix}--skeleton {
     th {


### PR DESCRIPTION
Fixes #2859.

#### Changelog

**Changed**

- Fixed the CSS class suffix for `v9` data table skeleton.

#### Testing / Reviewing

Testing should make sure the data table skeleton gets back working.