### PR TITLE
fix: update dropdown and listbox disabled color token

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -246,11 +246,11 @@
     }
 
     .#{$prefix}--dropdown-text {
-      color: $disabled-03;
+      color: $disabled-02;
     }
 
     .#{$prefix}--dropdown__arrow {
-      fill: $disabled-03;
+      fill: $disabled-02;
     }
 
     &.#{$prefix}--dropdown--light:hover {
@@ -300,7 +300,7 @@
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled
     .#{$prefix}--dropdown-text {
-    color: $disabled-03;
+    color: $disabled-02;
   }
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled:focus

--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -152,11 +152,11 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__label,
   .#{$prefix}--list-box--disabled.#{$prefix}--list-box--inline
     .#{$prefix}--list-box__label {
-    color: $disabled-03;
+    color: $disabled-02;
   }
 
   .#{$prefix}--list-box--disabled .#{$prefix}--list-box__menu-icon > svg {
-    fill: $disabled-03;
+    fill: $disabled-02;
   }
 
   .#{$prefix}--list-box--disabled,


### PR DESCRIPTION
Closes #3571 

#### Changelog

**Changed**

- changed disabled text and icon fill to `$disabled-02` for `Dropdown` and `ListBox` components