### PR TITLE
fix(Tile): add event.persist() to event handlers (#2713)

### DIFF
--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -66,21 +66,21 @@ describe('Tile', () => {
 
     it('toggles the clickable class on click', () => {
       expect(wrapper.hasClass(`${prefix}--tile--is-clicked`)).toEqual(false);
-      wrapper.simulate('click');
+      wrapper.simulate('click', { persist: () => {} });
       expect(wrapper.hasClass(`${prefix}--tile--is-clicked`)).toEqual(true);
     });
 
     it('toggles the clickable state on click', () => {
       expect(wrapper.state().clicked).toEqual(false);
-      wrapper.simulate('click');
+      wrapper.simulate('click', { persist: () => {} });
       expect(wrapper.state().clicked).toEqual(true);
     });
 
     it('toggles the clicked state when using enter or space', () => {
       expect(wrapper.state().clicked).toEqual(false);
-      wrapper.simulate('keydown', { which: 32 });
+      wrapper.simulate('keydown', { which: 32, persist: () => {} });
       expect(wrapper.state().clicked).toEqual(true);
-      wrapper.simulate('keydown', { which: 13 });
+      wrapper.simulate('keydown', { which: 13, persist: () => {} });
       expect(wrapper.state().clicked).toEqual(false);
     });
 

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -73,6 +73,7 @@ export class ClickableTile extends Component {
   };
 
   handleClick = evt => {
+    evt.persist();
     this.setState(
       {
         clicked: !this.state.clicked,
@@ -84,6 +85,7 @@ export class ClickableTile extends Component {
   };
 
   handleKeyDown = evt => {
+    evt.persist();
     if (matches(evt, [keys.ENTER, keys.SPACE])) {
       this.setState(
         {
@@ -205,6 +207,7 @@ export class SelectableTile extends Component {
 
   handleClick = evt => {
     evt.preventDefault();
+    evt.persist();
     const isInput = evt.target === this.input;
     if (!isInput) {
       this.setState(
@@ -221,6 +224,7 @@ export class SelectableTile extends Component {
   };
 
   handleKeyDown = evt => {
+    evt.persist();
     if (matches(evt, [keys.ENTER, keys.SPACE])) {
       evt.preventDefault();
       this.setState(
@@ -407,6 +411,7 @@ export class ExpandableTile extends Component {
     });
 
   handleClick = evt => {
+    evt.persist();
     this.setState(
       {
         expanded: !this.state.expanded,


### PR DESCRIPTION
Closes #2713 

This PR keeps the original synthetic event using event.persist(). 

See https://fb.me/react-event-pooling and #2713  for more information.

#### Changelog

**New**

- Add `event.persist()` function to `ClickableTile`, `SelectableTile` and `ExpandableTile` event handlers like `handleClick` and `handleKeyDown`.

#### Testing / Reviewing

1. Start a storybook/codesandbox ([example](https://03knn0o0lw.codesandbox.io/)) project with `ExpandableTile` and `SelectableTile` (the React has to be on development build for errors to appear in console)
2. Click on the components - notice that errors like such appear 
![image](https://user-images.githubusercontent.com/36169811/59151399-b9b2a000-8a32-11e9-87a9-2b073cf93c28.png)

3. Checkout this branch, run `yarn start`. Go on `Expandable` and `Multi-Select` stories under `Tile` component.
4. Click on the tiles, no more errors suggesting using `event.persist()` appear. Functionality of the tiles should stay the same.

