### PR TITLE
chore(project): run sync task for package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: Check for generated files that have not been committed
           command: |
             if [ -n "$(git status --porcelain)" ]; then
-              echo "Your git status is not clean. You may have forgot to check-in the following files:";
+              echo "Your git status is not clean. You may have forgotten to check-in the following files:";
               echo "$(git status --porcelain)";
               exit 1;
             fi
@@ -31,7 +31,7 @@ jobs:
             yarn sync
 
             if [ -n "$(git status --porcelain)" ]; then
-              echo "Your git status is not clean. You may have forgot to sync the following package.json files:";
+              echo "Your git status is not clean. You may have forgotten to sync the following package.json files:";
               echo "$(git status --porcelain)";
               echo 'You can fix this by running: `yarn sync`';
               exit 1;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,17 @@ jobs:
           name: Check for generated files that have not been committed
           command: |
             if [ -n "$(git status --porcelain)" ]; then
-              echo "Your git status is not clean. You might have forgot to check-in the following files:";
+              echo "Your git status is not clean. You may have forgot to check-in the following files:";
               echo "$(git status --porcelain)";
+              exit 1;
+            fi
+
+            yarn sync
+
+            if [ -n "$(git status --porcelain)" ]; then
+              echo "Your git status is not clean. You may have forgot to sync the following package.json files:";
+              echo "$(git status --porcelain)";
+              echo 'You can fix this by running: `yarn sync`';
               exit 1;
             fi
       - run:

