### PR TITLE
chore(react): update carbon-components peerDependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
     "storybook": "start-storybook -p 9000"
   },
   "peerDependencies": {
-    "carbon-components": "10.3.1",
+    "carbon-components": "^10.5.0",
     "carbon-icons": "^7.0.7",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
It seems like lerna does not update peerDependencies, so this update is to have it match the range ^10.5 that will match our upcoming release 👍 

In the future, this will be added to the endgame manual as a step to double-check.

#### Changelog

**New**

**Changed**

- Update peerDependency version of `carbon-components`

**Removed**
