### PR TITLE
fix(ui-shell): enforce height/width on svg directly

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -19917,8 +19917,6 @@ UI shell side nav
     display: flex;
     justify-content: center;
     align-items: center;
-    width: mini-units(2);
-    height: mini-units(2);
     // Helpful in flex containers so the icon does not have less than the
     // expected width
     flex: 0 0 mini-units(2);
@@ -19930,6 +19928,8 @@ UI shell side nav
 
   .#{$prefix}--side-nav__icon > svg {
     fill: $shell-side-nav-icon-01;
+    width: mini-units(2);
+    height: mini-units(2);
   }
 
   .#{$prefix}--side-nav__icon > svg.#{$prefix}--side-nav-collapse-icon {

--- a/packages/components/src/components/ui-shell/_side-nav.scss
+++ b/packages/components/src/components/ui-shell/_side-nav.scss
@@ -479,8 +479,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: mini-units(2);
-    height: mini-units(2);
     // Helpful in flex containers so the icon does not have less than the
     // expected width
     flex: 0 0 mini-units(2);
@@ -492,6 +490,8 @@
 
   .#{$prefix}--side-nav__icon > svg {
     fill: $shell-side-nav-icon-01;
+    width: mini-units(2);
+    height: mini-units(2);
   }
 
   .#{$prefix}--side-nav__icon > svg.#{$prefix}--side-nav-collapse-icon {


### PR DESCRIPTION
Arose from a discussion in Slack:

https://ibm-cloudplatform.slack.com/archives/C2K6RFJ1G/p1561493606434100


An icon is now sized directly, rather than relying on the container 