### PR TITLE
Fix(Modal): adds tabIndex so user can scroll with arrow key

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -345,7 +345,14 @@ export default class Modal extends Component {
           <h3 className={`${prefix}--modal-header__heading`}>{modalHeading}</h3>
           {!passiveModal && modalButton}
         </div>
-        <div className={`${prefix}--modal-content`}>{this.props.children}</div>
+        <div
+          // Needs the tabIndex so that this area is scrollable when the text is long
+          tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+          role="region"
+          aria-labelledby={getAriaLabelledBy}
+          className={`${prefix}--modal-content`}>
+          {this.props.children}
+        </div>
         {!passiveModal && (
           <div className={`${prefix}--modal-footer`}>
             <Button kind="secondary" onClick={onSecondaryButtonClick}>

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -346,7 +346,7 @@ export default class Modal extends Component {
           {!passiveModal && modalButton}
         </div>
         <div
-          // Needs the tabIndex so that this area is scrollable when the text is long
+          // Needs the tabIndex so that this area is focusable when the text is scrollable
           tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
           role="region"
           aria-labelledby={getAriaLabelledBy}


### PR DESCRIPTION
Closes #3261 

This PR adds `tabIndex="0"` to the modal content so that the text area can receive focus and be scrollable with arrow keys when necessary.  This seems to be an issue with webkit browsers that was supposedly fixed [here](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/Fku6784p0wI/3MyOMTk7BwAJ) but we aren't seeing that. Let me know if the aria-labelledby needs to be changed, the label already supplied to the modal seemed sufficient but I'm not sure! 

used this: https://developer.paciellogroup.com/blog/2016/02/short-note-on-improving-usability-of-scrollable-regions/ as guidance 
#### Changelog

**Changed**

- tabIndex added to modal body content

#### Testing / Reviewing

Go to the ModalWrapper -> transactional/passive modal open the modal and tab to the content, make sure it receives focus and that you can use the arrow keys to scroll
