### PR TITLE
fix(InlineLoading): support richer description

### DIFF
--- a/packages/react/src/components/InlineLoading/InlineLoading.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading.js
@@ -55,7 +55,7 @@ export default function InlineLoading({
     return undefined;
   };
   const loadingText = (
-    <p className={`${prefix}--inline-loading__text`}>{description}</p>
+    <div className={`${prefix}--inline-loading__text`}>{description}</div>
   );
   const loading = getLoading();
   const loadingAnimation = loading && (
@@ -94,7 +94,7 @@ InlineLoading.propTypes = {
   /**
    * Specify the description for the inline loading text
    */
-  description: PropTypes.string,
+  description: PropTypes.node,
 
   /**
    * Specify the description for the inline loading text


### PR DESCRIPTION
This change is for allowing `<InlineLoading>` to contain richer content in its `description` prop. As part of that, it changes the wrapping tag of `description` from `<p>` to `<div>`, given the former doesn't presumably allow block-level elements in it. (Ref: Issue# 1112 in w3c/html repo).

Fixes #3901.

CC @loganmccaul Just in case he has specific intent behind usage of `<p>`.

#### Changelog

**Changed**

- `description` prop from `string` to `node`.
- Replaced `<p>` with `<div>` for the wrapping element of `description`. (I saw UA-style of `<p>` or our reset style for `<p>` was _not_ effect in before-change code)

#### Testing / Reviewing

Testing should make sure our inline loading component is not broken.