### PR TITLE
refactor(react): move lib folder check to run in jest

### DIFF
--- a/packages/react/__tests__/ssr-test.js
+++ b/packages/react/__tests__/ssr-test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+test('should load', () => {
+  expect(() => require('../lib')).not.toThrow();
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,16 +26,10 @@
   "scripts": {
     "build": "yarn clean && node scripts/build.js",
     "build-storybook": "build-storybook",
-    "ci-check": "yarn test-ssr",
     "clean": "rimraf es lib umd storybook-static",
-    "contributors:add": "all-contributors add",
-    "contributors:generate": "all-contributors generate",
     "prepublish": "yarn build",
-    "semantic-release": "semantic-release",
     "start": "yarn storybook",
-    "storybook": "start-storybook -p 9000",
-    "test": "jest",
-    "test-ssr": "yarn build && node ssr-tests/*.js"
+    "storybook": "start-storybook -p 9000"
   },
   "peerDependencies": {
     "carbon-components": "10.3.1",

--- a/packages/react/ssr-tests/loads.js
+++ b/packages/react/ssr-tests/loads.js
@@ -1,9 +1,0 @@
-// Simple test to ensure the components can at least be loaded in Node.js
-// Note: this test is *not* run by Jest because Jest's pollyfills mask some errors
-
-'use strict';
-
-var assert = require('assert');
-var carbonComponentsReact = require('../lib');
-assert(carbonComponentsReact);
-console.log('server-side-rendering load test passed'); // eslint-disable-line no-console


### PR DESCRIPTION
A small QOL fix for the `ssr-tests` folder in the react package. I'm not quite sure what the history is behind this file, but I went ahead and ported it to run in Jest's `node` test environment. If we think this won't address the comments in the original file, definitely down to close but we should definitely document exactly what we're trying to test for.

#### Changelog

**New**

- Add top-level `__tests__` folder with `ssr-test` in `packages/react`

**Changed**

**Removed**

- `react/ssr-tests/*`
