### PR TITLE
feat(FileUploadButton): Allow node in place of string.

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -40,7 +40,7 @@ export class FileUploaderButton extends Component {
      * Provide the label text to be read by screen readers when interacting with
      * this control
      */
-    labelText: PropTypes.string,
+    labelText: PropTypes.node,
 
     /**
      * Specify whether you want the component to list the files that have been


### PR DESCRIPTION
This allows the end user to make the text more customizable
i.e. allow icons or other renderable items for the button.

#### Changelog

**Changed**

- FileUploadButtons `labelText: PropTypes.string` => `labelText: PropTypes.node`

#### Testing / Reviewing

Tested in story book. Removed the propType for labelText, and when adding the button supplied a rendered element to the FileUploadButton via a JSX prop.

```
const testSpan = (
  <span>Test</span>
)

...

<FileUploaderButton labelText={testSpan} {...props.fileUploaderButton()} />
```


