### PR TITLE
feat(side-nav): add isActive styles based on child props

### DIFF
--- a/packages/react/src/components/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/UIShell/SideNavMenu.js
@@ -76,9 +76,21 @@ export class SideNavMenu extends React.Component {
       title,
     } = this.props;
     const { isExpanded } = this.state;
+
+    let hasActiveChild;
+    if (children && typeof children === Object) {
+      hasActiveChild = children.some(child => {
+        if (child.props.isActive === true || child.props['aria-current']) {
+          return true;
+        }
+        return false;
+      });
+    }
+
     const className = cx({
       [`${prefix}--side-nav__item`]: true,
-      [`${prefix}--side-nav__item--active`]: isActive,
+      [`${prefix}--side-nav__item--active`]:
+        isActive || (hasActiveChild && !isExpanded),
       [`${prefix}--side-nav__item--icon`]: IconElement,
       [customClassName]: !!customClassName,
     });


### PR DESCRIPTION
Relates to https://github.com/carbon-design-system/carbon/pull/3105#issuecomment-509296190

A user can currently add `isActive` to `SideNavMenu` to achieve the `active` state when the menu is collapsed. This just makes it so that the styles are still applied if a user forgets to add `isActive` to the sub-menu component 