### PR TITLE
feat(tabs): support home/end keyboard navigation

### DIFF
--- a/packages/components/src/components/tabs/tabs.js
+++ b/packages/components/src/components/tabs/tabs.js
@@ -114,21 +114,40 @@ class Tab extends ContentSwitcher {
   _handleKeyDown(event) {
     const triggerNode = eventMatches(event, this.options.selectorTrigger);
     if (triggerNode) {
+      // enter
       if (event.which === 13) {
         this._updateMenuState();
       }
       return;
     }
 
+    const buttons = toArray(
+      this.element.querySelectorAll(this.options.selectorButtonEnabled)
+    );
+
+    // End or Home key handler
+    if (event.which === 35 || event.which === 36) {
+      event.preventDefault();
+      const activeIndex = {
+        35: buttons.length - 1,
+        36: 0,
+      }[event.which];
+      this.setActive(buttons[activeIndex], (error, item) => {
+        if (item) {
+          const link = item.querySelector(this.options.selectorLink);
+          if (link) {
+            link.focus();
+          }
+        }
+      });
+    }
+
     const direction = {
-      37: this.constructor.NAVIGATE.BACKWARD,
-      39: this.constructor.NAVIGATE.FORWARD,
+      37: this.constructor.NAVIGATE.BACKWARD, // left arrow
+      39: this.constructor.NAVIGATE.FORWARD, // right arrow
     }[event.which];
 
     if (direction) {
-      const buttons = toArray(
-        this.element.querySelectorAll(this.options.selectorButtonEnabled)
-      );
       const button = this.element.querySelector(
         this.options.selectorButtonSelected
       );

--- a/packages/components/tests/spec/tabs_spec.js
+++ b/packages/components/tests/spec/tabs_spec.js
@@ -246,6 +246,38 @@ describe('Test tabs', function() {
       ).toBe(true);
     });
 
+    it('Should update active tab on end key', function() {
+      const defaultPrevented = element.dispatchEvent(
+        Object.assign(new CustomEvent('keydown'), { which: 35 })
+      );
+      expect(defaultPrevented).toBe(true);
+      expect(
+        buttonNodes[0].classList.contains('bx--tabs__nav-item--selected')
+      ).toBe(false);
+      expect(
+        buttonNodes[1].classList.contains('bx--tabs__nav-item--selected')
+      ).toBe(false);
+      expect(
+        buttonNodes[2].classList.contains('bx--tabs__nav-item--selected')
+      ).toBe(true);
+    });
+
+    it('Should update active tab on home key', function() {
+      const defaultPrevented = element.dispatchEvent(
+        Object.assign(new CustomEvent('keydown'), { which: 36 })
+      );
+      expect(defaultPrevented).toBe(true);
+      expect(
+        buttonNodes[0].classList.contains('bx--tabs__nav-item--selected')
+      ).toBe(true);
+      expect(
+        buttonNodes[1].classList.contains('bx--tabs__nav-item--selected')
+      ).toBe(false);
+      expect(
+        buttonNodes[2].classList.contains('bx--tabs__nav-item--selected')
+      ).toBe(false);
+    });
+
     it('Should focus on the new active tab upon keyboard navigation', function() {
       const link = document.createElement('a');
       spyOn(link, 'focus');

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -10,6 +10,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import TabContent from '../TabContent';
+import { keys, matches } from '../../internal/keyboard';
 
 const { prefix } = settings;
 
@@ -109,14 +110,8 @@ export default class Tab extends React.Component {
   };
 
   setTabFocus(evt) {
-    const leftKey = 37;
-    const rightKey = 39;
-    if (evt.which === leftKey) {
-      this.props.handleTabAnchorFocus(this.props.index - 1);
-    } else if (evt.which === rightKey) {
-      this.props.handleTabAnchorFocus(this.props.index + 1);
-    } else {
-      return;
+    if (matches(evt, [keys.ArrowLeft, keys.ArrowRight, keys.End, keys.Home])) {
+      this.props.handleTabAnchorFocus(evt, { index: this.props.index });
     }
   }
 

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -7,11 +7,19 @@
 
 import React from 'react';
 import { ChevronDownGlyph } from '@carbon/icons-react';
+import { settings } from 'carbon-components';
+import { shallow, mount } from 'enzyme';
 import Tabs from '../Tabs';
 import Tab from '../Tab';
 import TabsSkeleton from '../Tabs/Tabs.Skeleton';
-import { shallow, mount } from 'enzyme';
-import { settings } from 'carbon-components';
+import {
+  ArrowLeft,
+  ArrowRight,
+  End,
+  Enter,
+  Home,
+  Space,
+} from '../../internal/keyboard/keys';
 
 const { prefix } = settings;
 
@@ -197,46 +205,40 @@ describe('Tabs', () => {
 
       const firstTab = wrapper.find('.firstTab').last();
       const lastTab = wrapper.find('.lastTab').last();
-      const endKey = 35;
-      const homeKey = 36;
-      const leftKey = 37;
-      const rightKey = 39;
-      const spaceKey = 32;
-      const enterKey = 13;
 
       describe('state: selected', () => {
         it('updates selected state when pressing arrow keys', () => {
-          firstTab.simulate('keydown', { which: rightKey });
+          firstTab.simulate('keydown', { ...ArrowRight });
           expect(wrapper.state().selected).toEqual(1);
-          lastTab.simulate('keydown', { which: leftKey });
+          lastTab.simulate('keydown', { ...ArrowLeft });
           expect(wrapper.state().selected).toEqual(0);
         });
 
         it('loops focus and selected state from lastTab to firstTab', () => {
-          lastTab.simulate('keydown', { which: rightKey });
+          lastTab.simulate('keydown', { ...ArrowRight });
           expect(wrapper.state().selected).toEqual(0);
         });
 
         it('loops focus and selected state from firstTab to lastTab', () => {
-          firstTab.simulate('keydown', { which: leftKey });
+          firstTab.simulate('keydown', { ...ArrowLeft });
           expect(wrapper.state().selected).toEqual(1);
         });
 
         it('updates selected state when pressing the End key', () => {
-          firstTab.simulate('keydown', { which: endKey });
+          firstTab.simulate('keydown', { ...End });
           expect(wrapper.state().selected).toEqual(1);
         });
 
         it('updates selected state when pressing the Home key', () => {
           wrapper.setState({ selected: 1 });
-          lastTab.simulate('keydown', { which: homeKey });
+          lastTab.simulate('keydown', { ...Home });
           expect(wrapper.state().selected).toEqual(0);
         });
 
         it('updates selected state when pressing space or enter key', () => {
-          firstTab.simulate('keydown', { which: spaceKey });
+          firstTab.simulate('keydown', { ...Space });
           expect(wrapper.state().selected).toEqual(0);
-          lastTab.simulate('keydown', { which: enterKey });
+          lastTab.simulate('keydown', { ...Enter });
           expect(wrapper.state().selected).toEqual(1);
         });
       });

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -197,6 +197,8 @@ describe('Tabs', () => {
 
       const firstTab = wrapper.find('.firstTab').last();
       const lastTab = wrapper.find('.lastTab').last();
+      const endKey = 35;
+      const homeKey = 36;
       const leftKey = 37;
       const rightKey = 39;
       const spaceKey = 32;
@@ -218,6 +220,17 @@ describe('Tabs', () => {
         it('loops focus and selected state from firstTab to lastTab', () => {
           firstTab.simulate('keydown', { which: leftKey });
           expect(wrapper.state().selected).toEqual(1);
+        });
+
+        it('updates selected state when pressing the End key', () => {
+          firstTab.simulate('keydown', { which: endKey });
+          expect(wrapper.state().selected).toEqual(1);
+        });
+
+        it('updates selected state when pressing the Home key', () => {
+          wrapper.setState({ selected: 1 });
+          lastTab.simulate('keydown', { which: homeKey });
+          expect(wrapper.state().selected).toEqual(0);
         });
 
         it('updates selected state when pressing space or enter key', () => {

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -107,11 +107,10 @@ export default class Tabs extends React.Component {
         };
   }
 
-  getTabs() {
-    return React.Children.map(this.props.children, (tab, index) =>
+  getTabs = () =>
+    React.Children.map(this.props.children, (tab, index) =>
       React.cloneElement(tab, { index })
     );
-  }
 
   getTabAt = (index, useFresh) => {
     return (
@@ -136,40 +135,41 @@ export default class Tabs extends React.Component {
     };
   };
 
-  handleTabKeyDown = onSelectionChange => {
-    return (index, evt) => {
-      const key = evt.key || evt.which;
-
-      if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
-        this.selectTabAt(index, onSelectionChange);
-        this.setState({
-          dropdownHidden: true,
-        });
-      }
-    };
+  handleTabKeyDown = onSelectionChange => (index, evt) => {
+    if (matches(evt, [keys.Enter, keys.Space])) {
+      this.selectTabAt(index, onSelectionChange);
+      this.setState({
+        dropdownHidden: true,
+      });
+    }
   };
 
   handleTabAnchorFocus = onSelectionChange => (evt, { index }) => {
     const newIndex = (() => {
-      const validTabs = this.getTabs().filter(tab => !tab.props.disabled);
-      const currentValidTabIndex = validTabs.findIndex(
-        tab => tab.props.index === index
-      ); // index of current tab in the array of valid tabs
+      const validTabIndices = this.getTabs().reduce(
+        (acc, curr) =>
+          !curr.props.disabled ? [...acc, curr.props.index] : acc,
+        []
+      );
+      // index of current tab in the array of valid tab indices
+      const currentValidTabIndex = validTabIndices.findIndex(
+        validIndex => validIndex === index
+      );
       if (matches(evt, [keys.ArrowLeft])) {
         return currentValidTabIndex - 1 < 0
-          ? validTabs[validTabs.length - 1].props.index
-          : validTabs[currentValidTabIndex - 1].props.index;
+          ? validTabIndices[validTabIndices.length - 1]
+          : validTabIndices[currentValidTabIndex - 1];
       }
       if (matches(evt, [keys.ArrowRight])) {
-        return currentValidTabIndex + 1 > validTabs.length - 1
-          ? validTabs[0].props.index
-          : validTabs[currentValidTabIndex + 1].props.index;
+        return currentValidTabIndex + 1 > validTabIndices.length - 1
+          ? validTabIndices[0]
+          : validTabIndices[currentValidTabIndex + 1];
       }
       if (matches(evt, [keys.End])) {
-        return validTabs[validTabs.length - 1].props.index;
+        return validTabIndices[validTabIndices.length - 1];
       }
       if (matches(evt, [keys.Home])) {
-        return validTabs[0].props.index;
+        return validTabIndices[0];
       }
       return null;
     })();


### PR DESCRIPTION
Closes #1495

This PR adds `Home` and `End` key support for the tabs component and addresses an issue where disabled tabs can still be focused via keyboard

#### Changelog

**New**

- support for home/end key press

**Changed**

- `Tabs.getTabs` now includes `index` information on each tab
- `Tabs.handleKeydown` refactored to use the internal keyboard event handler tools
- modified `Tabs.handleTabAnchorFocus` to ignore disabled tabs

#### Testing / Reviewing

Ensure there are no regressions with the tabs component keyboard navigation

Ensure that the home and end keydown event handlers behave as expected

Ensure that disabled tabs cannot be focused
