### PR TITLE
fix(tabs): use focus outline mixin

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -237,8 +237,7 @@
       width: 100%;
       margin: 0;
       padding-left: 16px;
-      outline: 2px solid $interactive-01;
-      outline-offset: -2px;
+      @include focus-outline('outline');
     }
 
     @include carbon--breakpoint(md) {


### PR DESCRIPTION
Closes #1757 

#### Changelog

**Changed**

- use `focus-outline` mixin so that the color of the outline will change depending on theme, specifically to fix how that outline looks in dark themes (currently it is blue60). See https://github.com/carbon-design-system/carbon/issues/1757#issuecomment-463303308