### PR TITLE
fix(modal): replace width rule with padding

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -13936,7 +13936,7 @@ Modal styles
 
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content {
-    width: 75%;
+    padding-right: 25%;
     padding-left: 1rem;
   }
 

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -101,7 +101,7 @@
 
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content {
-    width: 75%;
+    padding-right: 25%;
     padding-left: 1rem;
   }
 


### PR DESCRIPTION
Closes #3412

This PR replaces the width rule on modal header and content with a padding change instead

#### Testing / Reviewing

Ensure the modal appears correct
