### PR TITLE
feat: add Carbon theme switcher to React storybook

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -13,12 +13,6 @@ export default class Container extends Component {
 
   render() {
     const { story } = this.props;
-
-    let bgColor = '#ffffff';
-    if (story().props.context.kind === '[Experimental] UI Shell') {
-      bgColor = '#f3f3f3';
-    }
-
     return (
       <React.StrictMode>
         <div
@@ -29,7 +23,6 @@ export default class Container extends Component {
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
-            backgroundColor: bgColor,
           }}>
           {story()}
         </div>

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -14,3 +14,21 @@ $prefix: 'bx';
 // as `src` directory is _not_ meant to be shipped in our NPM package.
 // Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
 @import '~carbon-components/src/globals/scss/styles.scss'; // SEE THE NOTE ABOVE
+
+@if mixin-exists(carbon--theme--custom-properties) {
+  :root {
+    @include carbon--theme--custom-properties($carbon--theme--white);
+  }
+
+  :root[storybook-carbon-theme='g10'] {
+    @include carbon--theme--custom-properties($carbon--theme--g10);
+  }
+
+  :root[storybook-carbon-theme='g90'] {
+    @include carbon--theme--custom-properties($carbon--theme--g90);
+  }
+
+  :root[storybook-carbon-theme='g100'] {
+    @include carbon--theme--custom-properties($carbon--theme--g100);
+  }
+}

--- a/packages/react/.storybook/_container.scss
+++ b/packages/react/.storybook/_container.scss
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 $css--font-face: true;
 $css--reset: true;
 

--- a/packages/react/.storybook/addon-carbon-theme/components/Panel.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Panel.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form } from '@storybook/components';
+import { CURRENT_THEME } from '../shared';
+
+/**
+ * Storybook add-on panel for Carbon theme switcher.
+ */
+const Panel = ({ api, active }) => {
+  const [currentTheme, setCurrentTheme] = useState('white');
+  const handleChange = useCallback(
+    event => {
+      const { value } = event.target;
+      setCurrentTheme(value);
+      api.getChannel().emit(CURRENT_THEME, value);
+    },
+    [api]
+  );
+  return (
+    active && (
+      <Form>
+        <Form.Field label="Select Carbon theme:">
+          <Form.Select
+            name="carbon-theme"
+            value={currentTheme}
+            onChange={handleChange}
+            size="flex">
+            <option key="white" value="white">
+              white
+            </option>
+            <option key="g10" value="g10">
+              g10
+            </option>
+            <option key="g90" value="g90">
+              g90
+            </option>
+            <option key="g100" value="g100">
+              g100
+            </option>
+          </Form.Select>
+        </Form.Field>
+      </Form>
+    )
+  );
+};
+
+Panel.propTypes = {
+  /**
+   * The Storybook API object.
+   */
+  api: PropTypes.shape({
+    getChannel: PropTypes.func,
+  }).isRequired,
+
+  /**
+   * `true` if this Storybook add-on panel is active.
+   */
+  active: PropTypes.bool.isRequired,
+};
+
+export default Panel;

--- a/packages/react/.storybook/addon-carbon-theme/register.js
+++ b/packages/react/.storybook/addon-carbon-theme/register.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import addons from '@storybook/addons';
+import Panel from './components/Panel';
+import { ADDON_ID, PANEL_ID } from './shared';
+
+addons.register(ADDON_ID, api => {
+  addons.addPanel(PANEL_ID, {
+    title: 'Carbon theme',
+    render: ({ active, key }) => <Panel api={api} key={key} active={active} />,
+  });
+});

--- a/packages/react/.storybook/addon-carbon-theme/shared.js
+++ b/packages/react/.storybook/addon-carbon-theme/shared.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const ADDON_ID = 'carbon-theme';
+export const CURRENT_THEME = `${ADDON_ID}/current`;
+export const PANEL_ID = `${ADDON_ID}/panel`;

--- a/packages/react/.storybook/addons.js
+++ b/packages/react/.storybook/addons.js
@@ -13,3 +13,4 @@ import '@storybook/addon-a11y/register';
 
 // Community addons
 import 'storybook-readme/register';
+import './addon-carbon-theme/register';

--- a/packages/react/.storybook/addons.js
+++ b/packages/react/.storybook/addons.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import '@storybook/addon-storysource/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-actions/register';

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import { configure, addDecorator, addParameters } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -7,9 +7,11 @@
 
 import React from 'react';
 import { configure, addDecorator, addParameters } from '@storybook/react';
+import addons from '@storybook/addons';
 import { withInfo } from '@storybook/addon-info';
 import { configureActions } from '@storybook/addon-actions';
 // import { checkA11y } from 'storybook-addon-a11y';
+import { CURRENT_THEME } from './addon-carbon-theme/shared';
 import Container from './Container';
 
 addDecorator(
@@ -35,6 +37,10 @@ configureActions({
 
 addDecorator(story => <Container story={story} />);
 // addDecorator(checkA11y);
+
+addons.getChannel().on(CURRENT_THEME, theme => {
+  document.documentElement.setAttribute('storybook-carbon-theme', theme);
+});
 
 function loadStories() {
   const req = require.context('../src/components', true, /\-story\.js$/);

--- a/packages/react/.storybook/webpack.config.js
+++ b/packages/react/.storybook/webpack.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');

--- a/packages/react/.storybook/webpack.config.js
+++ b/packages/react/.storybook/webpack.config.js
@@ -9,6 +9,7 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const rtlcss = require('rtlcss');
+const customProperties = require('postcss-custom-properties');
 
 const useExternalCss =
   process.env.CARBON_REACT_STORYBOOK_USE_EXTERNAL_CSS === 'true';
@@ -39,7 +40,7 @@ const styleLoaders = [
         const autoPrefixer = require('autoprefixer')({
           overrideBrowserslist: ['last 1 version', 'ie >= 11'],
         });
-        return !useRtl ? [autoPrefixer] : [autoPrefixer, rtlcss];
+        return [customProperties(), autoPrefixer, ...(useRtl ? [rtlcss] : [])];
       },
       sourceMap: useStyleSourceMap,
     },
@@ -49,6 +50,11 @@ const styleLoaders = [
     options: {
       includePaths: [path.resolve(__dirname, '..', 'node_modules')],
       data: `
+        @import '${path.resolve(
+          __dirname,
+          '../src/globals/scss/carbon-theme'
+        )}';
+        $carbon--theme: map-get($carbon--theme--list, 'custom-properties');
         $feature-flags: (
           ui-shell: true,
         );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -94,6 +94,7 @@
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "4.10.0",
     "object-assign": "^4.1.1",
+    "postcss-custom-properties": "^9.0.2",
     "postcss-loader": "^3.0.0",
     "promise": "^8.0.1",
     "prop-types": "^15.7.2",

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -114,9 +114,8 @@ const StoryContent = () => {
     <Content
       id="main-content"
       style={{
-        backgroundColor: '#f3f3f3',
         margin: '0',
-        height: '100vh',
+        height: '100%',
         width: '100%',
       }}>
       {content}

--- a/packages/react/src/globals/scss/_carbon-theme.scss
+++ b/packages/react/src/globals/scss/_carbon-theme.scss
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/theme-maps';
+
+/// @param {Map} $theme-map [$carbon--theme] The theme map to base the result on.
+/// @return {Map} A Carbon theme map whose valus are CSS custom properties.
+@function carbon-get-theme-map-with-custom-properties(
+  $theme-map: $carbon--theme
+) {
+  $theme-map--with-custom-properties: ();
+  @each $key, $value in $theme-map {
+    $theme-map--with-custom-properties: map-merge(
+      $theme-map--with-custom-properties,
+      (
+        $key: var(--#{$key}, $value),
+      )
+    );
+  }
+  @return $theme-map--with-custom-properties;
+}
+
+/// Emits CSS custom properties from a Carbon theme map.
+/// @param {Map} $theme-map [$carbon--theme] The theme map to emit CSS custom properties from.
+/// @example @include carbon--theme--custom-properties($carbon--theme--white);
+@mixin carbon--theme--custom-properties($theme-map: $carbon--theme) {
+  @each $key, $value in $theme-map {
+    --#{$key}: #{$value};
+  }
+}
+
+/// The key/value map of Carbon themes, named by theme name.
+/// @type Map
+$carbon--theme--list: (
+  'white': $carbon--theme--white,
+  'g10': $carbon--theme--g10,
+  'g90': $carbon--theme--g90,
+  'g100': $carbon--theme--g100,
+  'custom-properties': carbon-get-theme-map-with-custom-properties(),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16518,7 +16518,7 @@ postcss-convert-values@^4.0.1:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-custom-properties@^9.0.0:
+postcss-custom-properties@^9.0.0, postcss-custom-properties@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-9.0.2.tgz#091aefaa309826302d53ec6d780fbe1df8f40fd4"
   integrity sha512-WHaQrEp3gJ6mgxBA4mGJKW6DSVfy2IFnKPFAb2IEulgxGUW8nWp1NkOD/rWR6e2uIuAdnTa0LXSupST7daniAw==


### PR DESCRIPTION
Closes #3981

Refs https://github.com/carbon-design-system/carbon-custom-elements/pull/39/ https://github.com/carbon-design-system/carbon-custom-elements/pull/109/ https://github.com/carbon-design-system/carbon-custom-elements/pull/122/

This PR ports the storybook Carbon theme switcher addon to the React components package. The addon uses Carbon theme token Sass maps and generates CSS custom properties, which are then used to construct a new Sass map for the storybook. The custom properties are scoped to their respective themes via the `storybook-carbon-theme` attribute placed on the storybook component container element. The value of that attribute is modified through a dropdown containing the possible theme values, and this is integrated into storybook as an addon

#### Changelog

**New**

- `addon-carbon-theme` storybook addon (ported from custom elements repo)

**Removed**

- removed hard coded background color leftover from experimental UI shell stories

#### Testing / Reviewing

Ensure the theme switcher functions as expected
