### PR TITLE
fix(cli): address default remote configuration

### DIFF
--- a/packages/cli/src/commands/release.js
+++ b/packages/cli/src/commands/release.js
@@ -53,7 +53,7 @@ async function release({ bump }) {
   logger.start('Getting latest tag');
 
   // Make sure we've fetched the latest tags from upstream
-  await execa('git', ['pull', 'upstream', '--tags']);
+  await execa('git', ['pull', 'upstream', 'master', '--tags']);
   const { stdout: tagInfo } = await execa('git', [
     'tag',
     '-l',


### PR DESCRIPTION
Addresses the following issue for some git configurations:

```
You asked to pull from the remote 'upstream', but did not specify
a branch. Because this is not the default configured remote
for your current branch, you must specify a branch on the command line.
```

#### Changelog

**New**

**Changed**

- Specify branch for `git pull upstream master --tags`

**Removed**
