### PR TITLE
fix(icons-react): format SVG props as camelCase

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -37,6 +37,7 @@
     "@carbon/cli-reporter": "10.3.0-rc.0",
     "@carbon/icons": "10.4.0-rc.0",
     "browserslist-config-carbon": "10.4.0-rc.0",
+    "change-case": "^3.1.0",
     "core-js": "^3.1.3",
     "fs-extra": "^7.0.0",
     "prop-types": "^15.6.2",

--- a/packages/icons-react/tasks/build.js
+++ b/packages/icons-react/tasks/build.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const meta = require('@carbon/icons/build-info.json');
+const { camel } = require('change-case');
 const fs = require('fs-extra');
 const path = require('path');
 const { rollup } = require('rollup');
@@ -183,7 +184,10 @@ function convertToJSX(node) {
  */
 function formatAttributes(attrs) {
   return Object.keys(attrs).reduce((acc, key, index) => {
-    const attribute = `${key}="${attrs[key]}"`;
+    const attribute = key.startsWith('data-')
+      ? `${key}="${attrs[key]}"`
+      : `${camel(key)}="${attrs[key]}"`;
+
     if (index === 0) {
       return attribute;
     }

--- a/packages/icons-react/tasks/build.js
+++ b/packages/icons-react/tasks/build.js
@@ -177,6 +177,18 @@ function convertToJSX(node) {
   return `<${elem} ${formatAttributes(attrs)} />`;
 }
 
+const attributeDenylist = ['data', 'aria'];
+
+/**
+ * Determine if the given attribute should be transformed when being converted
+ * to a React prop or if we should pass it through as-is
+ * @param {string} attribute
+ * @returns {boolean}
+ */
+function shouldTransformAttribute(attribute) {
+  return attributeDenylist.every(prefix => !attribute.startsWith(prefix));
+}
+
 /**
  * Serialize a given object of key, value pairs to an JSX-compatible string
  * @param {object} attrs
@@ -184,9 +196,9 @@ function convertToJSX(node) {
  */
 function formatAttributes(attrs) {
   return Object.keys(attrs).reduce((acc, key, index) => {
-    const attribute = key.startsWith('data-')
-      ? `${key}="${attrs[key]}"`
-      : `${camel(key)}="${attrs[key]}"`;
+    const attribute = shouldTransformAttribute(key)
+      ? `${camel(key)}="${attrs[key]}"`
+      : `${key}="${attrs[key]}"`;
 
     if (index === 0) {
       return attribute;


### PR DESCRIPTION
Noticed this while working on the website, some icons use props like `fill-rule` that are incorrectly formatted. This PR updates the convert logic to convert all attributes to camelCase, with an exception for data attributes which are passed through without being transformed.

#### Changelog

**New**

**Changed**

- Update build script for `@carbon/icons-react` to camelCase icon props

**Removed**
