### PR TITLE
fix(dropdown): update color tokens

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -239,11 +239,11 @@
     }
 
     .#{$prefix}--dropdown-text {
-      color: $disabled-02;
+      color: $disabled-03;
     }
 
     .#{$prefix}--dropdown__arrow {
-      fill: $disabled-02;
+      fill: $disabled-03;
     }
 
     &.#{$prefix}--dropdown--light:hover {
@@ -262,7 +262,7 @@
     border-bottom-color: transparent;
     width: auto;
     height: rem(32px);
-    background-color: $field-02;
+    background-color: $ui-background;
     transition: background $duration--fast-01 motion(entrance, productive);
 
     &:hover {
@@ -270,7 +270,7 @@
     }
 
     &.#{$prefix}--dropdown--disabled {
-      background-color: $field-02;
+      background-color: $ui-background;
     }
 
     .#{$prefix}--dropdown__arrow {
@@ -293,7 +293,7 @@
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled
     .#{$prefix}--dropdown-text {
-    color: $disabled-02;
+    color: $disabled-03;
   }
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled:focus

--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -152,11 +152,11 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__label,
   .#{$prefix}--list-box--disabled.#{$prefix}--list-box--inline
     .#{$prefix}--list-box__label {
-    color: $disabled-02;
+    color: $disabled-03;
   }
 
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__menu-icon > svg {
-    fill: $disabled-02;
+    fill: $disabled-03;
   }
 
   .#{$prefix}--list-box--disabled,
@@ -190,7 +190,7 @@ $list-box-menu-width: rem(300px);
 
   // Inline variant for a `list-box`
   .#{$prefix}--list-box.#{$prefix}--list-box--inline {
-    background-color: $field-02;
+    background-color: $ui-background;
     border-width: 0;
 
     &:hover {


### PR DESCRIPTION
Fixes #3217.

#### Changelog

**Changed**

- Update several color tokens in inline variant of dropdown.

#### Testing / Reviewing

Testing should make sure our dropdown is not broken. The React variant can be verified by:

1. Set `true` to `CARBON_REACT_STORYBOOK_USE_EXTERNAL_CSS` as well as `CARBON_REACT_STORYBOOK_USE_STYLE_SOURCEMAP` environment variables
2. `cd /path/to/carbon/packages/react`
3. `yarn storybook`
4. Go to Dropdown - Default and set `inline` to `type` and check off `disabled` in the Knobs tab at the bottom
5. Go to DOM inspector in Chrome DevTools and select `<div>` with `.bx--dropdown--inline` class
6. Click on the line number link of the style ruleset and see the color token applied
7. Do above two steps for `<span>` with `.bx--list-box__label` class and the icon `<svg>`