### PR TITLE
fix(pagination): adjust md breakpoint chevron position

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -55,7 +55,7 @@ $css--helpers: true;
     padding: 0 2.5rem 0 $spacing-md;
     margin-right: -0.65rem;
     @include carbon--breakpoint('md') {
-      padding: 0 1.5rem 0 0.5rem;
+      padding: 0 carbon--mini-units(3.5) 0 $carbon--spacing-03;
       margin-right: 0;
     }
   }
@@ -65,9 +65,7 @@ $css--helpers: true;
   }
 
   .#{$prefix}--pagination .#{$prefix}--select__arrow {
-    position: relative;
     top: auto;
-    right: 1.1rem;
     bottom: auto;
   }
 
@@ -75,28 +73,12 @@ $css--helpers: true;
     .#{$prefix}--select__item-count
     .#{$prefix}--select-input {
     border-right: $spacing-4xs solid $ui-03;
-    @include carbon--breakpoint('md') {
-      padding-right: 2rem;
-      margin-right: -0.65rem;
-    }
   }
 
   .#{$prefix}--pagination
     .#{$prefix}--select__page-number
     .#{$prefix}--select-input {
     border-left: 1px solid $ui-03;
-    @include carbon--breakpoint('md') {
-      padding-left: 1rem;
-      padding-right: 2rem;
-    }
-  }
-
-  .#{$prefix}--pagination
-    .#{$prefix}--select__page-number
-    .#{$prefix}--select__arrow {
-    @include carbon--breakpoint('md') {
-      right: 1.8rem;
-    }
   }
 
   .#{$prefix}--pagination__left,
@@ -137,10 +119,6 @@ $css--helpers: true;
   span.#{$prefix}--pagination__text {
     margin-left: $carbon--spacing-05;
     color: $text-01;
-  }
-
-  .#{$prefix}--pagination__right span.#{$prefix}--pagination__text {
-    margin-left: -0.5rem;
   }
 
   .#{$prefix}--pagination__button {

--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -55,7 +55,7 @@ $css--helpers: true;
     padding: 0 2.5rem 0 $spacing-md;
     margin-right: -0.65rem;
     @include carbon--breakpoint('md') {
-      padding: 0 carbon--mini-units(3.5) 0 $carbon--spacing-03;
+      padding-right: carbon--mini-units(4.5);
       margin-right: 0;
     }
   }
@@ -67,6 +67,9 @@ $css--helpers: true;
   .#{$prefix}--pagination .#{$prefix}--select__arrow {
     top: auto;
     bottom: auto;
+    @include carbon--breakpoint('md') {
+      right: $carbon--spacing-05;
+    }
   }
 
   .#{$prefix}--pagination

--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -118,7 +118,7 @@ $css--helpers: true;
 
   span.#{$prefix}--pagination__text {
     margin-left: $carbon--spacing-05;
-    color: $text-01;
+    color: $text-02;
   }
 
   .#{$prefix}--pagination__button {

--- a/packages/components/src/components/pagination/pagination.hbs
+++ b/packages/components/src/components/pagination/pagination.hbs
@@ -25,7 +25,7 @@
       {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
     </div>
     <span class="{{@root.prefix}}--pagination__text">
-      <span data-displayed-item-range>1–10</span> of
+      <span data-displayed-item-range>1 – 10</span> of
       <span data-total-items>
         {{#if disabledPaginationButton}}
         10

--- a/packages/components/src/components/pagination/pagination.hbs
+++ b/packages/components/src/components/pagination/pagination.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -17,9 +17,9 @@
         id="select-id-pagination-count{{#if disabledPaginationButton}}--disabled-example{{/if}}"
         aria-label="Items per page" tabindex="0" data-items-per-page>
         {{#each itemsPerPageChoices}}
-          <option class="{{@root.prefix}}--select-option" value="{{value}}">
-            {{label}}
-          </option>
+        <option class="{{@root.prefix}}--select-option" value="{{value}}">
+          {{label}}
+        </option>
         {{/each}}
       </select>
       {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
@@ -28,9 +28,9 @@
       <span data-displayed-item-range>1–10</span> of
       <span data-total-items>
         {{#if disabledPaginationButton}}
-          10
+        10
         {{else}}
-          40
+        40
         {{/if}}
       </span> items
     </span>
@@ -41,9 +41,9 @@
         id="select-id-pagination-page{{#if disabledPaginationButton}}--disabled-example{{/if}}"
         aria-label="page number, of {{totalPages}} pages" tabindex="0" data-page-number-input>
         {{#each pageNumberChoices}}
-          <option class="{{@root.prefix}}--select-option" value="{{value}}">
-            {{label}}
-          </option>
+        <option class="{{@root.prefix}}--select-option" value="{{value}}">
+          {{label}}
+        </option>
         {{/each}}
       </select>
       {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow')}}

--- a/packages/react/src/components/Select/Select-test.js
+++ b/packages/react/src/components/Select/Select-test.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { ChevronDownGlyph } from '@carbon/icons-react';
+import { ChevronDown16 } from '@carbon/icons-react';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
 import SelectSkeleton from '../Select/Select.Skeleton';
@@ -39,7 +39,7 @@ describe('Select', () => {
       });
 
       it('renders the down arrow icon', () => {
-        expect(selectContainer.find(ChevronDownGlyph).length).toEqual(1);
+        expect(selectContainer.find(ChevronDown16).length).toEqual(1);
       });
 
       it('has the expected classes', () => {
@@ -62,9 +62,7 @@ describe('Select', () => {
       });
 
       it('should have iconDescription match Icon component description prop', () => {
-        const description = wrapper.find(ChevronDownGlyph).props()[
-          'aria-label'
-        ];
+        const description = wrapper.find(ChevronDown16).props()['aria-label'];
         const matches = wrapper.props().iconDescription === description;
         expect(matches).toEqual(true);
       });

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import { ChevronDownGlyph, WarningFilled16 } from '@carbon/icons-react';
+import { ChevronDown16, WarningFilled16 } from '@carbon/icons-react';
 
 const { prefix } = settings;
 
@@ -73,11 +73,11 @@ const Select = React.forwardRef(function Select(
           ref={ref}>
           {children}
         </select>
-        <ChevronDownGlyph
+        <ChevronDown16
           className={`${prefix}--select__arrow`}
           aria-label={iconDescription}>
           <title>{iconDescription}</title>
-        </ChevronDownGlyph>
+        </ChevronDown16>
         {invalid && (
           <WarningFilled16 className={`${prefix}--select__invalid-icon`} />
         )}


### PR DESCRIPTION
Closes #3328

This PR adjusts the spacing between the select and chevron down icon in pagination components

#### Changelog

**Changed**

- incorrect style rules for selects in pagination component
- Replace chevron glyph icon in React `<Select>`

#### Testing / Reviewing

Ensure the pagination component is visually correct
