### PR TITLE
fix(select): inherit font-family

### DIFF
--- a/packages/components/src/globals/scss/_css--reset.scss
+++ b/packages/components/src/globals/scss/_css--reset.scss
@@ -124,6 +124,7 @@
 
     // Chrome 62 fix
     button,
+    select,
     input[type='button'],
     input[type='submit'],
     input[type='reset'],


### PR DESCRIPTION
Closes #3043

This PR includes `<select>` elements in our CSS reset so they render with the correct `font-family` rule

#### Testing / Reviewing

Ensure `<select>` elements are rendering properly
