### PR TITLE
fix(button): danger button border color same as bg color

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -194,7 +194,8 @@
     @include button-theme(
       // $support-01, TODO: replace with updated token
         #dc222b,
-      $support-01,
+      // $support-01, TODO: replace with updated token
+        #dc222b,
       $text-04,
       $hover-danger,
       $icon-03,


### PR DESCRIPTION
Closes #

#3037 

#### Changelog

**Changed**

- same as background color -- comment out the token & add custom color `#dc222b` until the token issue is resolved down the road