### PR TITLE
feat(FileUploader): add drag and drop file uploader

### DIFF
--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -31,7 +31,6 @@
   .#{$prefix}--file--label {
     @include reset;
     @include type-style('heading-01');
-
     color: $text-01;
     margin-bottom: $carbon--spacing-03;
   }
@@ -40,10 +39,58 @@
     @include hidden;
   }
 
+  /// This class is of old markup with "select file" button
+  /// New code should use link-style "select file" UI (`.bx--file-browse-btn`)
+  /// @deprecated
   .#{$prefix}--file-btn {
     display: inline-flex;
     margin: 0;
     padding-right: rem(64px);
+  }
+
+  .#{$prefix}--file-browse-btn {
+    margin-bottom: $carbon--spacing-03;
+    display: inline-block;
+    width: 100%;
+    color: $link-01;
+    outline: none;
+    transition: $duration--fast-02 motion(standard, productive);
+    cursor: pointer;
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+
+    &:focus,
+    &:hover {
+      outline: 2px solid $interactive-03;
+    }
+
+    &:hover,
+    &:focus,
+    &:active,
+    &:active:visited {
+      text-decoration: underline;
+    }
+
+    &:active {
+      color: $text-01;
+    }
+  }
+
+  .#{$prefix}--file-browse-btn--disabled {
+    cursor: no-drop;
+    text-decoration: none;
+    color: $disabled-02;
+
+    &:hover,
+    &:focus {
+      outline: none;
+      text-decoration: none;
+      color: $disabled-02;
+    }
+  }
+
+  .#{$prefix}--file-browse-btn--disabled .#{$prefix}--file__drop-container {
+    border: 1px dashed $disabled-01;
   }
 
   .#{$prefix}--label-description {
@@ -54,65 +101,104 @@
     margin-bottom: $carbon--spacing-05;
   }
 
-  .#{$prefix}--file-container {
-    display: block;
-    width: 100%;
+  .#{$prefix}--file-btn ~ .#{$prefix}--file-container {
     margin-top: $carbon--spacing-06;
   }
 
   .#{$prefix}--file__selected-file {
-    display: flex;
+    display: grid;
+    grid-gap: $carbon--spacing-03 $carbon--spacing-05;
+    grid-template-columns: 1fr auto;
+    grid-auto-rows: auto;
     align-items: center;
-    justify-content: space-between;
-    height: rem(40px);
-    max-width: rem(300px);
+    min-height: $carbon--spacing-07;
+    max-width: rem(320px);
     margin-bottom: $carbon--spacing-03;
-    padding: 0 $carbon--spacing-03 0 $carbon--spacing-05;
     background-color: $field-01;
-    overflow: hidden;
+    word-break: break-word;
 
     &:last-child {
       margin-bottom: 0;
     }
 
-    .#{$prefix}--inline-loading__animation,
-    .#{$prefix}--loading {
-      right: -0.25rem; // offset for loading svg container
-      width: 1.5rem;
-      height: 1.5rem;
+    .#{$prefix}--form-requirement {
+      grid-column-start: 1;
+      grid-column-end: -1;
+      max-height: none;
+      margin: 0;
     }
+
+    .#{$prefix}--loading {
+      width: $carbon--spacing-06;
+      height: $carbon--spacing-06;
+    }
+
+    .#{$prefix}--file-filename {
+      @include type-style('body-short-01');
+      margin-left: $carbon--spacing-05;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+  }
+
+  // TODO: deprecate this block
+  .#{$prefix}--file__selected-file--invalid__wrapper {
+    @include focus-outline('invalid');
+    outline-width: 1px;
+    background-color: $field-01;
+    max-width: rem(320px);
+    margin-bottom: $carbon--spacing-03;
   }
 
   .#{$prefix}--file__selected-file--invalid {
     @include focus-outline('invalid');
-    margin-bottom: $carbon--spacing-02;
+    outline-width: 1px;
+    padding: $carbon--spacing-04 0;
   }
 
+  .#{$prefix}--file__selected-file--invalid .#{$prefix}--form-requirement {
+    border-top: 1px solid $ui-03;
+    padding-top: $carbon--spacing-03;
+  }
+
+  .#{$prefix}--file__selected-file--invalid
+    .#{$prefix}--form-requirement__title,
+  .#{$prefix}--file__selected-file--invalid
+    .#{$prefix}--form-requirement__supplement {
+    @include type-style('label-01');
+    padding-right: $carbon--spacing-03;
+    padding-left: $carbon--spacing-05;
+  }
+
+  .#{$prefix}--file__selected-file--invalid
+    .#{$prefix}--form-requirement__supplement {
+    color: $text-01;
+  }
+
+  // TODO: deprecate
   .#{$prefix}--file__selected-file--invalid + .#{$prefix}--form-requirement {
