### PR TITLE
fix(date-picker): focus on current date on down key

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.js
+++ b/packages/components/src/components/date-picker/date-picker.js
@@ -142,6 +142,7 @@ class DatePicker extends mixin(
       this.manage(
         on(this.element, 'keydown', e => {
           if (e.which === 40) {
+            e.preventDefault();
             (
               this.calendar.selectedDateElem ||
               this.calendar.todayDateElem ||

--- a/packages/components/src/components/date-picker/date-picker.js
+++ b/packages/components/src/components/date-picker/date-picker.js
@@ -500,7 +500,6 @@ class DatePicker extends mixin(
       selectorFlatpickrMonthYearContainer: '.flatpickr-current-month',
       selectorFlatpickrYearContainer: '.numInputWrapper',
       selectorFlatpickrCurrentMonth: '.cur-month',
-      selectorCurrentDay: `.${prefix}--date-picker__day.today`,
       classCalendarContainer: `${prefix}--date-picker__calendar`,
       classMonth: `${prefix}--date-picker__month`,
       classWeekdays: `${prefix}--date-picker__weekdays`,

--- a/packages/components/src/components/date-picker/date-picker.js
+++ b/packages/components/src/components/date-picker/date-picker.js
@@ -142,7 +142,11 @@ class DatePicker extends mixin(
       this.manage(
         on(this.element, 'keydown', e => {
           if (e.which === 40) {
-            this.calendar.calendarContainer.focus();
+            (
+              this.calendar.selectedDateElem ||
+              this.calendar.todayDateElem ||
+              this.calendar.calendarContainer
+            ).focus();
           }
         })
       );
@@ -496,6 +500,7 @@ class DatePicker extends mixin(
       selectorFlatpickrMonthYearContainer: '.flatpickr-current-month',
       selectorFlatpickrYearContainer: '.numInputWrapper',
       selectorFlatpickrCurrentMonth: '.cur-month',
+      selectorCurrentDay: `.${prefix}--date-picker__day.today`,
       classCalendarContainer: `${prefix}--date-picker__calendar`,
       classMonth: `${prefix}--date-picker__month`,
       classWeekdays: `${prefix}--date-picker__weekdays`,

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -13,6 +13,7 @@ import l10n from 'flatpickr/dist/l10n/index';
 import rangePlugin from 'flatpickr/dist/plugins/rangePlugin';
 import { settings } from 'carbon-components';
 import DatePickerInput from '../DatePickerInput';
+import { match, keys } from '../../internal/keyboard';
 
 const { prefix } = settings;
 
@@ -401,7 +402,7 @@ export default class DatePicker extends Component {
   addKeyboardEvents = cal => {
     if (this.inputField) {
       this.inputField.addEventListener('keydown', e => {
-        if (e.which === 40) {
+        if (match(e, keys.ArrowDown)) {
           (
             cal.selectedDateElem ||
             cal.todayDateElem ||
@@ -418,7 +419,7 @@ export default class DatePicker extends Component {
         }
       });
       this.toInputField.addEventListener('keydown', e => {
-        if (e.which === 40) {
+        if (match(e, keys.ArrowDown)) {
           (
             cal.selectedDateElem ||
             cal.todayDateElem ||

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -402,7 +402,11 @@ export default class DatePicker extends Component {
     if (this.inputField) {
       this.inputField.addEventListener('keydown', e => {
         if (e.which === 40) {
-          cal.calendarContainer.focus();
+          (
+            cal.selectedDateElem ||
+            cal.todayDateElem ||
+            cal.calendarContainer
+          ).focus();
         }
       });
       this.inputField.addEventListener('change', this.onChange);
@@ -411,6 +415,15 @@ export default class DatePicker extends Component {
       this.toInputField.addEventListener('blur', evt => {
         if (!this.cal.calendarContainer.contains(evt.relatedTarget)) {
           this.cal.close();
+        }
+      });
+      this.toInputField.addEventListener('keydown', e => {
+        if (e.which === 40) {
+          (
+            cal.selectedDateElem ||
+            cal.todayDateElem ||
+            cal.calendarContainer
+          ).focus();
         }
       });
       this.toInputField.addEventListener('change', this.onChange);


### PR DESCRIPTION
This change makes date picker focus on the currently selected date (if available) rather than the whole date picker dropdown, which allows Flatpickr code to work on keyboard nav with left/right keys after.

Fixes #3638.

#### Changelog

**Changed**

- A change to make date picker focus on the currently selected date (if available) rather than the whole date picker dropdown.

#### Testing / Reviewing

Testing should make sure out date picker is not broken.