### PR TITLE
fix(dropdown): add aria-disabled to dropdown

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -313,6 +313,7 @@ export default class ComboBox extends React.Component {
               <input
                 className={`${prefix}--text-input`}
                 aria-label={ariaLabel}
+                aria-disabled={disabled}
                 aria-controls={`${id}__menu`}
                 aria-autocomplete="list"
                 ref={this.textInput}

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -245,6 +245,7 @@ export default class Dropdown extends React.Component {
                 id={id}
                 tabIndex="0"
                 disabled={disabled}
+                aria-disabled={disabled}
                 translateWithId={translateWithId}
                 {...getButtonProps({ disabled })}>
                 <span

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -82,6 +82,7 @@ exports[`Dropdown should render 1`] = `
           tabIndex="-1"
         >
           <ListBoxField
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             aria-label="open menu"
@@ -98,6 +99,7 @@ exports[`Dropdown should render 1`] = `
           >
             <div
               aria-controls={null}
+              aria-disabled={false}
               aria-expanded={false}
               aria-haspopup={true}
               aria-label="Open menu"
@@ -255,6 +257,7 @@ exports[`Dropdown should render custom item components 1`] = `
           tabIndex="-1"
         >
           <ListBoxField
+            aria-disabled={false}
             aria-expanded={true}
             aria-haspopup={true}
             aria-label="close menu"
@@ -271,6 +274,7 @@ exports[`Dropdown should render custom item components 1`] = `
           >
             <div
               aria-controls="test-dropdown__menu"
+              aria-disabled={false}
               aria-expanded={true}
               aria-haspopup={true}
               aria-label="Close menu"
@@ -585,6 +589,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           tabIndex="-1"
         >
           <ListBoxField
+            aria-disabled={false}
             aria-expanded={true}
             aria-haspopup={true}
             aria-label="close menu"
@@ -601,6 +606,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           >
             <div
               aria-controls="test-dropdown__menu"
+              aria-disabled={false}
               aria-expanded={true}
               aria-haspopup={true}
               aria-label="Close menu"

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -314,6 +314,7 @@ export default class MultiSelect extends React.Component {
                     id={id}
                     tabIndex="0"
                     disabled={disabled}
+                    aria-disabled={disabled}
                     translateWithId={translateWithId}
                     {...getButtonProps({ disabled })}>
                     {selectedItem.length > 0 && (

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -94,6 +94,7 @@ exports[`MultiSelect should render 1`] = `
             tabIndex="-1"
           >
             <ListBoxField
+              aria-disabled={false}
               aria-expanded={false}
               aria-haspopup={true}
               aria-label="open menu"
@@ -110,6 +111,7 @@ exports[`MultiSelect should render 1`] = `
             >
               <div
                 aria-controls={null}
+                aria-disabled={false}
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="Open menu"


### PR DESCRIPTION
Adds in `aria-disabled` to the `Dropdown` component for a11y purposes. 

Since the `Dropdown` is rendered as a `div` element, the `disabled` attribute is [not supported](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-disabled). This uses `aria-disabled` to convey that the `Dropdown` is in a disabled state.

Was not sure if removing `disabled` from this element altogether would have adverse effects on other elements that may depend on it (ComboBox, Multi-select, etc..)