### PR TITLE
fix(ui-shell): update right panel active link text color

### DIFF
--- a/packages/components/src/components/ui-shell/_switcher.scss
+++ b/packages/components/src/components/ui-shell/_switcher.scss
@@ -83,6 +83,7 @@
 
   .#{$prefix}--switcher__item-link--selected {
     background: $shell-panel-bg-04;
+    color: $shell-panel-text-02;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/2897

Sets active link text to `$shell-panel-text-02`, which is `gray-10`

<img width="399" alt="Screen Shot 2019-05-31 at 1 30 33 PM" src="https://user-images.githubusercontent.com/11928039/58733080-4f518e00-83a8-11e9-91f2-a291d17a8bd1.png">
