### PR TITLE
docs(icons-react): update usage on readme

### DIFF
--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -73,16 +73,18 @@ Certain icons in the library support two distinct fill colors. You can target
 the inner path by using the `[data-icon-path="inner-path"]` attribute selector.
 For example:
 
-```css
+```scss
 // CSS custom class name to set the fill of the icon to `yellow`
 svg.outer-icon-fill {
   fill: yellow;
 }
 
 // Use the `data-icon-path` attribute selector to target the inner path
-// where we want to set the fill to `black`
+// where we want to set the fill to `black`. We also set `opacity` to `1` so
+// that this inner-path is visible.
 svg.outer-icon-fill [data-icon-path='inner-path'] {
   fill: black;
+  opacity: 1;
 }
 ```
 

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -40,7 +40,7 @@ const { Add24 } = require('@carbon/icons-react');
 
 _Note: if you would like to find the import path for an icon, you can reference
 our
-[Icon guidelines](https://www.carbondesignsystem.com/guidelines/iconography/usage)_
+[Icon Library](https://www.carbondesignsystem.com/guidelines/iconography/library)_
 
 ### Icon fill
 

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -90,11 +90,7 @@ svg.outer-icon-fill [data-icon-path='inner-path'] {
 import { WarningFilled16 } from '@carbon/icons-react';
 
 function MyComponent() {
-  return (
-    <button>
-      <WarningFilled16 aria-label="Add" className="my-custom-class" />
-    </button>
-  );
+  return <WarningFilled16 aria-label="Add" className="my-custom-class" />;
 }
 ```
 

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -23,10 +23,10 @@ yarn add @carbon/icons-react
 
 Icons in this package support the following sizes: `16`, `20`, `24`, and `32`
 pixels. These sizes refer to the width and height of the icon. You can import an
-icon component into your project by doing one of the following:
+icon component into your project by referring to its name and size:
 
 ```jsx
-import Add24 from '@carbon/icons-react/es/add/16';
+import { Add24 } from '@carbon/icons-react';
 ```
 
 We also provide CommonJS and UMD files in the `lib` and `umd` directories,
@@ -35,11 +35,106 @@ respectively.
 To import using CommonJS, you can do the following:
 
 ```js
-const Add24 = require('@carbon/icons-react/lib/Add/24');
+const { Add24 } = require('@carbon/icons-react');
 ```
 
 _Note: if you would like to find the import path for an icon, you can reference
-our [icon preview](https://carbon-elements.netlify.com/icons/examples/preview/)_
+our
+[Icon guidelines](https://www.carbondesignsystem.com/guidelines/iconography/usage)_
+
+### Icon fill
+
+All icons from the library support being styled by the `fill` property. You can
+change the color of an icon by passing in a custom class name that sets this
+property (preferred), or by passing in an inline style. For example:
+
+```css
+// CSS custom class name to set the fill of the icon to `rebeccapurple`
+svg.my-custom-class {
+  fill: rebeccapurple;
+}
+```
+
+```jsx
+import { Add16 } from '@carbon/icons-react';
+
+function MyComponent() {
+  return (
+    <button>
+      <Add16 aria-label="Add" className="my-custom-class" />
+    </button>
+  );
+}
+```
+
+#### Two-tone icons
+
+Certain icons in the library support two distinct fill colors. You can target
+the inner path by using the `[data-icon-path="inner-path"]` attribute selector.
+For example:
+
+```css
+// CSS custom class name to set the fill of the icon to `yellow`
+svg.outer-icon-fill {
+  fill: yellow;
+}
+
+// Use the `data-icon-path` attribute selector to target the inner path
+// where we want to set the fill to `black`
+svg.outer-icon-fill [data-icon-path='inner-path'] {
+  fill: black;
+}
+```
+
+```jsx
+import { WarningFilled16 } from '@carbon/icons-react';
+
+function MyComponent() {
+  return (
+    <button>
+      <WarningFilled16 aria-label="Add" className="my-custom-class" />
+    </button>
+  );
+}
+```
+
+### Focus and `aria-label`
+
+By default, the icon components from `@carbon/icons-react` are treated as
+decorative content. This means that we set `aria-hidden="true"` unless certain
+props are passed to the component.
+
+If you would like the icon to be announced by a screen reader, you can supply an
+`aria-label` or `aria-labelledby`. For example:
+
+```jsx
+import { Add16 } from '@carbon/icons-react';
+
+function MyComponent() {
+  return (
+    <button>
+      <Add16 aria-label="Add" />
+    </button>
+  );
+}
+```
+
+Doing this will add the appropriate `role` to the `<svg>` node, as well.
+
+If you would like the `<svg>` to receive focus, you will need to pass in a
+`tabIndex` value. For example:
+
+```jsx
+import { Add16 } from '@carbon/icons-react';
+
+function MyComponent() {
+  return <Add16 aria-label="Add" tabIndex="0" />;
+}
+```
+
+Including `tabIndex` and `aria-label` (or `aria-labelledby`) will set the
+corresponding `tabindex` on the underlying `<svg>` and verify support in older
+browsers like Internet Explorer 11 by setting `focusable` to `true`.
 
 ## 🙌 Contributing
 

--- a/packages/icons-react/examples/storybook/stories/index.stories.js
+++ b/packages/icons-react/examples/storybook/stories/index.stories.js
@@ -6,5 +6,6 @@ import React from 'react';
 
 storiesOf('Icon', module)
   .add('default', () => <CheckmarkFilled32 />)
+  .add('with fill', () => <CheckmarkFilled32 style={{ fill: 'rebeccapurple' }} />)
   .add('with aria-label', () => <CheckmarkFilled32 aria-label="Label" />)
   .add('with focus', () => <CheckmarkFilled32 aria-label="Label" tabIndex="0" />);

--- a/packages/icons-react/examples/storybook/stories/index.stories.js
+++ b/packages/icons-react/examples/storybook/stories/index.stories.js
@@ -6,6 +6,5 @@ import React from 'react';
 
 storiesOf('Icon', module)
   .add('default', () => <CheckmarkFilled32 />)
-  .add('with fill', () => <CheckmarkFilled32 style={{ fill: 'rebeccapurple' }} />)
   .add('with aria-label', () => <CheckmarkFilled32 aria-label="Label" />)
   .add('with focus', () => <CheckmarkFilled32 aria-label="Label" tabIndex="0" />);


### PR DESCRIPTION
Updates `@carbon/icons-react`'s `README.md` with new usage instructions and guidance.

#### Changelog

**New**

**Changed**

- Update `icons-react/README.md` with content addressing new import pattern, alongside prop configuration for styling and focus management.

**Removed**
