### PR TITLE
fix(css): clean up css errors

### DIFF
--- a/packages/components/demo/scss/_prism.scss
+++ b/packages/components/demo/scss/_prism.scss
@@ -5,299 +5,307 @@
  * @author Tim  Shedor
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
-   font-size: 13px;
-   color: black;
-   background: none;
-   font-family: 'Menlo', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-   text-align: left;
-   white-space: pre-wrap;
-   word-spacing: normal;
-   word-break: normal;
-   word-wrap: normal;
-   line-height: 1.5;
- 
-   -moz-tab-size: 4;
-   -o-tab-size: 4;
-   tab-size: 4;
- 
-   -webkit-hyphens: none;
-   -moz-hyphens: none;
-   -ms-hyphens: none;
-   hyphens: none;
- }
- 
- /* Code blocks */
- pre[class*="language-"] {
-   border: 2px solid #F5F7FA;
-   position: relative;
-   background-color: #fdfdfd;
-   background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-   background-size: 3em 3em;
-   background-origin: content-box;
-   overflow: visible;
-   padding: 0;
- }
- 
- code[class*="language"] {
-   max-height: inherit;
-   height: 100%;
-   padding: 0 1em;
-   display: block;
-   overflow: auto;
- }
- 
- /* Margin bottom to accomodate shadow */
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-   background-color: #fdfdfd;
-   -webkit-box-sizing: border-box;
-   -moz-box-sizing: border-box;
-   box-sizing: border-box;
- }
- 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-   position: relative;
-   padding: .2em;
-   border-radius: 0.3em;
-   color: #c92c2c;
-   border: 1px solid rgba(0, 0, 0, 0.1);
-   display: inline;
-   white-space: normal;
- }
- 
- pre[class*="language-"]:before,
- pre[class*="language-"]:after {
-   content: '';
-   z-index: -2;
-   display: block;
-   position: absolute;
-   bottom: 0.75em;
-   left: 0.18em;
-   width: 40%;
-   height: 20%;
-   max-height: 13em;
-   box-shadow: 0px 13px 8px #979797;
-   -webkit-transform: rotate(-2deg);
-   -moz-transform: rotate(-2deg);
-   -ms-transform: rotate(-2deg);
-   -o-transform: rotate(-2deg);
-   transform: rotate(-2deg);
- }
- 
- :not(pre) > code[class*="language-"]:after,
- pre[class*="language-"]:after {
-   right: 0.75em;
-   left: auto;
-   -webkit-transform: rotate(2deg);
-   -moz-transform: rotate(2deg);
-   -ms-transform: rotate(2deg);
-   -o-transform: rotate(2deg);
-   transform: rotate(2deg);
- }
- 
- .token.comment,
- .token.block-comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-   color: #7D8B99;
- }
- 
- .token.punctuation {
-   color: #5F6364;
- }
- 
- .token.property,
- .token.tag,
- .token.boolean,
- .token.number,
- .token.function-name,
- .token.constant,
- .token.symbol,
- .token.deleted {
-   color: #c92c2c;
- }
- 
- .token.selector,
- .token.attr-name,
- .token.string,
- .token.char,
- .token.function,
- .token.builtin,
- .token.inserted {
-   color: #2f9c0a;
- }
- 
- .token.operator,
- .token.entity,
- .token.url,
- .token.variable {
-   color: #a67f59;
-   background: rgba(255, 255, 255, 0.5);
- }
- 
- .token.atrule,
- .token.attr-value,
- .token.keyword,
- .token.class-name {
-   color: #1990b8;
- }
- 
- .token.regex,
- .token.important {
-   color: #e90;
- }
- 
- .language-css .token.string,
- .style .token.string {
-   color: #a67f59;
-   background: rgba(255, 255, 255, 0.5);
- }
- 
- .token.important {
-   font-weight: normal;
- }
- 
- .token.bold {
-   font-weight: bold;
- }
- .token.italic {
-   font-style: italic;
- }
- 
- .token.entity {
-   cursor: help;
- }
- 
- @media screen and (max-width: 767px) {
-   pre[class*="language-"]:before,
-   pre[class*="language-"]:after {
-     bottom: 14px;
-     box-shadow: none;
-   }
- 
- }
- 
- /* Plugin styles */
- .token.tab:not(:empty):before,
- .token.cr:before,
- .token.lf:before {
-   color: #e0d7d1;
- }
- 
- /* Plugin styles: Line Numbers */
- pre[class*="language-"].line-numbers {
-   padding-left: 0;
- }
- 
- pre[class*="language-"].line-numbers code {
-   padding-left: 3.8em;
- }
- 
- pre[class*="language-"].line-numbers .line-numbers-rows {
-   left: 0;
- }
- 
- /* Plugin styles: Line Highlight */
- pre[class*="language-"][data-line] {
-   padding-top: 0;
-   padding-bottom: 0;
-   padding-left: 0;
- }
- pre[data-line] code {
-   position: relative;
-   padding-left: 4em;
- }
- pre .line-highlight {
-   margin-top: 0;
- }
- 
- pre[data-line] {
-   position: relative;
-   padding: 1em 0 1em 3em;
- }
- 
- .line-highlight {
-   position: absolute;
-   left: 0;
-   right: 0;
-   padding: inherit 0;
-   margin-top: 1em; /* Same as .prism’s padding-top */
- 
-   background: hsla(24, 20%, 50%,.08);
-   background: linear-gradient(to right, hsla(24, 20%, 50%,.1) 70%, hsla(24, 20%, 50%,0));
- 
-   pointer-events: none;
- 
-   line-height: inherit;
-   white-space: pre;
- }
- 
-   .line-highlight:before,
-   .line-highlight[data-end]:after {
-     content: attr(data-start);
-     position: absolute;
-     top: .4em;
-     left: .6em;
-     min-width: 1em;
-     padding: 0 .5em;
-     background-color: hsla(24, 20%, 50%,.4);
-     color: hsl(24, 20%, 95%);
-     font: bold 65%/1.5 sans-serif;
-     text-align: center;
-     vertical-align: .3em;
-     border-radius: 999px;
-     text-shadow: none;
-     box-shadow: 0 1px white;
-   }
- 
-   .line-highlight[data-end]:after {
-     content: attr(data-end);
-     top: auto;
-     bottom: .4em;
-   }
- 
- pre.line-numbers {
-   position: relative;
-   padding-left: 3.8em;
-   counter-reset: linenumber;
- }
- 
- pre.line-numbers > code {
-   position: relative;
- }
- 
- .line-numbers .line-numbers-rows {
-   position: absolute;
-   pointer-events: none;
-   top: 0;
-   font-size: 100%;
-   left: -3.8em;
-   width: 3em; /* works for line-numbers below 1000 lines */
-   letter-spacing: -1px;
-   border-right: 1px solid #999;
- 
-   -webkit-user-select: none;
-   -moz-user-select: none;
-   -ms-user-select: none;
-   user-select: none;
- 
- }
- 
-   .line-numbers-rows > span {
-     pointer-events: none;
-     display: block;
-     counter-increment: linenumber;
-   }
- 
-     .line-numbers-rows > span:before {
-       content: counter(linenumber);
-       color: #999;
-       display: block;
-       padding-right: 0.8em;
-       text-align: right;
-     }
- 
+code[class*='language-'],
+pre[class*='language-'] {
+  font-size: 13px;
+  color: black;
+  background: none;
+  font-family: 'Menlo', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono',
+    monospace;
+  text-align: left;
+  white-space: pre-wrap;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+pre[class*='language-'] {
+  border: 2px solid #f5f7fa;
+  position: relative;
+  background-color: #fdfdfd;
+  background-image: linear-gradient(
+    transparent 50%,
+    rgba(69, 142, 209, 0.04) 50%
+  );
+  background-size: 3em 3em;
+  background-origin: content-box;
+  overflow: visible;
+  padding: 0;
+}
+
+code[class*='language'] {
+  max-height: inherit;
+  height: 100%;
+  padding: 0 1em;
+  display: block;
+  overflow: auto;
+}
+
+/* Margin bottom to accomodate shadow */
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  background-color: #fdfdfd;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* Inline code */
+:not(pre) > code[class*='language-'] {
+  position: relative;
+  padding: 0.2em;
+  border-radius: 0.3em;
+  color: #c92c2c;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  display: inline;
+  white-space: normal;
+}
+
+pre[class*='language-']:before,
+pre[class*='language-']:after {
+  content: '';
+  z-index: -2;
+  display: block;
+  position: absolute;
+  bottom: 0.75em;
+  left: 0.18em;
+  width: 40%;
+  height: 20%;
+  max-height: 13em;
+  box-shadow: 0px 13px 8px #979797;
+  -webkit-transform: rotate(-2deg);
+  -moz-transform: rotate(-2deg);
+  -ms-transform: rotate(-2deg);
+  -o-transform: rotate(-2deg);
+  transform: rotate(-2deg);
+}
+
+:not(pre) > code[class*='language-']:after,
+pre[class*='language-']:after {
+  right: 0.75em;
+  left: auto;
+  -webkit-transform: rotate(2deg);
+  -moz-transform: rotate(2deg);
+  -ms-transform: rotate(2deg);
+  -o-transform: rotate(2deg);
+  transform: rotate(2deg);
+}
+
+.token.comment,
+.token.block-comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #7d8b99;
+}
+
+.token.punctuation {
+  color: #5f6364;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.function-name,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #c92c2c;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.function,
+.token.builtin,
+.token.inserted {
+  color: #2f9c0a;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.token.variable {
+  color: #a67f59;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword,
+.token.class-name {
+  color: #1990b8;
+}
+
+.token.regex,
+.token.important {
+  color: #e90;
+}
+
+.language-css .token.string,
+.style .token.string {
+  color: #a67f59;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.token.important {
+  font-weight: normal;
+}
+
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+@media screen and (max-width: 767px) {
+  pre[class*='language-']:before,
+  pre[class*='language-']:after {
+    bottom: 14px;
+    box-shadow: none;
+  }
+}
+
+/* Plugin styles */
+.token.tab:not(:empty):before,
+.token.cr:before,
+.token.lf:before {
+  color: #e0d7d1;
+}
+
+/* Plugin styles: Line Numbers */
+pre[class*='language-'].line-numbers {
+  padding-left: 0;
+}
+
+pre[class*='language-'].line-numbers code {
+  padding-left: 3.8em;
+}
+
+pre[class*='language-'].line-numbers .line-numbers-rows {
+  left: 0;
+}
+
+/* Plugin styles: Line Highlight */
+pre[class*='language-'][data-line] {
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+}
+pre[data-line] code {
+  position: relative;
+  padding-left: 4em;
+}
+pre .line-highlight {
+  margin-top: 0;
+}
+
+pre[data-line] {
+  position: relative;
+  padding: 1em 0 1em 3em;
+}
+
+.line-highlight {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding-top: inherit;
+  padding-bottom: inherit;
+  padding-left: 0;
+  padding-right: 0;
+  margin-top: 1em; /* Same as .prism’s padding-top */
+
+  background: hsla(24, 20%, 50%, 0.08);
+  background: linear-gradient(
+    to right,
+    hsla(24, 20%, 50%, 0.1) 70%,
+    hsla(24, 20%, 50%, 0)
+  );
+
+  pointer-events: none;
+
+  line-height: inherit;
+  white-space: pre;
+}
+
+.line-highlight:before,
+.line-highlight[data-end]:after {
+  content: attr(data-start);
+  position: absolute;
+  top: 0.4em;
+  left: 0.6em;
+  min-width: 1em;
+  padding: 0 0.5em;
+  background-color: hsla(24, 20%, 50%, 0.4);
+  color: hsl(24, 20%, 95%);
+  font: bold 65%/1.5 sans-serif;
+  text-align: center;
+  vertical-align: 0.3em;
+  border-radius: 999px;
+  text-shadow: none;
+  box-shadow: 0 1px white;
+}
+
+.line-highlight[data-end]:after {
+  content: attr(data-end);
+  top: auto;
+  bottom: 0.4em;
+}
+
+pre.line-numbers {
+  position: relative;
+  padding-left: 3.8em;
+  counter-reset: linenumber;
+}
+
+pre.line-numbers > code {
+  position: relative;
+}
+
+.line-numbers .line-numbers-rows {
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  font-size: 100%;
+  left: -3.8em;
+  width: 3em; /* works for line-numbers below 1000 lines */
+  letter-spacing: -1px;
+  border-right: 1px solid #999;
+
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.line-numbers-rows > span {
+  pointer-events: none;
+  display: block;
+  counter-increment: linenumber;
+}
+
+.line-numbers-rows > span:before {
+  content: counter(linenumber);
+  color: #999;
+  display: block;
+  padding-right: 0.8em;
+  text-align: right;
+}

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -98,7 +98,7 @@
     background-color: $ui-03;
   }
 
-  .#{$prefix}--data-table th:first-of-type:not(.#{$prefix}--table-expand th) {
+  .#{$prefix}--data-table th:first-of-type:not(.#{$prefix}--table-expand) {
     padding-left: $spacing-05;
   }
 

--- a/packages/components/src/components/date-picker/_flatpickr.scss
+++ b/packages/components/src/components/date-picker/_flatpickr.scss
@@ -338,7 +338,6 @@
 }
 .flatpickr-current-month .numInputWrapper {
   width: 6ch;
-  width: 7ch\0;
   display: inline-block;
 }
 .flatpickr-current-month .numInputWrapper span.arrowUp:after {

--- a/packages/components/src/components/form/_form.scss
+++ b/packages/components/src/components/form/_form.scss
@@ -106,17 +106,15 @@
     z-index: 0;
     opacity: 1;
     margin-bottom: $carbon--spacing-03;
+
+    @include carbon--breakpoint('sm') {
+      max-width: 75%;
+    }
   }
 
   .#{$prefix}--label--disabled,
   .#{$prefix}--form__helper-text--disabled {
     color: $disabled-02;
