### PR TITLE
fix(tile): a11y fixes for expandable tile

### DIFF
--- a/packages/components/src/components/tile/_tile.scss
+++ b/packages/components/src/components/tile/_tile.scss
@@ -110,7 +110,7 @@
 
   .#{$prefix}--tile--expandable {
     overflow: hidden;
-    transition: $duration--moderate-01 motion(standard, productive);
+    transition: max-height $duration--moderate-01 motion(standard, productive);
   }
 
   .#{$prefix}--tile-content__above-the-fold {
@@ -119,21 +119,25 @@
 
   .#{$prefix}--tile-content__below-the-fold {
     display: block;
+    visibility: hidden;
     opacity: 0;
-    transition: $duration--fast-02 motion(standard, productive);
+    transition: opacity $duration--fast-02 motion(standard, productive),
+      visibility $duration--fast-02 motion(standard, productive);
   }
 
   .#{$prefix}--tile--is-expanded {
     overflow: visible;
-    transition: $duration--fast-02 motion(standard, productive);
+    transition: max-height $duration--fast-02 motion(standard, productive);
 
     .#{$prefix}--tile__chevron svg {
       transform: rotate(-180deg);
     }
 
     .#{$prefix}--tile-content__below-the-fold {
+      visibility: visible;
       opacity: 1;
-      transition: $duration--fast-02 motion(standard, productive);
+      transition: opacity $duration--fast-02 motion(standard, productive),
+        visibility $duration--fast-02 motion(standard, productive);
     }
   }
 

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -434,6 +434,21 @@ export class ExpandableTile extends Component {
     );
   };
 
+  handleKeyDown = evt => {
+    if (matches(evt, [keys.Enter, keys.Space])) {
+      evt.persist();
+      this.setState(
+        {
+          expanded: !this.state.expanded,
+        },
+        () => {
+          this.setMaxHeight();
+          this.props.handleClick(evt);
+        }
+      );
+    }
+  };
+
   getChildren = () => {
     return React.Children.map(this.props.children, child => child);
   };
@@ -448,23 +463,24 @@ export class ExpandableTile extends Component {
       tileMaxHeight, // eslint-disable-line
       tilePadding, // eslint-disable-line
       handleClick, // eslint-disable-line
-      expanded, // eslint-disable-line
       tileCollapsedIconText, // eslint-disable-line
       tileExpandedIconText, // eslint-disable-line
       ...other
     } = this.props;
 
+    const { expanded } = this.state;
+
     const classes = classNames(
       `${prefix}--tile`,
       `${prefix}--tile--expandable`,
       {
-        [`${prefix}--tile--is-expanded`]: this.state.expanded,
+        [`${prefix}--tile--is-expanded`]: expanded,
       },
       className
     );
 
     const tileStyle = {
-      maxHeight: this.state.expanded
+      maxHeight: expanded
         ? null
         : this.state.tileMaxHeight + this.state.tilePadding,
     };
@@ -482,20 +498,18 @@ export class ExpandableTile extends Component {
         className={classes}
         {...other}
         onClick={this.handleClick}
+        onKeyPress={this.handleKeyDown}
         tabIndex={tabIndex}>
         <button
           className={`${prefix}--tile__chevron`}
-          aria-labelledby={buttonId}>
+          aria-labelledby={buttonId}
+          aria-expanded={expanded}>
           <ChevronDown16
             id={buttonId}
-            aria-label={
-              this.state.expanded ? tileExpandedIconText : tileCollapsedIconText
-            }
-            alt={
-              this.state.expanded ? tileExpandedIconText : tileCollapsedIconText
-            }
+            aria-label={expanded ? tileExpandedIconText : tileCollapsedIconText}
+            alt={expanded ? tileExpandedIconText : tileCollapsedIconText}
             description={
-              this.state.expanded ? tileExpandedIconText : tileCollapsedIconText
+              expanded ? tileExpandedIconText : tileCollapsedIconText
             }
           />
         </button>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3375
Closes https://github.com/carbon-design-system/carbon/issues/3374

A few a11y fixes for `ExpandableTile`

#### Changelog

**New**

- Keyboard opens / closes `ExpandableTile`
- `aria-expanded` role on `ExpandableTile`

**Changed**

- Below-the-fold text is hidden so it is not read when the `ExpandableTile` is collapsed
- Tweaked the transitions

**Removed**

- `expanded` being pulled from `this.props`, as it was not being used anywhere. Instead, we were pulling `expanded` from `this.state`, which was then shortened in this PR.

#### Testing / Reviewing

- Open `ExpandableTile`, try opening with the keyboard. Ensure `aria-expanded` is toggled. Make sure there are no DAP errors. 
