### PR TITLE
fix(ToggleSmall): add optional labels to ToggleSmall

### DIFF
--- a/packages/react/src/components/ToggleSmall/ToggleSmall-story.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall-story.js
@@ -67,4 +67,28 @@ storiesOf('ToggleSmall', module)
             Placeholder skeleton state to use when content is loading.
           `,
     },
-  });
+  })
+  .add(
+    'with labels',
+    () => (
+      <ToggleSmall
+        labelA="off"
+        labelB="on"
+        defaultToggled
+        {...toggleProps()}
+        className="some-class"
+        id="toggle-1"
+      />
+    ),
+    {
+      info: {
+        text: `
+            Toggles are controls that are used to quickly switch between two possible states. The example below shows
+            an uncontrolled Toggle component. To use the Toggle component as a controlled component, set the toggled property.
+            Setting the toggled property will allow you to change the value dynamically, whereas setting the defaultToggled
+            prop will only set the value initially. This example has defaultToggled set to true. Small toggles may be used
+            when there is not enough space for a regular sized toggle. This issue is most commonly found in tables.
+          `,
+      },
+    }
+  );

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import { keys, match } from '../../tools/key';
@@ -21,6 +21,8 @@ const ToggleSmall = ({
   onToggle,
   id,
   ariaLabel,
+  labelA,
+  labelB,
   ...other
 }) => {
   let input;
@@ -63,16 +65,34 @@ const ToggleSmall = ({
       />
 
       <label className={`${prefix}--toggle__label`} htmlFor={id}>
-        <span className={`${prefix}--toggle__appearance`}>
-          <svg
-            className={`${prefix}--toggle__check`}
-            width="6px"
-            height="5px"
-            viewBox="0 0 6 5">
-            <path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z" />
-          </svg>
-        </span>
-        <span className={`${prefix}--assistive-text`}>{ariaLabel}</span>
+        {labelA && labelB ? (
+          <Fragment>
+            <span
+              className={`${prefix}--toggle__text--left`}
+              aria-hidden="true">
+              {labelA}
+            </span>
+            <span className={`${prefix}--toggle__appearance`} />
+            <span
+              className={`${prefix}--toggle__text--right`}
+              aria-hidden="true">
+              {labelB}
+            </span>
+          </Fragment>
+        ) : (
+          <Fragment>
+            <span className={`${prefix}--toggle__appearance`}>
+              <svg
+                className={`${prefix}--toggle__check`}
+                width="6px"
+                height="5px"
+                viewBox="0 0 6 5">
+                <path d="M2.2403 2.7299L4.9245 0 6 1.1117 2.2384 5 0 2.6863 1.0612 1.511z" />
+              </svg>
+            </span>
+            <span className={`${prefix}--assistive-text`}>{ariaLabel}</span>
+          </Fragment>
+        )}
       </label>
     </div>
   );
@@ -108,6 +128,16 @@ ToggleSmall.propTypes = {
    * The `aria-label` attribute for the toggle
    */
   ariaLabel: PropTypes.string.isRequired,
+
+  /**
+   * Specify the label for the "off" position
+   */
+  labelA: PropTypes.string,
+
+  /**
+   * Specify the label for the "on" position
+   */
+  labelB: PropTypes.string,
 };
 
 ToggleSmall.defaultProps = {


### PR DESCRIPTION
Closes #2856 

Adds optional labels on ToggleSmall and adds an example to the documentation. 👍 

#### Changelog

\+ "with labels" story to docs
\+ `labelA` and `labelB` props to ToggleSmall (mirroring Toggle)
\+ a check in render for both props that displays labels over SVGs

#### To test
Go to the ToggleSmall section of our React documentation (the Netlify builds below) and select the "with labels" option.