### PR TITLE
ci(github): add github action for deploying storybook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,49 +25,6 @@ jobs:
             yarn ci-check
             yarn lerna run ci-check
 
-  deploy:
-    docker:
-      - image: circleci/node:10.15-browsers
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - run:
-          name: Install yarn
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
-            # Reference:
-            # https://circleci.com/docs/2.0/env-vars/#example-configuration-of-environment-variables
-            echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> $BASH_ENV
-      - run:
-          name: Install dependencies
-          command: yarn install --offline --frozen-lockfile
-      - run:
-          name: Build packages
-          command: yarn build
-      - deploy:
-          name: deploy to IBM Cloud
-          command: |
-            # Install `ibmcloud` CLI
-            curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
-
-            # Login and push staging manifest
-            ibmcloud login \
-              --apikey $CLOUD_API_KEY \
-              -a https://api.ng.bluemix.net \
-              -o carbon-design-system
-
-            ibmcloud target -s production
-
-            ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-            ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
-
-            # Default storybook build
-            cd packages/react
-            yarn build-storybook
-            ibmcloud cf blue-green-deploy carbon-storybook \
-              -f manifest.yml \
-              --delete-old-apps
-
   release:
     docker:
       - image: circleci/node:10.15-browsers
@@ -156,12 +113,3 @@ workflows:
             branches:
               only:
                 - master
-      - deploy:
-          requires:
-            - system
-            - artifacts
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/

--- a/.github/workflows/deploy-react-storybook.yml
+++ b/.github/workflows/deploy-react-storybook.yml
@@ -1,0 +1,54 @@
+name: Deploy React storybook to IBM Cloud
+
+on:
+  push:
+    tags:
+      # Matches tags that have the shape `vX.Y.Z`. This will also match tags
+      # with a preid, for example `vX.Y.Z-rc.0`. Reference:
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          version: 10.x
+
+      - name: Install dependencies
+        run: yarn install --offline
+
+      - name: Build project
+        run: yarn build
+
+      - name: Install ibmcloud CLI
+        run: curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
+
+      - name: Login to IBM Cloud
+        env:
+          CLOUD_API_KEY: ${{ secrets.CLOUD_API_KEY}}
+        run: |
+          ibmcloud login \
+          -a 'https://cloud.ibm.com' \
+          -u 'apikey' \
+          -p "$CLOUD_API_KEY" \
+          -o 'carbon-design-system' \
+          -s 'production' \
+          -r 'us-south'
+
+      - name: Install IBM Cloud plugins
+        run: |
+          ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+          ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
+
+      - name: Deploy React storybook
+        run: |
+          cd packages/react
+          yarn build-storybook
+          ibmcloud cf blue-green-deploy carbon-storybook \
+            -f manifest.yml \
+            --delete-old-apps


### PR DESCRIPTION
Updates our CI workflow for publishing storybook from CircleCI to GitHub Actions.

cc @alisonjoseph for help with syntax lol 😂 


#### Changelog

**New**

- New GitHub Action for deploying our React storybook on a tag push that matches `v*.*.*`

**Changed**

- CircleCI no longer publishes on tags

**Removed**

#### Testing / Reviewing

Honestly not sure, I think we'll have to wait till our next patch release when we push the tag! 😬 
