### PR TITLE
Fix(DataTable/Props) - props `small` should be `short`

### DIFF
--- a/packages/react/src/components/DataTable/Table.js
+++ b/packages/react/src/components/DataTable/Table.js
@@ -49,7 +49,7 @@ Table.propTypes = {
   /**
    * `normal` Change the row height of table
    */
-  size: PropTypes.oneOf(['compact', 'small', 'normal', 'tall']),
+  size: PropTypes.oneOf(['compact', 'short', 'normal', 'tall']),
 
   /**
    * `false` If true, will use a width of 'auto' instead of 100%


### PR DESCRIPTION
Proptypes requests small whereas short is used in code

#### Changelog
**Changed**

- Rename enum props to `short` instead of `small`

#### Testing / Reviewing

According to the [storybook](http://react.carbondesignsystem.com/?path=/story/datatable--with-options) and to the [way it's used](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/DataTable/Table.js#L27) `small` should be instead `short`

