### PR TITLE
fix wrong react migration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ we support!
   to this repo.
 - 🏃‍♀️ Migration Guides
   - [v9 to v10 (vanilla)](./packages/components/docs/migration/migrate-to-10.x.md)
-  - [v9 to v10 (v6 to v7 React)](./packages/components/docs/migration/migrate-to-7.x.md)
+  - [v9 to v10 (v6 to v7 React)](./packages/react/docs/migration/migrate-to-7.x.md)
 
 ## 🙌 Contributing
 


### PR DESCRIPTION
the  link for [v9 to v10 (v6 to v7 React)] in README is wrong.  change to right one
