### PR TITLE
fix(button): make small ghost button height 32px

### DIFF
--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -110,7 +110,7 @@
   /// @type Number
   /// @access public
   /// @group button
-  $button-padding-ghost-sm: 0.375rem 1rem !default !global;
+  $button-padding-ghost-sm: calc(0.375rem - 3px) 1rem !default !global;
 
   /// @type Number
   /// @access public


### PR DESCRIPTION
Closes #3323 

#### Changelog

**Changed**

- change padding so small ghost button height comes out to 32px instead of 36px
