### PR TITLE
fix(modal): ensure inputs on modal have correct background

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -55,7 +55,12 @@
     }
 
     .#{$prefix}--text-input,
-    .#{$prefix}--select-input {
+    .#{$prefix}--text-area,
+    .#{$prefix}--search-input,
+    .#{$prefix}--select-input,
+    .#{$prefix}--dropdown,
+    .#{$prefix}--dropdown-list,
+    .#{$prefix}--number input[type='number'] {
       background-color: $field-02;
     }
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/2912

Sets all input backgrounds to `$field-02` when placed inside a modal

<img width="672" alt="Screen Shot 2019-07-30 at 1 45 06 PM" src="https://user-images.githubusercontent.com/11928039/62163927-47db3200-b2d0-11e9-9eff-332d73de8752.png">
