### PR TITLE
fix: pass `light` prop into dropdown

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -234,6 +234,7 @@ export default class Dropdown extends React.Component {
               isOpen={isOpen}
               invalid={invalid}
               invalidText={invalidText}
+              light={light}
               {...getRootProps({ refKey: 'innerRef' })}>
               {invalid && (
                 <WarningFilled16

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -70,6 +70,7 @@ exports[`Dropdown should render 1`] = `
         id="test-dropdown"
         innerRef={[Function]}
         isOpen={false}
+        light={false}
         type="default"
       >
         <div
@@ -242,6 +243,7 @@ exports[`Dropdown should render custom item components 1`] = `
         id="test-dropdown"
         innerRef={[Function]}
         isOpen={true}
+        light={false}
         type="default"
       >
         <div
@@ -571,6 +573,7 @@ exports[`Dropdown should render with strings as items 1`] = `
         id="test-dropdown"
         innerRef={[Function]}
         isOpen={true}
+        light={false}
         type="default"
       >
         <div


### PR DESCRIPTION
Closes #3609

This PR passes the `light` prop into the underlying `<ListBox>` for the React dropdown

refs https://github.com/carbon-design-system/design-language-website/issues/135

#### Testing / Reviewing

Ensure the correct classes are applied to the dropdown's listbox when the `light` prop is true
