### PR TITLE
Fix broken developer guide link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ we support!
 We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
-[Developer Guide](./github/developing.md)! 👀
+[Developer Guide](./docs/developing.md)! 👀
 
 ## 📝 License
 


### PR DESCRIPTION
Closes # (No issue opened)

#### Changelog

**Changed**

chore(readme): fix broken developer guide link

#### Testing / Reviewing

Tested by clicking the new link and ensuring the page no longer returns a 404 
