### PR TITLE
fix(button): remove top level ampersand from btn-field selector

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -213,7 +213,7 @@
     padding: $button-padding-sm;
   }
 
-  &.#{$prefix}--btn--field {
+  .#{$prefix}--btn--field {
     height: 40px;
     min-height: 40px;
     padding: $button-padding-field;


### PR DESCRIPTION
Closes #3294

the `.bx--btn--field` selector was added with a top level ampersand in #2719 which causes Sass compilation errors. This PR removes the ampersand from that selector

#### Testing / Reviewing

Ensure our Sass compiles correctly
