### PR TITLE
fix(react): update deprecate helper

### DIFF
--- a/packages/react/src/prop-types/__tests__/deprecate-test.js
+++ b/packages/react/src/prop-types/__tests__/deprecate-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('deprecate', () => {
+  let warning;
+  let deprecate;
+  let mockPropType;
+  let mockArgs;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('warning');
+    warning = require('warning');
+    deprecate = require('../deprecate').default;
+
+    mockPropType = jest.fn();
+    mockArgs = [{ propName: true }, 'propName', 'ComponentName'];
+  });
+
+  it('should call warning and prop type checker if the prop type is called', () => {
+    deprecate(mockPropType)(...mockArgs);
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(mockPropType).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call warning more than once for a component and prop name', () => {
+    // Default mock args for component `ComponentName` and prop `propName`
+    // It should only display warning once
+    const checker = deprecate(mockPropType);
+    checker(...mockArgs);
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(mockPropType).toHaveBeenCalledTimes(1);
+
+    checker(...mockArgs);
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(mockPropType).toHaveBeenCalledTimes(2);
+
+    // Update to a new set of mock args to show that warning should be called
+    // again, but only once for this other variant
+    const otherMockArgs = [
+      { otherPropName: true },
+      'otherPropName',
+      'OtherComponentName',
+    ];
+
+    checker(...otherMockArgs);
+    expect(warning).toHaveBeenCalledTimes(2);
+    expect(mockPropType).toHaveBeenCalledTimes(3);
+
+    checker(...otherMockArgs);
+    expect(warning).toHaveBeenCalledTimes(2);
+    expect(mockPropType).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/react/src/prop-types/deprecate.js
+++ b/packages/react/src/prop-types/deprecate.js
@@ -7,7 +7,7 @@
 
 import warning from 'warning';
 
-let didWarnAboutDeprecation = false;
+const didWarnAboutDeprecation = {};
 
 export default function deprecate(propType) {
   function checker(props, propName, componentName, ...rest) {
@@ -15,8 +15,15 @@ export default function deprecate(propType) {
       return;
     }
 
-    if (!didWarnAboutDeprecation) {
-      didWarnAboutDeprecation = true;
+    if (
+      !didWarnAboutDeprecation[componentName] ||
+      !didWarnAboutDeprecation[componentName][propName]
+    ) {
+      didWarnAboutDeprecation[componentName] = {
+        ...didWarnAboutDeprecation[componentName],
+        [propName]: true,
+      };
+
       warning(
         false,
         `The prop \`${propName}\` has been deprecated for the ` +


### PR DESCRIPTION
Our deprecate helper had a 🐛 and this updates it to work for multiple component types with multiple prop names, it also adds associated tests for these abilities.

#### Changelog

**New**

**Changed**

- Update deprecate prop helper and add tests

**Removed**
