### PR TITLE
fix(label): remove old styles

### DIFF
--- a/packages/components/src/components/form/_form.scss
+++ b/packages/components/src/components/form/_form.scss
@@ -38,7 +38,6 @@
     vertical-align: baseline;
     margin-bottom: $carbon--spacing-03;
     line-height: rem(16px);
-    pointer-events: none;
   }
 
   .#{$prefix}--label .#{$prefix}--tooltip__trigger {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3448

`pointer-events: none` was in place to prevent label hover causing input field background change. Since we no longer have background color changes, this code is no longer needed. 