### PR TITLE
fix(button): use div for skeleton button

### DIFF
--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -23,7 +23,7 @@ const ButtonSkeleton = ({ small, href }) => {
     className: buttonClasses,
   };
 
-  const button = <button {...commonProps} type="button" />;
+  const button = <div {...commonProps} type="button" />;
 
   const anchor = <a {...commonProps} href={href} role="button" />; // eslint-disable-line
 

--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -23,7 +23,7 @@ const ButtonSkeleton = ({ small, href }) => {
     className: buttonClasses,
   };
 
-  const button = <div {...commonProps} type="button" />;
+  const button = <div {...commonProps} />;
 
   const anchor = <a {...commonProps} href={href} role="button" />; // eslint-disable-line
 


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/2958

Use `div` instead of `button` in `ButtonSkeleton` to fix a11y issues. Since the button is normally labeled via text, and the skeleton button has no text, it throws an error. Using a `div` alleviates this issue. 