### PR TITLE
fix(Button): require iconDescription for icon-only

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -172,7 +172,7 @@ Button.propTypes = {
    * be read by screen readers
    */
   iconDescription: props => {
-    if (props.renderIcon && !props.iconDescription) {
+    if (props.renderIcon && !props.children && !props.iconDescription) {
       return new Error(
         'renderIcon property specified without also providing an iconDescription property.'
       );
@@ -182,7 +182,6 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  iconDescription: 'Provide icon description if icon is used',
   tabIndex: 0,
   type: 'button',
   disabled: false,

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1918,7 +1918,6 @@ exports[`DataTable should render 1`] = `
                 </TableToolbarMenu>
                 <ForwardRef(Button)
                   disabled={false}
-                  iconDescription="Provide icon description if icon is used"
                   kind="primary"
                   onClick={[MockFunction]}
                   small={true}
@@ -2381,7 +2380,6 @@ exports[`DataTable should render 1`] = `
                   <ForwardRef(Button)
                     className="bx--batch-summary__cancel"
                     disabled={false}
-                    iconDescription="Provide icon description if icon is used"
                     kind="primary"
                     onClick={[Function]}
                     small={false}
@@ -2702,7 +2700,6 @@ exports[`DataTable should render 1`] = `
               </TableToolbarMenu>
               <ForwardRef(Button)
                 disabled={false}
-                iconDescription="Provide icon description if icon is used"
                 kind="primary"
                 onClick={[MockFunction]}
                 small={true}

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchActions-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchActions-test.js.snap
@@ -18,7 +18,6 @@ exports[`DataTable.TableBatchActions should render 1`] = `
         <ForwardRef(Button)
           className="bx--batch-summary__cancel"
           disabled={false}
-          iconDescription="Provide icon description if icon is used"
           kind="primary"
           onClick={[MockFunction]}
           small={false}
@@ -70,7 +69,6 @@ exports[`DataTable.TableBatchActions should render 2`] = `
         <ForwardRef(Button)
           className="bx--batch-summary__cancel"
           disabled={false}
-          iconDescription="Provide icon description if icon is used"
           kind="primary"
           onClick={[MockFunction]}
           small={false}

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -147,7 +147,6 @@ exports[`ModalWrapper should render 1`] = `
             >
               <ForwardRef(Button)
                 disabled={false}
-                iconDescription="Provide icon description if icon is used"
                 kind="secondary"
                 onClick={[Function]}
                 small={false}
@@ -166,7 +165,6 @@ exports[`ModalWrapper should render 1`] = `
               </ForwardRef(Button)>
               <ForwardRef(Button)
                 disabled={false}
-                iconDescription="Provide icon description if icon is used"
                 inputref={
                   Object {
                     "current": <button


### PR DESCRIPTION
Fixes #2884.

#### Changelog

**Changed**

- A change to `<Button>` to ensure its check for `iconDescription`'s existence only happens if the button is icon-only.

**Removed**

- The default prop of `iconDescription`.

#### Testing / Reviewing

Testing should make sure our React `<Button>` is not broken.
