### PR TITLE
fix: specify dropdown props shape

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -156,7 +156,7 @@ export default class ComboBox extends React.Component {
     /**
      * Additional props passed to Downshift
      */
-    downshiftProps: Downshift.propTypes,
+    downshiftProps: PropTypes.shape(Downshift.propTypes),
   };
 
   static defaultProps = {

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -130,7 +130,7 @@ export default class Dropdown extends React.Component {
     /**
      * Additional props passed to Downshift
      */
-    downshiftProps: Downshift.propTypes,
+    downshiftProps: PropTypes.shape(Downshift.propTypes),
   };
 
   static defaultProps = {

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -118,7 +118,7 @@ export default class FilterableMultiSelect extends React.Component {
     /**
      * Additional props passed to Downshift
      */
-    downshiftProps: Downshift.propTypes,
+    downshiftProps: PropTypes.shape(Downshift.propTypes),
   };
 
   static getDerivedStateFromProps({ open }, state) {


### PR DESCRIPTION
Closes #3088

This PR removes the prop type warnings on the remaining listbox components (refs #3109)

#### Changelog

**Changed**

- downshift prop types

#### Testing / Reviewing

Ensure no prop type warnings are emitted for the listbox components
