### PR TITLE
fix(data-table): split selector for header height, etc

### DIFF
--- a/packages/components/src/components/data-table/_data-table-sort.scss
+++ b/packages/components/src/components/data-table/_data-table-sort.scss
@@ -20,6 +20,9 @@
   .#{$prefix}--data-table--sort
     th:first-of-type:not(.#{$prefix}--table-column-checkbox):not(.#{$prefix}--table-expand) {
     padding: 0;
+  }
+
+  .#{$prefix}--data-table--sort th {
     height: $layout-04;
     border-top: none;
     border-bottom: none;


### PR DESCRIPTION
Fixes #3503.

#### Changelog

**Removed**

- `:first-of-type`, etc. check for column header style, of height/border.

#### Testing / Reviewing

Testing should make sure sortable version of data table is not broken.