### PR TITLE
feat(upgrade): update package name and icons-react migration

### DIFF
--- a/packages/upgrade/README.md
+++ b/packages/upgrade/README.md
@@ -1,24 +1,36 @@
-# carbon-upgrade
+# @carbon/upgrade
 
-> \[Experimental] A tool for upgrading Carbon versions
+> A tool for upgrading Carbon versions
 
 ## Getting started
 
-To install `carbon-upgrade` in your project, you will need to run the following
+To install `@carbon/upgrade` in your project, you will need to run the following
 command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S carbon-upgrade
+npm install -S @carbon/upgrade
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add carbon-upgrade
+yarn add @carbon/upgrade
 ```
 
 ## Usage
+
+You can install `@carbon/upgrade` in your project, or use a tool like
+[`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)
+by running the following command in your project:
+
+```
+# Runs the command in "dry" mode, which means no files are altered.
+# To update the files, re-run the command without the `-d` flag.
+npx @carbon/upgrade -d
+```
+
+Below is a full output of the options and commands available:
 
 ```bash
 Usage: carbon-upgrade [options]

--- a/packages/upgrade/fixtures/icons-react/index.js
+++ b/packages/upgrade/fixtures/icons-react/index.js
@@ -1,0 +1,3 @@
+import Bee from '@carbon/icons-react/es/bee/32';
+
+console.log(<Bee />);

--- a/packages/upgrade/fixtures/icons-react/package.json
+++ b/packages/upgrade/fixtures/icons-react/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@carbon/icons-react": "10.1.0"
+  }
+}
+

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "carbon-upgrade",
-  "description": "[Experimental] A tool for upgrading Carbon versions",
-  "version": "0.0.8",
+  "name": "@carbon/upgrade",
+  "description": "A tool for upgrading Carbon versions",
+  "version": "10.3.0",
   "license": "Apache-2.0",
   "bin": {
     "carbon-upgrade": "./bin/carbon-upgrade.js"
@@ -25,7 +25,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {},
   "dependencies": {
     "chalk": "^2.4.2",
     "change-case": "^3.1.0",
@@ -39,6 +38,5 @@
     "npm-which": "^3.0.1",
     "semver": "^5.6.0",
     "yargs": "^12.0.5"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/upgrade/src/migrations/carbon-icons-react/10.3.0/index.js
+++ b/packages/upgrade/src/migrations/carbon-icons-react/10.3.0/index.js
@@ -17,7 +17,7 @@ module.exports = {
   version: TARGET_VERSION,
   from: [
     {
-      version: '>=10.x',
+      version: '>=10.0.0 <=10.3.0',
       async migrate(options) {
         const transformFile = require.resolve('./update-icon-import-path');
         const answers = await prompt([

--- a/packages/upgrade/src/runner.js
+++ b/packages/upgrade/src/runner.js
@@ -104,13 +104,14 @@ async function runInDirectory(options) {
   const questions = packageDependencies.map(dependency => {
     const { name, version } = dependency;
     const supportedVersions = supportedPackages.get(name);
+
     return {
       name,
       type: 'list',
       message: `Choose which version you would like to migrate to for ${name}`,
       choices: [...supportedVersions]
         .filter(supportedVersion => {
-          return semver.satisfies(supportedVersion.version, version);
+          return semver.gt(supportedVersion.version, version);
         })
         .map(supportedVersion => ({
           name: supportedVersion.version,


### PR DESCRIPTION
This is the counterpart to our `@carbon/icons-react` update. This adds support for migration from versions `<=10.3.0` of `@carbon/icons-react` by updating the import path for icons:

```js
// Input
import Bee from '@carbon/icons-react/es/bee/32';

// Output
import { Bee32 as Bee } from '@carbon/icons-react';
```

This specific PR updates our package to be under our new `@carbon` scope and adds a fixture to verify the CLI tool picks up on `package.json` fields with a suitable dependency to migrate.

#### Changelog

**New**

**Changed**

- `upgrade` package is now `@carbon/upgrade` aligned on v10.3
- Update runner logic to better support options

**Removed**

#### Testing / Reviewing

```bash
# Visit the icons-react fixture
cd packages/upgrade/fixtures/icons-react

# Run the CLI in dry mode
../../bin/carbon-upgrade.js -d
```

Verify CLI outputs the following:

![image](https://user-images.githubusercontent.com/3901764/60849401-2c3caa00-a1b0-11e9-96b3-8000ccbf2988.png)

For the prompt, use the following answers:

> Choose which version you would like to migrate to for @carbon/icons-react

10.4.0

> What directory would you like this script to changes files in?

Press Enter

> Would you like us to print the changed file contents to the terminal?

Yes

After running the last command, you should see an output like:

![image](https://user-images.githubusercontent.com/3901764/60849439-50988680-a1b0-11e9-830d-fe6864f2e9ff.png)

Re-run command without dry flag to verify it updates the file and package.json accordingly