### PR TITLE
fix(tabs): use string for aria-hidden attribute on chevron icon

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -267,7 +267,7 @@ export default class Tabs extends React.Component {
               onClick={this.handleDropdownClick}>
               {selectedLabel}
             </a>
-            <ChevronDownGlyph aria-hidden>
+            <ChevronDownGlyph aria-hidden="true">
               {iconDescription && <title>{iconDescription}</title>}
             </ChevronDownGlyph>
           </div>


### PR DESCRIPTION
Closes #3417 

#### Changelog

**Changed**

- changed `aria-hidden` to `aria-hidden="true"`