+    @include type-style('caption-01');
     display: block;
     max-height: rem(200px);
     color: $support-01;
     font-weight: 400;
-    margin: 0 0 $carbon--spacing-03 0;
+    padding: $carbon--spacing-03 $carbon--spacing-05;
     overflow: visible;
   }
 
-  .#{$prefix}--file-filename {
-    @include type-style('body-short-01');
-    @include text-overflow(300px);
-    display: inline-block;
-    align-items: center;
+  .#{$prefix}--file__selected-file--invalid
+    + .#{$prefix}--form-requirement
+    .#{$prefix}--form-requirement__supplement {
+    padding-bottom: $carbon--spacing-03;
     color: $text-01;
-    margin-right: $carbon--spacing-05;
-    padding: 1px 0;
-    /*rtl:ignore*/
-    direction: ltr;
-    justify-content: flex-start; /*rtl:{flex-end}*/
   }
 
   .#{$prefix}--file__state-container {
     display: flex;
-    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    padding-right: $carbon--spacing-03;
 
     .#{$prefix}--loading__svg {
       stroke: $ui-05;
@@ -120,19 +206,60 @@
   }
 
   .#{$prefix}--file__state-container .#{$prefix}--file-complete {
-    fill: $support-02;
+    fill: $interactive-04;
     cursor: pointer;
+
+    &:focus {
+      @include focus-outline('border');
+    }
+
+    // for checkmark contrast
+    [data-icon-path='inner-path'] {
+      opacity: 1;
+      fill: $icon-03;
+    }
+  }
+
+  .#{$prefix}--file__state-container .#{$prefix}--file-invalid {
+    height: $carbon--spacing-05;
+    width: $carbon--spacing-05;
+    fill: $support-01;
+    margin-right: $carbon--spacing-03;
+  }
+
+  .#{$prefix}--file__state-container .#{$prefix}--file-close {
+    height: $carbon--spacing-05;
+    width: $carbon--spacing-05;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    fill: $icon-02;
 
     &:focus {
       @include focus-outline('border');
     }
   }
 
