### PR TITLE
feat(text-input): add read-only variant

### DIFF
--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -14,6 +14,7 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+@import '../../globals/scss/tooltip';
 @import '../form/form';
 
 /// Text area styles

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -145,9 +145,8 @@
     @include tooltip--placement('icon', 'bottom', 'end');
     z-index: z('floating') + 1;
     position: absolute;
-    top: 50%;
-    right: $carbon--spacing-07;
-    transform: translateY(-50%);
+    top: $carbon--spacing-04;
+    right: $carbon--spacing-06;
     cursor: default;
 
     &::after {

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -43,6 +43,16 @@
     transition: background-color $duration--fast-01 motion(standard, productive),
       outline $duration--fast-01 motion(standard, productive);
 
+    &:focus,
+    &:active {
+      @include focus-outline('outline');
+    }
+
+    &[readonly]:focus,
+    &[readonly]:active {
+      @include focus-outline('reset');
+    }
+
     &::placeholder {
       @include placeholder-colors;
       @include type-style('body-long-01');

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -147,7 +147,7 @@
     z-index: z('floating') + 1;
     position: absolute;
     top: $carbon--spacing-04;
-    right: $carbon--spacing-06;
+    right: $carbon--spacing-05;
     cursor: default;
 
     &::after {

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -42,32 +42,26 @@
     transition: background-color $duration--fast-01 motion(standard, productive),
       outline $duration--fast-01 motion(standard, productive);
 
-    & ~ .#{$prefix}--form__helper-text {
-      margin-top: 0;
-      order: 2;
-    }
-
-    & ~ .#{$prefix}--form-requirement {
-      order: 4;
-      color: $support-01;
-      font-weight: 400;
-      margin-top: $carbon--spacing-02;
-
-      &::before {
-        display: none;
-      }
+    &::placeholder {
+      @include placeholder-colors;
+      @include type-style('body-long-01');
     }
   }
 
-  .#{$prefix}--text-area:focus,
-  .#{$prefix}--text-area:active {
-    @include focus-outline('outline');
+  .#{$prefix}--text-area ~ .#{$prefix}--form__helper-text {
+    margin-top: 0;
+    order: 2;
   }
 
-  .#{$prefix}--text-area::placeholder {
-    @include placeholder-colors;
-    @include type-style('body-long-01');
-    opacity: 1;
+  .#{$prefix}--text-area ~ .#{$prefix}--form-requirement {
+    order: 4;
+    color: $support-01;
+    font-weight: 400;
+    margin-top: $carbon--spacing-02;
+
+    &::before {
+      display: none;
+    }
   }
 
   .#{$prefix}--text-area--light {
@@ -131,6 +125,34 @@
 
   .#{$prefix}--text-area:disabled::placeholder {
     color: $disabled-02;
+  }
+
+  //-----------------------------
+  // Read only
+  //-----------------------------
+  .#{$prefix}--text-area[readonly] {
+    padding-right: $carbon--spacing-08;
+    text-overflow: ellipsis;
+    background-color: $field-02;
+  }
+
+  .#{$prefix}--text-area--light[readonly] {
+    background-color: $field-01;
+  }
+
+  .#{$prefix}--text-area__readonly-icon {
+    @include tooltip--trigger('icon', 'bottom');
+    @include tooltip--placement('icon', 'bottom', 'end');
+    z-index: z('floating') + 1;
+    position: absolute;
+    top: 50%;
+    right: $carbon--spacing-07;
+    transform: translateY(-50%);
+    cursor: default;
+
+    &::after {
+      padding: 1rem;
+    }
   }
 
   // Skeleton State

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -151,7 +151,8 @@
     background-color: $field-01;
   }
 
-  .#{$prefix}--text-area__readonly-icon {
+  .#{$prefix}--text-area__wrapper
+    > .#{$prefix}--text-area__readonly-icon.#{$prefix}--tooltip__trigger {
     @include tooltip--trigger('icon', 'bottom');
     @include tooltip--placement('icon', 'bottom', 'end');
     z-index: z('floating') + 1;
@@ -163,6 +164,12 @@
     &::after {
       padding: 1rem;
     }
+  }
+
+  .#{$prefix}--text-area__readonly-icon
+    + .#{$prefix}--tooltip--definition
+    > .#{$prefix}--tooltip__trigger {
+    border-bottom: none;
   }
 
   // Skeleton State

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -20,6 +20,10 @@
 /// @access private
 /// @group text-area
 @mixin text-area {
+  .#{$prefix}--text-area__container {
+    position: relative;
+  }
+
   .#{$prefix}--text-area {
     @include reset;
     @include type-style('body-long-01');
@@ -77,6 +81,7 @@
   .#{$prefix}--text-area__wrapper {
     position: relative;
     display: flex;
+    width: 100%;
   }
 
   .#{$prefix}--text-area__invalid-icon {
@@ -84,6 +89,34 @@
     right: $carbon--spacing-05;
     top: $carbon--spacing-04;
     fill: $support-01;
+  }
+
+  // -----------------
+  // Character counter
+  // -----------------
+  .#{$prefix}--text-area__character-counter-title {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .#{$prefix}--text-area__character-counter-title .#{$prefix}--label {
+    margin-right: rem(16px);
+  }
+
+  .#{$prefix}--text-area__character-counter-title
+    + .#{$prefix}--form__helper-text {
+    margin-top: rem(-6px);
+  }
+
+  .#{$prefix}--text-area--character-counter {
+    margin-bottom: $carbon--spacing-03;
+    @include type-style('label-01');
+    color: $text-02;
+  }
+
+  .#{$prefix}--text-area--character-counter--disabled {
+    color: $disabled-02;
   }
 
   //-----------------------------

--- a/packages/components/src/components/text-area/text-area.config.js
+++ b/packages/components/src/components/text-area/text-area.config.js
@@ -29,5 +29,22 @@ module.exports = {
         light: true,
       },
     },
