### PR TITLE
feat(ListBox.Field): support ARIA attribute translations

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -302,6 +302,7 @@ export default class ComboBox extends React.Component {
             <ListBox.Field
               id={id}
               disabled={disabled}
+              translateWithId={translateWithId}
               {...getButtonProps({
                 disabled,
                 onClick: this.onToggleClick(isOpen),

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -244,6 +244,7 @@ export default class Dropdown extends React.Component {
                 id={id}
                 tabIndex="0"
                 disabled={disabled}
+                translateWithId={translateWithId}
                 {...getButtonProps({ disabled })}>
                 <span
                   className={`${prefix}--list-box__label`}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -92,13 +92,14 @@ exports[`Dropdown should render 1`] = `
             onKeyDown={[Function]}
             role="button"
             tabIndex="0"
+            translateWithId={[Function]}
             type="button"
           >
             <div
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup={true}
-              aria-label="open menu"
+              aria-label="Open menu"
               aria-owns={null}
               className="bx--list-box__field"
               data-toggle={true}
@@ -263,13 +264,14 @@ exports[`Dropdown should render custom item components 1`] = `
             onKeyDown={[Function]}
             role="button"
             tabIndex="0"
+            translateWithId={[Function]}
             type="button"
           >
             <div
               aria-controls="test-dropdown__menu"
               aria-expanded={true}
               aria-haspopup={true}
-              aria-label="close menu"
+              aria-label="Close menu"
               aria-owns="test-dropdown__menu"
               className="bx--list-box__field"
               data-toggle={true}
@@ -591,13 +593,14 @@ exports[`Dropdown should render with strings as items 1`] = `
             onKeyDown={[Function]}
             role="button"
             tabIndex="0"
+            translateWithId={[Function]}
             type="button"
           >
             <div
               aria-controls="test-dropdown__menu"
               aria-expanded={true}
               aria-haspopup={true}
-              aria-label="close menu"
+              aria-label="Close menu"
               aria-owns="test-dropdown__menu"
               className="bx--list-box__field"
               data-toggle={true}

--- a/packages/react/src/components/ListBox/ListBoxField.js
+++ b/packages/react/src/components/ListBox/ListBoxField.js
@@ -38,11 +38,9 @@ const ListBoxField = ({
   ...rest
 }) => (
   <div
-    role="combobox"
-    aria-haspopup="listbox"
-    aria-expanded={rest[`aria-expanded`]}
-    aria-owns={(rest[`aria-expanded`] && `${id}__menu`) || null}
-    aria-controls={(rest[`aria-expanded`] && `${id}__menu`) || null}
+    role={rest['aria-expanded'] ? 'combobox' : rest.role || 'combobox'}
+    aria-owns={(rest['aria-expanded'] && `${id}__menu`) || null}
+    aria-controls={(rest['aria-expanded'] && `${id}__menu`) || null}
     className={`${prefix}--list-box__field`}
     tabIndex={(!disabled && tabIndex) || -1}
     {...rest}

--- a/packages/react/src/components/ListBox/ListBoxField.js
+++ b/packages/react/src/components/ListBox/ListBoxField.js
@@ -14,12 +14,29 @@ import childrenOf from '../../prop-types/childrenOf';
 
 const { prefix } = settings;
 
+export const translationIds = {
+  'close.menu': 'close.menu',
+  'open.menu': 'open.menu',
+};
+
+const defaultTranslations = {
+  [translationIds['close.menu']]: 'Close menu',
+  [translationIds['open.menu']]: 'Open menu',
+};
+
 /**
  * `ListBoxField` is responsible for creating the containing node for valid
  * elements inside of a field. It also provides a11y-related attributes like
  * `role` to make sure a user can focus the given field.
  */
-const ListBoxField = ({ children, id, disabled, tabIndex, ...rest }) => (
+const ListBoxField = ({
+  children,
+  id,
+  disabled,
+  tabIndex,
+  translateWithId: t,
+  ...rest
+}) => (
   <div
     role="combobox"
     aria-haspopup="listbox"
@@ -28,7 +45,8 @@ const ListBoxField = ({ children, id, disabled, tabIndex, ...rest }) => (
     aria-controls={(rest[`aria-expanded`] && `${id}__menu`) || null}
     className={`${prefix}--list-box__field`}
     tabIndex={(!disabled && tabIndex) || -1}
-    {...rest}>
+    {...rest}
+    aria-label={rest['aria-expanded'] ? t('close.menu') : t('open.menu')}>
     {children}
   </div>
 );
@@ -53,6 +71,17 @@ ListBoxField.propTypes = {
    * Optional prop to specify the tabIndex of the <ListBox> trigger button
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+  /**
+   * i18n hook used to provide the appropriate description for the given menu
+   * icon. This function takes in an id defined in `translationIds` and should
+   * return a string message for that given message id.
+   */
+  translateWithId: PropTypes.func.isRequired,
+};
+
+ListBoxField.defaultProps = {
+  translateWithId: id => defaultTranslations[id],
 };
 
 export default ListBoxField;

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -17,6 +17,7 @@ exports[`ListBox should render 1`] = `
           >
             <div
               aria-haspopup="listbox"
+              aria-label="Open menu"
               class="bx--list-box__field"
               role="combobox"
               tabindex="-1"
@@ -44,10 +45,12 @@ exports[`ListBox should render 1`] = `
   >
     <ListBoxField
       id="test-listbox"
+      translateWithId={[Function]}
     >
       <div
         aria-controls={null}
         aria-haspopup="listbox"
+        aria-label="Open menu"
         aria-owns={null}
         className="bx--list-box__field"
         role="combobox"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -16,7 +16,6 @@ exports[`ListBox should render 1`] = `
             tabindex="-1"
           >
             <div
-              aria-haspopup="listbox"
               aria-label="Open menu"
               class="bx--list-box__field"
               role="combobox"
@@ -49,7 +48,6 @@ exports[`ListBox should render 1`] = `
     >
       <div
         aria-controls={null}
-        aria-haspopup="listbox"
         aria-label="Open menu"
         aria-owns={null}
         className="bx--list-box__field"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -7,7 +7,6 @@ exports[`ListBoxField should render 1`] = `
 >
   <div
     aria-controls={null}
-    aria-haspopup="listbox"
     aria-label="Open menu"
     aria-owns={null}
     className="bx--list-box__field"
@@ -73,7 +72,6 @@ exports[`ListBoxField should set \`aria-owns\` based when expanded 1`] = `
   <div
     aria-controls="test-listbox__menu"
     aria-expanded={true}
-    aria-haspopup="listbox"
     aria-label="Close menu"
     aria-owns="test-listbox__menu"
     className="bx--list-box__field"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -3,10 +3,12 @@
 exports[`ListBoxField should render 1`] = `
 <ListBoxField
   id="test-listbox"
+  translateWithId={[Function]}
 >
   <div
     aria-controls={null}
     aria-haspopup="listbox"
+    aria-label="Open menu"
     aria-owns={null}
     className="bx--list-box__field"
     role="combobox"
@@ -66,11 +68,13 @@ exports[`ListBoxField should set \`aria-owns\` based when expanded 1`] = `
 <ListBoxField
   aria-expanded={true}
   id="test-listbox"
+  translateWithId={[Function]}
 >
   <div
     aria-controls="test-listbox__menu"
     aria-expanded={true}
     aria-haspopup="listbox"
+    aria-label="Close menu"
     aria-owns="test-listbox__menu"
     className="bx--list-box__field"
     role="combobox"

--- a/packages/react/src/components/ListBox/test-helpers.js
+++ b/packages/react/src/components/ListBox/test-helpers.js
@@ -32,7 +32,7 @@ export const assertMenuOpen = (wrapper, mockProps) => {
     expect.objectContaining({
       'aria-expanded': true,
       'aria-haspopup': true,
-      'aria-label': 'close menu',
+      'aria-label': 'Close menu',
     })
   );
 };
@@ -47,7 +47,7 @@ export const assertMenuClosed = wrapper => {
     expect.objectContaining({
       'aria-expanded': false,
       'aria-haspopup': true,
-      'aria-label': 'open menu',
+      'aria-label': 'Open menu',
     })
   );
 };

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -351,6 +351,7 @@ export default class FilterableMultiSelect extends React.Component {
                   <ListBox.Field
                     id={id}
                     disabled={disabled}
+                    translateWithId={translateWithId}
                     {...getButtonProps({ disabled })}>
                     {selectedItem.length > 0 && (
                       <ListBox.Selection

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -314,6 +314,7 @@ export default class MultiSelect extends React.Component {
                     id={id}
                     tabIndex="0"
                     disabled={disabled}
+                    translateWithId={translateWithId}
                     {...getButtonProps({ disabled })}>
                     {selectedItem.length > 0 && (
                       <ListBox.Selection

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -104,13 +104,14 @@ exports[`MultiSelect.Filterable should render 1`] = `
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"
+              translateWithId={[Function]}
               type="button"
             >
               <div
                 aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-label="open menu"
+                aria-label="Open menu"
                 aria-owns={null}
                 className="bx--list-box__field"
                 data-toggle={true}

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -105,13 +105,14 @@ exports[`MultiSelect should render 1`] = `
               onKeyDown={[Function]}
               role="button"
               tabIndex="0"
+              translateWithId={[Function]}
               type="button"
             >
               <div
                 aria-controls={null}
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-label="open menu"
+                aria-label="Open menu"
                 aria-owns={null}
                 className="bx--list-box__field"
                 data-toggle={true}


### PR DESCRIPTION
Closes #3373

This PR modifies listbox components to support translation for ARIA labels, overriding the hard coded values passed along by Downshift

#### Changelog

**Changed**

- add `translateWithId` support to `ListBox.Field`

#### Testing / Reviewing

Ensure the ARIA labels can be configured as expected for the listbox components
