### PR TITLE
fix(type): remove italic from helper text 01

### DIFF
--- a/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
+++ b/packages/type/src/__tests__/__snapshots__/styles-test.js.snap
@@ -488,7 +488,6 @@ letter-spacing: 0;"
 exports[`styles helperText01 should be printable 1`] = `
 Object {
   "fontSize": "0.75rem",
-  "fontStyle": "italic",
   "letterSpacing": "0.32px",
   "lineHeight": "1rem",
 }
@@ -496,7 +495,6 @@ Object {
 
 exports[`styles helperText01 should be printable 2`] = `
 "font-size: 0.75rem;
-font-style: italic;
 line-height: 1rem;
 letter-spacing: 0.32px;"
 `;

--- a/packages/type/src/styles.js
+++ b/packages/type/src/styles.js
@@ -26,7 +26,6 @@ export const label01 = {
 
 export const helperText01 = {
   fontSize: rem(scale[0]),
-  fontStyle: 'italic',
   lineHeight: rem(16),
   letterSpacing: px(0.32),
 };


### PR DESCRIPTION
Ref #3999

Removes italic from `helper-text-01`

#### Changelog

**Removed**

- `fontStyle: 'italic',` from `helper-text-01` type token

#### Testing / Reviewing

Make sure `helper-text-01` is no longer showing up italic
https://deploy-preview-4004--carbon-elements.netlify.com/type/examples/preview/