### PR TITLE
rfc(themes): css custom properties

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -39,7 +39,13 @@
     align-items: center;
     justify-content: $accordion-justify-content;
     cursor: pointer;
+    --padding-top: #{rem(6px)};
+    --padding-right: 0;
+    --padding-bottom: #{rem(6px)};
+    --padding-left: 0;
     padding: rem(6px) 0;
+    padding: var(--padding-top) var(--padding-right) var(--padding-bottom)
+      var(--padding-left);
     flex-direction: $accordion-flex-direction;
     position: relative;
     width: 100%;
@@ -73,9 +79,16 @@
     @include focus-outline('reset');
     // Without flex basis and flex shrink being set here, our icon width can go
     // <16px and cause the icon to render in the incorrect artboard size
+    --flex-grow: 0;
+    --flex-shrink: 0;
+    --flex-basis: 1rem;
     flex: 0 0 1rem;
+    flex: var(--flex-grow) var(--flex-shrink) var(--flex-basis);
+    --width: 1rem;
     width: 1rem;
+    width: var(--width);
     height: 1rem;
+    height: var(--height);
     margin: $accordion-arrow-margin;
     fill: $ui-05;
     // TODO: RTL rotate(180deg);

--- a/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_inlined/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_inlined/_styles.scss
@@ -503,7 +503,7 @@ $tokens: (
   display-02: $display-02,
   display-03: $display-03,
   display-04: $display-04,
-);
+) !default;
 
 /// @param {Map} $map
 /// @access public

--- a/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_styles.scss
@@ -503,7 +503,7 @@ $tokens: (
   display-02: $display-02,
   display-03: $display-03,
   display-04: $display-04,
-);
+) !default;
 
 /// @param {Map} $map
 /// @access public

--- a/packages/components/src/globals/scss/vendor/@carbon/type/scss/_inlined/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/type/scss/_inlined/_styles.scss
@@ -503,7 +503,7 @@ $tokens: (
   display-02: $display-02,
   display-03: $display-03,
   display-04: $display-04,
-);
+) !default;
 
 /// @param {Map} $map
 /// @access public

--- a/packages/components/src/globals/scss/vendor/@carbon/type/scss/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/type/scss/_styles.scss
@@ -503,7 +503,7 @@ $tokens: (
   display-02: $display-02,
   display-03: $display-03,
   display-04: $display-04,
-);
+) !default;
 
 /// @param {Map} $map
 /// @access public

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -1,9 +1,84 @@
-$css--font-face: true;
-$css--reset: true;
+////////////////////////////////////////////////////////////////////////////////
+// These token transformations and defining custom properties in the `:root`
+// declaration block would need to be done in Carbon's default build. This set-
+// up is just to demonstrate how we can theme with custom properties.
+////////////////////////////////////////////////////////////////////////////////
 
-$prefix: 'bx';
+@import '~carbon-components/src/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
+@import '~carbon-components/src/globals/scss/vendor/@carbon/elements/scss/type/font-family';
+@import '~carbon-components/src/globals/scss/vendor/@carbon/elements/scss/type/styles';
 
-// IMPORTANT: This import path should _not_ be used outside our source tree
-// as `src` directory is _not_ meant to be shipped in our NPM package.
-// Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
-@import '~carbon-components/src/globals/scss/styles.scss'; // SEE THE NOTE ABOVE
+// transform color tokens as custom property variables instead of hex values
+// `$interactive-01: #0062ff;` becomes `$interactive-01: var(--interactive-01);`
+@each $key in map-keys($carbon--theme--white) {
+  $carbon--theme: map-merge(
+    $carbon--theme,
+    (
+      $key: var(--#{$key}),
+    )
+  );
+}
+
+// initialize custom properties
+// `--interactive-01: #0062ff;`
+:root {
+  @include carbon--theme($carbon--theme--white, true);
+
+  @each $tokenKey, $tokenValue in $tokens {
+    @each $key, $value in map-remove($tokenValue, 'breakpoints') {
+      --#{$tokenKey}-#{$key}: #{$value};
+    }
+  }
+}
+
+// transform type tokens as custom property variables instead px, rem, etc.
+@each $tokenKey, $token in $tokens {
+  $tokenIndex: index(($tokens), ($tokenKey $token));
+  $tokenNoBreakpoints: map-remove($token, 'breakpoints');
+
+  @each $propertyKey, $property in $tokenNoBreakpoints {
+    $propertyIndex: index(($token), ($propertyKey $property));
+    $propertyValue: var(--#{$tokenKey}-#{$propertyKey});
+
+    $tokenNoBreakpoints: map-merge(
+      $tokenNoBreakpoints,
+      (
+        $propertyKey: $propertyValue,
+      )
+    );
+  }
+
+  $tokens: map-merge(
+    $tokens,
+    (
+      $tokenKey: $tokenNoBreakpoints,
+    )
+  );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Below is an example of how one would build a custom theme.
+////////////////////////////////////////////////////////////////////////////////
+
+// import Carbon
+@import '~carbon-components/src/globals/scss/styles.scss';
+
+// treats accordion like a zone so the type changes affect the title and content
+.#{$prefix}--accordion {
+  --body-long-01-font-size: 1rem;
+  --body-long-01-line-height: 1.5rem;
+  --body-long-01-letter-spacing: 0;
+}
+
+// treats the element like a zone to override properties
+.#{$prefix}--accordion__heading {
+  --padding-top: #{rem(12px)};
+  --padding-bottom: #{rem(12px)};
+}
+
+// treats the element like a zone to override properties
+.#{$prefix}--accordion__arrow {
+  --flex-basis: 1.25rem;
+  --width: 1.25rem;
+  --height: 1.25rem;
+}

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -503,7 +503,7 @@ $tokens: (
   display-02: $display-02,
   display-03: $display-03,
   display-04: $display-04,
-);
+) !default;
 
 /// @param {Map} $map
 /// @access public


