### PR TITLE
fix(form): remove italic from helper text

### DIFF
--- a/packages/components/src/components/form/_form.scss
+++ b/packages/components/src/components/form/_form.scss
@@ -101,8 +101,7 @@
 
   .#{$prefix}--form__helper-text {
     @include type-style('helper-text-01');
-    font-style: italic;
-    color: $text-02;
+    color: $text-05;
     z-index: 0;
     opacity: 1;
     margin-bottom: $carbon--spacing-03;

--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -41,7 +41,6 @@
     & ~ .#{$prefix}--form__helper-text {
       margin-top: 0;
       order: 2;
-      font-style: italic;
     }
 
     & ~ .#{$prefix}--form-requirement {

--- a/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_inlined/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_inlined/_styles.scss
@@ -33,7 +33,6 @@ $label-01: (
 /// @group @carbon/type
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 ) !default;

--- a/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/elements/scss/type/_styles.scss
@@ -33,7 +33,6 @@ $label-01: (
 /// @group @carbon/type
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 ) !default;

--- a/packages/components/src/globals/scss/vendor/@carbon/type/scss/_inlined/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/type/scss/_inlined/_styles.scss
@@ -33,7 +33,6 @@ $label-01: (
 /// @group @carbon/type
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 ) !default;

--- a/packages/components/src/globals/scss/vendor/@carbon/type/scss/_styles.scss
+++ b/packages/components/src/globals/scss/vendor/@carbon/type/scss/_styles.scss
@@ -33,7 +33,6 @@ $label-01: (
 /// @group @carbon/type
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 ) !default;

--- a/packages/elements/docs/sass.md
+++ b/packages/elements/docs/sass.md
@@ -7018,7 +7018,6 @@ $label-01: (
 ```scss
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 );

--- a/packages/type/docs/sass.md
+++ b/packages/type/docs/sass.md
@@ -1988,7 +1988,6 @@ $label-01: (
 ```scss
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 );

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -33,7 +33,6 @@ $label-01: (
 /// @group @carbon/type
 $helper-text-01: (
   font-size: carbon--type-scale(1),
-  font-style: italic,
   line-height: carbon--rem(16px),
   letter-spacing: 0.32px,
 ) !default;


### PR DESCRIPTION
Fixes #3961.

#### Changelog

**Changed**

- Remove italic style from:
  - `helper-text-01` type
  - Several ruleset for helper text that manually defines the italic style
- Replaced `$text-02` with `$text-05` for helper text style

#### Testing / Reviewing

Testing should components that use helper text are not broken.