### PR TITLE
fix(TileGroup): Wrap RadioTiles inside TileGroup

### DIFF
--- a/packages/react/src/components/TileGroup/TileGroup.js
+++ b/packages/react/src/components/TileGroup/TileGroup.js
@@ -127,7 +127,9 @@ export default class TileGroup extends React.Component {
     return (
       <fieldset className={className} disabled={disabled}>
         {this.renderLegend(legend)}
-        {this.getRadioTiles()}
+        <div className={`${prefix}--tile-group-content`}>
+          {this.getRadioTiles()}
+        </div>
       </fieldset>
     );
   }

--- a/packages/react/src/components/TileGroup/TileGroup.js
+++ b/packages/react/src/components/TileGroup/TileGroup.js
@@ -127,7 +127,7 @@ export default class TileGroup extends React.Component {
     return (
       <fieldset className={className} disabled={disabled}>
         {this.renderLegend(legend)}
-        <div className={`${prefix}--tile-group-content`}>
+        <div>
           {this.getRadioTiles()}
         </div>
       </fieldset>


### PR DESCRIPTION
This adds a wrapper div element around the RadioTiles inside the TileGroup component so that a flex layout can be applied to the tiles to make them render horizontally.

#### Changelog

**Changed**

- The RadioTiles inside the TileGroup component are wrapped in a div

#### Testing / Reviewing

Apply `display: flex` to the `{prefix}--tile-group-content` element and make sure the tiles render horizontally.
