### PR TITLE
refactor(tooltip): avoid calc inside `transform` for IE support

### DIFF
--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -246,7 +246,7 @@
       } @else if ($align == 'end') {
         right: 0;
         left: initial;
-        transform: translate(0, calc(#{$translate-body}));
+        transform: translate(0, 100%);
       } @else {
         transform: translate(-50%, 100%);
       }
@@ -261,10 +261,8 @@
     &.#{$prefix}--tooltip--a11y + .#{$prefix}--assistive-text {
       @if ($position == 'bottom') {
         bottom: -$body-spacing;
-        @if ($align == 'start') {
+        @if ($align == 'start' or $align == 'end') {
           transform: translate(0, 100%);
-        } @else if ($align == 'end') {
-          transform: translate(0, calc(#{$translate-body} - 1px));
         } @else {
           transform: translate(-50%, 100%);
         }

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -161,6 +161,7 @@
   ); // space between caret and trigger button
   $caret-height: rem(5px);
   $caret-width: rem(8px);
+  $body-spacing: $caret-spacing + $caret-height - rem(1px);
   $translate-caret: #{$caret-height} + #{$caret-spacing};
   $translate-body: 100% + #{$caret-spacing} + #{$caret-height};
   $rotate-caret: set-caret-rotation($position);
@@ -202,9 +203,10 @@
       transform: translate(calc(#{$translate-caret}), -50%);
     }
     @if ($position == 'bottom') {
+      bottom: -$caret-spacing;
       border-width: 0 rem(4px) rem(5px) rem(4px);
       border-color: transparent transparent $inverse-02 transparent;
-      transform: translate(-50%, calc(#{$translate-caret}));
+      transform: translate(-50%, 100%);
     }
     @if ($position == 'left') {
       border-width: rem(4px) 0 rem(4px) rem(5px);
@@ -239,7 +241,8 @@
     @if ($position == 'bottom') {
       @if ($align == 'start') {
         left: 0;
-        transform: translate(0, calc(#{$translate-body}));
+        bottom: -$body-spacing;
+        transform: translate(0, 100%);
       } @else if ($align == 'end') {
         right: 0;
         left: initial;
@@ -258,7 +261,8 @@
     &.#{$prefix}--tooltip--a11y + .#{$prefix}--assistive-text {
       @if ($position == 'bottom') {
         @if ($align == 'start') {
-          transform: translate(0, calc(#{$translate-body} - 1px));
+          bottom: -$body-spacing;
+          transform: translate(0, 100%);
         } @else if ($align == 'end') {
           transform: translate(0, calc(#{$translate-body} - 1px));
         } @else {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -161,7 +161,7 @@
   ); // space between caret and trigger button
   $caret-height: rem(5px);
   $caret-width: rem(8px);
-  $body-spacing: $caret-spacing + $caret-height - rem(1px);
+  $body-spacing: $caret-spacing + $caret-height;
   $translate-caret: #{$caret-height} + #{$caret-spacing};
   $translate-body: 100% + #{$caret-spacing} + #{$caret-height};
   $rotate-caret: set-caret-rotation($position);
@@ -260,7 +260,9 @@
   @if $tooltip-type == 'definition' {
     &.#{$prefix}--tooltip--a11y + .#{$prefix}--assistive-text {
       @if ($position == 'bottom') {
-        bottom: -$body-spacing;
+        bottom: -(
+            $body-spacing - rem(1px)
+          ); // carryover from https://github.com/carbon-design-system/carbon/pull/3151/files#diff-93734be0784e9530b6d14a7b03b0d352R261-R265
         @if ($align == 'start' or $align == 'end') {
           transform: translate(0, 100%);
         } @else {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -162,9 +162,6 @@
   $caret-height: rem(5px);
   $caret-width: rem(8px);
   $body-spacing: $caret-spacing + $caret-height;
-  $translate-caret: #{$caret-height} + #{$caret-spacing};
-  $translate-body: 100% + #{$caret-spacing} + #{$caret-height};
-  $rotate-caret: set-caret-rotation($position);
 
   // @todo Simplify CSS selectors on next major release
   &::before,

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -211,9 +211,10 @@
       transform: translate(-50%, 100%);
     }
     @if ($position == 'left') {
+      left: -$caret-spacing;
       border-width: rem(4px) 0 rem(4px) rem(5px);
       border-color: transparent transparent transparent $inverse-02;
-      transform: translate(calc(-1 * (#{$translate-caret})), -50%);
+      transform: translate(-100%, -50%);
     }
   }
 
@@ -256,7 +257,8 @@
       }
     }
     @if ($position == 'left') {
-      transform: translate(calc(-1 * (#{$translate-body})), -50%);
+      left: -$body-spacing;
+      transform: translate(-100%, -50%);
     }
   }
 

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -199,9 +199,10 @@
       transform: translate(-50%, -100%);
     }
     @if ($position == 'right') {
+      right: -$caret-spacing;
       border-width: rem(4px) rem(5px) rem(4px) 0;
       border-color: transparent $inverse-02 transparent transparent;
-      transform: translate(calc(#{$translate-caret}), -50%);
+      transform: translate(100%, -50%);
     }
     @if ($position == 'bottom') {
       bottom: -$caret-spacing;
@@ -238,7 +239,8 @@
       }
     }
     @if ($position == 'right') {
-      transform: translate(calc(#{$translate-body}), -50%);
+      right: -$body-spacing;
+      transform: translate(100%, -50%);
     }
     @if ($position == 'bottom') {
       bottom: -$body-spacing;

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -234,7 +234,7 @@
         transform: translate(0, calc(-1 * (#{$translate-body})));
       } @else {
         left: 50%;
-        transform: translate(-50%, calc(-1 * (#{$translate-body})));
+        transform: translate(-50%, -100%);
       }
     }
     @if ($position == 'right') {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -46,6 +46,11 @@
     align-items: center;
     opacity: 0;
     pointer-events: none;
+
+    // IE media query
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      display: inline-block;
+    }
   }
 
   &::before,
@@ -100,6 +105,11 @@
     transform: translateX(-50%);
     pointer-events: none;
     background-color: $inverse-02;
+
+    // IE media query
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      width: rem(208px);
+    }
   }
 
   &::after {
@@ -229,7 +239,7 @@
         transform: translate(0, -100%);
       } @else if ($align == 'end') {
         right: 0;
-        left: initial;
+        left: auto;
         transform: translate(0, -100%);
       } @else {
         left: 50%;
@@ -247,7 +257,7 @@
         transform: translate(0, 100%);
       } @else if ($align == 'end') {
         right: 0;
-        left: initial;
+        left: auto;
         transform: translate(0, 100%);
       } @else {
         transform: translate(-50%, 100%);

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -110,6 +110,13 @@
     @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
       width: rem(208px);
     }
+    // Edge 12-15 and Edge 16 feature queries
+    @supports (-ms-accelerator: true) {
+      width: rem(208px);
+    }
+    @supports (-ms-ime-align: auto) {
+      width: rem(208px);
+    }
   }
 
   &::after {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -239,16 +239,16 @@
       transform: translate(calc(#{$translate-body}), -50%);
     }
     @if ($position == 'bottom') {
+      bottom: -$body-spacing;
       @if ($align == 'start') {
         left: 0;
-        bottom: -$body-spacing;
         transform: translate(0, 100%);
       } @else if ($align == 'end') {
         right: 0;
         left: initial;
         transform: translate(0, calc(#{$translate-body}));
       } @else {
-        transform: translate(-50%, calc(#{$translate-body}));
+        transform: translate(-50%, 100%);
       }
     }
     @if ($position == 'left') {
@@ -260,13 +260,13 @@
   @if $tooltip-type == 'definition' {
     &.#{$prefix}--tooltip--a11y + .#{$prefix}--assistive-text {
       @if ($position == 'bottom') {
+        bottom: -$body-spacing;
         @if ($align == 'start') {
-          bottom: -$body-spacing;
           transform: translate(0, 100%);
         } @else if ($align == 'end') {
           transform: translate(0, calc(#{$translate-body} - 1px));
         } @else {
-          transform: translate(-50%, calc(#{$translate-body} - 1px));
+          transform: translate(-50%, 100%);
         }
       }
     }

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -231,7 +231,7 @@
       } @else if ($align == 'end') {
         right: 0;
         left: initial;
-        transform: translate(0, calc(-1 * (#{$translate-body})));
+        transform: translate(0, -100%);
       } @else {
         left: 50%;
         transform: translate(-50%, -100%);

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -193,9 +193,10 @@
 
   &::before {
     @if ($position == 'top') {
+      top: -$caret-spacing;
       border-width: rem(5px) rem(4px) 0 rem(4px);
       border-color: $inverse-02 transparent transparent transparent;
-      transform: translate(-50%, calc(-1 * (#{$translate-caret})));
+      transform: translate(-50%, -100%);
     }
     @if ($position == 'right') {
       border-width: rem(4px) rem(5px) rem(4px) 0;
@@ -223,9 +224,10 @@
   &:hover + .#{$prefix}--assistive-text,
   &:focus + .#{$prefix}--assistive-text {
     @if ($position == 'top') {
+      top: -$body-spacing;
       @if ($align == 'start') {
         left: 0;
-        transform: translate(0, calc(-1 * (#{$translate-body})));
+        transform: translate(0, -100%);
       } @else if ($align == 'end') {
         right: 0;
         left: initial;


### PR DESCRIPTION
Closes #3671

Related: #2781, #3115, #3151

This PR refactors tooltip positioning logic to avoid `calc()` usage inside of CSS `transform` (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/104773/). We now use a combination of TRBL positioning and CSS transforms rather than relying solely on CSS transforms.

We use explicit `rem` values for TRBL positioning (dictated by the spec), and we use percentage values to further translate the position of the tooltip caret and body depending on the desired position and alignment

#### Changelog

**New**

- media query for IE tooltip width and inline block `display`

**Changed**

- tooltip body positioning logic (pure `transform` to TRBL + `transform`)
- tooltip caret positioning logic (pure `transform` to TRBL + `transform`)

**Removed**

- now unused Sass variables
- unsupported `initial` and `max-content` values in IE

#### Testing / Reviewing

Ensure tooltips appear correct on all platforms and all existing use cases (including password input, icon-only button)

---

Regarding the point made by @tw15egan in the issue, we have a few options WRT `width: max-content` usage:

we can either apply a workaround for all browsers or add IE specific rules (I guess this is progressive enhancement vs graceful degradation?)