### PR TITLE
fix(button): vertically align to top by default

### DIFF
--- a/packages/components/src/components/button/_mixins.scss
+++ b/packages/components/src/components/button/_mixins.scss
@@ -18,6 +18,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
+  vertical-align: top;
   flex-shrink: 0;
   min-height: rem($button-height);
   padding: $button-padding;


### PR DESCRIPTION
Closes #3938

This PR vertically aligns Carbon buttons to the top of their containing line boxes

#### Testing / Reviewing

Ensure adjacent buttons are correctly aligned in a non-flex container (example markup and suggested fixes from #3938 discussion can be viewed at https://codepen.io/elizabethsjudd/pen/qBWprrm)