### PR TITLE
feat(TooltipDefinition): support different elements as tooltip trigger

### DIFF
--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
@@ -37,6 +37,15 @@ const props = () => ({
     'Tooltip content (tooltipText)',
     'Brief description of the dotted, underlined word above.'
   ),
+  as: select(
+    'Base element for trigger button',
+    {
+      button: 'button',
+      div: 'div',
+      span: 'span',
+    },
+    'button'
+  ),
 });
 
 storiesOf('TooltipDefinition', module)

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
@@ -15,38 +15,56 @@ const directions = {
   'Bottom (bottom)': 'bottom',
   'Top (top)': 'top',
 };
-
 const alignments = {
   'Start (start)': 'start',
   'Center (center)': 'center',
   'End (end)': 'end',
 };
-
-const props = () => ({
-  triggerClassName: text(
-    'Trigger element CSS class name (triggerClassName)',
-    ''
+const triggerElements = {
+  button: 'button',
+  div: 'div',
+  span: 'span',
+};
+const triggerElementMap = {
+  button: undefined,
+  div: ({ id, children, ...props }) => (
+    <div aria-describedby={id} {...props}>
+      {children}
+    </div>
   ),
-  direction: select('Tooltip direction (direction)', directions, 'bottom'),
-  align: select(
-    'Tooltip alignment to trigger button (align)',
-    alignments,
-    'start'
+  span: ({ id, children, ...props }) => (
+    <span aria-describedby={id} {...props}>
+      {children}
+    </span>
   ),
-  tooltipText: text(
-    'Tooltip content (tooltipText)',
-    'Brief description of the dotted, underlined word above.'
-  ),
-  as: select(
-    'Base element for trigger button',
-    {
-      button: 'button',
-      div: 'div',
-      span: 'span',
-    },
-    'button'
-  ),
-});
+};
+const props = () => {
+  const triggerElementToUse =
+    triggerElementMap[
+      select(
+        'Base element for trigger button (renderTrigger)',
+        triggerElements,
+        'none'
+      )
+    ];
+  return {
+    triggerClassName: text(
+      'Trigger element CSS class name (triggerClassName)',
+      ''
+    ),
+    direction: select('Tooltip direction (direction)', directions, 'bottom'),
+    align: select(
+      'Tooltip alignment to trigger button (align)',
+      alignments,
+      'start'
+    ),
+    tooltipText: text(
+      'Tooltip content (tooltipText)',
+      'Brief description of the dotted, underlined word above.'
+    ),
+    renderTrigger: triggerElementToUse || undefined,
+  };
+};
 
 storiesOf('TooltipDefinition', module)
   .addDecorator(withKnobs)

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
@@ -40,4 +40,14 @@ describe('TooltipDefinition', () => {
     const wrapper = mount(<TooltipDefinition {...mockProps} direction="top" />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should allow the user to specify the alignment', () => {
+    const wrapper = mount(<TooltipDefinition {...mockProps} align="start" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should support custom elements for the trigger button base', () => {
+    const wrapper = mount(<TooltipDefinition {...mockProps} as="span" />);
+    expect(wrapper.find('span.bx--tooltip__trigger')).toHaveLength(1);
+  });
 });

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
@@ -47,7 +47,16 @@ describe('TooltipDefinition', () => {
   });
 
   it('should support custom elements for the trigger button base', () => {
-    const wrapper = mount(<TooltipDefinition {...mockProps} as="span" />);
+    const wrapper = mount(
+      <TooltipDefinition
+        {...mockProps}
+        renderTrigger={({ id, children, ...props }) => (
+          <span aria-describedby={id} {...props}>
+            {children}
+          </span>
+        )}
+      />
+    );
     expect(wrapper.find('span.bx--tooltip__trigger')).toHaveLength(1);
   });
 });

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -13,6 +13,11 @@ import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
+const DefaultTooltipDefinitionTrigger = ({ id, children, ...props }) => (
+  <button aria-describedby={id} {...props}>
+    {children}
+  </button>
+);
 const TooltipDefinition = ({
   id,
   className,
@@ -21,7 +26,7 @@ const TooltipDefinition = ({
   direction,
   align,
   tooltipText,
-  as = 'button',
+  renderTrigger: TooltipDefinitionTrigger = DefaultTooltipDefinitionTrigger,
   ...rest
 }) => {
   const tooltipId = id || `definition-tooltip-${getInstanceId()}`;
@@ -40,12 +45,10 @@ const TooltipDefinition = ({
       [`${prefix}--tooltip--align-${align}`]: align,
     }
   );
-  const TooltipDefinitionTrigger = as;
   return (
     <div {...rest} className={tooltipClassName}>
       <TooltipDefinitionTrigger
         className={tooltipTriggerClasses}
-        as={as}
         aria-describedby={tooltipId}>
         {children}
       </TooltipDefinitionTrigger>
@@ -95,10 +98,10 @@ TooltipDefinition.propTypes = {
   tooltipText: PropTypes.node.isRequired,
 
   /**
-   * Specify how the trigger button itself should be rendered.
-   * Make sure to apply all props to the root node and render children appropriately
+   * Optional prop to allow overriding the base trigger element rendering.
+   * Can be a React component class
    */
-  as: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  renderTrigger: PropTypes.func,
 };
 
 TooltipDefinition.defaultProps = {

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -21,6 +21,7 @@ const TooltipDefinition = ({
   direction,
   align,
   tooltipText,
+  as = 'button',
   ...rest
 }) => {
   const tooltipId = id || `definition-tooltip-${getInstanceId()}`;
@@ -39,11 +40,15 @@ const TooltipDefinition = ({
       [`${prefix}--tooltip--align-${align}`]: align,
     }
   );
+  const TooltipDefinitionTrigger = as;
   return (
     <div {...rest} className={tooltipClassName}>
-      <button className={tooltipTriggerClasses} aria-describedby={tooltipId}>
+      <TooltipDefinitionTrigger
+        className={tooltipTriggerClasses}
+        as={as}
+        aria-describedby={tooltipId}>
         {children}
-      </button>
+      </TooltipDefinitionTrigger>
       <div
         className={`${prefix}--assistive-text`}
         id={tooltipId}
@@ -88,6 +93,12 @@ TooltipDefinition.propTypes = {
    * TODO: rename this prop (will be a breaking change)
    */
   tooltipText: PropTypes.node.isRequired,
+
+  /**
+   * Specify how the trigger button itself should be rendered.
+   * Make sure to apply all props to the root node and render children appropriately
+   */
+  as: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 };
 
 TooltipDefinition.defaultProps = {

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -11,11 +11,11 @@ exports[`TooltipDefinition should allow the user to specify the alignment 1`] = 
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
     <DefaultTooltipDefinitionTrigger
-      aria-describedby="definition-tooltip-3"
+      aria-describedby="definition-tooltip-4"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
     >
       <button
-        aria-describedby="definition-tooltip-3"
+        aria-describedby="definition-tooltip-4"
         className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
       >
         tooltip trigger
@@ -23,7 +23,7 @@ exports[`TooltipDefinition should allow the user to specify the alignment 1`] = 
     </DefaultTooltipDefinitionTrigger>
     <div
       className="bx--assistive-text"
-      id="definition-tooltip-3"
+      id="definition-tooltip-4"
       role="tooltip"
     >
       tooltip text
@@ -43,11 +43,11 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
     <DefaultTooltipDefinitionTrigger
-      aria-describedby="definition-tooltip-2"
+      aria-describedby="definition-tooltip-3"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
     >
       <button
-        aria-describedby="definition-tooltip-2"
+        aria-describedby="definition-tooltip-3"
         className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
       >
         tooltip trigger
@@ -107,12 +107,17 @@ exports[`TooltipDefinition should support a custom trigger element class 1`] = `
   <div
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
-    <button
+    <DefaultTooltipDefinitionTrigger
       aria-describedby="definition-tooltip-2"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition custom-trigger-class bx--tooltip--bottom bx--tooltip--align-start"
     >
-      tooltip trigger
-    </button>
+      <button
+        aria-describedby="definition-tooltip-2"
+        className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition custom-trigger-class bx--tooltip--bottom bx--tooltip--align-start"
+      >
+        tooltip trigger
+      </button>
+    </DefaultTooltipDefinitionTrigger>
     <div
       className="bx--assistive-text"
       id="definition-tooltip-2"

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipDefinition should allow the user to specify the alignment 1`] = `
+<TooltipDefinition
+  align="start"
+  className="custom-class"
+  direction="bottom"
+  tooltipText="tooltip text"
+>
+  <div
+    className="bx--tooltip--definition bx--tooltip--a11y custom-class"
+  >
+    <button
+      aria-describedby="definition-tooltip-3"
+      as="button"
+      className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+    >
+      tooltip trigger
+    </button>
+    <div
+      className="bx--assistive-text"
+      id="definition-tooltip-3"
+      role="tooltip"
+    >
+      tooltip text
+    </div>
+  </div>
+</TooltipDefinition>
+`;
+
 exports[`TooltipDefinition should allow the user to specify the direction 1`] = `
 <TooltipDefinition
   align="start"
@@ -11,7 +39,8 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
     <button
-      aria-describedby="definition-tooltip-3"
+      aria-describedby="definition-tooltip-2"
+      as="button"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
     >
       tooltip trigger
@@ -39,6 +68,7 @@ exports[`TooltipDefinition should render 1`] = `
   >
     <button
       aria-describedby="definition-tooltip-1"
+      as="button"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
     >
       tooltip trigger

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -10,13 +10,17 @@ exports[`TooltipDefinition should allow the user to specify the alignment 1`] = 
   <div
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
-    <button
+    <DefaultTooltipDefinitionTrigger
       aria-describedby="definition-tooltip-3"
-      as="button"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
     >
-      tooltip trigger
-    </button>
+      <button
+        aria-describedby="definition-tooltip-3"
+        className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+      >
+        tooltip trigger
+      </button>
+    </DefaultTooltipDefinitionTrigger>
     <div
       className="bx--assistive-text"
       id="definition-tooltip-3"
@@ -38,13 +42,17 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
   <div
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
-    <button
+    <DefaultTooltipDefinitionTrigger
       aria-describedby="definition-tooltip-2"
-      as="button"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
     >
-      tooltip trigger
-    </button>
+      <button
+        aria-describedby="definition-tooltip-2"
+        className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
+      >
+        tooltip trigger
+      </button>
+    </DefaultTooltipDefinitionTrigger>
     <div
       className="bx--assistive-text"
       id="definition-tooltip-3"
@@ -66,13 +74,17 @@ exports[`TooltipDefinition should render 1`] = `
   <div
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
-    <button
+    <DefaultTooltipDefinitionTrigger
       aria-describedby="definition-tooltip-1"
-      as="button"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
     >
-      tooltip trigger
-    </button>
+      <button
+        aria-describedby="definition-tooltip-1"
+        className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+      >
+        tooltip trigger
+      </button>
+    </DefaultTooltipDefinitionTrigger>
     <div
       className="bx--assistive-text"
       id="definition-tooltip-1"


### PR DESCRIPTION
Closes #3985

This PR allows users to specify the element for the definition tooltip trigger button instead of hard coding it to be a `button` element

#### Changelog

**New**

- `renderTrigger` prop which takes a function and becomes the output element for the trigger button

#### Testing / Reviewing

Ensure the `renderTrigger` prop functions as expected
