### PR TITLE
Update eslint-config-carbon to use devdeps

### DIFF
--- a/packages/eslint-config-carbon/package.json
+++ b/packages/eslint-config-carbon/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "eslint": "^6.0.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-config-airbnb-base": "^13.0.0",


### PR DESCRIPTION
Installing `eslint-config-carbon` as a devDependancy doesn't download the required `dependancies`