### PR TITLE
fix: replace outdated precommit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,16 +91,18 @@
       "git add"
     ],
     "packages/components/**/*.scss": [
-      "yarn format:staged",
+      "prettier --write",
       "git add"
     ],
     "*.md": [
-      "yarn format:staged",
+      "prettier --write",
       "git add"
     ]
   },
   "eslintConfig": {
-    "extends": ["eslint-config-carbon"]
+    "extends": [
+      "eslint-config-carbon"
+    ]
   },
   "prettier": {
     "jsxBracketSameLine": true,


### PR DESCRIPTION
Closes #3008 

This PR replaces the missing `format:staged` script references with `prettier --write`