### PR TITLE
chore(data-table): mark sticky header experimental

### DIFF
--- a/packages/components/demo/js/components/CodePage/CodePage.js
+++ b/packages/components/demo/js/components/CodePage/CodePage.js
@@ -29,8 +29,8 @@ const CodePage = ({
           component={metadata.name}
           htmlFile={item.renderedContent}
           hideViewFullRender={hideViewFullRender}
-          linkOnly={metadata.meta.linkOnly}
-          useIframe={metadata.meta.useIframe}
+          linkOnly={metadata.meta.linkOnly || item.meta.linkOnly}
+          useIframe={metadata.meta.useIframe || item.meta.useIframe}
           useStaticFullRenderPage={useStaticFullRenderPage}
         />
       </div>

--- a/packages/components/src/components/data-table/data-table.config.js
+++ b/packages/components/src/components/data-table/data-table.config.js
@@ -365,7 +365,7 @@ module.exports = {
       context: {
         columns: columnsSmall,
         rows,
-        sticky: true,
+        sticky: false,
       },
     },
     {
@@ -402,6 +402,18 @@ module.exports = {
         columns: columnsSmall,
         rows,
         zebra: true,
+      },
+    },
+    {
+      name: 'sticky',
+      label: 'Sticky header (experimental)',
+      meta: {
+        linkOnly: true,
+      },
+      context: {
+        columns: columnsSmall,
+        rows,
+        sticky: true,
       },
     },
     {
@@ -633,7 +645,7 @@ module.exports = {
         sortLabel: 'Sort rows by this header in descending order',
         hasToolbar: true,
         sort: true,
-        sticky: true,
+        sticky: false,
       },
     },
     {


### PR DESCRIPTION
In #3876, @jnm2377 showed some concerns wrt the complete-ness of sticky header styles. Though we are aware that some teams have evaluated or even started using sticky header styles, we see that it makes sense to mark sticky header style as experimental in order to bring the concern of complete-ness to users' attention.

#### Changelog

**Changed**

- Regular table demos not to use sticky header style
- Vanilla dev env code to better demonstrate sticky header style

#### Testing / Reviewing

Testing should make sure the data table (vanilla) demos are not broken.