### PR TITLE
feat(tooltip): allow custom CSS classes for displaying tooltips

### DIFF
--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -190,10 +190,8 @@
   // @todo Simplify CSS selectors on next major release
   &::before,
   &::after,
-  &:hover .#{$prefix}--assistive-text,
-  &:focus .#{$prefix}--assistive-text,
-  &:hover + .#{$prefix}--assistive-text,
-  &:focus + .#{$prefix}--assistive-text {
+  .#{$prefix}--assistive-text,
+  + .#{$prefix}--assistive-text {
     @if ($position == 'top') {
       top: 0;
       left: 50%;
@@ -242,10 +240,8 @@
   // alignment options available only for top and bottom tooltip position
   // @todo Simplify CSS selectors on next major release
   &::after,
-  &:hover .#{$prefix}--assistive-text,
-  &:focus .#{$prefix}--assistive-text,
-  &:hover + .#{$prefix}--assistive-text,
-  &:focus + .#{$prefix}--assistive-text {
+  .#{$prefix}--assistive-text,
+  + .#{$prefix}--assistive-text {
     @if ($position == 'top') {
       top: -$body-spacing;
       @if ($align == 'start') {

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -8,7 +8,7 @@
 @import 'layer';
 
 // Tooltip
-// Definition and Icon CSS only tooltip
+// Forces visible state for definition and icon only tooltip
 /// @access public
 /// @group tooltip
 @mixin tooltip--visible() {
@@ -24,6 +24,7 @@
   }
 }
 
+/// A mix-in that represents the trigger button of definition and icon only tooltips
 /// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
 /// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
 /// @access public

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -9,6 +9,21 @@
 
 // Tooltip
 // Definition and Icon CSS only tooltip
+/// @access public
+/// @group tooltip
+@mixin tooltip--visible() {
+  &::before {
+    opacity: 1;
+  }
+
+  .#{$prefix}--assistive-text,
+  + .#{$prefix}--assistive-text {
+    clip: auto;
+    margin: auto;
+    overflow: visible;
+  }
+}
+
 /// @param {String} $tooltip-type ['icon'] - The type, from: `icon`, `definition`
 /// @param {String} $position ['bottom'] - The position, from: `top`, `right`, `bottom`, `left`
 /// @access public
@@ -85,10 +100,8 @@
   // content box
   // @todo Simplify CSS selectors on next major release
   &::after,
-  &:hover .#{$prefix}--assistive-text,
-  &:focus .#{$prefix}--assistive-text,
-  &:hover + .#{$prefix}--assistive-text,
-  &:focus + .#{$prefix}--assistive-text {
+  .#{$prefix}--assistive-text,
+  + .#{$prefix}--assistive-text {
     @include layer('overlay');
     width: max-content;
     max-width: rem(208px);
@@ -129,7 +142,8 @@
 
   &:hover,
   &:focus {
-    &::before,
+    @include tooltip--visible();
+
     &::after {
       opacity: 1;
     }
@@ -141,13 +155,6 @@
       to {
         opacity: 1;
       }
-    }
-
-    .#{$prefix}--assistive-text,
-    + .#{$prefix}--assistive-text {
-      clip: auto;
-      margin: auto;
-      overflow: visible;
     }
 
     .#{$prefix}--assistive-text,


### PR DESCRIPTION
Closes #4015

This PR extracts the tooltip display code in a new mixin called `tooltip--visible()`

#### Changelog

**New**

- `tooltip--visible()` Sass mixin containing style rules needed to display definition and icon tooltips

**Changed**

- refactor tooltip positioning selectors to remove unneeded `:hover` and `:focus` selectors

#### Testing / Reviewing

1. Create a new tooltip example with test classes (in this example, it is `.bx--test` and `.bx--test--focus`)

```html
<div class="{{@root.prefix}}--tooltip--definition {{@root.prefix}}--tooltip--a11y">
  <button
    class="{{@root.prefix}}--tooltip__trigger {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--tooltip--left {{@root.prefix}}--tooltip--align-start">
    <span class="{{@root.prefix}}--assistive-text">Filter</span>
    {{ carbon-icon 'Filter16' }}
  </button>
  <span aria-describedby="test"
    class="{{@root.prefix}}--test {{@root.prefix}}--tooltip--a11y {{@root.prefix}}--test--focus">
    Definition Tooltip (open)
  </span>
  <div class="bx--assistive-text" id="test" role="tooltip">Brief description of the dotted, underlined word
    above.</div>
</div>
```

2. apply the default tooltip mixins and the new tooltip mixin to the test classes

```scss
.#{$prefix}--test {
  @include tooltip--trigger('definition', 'bottom');
  @include tooltip--placement('definition', 'bottom', 'center');
}

.#{$prefix}--test--focus {
  @include tooltip--visible();
}
````

ensure that the tooltip is open by default and ensure existing tooltip implementation is not broken
