### PR TITLE
fix(stalebot): update stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,7 +4,7 @@ daysUntilStale: 30
 daysUntilClose: 3
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - 'type: a11y ♿️'
+  - 'type: a11y ♿'
   - 'type: bug 🐛'
   - 'Severity 1 🚨'
   - 'priority: high'


### PR DESCRIPTION
Noticed type: a11y ♿ labels were not properly being exempted and were having `inactive` labels added. I copied the text from the label edit screen directly and pasted it into the label exemptions, so hopefully, this will correctly exempt them. 