### PR TITLE
fix(modal): check that modal is open before closing

### DIFF
--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -159,7 +159,7 @@ describe('Modal', () => {
 
     it('should handle close keyDown events', () => {
       const onRequestClose = jest.fn();
-      const wrapper = mount(<Modal onRequestClose={onRequestClose} />);
+      const wrapper = mount(<Modal open onRequestClose={onRequestClose} />);
       wrapper.simulate('keyDown', { which: 26 });
       expect(onRequestClose).not.toBeCalled();
       wrapper.simulate('keyDown', { which: 27 });
@@ -169,7 +169,7 @@ describe('Modal', () => {
     it('should handle submit keyDown events with shouldSubmitOnEnter enabled', () => {
       const onRequestSubmit = jest.fn();
       const wrapper = mount(
-        <Modal onRequestSubmit={onRequestSubmit} shouldSubmitOnEnter />
+        <Modal open onRequestSubmit={onRequestSubmit} shouldSubmitOnEnter />
       );
       wrapper.simulate('keyDown', { which: 14 });
       expect(onRequestSubmit).not.toBeCalled();
@@ -179,7 +179,7 @@ describe('Modal', () => {
 
     it('should not handle submit keyDown events with shouldSubmitOnEnter not enabled', () => {
       const onRequestSubmit = jest.fn();
-      const wrapper = mount(<Modal onRequestSubmit={onRequestSubmit} />);
+      const wrapper = mount(<Modal open onRequestSubmit={onRequestSubmit} />);
       wrapper.simulate('keyDown', { which: 14 });
       expect(onRequestSubmit).not.toBeCalled();
       wrapper.simulate('keyDown', { which: 13 });

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -167,11 +167,13 @@ export default class Modal extends Component {
   };
 
   handleKeyDown = evt => {
-    if (evt.which === 27) {
-      this.props.onRequestClose(evt);
-    }
-    if (evt.which === 13 && this.props.shouldSubmitOnEnter) {
-      this.props.onRequestSubmit(evt);
+    if (this.props.open) {
+      if (evt.which === 27) {
+        this.props.onRequestClose(evt);
+      }
+      if (evt.which === 13 && this.props.shouldSubmitOnEnter) {
+        this.props.onRequestSubmit(evt);
+      }
     }
   };
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3684

Just adds a check to ensure the Modal is open before running any of the keydown close modal handlers