### PR TITLE
fix(Button): replace boolean aria attribute with string

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -63,7 +63,7 @@ const Button = React.forwardRef(function Button(
     <ButtonImageElement
       aria-label={iconDescription}
       className={`${prefix}--btn__icon`}
-      aria-hidden={true}
+      aria-hidden="true"
     />
   );
 

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1996,12 +1996,12 @@ exports[`DataTable should render 1`] = `
                       >
                         Ghost
                         <ForwardRef(AddFilled16)
-                          aria-hidden={true}
+                          aria-hidden="true"
                           aria-label="Add"
                           className="bx--btn__icon"
                         >
                           <Icon
-                            aria-hidden={true}
+                            aria-hidden="true"
                             aria-label="Add"
                             className="bx--btn__icon"
                             height={16}
@@ -2011,7 +2011,7 @@ exports[`DataTable should render 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-hidden={true}
+                              aria-hidden="true"
                               aria-label="Add"
                               className="bx--btn__icon"
                               focusable="false"
@@ -2069,12 +2069,12 @@ exports[`DataTable should render 1`] = `
                       >
                         Ghost
                         <ForwardRef(AddFilled16)
-                          aria-hidden={true}
+                          aria-hidden="true"
                           aria-label="Add"
                           className="bx--btn__icon"
                         >
                           <Icon
-                            aria-hidden={true}
+                            aria-hidden="true"
                             aria-label="Add"
                             className="bx--btn__icon"
                             height={16}
@@ -2084,7 +2084,7 @@ exports[`DataTable should render 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-hidden={true}
+                              aria-hidden="true"
                               aria-label="Add"
                               className="bx--btn__icon"
                               focusable="false"
@@ -2142,12 +2142,12 @@ exports[`DataTable should render 1`] = `
                       >
                         Ghost
                         <ForwardRef(AddFilled16)
-                          aria-hidden={true}
+                          aria-hidden="true"
                           aria-label="Add"
                           className="bx--btn__icon"
                         >
                           <Icon
-                            aria-hidden={true}
+                            aria-hidden="true"
                             aria-label="Add"
                             className="bx--btn__icon"
                             height={16}
@@ -2157,7 +2157,7 @@ exports[`DataTable should render 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-hidden={true}
+                              aria-hidden="true"
                               aria-label="Add"
                               className="bx--btn__icon"
                               focusable="false"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
@@ -32,12 +32,12 @@ exports[`DataTable.TableBatchAction should render 1`] = `
       type="button"
     >
       <ForwardRef(AddFilled16)
-        aria-hidden={true}
+        aria-hidden="true"
         aria-label="Add"
         className="bx--btn__icon"
       >
         <Icon
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label="Add"
           className="bx--btn__icon"
           height={16}
@@ -47,7 +47,7 @@ exports[`DataTable.TableBatchAction should render 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <svg
-            aria-hidden={true}
+            aria-hidden="true"
             aria-label="Add"
             className="bx--btn__icon"
             focusable="false"


### PR DESCRIPTION
Closes #3658 

This PR changes the `aria-hidden` prop type for the default button icon render prop

#### Testing / Reviewing

Ensure no errors are emitted when rendering custom icons in buttons (`<Button renderIcon={Add16} />`)
