### PR TITLE
button field deprecation warning: updated to only warn once

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -14,6 +14,8 @@ import warning from 'warning';
 
 const { prefix } = settings;
 
+let didWarnAboutDeprecation = false;
+
 const Button = React.forwardRef(function Button(
   {
     children,
@@ -46,10 +48,13 @@ const Button = React.forwardRef(function Button(
   });
 
   if (__DEV__) {
-    warning(
-      !small,
-      `\nThe prop \`small\` for Button has been deprecated in favor of \`size\`. Please use \`type="small"\` instead.`
-    );
+    if (small && !didWarnAboutDeprecation) {
+      warning(
+        false,
+        `\nThe prop \`small\` for Button has been deprecated in favor of \`size\`. Please use \`type="small"\` instead.`
+      );
+      didWarnAboutDeprecation = true;
+    }
   }
 
   const commonProps = {


### PR DESCRIPTION
makes warning only fire once, instead of each time a button is rendered. thanks @joshblack !

referred to https://github.com/carbon-design-system/carbon-components-react/blob/v6/src/components/Table/Table.js#L17-L27 for implementation