+    {
+      name: 'character-counter',
+      label: 'Text area with character counter',
+      context: {
+        charCounter: true,
+        maxLength: 3500,
+      },
+    },
+    {
+      name: 'character-counter--light',
+      label: 'Text area with character counter (light)',
+      context: {
+        charCounter: true,
+        maxLength: 3500,
+        light: true,
+      },
+    },
   ],
 };

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -5,47 +5,87 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div class="{{@root.prefix}}--form-item">
-  <label for="text-area-2" class="{{@root.prefix}}--label">Text Area label</label>
-  <div class="{{@root.prefix}}--text-area__wrapper">
-    <textarea id="text-area-2"
-      class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
-      rows="4" cols="50" placeholder="Placeholder text."></textarea>
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-2" class="{{prefix}}--label">Text Area label</label>
+  {{/if}}
+  <div class="{{prefix}}--text-area__wrapper">
+    <textarea id="text-area-2" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+      cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}></textarea>
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
-  <label for="text-area-3" class="{{@root.prefix}}--label">Text Area label</label>
-  <div class="{{@root.prefix}}--text-area__wrapper" data-invalid>
-    {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--text-area__invalid-icon')}}
-    <textarea id="text-area-3"
-      class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--invalid {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
-      rows="4" cols="50" placeholder="Placeholder text."></textarea>
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
   </div>
-  <div class="{{@root.prefix}}--form-requirement">
+  {{else}}
+  <label for="text-area-3" class="{{prefix}}--label">Text Area label</label>
+  {{/if}}
+  <div class="{{prefix}}--text-area__wrapper" data-invalid>
+    {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-area__invalid-icon')}}
+    <textarea id="text-area-3"
+      class="{{prefix}}--text-area {{prefix}}--text-area--invalid {{#if light}} {{prefix}}--text-area--light{{/if}}"
+      rows="4" cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}"
+      {{/if}}></textarea>
+  </div>
+  <div class="{{prefix}}--form-requirement">
     Validation message here
   </div>
 </div>
 
-<div class="{{@root.prefix}}--form-item">
-  <label for="text-area-4" class="{{@root.prefix}}--label">Text Area label</label>
-  <div class="{{@root.prefix}}--form__helper-text">
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-4" class="{{prefix}}--label">Text Area label</label>
+  {{/if}}
+  <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
-  <div class="{{@root.prefix}}--text-area__wrapper">
-    <textarea id="text-area-4"
-      class="{{@root.prefix}}--text-area {{@root.prefix}}--text-area--v2{{#if light}} {{@root.prefix}}--text-area--light{{/if}}"
-      rows="4" cols="50" placeholder="Placeholder text."></textarea>
+  <div class="{{prefix}}--text-area__wrapper">
+    <textarea id="text-area-4" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+      cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}></textarea>
   </div>
 </div>
 
-<div class="bx--form-item">
-  <label for="text-area-5" class="bx--label bx--label--disabled">Text Area label</label>
-  <div class="{{@root.prefix}}--form__helper-text {{@root.prefix}}--form__helper-text--disabled">
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter {{prefix}}--text-area--character-counter--disabled">
+      <span class="{{prefix}}--text-area--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-5" class="{{prefix}}--label {{prefix}}--label--disabled">Text Area label</label>
+  {{/if}}
+  <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
-  <div class="{{@root.prefix}}--text-area__wrapper">
-    <textarea id="text-area-5" class="bx--text-area bx--text-area--v2{{#if light}} bx--text-area--light{{/if}}" rows="4"
-      cols="50" placeholder="Placeholder text." disabled></textarea>
+  <div class="{{prefix}}--text-area__wrapper">
+    <textarea id="text-area-5" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}" rows="4"
+      cols="50" placeholder="Placeholder text." disabled{{#if charCounter}} maxlength="{{maxLength}}"
+      {{/if}}></textarea>
   </div>
 </div>

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -104,23 +104,23 @@
   <label for="text-area-6" class="{{prefix}}--label">Text Area label</label>
   {{/if}}
   <div class="{{prefix}}--text-area__wrapper">
-    <div class="{{prefix}}--text-area__readonly-icon"
-      aria-label="This field cannot be edited to ensure successful provisioning">
+    <button
+      class="{{prefix}}--text-area__readonly-icon {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom">
+      <span class="{{@root.prefix}}--assistive-text">This field cannot be edited to ensure successful
+        provisioning</span>
       {{ carbon-icon 'EditOff16' }}
-    </div>
-    <div id="tooltip-label" class="{{@root.prefix}}--tooltip__label" aria-describedby="unique-tooltip">
-      <div aria-labelledby="tooltip-label" data-tooltip-trigger data-tooltip-target="#unique-tooltip" role="tooltip">
+    </button>
+    <div class="{{@root.prefix}}--tooltip--definition {{@root.prefix}}--tooltip--a11y">
+      <div aria-describedby="unique-tooltip"
+        class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip__trigger--definition {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
         <textarea id="text-area-6" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}"
           rows="4" cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
           readonly>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus, exercitationem ducimus reiciendis.</textarea>
       </div>
-    </div>
-    <div id="unique-tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip"
-      data-avoid-focus-on-open>
-      <span class="{{@root.prefix}}--tooltip__caret"></span>
-      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate
+      <div class="bx--assistive-text" id="unique-tooltip" role="tooltip">Lorem ipsum dolor sit amet consectetur
+        adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate
         facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus,
-        exercitationem ducimus reiciendis.</p>
+        exercitationem ducimus reiciendis.</div>
     </div>
   </div>
 </div>

--- a/packages/components/src/components/text-area/text-area.hbs
+++ b/packages/components/src/components/text-area/text-area.hbs
@@ -89,3 +89,38 @@
       {{/if}}></textarea>
   </div>
 </div>
+
+
+<div data-text-area class="{{prefix}}--form-item{{#if charCounter}} {{prefix}}--text-area__container{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-area__character-counter-title">
+    <label for="text-area-6" class="{{prefix}}--label">Text Area label</label>
+    <span class="{{prefix}}--text-area--character-counter">
+      <span class="{{prefix}}--text-area--character-counter--length">243</span>/<span
+        class="{{prefix}}--text-area--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-area-6" class="{{prefix}}--label">Text Area label</label>
+  {{/if}}
+  <div class="{{prefix}}--text-area__wrapper">
+    <div class="{{prefix}}--text-area__readonly-icon"
+      aria-label="This field cannot be edited to ensure successful provisioning">
+      {{ carbon-icon 'EditOff16' }}
+    </div>
+    <div id="tooltip-label" class="{{@root.prefix}}--tooltip__label" aria-describedby="unique-tooltip">
+      <div aria-labelledby="tooltip-label" data-tooltip-trigger data-tooltip-target="#unique-tooltip" role="tooltip">
+        <textarea id="text-area-6" class="{{prefix}}--text-area {{#if light}} {{prefix}}--text-area--light{{/if}}"
+          rows="4" cols="50" placeholder="Placeholder text." {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+          readonly>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus, exercitationem ducimus reiciendis.</textarea>
+      </div>
+    </div>
+    <div id="unique-tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip"
+      data-avoid-focus-on-open>
+      <span class="{{@root.prefix}}--tooltip__caret"></span>
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate
+        facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus,
+        exercitationem ducimus reiciendis.</p>
+    </div>
+  </div>
+</div>

--- a/packages/components/src/components/text-area/text-area.js
+++ b/packages/components/src/components/text-area/text-area.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import settings from '../../globals/js/settings';
+import mixin from '../../globals/js/misc/mixin';
+import createComponent from '../../globals/js/mixins/create-component';
+import initComponentBySearch from '../../globals/js/mixins/init-component-by-search';
+import handles from '../../globals/js/mixins/handles';
+import on from '../../globals/js/misc/on';
+
+export default class TextArea extends mixin(
+  createComponent,
+  initComponentBySearch,
+  handles
+) {
+  /**
+   * Text Area.
+   * @extends CreateComponent
+   * @extends InitComponentBySearch
+   * @extends Handles
+   * @param {HTMLElement} element - The textarea element
+   */
+  constructor(element, options) {
+    super(element, options);
+    this.manage(
+      on(this.element, 'input', event => {
+        if (event.target.maxLength < 0) {
+          return;
+        }
+        this._handleInput({ element, length: event.target.value.length });
+      })
+    );
+  }
+
+  /**
+   * Updates the character counter
+   * @param {object} obj - The elements that can change in the component
+   * @param {HTMLElement} obj.element - The textarea element
+   * @param {HTMLElement} obj.length - The length of the textarea value
+   */
+  _handleInput = ({ element, length }) => {
+    element.querySelector(
+      this.options.selectorCharCounter
+    ).textContent = length;
+  };
+
+  /**
+   * The component options.
+   *
+   * If `options` is specified in the constructor,
+   * {@linkcode TextArea.create .create()},
+   * or {@linkcode TextArea.init .init()},
+   * properties in this object are overriden for the instance being
+   * created and how {@linkcode TextArea.init .init()} works.
+   * @property {string} selectorInit The CSS selector to find textarea UIs.
+   */
+  static get options() {
+    const { prefix } = settings;
+    return {
+      selectorInit: '[data-text-area]',
+      selectorCharCounter: `.${prefix}--text-area--character-counter--length`,
+    };
+  }
+
+  /**
+   * The map associating DOM element and textarea UI instance.
+   * @type {WeakMap}
+   */
+  static components /* #__PURE_CLASS_PROPERTY__ */ = new WeakMap();
+}

--- a/packages/components/src/components/text-area/text-area.js
+++ b/packages/components/src/components/text-area/text-area.js
@@ -28,9 +28,6 @@ export default class TextArea extends mixin(
     super(element, options);
     this.manage(
       on(this.element, 'input', event => {
-        if (event.target.maxLength < 0) {
-          return;
-        }
         this._handleInput({ element, length: event.target.value.length });
       })
     );

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -34,9 +34,14 @@
     transition: background-color $duration--fast-01 motion(standard, productive),
       outline $duration--fast-01 motion(standard, productive);
 
-    &:focus:not([readonly]),
-    &:active:not([readonly]) {
+    &:focus,
+    &:active {
       @include focus-outline('outline');
+    }
+
+    &[readonly]:focus,
+    &[readonly]:active {
+      @include focus-outline('reset');
     }
 
     &-wrapper svg[hidden] {

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -176,6 +176,7 @@
   .#{$prefix}--text-input__readonly-icon {
     @include tooltip--trigger('icon', 'bottom');
     @include tooltip--placement('icon', 'bottom', 'end');
+    z-index: z('floating') + 1;
     position: absolute;
     right: $carbon--spacing-05;
     cursor: default;

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -92,7 +92,6 @@
     display: flex;
     width: 100%;
     align-items: center;
-    width: 100%;
 
     .#{$prefix}--text-input__invalid-icon {
       position: absolute;

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -56,12 +56,41 @@
     background-color: $field-02;
   }
 
+  // -----------------
+  // Character counter
+  // -----------------
+  .#{$prefix}--text-input__character-counter-title {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .#{$prefix}--text-input__character-counter-title
+    + .#{$prefix}--form__helper-text {
+    margin-top: rem(-6px);
+  }
+
+  .#{$prefix}--text-input__character-counter-title .#{$prefix}--label {
+    margin-right: rem(16px);
+  }
+
+  .#{$prefix}--text-input--character-counter {
+    margin-bottom: $carbon--spacing-03;
+    @include type-style('label-01');
+    color: $text-02;
+  }
+
+  .#{$prefix}--text-input--character-counter--disabled {
+    color: $disabled-02;
+  }
+
   //-----------------------------
   // Disabled & Error icon spacing
   //-----------------------------
   .#{$prefix}--text-input__field-wrapper {
     position: relative;
     display: flex;
+    width: 100%;
     align-items: center;
     width: 100%;
 

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -34,8 +34,8 @@
     transition: background-color $duration--fast-01 motion(standard, productive),
       outline $duration--fast-01 motion(standard, productive);
 
-    &:focus,
-    &:active {
+    &:focus:not([readonly]),
+    &:active:not([readonly]) {
       @include focus-outline('outline');
     }
 
@@ -157,6 +157,40 @@
     // TODO: remove selector above
     .#{$prefix}--text-input--password__visibility__toggle {
       right: $carbon--spacing-08;
+    }
+  }
+
+  //-----------------------------
+  // Read only
+  //-----------------------------
+  .#{$prefix}--text-input[readonly] {
+    padding-right: $carbon--spacing-08;
+    text-overflow: ellipsis;
+    background-color: $field-02;
+  }
+
+  .#{$prefix}--text-input--light[readonly] {
+    background-color: $field-01;
+  }
+
+  .#{$prefix}--text-input__readonly-icon {
+    @include tooltip--trigger('icon', 'bottom');
+    @include tooltip--placement('icon', 'bottom', 'end');
+    position: absolute;
+    right: $carbon--spacing-05;
+    cursor: default;
+
+    &::after {
+      padding: 1rem;
+    }
+  }
+
+  .#{$prefix}--tooltip--icon.#{$prefix}--tooltip--icon__wrapper {
+    position: absolute;
+    right: $carbon--spacing-05;
+
+    .#{$prefix}--text-input__readonly-icon {
+      position: static;
     }
   }
 }

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -206,7 +206,8 @@
     background-color: $field-01;
   }
 
-  .#{$prefix}--text-input__readonly-icon {
+  .#{$prefix}--text-input__field-wrapper
+    > .#{$prefix}--text-input__readonly-icon.#{$prefix}--tooltip__trigger {
     @include tooltip--trigger('icon', 'bottom');
     @include tooltip--placement('icon', 'bottom', 'end');
     z-index: z('floating') + 1;
@@ -219,13 +220,10 @@
     }
   }
 
-  .#{$prefix}--tooltip--icon.#{$prefix}--tooltip--icon__wrapper {
-    position: absolute;
-    right: $carbon--spacing-05;
-
-    .#{$prefix}--text-input__readonly-icon {
-      position: static;
-    }
+  .#{$prefix}--text-input__readonly-icon
+    + .#{$prefix}--tooltip--definition
+    > .#{$prefix}--tooltip__trigger {
+    border-bottom: none;
   }
 }
 

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -99,7 +99,7 @@
     }
 
     .#{$prefix}--text-input--invalid.#{$prefix}--password-input {
-      padding-right: rem(64px);
+      padding-right: $carbon--spacing-10;
     }
 
     .#{$prefix}--text-input--invalid

