### PR TITLE
fix(tooltip): unable to control using open prop

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -165,7 +165,6 @@ class Tooltip extends Component {
   };
 
   static defaultProps = {
-    open: false,
     direction: DIRECTION_BOTTOM,
     renderIcon: Information,
     showIcon: true,
@@ -204,13 +203,11 @@ class Tooltip extends Component {
     /**
      * so that tooltip can be controlled programmatically through this `open` prop
      */
-    const { prevOpen } = state;
-    return prevOpen === open
-      ? null
-      : {
-          open,
-          prevOpen: open,
-        };
+	const currOpenState = state.open;
+	return (typeof open !== 'undefined' && currOpenState !== open)
+		? {
+			open
+		} : null;
   }
 
   getTriggerPosition = () => {


### PR DESCRIPTION
Fixes #2849

Making open prop single source of truth.

#### Changelog

**Changed**

- Tooltip.js

