### PR TITLE
fix(progress-indicator): remove unneeded flex rule

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -25,7 +25,6 @@
     position: relative;
     display: inline-flex;
     flex-direction: row;
-    flex: 1;
     min-width: 7rem;
     width: rem(128px);
     overflow: visible;


### PR DESCRIPTION
Closes #3526 

This PR removes a `flex` style rule from progress indicator steps

cc @jnm2377 just want to make sure this rule is not required for anything

#### Changelog

**Removed**

- `flex` CSS rule in `.bx--progress-step`

#### Testing / Reviewing

1. View the progress indicator story/page in the documentation

2. Move the element out of all wrapper `div`s in dev tools

3. Ensure the progress steps are not separated
