### PR TITLE
2880 disabled tabs bug

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -16726,6 +16726,11 @@ Tabs styles
   .#{$prefix}--tabs__nav-item--disabled,
   .#{$prefix}--tabs__nav-item--disabled:hover {
     cursor: not-allowed;
+    outline: none;
+  }
+
+  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
+    pointer-events: none;
   }
 
   //-----------------------------

--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -185,6 +185,11 @@
   .#{$prefix}--tabs__nav-item--disabled,
   .#{$prefix}--tabs__nav-item--disabled:hover {
     cursor: not-allowed;
+    outline: none;
+  }
+
+  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
+    pointer-events: none;
   }
 
   //-----------------------------

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -148,7 +148,7 @@ export default class Tab extends React.Component {
       className: `${prefix}--tabs__nav-link`,
       href,
       role: 'tab',
-      tabIndex,
+      tabIndex: !disabled ? tabIndex : -1,
       ['aria-selected']: selected,
       ref: e => {
         this.tabAnchor = e;
@@ -161,7 +161,7 @@ export default class Tab extends React.Component {
         tabIndex={-1}
         className={classes}
         onClick={evt => {
-          handleTabClick(index, label, evt);
+          handleTabClick(index, evt, disabled);
           onClick(evt);
         }}
         onKeyDown={evt => {

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -166,7 +166,7 @@ export default class Tab extends React.Component {
         }}
         onKeyDown={evt => {
           this.setTabFocus(evt);
-          handleTabKeyDown(index, label, evt);
+          handleTabKeyDown(index, evt, disabled);
           onKeyDown(evt);
         }}
         role="presentation"

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -161,12 +161,18 @@ export default class Tab extends React.Component {
         tabIndex={-1}
         className={classes}
         onClick={evt => {
-          handleTabClick(index, evt, disabled);
+          if (disabled) {
+            return;
+          }
+          handleTabClick(index, evt);
           onClick(evt);
         }}
         onKeyDown={evt => {
+          if (disabled) {
+            return;
+          }
           this.setTabFocus(evt);
-          handleTabKeyDown(index, evt, disabled);
+          handleTabKeyDown(index, evt);
           onKeyDown(evt);
         }}
         role="presentation"

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -135,16 +135,19 @@ export default class Tabs extends React.Component {
   };
 
   handleTabKeyDown = onSelectionChange => {
-    return (index, disabled, evt) => {
+    return (index, evt, disabled) => {
       const key = evt.key || evt.which;
 
-      if (!disabled) {
-        if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
-          this.selectTabAt(index, onSelectionChange);
-          this.setState({
-            dropdownHidden: true,
-          });
-        }
+      if (
+        key === 'Enter' ||
+        key === 13 ||
+        key === ' ' ||
+        (key === 32 && !disabled)
+      ) {
+        this.selectTabAt(index, onSelectionChange);
+        this.setState({
+          dropdownHidden: true,
+        });
       }
     };
   };

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -123,11 +123,10 @@ export default class Tabs extends React.Component {
 
   // following functions (handle*) are Props on Tab.js, see Tab.js for parameters
   handleTabClick = onSelectionChange => {
-    return (index, evt, disabled) => {
+    return (index, evt) => {
       evt.preventDefault();
-      if (!disabled) {
-        this.selectTabAt(index, onSelectionChange);
-      }
+
+      this.selectTabAt(index, onSelectionChange);
       this.setState({
         dropdownHidden: true,
       });
@@ -135,15 +134,10 @@ export default class Tabs extends React.Component {
   };
 
   handleTabKeyDown = onSelectionChange => {
-    return (index, evt, disabled) => {
+    return (index, evt) => {
       const key = evt.key || evt.which;
 
-      if (
-        key === 'Enter' ||
-        key === 13 ||
-        key === ' ' ||
-        (key === 32 && !disabled)
-      ) {
+      if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
         this.selectTabAt(index, onSelectionChange);
         this.setState({
           dropdownHidden: true,

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -35,7 +35,6 @@ export default class Tabs extends React.Component {
 
     /**
      * Specify whether the Tab content is hidden
-     */
     hidden: PropTypes.bool,
 
     /**
@@ -136,14 +135,16 @@ export default class Tabs extends React.Component {
   };
 
   handleTabKeyDown = onSelectionChange => {
-    return (index, label, evt) => {
+    return (index, disabled, evt) => {
       const key = evt.key || evt.which;
 
-      if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
-        this.selectTabAt(index, onSelectionChange);
-        this.setState({
-          dropdownHidden: true,
-        });
+      if (!disabled) {
+        if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
+          this.selectTabAt(index, onSelectionChange);
+          this.setState({
+            dropdownHidden: true,
+          });
+        }
       }
     };
   };

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -124,9 +124,11 @@ export default class Tabs extends React.Component {
 
   // following functions (handle*) are Props on Tab.js, see Tab.js for parameters
   handleTabClick = onSelectionChange => {
-    return (index, label, evt) => {
+    return (index, evt, disabled) => {
       evt.preventDefault();
-      this.selectTabAt(index, onSelectionChange);
+      if (!disabled) {
+        this.selectTabAt(index, onSelectionChange);
+      }
       this.setState({
         dropdownHidden: true,
       });
@@ -150,7 +152,6 @@ export default class Tabs extends React.Component {
     return index => {
       const tabCount = React.Children.count(this.props.children) - 1;
       let tabIndex = index;
-
       if (index < 0) {
         tabIndex = tabCount;
       } else if (index > tabCount) {


### PR DESCRIPTION
Closes #2880 

#### Changelog

**Changed**

- Passed in disabled argument to handleTabClick and handleTabKeyDown so content wouldn't switch when tabs disabled. 

#### Testing / Reviewing

## Steps to see if it works:

1. Go to the storybook
2. Under the `knobs` panel of storybook enable the `Disabled` knob
3. Click the tabs, they should now not switch content by clicking or with any keyDowns. 
