### PR TITLE
fix: set default `defaultValue` for TextInput and TextArea

### DIFF
--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -71,8 +71,8 @@ exports[`ModalWrapper should render 1`] = `
           className="bx--modal bx--modal-tall"
           id="modal"
           onBlur={[Function]}
-          onClick={[Function]}
           onKeyDown={[Function]}
+          onMouseDown={[Function]}
           role="presentation"
           tabIndex={-1}
         >

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
@@ -141,6 +141,10 @@ const TextArea = ({
       onInput={e => setInput(e.target.value)}
     />
   );
+
+  useEffect(() => {
+    setInput(other.value || defaultValue);
+  }, [other, defaultValue]);
 
   return (
     <div className={`${prefix}--form-item`}>

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -266,6 +266,7 @@ TextArea.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  defaultValue: '',
 };
 
 export default TextArea;

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -50,7 +50,7 @@ const TextArea = ({
   renderCharCounter: CharCounter = DefaultCharCounter,
   ...other
 }) => {
-  const [textareaVal, setInput] = useState(defaultValue);
+  const [textareaVal, setInput] = useState(other.value || defaultValue);
   const textareaProps = {
     id,
     onChange: evt => {

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
@@ -139,6 +139,10 @@ const TextInput = React.forwardRef(function TextInput(
 
     return helperContent;
   })();
+
+  useEffect(() => {
+    setInput(other.value || defaultValue);
+  }, [other, defaultValue]);
 
   return (
     <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -56,7 +56,7 @@ const TextInput = React.forwardRef(function TextInput(
   },
   ref
 ) {
-  const [inputVal, setInput] = useState(defaultValue);
+  const [inputVal, setInput] = useState(other.value || defaultValue);
   const errorId = id + '-error-msg';
   const textInputClasses = classNames(`${prefix}--text-input`, className, {
     [`${prefix}--text-input--light`]: light,

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -258,6 +258,7 @@ TextInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  defaultValue: '',
 };
 
 export default TextInput;


### PR DESCRIPTION
ref: #3015

when adding support for `defaultValue` in #3015, a default value was not assigned if the user did not provide one themselves

#### Changelog

**Changed**

- assign default value to `defaultValue` prop

#### Testing / Reviewing

Ensure `<TextInput>` and `<TextArea>` function as expected
