### PR TITLE
fix(data-table): avoid clipping toolbar content

### DIFF
--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -30,9 +30,12 @@
     width: 100%;
     justify-content: flex-end;
     transform: translate3d(0, 0, 0);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
     transition: transform $duration--fast-02 motion(standard, productive),
       clip-path $duration--fast-02 motion(standard, productive);
+  }
+
+  .#{$prefix}--batch-actions ~ .#{$prefix}--toolbar-content {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
   }
 
   .#{$prefix}--toolbar-content .#{$prefix}--search .#{$prefix}--search-input {


### PR DESCRIPTION
This change avoids clipping table toolbar unless batch action is enabled, so that we allow non-floating menus to be placed in there.

Note that clipping table toolbar is still needed for the animation of batch actions, though. Given that, we recommend not putting non-floating menus in table toolbar if batch action is enabled.

Fixes #3271.

#### Changelog

**Changed**

- Not setting `clip-path` CSS property to `.bx--toolbar-content`, unless it's used along with batch actions.

#### Testing / Reviewing

Testing should make sure table toolbar is not broken, especially with the combination of batch actions. Such testing can be done in batch actions demo and clicking on a check box in the table, preferably with slower animation set by DevTools.