### PR TITLE
fix(PasswordInput): prevent visibility toggle on form submit

### DIFF
--- a/packages/components/src/components/text-input/text-input.hbs
+++ b/packages/components/src/components/text-input/text-input.hbs
@@ -16,7 +16,7 @@
     <input id="text-input-3" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" data-toggle-password-visibility>
-    <button
+    <button type="button"
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
@@ -39,7 +39,7 @@
     <input data-invalid id="text-input-4" type="password"
       class="{{prefix}}--text-input {{prefix}}--text-input--invalid{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" data-toggle-password-visibility>
-    <button
+    <button type="button"
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
@@ -66,7 +66,7 @@
     <input id="text-input-5" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" data-toggle-password-visibility>
-    <button
+    <button type="button"
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
@@ -91,7 +91,7 @@
     <input id="text-input-6" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" data-toggle-password-visibility>
-    <button
+    <button type="button"
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}
@@ -116,7 +116,7 @@
     <input id="text-input-7" type="password"
       class="{{prefix}}--text-input{{#if light}} {{prefix}}--text-input--light{{/if}}{{#if password}} {{prefix}}--password-input{{/if}}"
       placeholder="Placeholder text" data-toggle-password-visibility disabled>
-    <button
+    <button type="button"
       class="{{prefix}}--text-input--password__visibility {{prefix}}--tooltip__trigger {{prefix}}--tooltip--icon__bottom"
       aria-label="Show password">
       {{ carbon-icon 'ViewOff16' class=(add prefix '--icon--visibility-off') hidden="true" }}

--- a/packages/react/src/components/TextInput/ControlledPasswordInput.js
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.js
@@ -88,6 +88,7 @@ const ControlledPasswordInput = React.forwardRef(
           data-toggle-password-visibility={type === 'password'}
         />
         <button
+          type="button"
           className={`${prefix}--text-input--password__visibility`}
           aria-label={
             alt ||

--- a/packages/react/src/components/TextInput/PasswordInput.js
+++ b/packages/react/src/components/TextInput/PasswordInput.js
@@ -82,6 +82,7 @@ export default function PasswordInput({
         data-toggle-password-visibility={inputType === 'password'}
       />
       <button
+        type="button"
         className={`${prefix}--text-input--password__visibility`}
         aria-label={alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`}
         onClick={togglePasswordVisibility}>


### PR DESCRIPTION
Closes #3461

This PR sets the type attribute on the password visibility toggle button so it is not submitted as part of a form