### PR TITLE
fix(link): force disabled style

### DIFF
--- a/packages/components/src/components/link/_link.scss
+++ b/packages/components/src/components/link/_link.scss
@@ -60,7 +60,10 @@
     color: $visited-link;
   }
 
-  .#{$prefix}--link--disabled {
+  .#{$prefix}--link.#{$prefix}--link--disabled,
+  .#{$prefix}--link.#{$prefix}--link--disabled:hover,
+  .#{$prefix}--link.#{$prefix}--link--disabled:active,
+  .#{$prefix}--link.#{$prefix}--link--disabled:visited {
     @include reset;
     @include type-style('body-long-01');
     display: inline;

--- a/packages/components/src/components/link/_link.scss
+++ b/packages/components/src/components/link/_link.scss
@@ -60,7 +60,13 @@
     color: $visited-link;
   }
 
+  #{$prefix}--link--disabled,
+  #{$prefix}--link--disabled:focus,
+  #{$prefix}--link--disabled:hover,
+  #{$prefix}--link--disabled:active,
+  #{$prefix}--link--disabled:visited,
   .#{$prefix}--link.#{$prefix}--link--disabled,
+  .#{$prefix}--link.#{$prefix}--link--disabled:focus,
   .#{$prefix}--link.#{$prefix}--link--disabled:hover,
   .#{$prefix}--link.#{$prefix}--link--disabled:active,
   .#{$prefix}--link.#{$prefix}--link--disabled:visited {

--- a/packages/components/src/components/link/link.hbs
+++ b/packages/components/src/components/link/link.hbs
@@ -7,7 +7,7 @@
 
 <a href="#" class="{{@root.prefix}}--link">Link</a>
 <a class="{{@root.prefix}}--link" aria-disabled="true">Placeholder link</a>
-<p class="{{@root.prefix}}--link--disabled">Disabled Link</p>
+<p class="{{@root.prefix}}--link {{@root.prefix}}--link--disabled">Disabled Link</p>
 <div style="width:200px">
   <a href="#" class="{{@root.prefix}}--link">Text wrap example for hover, focus, and active state testing.</a>
 </div>


### PR DESCRIPTION
For ones with active, etc. state.

Fixes #3428.

#### Changelog

**Changed**

- A change to force disabled style for `:active`, etc. state.

#### Testing / Reviewing

Testing should make sure link is not broken. The fix can be verified by selecting disabled link in Chrome DevTools' DOM inspector and forcing `:active`, etc. state in `:hov` section in the Styles tab.
