### PR TITLE
fix(select): remove dotted outline on select element

### DIFF
--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -68,6 +68,14 @@
     // Select text renders a little high on Firefox
     @-moz-document url-prefix() {
       padding-top: rem(4px);
+
+      // Removes dotted inner focus
+      &:-moz-focusring,
+      &::-moz-focus-inner {
+        color: transparent;
+        text-shadow: 0 0 0 #000;
+        background-image: none;
+      }
     }
 
     &:focus {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/1526

Removes dotted line outline on `select` element in Firefox


### Testing
Ensure no dotted line shows up on `select`