### PR TITLE
RFC: Refactor component tokens to support a type theme

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -74,6 +74,44 @@ Avoid nesting selectors, this will make it easier to maintain in the future.
 }
 ```
 
+### Variable naming
+
+Sass variables should be named according to the
+`$component-state-property-variant` format for consistency. Examples:
+
+```scss
+// component: button
+// property: font-weight
+$button-font-weight: 400;
+
+// component: button
+// property: padding
+// variant: ghost
+$button-padding-ghost: calc(0.875rem - 3px) 12px;
+
+// component: data-table-column
+// state: hover
+// property: background
+$data-table-column-hover-background: $hover-selected-ui;
+```
+
+For properties like `padding`, `margin`, `border-width`, etc. that have
+shorthand syntaxes, qualify the property with a suffix if the variable is meant
+for just the x-axis `-x` or y-axis `-y`, or top `-t`, right `-r`, bottom `-b`,
+or left `-l` directionality.
+
+For example, if an element's left and right padding is supposed to match, and
+the top and bottom padding is intended to have a different value, you could:
+
+```scss
+$button-padding-x: 1rem;
+$button-padding-y: 0.5rem;
+
+.button {
+  padding: $button-padding-y $button-padding-x;
+}
+```
+
 ### Sass documentation
 
 [SassDoc](http://sassdoc.com) is used to document the Carbon Sass source.


### PR DESCRIPTION
The purpose of this PR is to better define Carbon's theming strategy now vs what could be a priority in the future.

# As-Is

Carbon's [theming capabilities](https://www.carbondesignsystem.com/guidelines/themes) currently consist of color, typography, spacing, and some component-level tokens. [Colors](https://www.carbondesignsystem.com/guidelines/color/usage) come from the `@carbon/theme` package as four color themes. Those color tokens can also be emitted as custom properties (CSS variables) to support easier inline, runtime, etc. needs.

With the exception of some component-level tokens, all theming tokens for color, typography and spacing are global which is problematic when wanting to theme a component without the side-affect of also theming all components.

# Need

The dotcom team has the need for an editorial theme with increased font sizes on certain components. With that comes the need to theme icon size to better sit alongside the modified font size and spacing/dimension changes to better align the larger font size.

To do so, the dotcom team could maintain their own collection of override variables to use in their Sass build. This RFC suggests no structural changes to how Carbon can be themed today. Their custom editorial theme would not include any color changes, so you could cleanly layer this theme with a color theme.

There are three primary aspects to this RFC.

# (1) Theming scope

Components need more component-level tokens to achieve this where the goal would be for a component to only use component-level tokens, of which could be defaulted to global tokens where applicable. Doing so would allow you to theme a component in isolation.

As the number of component-level tokens could quickly get out of hand, it's important to specify what should and should not receive a token.

A reasonable scope for what deserves tokens could be: **colors, typography, spacing, and icons**. Any other Sass variables used for the construction of the component could be designated as part of our private API - variables not intended for use outside of the Carbon build.

**Colors** - We have this today at the global level. We'd need to refactor the components to use those global tokens in component-level tokens.

**Typography** - Similar effort to colors where component-level tokens would need introduced.

**Spacing** - These include various paddings, heights, widths, etc. that influence type alignment. For example, if a button has a min-height and also top/bottom padding, when setting a bigger font-size (thus bigger computed line-height) through a theming variable, you might also need to adjust some combination of padding and heights to hit the intended button size.

Note: component-level tokens for properties that influence type alignment is tough to fully comprehend without an example. We might want to implement tokens for a couple components to demonstrate.

**Icons** - There are a number of ways one *could* modify the icons used in components if supported, but since the need here is tied to typography changes, the easiest course of action is to set SVG icon heights and widths in component-level tokens so they can be resized in a simple editorial theme.

# (2) Naming convention

See the modified `.github/CONTRIBUTING.md` in this PR.

# (3) Variable files

Eventually we'll want each component to have its isolated styling for if we offer component packages (e.g. `@carbon/button`). As such, each component should have a `_variables.scss`, `_mixins.scss` and `_functions.scss`, plus an entry file. Until then, we can continue to put these new component-level tokens in `/packages/components/src/global/scss/_theme-tokens.scss`.

# Goal

The objective of this PR is to gather feedback and ultimately approve what theming is supported (e.g. colors, typography, spacing, icon sizes), how to do it (e.g. component-level tokens via a naming convention), and where to author the tokens (e.g. `_theme-tokens.scss` for now).