### PR TITLE
fix(tooltip): set width to content max

### DIFF
--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -55,11 +55,8 @@
   // content box
   &::after {
     @include layer('overlay');
-    min-width: rem(24px);
+    width: max-content;
     max-width: rem(208px);
-    @if ($tooltip-type == 'definition') {
-      width: 100%;
-    }
     height: auto;
     padding: if(
       $tooltip-type == 'definition',


### PR DESCRIPTION
Closes #2887 

This PR sets the tooltip body pseudoelement width so that it isn't limited by the width of its parent element

#### Testing / Reviewing

Ensure tooltips display properly, especially on browsers that do not support experimental `max-content` value