### PR TITLE
chore(project): move deploy step to git tag releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,34 +32,60 @@ jobs:
           command: |
             yarn ci-check
             yarn lerna run ci-check
+
+  deploy:
+    docker:
+      - image: circleci/node:10.15-browsers
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Install yarn
+          command: |
+            curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
+            # Reference:
+            # https://circleci.com/docs/2.0/env-vars/#example-configuration-of-environment-variables
+            echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> $BASH_ENV
+      - run:
+          name: Install dependencies
+          command: yarn install --offline --frozen-lockfile
+      - run:
+          name: Build packages
+          command: yarn build
       - deploy:
           name: deploy to IBM Cloud
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              # Install `ibmcloud` CLI
-              curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+            # Install `ibmcloud` CLI
+            curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 
-              # Login and push staging manifest
-              ibmcloud login \
-                --apikey $CLOUD_API_KEY \
-                -a https://api.ng.bluemix.net \
-                -o carbon-design-system
+            # Login and push staging manifest
+            ibmcloud login \
+              --apikey $CLOUD_API_KEY \
+              -a https://api.ng.bluemix.net \
+              -o carbon-design-system
 
-              ibmcloud target -s production
+            ibmcloud target -s production
 
-              ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-              ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
+            ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+            ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
 
-              # Default storybook build
-              cd packages/react
-              yarn build-storybook
-              ibmcloud cf blue-green-deploy carbon-storybook \
-                -f manifest.yml \
-                --delete-old-apps
-            fi
+            # Default storybook build
+            cd packages/react
+            yarn build-storybook
+            ibmcloud cf blue-green-deploy carbon-storybook \
+              -f manifest.yml \
+              --delete-old-apps
 
 workflows:
   version: 2
   main:
     jobs:
       - system
+      - deploy:
+          requires:
+            - system
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,4 +88,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
This moves our `deploy` step from continuously releasing to being triggered when a new `git` tag is created following the `vX.Y.Z`

#### Changelog

**New**

**Changed**

- `main` workflow in CI now has a deploy step triggered only on when a new git tag is created with a valid semver version

**Removed**
