### PR TITLE
fix(listboxfield): use oneOfType for tabIndex propType

### DIFF
--- a/packages/react/src/components/ListBox/ListBoxField.js
+++ b/packages/react/src/components/ListBox/ListBoxField.js
@@ -52,7 +52,7 @@ ListBoxField.propTypes = {
   /**
    * Optional prop to specify the tabIndex of the <ListBox> trigger button
    */
-  tabIndex: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default ListBoxField;


### PR DESCRIPTION
Closes ~#3424~ #3421 

#### Changelog

**Changed**

- use `oneOfType` instead of `oneOf` for `propType`
