### PR TITLE
docs(tag): add roles to tag list and wrap in container

### DIFF
--- a/packages/components/src/components/tag/tag.hbs
+++ b/packages/components/src/components/tag/tag.hbs
@@ -5,13 +5,17 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-{{#each tags}}
-<span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--{{type}}">{{label}}</span>
-{{/each}}
+<div role="list">
+  {{#each tags}}
+  <span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--{{type}}" role="listitem">{{label}}</span>
+  {{/each}}
+</div>
 
-{{#if filter}}
-<span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--filter" title="Clear filter" tabindex="0">
-  filter
-  {{ carbon-icon 'Close16' aria-label='Clear filter' }}
-</span>
-{{/if}}
+<div role="list">
+  {{#if filter}}
+  <span class="{{@root.prefix}}--tag {{@root.prefix}}--tag--filter" title="Clear filter" tabindex="0" role="listitem">
+    filter
+    {{ carbon-icon 'Close16' aria-label='Clear filter' }}
+  </span>
+  {{/if}}
+</div>

--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -26,6 +26,7 @@ const props = {
       'red'
     ),
     disabled: boolean('Disabled (disabled)', false),
+    role: 'listitem',
   }),
   filter() {
     return { ...this.regular(), onClick: action('onClick') };


### PR DESCRIPTION
Closes #2738

This PR adds a container `div[role="list"]` around tag lists in our docs and adds `role="listitem"` to each tag