### PR TITLE
chore(cli): make package public

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,52 @@
+# @carbon/cli
+
+> Task automation when working with the Carbon Design System
+
+## Getting started
+
+To install `@carbon/cli` in your project, you will need to run the following
+command using [npm](https://www.npmjs.com/):
+
+```bash
+npm install -S @carbon/cli
+```
+
+If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
+instead:
+
+```bash
+yarn add @carbon/cli
+```
+
+## Usage
+
+You can install `@carbon/cli` in your project, or use a tool like
+[`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)
+by running the following command in your project:
+
+```bash
+npx @carbon/cli --help
+```
+
+The output of the `--help` option is:
+
+```bash
+Usage: @carbon/cli [options]
+
+Commands:
+  @carbon/cli contribute <command>  get started contributing with Carbon
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+```
+
+## 🙌 Contributing
+
+We're always looking for contributors to help us fix bugs, build new features,
+or help us improve the project documentation. If you're interested, definitely
+check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
+
+## 📝 License
+
+Licensed under the [Apache 2.0 License](/LICENSE).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/cli",
-  "private": true,
+  "description": "Task automation for working with the Carbon Design System",
   "version": "10.3.0",
   "license": "Apache-2.0",
   "bin": {


### PR DESCRIPTION
Updates `packages/cli` to be public. Adds a `README.md` file.

#### Changelog

**New**

**Changed**

- Removed `private: true` from `packages/cli/package.json` and add README and description

**Removed**
