### PR TITLE
fix(InlineLoading): fix prop type

### DIFF
--- a/packages/react/src/components/InlineLoading/InlineLoading-story.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading-story.js
@@ -89,7 +89,7 @@ storiesOf('InlineLoading', module)
                 <InlineLoading
                   style={{ marginLeft: '1rem' }}
                   description={description}
-                  success={success}
+                  status={success ? 'finished' : 'active'}
                   aria-live={ariaLive}
                 />
               ) : (

--- a/packages/react/src/components/InlineLoading/InlineLoading.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading.js
@@ -89,7 +89,7 @@ InlineLoading.propTypes = {
   /**
    * Specify the loading status
    */
-  status: PropTypes.oneOf('inactive', 'active', 'finished', 'error'),
+  status: PropTypes.oneOf(['inactive', 'active', 'finished', 'error']),
 
   /**
    * Specify the description for the inline loading text
@@ -113,6 +113,5 @@ InlineLoading.propTypes = {
   successDelay: PropTypes.number,
 };
 InlineLoading.defaultProps = {
-  success: false,
   successDelay: 1500,
 };


### PR DESCRIPTION
Fixes #3932.

#### Changelog

**Changed**

- Fix the `status` prop type.

**Removed**

- The default prop for `success` given we no longer use it.

#### Testing / Reviewing

Testing should make sure our `<InlineLoading>` is not broken.