### PR TITLE
fix(icons-react): update CommonJS bundle aliases

### DIFF
--- a/e2e/icons-react/components-test.js
+++ b/e2e/icons-react/components-test.js
@@ -18,7 +18,11 @@ describe('@carbon/icons-react', () => {
     }).not.toThrow();
   });
 
-  test.each(meta.map(icon => [icon.moduleName]))('%s is require-able', name => {
-    expect(require('@carbon/icons-react')[name]).toBeDefined();
-  });
+  test.each(meta.map(icon => [icon.moduleName, icon.outputOptions.file]))(
+    '%s is require-able',
+    (name, file) => {
+      expect(require('@carbon/icons-react')[name]).toBeDefined();
+      expect(require(`@carbon/icons-react/${file}`)).toBeDefined();
+    }
+  );
 });

--- a/packages/icons-react/tasks/build.js
+++ b/packages/icons-react/tasks/build.js
@@ -132,7 +132,7 @@ export default ${moduleName};
       await fs.ensureFile(commonjsFilepath);
       await fs.writeFile(
         commonjsFilepath,
-        `const { ${moduleName} = require('${pathToEntrypoint}');
+        `const { ${moduleName} } = require('${pathToEntrypoint}');
 module.exports = ${moduleName};
 `
       );


### PR DESCRIPTION
Hotfix for `icons-react`'s CommonJS bundle (syntax error). Also updates e2e tests to catch for this in the future 👍 