### PR TITLE
fix(OverflowMenu): support automatic primary focus

### DIFF
--- a/packages/components/src/components/floating-menu/floating-menu.js
+++ b/packages/components/src/components/floating-menu/floating-menu.js
@@ -326,7 +326,7 @@ class FloatingMenu extends mixin(
           this.options.selectorPrimaryFocus
         );
         const focusableNode = this.element.querySelector(
-          settings.selectorTabbable
+          settings.selectorFocusable
         );
 
         if (primaryFocusNode) {

--- a/packages/components/src/globals/js/settings.js
+++ b/packages/components/src/globals/js/settings.js
@@ -20,10 +20,15 @@
  *   Brand prefix. Should be in sync with `$prefix` Sass variable in carbon-components/src/globals/scss/_vars.scss.
  * // @todo given that the default value is so long, is it appropriate to put in the JSDoc?
  * @property {string} [selectorTabbable]
- *   A selector selecting tabbable/focusable nodes.
+ *   A selector selecting tabbable nodes.
  *   By default selectorTabbable refereneces links, areas, inputs, buttons, selects, textareas,
  *   iframes, objects, embeds, or elements explicitly using tabindex or contenteditable attributes
  *   as long as the element is not `disabled` or the `tabindex="-1"`.
+ * @property {string} [selectorFocusable]
+ *   A selector selecting focusable nodes.
+ *   By default selectorFocusable refereneces links, areas, inputs, buttons, selects, textareas,
+ *   iframes, objects, embeds, or elements explicitly using tabindex or contenteditable attributes
+ *   as long as the element is not `disabled`.
  */
 const settings = {
   prefix: 'bx',
@@ -32,6 +37,12 @@ const settings = {
     button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
     textarea:not([disabled]):not([tabindex='-1']),
     iframe, object, embed, *[tabindex]:not([tabindex='-1']), *[contenteditable=true]
+  `,
+  selectorFocusable: `
+    a[href], area[href], input:not([disabled]),
+    button:not([disabled]),select:not([disabled]),
+    textarea:not([disabled]),
+    iframe, object, embed, *[tabindex], *[contenteditable=true]
   `,
 };
 

--- a/packages/react/.storybook/settings.js
+++ b/packages/react/.storybook/settings.js
@@ -1,4 +1,16 @@
 const settings = {
   prefix: 'bx',
+  selectorTabbable: `
+    a[href], area[href], input:not([disabled]):not([tabindex='-1']),
+    button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
+    textarea:not([disabled]):not([tabindex='-1']),
+    iframe, object, embed, *[tabindex]:not([tabindex='-1']), *[contenteditable=true]
+  `,
+  selectorFocusable: `
+    a[href], area[href], input:not([disabled]),
+    button:not([disabled]),select:not([disabled]),
+    textarea:not([disabled]),
+    iframe, object, embed, *[tabindex], *[contenteditable=true]
+  `,
 };
 module.exports = settings;

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -45,11 +45,7 @@ const props = {
 const OverflowMenuExample = ({ overflowMenuProps, overflowMenuItemProps }) => (
   <>
     <OverflowMenu {...overflowMenuProps}>
-      <OverflowMenuItem
-        {...overflowMenuItemProps}
-        itemText="Option 1"
-        primaryFocus
-      />
+      <OverflowMenuItem {...overflowMenuItemProps} itemText="Option 1" />
       <OverflowMenuItem
         {...overflowMenuItemProps}
         itemText="Option 2 is an example of a really long string and how we recommend handling this"
@@ -82,13 +78,12 @@ storiesOf('OverflowMenu', module)
   .addDecorator(withKnobs)
   .add(
     'basic',
-    withReadme(OverflowREADME, () => <OverflowMenu />),
-    () => (
+    withReadme(OverflowREADME, () => (
       <OverflowMenuExample
         overflowMenuProps={props.menu()}
         overflowMenuItemProps={props.menuItem()}
       />
-    ),
+    )),
     {
       info: {
         text: `
@@ -100,8 +95,7 @@ storiesOf('OverflowMenu', module)
   )
   .add(
     'with links',
-    withReadme(OverflowREADME, () => <OverflowMenu />),
-    () => (
+    withReadme(OverflowREADME, () => (
       <OverflowMenuExample
         overflowMenuProps={props.menu()}
         overflowMenuItemProps={{
@@ -109,7 +103,7 @@ storiesOf('OverflowMenu', module)
           href: 'https://www.ibm.com',
         }}
       />
-    ),
+    )),
     {
       info: {
         text: `
@@ -123,8 +117,7 @@ storiesOf('OverflowMenu', module)
   )
   .add(
     'custom trigger',
-    withReadme(OverflowREADME, () => <OverflowMenu />),
-    () => (
+    withReadme(OverflowREADME, () => (
       <OverflowMenuExample
         overflowMenuProps={{
           ...props.menu(),
@@ -135,7 +128,7 @@ storiesOf('OverflowMenu', module)
         }}
         overflowMenuItemProps={props.menuItem()}
       />
-    ),
+    )),
     {
       info: {
         text: `

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
@@ -261,6 +261,111 @@ describe('OverflowMenu', () => {
     });
   });
 
+  describe('focusing on the right item when the menu gets open', () => {
+    it('focuses on the explicitly defined node', () => {
+      const rootWrapper = mount(
+        <OverflowMenu>
+          <div className="test-child" />
+          <div className="test-child" data-floating-menu-primary-focus />
+          <div className="test-child" />
+        </OverflowMenu>
+      );
+
+      // Enzyme doesn't seem to allow setState() in a forwardRef-wrapped class component
+      rootWrapper
+        .find('OverflowMenu')
+        .instance()
+        .setState({ open: true });
+
+      rootWrapper.update();
+
+      const { _handlePlace: handlePlace } = rootWrapper
+        .find('OverflowMenu')
+        .instance();
+
+      const menuItems = rootWrapper.find('.test-child');
+      jest.spyOn(menuItems.at(0).getDOMNode(), 'focus');
+      jest.spyOn(menuItems.at(1).getDOMNode(), 'focus');
+      jest.spyOn(menuItems.at(2).getDOMNode(), 'focus');
+
+      handlePlace(rootWrapper.find('.bx--overflow-menu-options').getDOMNode());
+
+      expect(menuItems.at(0).getDOMNode().focus).toHaveBeenCalledTimes(0);
+      expect(menuItems.at(1).getDOMNode().focus).toHaveBeenCalledTimes(1);
+      expect(menuItems.at(2).getDOMNode().focus).toHaveBeenCalledTimes(0);
+    });
+
+    it('focuses on the first tabbable node', () => {
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+      const rootWrapper = mount(
+        <OverflowMenu>
+          <div className="test-child" />
+          <div className="test-child" tabIndex={0} />
+          <div className="test-child" tabIndex={-1} />
+        </OverflowMenu>
+      );
+      /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
+
+      // Enzyme doesn't seem to allow setState() in a forwardRef-wrapped class component
+      rootWrapper
+        .find('OverflowMenu')
+        .instance()
+        .setState({ open: true });
+
+      rootWrapper.update();
+
+      const { _handlePlace: handlePlace } = rootWrapper
+        .find('OverflowMenu')
+        .instance();
+
+      const menuItems = rootWrapper.find('.test-child');
+      jest.spyOn(menuItems.at(0).getDOMNode(), 'focus');
+      jest.spyOn(menuItems.at(1).getDOMNode(), 'focus');
+      jest.spyOn(menuItems.at(2).getDOMNode(), 'focus');
+
+      handlePlace(rootWrapper.find('.bx--overflow-menu-options').getDOMNode());
+
+      expect(menuItems.at(0).getDOMNode().focus).toHaveBeenCalledTimes(0);
+      expect(menuItems.at(1).getDOMNode().focus).toHaveBeenCalledTimes(1);
+      expect(menuItems.at(2).getDOMNode().focus).toHaveBeenCalledTimes(0);
+    });
+
+    it('focuses on the first focusable node', () => {
+      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+      const rootWrapper = mount(
+        <OverflowMenu>
+          <div className="test-child" />
+          <div className="test-child" tabIndex={-1} />
+          <div className="test-child" tabIndex={0} />
+        </OverflowMenu>
+      );
+      /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
+
+      // Enzyme doesn't seem to allow setState() in a forwardRef-wrapped class component
+      rootWrapper
+        .find('OverflowMenu')
+        .instance()
+        .setState({ open: true });
+
+      rootWrapper.update();
+
+      const { _handlePlace: handlePlace } = rootWrapper
+        .find('OverflowMenu')
+        .instance();
+
+      const menuItems = rootWrapper.find('.test-child');
+      jest.spyOn(menuItems.at(0).getDOMNode(), 'focus');
+      jest.spyOn(menuItems.at(1).getDOMNode(), 'focus');
+      jest.spyOn(menuItems.at(2).getDOMNode(), 'focus');
+
+      handlePlace(rootWrapper.find('.bx--overflow-menu-options').getDOMNode());
+
+      expect(menuItems.at(0).getDOMNode().focus).toHaveBeenCalledTimes(0);
+      expect(menuItems.at(1).getDOMNode().focus).toHaveBeenCalledTimes(1);
+      expect(menuItems.at(2).getDOMNode().focus).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('customized icon', () => {
     it('renders', () => {
       const rootWrapper = mount(

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -20,7 +20,7 @@ import { OverflowMenuVertical16 } from '@carbon/icons-react';
 import { keys, matches as keyCodeMatches } from '../../internal/keyboard';
 import mergeRefs from '../../tools/mergeRefs';
 
-const { prefix } = settings;
+const { prefix, selectorFocusable } = settings;
 
 const on = (element, ...args) => {
   element.addEventListener(...args);
@@ -253,25 +253,6 @@ class OverflowMenu extends Component {
     });
   }
 
-  getPrimaryFocusableElement = () => {
-    if (this.menuEl) {
-      const primaryFocusPropEl = this.menuEl.querySelector(
-        '[data-floating-menu-primary-focus]'
-      );
-      if (primaryFocusPropEl) {
-        return primaryFocusPropEl;
-      }
-    }
-    const firstItem = this.overflowMenuItem0;
-    if (
-      firstItem &&
-      firstItem.overflowMenuItem &&
-      firstItem.overflowMenuItem.current
-    ) {
-      return firstItem.overflowMenuItem.current;
-    }
-  };
-
   componentDidUpdate() {
     const { onClose } = this.props;
     if (!this.state.open) {
@@ -404,7 +385,9 @@ class OverflowMenu extends Component {
     if (menuBody) {
       this._menuBody = menuBody;
       (
-        menuBody.querySelector('[data-floating-menu-primary-focus]') || menuBody
+        menuBody.querySelector('[data-floating-menu-primary-focus]') ||
+        menuBody.querySelector(selectorFocusable) ||
+        menuBody
       ).focus();
       const hasFocusin = 'onfocusin' in window;
       const focusinEventName = hasFocusin ? 'focusin' : 'focus';


### PR DESCRIPTION
This change ports the logic introduced in #3476 that auto-detects an overflow menu item to put focus on, without needing to specify `data-floating-menu-primary-focus` in the menu item.

This change introduces `selectorFocusable` setting, for finding focusable DOM elements. The formerly-used `selectorTabbable` is for finding sequential-focus targets, which was not necessary the the right list for finding the menu item to focus on.

This change also fixes an issue in `OverflowMenu-story.js` where the menu could not be opened by mouse, etc.

Refs #3372.

#### Changelog

**New**

- `selectorFocusable` to `settings.js`, for finding focusable DOM elements (rather than click-focusable elements or sequential-focusable elements).
- Code to support focusing on first focusable element when React overflow menu gets open (that logic has already been supported in vanilla by #3476).

**Changed**

- Vanilla overflow menu code to use `selectorFocusable` rather than `selectorTabbable`.
- Storybook fix to get overflow menu demo back working.

**Removed**

- Unused code in React overflow menu.

#### Testing / Reviewing

Testing should make sure overflow menu, especially React one, is not broken.