### PR TITLE
Update error--filled.svg

### DIFF
--- a/packages/icons/src/svg/32/error--filled.svg
+++ b/packages/icons/src/svg/32/error--filled.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="24px" height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+	 width="32px" height="32px" viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}
 	.st1{opacity:0;fill:#FFFFFF;fill-opacity:0;}
 </style>
-<rect id="_Transparent_Rectangle_" class="st0" width="24" height="24"/>
-<path d="M12,1C5.9,1,1,5.9,1,12s4.9,11,11,11s11-4.9,11-11S18.1,1,12,1z M16.3,17.5L6.5,7.7l1.2-1.2l9.8,9.8L16.3,17.5z"/>
-<path id="inner-path" class="st1" d="M16.3,17.5L6.5,7.7l1.2-1.2l9.8,9.8L16.3,17.5z"/>
+<rect id="_Transparent_Rectangle_" class="st0" width="32" height="32"/>
+<path d="M16,2C8.2,2,2,8.2,2,16s6.2,14,14,14s14-6.2,14-14S23.8,2,16,2z M21.4,23L9,10.6L10.6,9L23,21.4L21.4,23z"/>
+<path id="inner-path" class="st1" d="M21.4,23L9,10.6L10.6,9L23,21.4L21.4,23z"/>
 </svg>


### PR DESCRIPTION
Closes #3548

{{short description}}

#### Changelog

**Changed**

- replaces 32/error--filled.svg which was 24x24 with correctly sized asset.

#### Testing / Reviewing

Verify `error--filled.svg` correctly sized in test build.
