### PR TITLE
fix(Modal): click-outside by mousedown

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -165,7 +165,7 @@ export default class Modal extends Component {
     }
   };
 
-  handleClick = evt => {
+  handleMousedown = evt => {
     if (
       this.innerModal.current &&
       !this.innerModal.current.contains(evt.target) &&
@@ -329,7 +329,7 @@ export default class Modal extends Component {
       <div
         {...other}
         onKeyDown={this.handleKeyDown}
-        onClick={this.handleClick}
+        onMouseDown={this.handleMousedown}
         onBlur={this.handleBlur}
         className={modalClasses}
         role="presentation"


### PR DESCRIPTION
Fixes #2968.

#### Changelog

**Changed**

- Use `mousedown` instead of `click` event for "close-on-click-outside" behavior.

#### Testing / Reviewing

Testing should make sure modal is not broken.