### PR TITLE
refactor(toggle): make toggle labels accessible

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -2493,6 +2493,7 @@ Get the value of the corresponding number of units
 - **Used by**:
   - [listbox [mixin]](#listbox-mixin)
   - [multiselect [mixin]](#multiselect-mixin)
+  - [toggle [mixin]](#toggle-mixin)
   - [carbon-header-panel [mixin]](#carbon-header-panel-mixin)
 
 ### ✅carbon--spacing-01 [variable]
@@ -2722,6 +2723,7 @@ $carbon--spacing-08: carbon--mini-units(5);
   - [listbox [mixin]](#listbox-mixin)
   - [search [mixin]](#search-mixin)
   - [text-area [mixin]](#text-area-mixin)
+  - [toggle [mixin]](#toggle-mixin)
 
 ### ✅carbon--spacing-09 [variable]
 
@@ -4542,6 +4544,7 @@ $text-02: map-get($carbon--theme, 'text-02');
   - [overflow-menu [mixin]](#overflow-menu-mixin)
   - [search [mixin]](#search-mixin)
   - [tabs [mixin]](#tabs-mixin)
+  - [toggle [mixin]](#toggle-mixin)
   - [toolbar [mixin]](#toolbar-mixin)
   - [tooltip [mixin]](#tooltip-mixin)
 
@@ -17605,28 +17608,6 @@ Toggle styles
     }
   }
 
-  .#{$prefix}--toggle--small
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__appearance {
-    width: rem(32px);
-    height: rem(16px);
-
-    &:before {
-      box-sizing: border-box;
-      height: rem(16px);
-      width: rem(32px);
-      border-radius: 0.9375rem;
-      top: 0;
-    }
-
-    &:after {
-      width: rem(10px);
-      height: rem(10px);
-      top: 3px;
-      left: 3px;
-    }
-  }
-
   .#{$prefix}--toggle__check {
     fill: $ui-03;
     position: absolute;
@@ -17635,13 +17616,6 @@ Toggle styles
     z-index: 1;
     transition: $duration--fast-01 motion(exit, productive);
     transform: scale(0.2);
-  }
-
-  .#{$prefix}--toggle--small:checked
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__check {
-    fill: $support-02;
-    transform: scale(1) translateX(16px);
   }
 
   .#{$prefix}--toggle__text--left,
@@ -17654,12 +17628,6 @@ Toggle styles
   .#{$prefix}--toggle__text--left {
     position: absolute;
     left: rem(48px);
-  }
-
-  .#{$prefix}--toggle--small
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__text--left {
-    left: rem(32px);
   }
 
   .#{$prefix}--toggle:checked
@@ -17690,15 +17658,6 @@ Toggle styles
     &:after {
       background-color: $icon-03;
       transform: translateX(24px);
-    }
-  }
-
-  .#{$prefix}--toggle--small:checked
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__appearance {
-    &:after {
-      margin-left: 0px;
-      transform: translateX(17px);
     }
   }
 
@@ -17763,6 +17722,245 @@ Toggle styles
     .#{$prefix}--toggle__check {
     fill: $disabled-02;
   }
+
+  //----------------------------------------------
+  // Small toggle
+  // ---------------------------------------------
+
+  .#{$prefix}--toggle--small
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__appearance {
+    width: rem(32px);
+    height: rem(16px);
+
+    &:before {
+      box-sizing: border-box;
+      height: rem(16px);
+      width: rem(32px);
+      border-radius: 0.9375rem;
+      top: 0;
+    }
+
+    &:after {
+      width: rem(10px);
+      height: rem(10px);
+      top: 3px;
+      left: 3px;
+    }
+  }
+
+  .#{$prefix}--toggle--small:checked
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__check {
+    fill: $support-02;
+    transform: scale(1) translateX(16px);
+  }
+
+  .#{$prefix}--toggle--small
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__text--left {
+    left: rem(32px);
+  }
+
+  .#{$prefix}--toggle--small:checked
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__appearance {
+    &:after {
+      margin-left: 0px;
+      transform: translateX(17px);
+    }
+  }
+
+  // -----------------------------------------------------
+  // new accessible toggle
+  // TODO: deprecate styles above this line
+  // -----------------------------------------------------
+
+  .#{$prefix}--toggle-input {
+    @include hidden;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .#{$prefix}--toggle-input__label {
+    @include type-style('label-01');
+    color: $text-02;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    cursor: pointer;
+  }
+
+  .#{$prefix}--toggle__switch {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: rem(48px);
+    height: rem(24px);
+    margin: $carbon--spacing-03 0;
+    cursor: pointer;
+
+    // Toggle background oval
+    &::before {
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      display: block;
+      width: rem(48px);
+      height: rem(24px);
+      border-radius: rem(15px);
+      content: '';
+      background-color: $ui-04;
+      will-change: box-shadow;
+      box-shadow: 0 0 0 2px transparent;
+      transition: box-shadow $duration--fast-01 motion(exit, productive), background-color
+          $duration--fast-01 motion(exit, productive);
+    }
+
+    // Toggle circle
+    &::after {
+      box-sizing: border-box;
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      display: block;
+      width: rem(18px);
+      height: rem(18px);
+      border-radius: 50%;
+      background-color: $ui-03;
+      content: '';
+      transition: transform $duration--fast-01 motion(exit, productive);
+    }
+  }
+
+  .#{$prefix}--toggle__text--off,
+  .#{$prefix}--toggle__text--on {
+    position: absolute;
+    margin-left: carbon--mini-units(7);
+    @include type-style('body-short-01');
+    user-select: none;
+  }
+
+  //----------------------------------------------
+  // Checked
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input:checked
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch
+    > .#{$prefix}--toggle__text--off,
+  .#{$prefix}--toggle-input:not(:checked)
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch
+    > .#{$prefix}--toggle__text--on {
+    visibility: hidden;
+  }
+
+  .#{$prefix}--toggle-input:checked
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch {
+    &::before {
+      background-color: $support-02;
+    }
+
+    &::after {
+      background-color: $icon-03;
+      transform: translateX(24px);
+    }
+  }
+
+  //----------------------------------------------
+  // Focus and active
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input:focus
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before,
+  .#{$prefix}--toggle-input:active
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before {
+    box-shadow: 0 0 0 2px $focus;
+  }
+
+  //----------------------------------------------
+  // Disabled
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input:disabled + .#{$prefix}--toggle-input__label {
+    cursor: not-allowed;
+  }
+
+  .#{$prefix}--toggle-input:disabled
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch {
+    cursor: not-allowed;
+
+    &::before {
+      background-color: $disabled-01;
+    }
+
+    &::after {
+      background-color: $disabled-02;
+    }
+
+    &::before,
+    &::after {
+      cursor: not-allowed;
+      transition: $duration--fast-01 motion(exit, productive);
+    }
+  }
+
+  .#{$prefix}--toggle-input:disabled + .#{$prefix}--toggle-input__label {
+    color: $disabled;
+  }
+
+  .#{$prefix}--toggle-input:disabled:active
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before {
+    box-shadow: none;
+  }
+
+  //----------------------------------------------
+  // Small toggle
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input--small + .#{$prefix}--toggle-input__label {
+    > .#{$prefix}--toggle__switch {
+      width: rem(32px);
+      height: rem(16px);
+
+      &::before {
+        width: rem(32px);
+        height: rem(16px);
+        border-radius: 0.9375rem;
+      }
+
+      &::after {
+        width: rem(10px);
+        height: rem(10px);
+      }
+    }
+
+    .#{$prefix}--toggle__text--off,
+    .#{$prefix}--toggle__text--on {
+      margin-left: $carbon--spacing-08;
+    }
+  }
+
+  .#{$prefix}--toggle-input--small:checked + .#{$prefix}--toggle-input__label {
+    > .#{$prefix}--toggle__switch::after {
+      transform: translateX(17px);
+    }
+
+    .#{$prefix}--toggle__check {
+      fill: $support-02;
+      transform: scale(1) translateX(16px);
+    }
+  }
+
+  .#{$prefix}--toggle-input--small:disabled:checked
+    + .#{$prefix}--toggle-input__label
+    .#{$prefix}--toggle__check {
+    fill: $disabled-02;
+  }
 }
 ```
 
@@ -17770,6 +17968,7 @@ Toggle styles
 
 - **Group**: [toggle](#toggle)
 - **Requires**:
+  - [carbon--mini-units [function]](#carbon--mini-units-function)
   - [prefix [variable]](#prefix-variable)
   - [carbon--spacing-03 [variable]](#carbon--spacing-03-variable)
   - [ui-04 [variable]](#ui-04-variable)
@@ -17779,6 +17978,8 @@ Toggle styles
   - [focus [variable]](#focus-variable)
   - [disabled-01 [variable]](#disabled-01-variable)
   - [disabled-02 [variable]](#disabled-02-variable)
+  - [text-02 [variable]](#text-02-variable)
+  - [carbon--spacing-08 [variable]](#carbon--spacing-08-variable)
 
 ## toolbar
 

--- a/packages/components/src/components/toggle/README.md
+++ b/packages/components/src/components/toggle/README.md
@@ -4,13 +4,18 @@
 
 Use these modifiers with `.bx--toggle` class.
 
-| Selector             | Description                               |
-| -------------------- | ----------------------------------------- |
-| `.bx--toggle--small` | Selector for applying small toggle styles |
+| Selector                   | Description                               |
+| -------------------------- | ----------------------------------------- |
+| `.bx--toggle-input--small` | Selector for applying small toggle styles |
 
 ### FAQ
 
 #### Best practice
 
-Since Toggle uses Checkbox inputs, it's best practice to use `<fieldset>` and
-`<legend>` elements to label the the group. See Form for more details.
+`.bx--toggle-input__label` must always have a value for the `aria-label`
+attribute. This makes it visible to screen readers.
+
+The `.bx--toggle__text--off` and `.bx--toggle__text--on` elements are completely
+optional. If they are present, they can be hidden from screen readers with
+`aria-hidden="true"` since the `checked` state of the checkbox will indicate
+this information already.

--- a/packages/components/src/components/toggle/_toggle.scss
+++ b/packages/components/src/components/toggle/_toggle.scss
@@ -255,6 +255,7 @@
 
   .#{$prefix}--toggle-input__label {
     @include type-style('label-01');
+    color: $text-02;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/packages/components/src/components/toggle/_toggle.scss
+++ b/packages/components/src/components/toggle/_toggle.scss
@@ -424,6 +424,12 @@
       transform: scale(1) translateX(16px);
     }
   }
+
+  .#{$prefix}--toggle-input--small:disabled:checked
+    + .#{$prefix}--toggle-input__label
+    .#{$prefix}--toggle__check {
+    fill: $disabled-02;
+  }
 }
 
 @include exports('toggle') {

--- a/packages/components/src/components/toggle/_toggle.scss
+++ b/packages/components/src/components/toggle/_toggle.scss
@@ -390,8 +390,8 @@
   //----------------------------------------------
   // Small toggle
   // ---------------------------------------------
-  .#{$prefix}--toggle-input--small {
-    + .#{$prefix}--toggle-input__label > .#{$prefix}--toggle__switch {
+  .#{$prefix}--toggle-input--small + .#{$prefix}--toggle-input__label {
+    > .#{$prefix}--toggle__switch {
       width: rem(32px);
       height: rem(16px);
 
@@ -407,15 +407,20 @@
       }
     }
 
-    + .#{$prefix}--toggle-input__label .#{$prefix}--toggle__text--off,
-    + .#{$prefix}--toggle-input__label .#{$prefix}--toggle__text--on {
+    .#{$prefix}--toggle__text--off,
+    .#{$prefix}--toggle__text--on {
       margin-left: $carbon--spacing-08;
     }
+  }
 
-    &:checked
-      + .#{$prefix}--toggle-input__label
-      > .#{$prefix}--toggle__switch::after {
+  .#{$prefix}--toggle-input--small:checked + .#{$prefix}--toggle-input__label {
+    > .#{$prefix}--toggle__switch::after {
       transform: translateX(17px);
+    }
+
+    .#{$prefix}--toggle__check {
+      fill: $support-02;
+      transform: scale(1) translateX(16px);
     }
   }
 }

--- a/packages/components/src/components/toggle/_toggle.scss
+++ b/packages/components/src/components/toggle/_toggle.scss
@@ -77,28 +77,6 @@
     }
   }
 
-  .#{$prefix}--toggle--small
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__appearance {
-    width: rem(32px);
-    height: rem(16px);
-
-    &:before {
-      box-sizing: border-box;
-      height: rem(16px);
-      width: rem(32px);
-      border-radius: 0.9375rem;
-      top: 0;
-    }
-
-    &:after {
-      width: rem(10px);
-      height: rem(10px);
-      top: 3px;
-      left: 3px;
-    }
-  }
-
   .#{$prefix}--toggle__check {
     fill: $ui-03;
     position: absolute;
@@ -107,13 +85,6 @@
     z-index: 1;
     transition: $duration--fast-01 motion(exit, productive);
     transform: scale(0.2);
-  }
-
-  .#{$prefix}--toggle--small:checked
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__check {
-    fill: $support-02;
-    transform: scale(1) translateX(16px);
   }
 
   .#{$prefix}--toggle__text--left,
@@ -126,12 +97,6 @@
   .#{$prefix}--toggle__text--left {
     position: absolute;
     left: rem(48px);
-  }
-
-  .#{$prefix}--toggle--small
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__text--left {
-    left: rem(32px);
   }
 
   .#{$prefix}--toggle:checked
@@ -162,15 +127,6 @@
     &:after {
       background-color: $icon-03;
       transform: translateX(24px);
-    }
-  }
-
-  .#{$prefix}--toggle--small:checked
-    + .#{$prefix}--toggle__label
-    .#{$prefix}--toggle__appearance {
-    &:after {
-      margin-left: 0px;
-      transform: translateX(17px);
     }
   }
 
@@ -234,6 +190,233 @@
     + .#{$prefix}--toggle__label
     .#{$prefix}--toggle__check {
     fill: $disabled-02;
+  }
+
+  //----------------------------------------------
+  // Small toggle
+  // ---------------------------------------------
+
+  .#{$prefix}--toggle--small
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__appearance {
+    width: rem(32px);
+    height: rem(16px);
+
+    &:before {
+      box-sizing: border-box;
+      height: rem(16px);
+      width: rem(32px);
+      border-radius: 0.9375rem;
+      top: 0;
+    }
+
+    &:after {
+      width: rem(10px);
+      height: rem(10px);
+      top: 3px;
+      left: 3px;
+    }
+  }
+
+  .#{$prefix}--toggle--small:checked
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__check {
+    fill: $support-02;
+    transform: scale(1) translateX(16px);
+  }
+
+  .#{$prefix}--toggle--small
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__text--left {
+    left: rem(32px);
+  }
+
+  .#{$prefix}--toggle--small:checked
+    + .#{$prefix}--toggle__label
+    .#{$prefix}--toggle__appearance {
+    &:after {
+      margin-left: 0px;
+      transform: translateX(17px);
+    }
+  }
+
+  // -----------------------------------------------------
+  // new accessible toggle
+  // TODO: deprecate styles above this line
+  // -----------------------------------------------------
+
+  .#{$prefix}--toggle-input {
+    @include hidden;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .#{$prefix}--toggle-input__label {
+    @include type-style('label-01');
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    cursor: pointer;
+  }
+
+  .#{$prefix}--toggle__switch {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: rem(48px);
+    height: rem(24px);
+    margin: $carbon--spacing-03 0;
+    cursor: pointer;
+
+    // Toggle background oval
+    &::before {
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      display: block;
+      width: rem(48px);
+      height: rem(24px);
+      border-radius: rem(15px);
+      content: '';
+      background-color: $ui-04;
+      will-change: box-shadow;
+      box-shadow: 0 0 0 2px transparent;
+      transition: box-shadow $duration--fast-01 motion(exit, productive),
+        background-color $duration--fast-01 motion(exit, productive);
+    }
+
+    // Toggle circle
+    &::after {
+      box-sizing: border-box;
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      display: block;
+      width: rem(18px);
+      height: rem(18px);
+      border-radius: 50%;
+      background-color: $ui-03;
+      content: '';
+      transition: transform $duration--fast-01 motion(exit, productive);
+    }
+  }
+
+  .#{$prefix}--toggle__text--off,
+  .#{$prefix}--toggle__text--on {
+    position: absolute;
+    margin-left: carbon--mini-units(7);
+    @include type-style('body-short-01');
+    user-select: none;
+  }
+
+  //----------------------------------------------
+  // Checked
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input:checked
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch
+    > .#{$prefix}--toggle__text--off,
+  .#{$prefix}--toggle-input:not(:checked)
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch
+    > .#{$prefix}--toggle__text--on {
+    visibility: hidden;
+  }
+
+  .#{$prefix}--toggle-input:checked
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch {
+    &::before {
+      background-color: $support-02;
+    }
+
+    &::after {
+      background-color: $icon-03;
+      transform: translateX(24px);
+    }
+  }
+
+  //----------------------------------------------
+  // Focus and active
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input:focus
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before,
+  .#{$prefix}--toggle-input:active
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before {
+    box-shadow: 0 0 0 2px $focus;
+  }
+
+  //----------------------------------------------
+  // Disabled
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input:disabled + .#{$prefix}--toggle-input__label {
+    cursor: not-allowed;
+  }
+
+  .#{$prefix}--toggle-input:disabled
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch {
+    cursor: not-allowed;
+
+    &::before {
+      background-color: $disabled-01;
+    }
+
+    &::after {
+      background-color: $disabled-02;
+    }
+
+    &::before,
+    &::after {
+      cursor: not-allowed;
+      transition: $duration--fast-01 motion(exit, productive);
+    }
+  }
+
+  .#{$prefix}--toggle-input:disabled + .#{$prefix}--toggle-input__label {
+    color: $disabled;
+  }
+
+  .#{$prefix}--toggle-input:disabled:active
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before {
+    box-shadow: none;
+  }
+
+  //----------------------------------------------
+  // Small toggle
+  // ---------------------------------------------
+  .#{$prefix}--toggle-input--small {
+    + .#{$prefix}--toggle-input__label > .#{$prefix}--toggle__switch {
+      width: rem(32px);
+      height: rem(16px);
+
+      &::before {
+        width: rem(32px);
+        height: rem(16px);
+        border-radius: 0.9375rem;
+      }
+
+      &::after {
+        width: rem(10px);
+        height: rem(10px);
+      }
+    }
+
+    + .#{$prefix}--toggle-input__label .#{$prefix}--toggle__text--off,
+    + .#{$prefix}--toggle-input__label .#{$prefix}--toggle__text--on {
+      margin-left: $carbon--spacing-08;
+    }
+
+    &:checked
+      + .#{$prefix}--toggle-input__label
+      > .#{$prefix}--toggle__switch::after {
+      transform: translateX(17px);
+    }
   }
 }
 

--- a/packages/components/src/components/toggle/toggle--small.hbs
+++ b/packages/components/src/components/toggle/toggle--small.hbs
@@ -26,7 +26,7 @@
 
 <div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle2" type="checkbox">
-  <label class="{{prefix}}--toggle-input__label" for="smalltoggle2" aria-label="example toggle with visible label">
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle2">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
@@ -56,8 +56,7 @@
 
 <div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle5" type="checkbox" disabled>
-  <label class="{{prefix}}--toggle-input__label" for="smalltoggle5"
-    aria-label="example disabled toggle with visible label">
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle5">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>

--- a/packages/components/src/components/toggle/toggle--small.hbs
+++ b/packages/components/src/components/toggle/toggle--small.hbs
@@ -9,7 +9,11 @@
   <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle0" type="checkbox">
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle0"
     aria-label="example toggle without state indicator text">
-    <span class="{{prefix}}--toggle__switch"></span>
+    <span class="{{prefix}}--toggle__switch">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+      </svg>
+    </span>
   </label>
 </div>
 
@@ -18,6 +22,9 @@
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle1"
     aria-label="example toggle with state indicator text">
     <span class="{{prefix}}--toggle__switch">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+      </svg>
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
       <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
     </span>
@@ -29,6 +36,9 @@
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle2">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+      </svg>
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
       <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
     </span>
@@ -39,7 +49,11 @@
   <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle3" type="checkbox" disabled>
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle3"
     aria-label="example disabled toggle without state indicator text">
-    <span class="{{prefix}}--toggle__switch"></span>
+    <span class="{{prefix}}--toggle__switch">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+      </svg>
+    </span>
   </label>
 </div>
 
@@ -48,6 +62,9 @@
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle4"
     aria-label="example disabled toggle with state indicator text">
     <span class="{{prefix}}--toggle__switch">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+      </svg>
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
       <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
     </span>
@@ -59,6 +76,9 @@
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle5">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
+      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
+        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+      </svg>
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
       <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
     </span>

--- a/packages/components/src/components/toggle/toggle--small.hbs
+++ b/packages/components/src/components/toggle/toggle--small.hbs
@@ -6,18 +6,6 @@
 -->
 
 <div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle0" type="checkbox">
-  <label class="{{prefix}}--toggle-input__label" for="smalltoggle0"
-    aria-label="example toggle without state indicator text">
-    <span class="{{prefix}}--toggle__switch">
-      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
-        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
-      </svg>
-    </span>
-  </label>
-</div>
-
-<div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle1" type="checkbox">
   <label class="{{prefix}}--toggle-input__label" for="smalltoggle1"
     aria-label="example toggle with state indicator text">
@@ -41,18 +29,6 @@
       </svg>
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
       <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
-    </span>
-  </label>
-</div>
-
-<div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle3" type="checkbox" disabled>
-  <label class="{{prefix}}--toggle-input__label" for="smalltoggle3"
-    aria-label="example disabled toggle without state indicator text">
-    <span class="{{prefix}}--toggle__switch">
-      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
-        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
-      </svg>
     </span>
   </label>
 </div>

--- a/packages/components/src/components/toggle/toggle--small.hbs
+++ b/packages/components/src/components/toggle/toggle--small.hbs
@@ -1,34 +1,67 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle4" type="checkbox"
-    aria-label="Label Name">
-  <label class="{{@root.prefix}}--toggle__label" for="toggle4">
-    <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
-    <span class="{{@root.prefix}}--toggle__appearance">
-      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
-        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
-      </svg>
-    </span>
-    <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle0" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle0"
+    aria-label="example toggle without state indicator text">
+    <span class="{{prefix}}--toggle__switch"></span>
   </label>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
-  <input class="{{@root.prefix}}--toggle {{@root.prefix}}--toggle--small" id="toggle5" type="checkbox"
-    aria-label="Label Name" disabled>
-  <label class="{{@root.prefix}}--toggle__label" for="toggle5">
-    <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
-    <span class="{{@root.prefix}}--toggle__appearance">
-      <svg class="{{@root.prefix}}--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
-        <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
-      </svg>
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle1" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle1"
+    aria-label="example toggle with state indicator text">
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
     </span>
-    <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle2" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle2" aria-label="example toggle with visible label">
+    Toggle with visible label
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle3" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle3"
+    aria-label="example disabled toggle without state indicator text">
+    <span class="{{prefix}}--toggle__switch"></span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle4" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle4"
+    aria-label="example disabled toggle with state indicator text">
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input {{prefix}}--toggle-input--small" id="smalltoggle5" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="smalltoggle5"
+    aria-label="example disabled toggle with visible label">
+    Toggle with visible label
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
   </label>
 </div>

--- a/packages/components/src/components/toggle/toggle.hbs
+++ b/packages/components/src/components/toggle/toggle.hbs
@@ -1,36 +1,36 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <input class="{{@root.prefix}}--toggle" id="toggle1" type="checkbox">
-  <label class="{{@root.prefix}}--toggle__label" for="toggle1">
-    <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
-    <span class="{{@root.prefix}}--toggle__appearance"></span>
-    <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle" id="toggle1" type="checkbox">
+  <label class="{{prefix}}--toggle__label" for="toggle1">
+    <span class="{{prefix}}--toggle__text--left">Off</span>
+    <span class="{{prefix}}--toggle__appearance"></span>
+    <span class="{{prefix}}--toggle__text--right">On</span>
   </label>
 </div>
 
-<fieldset class="{{@root.prefix}}--fieldset">
-  <legend class="{{@root.prefix}}--label">Toggle w/ Label</legend>
-  <div class="{{@root.prefix}}--form-item">
-    <input class="{{@root.prefix}}--toggle" id="toggle2" type="checkbox">
-    <label class="{{@root.prefix}}--toggle__label" for="toggle2">
-    <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
-    <span class="{{@root.prefix}}--toggle__appearance"></span>
-    <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
-  </label>
+<fieldset class="{{prefix}}--fieldset">
+  <legend class="{{prefix}}--label">Toggle w/ Label</legend>
+  <div class="{{prefix}}--form-item">
+    <input class="{{prefix}}--toggle" id="toggle2" type="checkbox">
+    <label class="{{prefix}}--toggle__label" for="toggle2">
+      <span class="{{prefix}}--toggle__text--left">Off</span>
+      <span class="{{prefix}}--toggle__appearance"></span>
+      <span class="{{prefix}}--toggle__text--right">On</span>
+    </label>
   </div>
 </fieldset>
 
-<div class="{{@root.prefix}}--form-item">
-  <input class="{{@root.prefix}}--toggle" id="toggle3" type="checkbox" disabled>
-  <label class="{{@root.prefix}}--toggle__label" for="toggle3">
-    <span class="{{@root.prefix}}--toggle__text--left" aria-hidden="true">Off</span>
-    <span class="{{@root.prefix}}--toggle__appearance"></span>
-    <span class="{{@root.prefix}}--toggle__text--right" aria-hidden="true">On</span>
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle" id="toggle3" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle__label" for="toggle3">
+    <span class="{{prefix}}--toggle__text--left">Off</span>
+    <span class="{{prefix}}--toggle__appearance"></span>
+    <span class="{{prefix}}--toggle__text--right">On</span>
   </label>
 </div>

--- a/packages/components/src/components/toggle/toggle.hbs
+++ b/packages/components/src/components/toggle/toggle.hbs
@@ -7,14 +7,7 @@
 
 <div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input" id="toggle0" type="checkbox">
-  <label class="{{prefix}}--toggle-input__label" for="toggle0" aria-label="example toggle without state indicator text">
-    <span class="{{prefix}}--toggle__switch"></span>
-  </label>
-</div>
-
-<div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle-input" id="toggle1" type="checkbox">
-  <label class="{{prefix}}--toggle-input__label" for="toggle1" aria-label="example toggle with state indicator text">
+  <label class="{{prefix}}--toggle-input__label" for="toggle0" aria-label="example toggle with state indicator text">
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
       <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
@@ -23,8 +16,8 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle-input" id="toggle2" type="checkbox">
-  <label class="{{prefix}}--toggle-input__label" for="toggle2">
+  <input class="{{prefix}}--toggle-input" id="toggle1" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="toggle1">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
@@ -36,14 +29,6 @@
 <div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input" id="toggle3" type="checkbox" disabled>
   <label class="{{prefix}}--toggle-input__label" for="toggle3"
-    aria-label="example disabled toggle without state indicator text">
-    <span class="{{prefix}}--toggle__switch"></span>
-  </label>
-</div>
-
-<div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle-input" id="toggle4" type="checkbox" disabled>
-  <label class="{{prefix}}--toggle-input__label" for="toggle4"
     aria-label="example disabled toggle with state indicator text">
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
@@ -53,8 +38,8 @@
 </div>
 
 <div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle-input" id="toggle5" type="checkbox" disabled>
-  <label class="{{prefix}}--toggle-input__label" for="toggle5">
+  <input class="{{prefix}}--toggle-input" id="toggle4" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="toggle4">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>

--- a/packages/components/src/components/toggle/toggle.hbs
+++ b/packages/components/src/components/toggle/toggle.hbs
@@ -24,7 +24,7 @@
 
 <div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input" id="toggle2" type="checkbox">
-  <label class="{{prefix}}--toggle-input__label" for="toggle2" aria-label="example toggle with visible label">
+  <label class="{{prefix}}--toggle-input__label" for="toggle2">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
@@ -54,7 +54,7 @@
 
 <div class="{{prefix}}--form-item">
   <input class="{{prefix}}--toggle-input" id="toggle5" type="checkbox" disabled>
-  <label class="{{prefix}}--toggle-input__label" for="toggle5" aria-label="example disabled toggle with visible label">
+  <label class="{{prefix}}--toggle-input__label" for="toggle5">
     Toggle with visible label
     <span class="{{prefix}}--toggle__switch">
       <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>

--- a/packages/components/src/components/toggle/toggle.hbs
+++ b/packages/components/src/components/toggle/toggle.hbs
@@ -6,31 +6,59 @@
 -->
 
 <div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle" id="toggle1" type="checkbox">
-  <label class="{{prefix}}--toggle__label" for="toggle1">
-    <span class="{{prefix}}--toggle__text--left">Off</span>
-    <span class="{{prefix}}--toggle__appearance"></span>
-    <span class="{{prefix}}--toggle__text--right">On</span>
+  <input class="{{prefix}}--toggle-input" id="toggle0" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="toggle0" aria-label="example toggle without state indicator text">
+    <span class="{{prefix}}--toggle__switch"></span>
   </label>
 </div>
 
-<fieldset class="{{prefix}}--fieldset">
-  <legend class="{{prefix}}--label">Toggle w/ Label</legend>
-  <div class="{{prefix}}--form-item">
-    <input class="{{prefix}}--toggle" id="toggle2" type="checkbox">
-    <label class="{{prefix}}--toggle__label" for="toggle2">
-      <span class="{{prefix}}--toggle__text--left">Off</span>
-      <span class="{{prefix}}--toggle__appearance"></span>
-      <span class="{{prefix}}--toggle__text--right">On</span>
-    </label>
-  </div>
-</fieldset>
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input" id="toggle1" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="toggle1" aria-label="example toggle with state indicator text">
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
+  </label>
+</div>
 
 <div class="{{prefix}}--form-item">
-  <input class="{{prefix}}--toggle" id="toggle3" type="checkbox" disabled>
-  <label class="{{prefix}}--toggle__label" for="toggle3">
-    <span class="{{prefix}}--toggle__text--left">Off</span>
-    <span class="{{prefix}}--toggle__appearance"></span>
-    <span class="{{prefix}}--toggle__text--right">On</span>
+  <input class="{{prefix}}--toggle-input" id="toggle2" type="checkbox">
+  <label class="{{prefix}}--toggle-input__label" for="toggle2" aria-label="example toggle with visible label">
+    Toggle with visible label
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input" id="toggle3" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="toggle3"
+    aria-label="example disabled toggle without state indicator text">
+    <span class="{{prefix}}--toggle__switch"></span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input" id="toggle4" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="toggle4"
+    aria-label="example disabled toggle with state indicator text">
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
+  </label>
+</div>
+
+<div class="{{prefix}}--form-item">
+  <input class="{{prefix}}--toggle-input" id="toggle5" type="checkbox" disabled>
+  <label class="{{prefix}}--toggle-input__label" for="toggle5" aria-label="example disabled toggle with visible label">
+    Toggle with visible label
+    <span class="{{prefix}}--toggle__switch">
+      <span class="{{prefix}}--toggle__text--off" aria-hidden="true">Off</span>
+      <span class="{{prefix}}--toggle__text--on" aria-hidden="true">On</span>
+    </span>
   </label>
 </div>

--- a/packages/react/src/components/Toggle/Toggle-story.js
+++ b/packages/react/src/components/Toggle/Toggle-story.js
@@ -15,6 +15,7 @@ import ToggleSkeleton from '../Toggle/Toggle.Skeleton';
 const toggleProps = () => ({
   className: 'some-class',
   labelText: text('Label for toggle button input (labelText)', ''),
+  ['aria-label']: text('ARIA label of the toggle (aria-label)', ''),
   labelA: text('Label for untoggled state (labelA)', 'Off'),
   labelB: text('Label for toggled state (labelB)', 'On'),
   disabled: boolean('Disabled (disabled)', false),

--- a/packages/react/src/components/Toggle/Toggle-story.js
+++ b/packages/react/src/components/Toggle/Toggle-story.js
@@ -14,7 +14,7 @@ import ToggleSkeleton from '../Toggle/Toggle.Skeleton';
 
 const toggleProps = () => ({
   className: 'some-class',
-  labelText: text('Label for toggle button input', ''),
+  labelText: text('Label for toggle button input (labelText)', ''),
   labelA: text('Label for untoggled state (labelA)', 'Off'),
   labelB: text('Label for toggled state (labelB)', 'On'),
   disabled: boolean('Disabled (disabled)', false),

--- a/packages/react/src/components/Toggle/Toggle-test.js
+++ b/packages/react/src/components/Toggle/Toggle-test.js
@@ -31,9 +31,9 @@ describe('Toggle', () => {
 
     it('Can set defaultToggled state', () => {
       wrapper.setProps({ defaultToggled: true });
-      expect(wrapper.find(`.${prefix}--toggle`).props().defaultChecked).toEqual(
-        true
-      );
+      expect(
+        wrapper.find(`.${prefix}--toggle-input`).props().defaultChecked
+      ).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -43,19 +43,21 @@ describe('Toggle', () => {
 
     it('Can be disabled', () => {
       wrapper.setProps({ disabled: true });
-      expect(wrapper.find(`.${prefix}--toggle`).props().disabled).toEqual(true);
+      expect(wrapper.find(`.${prefix}--toggle-input`).props().disabled).toEqual(
+        true
+      );
     });
 
     it('Can have a labelA', () => {
       wrapper.setProps({ labelA: 'labelA-test' });
-      expect(wrapper.find(`.${prefix}--toggle__text--left`).text()).toEqual(
+      expect(wrapper.find(`.${prefix}--toggle__text--off`).text()).toEqual(
         'labelA-test'
       );
     });
 
     it('Can have a labelB', () => {
       wrapper.setProps({ labelB: 'labelB-test' });
-      expect(wrapper.find(`.${prefix}--toggle__text--right`).text()).toEqual(
+      expect(wrapper.find(`.${prefix}--toggle__text--on`).text()).toEqual(
         'labelB-test'
       );
     });

--- a/packages/react/src/components/Toggle/Toggle.js
+++ b/packages/react/src/components/Toggle/Toggle.js
@@ -43,6 +43,15 @@ class Toggle extends React.Component {
     toggled: PropTypes.bool,
 
     /**
+     * Provide the text that will be read by a screen reader when visiting this
+     * control
+     * `aria-label` is always required but will be null if `labelText` is also
+     * provided
+     */
+    labelText: PropTypes.string,
+    ['aria-label']: PropTypes.string.isRequired,
+
+    /**
      * Specify the label for the "off" position
      */
     labelA: PropTypes.string.isRequired,
@@ -55,7 +64,7 @@ class Toggle extends React.Component {
 
   static defaultProps = {
     defaultToggled: false,
-    label: '',
+    ['aria-label']: 'Toggle',
     labelA: 'Off',
     labelB: 'On',
     onToggle: () => {},
@@ -77,8 +86,7 @@ class Toggle extends React.Component {
     } = this.props;
 
     let input;
-    const wrapperClasses = classNames({
-      [`${prefix}--form-item`]: true,
+    const wrapperClasses = classNames(`${prefix}--form-item`, {
       [className]: className,
     });
 
@@ -90,54 +98,45 @@ class Toggle extends React.Component {
       checkedProps.defaultChecked = defaultToggled;
     }
 
-    const labelTextId = !labelText ? undefined : `${id}-label`;
-
     return (
-      <>
-        {labelText && (
-          <div id={labelTextId} className={`${prefix}--label`}>
-            {labelText}
-          </div>
-        )}
-        <div className={wrapperClasses}>
-          <input
-            {...other}
-            {...checkedProps}
-            type="checkbox"
-            id={id}
-            className={`${prefix}--toggle`}
-            aria-labelledby={labelTextId}
-            onChange={evt => {
-              onChange && onChange(evt);
+      <div className={wrapperClasses}>
+        <input
+          {...other}
+          {...checkedProps}
+          aria-label={null}
+          type="checkbox"
+          id={id}
+          className={`${prefix}--toggle-input`}
+          onChange={evt => {
+            onChange && onChange(evt);
+            onToggle(input.checked, id, evt);
+          }}
+          ref={el => {
+            input = el;
+          }}
+          onKeyUp={evt => {
+            if (match(evt, keys.ENTER)) {
+              input.checked = !input.checked;
+              onChange(evt);
               onToggle(input.checked, id, evt);
-            }}
-            ref={el => {
-              input = el;
-            }}
-            onKeyUp={evt => {
-              if (match(evt, keys.ENTER)) {
-                input.checked = !input.checked;
-                onChange(evt);
-                onToggle(input.checked, id, evt);
-              }
-            }}
-          />
-
-          <label className={`${prefix}--toggle__label`} htmlFor={id}>
-            <span
-              className={`${prefix}--toggle__text--left`}
-              aria-hidden="true">
+            }
+          }}
+        />
+        <label
+          className={`${prefix}--toggle-input__label`}
+          htmlFor={id}
+          aria-label={labelText ? null : this.props['aria-label']}>
+          {labelText}
+          <span className={`${prefix}--toggle__switch`}>
+            <span className={`${prefix}--toggle__text--off`} aria-hidden="true">
               {labelA}
             </span>
-            <span className={`${prefix}--toggle__appearance`} />
-            <span
-              className={`${prefix}--toggle__text--right`}
-              aria-hidden="true">
+            <span className={`${prefix}--toggle__text--on`} aria-hidden="true">
               {labelB}
             </span>
-          </label>
-        </div>
-      </>
+          </span>
+        </label>
+      </div>
     );
   }
 }

--- a/packages/react/src/components/ToggleSmall/ToggleSmall-story.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall-story.js
@@ -14,7 +14,10 @@ import ToggleSmallSkeleton from '../ToggleSmall/ToggleSmall.Skeleton';
 
 const toggleProps = () => ({
   className: 'some-class',
-  ariaLabel: text('ARIA label (ariaLabel)', 'Label Name'),
+  labelText: text('Label for toggle button input (labelText)', ''),
+  ['aria-label']: text('ARIA label of the toggle (aria-label)', ''),
+  labelA: text('Label for untoggled state (labelA)', ''),
+  labelB: text('Label for toggled state (labelB)', ''),
   disabled: boolean('Disabled (disabled)', false),
   onChange: action('onChange'),
   onToggle: action('onToggle'),

--- a/packages/react/src/components/ToggleSmall/ToggleSmall-test.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall-test.js
@@ -14,7 +14,14 @@ import { settings } from 'carbon-components';
 const { prefix } = settings;
 describe('ToggleSmall', () => {
   describe('Renders as expected', () => {
-    const wrapper = mount(<ToggleSmall id="toggle-1" ariaLabel="test label" />);
+    const wrapper = mount(
+      <ToggleSmall
+        id="toggle-1"
+        aria-label="test label"
+        labelA="Off"
+        labelB="On"
+      />
+    );
 
     const input = wrapper.find('input');
 
@@ -31,9 +38,9 @@ describe('ToggleSmall', () => {
 
     it('Can set defaultToggled state', () => {
       wrapper.setProps({ defaultToggled: true });
-      expect(wrapper.find(`.${prefix}--toggle`).props().defaultChecked).toEqual(
-        true
-      );
+      expect(
+        wrapper.find(`.${prefix}--toggle-input`).props().defaultChecked
+      ).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -43,13 +50,15 @@ describe('ToggleSmall', () => {
 
     it('Can be disabled', () => {
       wrapper.setProps({ disabled: true });
-      expect(wrapper.find(`.${prefix}--toggle`).props().disabled).toEqual(true);
+      expect(wrapper.find(`.${prefix}--toggle-input`).props().disabled).toEqual(
+        true
+      );
     });
   });
 
   it('toggled prop sets checked prop on input', () => {
     const wrapper = mount(
-      <ToggleSmall id="test" ariaLabel="test label" toggled />
+      <ToggleSmall id="test" aria-label="test label" toggled />
     );
 
     const input = () => wrapper.find('input');
@@ -64,7 +73,7 @@ describe('ToggleSmall', () => {
       const onChange = jest.fn();
       const id = 'test-input';
       const wrapper = mount(
-        <ToggleSmall ariaLabel="test label" id={id} onChange={onChange} />
+        <ToggleSmall aria-label="test label" id={id} onChange={onChange} />
       );
 
       const input = wrapper.find('input');
@@ -84,7 +93,7 @@ describe('ToggleSmall', () => {
       const onToggle = jest.fn();
       const id = 'test-input';
       const wrapper = mount(
-        <ToggleSmall ariaLabel="test label" id={id} onToggle={onToggle} />
+        <ToggleSmall aria-label="test label" id={id} onToggle={onToggle} />
       );
 
       const input = wrapper.find('input');

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.js
@@ -21,7 +21,6 @@ const ToggleSmall = ({
   onToggle,
   id,
   labelText,
-  ariaLabel,
   labelA,
   labelB,
   ...other
@@ -38,6 +37,7 @@ const ToggleSmall = ({
   } else {
     checkedProps.defaultChecked = defaultToggled;
   }
+  const ariaLabel = labelText || other['aria-label'] || other.ariaLabel || null;
 
   return (
     <div className={wrapperClasses}>
@@ -66,9 +66,9 @@ const ToggleSmall = ({
       <label
         className={`${prefix}--toggle-input__label`}
         htmlFor={id}
-        aria-label={labelText ? null : ariaLabel || other['aria-label']}>
+        aria-label={ariaLabel}>
         {labelText}
-        <span class={`${prefix}--toggle__switch`}>
+        <span className={`${prefix}--toggle__switch`}>
           <svg
             className={`${prefix}--toggle__check`}
             width="6px"
@@ -134,6 +134,8 @@ ToggleSmall.propTypes = {
 ToggleSmall.defaultProps = {
   defaultToggled: false,
   onToggle: () => {},
+  labelA: 'Off',
+  labelB: 'On',
 };
 
 export default ToggleSmall;

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.js
@@ -20,12 +20,14 @@ const ToggleSmall = ({
   onChange,
   onToggle,
   id,
+  labelText,
   ariaLabel,
+  labelA,
+  labelB,
   ...other
 }) => {
   let input;
-  const wrapperClasses = classNames({
-    [`${prefix}--form-item`]: true,
+  const wrapperClasses = classNames(`${prefix}--form-item`, {
     [className]: className,
   });
 
@@ -42,9 +44,10 @@ const ToggleSmall = ({
       <input
         {...other}
         {...checkedProps}
+        aria-label={null}
         type="checkbox"
         id={id}
-        className={`${prefix}--toggle ${prefix}--toggle--small`}
+        className={`${prefix}--toggle-input ${prefix}--toggle-input--small`}
         onChange={evt => {
           onChange && onChange(evt);
           onToggle(input.checked, id, evt);
@@ -52,7 +55,6 @@ const ToggleSmall = ({
         ref={el => {
           input = el;
         }}
-        aria-label={ariaLabel}
         onKeyUp={evt => {
           if (match(evt, keys.ENTER)) {
             input.checked = !input.checked;
@@ -61,18 +63,26 @@ const ToggleSmall = ({
           }
         }}
       />
-
-      <label className={`${prefix}--toggle__label`} htmlFor={id}>
-        <span className={`${prefix}--toggle__appearance`}>
+      <label
+        className={`${prefix}--toggle-input__label`}
+        htmlFor={id}
+        aria-label={labelText ? null : ariaLabel || other['aria-label']}>
+        {labelText}
+        <span class={`${prefix}--toggle__switch`}>
           <svg
             className={`${prefix}--toggle__check`}
             width="6px"
             height="5px"
             viewBox="0 0 6 5">
-            <path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z" />
+            <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
           </svg>
+          <span className={`${prefix}--toggle__text--off`} aria-hidden="true">
+            {labelA}
+          </span>
+          <span className={`${prefix}--toggle__text--on`} aria-hidden="true">
+            {labelB}
+          </span>
         </span>
-        <span className={`${prefix}--assistive-text`}>{ariaLabel}</span>
       </label>
     </div>
   );
@@ -107,7 +117,18 @@ ToggleSmall.propTypes = {
   /**
    * The `aria-label` attribute for the toggle
    */
-  ariaLabel: PropTypes.string.isRequired,
+  labelText: PropTypes.string,
+  ['aria-label']: PropTypes.string.isRequired,
+
+  /**
+   * Specify the label for the "off" position
+   */
+  labelA: PropTypes.string.isRequired,
+
+  /**
+   * Specify the label for the "on" position
+   */
+  labelB: PropTypes.string.isRequired,
 };
 
 ToggleSmall.defaultProps = {


### PR DESCRIPTION
Closes #2809

This PR refactors the toggle and small toggle components to have accessible labels.

question for reviewers: Do we want to wrap the component in a `div.toggle`? Do we also want to support an inline toggle?

#### Changelog

**New**

- class names for accessible toggle version (old classes and markup will be deprecated)

**Changed**

- markup structure of toggle label and switch

**Removed**

- deprecated check mark in small toggle (not found in v10 spec according to images in https://github.com/carbon-design-system/carbon/pull/1267)
- redundant style rules

#### Testing / Reviewing

Ensure the toggle and small toggle function and appear correctly
