### PR TITLE
fix(sass): port support for dart-sass 1.x

### DIFF
--- a/src/globals/scss/styles.scss
+++ b/src/globals/scss/styles.scss
@@ -132,8 +132,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @if (length($deprecations--reasons) > 0) {
   $deprecations--message: '';
   @each $reason in $deprecations--reasons {
-    $deprecations--message: '#{$deprecations--message}
-REASON: #{$reason}';
+    $deprecations--message: '#{$deprecations--message} REASON: #{$reason}';
   }
 
   @warn $deprecations--message;


### PR DESCRIPTION
With the exception of removing !globals, this will at least
be compatible with dart-sass 1.x.

#### Changelog

**New**

- Support for dart-sass 1.x

Additional work would be needed to add dart-sass 2.x support as !global has been deprecated.

Basically just a port of https://github.com/carbon-design-system/carbon/pull/2905