### PR TITLE
refactor(TableToolbarSearch): use correct class name

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.Skeleton.js
+++ b/packages/react/src/components/Accordion/Accordion.Skeleton.js
@@ -53,7 +53,7 @@ AccordionSkeleton.propTypes = {
   /**
    * Set unique identifier to generate unique item keys
    */
-  uid: deprecate(PropTypes.any),
+  uid: deprecate({ propType: PropTypes.any }),
 };
 
 AccordionSkeleton.defaultProps = {

--- a/packages/react/src/components/Accordion/Accordion.Skeleton.js
+++ b/packages/react/src/components/Accordion/Accordion.Skeleton.js
@@ -53,7 +53,7 @@ AccordionSkeleton.propTypes = {
   /**
    * Set unique identifier to generate unique item keys
    */
-  uid: deprecate({ propType: PropTypes.any }),
+  uid: deprecate(PropTypes.any),
 };
 
 AccordionSkeleton.defaultProps = {

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -54,7 +54,7 @@ const TableToolbarSearch = ({
     [`${prefix}--toolbar-action`]: true,
     [`${prefix}--toolbar-search-container-active`]: expanded,
     [`${prefix}--toolbar-search-container-expandable`]:
-      !persistent || !persistant,
+      !persistent || (!persistent && !persistant),
     [`${prefix}--toolbar-search-container-persistent`]:
       persistent || persistant,
   });
@@ -65,7 +65,7 @@ const TableToolbarSearch = ({
   });
 
   const handleExpand = (event, value = !expanded) => {
-    if (!controlled && (!persistent || !persistant)) {
+    if (!controlled && (!persistent || (!persistent && !persistant))) {
       setExpandedState(value);
     }
     if (onExpand) {

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -11,19 +11,17 @@ import React, { useRef, useState, useEffect } from 'react';
 import { settings } from 'carbon-components';
 import Search from '../Search';
 import setupGetInstanceId from './tools/instanceId';
+import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
-
 const getInstanceId = setupGetInstanceId();
 const translationKeys = {
   'carbon.table.toolbar.search.label': 'Filter table',
   'carbon.table.toolbar.search.placeholder': 'Search',
 };
-
 const translateWithId = id => {
   return translationKeys[id];
 };
-
 const TableToolbarSearch = ({
   className,
   searchContainerClass,
@@ -35,13 +33,13 @@ const TableToolbarSearch = ({
   defaultExpanded,
   onExpand,
   persistent,
+  persistant,
   id = `data-table-search-${getInstanceId()}`,
   ...rest
 }) => {
   const { current: controlled } = useRef(expandedProp !== undefined);
   const [expandedState, setExpandedState] = useState(defaultExpanded);
   const expanded = controlled ? expandedProp : expandedState;
-
   const searchRef = useRef(null);
   const [value, setValue] = useState('');
 
@@ -56,9 +54,9 @@ const TableToolbarSearch = ({
     [`${prefix}--toolbar-action`]: true,
     [`${prefix}--toolbar-search-container-active`]: expanded,
     [`${prefix}--toolbar-search-container-expandable`]:
-      !persistent || !rest.persistant,
+      !persistent || !persistant,
     [`${prefix}--toolbar-search-container-persistent`]:
-      persistent || rest.persistant,
+      persistent || persistant,
   });
 
   const searchClasses = cx({
@@ -67,7 +65,7 @@ const TableToolbarSearch = ({
   });
 
   const handleExpand = (event, value = !expanded) => {
-    if (!controlled && (!persistent || !rest.persistant)) {
+    if (!controlled && (!persistent || !persistant)) {
       setExpandedState(value);
     }
     if (onExpand) {
@@ -150,6 +148,10 @@ TableToolbarSearch.propTypes = {
    * Whether the search should be allowed to expand
    */
   persistent: PropTypes.bool,
+  persistant: deprecate({
+    propType: PropTypes.bool,
+    message: `\nThe prop \`persistant\` for TableToolbarSearch has been deprecated in favor of \`persistent\`. Please use \`persistent\` instead.`,
+  }),
 };
 
 TableToolbarSearch.defaultProps = {

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -34,7 +34,7 @@ const TableToolbarSearch = ({
   expanded: expandedProp,
   defaultExpanded,
   onExpand,
-  persistant,
+  persistent,
   id = `data-table-search-${getInstanceId()}`,
   ...rest
 }) => {
@@ -55,8 +55,10 @@ const TableToolbarSearch = ({
     [searchContainerClass]: searchContainerClass,
     [`${prefix}--toolbar-action`]: true,
     [`${prefix}--toolbar-search-container-active`]: expanded,
-    [`${prefix}--toolbar-search-container-expandable`]: !persistant,
-    [`${prefix}--toolbar-search-container-persistant`]: persistant,
+    [`${prefix}--toolbar-search-container-expandable`]:
+      !persistent || !rest.persistant,
+    [`${prefix}--toolbar-search-container-persistent`]:
+      persistent || rest.persistent,
   });
 
   const searchClasses = cx({
@@ -65,7 +67,7 @@ const TableToolbarSearch = ({
   });
 
   const handleExpand = (event, value = !expanded) => {
-    if (!controlled && !persistant) {
+    if (!controlled && (!persistent || !rest.persistant)) {
       setExpandedState(value);
     }
     if (onExpand) {
@@ -147,12 +149,12 @@ TableToolbarSearch.propTypes = {
   /**
    * Whether the search should be allowed to expand
    */
-  persistant: PropTypes.bool,
+  persistent: PropTypes.bool,
 };
 
 TableToolbarSearch.defaultProps = {
   translateWithId,
-  persistant: false,
+  persistent: false,
 };
 
 export default TableToolbarSearch;

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -58,7 +58,7 @@ const TableToolbarSearch = ({
     [`${prefix}--toolbar-search-container-expandable`]:
       !persistent || !rest.persistant,
     [`${prefix}--toolbar-search-container-persistent`]:
-      persistent || rest.persistent,
+      persistent || rest.persistant,
   });
 
   const searchClasses = cx({

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -148,10 +148,10 @@ TableToolbarSearch.propTypes = {
    * Whether the search should be allowed to expand
    */
   persistent: PropTypes.bool,
-  persistant: deprecate({
-    propType: PropTypes.bool,
-    message: `\nThe prop \`persistant\` for TableToolbarSearch has been deprecated in favor of \`persistent\`. Please use \`persistent\` instead.`,
-  }),
+  persistant: deprecate(
+    PropTypes.bool,
+    `\nThe prop \`persistant\` for TableToolbarSearch has been deprecated in favor of \`persistent\`. Please use \`persistent\` instead.`
+  ),
 };
 
 TableToolbarSearch.defaultProps = {

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -94,7 +94,7 @@ describe('DataTable', () => {
               </TableBatchActions>
               <TableToolbarContent>
                 <TableToolbarSearch
-                  persistant
+                  persistent
                   onChange={onInputChange}
                   id="custom-id"
                 />

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1804,8 +1804,7 @@ exports[`DataTable should render 1`] = `
                 <TableToolbarSearch
                   id="custom-id"
                   onChange={[Function]}
-                  persistant={true}
-                  persistent={false}
+                  persistent={true}
                   translateWithId={[Function]}
                 />
                 <TableToolbarMenu
@@ -2227,12 +2226,11 @@ exports[`DataTable should render 1`] = `
               <TableToolbarSearch
                 id="custom-id"
                 onChange={[Function]}
-                persistant={true}
-                persistent={false}
+                persistent={true}
                 translateWithId={[Function]}
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable bx--toolbar-search-container-persistent"
+                  className="bx--toolbar-action bx--toolbar-search-container-persistent"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
@@ -2245,7 +2243,6 @@ exports[`DataTable should render 1`] = `
                     id="custom-id"
                     labelText="Filter table"
                     onChange={[Function]}
-                    persistant={true}
                     placeHolderText="Search"
                     small={true}
                     type="text"
@@ -2305,7 +2302,6 @@ exports[`DataTable should render 1`] = `
                         className="bx--search-input"
                         id="custom-id"
                         onChange={[Function]}
-                        persistant={true}
                         placeholder="Search"
                         type="text"
                         value=""

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2232,7 +2232,7 @@ exports[`DataTable should render 1`] = `
                 translateWithId={[Function]}
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable bx--toolbar-search-container-persistent"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1805,6 +1805,7 @@ exports[`DataTable should render 1`] = `
                   id="custom-id"
                   onChange={[Function]}
                   persistant={true}
+                  persistent={false}
                   translateWithId={[Function]}
                 />
                 <TableToolbarMenu
@@ -2227,10 +2228,11 @@ exports[`DataTable should render 1`] = `
                 id="custom-id"
                 onChange={[Function]}
                 persistant={true}
+                persistent={false}
                 translateWithId={[Function]}
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-persistant"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
@@ -2243,6 +2245,7 @@ exports[`DataTable should render 1`] = `
                     id="custom-id"
                     labelText="Filter table"
                     onChange={[Function]}
+                    persistant={true}
                     placeHolderText="Search"
                     small={true}
                     type="text"
@@ -2302,6 +2305,7 @@ exports[`DataTable should render 1`] = `
                         className="bx--search-input"
                         id="custom-id"
                         onChange={[Function]}
+                        persistant={true}
                         placeholder="Search"
                         type="text"
                         value=""

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -5,7 +5,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
   className="custom-class"
   id="custom-id"
   onChange={[MockFunction]}
-  persistant={false}
+  persistent={false}
   translateWithId={[Function]}
 >
   <div

--- a/packages/react/src/prop-types/__tests__/deprecate-test.js
+++ b/packages/react/src/prop-types/__tests__/deprecate-test.js
@@ -16,15 +16,14 @@ describe('deprecate', () => {
     jest.mock('warning');
     warning = require('warning');
     deprecate = require('../deprecate').default;
-
-    mockPropType = jest.fn();
+    mockPropType = { propType: jest.fn() };
     mockArgs = [{ propName: true }, 'propName', 'ComponentName'];
   });
 
   it('should call warning and prop type checker if the prop type is called', () => {
     deprecate(mockPropType)(...mockArgs);
     expect(warning).toHaveBeenCalledTimes(1);
-    expect(mockPropType).toHaveBeenCalledTimes(1);
+    expect(mockPropType.propType).toHaveBeenCalledTimes(1);
   });
 
   it('should not call warning more than once for a component and prop name', () => {
@@ -33,11 +32,11 @@ describe('deprecate', () => {
     const checker = deprecate(mockPropType);
     checker(...mockArgs);
     expect(warning).toHaveBeenCalledTimes(1);
-    expect(mockPropType).toHaveBeenCalledTimes(1);
+    expect(mockPropType.propType).toHaveBeenCalledTimes(1);
 
     checker(...mockArgs);
     expect(warning).toHaveBeenCalledTimes(1);
-    expect(mockPropType).toHaveBeenCalledTimes(2);
+    expect(mockPropType.propType).toHaveBeenCalledTimes(2);
 
     // Update to a new set of mock args to show that warning should be called
     // again, but only once for this other variant
@@ -49,10 +48,10 @@ describe('deprecate', () => {
 
     checker(...otherMockArgs);
     expect(warning).toHaveBeenCalledTimes(2);
-    expect(mockPropType).toHaveBeenCalledTimes(3);
+    expect(mockPropType.propType).toHaveBeenCalledTimes(3);
 
     checker(...otherMockArgs);
     expect(warning).toHaveBeenCalledTimes(2);
-    expect(mockPropType).toHaveBeenCalledTimes(4);
+    expect(mockPropType.propType).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/react/src/prop-types/__tests__/deprecate-test.js
+++ b/packages/react/src/prop-types/__tests__/deprecate-test.js
@@ -16,14 +16,14 @@ describe('deprecate', () => {
     jest.mock('warning');
     warning = require('warning');
     deprecate = require('../deprecate').default;
-    mockPropType = { propType: jest.fn() };
+    mockPropType = jest.fn();
     mockArgs = [{ propName: true }, 'propName', 'ComponentName'];
   });
 
   it('should call warning and prop type checker if the prop type is called', () => {
     deprecate(mockPropType)(...mockArgs);
     expect(warning).toHaveBeenCalledTimes(1);
-    expect(mockPropType.propType).toHaveBeenCalledTimes(1);
+    expect(mockPropType).toHaveBeenCalledTimes(1);
   });
 
   it('should not call warning more than once for a component and prop name', () => {
@@ -32,11 +32,11 @@ describe('deprecate', () => {
     const checker = deprecate(mockPropType);
     checker(...mockArgs);
     expect(warning).toHaveBeenCalledTimes(1);
-    expect(mockPropType.propType).toHaveBeenCalledTimes(1);
+    expect(mockPropType).toHaveBeenCalledTimes(1);
 
     checker(...mockArgs);
     expect(warning).toHaveBeenCalledTimes(1);
-    expect(mockPropType.propType).toHaveBeenCalledTimes(2);
+    expect(mockPropType).toHaveBeenCalledTimes(2);
 
     // Update to a new set of mock args to show that warning should be called
     // again, but only once for this other variant
@@ -48,10 +48,10 @@ describe('deprecate', () => {
 
     checker(...otherMockArgs);
     expect(warning).toHaveBeenCalledTimes(2);
-    expect(mockPropType.propType).toHaveBeenCalledTimes(3);
+    expect(mockPropType).toHaveBeenCalledTimes(3);
 
     checker(...otherMockArgs);
     expect(warning).toHaveBeenCalledTimes(2);
-    expect(mockPropType.propType).toHaveBeenCalledTimes(4);
+    expect(mockPropType).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/react/src/prop-types/deprecate.js
+++ b/packages/react/src/prop-types/deprecate.js
@@ -9,7 +9,7 @@ import warning from 'warning';
 
 const didWarnAboutDeprecation = {};
 
-export default function deprecate(propType) {
+export default function deprecate({ propType, message }) {
   function checker(props, propName, componentName, ...rest) {
     if (props[propName] === undefined) {
       return;
@@ -26,9 +26,10 @@ export default function deprecate(propType) {
 
       warning(
         false,
-        `The prop \`${propName}\` has been deprecated for the ` +
-          `${componentName} component. It will be removed in the next major ` +
-          `release`
+        message ||
+          `The prop \`${propName}\` has been deprecated for the ` +
+            `${componentName} component. It will be removed in the next major ` +
+            `release`
       );
     }
 

--- a/packages/react/src/prop-types/deprecate.js
+++ b/packages/react/src/prop-types/deprecate.js
@@ -9,7 +9,7 @@ import warning from 'warning';
 
 const didWarnAboutDeprecation = {};
 
-export default function deprecate({ propType, message }) {
+export default function deprecate(propType, message) {
   function checker(props, propName, componentName, ...rest) {
     if (props[propName] === undefined) {
       return;


### PR DESCRIPTION
Closes #3108

This PR corrects the "persistant" class name on the React data table, which was causing issues with applying correct styles

#### Changelog

**Changed**

- change `persistant` prop and associated class name to map to correct vanilla class
- maintain backwards compatibility for incorrect spelling

#### Testing / Reviewing

Ensure persistent mode styles are applied to the React data table
