### PR TITLE
chore(icons-angular): update package to private

### DIFF
--- a/packages/icons-angular/package.json
+++ b/packages/icons-angular/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@carbon/icons-angular",
+  "private": true,
   "description": "Angular components for icons in digital and software products using the Carbon Design System",
   "version": "10.5.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
Quickfix for icons-angular to set package to `private`. This will prevent it from being published while it's in a broken state.