### PR TITLE
refactor(TableToolbarSearch): remove unused classname

### DIFF
--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -59,11 +59,6 @@ const TableToolbarSearch = ({
       persistent || persistant,
   });
 
-  const searchClasses = cx({
-    className,
-    [`${prefix}--search-maginfier`]: true,
-  });
-
   const handleExpand = (event, value = !expanded) => {
     if (!controlled && (!persistent || (!persistent && !persistant))) {
       setExpandedState(value);
@@ -92,7 +87,7 @@ const TableToolbarSearch = ({
       <Search
         {...rest}
         small
-        className={searchClasses}
+        className={className}
         value={value}
         id={id}
         aria-hidden={!expanded}

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2235,7 +2235,6 @@ exports[`DataTable should render 1`] = `
                 >
                   <Search
                     aria-hidden={true}
-                    className="bx--search-maginfier"
                     closeButtonLabelText="Clear search input"
                     id="custom-id"
                     labelText="Filter table"
@@ -2246,7 +2245,7 @@ exports[`DataTable should render 1`] = `
                     value=""
                   >
                     <div
-                      className="bx--search bx--search--sm bx--search-maginfier"
+                      className="bx--search bx--search--sm"
                     >
                       <ForwardRef(Search16)
                         className="bx--search-magnifier"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -18,7 +18,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
   >
     <Search
       aria-hidden={true}
-      className="className bx--search-maginfier"
+      className="custom-class"
       closeButtonLabelText="Clear search input"
       id="custom-id"
       labelText="Filter table"
@@ -29,7 +29,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
       value=""
     >
       <div
-        className="bx--search bx--search--sm className bx--search-maginfier"
+        className="bx--search bx--search--sm custom-class"
       >
         <ForwardRef(Search16)
           className="bx--search-magnifier"


### PR DESCRIPTION
Closes #3838

#### Changelog

**Removed**

- unused class name

#### Testing / Reviewing

Ensure `<TableToolbarSearch>` in `<DataTable>` appears correct