--- a/packages/browserslist-config-carbon/.npmignore
+++ b/packages/browserslist-config-carbon/.npmignore
@@ -1,0 +1,4 @@
+**/__mocks__/**
+**/__tests__/**
+**/examples/**
+**/tasks/**

--- a/packages/browserslist-config-carbon/package.json
+++ b/packages/browserslist-config-carbon/package.json
@@ -4,15 +4,17 @@
   "version": "10.3.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/browserslist-config-carbon",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/browserslist-config-carbon",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "eyeglass-module",
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -6,14 +6,16 @@
   "bin": {
     "bundler": "./bin/bundler.js"
   },
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/bundler",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/bundler",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/cli-reporter/package.json
+++ b/packages/cli-reporter/package.json
@@ -4,14 +4,16 @@
   "version": "10.2.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/cli-reporter",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/cli-reporter",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/colors",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/colors",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
     "lib",
@@ -19,7 +19,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "main": "umd/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/carbon-components/tree/master/packages/components",
-  "bugs": "https://github.com/carbon-design-system/carbon-components/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/components",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "homepage": "https://www.carbondesignsystem.com/",
   "engines": {
     "node": ">=6.x"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/elements",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/elements",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
     "lib",
@@ -19,7 +19,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -3,8 +3,8 @@
   "description": "Grid for digital and software products using the Carbon Design System",
   "version": "10.3.0",
   "license": "Apache-2.0",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/grid",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/grid",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "css",
     "scss"
@@ -15,7 +15,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icon-helpers/package.json
+++ b/packages/icon-helpers/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/icon-helpers",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/icon-helpers",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
     "lib",
@@ -17,7 +17,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icons-angular/package.json
+++ b/packages/icons-angular/package.json
@@ -4,8 +4,8 @@
   "version": "10.3.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/icons-angular",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/icons-angular",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "lib",
     "umd"
@@ -15,7 +15,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icons-handlebars/package.json
+++ b/packages/icons-handlebars/package.json
@@ -4,14 +4,16 @@
   "version": "10.3.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/icons-handlebars",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/icons-handlebars",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -3,8 +3,8 @@
   "description": "React components for icons in digital and software products using the Carbon Design System",
   "version": "10.3.0",
   "license": "Apache-2.0",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/icons-react",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/icons-react",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
     "lib",
@@ -15,7 +15,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -5,14 +5,16 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/icons-vue",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/icons-vue",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/icons",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/icons",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
     "lib",
@@ -19,7 +19,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/import-once/package.json
+++ b/packages/import-once/package.json
@@ -3,15 +3,17 @@
   "description": "Sass helper for importing files only once. Used in the Carbon Design System",
   "version": "10.2.0",
   "license": "Apache-2.0",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/import-once",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/import-once",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "eyeglass-module",
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -5,15 +5,17 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/layout",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/layout",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "eyeglass-module",
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -5,15 +5,17 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/motion",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/motion",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "eyeglass-module",
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/pictograms/package.json
+++ b/packages/pictograms/package.json
@@ -4,15 +4,17 @@
   "description": "Pictograms for digital and software products using the Carbon Design System",
   "version": "10.0.0",
   "license": "Apache-2.0",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/pictograms",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/pictograms",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "pictograms",
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -1,0 +1,4 @@
+**/__mocks__/**
+**/__tests__/**
+**/examples/**
+**/tasks/**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,11 +1,28 @@
 {
   "name": "carbon-components-react",
-  "version": "7.3.0",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
+  "version": "7.3.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "sideEffects": false,
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/react",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
+  "files": [
+    "lib/**/*",
+    "es/**/*",
+    "umd/**/*"
+  ],
+  "keywords": [
+    "react",
+    "carbon",
+    "carbon-components",
+    "ibm",
+    "carbon-design-system",
+    "components"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn clean && node scripts/build.js",
     "build-storybook": "build-storybook",
@@ -21,103 +38,6 @@
     "storybook": "start-storybook -p 9000",
     "test": "jest",
     "test-ssr": "yarn build && node ssr-tests/*.js"
-  },
-  "keywords": [
-    "react",
-    "carbon",
-    "carbon-components"
-  ],
-  "files": [
-    "lib/**/*",
-    "es/**/*",
-    "umd/**/*"
-  ],
-  "contributors": [
-    {
-      "name": "Brian Han",
-      "email": "bthan@us.ibm.com"
-    },
-    {
-      "name": "Aziz Punjani",
-      "email": "punjani@us.ibm.com"
-    },
-    {
-      "name": "Mari Johannessen",
-      "email": "mjohannessen@us.ibm.com"
-    },
-    {
-      "name": "TJ Egan",
-      "email": "twegan@us.ibm.com"
-    },
-    {
-      "name": "Ian Fleming",
-      "email": "ianfleming@us.ibm.com"
-    },
-    {
-      "name": "Chris Dhanaraj",
-      "email": "chrisdhanaraj@us.ibm.com"
-    }
-  ],
-  "eslintConfig": {
-    "parser": "babel-eslint",
-    "extends": [
-      "eslint:recommended",
-      "plugin:jsx-a11y/recommended"
-    ],
-    "plugins": [
-      "react",
-      "jsdoc",
-      "jsx-a11y"
-    ],
-    "rules": {
-      "react/jsx-uses-vars": 1,
-      "react/jsx-uses-react": 1,
-      "react/no-find-dom-node": 1,
-      "react/no-typos": 2,
-      "jsdoc/check-param-names": 2,
-      "jsdoc/check-tag-names": 2,
-      "jsdoc/check-types": 2,
-      "jsx-a11y/no-static-element-interactions": 1,
-      "jsx-a11y/no-noninteractive-element-interactions": 1,
-      "jsx-a11y/click-events-have-key-events": 1,
-      "jsx-a11y/anchor-is-valid": 1,
-      "jsx-a11y/interactive-supports-focus": 1,
-      "jsx-a11y/label-has-for": [
-        1,
-        {
-          "components": [
-            "Label"
-          ],
-          "required": {
-            "some": [
-              "nesting",
-              "id"
-            ]
-          },
-          "allowChildren": true
-        }
-      ]
-    },
-    "env": {
-      "node": true,
-      "browser": true,
-      "es6": true,
-      "jest": true,
-      "jasmine": true
-    },
-    "globals": {
-      "__DEV__": true
-    },
-    "settings": {
-      "jsdoc": {
-        "tagNamePreference": {
-          "augments": "extends"
-        }
-      },
-      "react": {
-        "version": "detect"
-      }
-    }
   },
   "peerDependencies": {
     "carbon-components": "10.3.0-rc.2",
@@ -212,8 +132,67 @@
     "webpack": "^4.25.1",
     "whatwg-fetch": "^2.0.3"
   },
