### PR TITLE
chore(storybook): update brand url to new monorepo pkg

### DIFF
--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -15,7 +15,8 @@ addParameters({
   options: {
     theme: {
       brandTitle: 'carbon components react',
-      brandUrl: 'https://github.com/carbon-design-system/carbon/tree/master/packages/react',
+      brandUrl:
+        'https://github.com/carbon-design-system/carbon/tree/master/packages/react',
     },
   },
 });

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -15,7 +15,7 @@ addParameters({
   options: {
     theme: {
       brandTitle: 'carbon components react',
-      brandUrl: 'https://github.com/IBM/carbon-components-react',
+      brandUrl: 'https://github.com/carbon-design-system/carbon/tree/master/packages/react',
     },
   },
 });


### PR DESCRIPTION
Currently if you click on the brand link in the top left of storybook, it goes to the old deprecated React repo. This change will update the link to the new package location.

#### Changelog

**Changed**

- update `brandURL` to new monorepo React package URL