### PR TITLE
fix(pagination): arrow icon misalignment

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -136,6 +136,7 @@ $css--helpers: true;
     }
 
     .#{$prefix}--select .#{$prefix}--select-input ~ .#{$prefix}--select__arrow {
+      position: absolute;
       right: 0.3rem;
       top: 0.625rem;
     }


### PR DESCRIPTION
Closes #2502

PaginationV2 arrow icon misalignment

#### Changelog
**Changed**

- Restore the `position: absolute` on the arrow SVG seen here the DOM on the demo site: https://v9.carbondesignsystem.com/components/pagination/code


#### Testing / Reviewing

Tested the fix using Chrome debugger by adding `position: absolute` to the CSS selector `.bx--pagination .bx--select .bx--select-input ~ .bx--select__arrow`