### PR TITLE
fix(ComboBox): switch from onInputValueChange to onStateChange

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -25,7 +25,7 @@ const downshiftActions = {
   setHighlightedIndex: jest.fn(),
 };
 const clearInput = wrapper =>
-  wrapper.instance().handleOnInputValueChange('', downshiftActions);
+  wrapper.instance().handleOnStateChange({ inputValue: '' }, downshiftActions);
 
 describe('ComboBox', () => {
   let mockProps;
@@ -156,10 +156,14 @@ describe('ComboBox', () => {
     it('should set `inputValue` to an empty string if a falsey-y value is given', () => {
       const wrapper = mount(<ComboBox {...mockProps} />);
 
-      wrapper.instance().handleOnInputValueChange('foo', downshiftActions);
+      wrapper
+        .instance()
+        .handleOnStateChange({ inputValue: 'foo' }, downshiftActions);
       expect(wrapper.state('inputValue')).toBe('foo');
 
-      wrapper.instance().handleOnInputValueChange(null, downshiftActions);
+      wrapper
+        .instance()
+        .handleOnStateChange({ inputValue: null }, downshiftActions);
       expect(wrapper.state('inputValue')).toBe('');
     });
   });

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -204,22 +204,25 @@ export default class ComboBox extends React.Component {
     event.stopPropagation();
   };
 
-  handleOnInputValueChange = (inputValue, { setHighlightedIndex }) => {
-    const { onInputChange } = this.props;
+  handleOnStateChange = (newState, { setHighlightedIndex }) => {
+    if (Object.prototype.hasOwnProperty.call(newState, 'inputValue')) {
+      const { inputValue } = newState;
+      const { onInputChange } = this.props;
 
-    setHighlightedIndex(findHighlightedIndex(this.props, inputValue));
+      setHighlightedIndex(findHighlightedIndex(this.props, inputValue));
 
-    this.setState(
-      () => ({
-        // Default to empty string if we have a false-y `inputValue`
-        inputValue: inputValue || '',
-      }),
-      () => {
-        if (onInputChange) {
-          onInputChange(inputValue);
+      this.setState(
+        () => ({
+          // Default to empty string if we have a false-y `inputValue`
+          inputValue: inputValue || '',
+        }),
+        () => {
+          if (onInputChange) {
+            onInputChange(inputValue);
+          }
         }
-      }
-    );
+      );
+    }
   };
 
   onToggleClick = isOpen => event => {
@@ -276,7 +279,7 @@ export default class ComboBox extends React.Component {
       <Downshift
         {...downshiftProps}
         onChange={this.handleOnChange}
-        onInputValueChange={this.handleOnInputValueChange}
+        onStateChange={this.handleOnStateChange}
         inputValue={this.state.inputValue || ''}
         itemToString={itemToString}
         defaultSelectedItem={initialSelectedItem}>


### PR DESCRIPTION
Downshift's `onInputValueChange` seems to be called from React state updater function and thus calling `setState()` in `onInputValueChange` handler causes React's "An update was scheduled from inside an update function" warning.

Fixes #2543.
Fixes #3637.

#### Changelog

**Changed**

- Switch from `onInputValueChange` to `onStateChange` in our `<ComboBox>` code for keeping track of user-typed value of `<input>`.

#### Testing / Reviewing

Testing should make sure our `<Combobox>` is not broken.