### PR TITLE
fix(button): update deprecation warning with correct prop

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -51,7 +51,7 @@ const Button = React.forwardRef(function Button(
     if (small && !didWarnAboutDeprecation) {
       warning(
         false,
-        `\nThe prop \`small\` for Button has been deprecated in favor of \`size\`. Please use \`type="small"\` instead.`
+        `\nThe prop \`small\` for Button has been deprecated in favor of \`size\`. Please use \`size="small"\` instead.`
       );
       didWarnAboutDeprecation = true;
     }


### PR DESCRIPTION
The deprecation warning here is showing an incorrect example. (Should direct users to use `size`, not `type` in this case)

#### Changelog

**Changed**

- change `type="small"` to `size="small"` in the deprecation warning