### PR TITLE
chore(tooltip): use small button component in story

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -11,6 +11,7 @@ import { settings } from 'carbon-components';
 
 import { withKnobs, select, text, number } from '@storybook/addon-knobs';
 import Tooltip from '../Tooltip';
+import Button from '../Button';
 
 import { OverflowMenuVertical16 } from '@carbon/icons-react';
 
@@ -76,11 +77,7 @@ storiesOf('Tooltip', module)
             <a href="/" className={`${prefix}--link`}>
               Learn More
             </a>
-            <button
-              className={`${prefix}--btn ${prefix}--btn--primary`}
-              type="button">
-              Create
-            </button>
+            <Button size="small">Create</Button>
           </div>
         </Tooltip>
       </div>


### PR DESCRIPTION
Closes #2667

I'm assuming the issue identified in #2667 lies with the presentation of the `Tooltip` in the story (i.e., using the wrong type of `Button` in the story example) rather than something with the `Tooltip` code itself. 👍 But please let me know if I missed something here.

#### Changelog

**Changed**

- use small `Button` component in story