### PR TITLE
fix: failing OverflowMenu and Modal tests

### DIFF
--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -147,7 +147,7 @@ describe('Modal', () => {
       const modal = wrapper.find(Modal);
       const div = modal.find(`.${prefix}--modal`);
       wrapper.setState({ isOpen: true });
-      div.simulate('click');
+      div.simulate('mousedown');
       expect(wrapper.state('isOpen')).toEqual(false);
     });
 

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -71,8 +71,8 @@ exports[`ModalWrapper should render 1`] = `
           className="bx--modal bx--modal-tall"
           id="modal"
           onBlur={[Function]}
-          onClick={[Function]}
           onKeyDown={[Function]}
+          onMouseDown={[Function]}
           role="presentation"
           tabIndex={-1}
         >

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
@@ -21,7 +21,7 @@ describe('OverflowMenu', () => {
         <div className="test-child" />
       </OverflowMenu>
     );
-    const menu = rootWrapper.find('div[role="menu"]');
+    const menu = rootWrapper.find(`div.${prefix}--overflow-menu`);
     const icon = menu.find(OverflowMenuVertical16);
 
     it('should render an Icon', () => {
@@ -50,21 +50,23 @@ describe('OverflowMenu', () => {
     it('should set tabIndex if one is passed via props', () => {
       rootWrapper.setProps({ tabIndex: 2 });
 
-      expect(rootWrapper.find('div[role="menu"]').props().tabIndex).toEqual(2);
+      expect(
+        rootWrapper.find(`div.${prefix}--overflow-menu`).props().tabIndex
+      ).toEqual(2);
     });
 
     it('should set ariaLabel if one is passed via props', () => {
       rootWrapper.setProps({ ariaLabel: 'test label' });
       expect(
-        rootWrapper.find('div[role="menu"]').props()['aria-label']
+        rootWrapper.find(`div.${prefix}--overflow-menu`).props()['aria-label']
       ).toEqual('test label');
     });
 
     it('should set id if one is passed via props', () => {
       rootWrapper.setProps({ id: 'uniqueId' });
-      expect(rootWrapper.find('div[role="menu"]').props().id).toEqual(
-        'uniqueId'
-      );
+      expect(
+        rootWrapper.find(`div.${prefix}--overflow-menu`).props().id
+      ).toEqual('uniqueId');
     });
 
     it('should apply a tabindex to the menu', () => {


### PR DESCRIPTION
Closes #3111

This PR fixes several failing test suites and updates snapshots to pass CI. ~It looks like the React test suite does not run in CI?~ addressed in #3120 

#### Changelog

**Changed**

- fix overflow menu body selector in tests
- simulate `mousedown` event in modal tests
- update snapshots

#### Testing / Reviewing

Ensure CI passes
