### PR TITLE
docs(developer): add publishing steps

### DIFF
--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -19,9 +19,12 @@
   - [Body](#body)
   - [Footer](#footer)
   - [Examples](#examples)
+- [Publishing](#publishing)
+  - [Publishing older library versions](#publishing-older-library-versions)
 - [FAQ](#faq)
     - [How do I install a dependency?](#how-do-i-install-a-dependency)
     - [CircleCI is failing saying that it cannot find a dependency in offline mode](#circleci-is-failing-saying-that-it-cannot-find-a-dependency-in-offline-mode)
+    - [How do I fix the repo state if I cancel during a publish?](#how-do-i-fix-the-repo-state-if-i-cancel-during-a-publish)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- prettier-ignore-end -->
@@ -259,6 +262,70 @@ considered a chore that we are doing to keep things up-to-date.
 
 </details>
 
+## Publishing
+
+### Publishing older library versions
+
+We offer ad-hoc backwards-support for older version of the system. This work is
+primarly driven by external contributors who may still need these older versions
+for legacy code. When updates are received and merged into the codebase, the
+release process will be a bit different than the one described above.
+
+For example, with
+[`carbon-components-react`](https://github.com/carbon-design-system/carbon-components-react)
+we have specific branches for older major versions like `v5` or `v6`. If we
+wanted to publish an update to either of these major versions, this process
+would look like:
+
+- Checkout the branch locally, making sure to pull in the latest from upstream
+- Manually update `package.json` with the new version to publish in a branch
+  called `chore/release-vX.Y.Z` and a commit message: `chore(release): vX.Y.Z`
+- Create a Pull Request with this new branch and commit message
+- Once this is merged into the branch, checkout locally and pull latest. Now we
+  can publish by running `npm publish .`, if you want to do a dry run first you
+  can do `npm publish . --dry-run`. This is helpful when dependencies may be
+  different than in newer versions of the system
+
+One important thing to verify is that `package.json` has a `publishConfig` field
+that looks like the following:
+
+```json
+{
+  "publishConfig": {
+    "tag": "<VERSION>.x"
+  }
+}
+```
+
+For example, `carbon-components-react` v5 would look like:
+
+```json
+{
+  "publishConfig": {
+    "tag": "5.x"
+  }
+}
+```
+
+This tag verifies that when we publish we do not publish to the `latest` tag but
+instead to the major-specific tag for the package.
+
+After running `npm publish .` and seeing the package publish to the registry,
+you could create a git tag by running:
+
+```bash
+git tag -a vX.Y.Z # The commit message should match vX.Y.Z
+```
+
+You should then push this tag to the project by running:
+
+```bash
+git push upstream vX.Y.Z
+```
+
+This helps keep track of what versions have been published and snapshotting the
+code at that point in time.
+
 ## FAQ
 
 #### How do I install a dependency?
@@ -280,3 +347,24 @@ yarn clean
 yarn cache clean
 yarn
 ```
+
+#### How do I fix the repo state if I cancel during a publish?
+
+The first things Lerna will do are create a git tag and update `package.json`
+versions. If you cancel before any packages publish, then you can do the
+following:
+
+```bash
+# Delete the specific tag, usually something like v0.1.0
+git tag -d name-of-tag
+```
+
+```bash
+# Undo the last commit
+git reset HEAD~
+
+# Remove all staged files
+git checkout -- .
+```
+
+You should be good to go after this!


### PR DESCRIPTION
Updates the developer handbook with steps to publish older versions of the system (used to live in the now deleted publishing.md file)

#### Changelog

**New**

**Changed**

- Add back in publishing steps for old version of the system

**Removed**