-  "release": {
-    "branch": "master"
+  "sideEffects": false,
+  "eslintConfig": {
+    "parser": "babel-eslint",
+    "extends": [
+      "eslint:recommended",
+      "plugin:jsx-a11y/recommended"
+    ],
+    "plugins": [
+      "react",
+      "jsdoc",
+      "jsx-a11y"
+    ],
+    "rules": {
+      "react/jsx-uses-vars": 1,
+      "react/jsx-uses-react": 1,
+      "react/no-find-dom-node": 1,
+      "react/no-typos": 2,
+      "jsdoc/check-param-names": 2,
+      "jsdoc/check-tag-names": 2,
+      "jsdoc/check-types": 2,
+      "jsx-a11y/no-static-element-interactions": 1,
+      "jsx-a11y/no-noninteractive-element-interactions": 1,
+      "jsx-a11y/click-events-have-key-events": 1,
+      "jsx-a11y/anchor-is-valid": 1,
+      "jsx-a11y/interactive-supports-focus": 1,
+      "jsx-a11y/label-has-for": [
+        1,
+        {
+          "components": [
+            "Label"
+          ],
+          "required": {
+            "some": [
+              "nesting",
+              "id"
+            ]
+          },
+          "allowChildren": true
+        }
+      ]
+    },
+    "env": {
+      "node": true,
+      "browser": true,
+      "es6": true,
+      "jest": true,
+      "jasmine": true
+    },
+    "globals": {
+      "__DEV__": true
+    },
+    "settings": {
+      "jsdoc": {
+        "tagNamePreference": {
+          "augments": "extends"
+        }
+      },
+      "react": {
+        "version": "detect"
+      }
+    }
   },
   "babel": {
     "presets": [
@@ -228,10 +207,6 @@
       "@babel/plugin-proposal-export-namespace-from",
       "@babel/plugin-proposal-export-default-from"
     ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/IBM/carbon-components-react.git"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/packages/scss-generator/package.json
+++ b/packages/scss-generator/package.json
@@ -4,14 +4,16 @@
   "version": "10.2.0",
   "license": "Apache-2.0",
   "main": "src/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/scss-generator",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/scss-generator",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/sketch/.npmignore
+++ b/packages/sketch/.npmignore
@@ -1,0 +1,4 @@
+**/__mocks__/**
+**/__tests__/**
+**/examples/**
+**/tasks/**

--- a/packages/sketch/package.json
+++ b/packages/sketch/package.json
@@ -1,9 +1,21 @@
 {
   "name": "@carbon/sketch",
-  "description": "Tooling for generating a sketch plugin to bring code to design",
   "private": true,
+  "description": "Tooling for generating a sketch plugin to bring code to design",
   "version": "10.3.0",
   "license": "Apache-2.0",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/sketch",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
+  "keywords": [
+    "ibm",
+    "carbon",
+    "carbon-design-system",
+    "components",
+    "react"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "cross-env NODE_ENV=production skpm-build",
     "clean": "rimraf carbon-elements.sketchplugin",

--- a/packages/stylelint-config-elements/package.json
+++ b/packages/stylelint-config-elements/package.json
@@ -5,14 +5,16 @@
   "version": "10.0.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/stylelint-config-elements",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/stylelint-config-elements",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -2,14 +2,16 @@
   "name": "@carbon/test-utils",
   "version": "10.2.0",
   "license": "Apache-2.0",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/test-utils",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/test-utils",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -5,14 +5,16 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/themes",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/themes",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "keywords": [
     "ibm",
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/IBM/carbon-elements/tree/master/packages/type",
-  "bugs": "https://github.com/IBM/carbon-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/type",
+  "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
     "lib",
@@ -20,7 +20,9 @@
     "elements",
     "carbon",
     "carbon-elements",
-    "carbon-design-system"
+    "carbon-design-system",
+    "components",
+    "react"
   ],
   "publishConfig": {
     "access": "public"

--- a/tasks/sync.js
+++ b/tasks/sync.js
@@ -61,6 +61,7 @@ const packageJsonFields = [
   'devDependencies',
   'sideEffects',
   'eyeglass',
+  'eslintConfig',
   'prettier',
   'babel',
   'jest',

--- a/tasks/sync.js
+++ b/tasks/sync.js
@@ -20,7 +20,7 @@ const prettierOptions = {
 
 const PACKAGES_DIR = path.resolve(__dirname, '../packages');
 const REPO_URL_BASE =
-  'https://github.com/carbon-design-system/carbon-components/tree/master/packages';
+  'https://github.com/carbon-design-system/carbon/tree/master/packages';
 
 // This is our default set of keywords to include in each `package.json` file
 const DEFAULT_KEYWORDS = [
@@ -44,6 +44,7 @@ const packageJsonFields = [
   'description',
   'version',
   'license',
+  'bin',
   'main',
   'module',
   'repository',
@@ -93,8 +94,7 @@ async function sync() {
   const packages = await Promise.all(
     packagePaths.map(async ({ basename, filepath, file, ...rest }) => {
       file.repository = `${REPO_URL_BASE}/${basename}`;
-      file.bugs =
-        'https://github.com/carbon-design-system/carbon-components/issues';
+      file.bugs = 'https://github.com/carbon-design-system/carbon/issues';
       file.license = 'Apache-2.0';
       file.publishConfig = {
         access: 'public',


### PR DESCRIPTION
Runs `yarn sync` to keep `package.json` and `.npmignore` files in sync across packages. Also adds step to generated files task in CI to verify that these are kept in sync.

#### Changelog

**New**

- `.npmignore` files for various packages

**Changed**

- `package.json` files for various packages

**Removed**
