### PR TITLE
chore(test): migrate away from done.fail()

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -277,7 +277,7 @@ describe('DatePicker', () => {
     beforeEach(done => {
       const spy = {};
       spy.console = jest.spyOn(console, 'error').mockImplementation(e => {
-        done.fail(e);
+        done(e);
       });
       done();
     });


### PR DESCRIPTION
`jest-circus`, the test runner we are using, does not seem to support Jasmine `done.fail()` API.

Found in a CI for #3054.

#### Changelog

**Changed**

- Replaced `done.fail(error)` with `done(error)` or an async function.

#### Testing / Reviewing

Testing should make sure our CI is not broken.