### PR TITLE
fix(dropdown): use helper mixin for hidden dropdown items

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -12255,6 +12255,11 @@ Dropdown styles
     overflow: hidden auto;
   }
 
+  .#{$prefix}--dropdown:not(.#{$prefix}--dropdown--open)
+    .#{$prefix}--dropdown-item {
+    @include hidden;
+  }
+
   .#{$prefix}--dropdown-item {
     transition: opacity $duration--fast-01 motion(standard, productive), background-color
         $duration--fast-01 motion(standard, productive);

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -151,6 +151,11 @@
     overflow: hidden auto;
   }
 
+  .#{$prefix}--dropdown:not(.#{$prefix}--dropdown--open)
+    .#{$prefix}--dropdown-item {
+    @include hidden;
+  }
+
   .#{$prefix}--dropdown-item {
     transition: opacity $duration--fast-01 motion(standard, productive),
       background-color $duration--fast-01 motion(standard, productive);


### PR DESCRIPTION
Closes #3539 

By using the `@hidden` helper mixin for dropdown items when the menu is not opened, we can make sure that there's `visibility: hidden` etc style rules added for `a11y` purposes.

#### Changelog

**Changed**

- apply `@hidden` helper mixin to un-opened dropdown menu items