### PR TITLE
fix(ListBoxSelection): exclude MultiSelect classes from ComboBox

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -13241,10 +13241,6 @@ List box styles
     }
   }
 
-  .#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__selection {
-    right: rem(57px); // 33px + 1.5rem when invalid
-  }
-
   .#{$prefix}--list-box__selection > svg {
     fill: $icon-02;
   }

--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -346,10 +346,6 @@ $list-box-menu-width: rem(300px);
     }
   }
 
-  .#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__selection {
-    right: rem(57px); // 33px + 1.5rem when invalid
-  }
-
   .#{$prefix}--list-box__selection > svg {
     fill: $icon-02;
   }

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -305,11 +305,6 @@ export default class ComboBox extends React.Component {
                 disabled,
                 onClick: this.onToggleClick(isOpen),
               })}>
-              {invalid && (
-                <WarningFilled16
-                  className={`${prefix}--list-box__invalid-icon`}
-                />
-              )}
               <input
                 className={`${prefix}--text-input`}
                 aria-label={ariaLabel}
@@ -324,6 +319,11 @@ export default class ComboBox extends React.Component {
                   onKeyDown: this.handleOnInputKeyDown,
                 })}
               />
+              {invalid && (
+                <WarningFilled16
+                  className={`${prefix}--list-box__invalid-icon`}
+                />
+              )}
               {inputValue && (
                 <ListBox.Selection
                   clearSelection={clearSelection}

--- a/packages/react/src/components/ListBox/ListBoxSelection.js
+++ b/packages/react/src/components/ListBox/ListBoxSelection.js
@@ -23,13 +23,10 @@ const ListBoxSelection = ({
   selectionCount,
   translateWithId: t,
 }) => {
-  const className = cx(
-    `${prefix}--tag--filter`,
-    `${prefix}--list-box__selection`,
-    {
-      [`${prefix}--list-box__selection--multi`]: selectionCount,
-    }
-  );
+  const className = cx(`${prefix}--list-box__selection`, {
+    [`${prefix}--tag--filter`]: selectionCount,
+    [`${prefix}--list-box__selection--multi`]: selectionCount,
+  });
   const handleOnClick = event => {
     event.stopPropagation();
     clearSelection(event);

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -81,7 +81,7 @@ exports[`ListBoxField should set \`aria-owns\` based when expanded 1`] = `
       translateWithId={[Function]}
     >
       <div
-        className="bx--tag--filter bx--list-box__selection"
+        className="bx--list-box__selection"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="button"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -17,7 +17,7 @@ exports[`ListBoxField should render 1`] = `
       translateWithId={[Function]}
     >
       <div
-        className="bx--tag--filter bx--list-box__selection"
+        className="bx--list-box__selection"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="button"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -27,7 +27,7 @@ exports[`ListBoxSelection should render 1`] = `
   }
 >
   <div
-    className="bx--tag--filter bx--list-box__selection"
+    className="bx--list-box__selection"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="button"
@@ -98,7 +98,7 @@ exports[`ListBoxSelection should render 2`] = `
   }
 >
   <div
-    className="bx--tag--filter bx--list-box__selection bx--list-box__selection--multi"
+    className="bx--list-box__selection bx--tag--filter bx--list-box__selection--multi"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="button"


### PR DESCRIPTION
Closes #3117

This PR excludes MultiSelect classes from ComboBox so that the component displays properly when an option is selected. Also aligns the React markup with the vanilla markup

#### Testing / Reviewing

Ensure the combobox displays correctly
