### PR TITLE
feat(react): add unstable_Grid components

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@carbon/icons-react": "10.5.0",
+    "@carbon/layout": "10.4.0",
     "classnames": "2.2.6",
     "downshift": "^1.31.14",
     "flatpickr": "4.6.1",

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -181,6 +181,9 @@ describe('Carbon Components React', () => {
         "TooltipDefinition",
         "TooltipIcon",
         "UnorderedList",
+        "unstable_Column",
+        "unstable_Grid",
+        "unstable_Row",
       ]
     `);
   });

--- a/packages/react/src/components/Layout/Column.js
+++ b/packages/react/src/components/Layout/Column.js
@@ -35,6 +35,8 @@ function unstable_Column({
   );
   const className = cx(
     {
+      // By default, we'll want to use an auto-column if no span or offset is
+      // given
       [`${prefix}--col`]:
         columnsPerBreakpoint.length === 0 && offsetsPerBreakpoint.length === 0,
       [`${prefix}--no-gutter`]: noGutter,
@@ -104,6 +106,15 @@ unstable_Column.propTypes = {
 
 const breakpoints = Object.keys(gridBreakpoints);
 
+/**
+ * Map a given object or array that represents breakpoint options to an array
+ * that will be used to specify column count classes. This should transform a
+ * given object in the shape: `{ sm: 4, md: 8, lg: 16}` into: `[4, 8, 16]`. Any
+ * gaps between breakpoints will be considered holes in the resulting array.
+ *
+ * @param {Array|object} object
+ * @returns {Array}
+ */
 function mapBreakpointsToArray(object) {
   if (Array.isArray(object)) {
     return object;

--- a/packages/react/src/components/Layout/Column.js
+++ b/packages/react/src/components/Layout/Column.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { breakpoints as gridBreakpoints } from '@carbon/layout';
+import { settings } from 'carbon-components';
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const { prefix } = settings;
+
+function unstable_Column({
+  as = 'div',
+  className: customClassName,
+  offset = [],
+  span = [],
+  noGutter,
+  noGutterLeft,
+  noGutterRight,
+  ...rest
+}) {
+  const columnsPerBreakpoint = mapBreakpointsToArray(span).map(
+    (columnCount, i) => {
+      return `${prefix}--col-${breakpoints[i]}-${columnCount}`;
+    }
+  );
+  const offsetsPerBreakpoint = mapBreakpointsToArray(offset).map(
+    (offsetCount, i) => {
+      return `${prefix}--offset-${breakpoints[i]}-${offsetCount}`;
+    }
+  );
+  const className = cx(
+    {
+      [`${prefix}--col`]:
+        columnsPerBreakpoint.length === 0 && offsetsPerBreakpoint.length === 0,
+      [`${prefix}--no-gutter`]: noGutter,
+      [`${prefix}--no-gutter--left`]: noGutterLeft,
+      [`${prefix}--no-gutter--right`]: noGutterRight,
+    },
+    ...columnsPerBreakpoint,
+    ...offsetsPerBreakpoint,
+    customClassName
+  );
+
+  return React.createElement(as, {
+    ...rest,
+    className,
+  });
+}
+
+const breakpointPropType = PropTypes.oneOfType([
+  PropTypes.arrayOf(PropTypes.number),
+  PropTypes.shape({
+    sm: PropTypes.number,
+    md: PropTypes.number,
+    lg: PropTypes.number,
+    xlg: PropTypes.number,
+    max: PropTypes.number,
+  }),
+]);
+
+unstable_Column.propTypes = {
+  /**
+   * Provide a custom element to render instead of the default <div>
+   */
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+  /**
+   * Provide a custom className to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the number of columns to offset in either an object syntax or in an
+   * array syntax
+   */
+  offset: breakpointPropType,
+
+  /**
+   * Specify the number of columns to span in either an object syntax or in an
+   * array syntax
+   */
+  span: breakpointPropType,
+
+  /**
+   * Specify if the column should have no gutter
+   */
+  noGutter: PropTypes.bool,
+
+  /**
+   * Specify if the column should have no left gutter
+   */
+  noGutterLeft: PropTypes.bool,
+
+  /**
+   * Specify if the column should have no right gutter
+   */
+  noGutterRight: PropTypes.bool,
+};
+
+const breakpoints = Object.keys(gridBreakpoints);
+
+function mapBreakpointsToArray(object) {
+  if (Array.isArray(object)) {
+    return object;
+  }
+  return Object.keys(object).reduce((acc, key) => {
+    const index = breakpoints.indexOf(key);
+    acc[index] = object[key];
+    return acc;
+  }, []);
+}
+
+export default unstable_Column;

--- a/packages/react/src/components/Layout/Grid-story.js
+++ b/packages/react/src/components/Layout/Grid-story.js
@@ -1,0 +1,256 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './story.scss';
+
+import { storiesOf } from '@storybook/react';
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import {
+  unstable_Grid as Grid,
+  unstable_Row as Row,
+  unstable_Column as Column,
+} from '../Layout';
+
+function DemoFullPage({ children }) {
+  const [portalNode, setPortalNode] = useState(null);
+
+  useEffect(() => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+
+    setPortalNode(node);
+
+    return () => {
+      document.body.removeChild(node);
+    };
+  }, []);
+
+  return (
+    portalNode &&
+    ReactDOM.createPortal(<div className="example">{children}</div>, portalNode)
+  );
+}
+
+function DemoContent({ children }) {
+  return (
+    <div className="outside">
+      <div className="inside">{children}</div>
+    </div>
+  );
+}
+
+storiesOf('Layout/Grid', module)
+  .addDecorator(story => <DemoFullPage>{story()}</DemoFullPage>)
+  .add('auto-columns', () => (
+    <Grid>
+      <Row>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('responsive grid', () => (
+    <Grid>
+      <Row>
+        <Column span={[1, 4, 8]}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column span={[1, 2, 2]}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column span={[1, 1, 1]}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column span={[1, 1, 1]}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('responsive grid - object syntax', () => (
+    <Grid>
+      <Row>
+        <Column span={{ sm: 1, md: 4, lg: 8 }}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column span={{ sm: 1, md: 2, lg: 2 }}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column span={{ sm: 1, md: 1, lg: 1 }}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column span={{ sm: 1, md: 1, lg: 1 }}>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('offset', () => (
+    <Grid>
+      <Row>
+        <Column offset={[3]} span={[1]}>
+          <DemoContent>Offset 3</DemoContent>
+        </Column>
+        <Column offset={[2]} span={[2]}>
+          <DemoContent>Offset 3</DemoContent>
+        </Column>
+        <Column offset={[1]} span={[3]}>
+          <DemoContent>Offset 3</DemoContent>
+        </Column>
+        <Column offset={[0]} span={[4]}>
+          <DemoContent>Offset 3</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('condensed', () => (
+    <Grid condensed>
+      <Row>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('condensed row', () => (
+    <Grid>
+      <Row>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+      <Row condensed>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+      <Row>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('no gutter - column', () => (
+    <Grid>
+      <Row>
+        <Column noGutter>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column noGutter>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column noGutter>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column noGutter>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('no gutter - row', () => (
+    <Grid>
+      <Row noGutter>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('no gutter - directional', () => (
+    <Grid>
+      <Row>
+        <Column noGutterLeft>
+          <DemoContent>No Gutter on the left-hand side</DemoContent>
+        </Column>
+        <Column noGutterLeft>
+          <DemoContent>No Gutter on the left-hand side</DemoContent>
+        </Column>
+        <Column noGutterRight>
+          <DemoContent>No Gutter on the right-hand side</DemoContent>
+        </Column>
+        <Column noGutterRight>
+          <DemoContent>No Gutter on the right-hand side</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ))
+  .add('full width', () => (
+    <Grid fullWidth>
+      <Row>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+        <Column>
+          <DemoContent>1/4</DemoContent>
+        </Column>
+      </Row>
+    </Grid>
+  ));

--- a/packages/react/src/components/Layout/Grid.js
+++ b/packages/react/src/components/Layout/Grid.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { settings } from 'carbon-components';
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const { prefix } = settings;
+
+function unstable_Grid({
+  as = 'div',
+  className: customClassName,
+  condensed,
+  fullWidth,
+  ...rest
+}) {
+  const className = cx({
+    [`${prefix}--grid`]: true,
+    [`${prefix}--grid--condensed`]: condensed,
+    [`${prefix}--grid--full-width`]: fullWidth,
+    [customClassName]: !!customClassName,
+  });
+  return React.createElement(as, {
+    ...rest,
+    className,
+  });
+}
+
+unstable_Grid.propTypes = {
+  /**
+   * Provide a custom element to render instead of the default <div>
+   */
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+  /**
+   * Provide a custom className to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify if the grid should be rendered as a condensed grid
+   */
+  condensed: PropTypes.bool,
+
+  /**
+   * Specify if the grid should span full-width at the maximum breakpoint
+   */
+  fullWidth: PropTypes.bool,
+};
+
+export default unstable_Grid;

--- a/packages/react/src/components/Layout/Row.js
+++ b/packages/react/src/components/Layout/Row.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { settings } from 'carbon-components';
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const { prefix } = settings;
+
+function unstable_Row({
+  as = 'div',
+  className: customClassName,
+  condensed,
+  noGutter,
+  noGutterLeft,
+  noGutterRight,
+  ...rest
+}) {
+  const className = cx({
+    [`${prefix}--row`]: true,
+    [`${prefix}--row--condensed`]: condensed,
+    [`${prefix}--no-gutter`]: noGutter,
+    [`${prefix}--no-gutter--left`]: noGutterLeft,
+    [`${prefix}--no-gutter--right`]: noGutterRight,
+    [customClassName]: !!customClassName,
+  });
+  return React.createElement(as, {
+    ...rest,
+    className,
+  });
+}
+
+unstable_Row.propTypes = {
+  /**
+   * Provide a custom element to render instead of the default <div>
+   */
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+  /**
+   * Provide a custom className to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify if the row should be rendered as a condensed row
+   */
+  condensed: PropTypes.bool,
+
+  /**
+   * Specify if each column in a row should have no gutter
+   */
+  noGutter: PropTypes.bool,
+
+  /**
+   * Specify if each column in a row should have no gutter on the left-hand side
+   */
+  noGutterLeft: PropTypes.bool,
+
+  /**
+   * Specify if each column in a row should have no gutter on the right-hand side
+   */
+  noGutterRight: PropTypes.bool,
+};
+
+export default unstable_Row;

--- a/packages/react/src/components/Layout/__tests__/Column-test.js
+++ b/packages/react/src/components/Layout/__tests__/Column-test.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { unstable_Column as Column } from '../';
+
+describe('Column', () => {
+  let mountNode;
+
+  beforeEach(() => {
+    mountNode = document.createElement('div');
+    document.body.appendChild(mountNode);
+  });
+
+  afterEach(() => {
+    mountNode.parentNode.removeChild(mountNode);
+  });
+
+  it('should support a custom element as the root node', () => {
+    const CustomComponent = jest.fn(props => <section {...props} />);
+    mount(<Column as={CustomComponent} />, {
+      attachTo: mountNode,
+    });
+
+    expect(CustomComponent).toHaveBeenCalledTimes(1);
+    expect(mountNode.querySelector('section')).toBeInstanceOf(HTMLElement);
+  });
+
+  it('should allow custom class names', () => {
+    const className = 'custom-class';
+    mount(<Column className={className} />, {
+      attachTo: mountNode,
+    });
+    expect(mountNode.querySelector('.custom-class')).toBeInstanceOf(
+      HTMLDivElement
+    );
+  });
+
+  it('should support different column modes', () => {
+    const modes = [
+      {
+        prop: 'noGutter',
+        className: 'no-gutter',
+      },
+      {
+        prop: 'noGutterLeft',
+        className: 'no-gutter--left',
+      },
+      {
+        prop: 'noGutterRight',
+        className: 'no-gutter--right',
+      },
+    ];
+
+    for (const mode of modes) {
+      const props = {
+        [mode.prop]: true,
+      };
+      mount(<Column {...props} />, {
+        attachTo: mountNode,
+      });
+      expect(mountNode.firstChild.className).toEqual(
+        expect.stringContaining(mode.className)
+      );
+    }
+  });
+
+  it('should support specifying column span', () => {
+    const checkClassName = element => {
+      const { className } = element;
+      expect(className).toEqual(expect.stringContaining('col-sm-4'));
+      expect(className).toEqual(expect.stringContaining('col-md-8'));
+      expect(className).toEqual(expect.stringContaining('col-lg-10'));
+      expect(className).toEqual(expect.stringContaining('col-xlg-12'));
+      expect(className).toEqual(expect.stringContaining('col-max-16'));
+    };
+
+    mount(<Column span={[4, 8, 10, 12, 16]} />, {
+      attachTo: mountNode,
+    });
+    checkClassName(mountNode.firstChild);
+
+    mount(<Column span={{ sm: 4, md: 8, lg: 10, xlg: 12, max: 16 }} />, {
+      attachTo: mountNode,
+    });
+    checkClassName(mountNode.firstChild);
+  });
+
+  it('should support specifying offset amount', () => {
+    const checkClassName = element => {
+      const { className } = element;
+      expect(className).toEqual(expect.stringContaining('offset-sm-4'));
+      expect(className).toEqual(expect.stringContaining('offset-md-8'));
+      expect(className).toEqual(expect.stringContaining('offset-lg-10'));
+      expect(className).toEqual(expect.stringContaining('offset-xlg-12'));
+      expect(className).toEqual(expect.stringContaining('offset-max-16'));
+    };
+
+    mount(<Column offset={[4, 8, 10, 12, 16]} />, {
+      attachTo: mountNode,
+    });
+    checkClassName(mountNode.firstChild);
+
+    mount(<Column offset={{ sm: 4, md: 8, lg: 10, xlg: 12, max: 16 }} />, {
+      attachTo: mountNode,
+    });
+    checkClassName(mountNode.firstChild);
+  });
+});

--- a/packages/react/src/components/Layout/__tests__/Grid-test.js
+++ b/packages/react/src/components/Layout/__tests__/Grid-test.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { unstable_Grid as Grid } from '../';
+
+describe('Grid', () => {
+  let mountNode;
+
+  beforeEach(() => {
+    mountNode = document.createElement('div');
+    document.body.appendChild(mountNode);
+  });
+
+  afterEach(() => {
+    mountNode.parentNode.removeChild(mountNode);
+  });
+
+  it('should support a custom element as the root node', () => {
+    const CustomComponent = jest.fn(props => <section {...props} />);
+    mount(<Grid as={CustomComponent} />, {
+      attachTo: mountNode,
+    });
+
+    expect(CustomComponent).toHaveBeenCalledTimes(1);
+    expect(mountNode.querySelector('section')).toBeInstanceOf(HTMLElement);
+  });
+
+  it('should allow custom class names', () => {
+    const className = 'custom-class';
+    mount(<Grid className={className} />, {
+      attachTo: mountNode,
+    });
+    expect(mountNode.querySelector('.custom-class')).toBeInstanceOf(
+      HTMLDivElement
+    );
+  });
+
+  it('should support different grid modes', () => {
+    const modes = [
+      {
+        prop: 'condensed',
+        className: 'grid--condensed',
+      },
+      {
+        prop: 'fullWidth',
+        className: 'grid--full-width',
+      },
+    ];
+
+    for (const mode of modes) {
+      const props = {
+        [mode.prop]: true,
+      };
+      mount(<Grid {...props} />, {
+        attachTo: mountNode,
+      });
+      expect(mountNode.firstChild.className).toEqual(
+        expect.stringContaining(mode.className)
+      );
+    }
+  });
+});

--- a/packages/react/src/components/Layout/__tests__/Row-test.js
+++ b/packages/react/src/components/Layout/__tests__/Row-test.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { unstable_Row as Row } from '../';
+
+describe('Row', () => {
+  let mountNode;
+
+  beforeEach(() => {
+    mountNode = document.createElement('div');
+    document.body.appendChild(mountNode);
+  });
+
+  afterEach(() => {
+    mountNode.parentNode.removeChild(mountNode);
+  });
+
+  it('should support a custom element as the root node', () => {
+    const CustomComponent = jest.fn(props => <section {...props} />);
+    mount(<Row as={CustomComponent} />, {
+      attachTo: mountNode,
+    });
+
+    expect(CustomComponent).toHaveBeenCalledTimes(1);
+    expect(mountNode.querySelector('section')).toBeInstanceOf(HTMLElement);
+  });
+
+  it('should allow custom class names', () => {
+    const className = 'custom-class';
+    mount(<Row className={className} />, {
+      attachTo: mountNode,
+    });
+    expect(mountNode.querySelector('.custom-class')).toBeInstanceOf(
+      HTMLDivElement
+    );
+  });
+
+  it('should support different row modes', () => {
+    const modes = [
+      {
+        prop: 'condensed',
+        className: 'row--condensed',
+      },
+      {
+        prop: 'noGutter',
+        className: 'no-gutter',
+      },
+      {
+        prop: 'noGutterLeft',
+        className: 'no-gutter--left',
+      },
+      {
+        prop: 'noGutterRight',
+        className: 'no-gutter--right',
+      },
+    ];
+
+    for (const mode of modes) {
+      const props = {
+        [mode.prop]: true,
+      };
+      mount(<Row {...props} />, {
+        attachTo: mountNode,
+      });
+      expect(mountNode.firstChild.className).toEqual(
+        expect.stringContaining(mode.className)
+      );
+    }
+  });
+});

--- a/packages/react/src/components/Layout/index.js
+++ b/packages/react/src/components/Layout/index.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as unstable_Column } from './Column';
+export { default as unstable_Grid } from './Grid';
+export { default as unstable_Row } from './Row';

--- a/packages/react/src/components/Layout/story.scss
+++ b/packages/react/src/components/Layout/story.scss
@@ -1,0 +1,46 @@
+///
+/// Copyright IBM Corp. 2016, 2018
+///
+/// This source code is licensed under the Apache-2.0 license found in the
+/// LICENSE file in the root directory of this source tree.
+///
+
+.example .outside {
+  min-height: 80px;
+  height: 100%;
+}
+
+.example .inside {
+  background-color: #edf4ff;
+  min-height: 80px;
+  height: 100%;
+}
+
+.example [class*='col'] {
+  background-color: #dbeaff;
+  outline: 1px dashed #97c1ff;
+}
+
+// Condensed
+.example .bx--grid--condensed,
+.example .bx--row--condensed {
+  background-color: #171717;
+  color: white;
+}
+
+.example .bx--grid--condensed [class*='col'],
+.example .bx--row--condensed [class*='col'] {
+  background: none;
+  outline: none;
+}
+
+.bx--grid--condensed .outside,
+.bx--row--condensed .outside {
+  background-color: #3d3d3d;
+  outline: none;
+}
+
+.bx--grid--condensed .inside,
+.bx--row--condensed .inside {
+  background: none;
+}

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -155,3 +155,6 @@ export ToggleSmallSkeleton from './components/ToggleSmall/ToggleSmall.Skeleton';
 export IconSkeleton from './components/Icon/Icon.Skeleton';
 export DatePickerSkeleton from './components/DatePicker/DatePicker.Skeleton';
 export * from './components/UIShell';
+
+// Unstable
+export * from './components/Layout';


### PR DESCRIPTION
Add layout helpers for managing a Grid alongside the Carbon Design System layout guidance. Namely, this PR adds support for `Grid`, `Row`, and `Column` components. `Grid` and `Row` are roughly the same layout containers, supporting various modes for "condensed" or "no gutter' moments. `Column` provides support for specifying responsive breakpoints using either array or object syntax, as demonstrated by the storybook story and tests.

These helpers are brought in under the `unstable_*` namespace as we experiment to figure out the best component API for these helpers.

For reviewers, the styles and examples come roughly from the [Grid elements preview](https://carbon-elements.netlify.com/grid/examples/preview/)

#### Changelog

**New**

- add `components/Layout` with `unstable_Grid`, `unstable_Row`, and `unstable_Column` helpers

**Changed**

**Removed**
