### PR TITLE
docs(Tooltip): use small button variant in tooltip stories

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -106,11 +106,7 @@ storiesOf('Tooltip', module)
             <a href="/" className={`${prefix}--link`}>
               Learn More
             </a>
-            <button
-              className={`${prefix}--btn ${prefix}--btn--primary`}
-              type="button">
-              Create
-            </button>
+            <Button size="small">Create</Button>
           </div>
         </Tooltip>
       </div>
@@ -139,11 +135,7 @@ storiesOf('Tooltip', module)
             <a href="/" className={`${prefix}--link`}>
               Learn More
             </a>
-            <button
-              className={`${prefix}--btn ${prefix}--btn--primary`}
-              type="button">
-              Create
-            </button>
+            <Button size="small">Create</Button>
           </div>
         </Tooltip>
       </div>
@@ -172,11 +164,7 @@ storiesOf('Tooltip', module)
             <a href="/" className={`${prefix}--link`}>
               Learn More
             </a>
-            <button
-              className={`${prefix}--btn ${prefix}--btn--primary`}
-              type="button">
-              Create
-            </button>
+            <Button size="small">Create</Button>
           </div>
         </Tooltip>
       </div>


### PR DESCRIPTION
Closes #3464

This PR replaces the buttons in the interactive tooltip stories with small button variants

refs #2667, #3432, which applied this change to the default tooltip story
