### PR TITLE
fix(select): move selector under select input (v9) 

### DIFF
--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -60,6 +60,10 @@
       box-shadow: 0 2px 0 0 $support-01;
     }
 
+    &[data-invalid] ~ .#{$prefix}--select__arrow {
+      bottom: 2.25rem;
+    }
+
     &:focus ~ .#{$prefix}--label {
       color: $brand-01;
     }
@@ -96,10 +100,6 @@
     width: rem(10px);
     height: rem(5px);
     pointer-events: none;
-  }
-
-  &[data-invalid] ~ .#{$prefix}--select__arrow {
-    bottom: 2.25rem;
   }
 
   .#{$prefix}--select-optgroup,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3651

Correctly nests selector under `bx--select-input`