### PR TITLE
fix(TableToolbarSearch): support back-tab

### DIFF
--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -230,6 +230,11 @@
   .#{$prefix}--toolbar-action:focus:not([disabled]),
   .#{$prefix}--toolbar-action:active:not([disabled]) {
     @include focus-outline('outline');
+
+    &.#{$prefix}--toolbar-search-container-expandable {
+      // The focus style is handled by search input in it, need to avoid duplicate animation
+      outline: none;
+    }
   }
 
   .#{$prefix}--toolbar-action ~ .#{$prefix}--btn {

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -7,7 +7,7 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useMemo, useRef, useState, useEffect } from 'react';
 import { settings } from 'carbon-components';
 import Search from '../Search';
 import setupGetInstanceId from './tools/instanceId';
@@ -34,7 +34,7 @@ const TableToolbarSearch = ({
   onExpand,
   persistent,
   persistant,
-  id = `data-table-search-${getInstanceId()}`,
+  id,
   ...rest
 }) => {
   const { current: controlled } = useRef(expandedProp !== undefined);
@@ -42,12 +42,13 @@ const TableToolbarSearch = ({
   const expanded = controlled ? expandedProp : expandedState;
   const searchRef = useRef(null);
   const [value, setValue] = useState('');
+  const uniqueId = useMemo(getInstanceId, []);
 
   useEffect(() => {
-    if (searchRef.current) {
+    if (!controlled && expandedState && searchRef.current) {
       searchRef.current.querySelector('input').focus();
     }
-  });
+  }, [controlled, expandedState]);
 
   const searchContainerClasses = cx({
     [searchContainerClass]: searchContainerClass,
@@ -82,7 +83,7 @@ const TableToolbarSearch = ({
 
   return (
     <div
-      tabIndex="0"
+      tabIndex={expandedState ? '-1' : '0'}
       role="searchbox"
       ref={searchRef}
       onClick={event => handleExpand(event, true)}
@@ -94,7 +95,7 @@ const TableToolbarSearch = ({
         small
         className={searchClasses}
         value={value}
-        id={id}
+        id={typeof id !== 'undefined' ? id : uniqueId}
         aria-hidden={!expanded}
         labelText={labelText || t('carbon.table.toolbar.search.label')}
         placeHolderText={


### PR DESCRIPTION
This change fixes the issue with `<TableToolbarSearch>` that happens when the `<input>` in it has focus and user performs back-tab gesture (Shift-Tab key).

In such scenario (in before-change version), the root element of `<TableToolbarSearch>` (`<div class="bx--toolbar-search-container-expandable">`) gets focus given it has `tabindex="0"`, and the `onFocus()` handler of the element attempts to send focus back to the `<input>` no matter what.

This change also fixes the following found in the debugging effort:

* An issue where `id` of `<Search>` in `<TableToolbarSearch>` is regenerated for every render
* Issues focus on `<input>` happening:
  * For every render, regardless of change in expanded state
  * Even for controlled change in expanded state (without user gesture)

Fixes #3762.

#### Changelog

**New**

- Code to memorize auto-generated unique ID
- Code to prevent focusing-on-`<input>` code from running
  - In controlled mode
  - Unless the expanded state changes

**Changed**

- The `tabindex` of the outer container of `<TableToolbarSearch>`, so it's focusable only when it's collapsed

**Removed**

- Focus style of the outer container of `<TableToolbarSearch>` given the `<input>` in it handles that

#### Testing / Reviewing

Testing should make sure `<TableToolbarSearch>` is not broken.