-  .#{$prefix}--file__state-container .#{$prefix}--file-close {
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 0;
+  .#{$prefix}--file__state-container .#{$prefix}--file-close svg path {
+    fill: $icon-02;
+  }
+
+  .#{$prefix}--file__drop-container {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    height: rem(96px);
+    max-width: rem(320px);
+    padding: $carbon--spacing-05;
+    overflow: hidden;
+    border: 1px dashed $ui-04;
+  }
+
+  .#{$prefix}--file__drop-container--drag-over {
+    background: none;
+    outline: 2px solid $interactive-03;
+    outline-offset: -2px;
   }
 }
 

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -45,6 +45,8 @@ describe('Carbon Components React', () => {
         "ExpandableTile",
         "FileUploader",
         "FileUploaderButton",
+        "FileUploaderDropContainer",
+        "FileUploaderItem",
         "FileUploaderSkeleton",
         "Filename",
         "Form",

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -10,7 +10,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-
 import {
   withKnobs,
   array,
@@ -19,10 +18,12 @@ import {
   select,
   text,
 } from '@storybook/addon-knobs';
+import { settings } from 'carbon-components';
 import FileUploader, { FileUploaderButton } from '../FileUploader';
 import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
 import Button from '../Button';
-import { settings } from 'carbon-components';
+import FileUploaderItem from './FileUploaderItem';
+import FileUploaderDropContainer from './FileUploaderDropContainer';
 
 const { prefix } = settings;
 const buttonKinds = {
@@ -75,6 +76,38 @@ const props = {
     name: text('Form item name: (name)', ''),
     multiple: boolean('Supports multiple files (multiple)', true),
   }),
+  fileUploaderItem: () => ({
+    name: text('Filename (name)', 'README.md'),
+    status: select('Status for file name (status)', filenameStatuses, 'edit'),
+    iconDescription: text('(iconDescription)', 'Icon description'),
+    onDelete: action('onDelete'),
+    invalid: boolean('Invalid (invalid)', false),
+    errorSubject: text(
+      'Error subject (errorSubject)',
+      'File size exceeds limit'
+    ),
+    errorBody: text(
+      'Error body (errorBody)',
+      '500kb max file size. Select a new file and try again.'
+    ),
+  }),
+  fileUploaderDropContainer: () => ({
+    labelText: text(
+      'Label text (labelText)',
+      'Drag and drop files here or click to upload'
+    ),
+    name: text('Form item name (name)', ''),
+    multiple: boolean('Supports multiple files (multiple)', true),
+    accept: array(
+      'Accepted MIME types or file extensions (accept)',
+      ['image/jpeg', 'image/png'],
+      ','
+    ),
+    disabled: boolean('Disabled (disabled)', false),
+    role: text('ARIA role of the button (role)', ''),
+    tabIndex: number('Tab index (tabIndex)', 0),
+    onChange: action('onChange'),
+  }),
 };
 
 storiesOf('FileUploader', module)
@@ -117,6 +150,39 @@ storiesOf('FileUploader', module)
         text: `
             The FileUploader components allow the user to upload any necessary files. This uses the FileUploaderButton and Filename components. Filename components will appear below the FileUploaderButton when files are added. Use the filenameStatus prop to control what icon appears in Filename ('edit', 'complete', or 'uploading').
           `,
+      },
+    }
+  )
+  .add(
+    'FileUploaderItem',
+    () => <FileUploaderItem {...props.fileUploaderItem()} />,
+    {
+      info: {
+        text: `
+          <FileUploaderItem /> represents an item that has been uploaded to the file uploader component. Use the \`status\` prop to control which icon appears ('edit', 'complete', or 'uploading').
+        `,
+      },
+    }
+  )
+  .add(
+    'FileUploaderDropContainer',
+    () => <FileUploaderDropContainer {...props.fileUploaderDropContainer()} />,
+    {
+      info: {
+        text:
+          '<FileUploaderDropContainer /> is a drag and drop file uploader which allows users to upload files via both the normal file selection dialog and by dragging and dropping files.',
+      },
+    }
+  )
+  .add(
+    'Drag and drop upload container example application',
+    () =>
+      require('./stories/drop-container').default(
+        props.fileUploaderDropContainer()
+      ),
+    {
+      info: {
+        text: 'Example application with drag and drop file uploader',
       },
     }
   )

--- a/packages/react/src/components/FileUploader/FileUploader-test.js
+++ b/packages/react/src/components/FileUploader/FileUploader-test.js
@@ -6,23 +6,81 @@
  */
 
 import React from 'react';
-import { CloseFilled16 } from '@carbon/icons-react';
-import FileUploader, { FileUploaderButton, Filename } from '../FileUploader';
-import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
-import { mount, shallow } from 'enzyme';
 import { settings } from 'carbon-components';
+import { Close16, CheckmarkFilled16 } from '@carbon/icons-react';
+import { mount, shallow } from 'enzyme';
+import FileUploader, { FileUploaderButton, Filename } from './FileUploader';
+import FileUploaderDropContainer from './FileUploaderDropContainer';
+import FileUploaderItem from './FileUploaderItem';
+import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
+import Loading from '../Loading';
 
 const { prefix } = settings;
 
 describe('Filename', () => {
-  const mountWrapper = mount(<Filename name={'trees.jpg'} />);
+  describe('renders as expected', () => {
+    const icons = [Loading, Close16, CheckmarkFilled16];
+    const statuses = ['uploading', 'edit', 'complete'];
+    statuses.forEach((status, i) => {
+      const wrapper = mount(
+        <Filename iconDescription="Upload complete" status={status} />
+      );
+
+      it('renders upload status icon as expected', () => {
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(icons[i]).length).toBe(1);
+      });
+    });
+  });
+
+  describe('Check that functions passed in as props are called', () => {
+    let wrapper;
+    let mockProps;
+
+    beforeEach(() => {
+      mockProps = {
+        onClick: jest.fn(),
+        onKeyDown: jest.fn(),
+        status: 'complete',
+      };
+      wrapper = mount(<Filename {...mockProps} />);
+    });
+
+    it('should call onClick', () => {
+      wrapper.simulate('click');
+      expect(mockProps.onClick).toBeCalled();
+    });
+
+    it('should call onKeyDown', () => {
+      wrapper.simulate('keydown');
+      expect(mockProps.onKeyDown).toBeCalled();
+    });
+  });
 
   describe('click on edit icon (close--solid)', () => {
     it('should have a click event', () => {
+      const mountWrapper = mount(
+        <Filename iconDescription="Upload complete" status="complete" />
+      );
       const onClick = jest.fn();
       mountWrapper.setProps({ onClick, status: 'edit' });
-      mountWrapper.find(CloseFilled16).simulate('click');
+      mountWrapper.find(Close16).simulate('click');
       expect(onClick).toBeCalled();
+    });
+  });
+});
+
+describe('FileUploaderItem', () => {
+  const mountWrapper = mount(
+    <FileUploaderItem file={{ name: 'jd.jpg', status: 'edit' }} />
+  );
+
+  describe('click on edit icon (close--solid)', () => {
+    it('should have a click event', () => {
+      const onDelete = jest.fn();
+      mountWrapper.setProps({ onDelete, status: 'edit' });
+      mountWrapper.find(Close16).simulate('click');
+      expect(onDelete).toBeCalled();
     });
   });
 });
