### PR TITLE
feat: fix inline notification focus indicator

### DIFF
--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -53,6 +53,7 @@
   .#{$prefix}--inline-notification__details {
     display: flex;
     align-items: center;
+    width: 100%;
   }
 
   .#{$prefix}--inline-notification__icon {

--- a/src/components/notification/_inline-notification.scss
+++ b/src/components/notification/_inline-notification.scss
@@ -53,7 +53,6 @@
   .#{$prefix}--inline-notification__details {
     display: flex;
     align-items: center;
-    width: 100%;
   }
 
   .#{$prefix}--inline-notification__icon {
@@ -104,7 +103,6 @@
     height: 10px;
     width: 10px;
     fill: $ui-05;
-    position: absolute;
     top: 3px;
     right: 1px;
   }


### PR DESCRIPTION
Set inline notification details width to 100% so that the focus indicator
for the close button will not be squashed if the subtitle for the notification
is long.

Closes #3973

We noticed that the focus indicator was squashed for some of our inline notifications. After testing with the vanilla carbon component on the storybook, we determined that this required a change in carbon.

#### Changelog

**Removed**

- removed `position: absolute` from `.bx--inline-notification__close-icon`