### PR DESCRIPTION
This RFC builds on previous theming explorations (https://github.com/carbon-design-system/carbon/pull/3306) (https://github.com/carbon-design-system/carbon/pull/3502) (https://github.com/carbon-design-system/carbon/pull/3554) with the 
goal of aligning on Carbon's theming direction, including the detailed tasks to get there. 
Once alignment, turn this RFC into an epic - no merge intent.

# Background

A few relevant definitions and principles from
[About Carbon](https://www.carbondesignsystem.com/getting-started/about-carbon):

- Carbon is IBM's open-source design system for digital products and experiences
- Carbon's foundation is the IBM Design Language (IDL)
- Carbon's elements and components elegantly work together to ensure consistent,
  cohesive user experiences
- Carbon's modularity ensures maximum flexibility in execution

Carbon is a lot, but at the same time, an important distinction is that Carbon
is not a utility-first CSS framework. Carbon is uniquely positioned by the
guiding philosophy and principles of the IDL. Carbon is opinionated towards IDL
adherence but there are scenarios where "maximum flexibility in execution" is
needed via theming:

- End-user customization
- Incremental adoption strategies
- IBM brand variances
- IBM services and community adoption

# Tokens and variables

#### Design tokens

Carbon uses tokens to provide consistency and shared vocabulary between design
and development. Those tokens are often authored in JavaScript so they can be
shared across platforms, tooling, and assets.

#### Sass variables

Carbon elements and components implement those tokens through Sass variables.
These build-time tokens make dynamic and zoned theming difficult by having to
deal with complex Sass builds (and re-builds), increased specificities, CSS
de-duping, etc.

#### CSS variables

The `@carbon/themes` package has an option to emit CSS custom properties, but
that has yet to be implemented throughout the components. Being run-time, custom
properties open many doors for advanced theming. Going forward in this RFC we'll
reference custom properties as "CSS variables".

# Recommendation

There is no one single theming approach that will fit all needs; theming
strategy depends the application's user experience, browser support, etc. But,
with the guiding IDL and modern styling practices, we can provide multiple
theming options to achieve the desired outcome.

#### Global theming

Our global tokens should remain in our public Sass API. That provides the
baseline theming capabilities through a Sass build. By default (with the ability
to disable), certain token categories should be implemented as CSS variables to
accommodate common theming scenarios.

| Category   | Package             | Sass variables | CSS variables |
| ---------- | ------------------- | -------------- | ------------- |
| Colors     | `@carbon/themes`    | Yes            | Yes           |
| Icons \*   | `@carbon/icons`     | Yes            | Yes \*\*      |
| Shape \*\* | `carbon-components` | Yes            | Yes \*\*      |
| Typography | `@carbon/type`      | Yes            | Yes \*\*      |
| Grid       | `@carbon/grid`      | Yes            | No            |
| Layout     | `@carbon/layout`    | Yes            | No            |
| Motion     | `@carbon/motion`    | Yes            | No            |
| Spacing    | `@carbon/layout`    | Yes            | No            |

\* Inline icon size, maybe best set in `@carbon/type` so if overriding type
token font size, you could also easily override inline icon size too (e.g. 14px
font pairs with 16px icon, 16px font pairs with 20px icon, etc.)

\*\* New

#### Component theming

Carbon currently supports a mix of global and component tokens in
`_theme-tokens.scss`. To prevent an unmaintainable number of component tokens to
support various theming needs, the recommendation is that all component
variables are designated as private in our Sass API. Instead, encourage CSS
overrides to customize components (through CSS variables if possible) when the
customizations can't be handled by the global tokens.

#### Browser support

It's up to you how you want to handle IE11, as IE11 does not support CSS custom
properties. One option would be the
[css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill), although
it has limitations like only supporting `:root` declarations.

Another option is to embrace graceful degradation where IE11 only gets the
build-time default theme.

Or, take a blended approach. For example, create a color theme through your Sass
build so IE11 picks up the color customizations, and a typography theme through
CSS variables that IE11 gracefully ignores.

# Tasks

Here's an initial list of high-level tasks that would need to be done to support
this theming strategy.

#### (1) Consolidate theming Sass map

The `@carbon/themes` has a mixin called `carbon--theme` that lets you set custom
color tokens, apply content, then reset the color tokens. E.g.:

```scss
@include carbon--theme($custom-theme-map) {
  @include button();
}
```

It would be great if the theming mixin supported all global token categories so
there was one way to override tokens > print styles > reset tokens in a Sass
build.

#### (2) Component entrypoint public mixins

Most, but not all, components have entrypoint mixins to prevent side-effects.
Every component needs a public entrypoint mixin, so you can use those in Sass
zoned themes. E.g.:

```scss
.my-dark-theme {
  @include carbon--theme($carbon--theme--g90) {
    @include accordion();
    @include button();
    @include breadcrumb();
  }
}
```

#### (3) Isolate component functions, mixins, variables

Related to (2), every component should have standardized `_functions.scss`,
`_mixins.scss`, and `_variables.scss` files that live alongside the rest of that
component's source. Isolating component styles will be necessary for future
component packages. This will clean up the `_theme-tokens.scss` to only global
tokens.

#### (4) Use CSS variables

Behind a feature flag that is defaulted to true, define all global CSS variables
on root. E.g.:

```scss
:root {
  --interactive-01: #0062ff;
  --interactive-02: #3d3d3d;
  --body-short-01-font-size: 0.75rem;
  --body-short-01-font-weight: 400;
  // couple hundred other variables
}
```

Then use the global CSS variables with appropriate fallbacks. E.g.:

```scss
.bx--btn--primary {
  background-color: #0062ff; // IE11 fallback
  background-color: var(--interactive-01);
}
```

Since the CSS variables are used at run-time, we'd need to namespace them to
prevent collisions. E.g. `--carbon-interactive-01`,

#### (5) New icon tokens

Inline icons are sized relative to font size. Currently, icons are hardcoded to
16px. If inline icons had a global token for size, they could easily be themed
alongside font-size customizations.

| Font size | Icon size |
| --------- | --------- |
| 14px      | 16px      |
| 16px      | 20px      |
| 20px      | 24px      |
| 24px      | 32px      |

#### (6) New shape tokens

One new global token that gets used on component elements that could receive a
non-zero border radius.

#### (7) PostCSS build

The idea is to identify CSS properties that would be good theming candidates:
`color`, `fill`, `background-color`, `margin`, `padding`, `border`, `height`,
`width`, `min-height`, `min-width`, `flex-basis` for starters.

With no changes to our SCSS source, we create unnamespaced CSS variables per
"themable property". This PostCSS build provided by Carbon. E.g. this:

```scss
.bx--element {
  color: $text-01;
  display: flex;
  padding: rem(6px) 0;
  transform: rotate(90deg);
}
```

Becomes:

```scss
.bx--element {
  --color: var(--text-01);
  color: #171717; // IE11 fallback
  color: var(--color);
  display: flex;
  --padding-top: 0.375rem;
  --padding-right: 0;
  --padding-bottom: 0.375rem;
  --padding-left: 0;
  padding: 0.375rem 0; // IE11 fallback
  padding: var(--padding-top) var(--padding-right) var(--padding-bottom) var(
      --padding-left
    );
  transform: rotate(90deg);
}
```

Unpacking this example: there is a build-time IE11 fallback. Color uses the
`text-01` global color token whose value would be its most immediate parent that
sets `--text-01`. That could be the page's root:

```scss
:root {
  --text-01: pink;
}
```

Or a zoned theme:

```scss
.my-pink-theme {
  --text-01: pink;
}
```

Also, properties could be set at the element level. E.g.:

```scss
.bx--element {
  --color: pink;
  --padding-right: 8px;
}
```

The theming mindset is that everything is a zone. That could be the entire page,
a container, or element. Theming at the element level feels very "CSS override",
but it allows ultimate flexibility and by using CSS variables, you could have
IE11 gracefully fall back to the default theme like any uses of page or
container-level themes.

#### (8) Document everything

Document everything from high-level theming strategy to technical approaches to
examples with pro/cons of each.

# Scenarios

TODO: Would it be helpful to provide examples and the pros/cons of each?

## Default color theme

#### Sass variables

#### CSS variables

## Zoned color theme

#### Sass variables

#### CSS variables

## Typography theme

#### Sass variables

#### CSS variables

## White label theme

#### Sass variables

#### CSS variables

# Changed files

Files changed in this PR are for demonstration purposes only, so components are
built using CSS variables. The first commit demonstrates how you could apply an "editorial theme" to the accordion (larger font-sizes, icon size, paddings). https://deploy-preview-3705--carbon-components-react.netlify.com/?path=/story/accordion--default