### PR TITLE
docs(DataTable): adds with OverflowMenu story

### DIFF
--- a/packages/react/src/components/DataTable/DataTable-story.js
+++ b/packages/react/src/components/DataTable/DataTable-story.js
@@ -205,4 +205,20 @@ storiesOf('DataTable', module)
       `,
       },
     }
+  )
+  .add(
+    'with overflow menu',
+    withReadme(readme, () =>
+      require('./stories/with-overflow-menu').default(props())
+    ),
+    {
+      info: {
+        text: `
+      DataTable with an overFlow menu.
+
+      You can find more detailed information surrounding usage of this component
+      at the following url: ${readmeURL}
+    `,
+      },
+    }
   );

--- a/packages/react/src/components/DataTable/DataTable-story.js
+++ b/packages/react/src/components/DataTable/DataTable-story.js
@@ -215,7 +215,7 @@ storiesOf('DataTable', module)
     {
       info: {
         text: `
-      DataTable with an overFlow menu.
+      DataTable with Overflow menus added.
 
       You can find more detailed information surrounding usage of this component
       at the following url: ${readmeURL}

--- a/packages/react/src/components/DataTable/stories/with-overflow-menu.js
+++ b/packages/react/src/components/DataTable/stories/with-overflow-menu.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// /Users/Abagail.Hart@ibm.com/Projects/my-carbon-fork/packages/react/src/components/OverflowMenu/OverflowMenu.js
+import React from 'react';
+import OverflowMenu from '../../OverflowMenu';
+import OverflowMenuItem from '../../OverflowMenuItem';
+import DataTable, {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSelectAll,
+  TableSelectRow,
+} from '../../DataTable';
+import { initialRows, headers } from './shared';
+
+export default props => (
+  <DataTable
+    rows={initialRows}
+    headers={headers}
+    {...props}
+    render={({
+      rows,
+      headers,
+      getHeaderProps,
+      getRowProps,
+      getSelectionProps,
+      getTableProps,
+    }) => (
+      <TableContainer title="DataTable" description="With selection">
+        <Table {...getTableProps()}>
+          <TableHead>
+            <TableRow>
+              <TableSelectAll {...getSelectionProps()} />
+              {headers.map(header => (
+                <TableHeader {...getHeaderProps({ header })}>
+                  {header.header}
+                </TableHeader>
+              ))}
+              <TableHeader />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(row => (
+              <TableRow {...getRowProps({ row })}>
+                <TableSelectRow {...getSelectionProps({ row })} />
+                {row.cells.map(cell => (
+                  <TableCell key={cell.id}>{cell.value}</TableCell>
+                ))}
+                <TableCell>
+                  <OverflowMenu flipped>
+                    <OverflowMenuItem primaryFocus>Action 1</OverflowMenuItem>
+                    <OverflowMenuItem>Action 2</OverflowMenuItem>
+                    <OverflowMenuItem>Action 3</OverflowMenuItem>
+                  </OverflowMenu>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    )}
+  />
+);


### PR DESCRIPTION
Refs #3673 #3372 

This doesn't close anything, we just had a couple of issues around OverflowMenus in DataTable specifically and I added a story to explore those issues. Thought it might be helpful to have in the react storybook. This is already in the vanilla examples and I generally tried to match that.

#### Changelog

**New**

- with-overflowmenu story for DataTable 

**Changed**

- DataTable-story to add new story

#### Testing / Reviewing

Check the new story and make sure it looks okay in Storybook. Also let me know if we just don't want this added and I'll close the PR! 