### PR TITLE
fix(DatePicker): fix for new onChange ref after mount

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -316,7 +316,6 @@ export default class DatePicker extends Component {
       datePickerType,
       dateFormat,
       locale,
-      onChange,
       minDate,
       maxDate,
       value,
@@ -354,6 +353,7 @@ export default class DatePicker extends Component {
           nextArrow: this.rightArrowHTML(),
           prevArrow: this.leftArrowHTML(),
           onChange: (...args) => {
+            const { onChange } = this.props;
             if (onChange) {
               onChange(...args);
             }


### PR DESCRIPTION
Fixes #3042.

#### Changelog

**Changed**

- A fix to code running `onChange` prop, so it grab the latest ref.

#### Testing / Reviewing

Testing should make sure our React date picker is not broken.