@@ -192,6 +250,67 @@ describe('FileUploader', () => {
       mountWrapper.setState({ filenameStatus: 'edit' });
       mountWrapper.setProps({ filenameStatus: 'uploading' });
       expect(mountWrapper.state().filenameStatus).toEqual('edit');
+    });
+  });
+});
+
+describe('FileUploaderDropContainer', () => {
+  const dropContainer = <FileUploaderDropContainer className="extra-class" />;
+  const mountWrapper = mount(dropContainer);
+
+  describe('Renders as expected with default props', () => {
+    it('renders with given className', () => {
+      expect(mountWrapper.hasClass('extra-class')).toBe(true);
+    });
+
+    it('renders with default labelText prop', () => {
+      expect(mountWrapper.props().labelText).toEqual('Add file');
+    });
+
+    it('renders with default multiple prop', () => {
+      expect(mountWrapper.props().multiple).toEqual(false);
+    });
+
+    it('renders with default accept prop', () => {
+      expect(mountWrapper.props().accept).toEqual([]);
+    });
+
+    it('disables file upload input', () => {
+      const wrapper = shallow(dropContainer);
+      wrapper.setProps({ disabled: true });
+      expect(wrapper.find('input').prop('disabled')).toEqual(true);
+    });
+
+    it('does not have default role', () => {
+      expect(mountWrapper.props().role).not.toBeTruthy();
+    });
+
+    it('resets the input value onClick', () => {
+      const input = mountWrapper.find(`.${prefix}--file-input`);
+      input.instance().value = '';
+      const evt = { target: { value: input.instance().value } };
+      input.simulate('click', evt);
+
+      expect(evt.target.value).toEqual(null);
+    });
+  });
+
+  describe('Unique id props', () => {
+    it('each FileUploaderDropContainer should have a unique ID', () => {
+      const mountedDropContainers = mount(
+        <div>
+          <FileUploaderDropContainer className="extra-class" />
+          <FileUploaderDropContainer className="extra-class" />
+        </div>
+      );
+      const firstDropContainer = mountedDropContainers
+        .find(FileUploaderDropContainer)
+        .at(0);
+      const lastDropContainer = mountedDropContainers
+        .find(FileUploaderDropContainer)
+        .at(1);
+      const isEqual = firstDropContainer === lastDropContainer;
+      expect(isEqual).toBe(false);
     });
   });
 });

--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -10,9 +10,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import {
+  Close16,
+  WarningFilled16,
+  CheckmarkFilled16,
+} from '@carbon/icons-react';
+import Loading from '../Loading';
 import uid from '../../tools/uniqueId';
 import { ButtonTypes } from '../../prop-types/types';
-import { CloseFilled16, CheckmarkFilled16 } from '@carbon/icons-react';
 
 const { prefix } = settings;
 
@@ -194,71 +199,60 @@ export class FileUploaderButton extends Component {
   }
 }
 