-  }
-
-  @media (min-width: breakpoint('sm')) {
-    .#{$prefix}--form__helper-text {
-      max-width: 75%;
-    }
   }
 }
 

--- a/packages/components/src/components/number-input/_number-input.scss
+++ b/packages/components/src/components/number-input/_number-input.scss
@@ -56,7 +56,7 @@
       fill: $disabled;
     }
 
-    appearance: textfield; // Firefox: Hide spinner (up and down buttons)
+    -moz-appearance: textfield; // Firefox: Hide spinner (up and down buttons)
 
     &::-ms-clear {
       display: none; // IE: Hide "clear-field" `x` button on input field

--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -114,7 +114,6 @@
       box-shadow: none;
       z-index: auto;
       transition: inherit;
-      max-height: auto;
       width: auto;
     }
   }

--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -113,14 +113,9 @@
 
   // Skeleton state
   .#{$prefix}--tag.#{$prefix}--skeleton {
+    @include skeleton;
     width: rem(60px);
-
-    &:after {
-      @include skeleton;
-      content: '';
-      height: rem(6px);
-      width: 100%;
-    }
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3688

Cleans up some CSS [errors](https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Funpkg.com%2Fcarbon-components%4010.4.1%2Fcss%2Fcarbon-components.min.css&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en) we've had in our code base 

<img width="1251" alt="Screen Shot 2019-08-08 at 1 54 39 PM" src="https://user-images.githubusercontent.com/11928039/62737212-19eaa180-b9e4-11e9-8ad8-00bff8d18f07.png">


#### Changelog

**Changed**

- `Tag` skeleton now works properly 

**Removed**

- Extra code that was causing errors and not rendering anyways

#### Testing / Reviewing

Check `/demo/demo.css` at https://jigsaw.w3.org/css-validator/#validate_by_input and ensure there are no errors (Helps to comment out `L86 - L124` in `/demo/scss/demo.scss` to reduce custom property errors