--- a/packages/components/src/components/text-input/text-input.config.js
+++ b/packages/components/src/components/text-input/text-input.config.js
@@ -31,6 +31,23 @@ module.exports = {
       },
     },
     {
+      name: 'character-counter',
+      label: 'Text Input with character counter',
+      context: {
+        charCounter: true,
+        maxLength: 100,
+      },
+    },
+    {
+      name: 'character-counter--light',
+      label: 'Text Input with character counter (light)',
+      context: {
+        charCounter: true,
+        maxLength: 100,
+        light: true,
+      },
+    },
+    {
       name: 'password',
       label: 'Password Input',
       context: {
@@ -41,6 +58,25 @@ module.exports = {
       name: 'password--light',
       label: 'Password Input (Light)',
       context: {
+        light: true,
+        password: true,
+      },
+    },
+    {
+      name: 'password--character-counter',
+      label: 'Password Input with character counter',
+      context: {
+        charCounter: true,
+        maxLength: 100,
+        password: true,
+      },
+    },
+    {
+      name: 'password--light--character-counter',
+      label: 'Password Input with character counter (Light)',
+      context: {
+        charCounter: true,
+        maxLength: 100,
         light: true,
         password: true,
       },

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -5,17 +5,29 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-3" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-3" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-3" type="text"
-      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
+      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input id="text-input-3" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" data-toggle-password-visibility{{#if charCounter}} maxlength="{{maxLength}}"
+      {{/if}}>
     <button type="button"
       class="{{prefix}}--text-input--password__visibility__toggle {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
       <span class="{{@root.prefix}}--assistive-text">Show password</span>
@@ -26,19 +38,30 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
-  <label for="text-input-4" class="{{prefix}}--label">Text Input label</label>
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}} class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}
+  {{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for=" text-input-4" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for=" text-input-4" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper" data-invalid>
     {{ carbon-icon 'WarningFilled16' class=(add prefix '--text-input__invalid-icon')}}
     {{#unless password}}
     <input id="text-input-4" type="text"
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid {{#if light}} {{prefix}}--text-input--light{{/if}}"
-      placeholder="Placeholder text">
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input data-invalid id="text-input-4" type="password"
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility>
     <button type="button"
       class="{{prefix}}--text-input--password__visibility__toggle {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
       <span class="{{@root.prefix}}--assistive-text">Show password</span>
@@ -52,20 +75,32 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-5" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-5" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text">
     Optional helper text goes here
   </div>
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-5" type="text"
-      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
+      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input id="text-input-5" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility>
     <button type="button"
       class="{{prefix}}--text-input--password__visibility__toggle {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
       <span class="{{@root.prefix}}--assistive-text">Show password</span>
@@ -76,21 +111,33 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}"
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}"
   style="width: 320px">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-6" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-6" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text">
     Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)
   </div>
   <div class="{{prefix}}--text-input__field-wrapper">
     {{#unless password}}
     <input id="text-input-6" type="text"
-      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text">
+      class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}>
     {{else}}
     <input id="text-input-6" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility>
     <button type="button"
       class="{{prefix}}--text-input--password__visibility__toggle {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
       <span class="{{@root.prefix}}--assistive-text">Show password</span>
@@ -101,9 +148,19 @@
   </div>
 </div>
 
-<div {{#if password}} data-text-input {{/if}}
-  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}">
+<div {{#if password}} data-text-input {{else}} {{#if charCounter}} data-text-input {{/if}} {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if password}} {{prefix}}--password-input-wrapper{{/if}}{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter {{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-7" class="{{prefix}}--label {{prefix}}--label--disabled">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter {{prefix}}--text-input--character-counter--disabled">
+      <span class="{{prefix}}--text-input--character-counter--length">0</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
   <label for="text-input-7" class="{{prefix}}--label {{prefix}}--label--disabled">Text Input label</label>
+  {{/if}}
   <div class="{{prefix}}--form__helper-text {{prefix}}--form__helper-text--disabled">
     Optional helper text goes here
   </div>
@@ -111,11 +168,12 @@
     {{#unless password}}
     <input id="text-input-7" type="text"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}" placeholder="Placeholder text"
-      disabled>
+      {{#if charCounter}} maxlength="{{maxLength}}" {{/if}} disabled>
     {{else}}
     <input id="text-input-7" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
-      placeholder="Placeholder text" data-toggle-password-visibility disabled>
+      placeholder="Placeholder text" {{#if charCounter}} maxlength="{{maxLength}}" {{/if}}
+      data-toggle-password-visibility disabled>
     <button type="button"
       class="{{prefix}}--text-input--password__visibility__toggle {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
       <span class="{{@root.prefix}}--assistive-text">Show password</span>

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -200,25 +200,25 @@
   <label for="text-input-8" class="{{prefix}}--label">Text Input label</label>
   {{/if}}
   <div class="{{prefix}}--text-input__field-wrapper">
-    <div class="{{prefix}}--text-input__readonly-icon"
-      aria-label="This field cannot be edited to ensure successful provisioning">
+    <button
+      class="{{prefix}}--text-input__readonly-icon {{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--bottom">
+      <span class="{{@root.prefix}}--assistive-text">This field cannot be edited to ensure successful
+        provisioning</span>
       {{ carbon-icon 'EditOff16' }}
-    </div>
-    <div id="tooltip-label" class="{{@root.prefix}}--tooltip__label" aria-describedby="unique-tooltip">
-      <div aria-labelledby="tooltip-label" data-tooltip-trigger data-tooltip-target="#unique-tooltip" role="tooltip">
+    </button>
+    <div class="{{@root.prefix}}--tooltip--definition {{@root.prefix}}--tooltip--a11y">
+      <div aria-describedby="unique-tooltip"
+        class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip__trigger--definition {{@root.prefix}}--tooltip--bottom {{@root.prefix}}--tooltip--align-center">
         <input id="text-input-8" type="text"
           class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}"
           placeholder="Placeholder text"
           value="Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus, exercitationem ducimus reiciendis."
           readonly>
       </div>
-    </div>
-    <div id="unique-tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip"
-      data-avoid-focus-on-open>
-      <span class="{{@root.prefix}}--tooltip__caret"></span>
-      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate
+      <div class="bx--assistive-text" id="unique-tooltip" role="tooltip">Lorem ipsum dolor sit amet consectetur
+        adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate
         facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus,
-        exercitationem ducimus reiciendis.</p>
+        exercitationem ducimus reiciendis.</div>
     </div>
   </div>
 </div>

--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -126,3 +126,42 @@
     {{/unless}}
   </div>
 </div>
+
+{{#unless password}}
+<div {{#if charCounter}} data-text-input {{/if}}
+  class="{{prefix}}--form-item {{prefix}}--text-input-wrapper{{#if charCounter}} {{prefix}}--text-input-wrapper--character-counter{{/if}}">
+  {{#if charCounter}}
+  <div class="{{prefix}}--text-input__character-counter-title">
+    <label for="text-input-8" class="{{prefix}}--label">Text Input label</label>
+    <span class="{{prefix}}--text-input--character-counter">
+      <span class="{{prefix}}--text-input--character-counter--length">243</span>/<span
+        class="{{prefix}}--text-input--character-counter--maxlength">{{maxLength}}</span>
+    </span>
+  </div>
+  {{else}}
+  <label for="text-input-8" class="{{prefix}}--label">Text Input label</label>
+  {{/if}}
+  <div class="{{prefix}}--text-input__field-wrapper">
+    <div class="{{prefix}}--text-input__readonly-icon"
+      aria-label="This field cannot be edited to ensure successful provisioning">
+      {{ carbon-icon 'EditOff16' }}
+    </div>
+    <div id="tooltip-label" class="{{@root.prefix}}--tooltip__label" aria-describedby="unique-tooltip">
+      <div aria-labelledby="tooltip-label" data-tooltip-trigger data-tooltip-target="#unique-tooltip" role="tooltip">
+        <input id="text-input-8" type="text"
+          class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}"
+          placeholder="Placeholder text"
+          value="Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus, exercitationem ducimus reiciendis."
+          readonly>
+      </div>
+    </div>
+    <div id="unique-tooltip" data-floating-menu-direction="bottom" class="{{@root.prefix}}--tooltip"
+      data-avoid-focus-on-open>
+      <span class="{{@root.prefix}}--tooltip__caret"></span>
+      <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat cupiditate sapiente ullam. Quod voluptate
+        facere, dolore sit natus repellendus sint dolorem nesciunt eos vitae magni reprehenderit voluptatibus,
+        exercitationem ducimus reiciendis.</p>
+    </div>
+  </div>
+</div>
+{{/unless}}

--- a/packages/components/src/components/text-input/text-input.js
+++ b/packages/components/src/components/text-input/text-input.js
@@ -38,7 +38,27 @@ export default class TextInput extends mixin(
         }
       })
     );
+    this.manage(
+      on(this.element, 'input', event => {
+        if (event.target.maxLength < 0) {
+          return;
+        }
+        this._handleInput({ element, length: event.target.value.length });
+      })
+    );
   }
+
+  /**
+   * Updates the character counter
+   * @param {object} obj - The elements that can change in the component
+   * @param {HTMLElement} obj.element - The element functioning as a text field
+   * @param {HTMLElement} obj.length - The length of the text field value
+   */
+  _handleInput = ({ element, length }) => {
+    element.querySelector(
+      this.options.selectorCharCounter
+    ).textContent = length;
+  };
 
   /**
    *
@@ -119,6 +139,7 @@ export default class TextInput extends mixin(
       passwordIsVisible: `${prefix}--text-input--password-visible`,
       svgIconVisibilityOn: `svg.${prefix}--icon--visibility-on`,
       svgIconVisibilityOff: `svg.${prefix}--icon--visibility-off`,
+      selectorCharCounter: `.${prefix}--text-input--character-counter--length`,
     };
   }
 

--- a/packages/components/src/components/text-input/text-input.js
+++ b/packages/components/src/components/text-input/text-input.js
@@ -40,9 +40,6 @@ export default class TextInput extends mixin(
     );
     this.manage(
       on(this.element, 'input', event => {
-        if (event.target.maxLength < 0) {
-          return;
-        }
         this._handleInput({ element, length: event.target.value.length });
       })
     );

--- a/packages/components/src/globals/js/components.js
+++ b/packages/components/src/globals/js/components.js
@@ -57,6 +57,7 @@ export { default as Tile } from '../../components/tile/tile';
 export {
   default as CodeSnippet,
 } from '../../components/code-snippet/code-snippet';
+export { default as TextArea } from '../../components/text-area/text-area';
 export { default as TextInput } from '../../components/text-input/text-input';
 export { default as SideNav } from '../../components/ui-shell/side-nav';
 export {

--- a/packages/components/tests/spec/text-area_spec.js
+++ b/packages/components/tests/spec/text-area_spec.js
@@ -1,0 +1,103 @@
+import TextArea from '../../src/components/text-area/text-area';
+import TextAreaHTML from '../../html/text-area/text-area.html';
+import CharacterCounterHTML from '../../html/text-area/text-area--character-counter.html';
+import flattenOptions from '../utils/flatten-options';
+import { prefix } from '../../src/globals/js/settings';
+
+describe('Test textarea', () => {
+  describe('Constructor', () => {
+    let instance;
+    const container = document.createElement('div');
+    container.innerHTML = TextAreaHTML;
+
+    beforeAll(() => {
+      document.body.appendChild(container);
+      instance = new TextArea(document.querySelector('[data-text-area]'));
+    });
+
+    it('Should throw if root element is not given', () => {
+      expect(() => {
+        new TextArea();
+      }).toThrowError(
+        TypeError,
+        'DOM element should be given to initialize this widget.'
+      );
+    });
+
+    it('Should throw if root element is not a DOM element', () => {
+      expect(() => {
+        new TextArea(document.createTextNode(''));
+      }).toThrowError(
+        TypeError,
+        'DOM element should be given to initialize this widget.'
+      );
+    });
+
+    it('Should set default options', () => {
+      expect(flattenOptions(instance.options)).toEqual({
+        selectorInit: '[data-text-area]',
+        selectorCharCounter: `.${prefix}--text-area--character-counter--length`,
+      });
+    });
+
+    afterAll(() => {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+
+  describe('Character counter', () => {
+    let textArea;
+    let charCounter;
+    const container = document.createElement('div');
+    container.innerHTML = CharacterCounterHTML;
+    const aKeyInput = new InputEvent('input', {
+      inputType: 'insertText',
+      type: 'input',
+      bubbles: true,
+      data: 'a',
+    });
+    if (!aKeyInput.data) {
+      aKeyInput.data = 'a';
+    }
+    const deleteKeyInput = new InputEvent('input', {
+      inputType: 'deleteContentBackward',
+      type: 'input',
+      bubbles: true,
+      data: null,
+    });
+
+    beforeAll(() => {
+      document.body.appendChild(container);
+      new TextArea(document.querySelector('[data-text-area]'));
+      textArea = document.querySelector('[data-text-area] textarea');
+      charCounter = document.querySelector(
+        `.${prefix}--text-area--character-counter--length`
+      );
+    });
+
+    beforeEach(() => {
+      textArea.value = '';
+    });
+
+    it('Should increment character counter on input value length increase', () => {
+      textArea.value += aKeyInput.data;
+      textArea.dispatchEvent(aKeyInput);
+      expect(textArea.value).toBe('a');
+      expect(charCounter.textContent).toBe('1');
+    });
+
+    it('Should decrement character counter on input value length decrease', () => {
+      textArea.dispatchEvent(deleteKeyInput);
+      expect(textArea.value).toBe('');
+      expect(charCounter.textContent).toBe('0');
+    });
+
+    afterAll(() => {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+});

--- a/packages/components/tests/spec/text-input_spec.js
+++ b/packages/components/tests/spec/text-input_spec.js
@@ -1,7 +1,9 @@
 // only test JS class since it is only instantiated with password fields
 import TextInput from '../../src/components/text-input/text-input';
 import PasswordVisibilityHTML from '../../html/text-input/text-input--password.html';
+import CharacterCounterHTML from '../../html/text-input/text-input--character-counter.html';
 import flattenOptions from '../utils/flatten-options';
+import { prefix } from '../../src/globals/js/settings';
 
 describe('Test text input', () => {
   describe('Constructor', () => {
@@ -35,12 +37,16 @@ describe('Test text input', () => {
     it('Should set default options', () => {
       expect(flattenOptions(instance.options)).toEqual({
         selectorInit: '[data-text-input]',
-        selectorPasswordField: `.bx--text-input[data-toggle-password-visibility]`,
-        selectorPasswordVisibilityButton: `.bx--text-input--password__visibility__toggle`,
-        selectorPasswordVisibilityTooltip: `.bx--text-input--password__visibility__toggle > .bx--assistive-text`,
-        passwordIsVisible: `bx--text-input--password-visible`,
+        selectorPasswordField:
+          '.bx--text-input[data-toggle-password-visibility]',
+        selectorPasswordVisibilityButton:
+          '.bx--text-input--password__visibility__toggle',
+        selectorPasswordVisibilityTooltip:
+          '.bx--text-input--password__visibility__toggle > .bx--assistive-text',
+        passwordIsVisible: 'bx--text-input--password-visible',
         svgIconVisibilityOn: 'svg.bx--icon--visibility-on',
         svgIconVisibilityOff: 'svg.bx--icon--visibility-off',
+        selectorCharCounter: '.bx--text-input--character-counter--length',
       });
     });
 
@@ -67,7 +73,7 @@ describe('Test text input', () => {
     });
 
     beforeEach(() => {
-      textInput.classList.remove('bx--text-input--password-visible');
+      textInput.classList.remove(`${prefix}--text-input--password-visible`);
     });
 
     it('Should set password visibility state on 2n+1 clicks', () => {
@@ -75,18 +81,72 @@ describe('Test text input', () => {
         new CustomEvent('click', { bubbles: true })
       );
       expect(
-        textInput.classList.contains('bx--text-input--password-visible')
+        textInput.classList.contains(`${prefix}--text-input--password-visible`)
       ).toBe(true);
     });
 
     it('Should remove password visibility state on 2n clicks', () => {
-      textInput.classList.add('bx--text-input--password-visible');
+      textInput.classList.add(`${prefix}--text-input--password-visible`);
       passwordVisibilityButton.dispatchEvent(
         new CustomEvent('click', { bubbles: true })
       );
       expect(
-        textInput.classList.contains('bx--text-input--password-visible')
+        textInput.classList.contains(`${prefix}--text-input--password-visible`)
       ).toBe(false);
+    });
+
+    afterAll(() => {
+      if (document.body.contains(container)) {
+        document.body.removeChild(container);
+      }
+    });
+  });
+
+  describe('Character counter', () => {
+    let textInput;
+    let charCounter;
+    const container = document.createElement('div');
+    container.innerHTML = CharacterCounterHTML;
+    const aKeyInput = new InputEvent('input', {
+      inputType: 'insertText',
+      type: 'input',
+      bubbles: true,
+      data: 'a',
+    });
+    const deleteKeyInput = new InputEvent('input', {
+      inputType: 'deleteContentBackward',
+      type: 'input',
+      bubbles: true,
+      data: null,
+    });
+    if (!aKeyInput.data) {
+      aKeyInput.data = 'a';
+    }
+
+    beforeAll(() => {
+      document.body.appendChild(container);
+      new TextInput(document.querySelector('[data-text-input]'));
+      textInput = document.querySelector('[data-text-input] input');
+      charCounter = document.querySelector(
+        `.${prefix}--text-input--character-counter--length`
+      );
+    });
+
+    beforeEach(() => {
+      textInput.value = '';
+    });
+
+    it('Should increment character counter on input value length increase', () => {
+      textInput.value += aKeyInput.data;
+      textInput.dispatchEvent(aKeyInput);
+      expect(textInput.value).toBe('a');
+      expect(charCounter.textContent).toBe('1');
+    });
+
+    it('Should decrement character counter on input value length decrease', () => {
+      textInput.dispatchEvent(deleteKeyInput);
+      expect(textInput.value).toBe('');
+      expect(charCounter.textContent).toBe('0');
     });
 
     afterAll(() => {

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -20,6 +20,7 @@ describe('TextArea', () => {
         labelText="testlabel"
         className="extra-class"
         helperText="testHelper"
+        defaultValue="default value"
       />
     );
 
@@ -63,12 +64,29 @@ describe('TextArea', () => {
 
       it('should set value as expected', () => {
         wrapper.setProps({ value: 'value set' });
-        expect(textarea().props().value).toEqual('value set');
+        expect(wrapper.props().value).toEqual('value set');
       });
 
       it('should set defaultValue as expected', () => {
-        wrapper.setProps({ defaultValue: 'default value' });
-        expect(textarea().props().defaultValue).toEqual('default value');
+        expect(textarea().props().value).toEqual('default value');
+      });
+
+      it('should count length increases in textarea value', () => {
+        const event = { target: { value: 'z' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textarea().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-area--character-counter`).text()
+        ).toBe('1/10');
+      });
+
+      it('should count length decreases in textarea value', () => {
+        const event = { target: { value: '' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textarea().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-area--character-counter`).text()
+        ).toBe('0/10');
       });
 
       it('should specify light version as expected', () => {

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -196,7 +196,9 @@ describe('TextArea', () => {
 
       it('should invoke onChange when textarea value is changed', () => {
         textarea.simulate('change', eventObject);
-        expect(onChange).toBeCalledWith(eventObject);
+        expect(onChange).toBeCalledWith(eventObject, {
+          value: eventObject.target.value,
+        });
       });
     });
   });

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -73,7 +73,7 @@ describe('TextArea', () => {
 
       it('should count length increases in textarea value', () => {
         const event = { target: { value: 'z' } };
-        wrapper.setProps({ charCount: true, maxLength: 10 });
+        wrapper.setProps({ useCharCount: true, maxLength: 10 });
         textarea().simulate('input', event);
         expect(
           wrapper.find(`span.${prefix}--text-area--character-counter`).text()
@@ -82,7 +82,7 @@ describe('TextArea', () => {
 
       it('should count length decreases in textarea value', () => {
         const event = { target: { value: '' } };
-        wrapper.setProps({ charCount: true, maxLength: 10 });
+        wrapper.setProps({ useCharCount: true, maxLength: 10 });
         textarea().simulate('input', event);
         expect(
           wrapper.find(`span.${prefix}--text-area--character-counter`).text()

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -123,14 +123,14 @@ describe('TextArea', () => {
         wrapper.setProps({
           helperText: (
             <span>
-              This helper text has <a href="#">a link</a>.
+              This helper text has <a href="/">a link</a>.
             </span>
           ),
         });
         const renderedHelper = wrapper.find(`.${prefix}--form__helper-text`);
         expect(renderedHelper.props().children).toEqual(
           <span>
-            This helper text has <a href="#">a link</a>.
+            This helper text has <a href="/">a link</a>.
           </span>
         );
       });

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -81,7 +81,7 @@ const TextArea = React.forwardRef(function TextArea(
     [`${prefix}--label--disabled`]: other.disabled,
   });
 
-  const label = (() => {
+  const TextAreaLabel = () => {
     const labelContent = labelText && (
       <label htmlFor={id} className={labelClasses}>
         {labelText}
@@ -100,13 +100,13 @@ const TextArea = React.forwardRef(function TextArea(
       );
     }
     return labelContent;
-  })();
+  };
 
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
 
-  const helper = (() => {
+  const TextAreaHelperText = () => {
     const helperContent = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
@@ -124,7 +124,7 @@ const TextArea = React.forwardRef(function TextArea(
     }
 
     return helperContent;
-  })();
+  };
 
   const errorId = id + '-error-msg';
 
@@ -164,8 +164,8 @@ const TextArea = React.forwardRef(function TextArea(
 
   return (
     <div className={`${prefix}--form-item`}>
-      {label}
-      {helper}
+      <TextAreaLabel />
+      <TextAreaHelperText />
       <div
         className={`${prefix}--text-area__wrapper`}
         data-invalid={invalid || null}>

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -9,7 +9,8 @@ import PropTypes from 'prop-types';
 import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import { WarningFilled16 } from '@carbon/icons-react';
+import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
+import Tooltip from '../Tooltip';
 
 const { prefix } = settings;
 
@@ -48,6 +49,8 @@ const TextArea = React.forwardRef(function TextArea(
     useCharCount,
     maxLength,
     defaultValue,
+    readOnly,
+    readOnlyIconLabel,
     renderCharCounter: CharCounter = DefaultCharCounter,
     ...other
   },
@@ -88,7 +91,7 @@ const TextArea = React.forwardRef(function TextArea(
           {labelContent}
           <CharCounter
             disabled={other.disabled}
-            count={textareaVal.length}
+            count={isControlled ? other.value.length : textareaVal.length}
             maxLength={maxLength}
           />
         </div>
@@ -111,7 +114,7 @@ const TextArea = React.forwardRef(function TextArea(
           {helperContent}
           <CharCounter
             disabled={other.disabled}
-            count={textareaVal.length}
+            count={isControlled ? other.value.length : textareaVal.length}
             maxLength={maxLength}
           />
         </div>
@@ -134,7 +137,7 @@ const TextArea = React.forwardRef(function TextArea(
     [`${prefix}--text-area--invalid`]: invalid,
   });
 
-  const input = (
+  const inputField = (
     <textarea
       {...other}
       {...textareaProps}
@@ -144,8 +147,18 @@ const TextArea = React.forwardRef(function TextArea(
       disabled={other.disabled}
       value={isControlled ? other.value : textareaVal}
       onInput={e => setInput(e.target.value)}
+      readOnly={readOnly || null}
     />
   );
+
+  const input =
+    readOnly && (other.value || other.defaultValue || textareaVal) ? (
+      <Tooltip showIcon={false} triggerText={inputField}>
+        {other.value || other.defaultValue || textareaVal}
+      </Tooltip>
+    ) : (
+      inputField
+    );
 
   return (
     <div className={`${prefix}--form-item`}>
@@ -156,6 +169,13 @@ const TextArea = React.forwardRef(function TextArea(
         data-invalid={invalid || null}>
         {invalid && (
           <WarningFilled16 className={`${prefix}--text-area__invalid-icon`} />
+        )}
+        {readOnly && (
+          <div
+            className={`${prefix}--text-area__readonly-icon`}
+            aria-label={readOnlyIconLabel}>
+            <EditOff16 />
+          </div>
         )}
         {input}
       </div>
@@ -249,6 +269,16 @@ TextArea.propTypes = {
    * Specify whether you want the light version of this control
    */
   light: PropTypes.bool,
+
+  /**
+   * Specify if the user should be able to edit the value of the input
+   */
+  readOnly: PropTypes.bool,
+
+  /**
+   * The label for the read-only status icon
+   */
+  readOnlyIconLabel: PropTypes.string,
 
   /**
    * Specify whether the character counter is shown

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -149,14 +149,14 @@ const TextArea = React.forwardRef(function TextArea(
       disabled={other.disabled}
       value={isControlled ? other.value : textareaVal}
       onInput={e => setInput(e.target.value)}
-      readOnly={readOnly || null}
+      readOnly={readOnly}
     />
   );
 
   const input =
-    readOnly && (other.value || other.defaultValue || textareaVal) ? (
+    readOnly && (other.value || defaultValue || textareaVal) ? (
       <Tooltip showIcon={false} triggerText={inputField}>
-        {other.value || other.defaultValue || textareaVal}
+        {other.value || defaultValue || textareaVal}
       </Tooltip>
     ) : (
       inputField

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -82,11 +82,11 @@ const TextArea = React.forwardRef(function TextArea(
   });
 
   const label = (() => {
-    const labelContent = labelText ? (
+    const labelContent = labelText && (
       <label htmlFor={id} className={labelClasses}>
         {labelText}
       </label>
-    ) : null;
+    );
     if (labelContent && useCharCount) {
       return (
         <div className={`${prefix}--text-area__character-counter-title`}>

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -45,7 +45,7 @@ const TextArea = React.forwardRef(function TextArea(
     invalidText,
     helperText,
     light,
-    charCount,
+    useCharCount,
     maxLength,
     defaultValue,
     renderCharCounter: CharCounter = DefaultCharCounter,
@@ -82,7 +82,7 @@ const TextArea = React.forwardRef(function TextArea(
         {labelText}
       </label>
     ) : null;
-    if (labelContent && charCount) {
+    if (labelContent && useCharCount) {
       return (
         <div className={`${prefix}--text-area__character-counter-title`}>
           {labelContent}
@@ -105,7 +105,7 @@ const TextArea = React.forwardRef(function TextArea(
     const helperContent = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
-    if (!labelText && charCount) {
+    if (!labelText && useCharCount) {
       return (
         <div className={`${prefix}--text-area__character-counter-title`}>
           {helperContent}
@@ -253,7 +253,7 @@ TextArea.propTypes = {
   /**
    * Specify whether the character counter is shown
    */
-  charCount: PropTypes.bool,
+  useCharCount: PropTypes.bool,
 
   /**
    * The maximum allowed input value length

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -59,6 +59,7 @@ const TextArea = React.forwardRef(function TextArea(
 ) {
   const [textareaVal, setInput] = useState(defaultValue);
   const isControlled = useRef(other.value !== undefined).current;
+  const value = isControlled ? other.value || defaultValue : textareaVal;
   const textareaProps = {
     id,
     onChange: evt => {
@@ -92,7 +93,7 @@ const TextArea = React.forwardRef(function TextArea(
           {labelContent}
           <CharCounter
             disabled={other.disabled}
-            count={isControlled ? other.value.length : textareaVal.length}
+            count={value.length}
             maxLength={maxLength}
           />
         </div>
@@ -115,7 +116,7 @@ const TextArea = React.forwardRef(function TextArea(
           {helperContent}
           <CharCounter
             disabled={other.disabled}
-            count={isControlled ? other.value.length : textareaVal.length}
+            count={value.length}
             maxLength={maxLength}
           />
         </div>
@@ -146,16 +147,16 @@ const TextArea = React.forwardRef(function TextArea(
       aria-invalid={invalid || null}
       aria-describedby={invalid ? errorId : null}
       disabled={other.disabled}
-      value={isControlled ? other.value : textareaVal}
+      value={value}
       onInput={e => setInput(e.target.value)}
       readOnly={readOnly}
     />
   );
 
   const input =
-    readOnly && (other.value || defaultValue || textareaVal) ? (
+    readOnly && value ? (
       <Tooltip showIcon={false} triggerText={inputField}>
-        {other.value || defaultValue || textareaVal}
+        {value}
       </Tooltip>
     ) : (
       inputField

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -10,7 +10,8 @@ import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
-import Tooltip from '../Tooltip';
+import TooltipDefinition from '../TooltipDefinition/TooltipDefinition';
+import TooltipIcon from '../TooltipIcon/TooltipIcon';
 import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
 
 const { prefix } = settings;
@@ -52,6 +53,14 @@ const TextArea = React.forwardRef(function TextArea(
     defaultValue,
     readOnly,
     readOnlyIconLabel,
+    readOnlyIconTooltipProps = {
+      direction: 'bottom',
+      align: 'center',
+    },
+    readOnlyInputTooltipProps = {
+      direction: 'bottom',
+      align: 'center',
+    },
     renderCharCounter: CharCounter = DefaultCharCounter,
     ...other
   },
@@ -155,9 +164,9 @@ const TextArea = React.forwardRef(function TextArea(
 
   const input =
     readOnly && value ? (
-      <Tooltip showIcon={false} triggerText={inputField}>
-        {value}
-      </Tooltip>
+      <TooltipDefinition {...readOnlyInputTooltipProps} tooltipText={value}>
+        {inputField}
+      </TooltipDefinition>
     ) : (
       inputField
     );
@@ -173,11 +182,12 @@ const TextArea = React.forwardRef(function TextArea(
           <WarningFilled16 className={`${prefix}--text-area__invalid-icon`} />
         )}
         {readOnly && (
-          <div
+          <TooltipIcon
+            {...readOnlyIconTooltipProps}
             className={`${prefix}--text-area__readonly-icon`}
-            aria-label={readOnlyIconLabel}>
+            tooltipText={readOnlyIconLabel}>
             <EditOff16 />
-          </div>
+          </TooltipIcon>
         )}
         {input}
       </div>
@@ -291,6 +301,50 @@ TextArea.propTypes = {
    * The maximum allowed input value length
    */
   maxLength: PropTypes.number,
+
+  /**
+   * Optionally specify props for the tooltip on the read only icon
+   */
+  readOnlyInputIconProps: PropTypes.shape({
+    /**
+     * Specify the direction of the tooltip. Can be either top or bottom.
+     */
+    direction: PropTypes.oneOf(['top', 'bottom']),
+
+    /**
+     * Specify the alignment (to the trigger button) of the tooltip.
+     * Can be one of: start, center, or end.
+     */
+    align: PropTypes.oneOf(['start', 'center', 'end']),
+
+    /**
+     * Optionally specify a custom id for the tooltip. If one is not provided,
+     * we generate a unique id for you.
+     */
+    id: PropTypes.string,
+  }),
+
+  /**
+   * Optionally specify props for the tooltip on the read only input field
+   */
+  readOnlyInputTooltipProps: PropTypes.shape({
+    /**
+     * Specify the direction of the tooltip. Can be either top or bottom.
+     */
+    direction: PropTypes.oneOf(['top', 'bottom']),
+
+    /**
+     * Specify the alignment (to the trigger button) of the tooltip.
+     * Can be one of: start, center, or end.
+     */
+    align: PropTypes.oneOf(['start', 'center', 'end']),
+
+    /**
+     * Optionally specify a custom id for the tooltip. If one is not provided,
+     * we generate a unique id for you.
+     */
+    id: PropTypes.string,
+  }),
 };
 
 TextArea.defaultProps = {

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
 import Tooltip from '../Tooltip';
+import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
+import { useControlledStateWithValue } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -222,7 +224,9 @@ TextArea.propTypes = {
    * Optionally provide an `onChange` handler that is called whenever <textarea>
    * is updated
    */
-  onChange: PropTypes.func,
+  onChange: !useControlledStateWithValue
+    ? PropTypes.func
+    : requiredIfValueExists(PropTypes.func),
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -12,7 +12,6 @@ import { settings } from 'carbon-components';
 import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
 import Tooltip from '../Tooltip';
 import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
-import { useControlledStateWithValue } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -224,9 +223,7 @@ TextArea.propTypes = {
    * Optionally provide an `onChange` handler that is called whenever <textarea>
    * is updated
    */
-  onChange: !useControlledStateWithValue
-    ? PropTypes.func
-    : requiredIfValueExists(PropTypes.func),
+  onChange: requiredIfValueExists(PropTypes.func),
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the

--- a/packages/react/src/components/TextArea/Textarea-story.js
+++ b/packages/react/src/components/TextArea/Textarea-story.js
@@ -20,7 +20,7 @@ const TextAreaProps = () => ({
   hideLabel: boolean('No label (hideLabel)', false),
   labelText: text('Label text (labelText)', 'Text Area label'),
   invalid: boolean('Show form validation UI (invalid)', false),
-  charCount: boolean('Add character counter (charCount)', false),
+  useCharCount: boolean('Add character counter (useCharCount)', false),
   maxLength: number('Input length limit (maxLength)', 100),
   defaultValue: text(
     'Default value (defaultValue)',

--- a/packages/react/src/components/TextArea/Textarea-story.js
+++ b/packages/react/src/components/TextArea/Textarea-story.js
@@ -45,7 +45,7 @@ const TextAreaProps = () => ({
 });
 
 function ControlledTextArea(controlledProps) {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(controlledProps.defaultValue || '');
   return (
     <>
       <TextArea
@@ -54,6 +54,9 @@ function ControlledTextArea(controlledProps) {
         onChange={(evt, { value }) => setValue(value)}
       />
       <br />
+      <button onClick={() => setValue(controlledProps.defaultValue || '')}>
+        Reset
+      </button>
       <button onClick={() => setValue(value + '1')}>Append 1</button>
     </>
   );

--- a/packages/react/src/components/TextArea/Textarea-story.js
+++ b/packages/react/src/components/TextArea/Textarea-story.js
@@ -20,6 +20,12 @@ const TextAreaProps = () => ({
   hideLabel: boolean('No label (hideLabel)', false),
   labelText: text('Label text (labelText)', 'Text Area label'),
   invalid: boolean('Show form validation UI (invalid)', false),
+  charCount: boolean('Add character counter (charCount)', false),
+  maxLength: number('Input length limit (maxLength)', 100),
+  defaultValue: text(
+    'Default value (defaultValue)',
+    'This is not a default value'
+  ),
   invalidText: text(
     'Content of form validation UI (invalidText)',
     'A valid value is required'

--- a/packages/react/src/components/TextArea/Textarea-story.js
+++ b/packages/react/src/components/TextArea/Textarea-story.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -20,7 +20,12 @@ const TextAreaProps = () => ({
   hideLabel: boolean('No label (hideLabel)', false),
   labelText: text('Label text (labelText)', 'Text Area label'),
   invalid: boolean('Show form validation UI (invalid)', false),
-  useCharCount: boolean('Add character counter (useCharCount)', false),
+  readOnly: boolean('Read only (readOnly)', false),
+  readOnlyIconLabel: text(
+    'Read-only icon label (readOnlyIconLabel)',
+    'This input field is read-only'
+  ),
+  useCharCount: boolean('Add character counter (useCharCount)', true),
   maxLength: number('Input length limit (maxLength)', 100),
   defaultValue: text(
     'Default value (defaultValue)',
@@ -39,6 +44,21 @@ const TextAreaProps = () => ({
   onClick: action('onClick'),
 });
 
+function ControlledTextArea(controlledProps) {
+  const [value, setValue] = useState('');
+  return (
+    <>
+      <TextArea
+        value={value}
+        {...controlledProps}
+        onChange={(evt, { value }) => setValue(value)}
+      />
+      <br />
+      <button onClick={() => setValue(value + '1')}>Append 1</button>
+    </>
+  );
+}
+
 storiesOf('TextArea', module)
   .addDecorator(withKnobs)
   .add('Default', () => <TextArea {...TextAreaProps()} />, {
@@ -49,6 +69,17 @@ storiesOf('TextArea', module)
           `,
     },
   })
+  .add(
+    'Fully controlled textarea',
+    () => <ControlledTextArea {...TextAreaProps()} />,
+    {
+      info: {
+        text: `
+        Fully controlled textarea.
+      `,
+      },
+    }
+  )
   .add('skeleton', () => <TextAreaSkeleton />, {
     info: {
       text: `

--- a/packages/react/src/components/TextInput/ControlledPasswordInput-test.js
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput-test.js
@@ -184,7 +184,7 @@ describe('TextInput', () => {
       const input = wrapper.find('input');
       const eventObject = {
         target: {
-          defaultValue: 'test',
+          value: 'test',
         },
       };
 
@@ -195,7 +195,9 @@ describe('TextInput', () => {
 
       it('should invoke onChange when input value is changed', () => {
         input.simulate('change', eventObject);
-        expect(onChange).toBeCalledWith(eventObject);
+        expect(onChange).toBeCalledWith(eventObject, {
+          value: eventObject.target.value,
+        });
       });
     });
   });

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -55,6 +55,11 @@ const props = {
       'Form validation UI content (invalidText)',
       'A valid value is required'
     ),
+    readOnly: boolean('Read only (readOnly)', false),
+    readOnlyIconLabel: text(
+      'Read-only icon label (readOnlyIconLabel)',
+      'This input field is read-only'
+    ),
     helperText: text('Helper text (helperText)', 'Optional helper text.'),
     onClick: action('onClick'),
     onChange: action('onChange'),
@@ -81,6 +86,11 @@ storiesOf('TextInput', module)
       <TextInput
         type={select('Form control type (type)', types, 'text')}
         {...props.TextInputProps()}
+        invalid={
+          props.TextInputProps().readOnly
+            ? false
+            : props.TextInputProps().invalid
+        }
       />
     ),
     {

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -8,7 +8,13 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  boolean,
+  select,
+  text,
+  number,
+} from '@storybook/addon-knobs';
 import TextInput from '../TextInput';
 import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
 
@@ -19,26 +25,8 @@ const types = {
   'For password (password)': 'password',
 };
 
-function ControlledPasswordInputApp(props) {
-  const [type, setType] = useState('password');
-  const togglePasswordVisibility = () => {
-    setType(type === 'password' ? 'text' : 'password');
-  };
-  return (
-    <>
-      <TextInput.ControlledPasswordInput
-        type={type}
-        togglePasswordVisibility={togglePasswordVisibility}
-        {...props}
-      />
-      <button onClick={() => setType('text')}>Show password</button>
-      <button onClick={() => setType('password')}>Hide password</button>
-    </>
-  );
-}
-
 const props = {
-  TextInputProps: () => ({
+  textInput: () => ({
     className: 'some-class',
     id: 'test2',
     defaultValue: text(
@@ -60,11 +48,33 @@ const props = {
       'Read-only icon label (readOnlyIconLabel)',
       'This input field is read-only'
     ),
+    useCharCount: boolean('Add character counter (useCharCount)', false),
+    maxLength: number('Input length limit (maxLength)', 100),
     helperText: text('Helper text (helperText)', 'Optional helper text.'),
     onClick: action('onClick'),
     onChange: action('onChange'),
   }),
-  PasswordInputProps: () => ({
+  passwordInput: () => ({
+    className: 'some-class',
+    id: 'test2',
+    defaultValue: text(
+      'Default value (defaultValue)',
+      'This is not a default value'
+    ),
+    labelText: text('Label text (labelText)', 'Text Input label'),
+    placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
+    light: boolean('Light variant (light)', false),
+    disabled: boolean('Disabled (disabled)', false),
+    hideLabel: boolean('No label (hideLabel)', false),
+    invalid: boolean('Show form validation UI (invalid)', false),
+    maxLength: number('Input length limit (maxLength)', 100),
+    invalidText: text(
+      'Form validation UI content (invalidText)',
+      'A valid value is required'
+    ),
+    helperText: text('Helper text (helperText)', 'Optional helper text.'),
+    onClick: action('onClick'),
+    onChange: action('onChange'),
     tooltipPosition: select(
       'Tooltip position (tooltipPosition)',
       ['top', 'right', 'bottom', 'left'],
@@ -77,6 +87,40 @@ const props = {
     ),
   }),
 };
+function ControlledTextInput(controlledProps) {
+  const [value, setValue] = useState(controlledProps.defaultValue || '');
+  return (
+    <>
+      <TextInput
+        value={value}
+        {...controlledProps}
+        onChange={(evt, { value }) => setValue(value)}
+      />
+      <br />
+      <button onClick={() => setValue(controlledProps.defaultValue || '')}>
+        Reset
+      </button>
+      <button onClick={() => setValue(value + '1')}>Append 1</button>
+    </>
+  );
+}
+function ControlledPasswordInputApp(props) {
+  const [type, setType] = useState('password');
+  const togglePasswordVisibility = () => {
+    setType(type === 'password' ? 'text' : 'password');
+  };
+  return (
+    <>
+      <TextInput.ControlledPasswordInput
+        type={type}
+        togglePasswordVisibility={togglePasswordVisibility}
+        {...props}
+      />
+      <button onClick={() => setType('text')}>Show password</button>
+      <button onClick={() => setType('password')}>Hide password</button>
+    </>
+  );
+}
 
 storiesOf('TextInput', module)
   .addDecorator(withKnobs)
@@ -85,12 +129,8 @@ storiesOf('TextInput', module)
     () => (
       <TextInput
         type={select('Form control type (type)', types, 'text')}
-        {...props.TextInputProps()}
-        invalid={
-          props.TextInputProps().readOnly
-            ? false
-            : props.TextInputProps().invalid
-        }
+        {...props.textInput()}
+        invalid={props.textInput().readOnly ? false : props.textInput().invalid}
       />
     ),
     {
@@ -105,13 +145,19 @@ storiesOf('TextInput', module)
     }
   )
   .add(
+    'Fully controlled text input',
+    () => <ControlledTextInput {...props.textInput()} />,
+    {
+      info: {
+        text: `
+        Fully controlled text field.
+      `,
+      },
+    }
+  )
+  .add(
     'Toggle password visibility',
-    () => (
-      <TextInput.PasswordInput
-        {...props.TextInputProps()}
-        {...props.PasswordInputProps()}
-      />
-    ),
+    () => <TextInput.PasswordInput {...props.passwordInput()} />,
     {
       info: {
         text: `
@@ -122,12 +168,7 @@ storiesOf('TextInput', module)
   )
   .add(
     'Fully controlled toggle password visibility',
-    () => (
-      <ControlledPasswordInputApp
-        {...props.TextInputProps()}
-        {...props.PasswordInputProps()}
-      />
-    ),
+    () => <ControlledPasswordInputApp {...props.passwordInput()} />,
     {
       info: {
         text: `

--- a/packages/react/src/components/TextInput/TextInput-test.js
+++ b/packages/react/src/components/TextInput/TextInput-test.js
@@ -82,7 +82,7 @@ describe('TextInput', () => {
 
       it('should count length increases in text input value', () => {
         const event = { target: { value: 'z' } };
-        wrapper.setProps({ charCount: true, maxLength: 10 });
+        wrapper.setProps({ useCharCount: true, maxLength: 10 });
         textInput().simulate('input', event);
         expect(
           wrapper.find(`span.${prefix}--text-input--character-counter`).text()
@@ -91,7 +91,7 @@ describe('TextInput', () => {
 
       it('should count length decreases in text input value', () => {
         const event = { target: { value: '' } };
-        wrapper.setProps({ charCount: true, maxLength: 10 });
+        wrapper.setProps({ useCharCount: true, maxLength: 10 });
         textInput().simulate('input', event);
         expect(
           wrapper.find(`span.${prefix}--text-input--character-counter`).text()

--- a/packages/react/src/components/TextInput/TextInput-test.js
+++ b/packages/react/src/components/TextInput/TextInput-test.js
@@ -20,6 +20,7 @@ describe('TextInput', () => {
         className="extra-class"
         labelText="testlabel"
         helperText="testHelper"
+        defaultValue="test"
         light
       />
     );
@@ -75,9 +76,26 @@ describe('TextInput', () => {
       });
 
       it('should set value as expected', () => {
-        expect(textInput().props().defaultValue).toEqual(undefined);
         wrapper.setProps({ defaultValue: 'test' });
-        expect(textInput().props().defaultValue).toEqual('test');
+        expect(wrapper.find('input').props().value).toEqual('test');
+      });
+
+      it('should count length increases in text input value', () => {
+        const event = { target: { value: 'z' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textInput().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-input--character-counter`).text()
+        ).toBe('1/10');
+      });
+
+      it('should count length decreases in text input value', () => {
+        const event = { target: { value: '' } };
+        wrapper.setProps({ charCount: true, maxLength: 10 });
+        textInput().simulate('input', event);
+        expect(
+          wrapper.find(`span.${prefix}--text-input--character-counter`).text()
+        ).toBe('0/10');
       });
 
       it('should set disabled as expected', () => {
@@ -120,14 +138,14 @@ describe('TextInput', () => {
         wrapper.setProps({
           helperText: (
             <span>
-              This helper text has <a href="#">a link</a>.
+              This helper text has <a href="/">a link</a>.
             </span>
           ),
         });
         const renderedHelper = wrapper.find(`.${prefix}--form__helper-text`);
         expect(renderedHelper.props().children).toEqual(
           <span>
-            This helper text has <a href="#">a link</a>.
+            This helper text has <a href="/">a link</a>.
           </span>
         );
       });
@@ -184,7 +202,7 @@ describe('TextInput', () => {
       const input = wrapper.find('input');
       const eventObject = {
         target: {
-          defaultValue: 'test',
+          value: 'test',
         },
       };
 
@@ -195,7 +213,9 @@ describe('TextInput', () => {
 
       it('should invoke onChange when input value is changed', () => {
         input.simulate('change', eventObject);
-        expect(onChange).toBeCalledWith(eventObject);
+        expect(onChange).toBeCalledWith(eventObject, {
+          value: eventObject.target.value,
+        });
       });
     });
   });

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -201,7 +201,7 @@ TextInput.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * The maximum allowed input value length
+   * Specify if the user should be able to edit the value of the input
    */
   readOnly: PropTypes.bool,
 

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -14,6 +14,8 @@ import PasswordInput from './PasswordInput';
 import ControlledPasswordInput from './ControlledPasswordInput';
 import Tooltip from '../Tooltip';
 import { textInputProps } from './util';
+import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
+import { useControlledStateWithValue } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 const DefaultCharCounter = ({ disabled, count, maxLength }) => {
@@ -210,7 +212,9 @@ TextInput.propTypes = {
    * Optionally provide an `onChange` handler that is called whenever <input>
    * is updated
    */
-  onChange: PropTypes.func,
+  onChange: !useControlledStateWithValue
+    ? PropTypes.func
+    : requiredIfValueExists(PropTypes.func),
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -62,6 +62,7 @@ const TextInput = React.forwardRef(function TextInput(
 ) {
   const [inputVal, setInput] = useState(defaultValue);
   const isControlled = useRef(other.value !== undefined).current;
+  const value = isControlled ? other.value || other.defaultValue : inputVal;
   const errorId = id + '-error-msg';
   const textInputClasses = classNames(`${prefix}--text-input`, className, {
     [`${prefix}--text-input--light`]: light,
@@ -106,7 +107,7 @@ const TextInput = React.forwardRef(function TextInput(
           {labelContent}
           <CharCounter
             disabled={other.disabled}
-            count={isControlled ? other.value.length : inputVal.length}
+            count={value.length}
             maxLength={maxLength}
           />
         </div>
@@ -122,14 +123,14 @@ const TextInput = React.forwardRef(function TextInput(
   const inputField = (
     <input
       {...textInputProps({ invalid, sharedTextInputProps, errorId })}
-      value={isControlled ? other.value : inputVal}
+      value={value}
       onInput={e => setInput(e.target.value)}
     />
   );
   const input =
-    readOnly && (other.value || other.defaultValue || inputVal) ? (
+    readOnly && value ? (
       <Tooltip showIcon={false} triggerText={inputField}>
-        {other.value || other.defaultValue || inputVal}
+        {value}
       </Tooltip>
     ) : (
       inputField
@@ -144,7 +145,7 @@ const TextInput = React.forwardRef(function TextInput(
           {helperContent}
           <CharCounter
             disabled={other.disabled}
-            count={isControlled ? other.value.length : inputVal.length}
+            count={value.length}
             maxLength={maxLength}
           />
         </div>

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -16,6 +16,25 @@ import Tooltip from '../Tooltip';
 import { textInputProps } from './util';
 
 const { prefix } = settings;
+const DefaultCharCounter = ({ disabled, count, maxLength }) => {
+  const charCounterClasses = classNames(
+    `${prefix}--text-input--character-counter`,
+    {
+      [`${prefix}--text-input--character-counter--disabled`]: disabled,
+    }
+  );
+  return (
+    <span className={charCounterClasses}>
+      <span className={`${prefix}--text-input--character-counter--length`}>
+        {count}
+      </span>
+      /
+      <span className={`${prefix}--text-input--character-counter--maxlength`}>
+        {maxLength}
+      </span>
+    </span>
+  );
+};
 const TextInput = React.forwardRef(function TextInput(
   {
     labelText,
@@ -32,7 +51,10 @@ const TextInput = React.forwardRef(function TextInput(
     light,
     readOnly,
     readOnlyIconLabel,
+    charCount,
+    renderCharCounter: CharCounter = DefaultCharCounter,
     defaultValue,
+    maxLength,
     ...other
   },
   ref
@@ -61,6 +83,7 @@ const TextInput = React.forwardRef(function TextInput(
     ref,
     className: textInputClasses,
     readOnly,
+    maxLength: maxLength || null,
     ...other,
   };
   const labelClasses = classNames(`${prefix}--label`, {
@@ -76,6 +99,18 @@ const TextInput = React.forwardRef(function TextInput(
         {labelText}
       </label>
     );
+    if (labelContent && charCount) {
+      return (
+        <div className={`${prefix}--text-input__character-counter-title`}>
+          {labelContent}
+          <CharCounter
+            disabled={other.disabled}
+            count={isControlled ? other.value.length : inputVal.length}
+            maxLength={maxLength}
+          />
+        </div>
+      );
+    }
     return labelContent;
   })();
   const error = invalid ? (
@@ -102,6 +137,19 @@ const TextInput = React.forwardRef(function TextInput(
     const helperContent = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
+    if (!labelText && charCount) {
+      return (
+        <div className={`${prefix}--text-input__character-counter-title`}>
+          {helperContent}
+          <CharCounter
+            disabled={other.disabled}
+            count={isControlled ? other.value.length : inputVal.length}
+            maxLength={maxLength}
+          />
+        </div>
+      );
+    }
+
     return helperContent;
   })();
 
@@ -219,6 +267,16 @@ TextInput.propTypes = {
    * The label for the read-only status icon
    */
   readOnlyIconLabel: PropTypes.string,
+
+  /**
+   * Specify whether the character counter is shown
+   */
+  charCount: PropTypes.bool,
+
+  /**
+   * The maximum allowed input value length
+   */
+  maxLength: PropTypes.number,
 };
 
 TextInput.defaultProps = {

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -9,9 +9,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import { WarningFilled16 } from '@carbon/icons-react';
+import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
 import PasswordInput from './PasswordInput';
 import ControlledPasswordInput from './ControlledPasswordInput';
+import Tooltip from '../Tooltip';
 import { textInputProps } from './util';
 
 const { prefix } = settings;
@@ -29,6 +30,8 @@ const TextInput = React.forwardRef(function TextInput(
     invalidText,
     helperText,
     light,
+    readOnly,
+    readOnlyIconLabel,
     ...other
   },
   ref
@@ -54,6 +57,7 @@ const TextInput = React.forwardRef(function TextInput(
     type,
     ref,
     className: textInputClasses,
+    readOnly,
     ...other,
   };
   const labelClasses = classNames(`${prefix}--label`, {
@@ -73,12 +77,23 @@ const TextInput = React.forwardRef(function TextInput(
       {invalidText}
     </div>
   ) : null;
-  const input = (
+  const inputField = (
     <input {...textInputProps({ invalid, sharedTextInputProps, errorId })} />
   );
-  const helper = helperText ? (
-    <div className={helperTextClasses}>{helperText}</div>
-  ) : null;
+  const input =
+    readOnly && inputField.value ? (
+      <Tooltip showIcon={false} triggerText={inputField}>
+        {inputField.value}
+      </Tooltip>
+    ) : (
+      inputField
+    );
+  const helper = (() => {
+    const helperContent = helperText ? (
+      <div className={helperTextClasses}>{helperText}</div>
+    ) : null;
+    return helperContent;
+  })();
 
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>
@@ -89,6 +104,13 @@ const TextInput = React.forwardRef(function TextInput(
         data-invalid={invalid || null}>
         {invalid && (
           <WarningFilled16 className={`${prefix}--text-input__invalid-icon`} />
+        )}
+        {readOnly && (
+          <div
+            className={`${prefix}--text-input__readonly-icon`}
+            aria-label={readOnlyIconLabel}>
+            <EditOff16 />
+          </div>
         )}
         {input}
       </div>
@@ -177,6 +199,16 @@ TextInput.propTypes = {
    * `true` to use the light version.
    */
   light: PropTypes.bool,
+
+  /**
+   * The maximum allowed input value length
+   */
+  readOnly: PropTypes.bool,
+
+  /**
+   * The label for the read-only status icon
+   */
+  readOnlyIconLabel: PropTypes.string,
 };
 
 TextInput.defaultProps = {
@@ -188,6 +220,8 @@ TextInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  readOnly: false,
+  readOnlyIconLabel: 'This input field is read-only',
 };
 
 export default TextInput;

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -81,9 +81,9 @@ const TextInput = React.forwardRef(function TextInput(
     <input {...textInputProps({ invalid, sharedTextInputProps, errorId })} />
   );
   const input =
-    readOnly && inputField.value ? (
+    readOnly && (other.value || other.defaultValue) ? (
       <Tooltip showIcon={false} triggerText={inputField}>
-        {inputField.value}
+        {other.value || other.defaultValue}
       </Tooltip>
     ) : (
       inputField

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -51,7 +51,7 @@ const TextInput = React.forwardRef(function TextInput(
     light,
     readOnly,
     readOnlyIconLabel,
-    charCount,
+    useCharCount,
     renderCharCounter: CharCounter = DefaultCharCounter,
     defaultValue,
     maxLength,
@@ -99,7 +99,7 @@ const TextInput = React.forwardRef(function TextInput(
         {labelText}
       </label>
     );
-    if (labelContent && charCount) {
+    if (labelContent && useCharCount) {
       return (
         <div className={`${prefix}--text-input__character-counter-title`}>
           {labelContent}
@@ -137,7 +137,7 @@ const TextInput = React.forwardRef(function TextInput(
     const helperContent = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
-    if (!labelText && charCount) {
+    if (!labelText && useCharCount) {
       return (
         <div className={`${prefix}--text-input__character-counter-title`}>
           {helperContent}
@@ -271,7 +271,7 @@ TextInput.propTypes = {
   /**
    * Specify whether the character counter is shown
    */
-  charCount: PropTypes.bool,
+  useCharCount: PropTypes.bool,
 
   /**
    * The maximum allowed input value length

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -15,7 +15,6 @@ import ControlledPasswordInput from './ControlledPasswordInput';
 import Tooltip from '../Tooltip';
 import { textInputProps } from './util';
 import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
-import { useControlledStateWithValue } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 const DefaultCharCounter = ({ disabled, count, maxLength }) => {
@@ -212,9 +211,7 @@ TextInput.propTypes = {
    * Optionally provide an `onChange` handler that is called whenever <input>
    * is updated
    */
-  onChange: !useControlledStateWithValue
-    ? PropTypes.func
-    : requiredIfValueExists(PropTypes.func),
+  onChange: requiredIfValueExists(PropTypes.func),
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
@@ -32,10 +32,13 @@ const TextInput = React.forwardRef(function TextInput(
     light,
     readOnly,
     readOnlyIconLabel,
+    defaultValue,
     ...other
   },
   ref
 ) {
+  const [inputVal, setInput] = useState(defaultValue);
+  const isControlled = useRef(other.value !== undefined).current;
   const errorId = id + '-error-msg';
   const textInputClasses = classNames(`${prefix}--text-input`, className, {
     [`${prefix}--text-input--light`]: light,
@@ -45,7 +48,7 @@ const TextInput = React.forwardRef(function TextInput(
     id,
     onChange: evt => {
       if (!other.disabled) {
-        onChange(evt);
+        onChange && onChange(evt, { value: evt.target.value });
       }
     },
     onClick: evt => {
@@ -67,23 +70,30 @@ const TextInput = React.forwardRef(function TextInput(
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
-  const label = labelText ? (
-    <label htmlFor={id} className={labelClasses}>
-      {labelText}
-    </label>
-  ) : null;
+  const label = (() => {
+    const labelContent = labelText && (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    );
+    return labelContent;
+  })();
   const error = invalid ? (
     <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
     </div>
   ) : null;
   const inputField = (
-    <input {...textInputProps({ invalid, sharedTextInputProps, errorId })} />
+    <input
+      {...textInputProps({ invalid, sharedTextInputProps, errorId })}
+      value={isControlled ? other.value : inputVal}
+      onInput={e => setInput(e.target.value)}
+    />
   );
   const input =
-    readOnly && (other.value || other.defaultValue) ? (
+    readOnly && (other.value || other.defaultValue || inputVal) ? (
       <Tooltip showIcon={false} triggerText={inputField}>
-        {other.value || other.defaultValue}
+        {other.value || other.defaultValue || inputVal}
       </Tooltip>
     ) : (
       inputField

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -12,7 +12,8 @@ import { settings } from 'carbon-components';
 import { WarningFilled16, EditOff16 } from '@carbon/icons-react';
 import PasswordInput from './PasswordInput';
 import ControlledPasswordInput from './ControlledPasswordInput';
-import Tooltip from '../Tooltip';
+import TooltipDefinition from '../TooltipDefinition/TooltipDefinition';
+import TooltipIcon from '../TooltipIcon/TooltipIcon';
 import { textInputProps } from './util';
 import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
 
@@ -52,6 +53,14 @@ const TextInput = React.forwardRef(function TextInput(
     light,
     readOnly,
     readOnlyIconLabel,
+    readOnlyIconTooltipProps = {
+      direction: 'bottom',
+      align: 'center',
+    },
+    readOnlyInputTooltipProps = {
+      direction: 'bottom',
+      align: 'center',
+    },
     useCharCount,
     renderCharCounter: CharCounter = DefaultCharCounter,
     defaultValue,
@@ -129,9 +138,9 @@ const TextInput = React.forwardRef(function TextInput(
   );
   const input =
     readOnly && value ? (
-      <Tooltip showIcon={false} triggerText={inputField}>
-        {value}
-      </Tooltip>
+      <TooltipDefinition {...readOnlyInputTooltipProps} tooltipText={value}>
+        {inputField}
+      </TooltipDefinition>
     ) : (
       inputField
     );
@@ -166,11 +175,12 @@ const TextInput = React.forwardRef(function TextInput(
           <WarningFilled16 className={`${prefix}--text-input__invalid-icon`} />
         )}
         {readOnly && (
-          <div
+          <TooltipIcon
+            {...readOnlyIconTooltipProps}
             className={`${prefix}--text-input__readonly-icon`}
-            aria-label={readOnlyIconLabel}>
+            tooltipText={readOnlyIconLabel}>
             <EditOff16 />
-          </div>
+          </TooltipIcon>
         )}
         {input}
       </div>
@@ -279,6 +289,50 @@ TextInput.propTypes = {
    * The maximum allowed input value length
    */
   maxLength: PropTypes.number,
+
+  /**
+   * Optionally specify props for the tooltip on the read only icon
+   */
+  readOnlyInputIconProps: PropTypes.shape({
+    /**
+     * Specify the direction of the tooltip. Can be either top or bottom.
+     */
+    direction: PropTypes.oneOf(['top', 'bottom']),
+
+    /**
+     * Specify the alignment (to the trigger button) of the tooltip.
+     * Can be one of: start, center, or end.
+     */
+    align: PropTypes.oneOf(['start', 'center', 'end']),
+
+    /**
+     * Optionally specify a custom id for the tooltip. If one is not provided,
+     * we generate a unique id for you.
+     */
+    id: PropTypes.string,
+  }),
+
+  /**
+   * Optionally specify props for the tooltip on the read only input field
+   */
+  readOnlyInputTooltipProps: PropTypes.shape({
+    /**
+     * Specify the direction of the tooltip. Can be either top or bottom.
+     */
+    direction: PropTypes.oneOf(['top', 'bottom']),
+
+    /**
+     * Specify the alignment (to the trigger button) of the tooltip.
+     * Can be one of: start, center, or end.
+     */
+    align: PropTypes.oneOf(['start', 'center', 'end']),
+
+    /**
+     * Optionally specify a custom id for the tooltip. If one is not provided,
+     * we generate a unique id for you.
+     */
+    id: PropTypes.string,
+  }),
 };
 
 TextInput.defaultProps = {

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -95,7 +95,7 @@ const TextInput = React.forwardRef(function TextInput(
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
-  const label = (() => {
+  const TextInputLabel = () => {
     const labelContent = labelText && (
       <label htmlFor={id} className={labelClasses}>
         {labelText}
@@ -114,7 +114,7 @@ const TextInput = React.forwardRef(function TextInput(
       );
     }
     return labelContent;
-  })();
+  };
   const error = invalid ? (
     <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
@@ -135,7 +135,7 @@ const TextInput = React.forwardRef(function TextInput(
     ) : (
       inputField
     );
-  const helper = (() => {
+  const TextInputHelperText = () => {
     const helperContent = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
@@ -153,12 +153,12 @@ const TextInput = React.forwardRef(function TextInput(
     }
 
     return helperContent;
-  })();
+  };
 
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>
-      {label}
-      {helper}
+      <TextInputLabel />
+      <TextInputHelperText />
       <div
         className={`${prefix}--text-input__field-wrapper`}
         data-invalid={invalid || null}>

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -57,7 +57,7 @@ TooltipDefinition.propTypes = {
    * Specify the tooltip trigger text that is rendered to the UI for the user to
    * interact with in order to display the tooltip.
    */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 
   /**
    * Specify the direction of the tooltip. Can be either top or bottom.


### PR DESCRIPTION
Closes #3018

Closes #1672

This PR adds read-only support to the text input and textarea components alongside a mechanism to convert the inputs to controlled mode based on the `onChange` handler and `value` prop. This PR also reimplements character counter (which was previously reverted but depends on the controlled/uncontrolled separation). Since controlled/uncontrolled separation itself doesn’t provide any benefit from user’s perspective until character counter is introduced, it is being introduced alongside the character counter feature here

#### Changelog

**New**

- mechanism to turn `TextInput` and `TextArea` to controlled components based on `onChange` handler and `value` prop
- `readOnly` mode styles
- character counter for `TextInput` and `TextArea` (ref: https://github.com/carbon-design-system/carbon/pull/2745 which was previously reverted)

#### Testing / Reviewing

Ensure the read-only text input and character counters behave as expected
