### PR TITLE
fix(Button): remove deprecated prop from default props

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -205,7 +205,6 @@ Button.defaultProps = {
   tabIndex: 0,
   type: 'button',
   disabled: false,
-  small: false,
   kind: 'primary',
 };
 

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1984,7 +1984,6 @@ exports[`DataTable should render 1`] = `
                           "render": [Function],
                         }
                       }
-                      small={false}
                       tabIndex={0}
                       type="button"
                     >
@@ -2058,7 +2057,6 @@ exports[`DataTable should render 1`] = `
                           "render": [Function],
                         }
                       }
-                      small={false}
                       tabIndex={0}
                       type="button"
                     >
@@ -2132,7 +2130,6 @@ exports[`DataTable should render 1`] = `
                           "render": [Function],
                         }
                       }
-                      small={false}
                       tabIndex={0}
                       type="button"
                     >
@@ -2190,7 +2187,6 @@ exports[`DataTable should render 1`] = `
                     disabled={false}
                     kind="primary"
                     onClick={[Function]}
-                    small={false}
                     tabIndex={0}
                     type="button"
                   >

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
@@ -22,7 +22,6 @@ exports[`DataTable.TableBatchAction should render 1`] = `
         "render": [Function],
       }
     }
-    small={false}
     tabIndex={0}
     type="button"
   >

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchActions-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchActions-test.js.snap
@@ -20,7 +20,6 @@ exports[`DataTable.TableBatchActions should render 1`] = `
           disabled={false}
           kind="primary"
           onClick={[MockFunction]}
-          small={false}
           tabIndex={0}
           type="button"
         >
@@ -71,7 +70,6 @@ exports[`DataTable.TableBatchActions should render 2`] = `
           disabled={false}
           kind="primary"
           onClick={[MockFunction]}
-          small={false}
           tabIndex={0}
           type="button"
         >

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -27,7 +27,6 @@ exports[`ModalWrapper should render 1`] = `
       iconDescription="Provide icon description if icon is used"
       kind="primary"
       onClick={[Function]}
-      small={false}
       tabIndex={0}
       type="button"
     >
@@ -156,7 +155,6 @@ exports[`ModalWrapper should render 1`] = `
                 disabled={false}
                 kind="secondary"
                 onClick={[Function]}
-                small={false}
                 tabIndex={0}
                 type="button"
               >
@@ -200,7 +198,6 @@ exports[`ModalWrapper should render 1`] = `
                 }
                 kind="primary"
                 onClick={[Function]}
-                small={false}
                 tabIndex={0}
                 type="button"
               >


### PR DESCRIPTION
Closes #3413 
Closes #3427

related: #2719

This PR removes a deprecated prop from the default props defined for `<Button>`

#### Changelog

**Removed**

- deprecated `small` prop from `Button.defaultProps`

#### Testing / Reviewing

Ensure that no deprecation warnings are emitted for components that depend on `<Button>`
