### PR TITLE
fix(checkbox): reverse label text

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.hbs
+++ b/packages/components/src/components/checkbox/checkbox.hbs
@@ -40,7 +40,7 @@
   </div>
 </fieldset>
 <fieldset class="{{@root.prefix}}--fieldset">
-  <legend class="{{@root.prefix}}--label">Checkbox (input > label)</legend>
+  <legend class="{{@root.prefix}}--label">Checkbox (label > input)</legend>
   <!-- label > input -->
   <div class="{{@root.prefix}}--form-item {{@root.prefix}}--checkbox-wrapper">
     <label for="{{@root.prefix}}--checkbox-new2" class="{{@root.prefix}}--checkbox-label">


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/176

The label text was in reverse order 