### PR TITLE
fix(stalebot): update exemptLabel

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,7 +4,7 @@ daysUntilStale: 30
 daysUntilClose: 3
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - 'type: a11y ♿️'
+  - 'type: a11y ♿'
   - 'type: bug 🐛'
   - 'Severity 1 🚨'
   - 'priority: high'
@@ -12,9 +12,11 @@ exemptLabels:
 staleLabel: inactive
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  We've marked this issue as stale because there hasn't been any activity for a couple of weeks.
-  If there's no further activity on this issue in the next three days then we'll close it. You can
-  keep the conversation going with just a short comment. Thanks for your contributions.
+  We've marked this issue as stale because there hasn't been any activity for a
+  couple of weeks. If there's no further activity on this issue in the next
+  three days then we'll close it. You can keep the conversation going with just
+  a short comment. Thanks for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  As there's been no activity since this issue was marked as stale, we are auto-closing it.
+  As there's been no activity since this issue was marked as stale, we are
+  auto-closing it.


### PR DESCRIPTION
Noticed type: a11y ♿ labels were not properly being exempted and were having `inactive` labels added. I copied the text from the label edit screen directly and pasted it into the label exemptions, so hopefully, this will correctly exempt them. 

(Not sure why it is saying I changed the entire file, the editor only showed 1 line changed 🤔