### PR TITLE
feat(TooltipIcon): auto generate default IDs

### DIFF
--- a/packages/react/src/components/TooltipIcon/TooltipIcon-test.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon-test.js
@@ -26,6 +26,16 @@ describe('TooltipIcon', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should add extra classes via className', () => {
+    const wrapper = mount(<TooltipIcon {...mockProps} />);
+    expect(wrapper.hasClass('custom-class')).toBe(true);
+  });
+
+  it('should have an ID on the content container by default', () => {
+    const wrapper = mount(<TooltipIcon {...mockProps} />);
+    expect(wrapper.find('.bx--assistive-text').props().id).toBeTruthy();
+  });
+
   it('should allow the user to specify the direction', () => {
     const wrapper = mount(<TooltipIcon {...mockProps} direction="top" />);
     expect(wrapper).toMatchSnapshot();

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -9,9 +9,12 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
+import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
+const getInstanceId = setupGetInstanceId();
 const TooltipIcon = ({
+  id,
   className,
   children,
   direction,
@@ -19,6 +22,7 @@ const TooltipIcon = ({
   tooltipText,
   ...rest
 }) => {
+  const tooltipId = id || `icon-tooltip-${getInstanceId()}`;
   const tooltipTriggerClasses = cx(
     `${prefix}--tooltip__trigger`,
     `${prefix}--tooltip--a11y`,
@@ -29,8 +33,13 @@ const TooltipIcon = ({
     }
   );
   return (
-    <button {...rest} className={tooltipTriggerClasses}>
-      <span className={`${prefix}--assistive-text`}>{tooltipText}</span>
+    <button
+      {...rest}
+      className={tooltipTriggerClasses}
+      aria-describedby={tooltipId}>
+      <span className={`${prefix}--assistive-text`} id={tooltipId}>
+        {tooltipText}
+      </span>
       {children}
     </button>
   );

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -26,10 +26,10 @@ const TooltipIcon = ({
   const tooltipTriggerClasses = cx(
     `${prefix}--tooltip__trigger`,
     `${prefix}--tooltip--a11y`,
+    className,
     {
       [`${prefix}--tooltip--${direction}`]: direction,
       [`${prefix}--tooltip--align-${align}`]: align,
-      className,
     }
   );
   return (

--- a/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
+++ b/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
@@ -8,10 +8,12 @@ exports[`TooltipIcon should allow the user to specify the direction 1`] = `
   tooltipText="tooltip text"
 >
   <button
-    className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--top bx--tooltip--align-center className"
+    aria-describedby="icon-tooltip-4"
+    className="bx--tooltip__trigger bx--tooltip--a11y custom-class bx--tooltip--top bx--tooltip--align-center"
   >
     <span
       className="bx--assistive-text"
+      id="icon-tooltip-4"
     >
       tooltip text
     </span>
@@ -28,10 +30,12 @@ exports[`TooltipIcon should render 1`] = `
   tooltipText="tooltip text"
 >
   <button
-    className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center className"
+    aria-describedby="icon-tooltip-1"
+    className="bx--tooltip__trigger bx--tooltip--a11y custom-class bx--tooltip--bottom bx--tooltip--align-center"
   >
     <span
       className="bx--assistive-text"
+      id="icon-tooltip-1"
     >
       tooltip text
     </span>


### PR DESCRIPTION
Closes #3953

Refs #3148 #3813 #3811 

This PR adds default ID generation (in line with `<TooltipDefinition>`) and resolves an issue where custom classes were not being passed down correctly

#### Testing / Reviewing

Ensure a default ID is generated and custom classes are applied to the tooltip trigger button
