### PR TITLE
fix(dropdown): use visibility instead of hidden mixin

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -153,13 +153,15 @@
 
   .#{$prefix}--dropdown:not(.#{$prefix}--dropdown--open)
     .#{$prefix}--dropdown-item {
-    @include hidden;
+    visibility: hidden;
   }
 
   .#{$prefix}--dropdown-item {
-    transition: opacity $duration--fast-01 motion(standard, productive),
+    transition: visibility $duration--fast-01 motion(standard, productive),
+      opacity $duration--fast-01 motion(standard, productive),
       background-color $duration--fast-01 motion(standard, productive);
     opacity: 0;
+    visibility: inherit;
 
     &:hover {
       background-color: $hover-ui;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3539
Refs https://github.com/carbon-design-system/carbon/pull/3541

Use `visibility: hidden` instead of the `hidden` mixin, which just visually hides an element but is still accessible by a screen reader. Also adjusts the animations so they stay intact. 