### PR TITLE
chore(Tooltip): cleanup and remove outdated `clickToOpen` tests

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip-test.js
+++ b/packages/react/src/components/Tooltip/Tooltip-test.js
@@ -131,98 +131,8 @@ describe('Tooltip', () => {
   });
 
   describe('events', () => {
-    it('click changes state when clickToOpen is set', () => {
-      const wrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
-      const icon = wrapper.find(Information);
-      icon.simulate('click');
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(true);
-      icon.simulate('click');
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(false);
-    });
-
-    it('click changes state when clickToOpen and custom icon are set', () => {
-      const wrapper = mount(
-        <Tooltip
-          renderIcon={React.forwardRef((props, ref) => (
-            <div className="custom-icon" ref={ref} />
-          ))}
-          clickToOpen
-          triggerText="Tooltip"
-        />
-      );
-      const icon = wrapper.find('.custom-icon');
-      icon.simulate('click');
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(true);
-      icon.simulate('click');
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(false);
-    });
-
-    it('Enter key press changes state when clickToOpen is set', () => {
-      const wrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
-      const icon = wrapper.find(Information);
-      icon.simulate('keyDown', { key: 'Enter', which: 13 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(true);
-      icon.simulate('keyDown', { which: 13 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(false);
-    });
-
-    it('Enter key press changes state when clickToOpen and custom icon are set', () => {
-      const wrapper = mount(
-        <Tooltip
-          renderIcon={React.forwardRef((props, ref) => (
-            <div className="custom-icon" ref={ref} />
-          ))}
-          clickToOpen
-          triggerText="Tooltip"
-        />
-      );
-      const icon = wrapper.find('.custom-icon');
-      icon.simulate('keyDown', { key: 'Enter', which: 13 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(true);
-      icon.simulate('keyDown', { which: 13 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(false);
-    });
-
-    it('Space key press changes state when clickToOpen is set', () => {
-      const wrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
-      const icon = wrapper.find(Information);
-      icon.simulate('keyDown', { key: ' ', which: 32 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(true);
-      icon.simulate('keyDown', { which: 32 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(false);
-    });
-
-    it('Space key press changes state when clickToOpen and custom icon are set', () => {
-      const wrapper = mount(
-        <Tooltip
-          renderIcon={React.forwardRef((props, ref) => (
-            <div className="custom-icon" ref={ref} />
-          ))}
-          clickToOpen
-          triggerText="Tooltip"
-        />
-      );
-      const icon = wrapper.find('.custom-icon');
-      icon.simulate('keyDown', { key: ' ', which: 32 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(true);
-      icon.simulate('keyDown', { which: 32 });
-      // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
-      expect(wrapper.find('Tooltip').instance().state.open).toEqual(false);
-    });
-
     it('A different key press does not change state', () => {
-      const wrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
+      const wrapper = mount(<Tooltip triggerText="Tooltip" />);
       const icon = wrapper.find(Information);
       icon.simulate('keyDown', { which: 'x' });
       // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
@@ -235,7 +145,6 @@ describe('Tooltip', () => {
           renderIcon={React.forwardRef((props, ref) => (
             <div className="custom-icon" ref={ref} />
           ))}
-          clickToOpen
           triggerText="Tooltip"
         />
       );
@@ -246,7 +155,7 @@ describe('Tooltip', () => {
     });
 
     it('should be in a closed state after handleOutsideClick() is invoked', () => {
-      const rootWrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
+      const rootWrapper = mount(<Tooltip triggerText="Tooltip" />);
       // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
       expect(rootWrapper.find('Tooltip').instance().state.open).toBeFalsy();
       // Enzyme doesn't seem to allow setState() in a forwardRef-wrapped class component
@@ -292,7 +201,7 @@ describe('Tooltip', () => {
 
   describe('getTriggerPosition', () => {
     it('sets triggerPosition when triggerEl is set', () => {
-      const rootWrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
+      const rootWrapper = mount(<Tooltip triggerText="Tooltip" />);
       // Enzyme doesn't seem to allow setState() in a forwardRef-wrapped class component
       rootWrapper
         .find('Tooltip')
@@ -314,7 +223,7 @@ describe('Tooltip', () => {
       });
     });
     it('does not set triggerPosition when triggerEl is not set', () => {
-      const rootWrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
+      const rootWrapper = mount(<Tooltip triggerText="Tooltip" />);
       // Enzyme doesn't seem to allow setState() in a forwardRef-wrapped class component
       rootWrapper
         .find('Tooltip')


### PR DESCRIPTION
Closes #3864

The interactive tooltip's `clickToOpen` prop no longer needs to be tested for since it's been removed from the library, so this PR removes outdated tests and cleans up the remaining tests that still set the prop

#### Changelog

**Removed**

- outdated interactive tooltip tests referencing `clickToOpen`

#### Testing / Reviewing

Ensure the interactive tooltip still has sufficient test coverage
