### PR TITLE
fix(icons-angular): update node parse logic

### DIFF
--- a/packages/icons-angular/src/templates.js
+++ b/packages/icons-angular/src/templates.js
@@ -66,7 +66,9 @@ export class ${className}Directive implements AfterViewInit {
 
     let node = svgElement.firstChild;
     while (node) {
-      svg.appendChild(node);
+      // importNode makes a clone of the node
+      // this ensures we keep looping over the nodes in the parsed document
+      svg.appendChild(svg.ownerDocument.importNode(node, true));
       node = node.nextSibling;
     }
 


### PR DESCRIPTION
- use importNode to keep ownerDocument references in sync

Closes #2826 (again)

Turns out the original node looping logic only completed one loop - because `appendChild` pulled the node into the document, and broke the `nextSibling` chain ... oops!