### PR TITLE
fix(content-switcher): set height in button container instead of button

### DIFF
--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -19,7 +19,7 @@
     display: flex;
     justify-content: space-evenly;
     width: 100%;
-    height: rem(32px);
+    height: rem(40px);
   }
 
   .#{$prefix}--content-switcher--disabled {
@@ -35,7 +35,6 @@
     display: inline-flex;
     align-items: center;
     width: 100%;
-    height: rem(40px);
     padding: $carbon--spacing-03 $carbon--spacing-05;
     margin: 0;
     white-space: nowrap;


### PR DESCRIPTION
The latest code that dictates the height of content switcher buttons is introduced in #2085, whereas the height of their (the buttons') container is dictated by code from older commit. Given the issue #2085 refers to (#1956) seems to request simply for the button's height and doesn't seem to mention how buttons' height should work with their container's height, this change moves the code to define the height back to the container.

@aledavila Please don't hesitate to speak up if I'm missing anything!

Fixes #3751.

#### Changelog

**Changed**

- A change to set content switcher button's height (`40px`) in their container, instead of in the buttons themselves.

#### Testing / Reviewing

Testing should make sure content switcher is not broken.