### PR TITLE
fix(dropdown): fix dropdown bugs, refine transitions

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -79,7 +79,7 @@ $list-box-menu-width: rem(300px);
     border-bottom: 1px solid $ui-04;
     cursor: pointer;
     color: $text-01;
-    transition: all $duration--fast-02 motion(standard, productive);
+    transition: all $duration--fast-01 motion(standard, productive);
 
     &:hover {
       background-color: $hover-ui;
@@ -315,7 +315,7 @@ $list-box-menu-width: rem(300px);
     position: absolute;
     right: $carbon--spacing-05;
     height: 100%;
-    transition: transform $duration--fast-02 motion(standard, productive);
+    transition: transform $duration--fast-01 motion(standard, productive);
     cursor: pointer;
   }
 
@@ -339,7 +339,7 @@ $list-box-menu-width: rem(300px);
     width: rem(30px);
     cursor: pointer;
     user-select: none;
-    transition: background-color $duration--fast-02 motion(standard, productive);
+    transition: background-color $duration--fast-01 motion(standard, productive);
 
     &:focus {
       @include focus-outline('outline');
@@ -417,6 +417,7 @@ $list-box-menu-width: rem(300px);
     cursor: pointer;
     user-select: none;
     position: relative;
+    transition: background $duration--fast-01 motion(standard, productive);
 
     &:hover {
       background-color: $hover-ui;
@@ -475,6 +476,8 @@ $list-box-menu-width: rem(300px);
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    transition: border-color $duration--fast-01 motion(standard, productive),
+      color $duration--fast-01 motion(standard, productive);
 
     &:focus {
       @include focus-outline('outline');
@@ -511,6 +514,14 @@ $list-box-menu-width: rem(300px);
     background-color: $hover-ui;
     color: $text-01;
     border-color: transparent;
+  }
+
+  .#{$prefix}--list-box__menu-item--highlighted
+    .#{$prefix}--list-box__menu-item__option,
+  .#{$prefix}--list-box__menu-item--highlighted
+    + .#{$prefix}--list-box__menu-item
+    .#{$prefix}--list-box__menu-item__option {
+    border-top-color: transparent;
   }
 
   .#{$prefix}--list-box__menu-item--highlighted


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3716

Adds selectors to hide border in React `Dropdown`, which is using `ListBox` styles. Cleaned up animations to match vanilla `Dropdown` component.

#### Changelog

**New**

- border, background-color transitions

**Removed**

- Borders that remained when the item was moused off of while Dropdown is open 

#### Testing / Reviewing

Open `Dropdown`, hover over an item, and then hover off the Dropdown. Ensure no border is added when Dropdown is moused off. 
