### PR TITLE
fix(cli): add step to pull from upstream for tags

### DIFF
--- a/packages/cli/src/commands/release.js
+++ b/packages/cli/src/commands/release.js
@@ -50,6 +50,8 @@ async function release({ bump }) {
   const logger = createLogger();
   logger.start('Getting latest tag');
 
+  // Make sure we've fetched the latest tags from upstream
+  await execa('git', ['pull', 'upstream', '--tags']);
   const { stdout: tagInfo } = await execa('git', [
     'tag',
     '-l',


### PR DESCRIPTION
Update CLI release command to pull from upstream to get latest tag info.

#### Changelog

**New**

**Changed**

- `@carbon/cli release` now fetches tags from upstream first before finding latest tag

**Removed**
