### PR TITLE
fix(number-input): use aria-label for input attribute

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -298,7 +298,7 @@ class NumberInput extends Component {
           ? value
           : this.state.value,
       readOnly,
-      ariaLabel,
+      'aria-label': ariaLabel,
     };
 
     const buttonProps = {


### PR DESCRIPTION
Closes #3233 

#### Changelog

**Changed**

- use `aria-label` for the `input` element's attribute instead of `ariaLabel`
