### PR TITLE
fix(tags): remove old documentation

### DIFF
--- a/packages/components/src/components/tag/README.md
+++ b/packages/components/src/components/tag/README.md
@@ -7,20 +7,3 @@ Mixins specific to tag are located in [src/components/tag/\_mixins.scss]().
 | Name        | Params                     | Description                                |
 | ----------- | -------------------------- | ------------------------------------------ |
 | `tag-theme` | `$bg-color`, `$text-color` | Adds given background-color and text color |
-
-#### Modifiers
-
-Use these modifiers with `.bx--tag` class.
-
-| Selector                 | Description                                          |
-| ------------------------ | ---------------------------------------------------- |
-| `.bx--tag--ibm`          | Apply the colors for an IBM branded service tag.     |
-| `.bx--tag--beta`         | Apply the colors for a beta service tag.             |
-| `.bx--tag--third-party`  | Apply the colors for a third-party vendor tag.       |
-| `.bx--tag--local`        | Apply the colors for a local tag.                    |
-| `.bx--tag--dedicated`    | Apply the colors for a dedicated tag.                |
-| `.bx--tag--custom`       | Apply the colors for a custom tag.                   |
-| `.bx--tag--experimental` | Apply the colors for an experimental tag.            |
-| `.bx--tag--community`    | Apply the colors for a community-driven service tag. |
-| `.bx--tag--private`      | Apply the colors for a private tag.                  |
-| `.bx--tag--deprecated`   | Apply the colors for a deprecated tag.               |


### PR DESCRIPTION
Removes old `Tag` guidance that is no longer relevant. 

<img width="323" alt="Screen Shot 2019-07-11 at 9 05 39 AM" src="https://user-images.githubusercontent.com/11928039/61066807-18b15f00-a3bb-11e9-964b-e04d30bc69a1.png">