-export class Filename extends Component {
-  static propTypes = {
-    /**
-     * Specify an optional object of styles to be applied inline to the root
-     * node
-     */
-    style: PropTypes.object,
-
-    /**
-     * Specify the status of the File Upload
-     */
-    status: PropTypes.oneOf(['edit', 'complete', 'uploading']),
-
-    /**
-     * Provide a description for the complete/close icon that can be read by screen readers
-     */
-    iconDescription: PropTypes.string,
-  };
-
-  static defaultProps = {
-    onKeyDown: () => {},
-    status: 'uploading',
-    style: {},
-    tabIndex: 0,
-  };
-
-  render() {
-    const { iconDescription, status, style, ...other } = this.props;
-
-    if (status === 'uploading') {
+export function Filename({ iconDescription, status, invalid, ...other }) {
+  switch (status) {
+    case 'uploading':
       return (
-        <div
-          className={`${prefix}--loading`}
-          style={{ ...style, width: '1rem', height: '1rem' }}
-          {...other}>
-          <svg className={`${prefix}--loading__svg`} viewBox="-42 -42 84 84">
-            <circle cx="0" cy="0" r="37.5" />
-          </svg>
-        </div>
+        <Loading description={iconDescription} withOverlay={false} small />
       );
-    } else if (status === 'edit') {
+    case 'edit':
       return (
-        <CloseFilled16
-          className={`${prefix}--file-close`}
-          aria-label={iconDescription}
-          style={style}
-          {...other}>
-          {iconDescription && <title>{iconDescription}</title>}
-        </CloseFilled16>
+        <>
+          {invalid && <WarningFilled16 className={`${prefix}--file-invalid`} />}
+          <Close16
+            className={`${prefix}--file-close`}
+            aria-label={iconDescription}
+            {...other}>
+            {iconDescription && <title>{iconDescription}</title>}
+          </Close16>
+        </>
       );
-    } else if (status === 'complete') {
+    case 'complete':
       return (
         <CheckmarkFilled16
           className={`${prefix}--file-complete`}
           aria-label={iconDescription}
-          style={style}
           {...other}>
           {iconDescription && <title>{iconDescription}</title>}
         </CheckmarkFilled16>
       );
-    } else {
+    default:
       return null;
-    }
   }
 }
+
+Filename.propTypes = {
+  /**
+   * Provide a description of the SVG icon to denote file upload status
+   */
+  iconDescription: PropTypes.string,
+
+  /**
+   * Status of the file upload
+   */
+  status: PropTypes.oneOf(['edit', 'complete', 'uploading']),
+
+  /**
+   * Provide a custom tabIndex value for the <Filename>
+   */
+  tabIndex: PropTypes.string,
+};
+
+Filename.defaultProps = {
+  iconDescription: 'Uploading file',
+  status: 'uploading',
+  tabIndex: '0',
+};
 
 export default class FileUploader extends Component {
   static propTypes = {

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
@@ -1,0 +1,192 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { settings } from 'carbon-components';
+import { keys, matches } from '../../internal/keyboard';
+import uniqueId from '../../tools/uniqueId';
+
+const { prefix } = settings;
+
+export default function FileUploaderDropContainer(props) {
+  const inputRef = useRef();
+  const {
+    accept,
+    className,
+    id,
+    disabled,
+    labelText,
+    multiple,
+    name,
+    onAddFiles,
+    role,
+    tabIndex,
+    ...other
+  } = props;
+  const uid = useRef(uniqueId());
+  const [isActive, setActive] = useState(false);
+  const labelClasses = classNames(`${prefix}--file-browse-btn`, {
+    [`${prefix}--file-browse-btn--disabled`]: disabled,
+  });
+  const dropareaClasses = classNames(`${prefix}--file__drop-container`, {
+    [`${prefix}--file__drop-container--drag-over`]: isActive,
+    [className]: className,
+  });
+  /**
+   * Filters the array of added files based on file type restrictions
+   * @param {Event} evt - Event object, used to get the list of files added
+   */
+  const validateFiles = evt => {
+    if (evt.type === 'drop') {
+      const acceptedTypes = new Set(accept);
+      return [...evt.dataTransfer.files].filter(
+        ({ name, type: mimeType = '' }) => {
+          const fileExtensionRegExp = new RegExp(/\.[0-9a-z]+$/, 'i');
+          const hasFileExtension = fileExtensionRegExp.test(name);
+          if (!hasFileExtension) {
+            return false;
+          }
+          const [fileExtension] = name.match(fileExtensionRegExp);
+          return (
+            acceptedTypes.has(mimeType) || acceptedTypes.has(fileExtension)
+          );
+        }
+      );
+    }
+    return [...evt.target.files];
+  };
+  const handleChange = evt => {
+    const addedFiles = validateFiles(evt);
+    return onAddFiles(evt, { addedFiles });
+  };
+  return (
+    <div
+      className={`${prefix}--file`}
+      onDragOver={evt => {
+        evt.stopPropagation();
+        evt.preventDefault();
+        if (disabled) {
+          return;
+        }
+        setActive(true);
+        evt.dataTransfer.dropEffect = 'copy';
+      }}
+      onDragLeave={evt => {
+        evt.stopPropagation();
+        evt.preventDefault();
+        if (disabled) {
+          return;
+        }
+        setActive(false);
+        evt.dataTransfer.dropEffect = 'move';
+      }}
+      onDrop={evt => {
+        evt.stopPropagation();
+        evt.preventDefault();
+        if (disabled) {
+          return;
+        }
+        setActive(false);
+        handleChange(evt);
+      }}>
+      <label
+        className={labelClasses}
+        htmlFor={id || uid.current}
+        role={role || 'button'}
+        tabIndex={tabIndex || 0}
+        onKeyDown={evt => {
+          if (matches(evt, [keys.Enter, keys.Space])) {
+            inputRef.current.click();
+          }
+        }}
+        {...other}>
+        <div className={dropareaClasses}>
+          {labelText}
+          <input
+            type="file"
+            id={id || uid.current}
+            className={`${prefix}--file-input`}
+            ref={inputRef}
+            tabIndex="-1"
+            disabled={disabled}
+            accept={accept}
+            name={name}
+            multiple={multiple}
+            onChange={handleChange}
+            onClick={evt => {
+              evt.target.value = null;
+            }}
+          />
+        </div>
+      </label>
+    </div>
+  );
+}
+
+FileUploaderDropContainer.propTypes = {
+  /**
+   * Provide a custom className to be applied to the container node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Provide a unique id for the underlying <input> node
+   */
+  id: PropTypes.string,
+
+  /**
+   * Provide the label text to be read by screen readers when interacting with
+   * this control
+   */
+  labelText: PropTypes.string.isRequired,
+
+  /**
+   * Specify if the component should accept multiple files to upload
+   */
+  multiple: PropTypes.bool,
+
+  /**
+   * Provide a name for the underlying <input> node
+   */
+  name: PropTypes.string,
+
+  /**
+   * Provide an accessibility role for the <FileUploaderButton>
+   */
+  role: PropTypes.string,
+
+  /**
+   * Provide a custom tabIndex value for the <FileUploaderButton>
+   */
+  tabIndex: PropTypes.number,
+
+  /**
+   * Specify whether file input is disabled
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Specify the types of files that this input should be able to receive
+   */
+  accept: PropTypes.arrayOf(PropTypes.string),
+
+  /**
+   * Event handler that is called after files are added to the uploader
+   * The event handler signature looks like `onAddFiles(evt, { addedFiles })`
+   */
+  onAddFiles: PropTypes.func,
+};
+
+FileUploaderDropContainer.defaultProps = {
+  tabIndex: 0,
+  labelText: 'Add file',
+  multiple: false,
+  onAddFiles: () => {},
+  accept: [],
+};

--- a/packages/react/src/components/FileUploader/FileUploaderItem.js
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { settings } from 'carbon-components';
+import classNames from 'classnames';
+import { Filename } from './FileUploader';
+import { keys, matches } from '../../internal/keyboard';
+import uid from '../../tools/uniqueId';
+
+const { prefix } = settings;
+
+export default function FileUploaderItem({
+  uuid,
+  name,
+  status,
+  iconDescription,
+  onDelete,
+  invalid,
+  errorSubject,
+  errorBody,
+  ...other
+}) {
+  const classes = classNames(`${prefix}--file__selected-file`, {
+    [`${prefix}--file__selected-file--invalid`]: invalid,
+  });
+  return (
+    <span className={classes} {...other}>
+      <p className={`${prefix}--file-filename`}>{name}</p>
+      <span className={`${prefix}--file__state-container`}>
+        <Filename
+          iconDescription={iconDescription}
+          status={status}
+          invalid={invalid}
+          onKeyDown={evt => {
+            if (matches(evt, [keys.Enter, keys.Space])) {
+              if (status === 'edit') {
+                onDelete(evt, { uuid });
+              }
+            }
+          }}
+          onClick={evt => {
+            if (status === 'edit') {
+              onDelete(evt, { uuid });
+            }
+          }}
+        />
+      </span>
+      {invalid &&
+        (errorSubject && (
+          <div className={`${prefix}--form-requirement`}>
+            <div className={`${prefix}--form-requirement__title`}>
+              {errorSubject}
+            </div>
+            {errorBody && (
+              <p className={`${prefix}--form-requirement__supplement`}>
+                {errorBody}
+              </p>
+            )}
+          </div>
+        ))}
+    </span>
+  );
+}
+
+FileUploaderItem.propTypes = {
+  /**
+   * Unique identifier for the file object
+   */
+  uuid: PropTypes.string.isRequired,
+
+  /**
+   * Name of the uploaded file
+   */
+  name: PropTypes.string,
+
+  /**
+   * Status of the file upload
+   */
+  status: PropTypes.oneOf(['uploading', 'edit', 'complete']),
+
+  /**
+   * Description of status icon (displayed in native tooltip)
+   */
+  iconDescription: PropTypes.string,
+
+  /**
+   * Specify if the currently uploaded file is invalid
+   */
+  invalid: PropTypes.bool,
+
+  /**
+   * Event handler that is called after removing a file from the file uploader
+   * The event handler signature looks like `onDelete(evt, { uuid })`
+   */
+  onDelete: PropTypes.func,
+
+  /**
+   * Error message subject for an invalid file upload
+   */
+  errorSubject: PropTypes.string,
+
+  /**
+   * Error message body for an invalid file upload
+   */
+  errorBody: PropTypes.string,
+};
+
+FileUploaderItem.defaultProps = {
+  uuid: uid(),
+  status: 'uploading',
+  onDelete: () => {},
+};

--- a/packages/react/src/components/FileUploader/__snapshots__/FileUploader-test.js.snap
+++ b/packages/react/src/components/FileUploader/__snapshots__/FileUploader-test.js.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Filename renders as expected renders upload status icon as expected 1`] = `
+<Filename
+  iconDescription="Upload complete"
+  status="uploading"
+  tabIndex="0"
+>
+  <Loading
+    active={true}
+    description="Upload complete"
+    small={true}
+    withOverlay={false}
+  >
+    <div
+      aria-label="Upload complete"
+      aria-live="assertive"
+      className="bx--loading bx--loading--small"
+    >
+      <svg
+        className="bx--loading__svg"
+        viewBox="-75 -75 150 150"
+      >
+        <title>
+          Upload complete
+        </title>
+        <circle
+          className="bx--loading__background"
+          cx="0"
+          cy="0"
+          r="37.5"
+        />
+        <circle
+          className="bx--loading__stroke"
+          cx="0"
+          cy="0"
+          r="37.5"
+        />
+      </svg>
+    </div>
+  </Loading>
+</Filename>
+`;
+
+exports[`Filename renders as expected renders upload status icon as expected 2`] = `
+<Filename
+  iconDescription="Upload complete"
+  status="edit"
+  tabIndex="0"
+>
+  <ForwardRef(Close16)
+    aria-label="Upload complete"
+    className="bx--file-close"
+    tabIndex="0"
+  >
+    <Icon
+      aria-label="Upload complete"
+      className="bx--file-close"
+      height={16}
+      preserveAspectRatio="xMidYMid meet"
+      tabIndex="0"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <svg
+        aria-label="Upload complete"
+        className="bx--file-close"
+        focusable="true"
+        height={16}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        style={
+          Object {
+            "willChange": "transform",
+          }
+        }
+        tabIndex="0"
+        viewBox="0 0 16 16"
+        width={16}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+        />
+        <title>
+          Upload complete
+        </title>
+      </svg>
+    </Icon>
+  </ForwardRef(Close16)>
+</Filename>
+`;
+
+exports[`Filename renders as expected renders upload status icon as expected 3`] = `
+<Filename
+  iconDescription="Upload complete"
+  status="complete"
+  tabIndex="0"
+>
+  <ForwardRef(CheckmarkFilled16)
+    aria-label="Upload complete"
+    className="bx--file-complete"
+    tabIndex="0"
+  >
+    <Icon
+      aria-label="Upload complete"
+      className="bx--file-complete"
+      height={16}
+      preserveAspectRatio="xMidYMid meet"
+      tabIndex="0"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <svg
+        aria-label="Upload complete"
+        className="bx--file-complete"
+        focusable="true"
+        height={16}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        style={
+          Object {
+            "willChange": "transform",
+          }
+        }
+        tabIndex="0"
+        viewBox="0 0 16 16"
+        width={16}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+        />
+        <path
+          d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+          data-icon-path="inner-path"
+          opacity="0"
+        />
+        <title>
+          Upload complete
+        </title>
+      </svg>
+    </Icon>
+  </ForwardRef(CheckmarkFilled16)>
+</Filename>
+`;

--- a/packages/react/src/components/FileUploader/index.js
+++ b/packages/react/src/components/FileUploader/index.js
@@ -6,5 +6,7 @@
  */
 
 export * from './FileUploader.Skeleton';
+export FileUploaderItem from './FileUploaderItem';
+export FileUploaderDropContainer from './FileUploaderDropContainer';
 export * from './FileUploader';
 export default from './FileUploader';

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { settings } from 'carbon-components';
+import FileUploaderItem from '../FileUploaderItem';
+import FileUploaderDropContainer from '../FileUploaderDropContainer';
+import FormItem from '../../FormItem';
+import uid from '../../../tools/uniqueId';
+
+const { prefix } = settings;
+
+function ExampleDropContainerApp(props) {
+  const [files, setFiles] = useState([]);
+  const uploadFile = async fileToUpload => {
+    // file size validation
+    if (fileToUpload.size > 512000) {
+      const updatedFile = {
+        ...fileToUpload,
+        status: 'edit',
+        iconDescription: 'Delete file',
+        invalid: true,
+        errorSubject: 'File size exceeds limit',
+        errorBody: '500kb max file size. Select a new file and try again.',
+      };
+      setFiles(files =>
+        files.map(file =>
+          file.uuid === fileToUpload.uuid ? updatedFile : file
+        )
+      );
+      return;
+    }
+
+    // simulate network request time
+    const rand = Math.random() * 1000;
+    setTimeout(() => {
+      const updatedFile = {
+        ...fileToUpload,
+        status: 'complete',
+        iconDescription: 'Upload complete',
+      };
+      setFiles(files =>
+        files.map(file =>
+          file.uuid === fileToUpload.uuid ? updatedFile : file
+        )
+      );
+    }, rand);
+
+    // show x icon after 1 second
+    setTimeout(() => {
+      const updatedFile = {
+        ...fileToUpload,
+        status: 'edit',
+        iconDescription: 'Delete file',
+      };
+      setFiles(files =>
+        files.map(file =>
+          file.uuid === fileToUpload.uuid ? updatedFile : file
+        )
+      );
+    }, rand + 1000);
+  };
+  const onAddFiles = useCallback(
+    (evt, { addedFiles }) => {
+      evt.stopPropagation();
+      const newFiles = addedFiles.map(file => ({
+        uuid: uid(),
+        name: file.name,
+        size: file.size,
+        status: 'uploading',
+        iconDescription: 'Uploading',
+      }));
+      props.multiple
+        ? setFiles([...files, ...newFiles])
+        : setFiles([...files, newFiles[0]]);
+      newFiles.forEach(uploadFile);
+    },
+    [files, props.multiple]
+  );
+  const handleFileUploaderItemClick = useCallback(
+    (evt, { uuid: clickedUuid }) =>
+      setFiles(files.filter(({ uuid }) => clickedUuid !== uuid)),
+    [files]
+  );
+  return (
+    <FormItem>
+      <strong className={`${prefix}--file--label`}>Account photo</strong>
+      <p className={`${prefix}--label-description`}>
+        Only .jpg and .png files. 500kb max file size
+      </p>
+      <FileUploaderDropContainer {...props} onAddFiles={onAddFiles} />
+      <div className="uploaded-files" style={{ width: '100%' }}>
+        {files.map(
+          ({ uuid, name, size, status, iconDescription, invalid, ...rest }) => (
+            <FileUploaderItem
+              key={uid()}
+              uuid={uuid}
+              name={name}
+              size={size}
+              status={status}
+              iconDescription={iconDescription}
+              invalid={invalid}
+              onDelete={handleFileUploaderItemClick}
+              {...rest}
+            />
+          )
+        )}
+      </div>
+    </FormItem>
+  );
+}
+
+export default props => <ExampleDropContainerApp {...props} />;

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -50,6 +50,8 @@ export Dropdown from './components/Dropdown';
 export FileUploader, {
   Filename,
   FileUploaderButton,
+  FileUploaderDropContainer,
+  FileUploaderItem,
 } from './components/FileUploader';
 export Form from './components/Form';
 export FormGroup from './components/FormGroup';


### PR DESCRIPTION
Closes #2088 
Closes #2916
Closes #2917 
Closes #3252

refs #2848 #3016 #3175

This PR adds drag and drop support to the React file uploader component.

#### Changelog

**New**

- `<FileUploaderDropContainer>` component to represent drop area for file uploads
- `<FileUploaderItem>` component to represented uploaded items
- example application showing drag and drop file uploader workflow, error handling, etc

**Changed**

- correct file upload status icons
- match invalid file upload markup structure with loading and success upload structures
- deprecate legacy styles
- convert `<Filename>` to stateless functional component

**Removed**

- replace hard coded loader with `<InlineLoading />` (to make use of #2955)

#### Testing / Reviewing

Ensure the new file uploader functions as expected and ensure the existing file loader does not have any regressions
