### PR TITLE
fix(TextArea): add ref forwarding to TextArea

### DIFF
--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -13,19 +13,22 @@ import { WarningFilled16 } from '@carbon/icons-react';
 
 const { prefix } = settings;
 
-const TextArea = ({
-  className,
-  id,
-  labelText,
-  hideLabel,
-  onChange,
-  onClick,
-  invalid,
-  invalidText,
-  helperText,
-  light,
-  ...other
-}) => {
+const TextArea = React.forwardRef(function  TextArea(
+    {
+      className,
+      id,
+      labelText,
+      hideLabel,
+      onChange,
+      onClick,
+      invalid,
+      invalidText,
+      helperText,
+      light,
+      ...other
+    },
+    ref
+)  {
   const textareaProps = {
     id,
     onChange: evt => {
@@ -38,6 +41,7 @@ const TextArea = ({
         onClick(evt);
       }
     },
+    ref,
   };
 
   const labelClasses = classNames(`${prefix}--label`, {
@@ -98,7 +102,7 @@ const TextArea = ({
       {error}
     </div>
   );
-};
+});
 
 TextArea.propTypes = {
   /**

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -13,7 +13,7 @@ import { WarningFilled16 } from '@carbon/icons-react';
 
 const { prefix } = settings;
 
-const TextArea = React.forwardRef(function  TextArea(
+const TextArea = React.forwardRef(function TextArea(
     {
       className,
       id,
@@ -104,6 +104,7 @@ const TextArea = React.forwardRef(function  TextArea(
   );
 });
 
+TextArea.displayName = 'TextArea';
 TextArea.propTypes = {
   /**
    * Provide a custom className that is applied directly to the underlying


### PR DESCRIPTION
I've added ref forwarding to the TextArea component the same way it's done in the TextInput component.

#### Changelog

**Changed**

- TextArea

#### Testing / Reviewing

In theory this change should not affect existing functionality of the TextArea component-
