### PR TITLE
fix(icons-react): add support for aliases

### DIFF
--- a/packages/icons-react/tasks/build.js
+++ b/packages/icons-react/tasks/build.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const meta = require('@carbon/icons/build-info.json');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const { rollup } = require('rollup');
 const babel = require('rollup-plugin-babel');
@@ -103,6 +103,38 @@ export { Icon };
       }
 
       return bundle.write(outputOptions);
+    })
+  );
+
+  // Create aliases for `@carbon/icons-react/<bundle-type>/<icon-name>/<size>`
+  await Promise.all(
+    meta.map(async info => {
+      const { moduleName, outputOptions } = info;
+      const pathToEntrypoint = Array.from({
+        // The length of this is determined by the number of directories from
+        // our `outputOptions` minus 1 for the bundle type (`es` for example)
+        // and minus 1 for the filename as it does not count as a directory jump
+        length: outputOptions.file.split('/').length - 2,
+      })
+        .fill('..')
+        .join('/');
+
+      await fs.ensureFile(outputOptions.file);
+      await fs.writeFile(
+        outputOptions.file,
+        `import { ${moduleName} } from '${pathToEntrypoint}';
+export default ${moduleName};
+`
+      );
+
+      const commonjsFilepath = outputOptions.file.replace(/es\//, 'lib/');
+      await fs.ensureFile(commonjsFilepath);
+      await fs.writeFile(
+        commonjsFilepath,
+        `const { ${moduleName} = require('${pathToEntrypoint}');
+module.exports = ${moduleName};
+`
+      );
     })
   );
 }


### PR DESCRIPTION
This adds in a smooth migration path for teams that are currently using `@carbon/icons-react` by adding in aliases at the old import paths and re-exporting from the main `index.js` for the bundle type. 

Note: this is only done for `es` and `commonjs`.

#### Changelog

**New**

**Changed**

- Update build step for icons-react to output back to icon paths like in older versions by re-exporting from newly generated entrypoint

**Removed**

#### Testing / Reviewing

```
cd packages/icons-react
yarn link
# Open new terminal tab at some location
npx create-react-app tmp
cd tmp
yarn link @carbon/icons-react
# Include below icon in `App.js`
```

```jsx
// App.js
import Bee32 from '@carbon/icons-react/es/bee/32';
import React from 'react';
import logo from './logo.svg';
import './App.css';

function App() {
  return (
    <div className="App">
      <header className="App-header">
        <img src={logo} className="App-logo" alt="logo" />
        <p>
          Edit <code>src/App.js</code> and save to reload.
        </p>
        <a
          className="App-link"
          href="https://reactjs.org"
          target="_blank"
          rel="noopener noreferrer"
        >
          Learn React
        </a>
        <Bee32 style={{ fill: 'currentColor' }} />
      </header>
    </div>
  );
}

export default App;
```

Verify it renders as:

![image](https://user-images.githubusercontent.com/3901764/60848450-47a5b600-a1ac-11e9-94de-05a1dd59f4fd.png)

In addition, to test tree-shaking, run:

```
yarn build
npx source-map-explorer build/static/js/main.<hash>.chunk.js
```

Verify that the size of `icons-react` does not exceed 5kb

![image](https://user-images.githubusercontent.com/3901764/60848487-7459cd80-a1ac-11e9-8854-96dbbd13b2f6.png)
