### PR TITLE
feat(TooltipDefinition): support custom trigger element class names

### DIFF
--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
@@ -23,6 +23,10 @@ const alignments = {
 };
 
 const props = () => ({
+  triggerClassName: text(
+    'Trigger element CSS class name (triggerClassName)',
+    ''
+  ),
   direction: select('Tooltip direction (direction)', directions, 'bottom'),
   align: select(
     'Tooltip alignment to trigger button (align)',

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
@@ -26,6 +26,16 @@ describe('TooltipDefinition', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should support a custom trigger element class', () => {
+    const wrapper = mount(
+      <TooltipDefinition
+        {...mockProps}
+        triggerClassName="custom-trigger-class"
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should allow the user to specify the direction', () => {
     const wrapper = mount(<TooltipDefinition {...mockProps} direction="top" />);
     expect(wrapper).toMatchSnapshot();

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -16,6 +16,7 @@ const getInstanceId = setupGetInstanceId();
 const TooltipDefinition = ({
   id,
   className,
+  triggerClassName,
   children,
   direction,
   align,
@@ -32,6 +33,7 @@ const TooltipDefinition = ({
     `${prefix}--tooltip__trigger`,
     `${prefix}--tooltip--a11y`,
     `${prefix}--tooltip__trigger--definition`,
+    triggerClassName,
     {
       [`${prefix}--tooltip--${direction}`]: direction,
       [`${prefix}--tooltip--align-${align}`]: align,
@@ -58,6 +60,11 @@ TooltipDefinition.propTypes = {
    * interact with in order to display the tooltip.
    */
   children: PropTypes.string.isRequired,
+
+  /**
+   * The CSS class name of the trigger element
+   */
+  triggerClassName: PropTypes.string,
 
   /**
    * Specify the direction of the tooltip. Can be either top or bottom.

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -11,14 +11,14 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
     className="bx--tooltip--definition bx--tooltip--a11y custom-class"
   >
     <button
-      aria-describedby="definition-tooltip-2"
+      aria-describedby="definition-tooltip-3"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
     >
       tooltip trigger
     </button>
     <div
       className="bx--assistive-text"
-      id="definition-tooltip-2"
+      id="definition-tooltip-3"
       role="tooltip"
     >
       tooltip text
@@ -46,6 +46,34 @@ exports[`TooltipDefinition should render 1`] = `
     <div
       className="bx--assistive-text"
       id="definition-tooltip-1"
+      role="tooltip"
+    >
+      tooltip text
+    </div>
+  </div>
+</TooltipDefinition>
+`;
+
+exports[`TooltipDefinition should support a custom trigger element class 1`] = `
+<TooltipDefinition
+  align="start"
+  className="custom-class"
+  direction="bottom"
+  tooltipText="tooltip text"
+  triggerClassName="custom-trigger-class"
+>
+  <div
+    className="bx--tooltip--definition bx--tooltip--a11y custom-class"
+  >
+    <button
+      aria-describedby="definition-tooltip-2"
+      className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition custom-trigger-class bx--tooltip--bottom bx--tooltip--align-start"
+    >
+      tooltip trigger
+    </button>
+    <div
+      className="bx--assistive-text"
+      id="definition-tooltip-2"
       role="tooltip"
     >
       tooltip text


### PR DESCRIPTION
Closes #3994

This PR adds support for custom trigger element class names in the `<TooltipDefinition>` component (to match interactive and icon tooltips)

#### Changelog

**New**

- `triggerClassName` for the definition tooltip trigger element

#### Testing / Reviewing

Ensure custom class names can be added to the tooltip trigger element
