### PR TITLE
docs(Slider): add default knob value for ariaLabelInput prop

### DIFF
--- a/packages/react/src/components/Slider/Slider-story.js
+++ b/packages/react/src/components/Slider/Slider-story.js
@@ -17,7 +17,10 @@ import { sliderValuePropSync } from '../../internal/FeatureFlags';
 const props = () => ({
   name: text('Form item name (name)', ''),
   inputType: text('The form element type (inputType)', 'number'),
-  ariaLabelInput: text('The ARIA label for the <input> (ariaLabelInput)', ''),
+  ariaLabelInput: text(
+    'The ARIA label for the <input> (ariaLabelInput)',
+    'Label for slider value'
+  ),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
   hideTextInput: boolean('Without text input (hideTextInput)', false),


### PR DESCRIPTION
Closes #3061

This PR adds a default value for the `ariaLabelInput` knob for our `<Slider>` story to remove a DAP violation

#### Testing / Reviewing

Ensure that the form control label violation is not thrown in DAP (I've tested and confirmed locally)

the Netlify build is likely going to time out, so best to confirm locally as well