### PR TITLE
feat(DatePicker): pass along onClose

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-story.js
+++ b/packages/react/src/components/DatePicker/DatePicker-story.js
@@ -31,6 +31,7 @@ const props = {
     id: 'date-picker',
     light: boolean('Light variant (light in <DatePicker>)', false),
     onChange: datePickerOnChangeActions('onPickerChange'),
+    onClose: action('onClose'),
   }),
   datePickerInput: () => ({
     id: 'date-picker-input-id',

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -281,6 +281,11 @@ export default class DatePicker extends Component {
     onChange: PropTypes.func,
 
     /**
+     * The `close` event handler.
+     */
+    onClose: PropTypes.func,
+
+    /**
      * The minimum date that a user can start picking from.
      */
     minDate: PropTypes.string,
@@ -319,6 +324,7 @@ export default class DatePicker extends Component {
       minDate,
       maxDate,
       value,
+      onClose,
     } = this.props;
     if (datePickerType === 'single' || datePickerType === 'range') {
       const onHook = (electedDates, dateStr, instance) => {
@@ -358,6 +364,7 @@ export default class DatePicker extends Component {
               onChange(...args);
             }
           },
+          onClose,
           onReady: onHook,
           onMonthChange: onHook,
           onYearChange: onHook,


### PR DESCRIPTION
This change adds `onClose` prop to `carbon-components-react`'s `<DatePicker>` component, which is passed along to Flatpickr library.

Fixes #2874.

#### Changelog

**New**

- `onClose` prop to `<DatePicker>`, which is passed along to Flatpickr library.

#### Testing / Reviewing

Testing should make sure React `<DatePicker>` component is not broken.