### PR TITLE
feat(components): add sass build pipeline

### DIFF
--- a/packages/components/gulpfile.js
+++ b/packages/components/gulpfile.js
@@ -10,12 +10,14 @@ const sass = require('gulp-sass');
 const postcss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');
 const customProperties = require('postcss-custom-properties');
+const scss = require('postcss-scss');
 // load dart-sass
 const dartSass = require('sass');
 // required for dart-sass - async builds are significantly slower without this package
 const Fiber = require('fibers');
 // require node-sass so we can explicitly set `gulp-sass`s `.compiler` property
 const nodeSass = require('node-sass');
+const transformCustomProperties = require('./tools/postcss/transform-custom-properties');
 
 // Javascript deps
 const babel = require('gulp-babel');
@@ -460,7 +462,14 @@ gulp.task('sass:dev:server', () => {
 });
 
 gulp.task('sass:source', () =>
-  gulp.src('./src/**/*.scss').pipe(gulp.dest('scss'))
+  gulp
+    .src('./src/**/*.scss')
+    .pipe(
+      postcss([transformCustomProperties()], {
+        parser: scss,
+      })
+    )
+    .pipe(gulp.dest('scss'))
 );
 
 const buildDemoHTML = () => {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "gulp build && ./tools/copy-vendor-styles.sh && bundler check \"scss/**/*.scss\" && yarn docs",
+    "build": "./tools/copy-vendor-styles.sh && gulp build && bundler check \"scss/**/*.scss\" && yarn docs",
     "build-dev": "gulp build:dev",
     "build-dev-rollup": "gulp build:dev:deploy --rollup --use-custom-properties",
     "clean": "gulp clean",

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -23,28 +23,33 @@
   }
 
   .#{$prefix}--accordion__item {
-    transition: all $duration--fast-02 motion(standard, productive);
-    border-top: 1px solid $ui-03;
+    transition: all var(--duration-fast-02, $duration--fast-02)
+      motion(standard, productive);
+    border-top: 1px solid var(--ui-03, $ui-03);
     overflow: visible;
 
     &:last-child {
-      border-bottom: 1px solid $ui-03;
+      border-bottom: 1px solid var(--ui-03, $ui-03);
     }
   }
 
   .#{$prefix}--accordion__heading {
     @include button-reset;
-    color: $text-01;
+    color: var(--text-01, $text-01);
     display: flex;
     align-items: center;
-    justify-content: $accordion-justify-content;
+    justify-content: var(
+      --accordion-justify-content,
+      $accordion-justify-content
+    );
     cursor: pointer;
     padding: rem(6px) 0;
-    flex-direction: $accordion-flex-direction;
+    flex-direction: var(--accordion-flex-direction, $accordion-flex-direction);
     position: relative;
     width: 100%;
     margin: 0;
-    transition: background-color motion(standard, productive) $duration--fast-02;
+    transition: background-color motion(standard, productive)
+      var(--duration--fast-02, $duration--fast-02);
 
     &:hover:before,
     &:focus:before {
@@ -57,7 +62,7 @@
     }
 
     &:hover:before {
-      background-color: $hover-ui;
+      background-color: var(--hover-ui, $hover-ui);
     }
 
     &:focus {
@@ -76,17 +81,18 @@
     flex: 0 0 1rem;
     width: 1rem;
     height: 1rem;
-    margin: $accordion-arrow-margin;
-    fill: $ui-05;
+    margin: var(--accordion-arrow-margin, $accordion-arrow-margin);
+    fill: var(--ui-05, $ui-05);
     // TODO: RTL rotate(180deg);
     transform: rotate(90deg);
-    transition: all $duration--fast-02 motion(standard, productive);
+    transition: all var(--duration--fast-02, $duration--fast-02)
+      motion(standard, productive);
   }
 
   .#{$prefix}--accordion__title {
     @include type-style('body-long-01');
 
-    margin: $accordion-title-margin;
+    margin: var(--accordion-title-margin, $accordion-title-margin);
     width: 100%;
     text-align: left;
     z-index: 0;
@@ -94,9 +100,11 @@
 
   .#{$prefix}--accordion__content {
     // Transition property for when the accordion closes
-    transition: height motion(standard, productive) $duration--fast-02,
-      padding motion(standard, productive) $duration--fast-02;
-    padding-left: $carbon--spacing-05;
+    transition: height motion(standard, productive)
+        var(--duration--fast-02, $duration--fast-02),
+      padding motion(standard, productive)
+        var(--duration--fast-02, $duration--fast-02);
+    padding-left: var(--carbon--spacing-05, $carbon--spacing-05);
 
     padding-right: 25%;
     height: 0;
@@ -104,7 +112,7 @@
     opacity: 0;
 
     @include carbon--breakpoint-down('md') {
-      padding-right: $carbon--spacing-09;
+      padding-right: var(--carbon--spacing-09, $carbon--spacing-09);
     }
 
     p {
@@ -116,21 +124,24 @@
     overflow: visible;
 
     .#{$prefix}--accordion__content {
-      padding-bottom: $carbon--spacing-06;
+      padding-bottom: var(--carbon--spacing-06, $carbon--spacing-06);
       padding-top: $spacing-xs;
       height: auto;
       visibility: visible;
       opacity: 1;
       // Transition property for when the accordion opens
-      transition: height motion(entrance, productive) $duration--fast-02,
-        padding-top motion(entrance, productive) $duration--fast-02,
-        padding-bottom motion(entrance, productive) $duration--fast-02;
+      transition: height motion(entrance, productive)
+          var(--duration--fast-02, $duration--fast-02),
+        padding-top motion(entrance, productive)
+          var(--duration--fast-02, $duration--fast-02),
+        padding-bottom motion(entrance, productive)
+          var(--duration--fast-02, $duration--fast-02);
     }
 
     .#{$prefix}--accordion__arrow {
       /*rtl:ignore*/
       transform: rotate(-90deg);
-      fill: $ui-05;
+      fill: var(--ui-05, $ui-05);
     }
   }
 
@@ -142,7 +153,7 @@
 
   .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__arrow {
     pointer-events: none;
-    fill: $ui-05;
+    fill: var(--ui-05, $ui-05);
     cursor: default;
 
     &:hover,

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -23,12 +23,13 @@
   }
 
   .#{$prefix}--accordion__item {
-    transition: all $duration--fast-02 motion(standard, productive);
+    transition: all var(--c-duration-fast-02, $duration--fast-02)
+      motion(standard, productive);
     border-top: 1px solid $ui-03;
     overflow: visible;
 
     &:last-child {
-      border-bottom: 1px solid $ui-03;
+      border-bottom: 1px solid var(--c-ui-03, $ui-03);
     }
   }
 

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -23,33 +23,28 @@
   }
 
   .#{$prefix}--accordion__item {
-    transition: all var(--duration-fast-02, $duration--fast-02)
-      motion(standard, productive);
-    border-top: 1px solid var(--ui-03, $ui-03);
+    transition: all $duration--fast-02 motion(standard, productive);
+    border-top: 1px solid $ui-03;
     overflow: visible;
 
     &:last-child {
-      border-bottom: 1px solid var(--ui-03, $ui-03);
+      border-bottom: 1px solid $ui-03;
     }
   }
 
   .#{$prefix}--accordion__heading {
     @include button-reset;
-    color: var(--text-01, $text-01);
+    color: $text-01;
     display: flex;
     align-items: center;
-    justify-content: var(
-      --accordion-justify-content,
-      $accordion-justify-content
-    );
+    justify-content: $accordion-justify-content;
     cursor: pointer;
     padding: rem(6px) 0;
-    flex-direction: var(--accordion-flex-direction, $accordion-flex-direction);
+    flex-direction: $accordion-flex-direction;
     position: relative;
     width: 100%;
     margin: 0;
-    transition: background-color motion(standard, productive)
-      var(--duration--fast-02, $duration--fast-02);
+    transition: background-color motion(standard, productive) $duration--fast-02;
 
     &:hover:before,
     &:focus:before {
@@ -62,7 +57,7 @@
     }
 
     &:hover:before {
-      background-color: var(--hover-ui, $hover-ui);
+      background-color: $hover-ui;
     }
 
     &:focus {
@@ -81,18 +76,17 @@
     flex: 0 0 1rem;
     width: 1rem;
     height: 1rem;
-    margin: var(--accordion-arrow-margin, $accordion-arrow-margin);
-    fill: var(--ui-05, $ui-05);
+    margin: $accordion-arrow-margin;
+    fill: $ui-05;
     // TODO: RTL rotate(180deg);
     transform: rotate(90deg);
-    transition: all var(--duration--fast-02, $duration--fast-02)
-      motion(standard, productive);
+    transition: all $duration--fast-02 motion(standard, productive);
   }
 
   .#{$prefix}--accordion__title {
     @include type-style('body-long-01');
 
-    margin: var(--accordion-title-margin, $accordion-title-margin);
+    margin: $accordion-title-margin;
     width: 100%;
     text-align: left;
     z-index: 0;
@@ -100,11 +94,9 @@
 
   .#{$prefix}--accordion__content {
     // Transition property for when the accordion closes
-    transition: height motion(standard, productive)
-        var(--duration--fast-02, $duration--fast-02),
-      padding motion(standard, productive)
-        var(--duration--fast-02, $duration--fast-02);
-    padding-left: var(--carbon--spacing-05, $carbon--spacing-05);
+    transition: height motion(standard, productive) $duration--fast-02,
+      padding motion(standard, productive) $duration--fast-02;
+    padding-left: $carbon--spacing-05;
 
     padding-right: 25%;
     height: 0;
@@ -112,7 +104,7 @@
     opacity: 0;
 
     @include carbon--breakpoint-down('md') {
-      padding-right: var(--carbon--spacing-09, $carbon--spacing-09);
+      padding-right: $carbon--spacing-09;
     }
 
     p {
@@ -124,24 +116,21 @@
     overflow: visible;
 
     .#{$prefix}--accordion__content {
-      padding-bottom: var(--carbon--spacing-06, $carbon--spacing-06);
+      padding-bottom: $carbon--spacing-06;
       padding-top: $spacing-xs;
       height: auto;
       visibility: visible;
       opacity: 1;
       // Transition property for when the accordion opens
-      transition: height motion(entrance, productive)
-          var(--duration--fast-02, $duration--fast-02),
-        padding-top motion(entrance, productive)
-          var(--duration--fast-02, $duration--fast-02),
-        padding-bottom motion(entrance, productive)
-          var(--duration--fast-02, $duration--fast-02);
+      transition: height motion(entrance, productive) $duration--fast-02,
+        padding-top motion(entrance, productive) $duration--fast-02,
+        padding-bottom motion(entrance, productive) $duration--fast-02;
     }
 
     .#{$prefix}--accordion__arrow {
       /*rtl:ignore*/
       transform: rotate(-90deg);
-      fill: var(--ui-05, $ui-05);
+      fill: $ui-05;
     }
   }
 
@@ -153,7 +142,7 @@
 
   .#{$prefix}--accordion.#{$prefix}--skeleton .#{$prefix}--accordion__arrow {
     pointer-events: none;
-    fill: var(--ui-05, $ui-05);
+    fill: $ui-05;
     cursor: default;
 
     &:hover,

--- a/packages/components/tools/postcss/transform-custom-properties-test.js
+++ b/packages/components/tools/postcss/transform-custom-properties-test.js
@@ -15,6 +15,24 @@ const plugin = require('./transform-custom-properties');
 
 const tests = [
   {
+    name: 'property with no token',
+    input: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+  }
+}
+`,
+    output: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+  }
+}
+`,
+  },
+
+  {
     name: 'sass maps',
     input: `$config: ( foo: 'bar' );`,
     output: `$config: ( foo: 'bar' );`,
@@ -26,8 +44,7 @@ const tests = [
 @mixin my-component {
   .#{$prefix}--component {
     display: block;
-    color: var(--token-01, $token-01);
-  }
+    color: var(--token-01, $token-01); }
 }
 `,
     output: `
@@ -35,8 +52,7 @@ const tests = [
   .#{$prefix}--component {
     display: block;
     color: $token-01;
-    color: var(--token-01, $token-01);
-  }
+    color: var(--token-01, $token-01); }
 }
 `,
   },
@@ -90,23 +106,42 @@ const tests = [
   },
 
   {
+    name: 'middle position',
+    input: `
+@mixin my-component {
+  .#{$prefix}--component {
+    transition: all var(--duration-fast-02, $duration--fast-02)
+      motion(standard, productive);
+  }
+}
+`,
+    output: `
+@mixin my-component {
+  .#{$prefix}--component {
+    transition: all $duration--fast-02 motion(standard, productive);
+    transition: all var(--duration-fast-02, $duration--fast-02)
+      motion(standard, productive);
+  }
+}
+`,
+  },
+
+  {
     name: 'multiline properties',
     input: `
 .#{$prefix}--component {
   transition: height motion(standard, productive)
-      var(--duration--fast-02, $duration--fast-02),
+      var(--duration--fast-01, $duration--fast-01),
     padding motion(standard, productive)
       var(--duration--fast-02, $duration--fast-02);
 }
 `,
     output: `
 .#{$prefix}--component {
+  transition: height motion(standard, productive) $duration--fast-01,
+padding motion(standard, productive) $duration--fast-02;
   transition: height motion(standard, productive)
-      $duration--fast-02,
-    padding motion(standard, productive)
-      $duration--fast-02;
-  transition: height motion(standard, productive)
-      var(--duration--fast-02, $duration--fast-02),
+      var(--duration--fast-01, $duration--fast-01),
     padding motion(standard, productive)
       var(--duration--fast-02, $duration--fast-02);
 }
@@ -114,13 +149,12 @@ const tests = [
   },
 ];
 
-for (const { name, input, output } of tests.slice(tests.length - 1)) {
+for (const { name, input, output } of tests) {
   test(`${name} should compile`, async () => {
     const result = await postcss([plugin()]).process(input, {
       from: undefined,
       parser: scss,
     });
-    console.log(result.css);
-    // expect(result.css).toBe(output);
+    expect(result.css).toBe(output);
   });
 }

--- a/packages/components/tools/postcss/transform-custom-properties-test.js
+++ b/packages/components/tools/postcss/transform-custom-properties-test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const postcss = require('postcss');
+const scss = require('postcss-scss');
+const plugin = require('./transform-custom-properties');
+
+const tests = [
+  {
+    name: 'sass maps',
+    input: `$config: ( foo: 'bar' );`,
+    output: `$config: ( foo: 'bar' );`,
+  },
+
+  {
+    name: 'mixin with selector',
+    input: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+    color: var(--token-01, $token-01);
+  }
+}
+`,
+    output: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+    color: $token-01;
+    color: var(--token-01, $token-01);
+  }
+}
+`,
+  },
+
+  {
+    name: 'mixin with nested selector',
+    input: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+
+    .nested {
+      color: var(--token-01, $token-01);
+    }
+  }
+}
+`,
+    output: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+
+    .nested {
+      color: $token-01;
+      color: var(--token-01, $token-01);
+    }
+  }
+}
+`,
+  },
+
+  {
+    name: 'value with more than just custom property',
+    input: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+    transition: 0.3s all var(--motion-01, $motion-01) reverse;
+  }
+}
+`,
+    output: `
+@mixin my-component {
+  .#{$prefix}--component {
+    display: block;
+    transition: 0.3s all $motion-01 reverse;
+    transition: 0.3s all var(--motion-01, $motion-01) reverse;
+  }
+}
+`,
+  },
+
+  {
+    name: 'multiline properties',
+    input: `
+.#{$prefix}--component {
+  transition: height motion(standard, productive)
+      var(--duration--fast-02, $duration--fast-02),
+    padding motion(standard, productive)
+      var(--duration--fast-02, $duration--fast-02);
+}
+`,
+    output: `
+.#{$prefix}--component {
+  transition: height motion(standard, productive)
+      $duration--fast-02,
+    padding motion(standard, productive)
+      $duration--fast-02;
+  transition: height motion(standard, productive)
+      var(--duration--fast-02, $duration--fast-02),
+    padding motion(standard, productive)
+      var(--duration--fast-02, $duration--fast-02);
+}
+`,
+  },
+];
+
+for (const { name, input, output } of tests.slice(tests.length - 1)) {
+  test(`${name} should compile`, async () => {
+    const result = await postcss([plugin()]).process(input, {
+      from: undefined,
+      parser: scss,
+    });
+    console.log(result.css);
+    // expect(result.css).toBe(output);
+  });
+}

--- a/packages/components/tools/postcss/transform-custom-properties.js
+++ b/packages/components/tools/postcss/transform-custom-properties.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const postcss = require('postcss');
+const scss = require('postcss-scss');
+
+const CUSTOM_PROPERTY_REGEX = /^(.*)var\(--(.+),\s\$(.+)\)(.*)$/m;
+const plugin = postcss.plugin('transform-custom-properties', () => {
+  return root => {
+    root.walkDecls(declaration => {
+      const { prop, value, parent, raws } = declaration;
+      // We're most likely in a Sass variable map
+      if (prop[0] === '$') {
+        return;
+      }
+
+      const match = CUSTOM_PROPERTY_REGEX.exec(declaration.value);
+      if (!match) {
+        return;
+      }
+
+      const before = match[1];
+      const customPropertyName = match[2];
+      const tokenName = match[3];
+      const after = match[4];
+
+      if (customPropertyName !== tokenName) {
+        throw new Error('Expected token name to match property name');
+      }
+
+      declaration.before(
+        `${raws.before}${prop}: ${before}$${tokenName}${after}`
+      );
+    });
+  };
+});
+
+module.exports = plugin;

--- a/packages/components/tools/postcss/transform-custom-properties.js
+++ b/packages/components/tools/postcss/transform-custom-properties.js
@@ -10,8 +10,30 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const postcss = require('postcss');
 
+/**
+ * This plugin transforms our usage of custom properties to an appropriate
+ * fallback in the Sass source. For full support, view the test file associated
+ * with this transform. A quick overview:
+ *
+ * Input:
+ * .my-selector {
+ *   // How we author in our source code
+ *   color: var(--token-01, $token-01);
+ * }
+ *
+ * Output:
+ * .my-selector {
+ *   // Output fallback in code shipped in `scss` folder
+ *   color: $token-01;
+ *   color: var(--token-01, $token-01);
+ * }
+ */
 const plugin = postcss.plugin('transform-custom-properties', () => {
   return root => {
+    // Our strategy for this plugin is to walk through all the declarations that
+    // it can find and test for the existence of a custom property using the
+    // `CUSTOM_PROPERTY_REGEX`. If we've found matches, then we know that we
+    // have to provide a fallback in the resulting code.
     root.walkDecls(declaration => {
       const CUSTOM_PROPERTY_REGEX = /var\(--([a-z-0-9]+),\s\$([a-z-0-9]+)\)/g;
       const { prop, raws } = declaration;
@@ -20,6 +42,12 @@ const plugin = postcss.plugin('transform-custom-properties', () => {
         return;
       }
 
+      // Before testing our regex, we try and map source code to a normal-ish
+      // structure given that formatting tools can cause values to wrap in
+      // unpredictable ways. As a result, we're going to split on newlines and
+      // then consolidate values between `,` so that we can view each part of
+      // the value of property in isolation and safely substitute CSS Custom
+      // Properties
       const lines = declaration.value.split('\n');
       const values = [];
       let index = 0;
@@ -45,6 +73,8 @@ const plugin = postcss.plugin('transform-custom-properties', () => {
         return;
       }
 
+      // For our fallback values, we're going to replace any `var()` match with
+      // the fallback token in capture group $2
       const fallback = values.map(value => {
         return value.replace(CUSTOM_PROPERTY_REGEX, '$$$2');
       });

--- a/packages/components/tools/postcss/transform-custom-properties.js
+++ b/packages/components/tools/postcss/transform-custom-properties.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2018, 2018
+ * Copyright IBM Corp. 2016, 2018
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,16 +7,14 @@
 
 'use strict';
 
-// ^([\s\S]*)var\(--([a-z-]+),\s\$([a-z-]+)\)*([\s\S])$
-
+// eslint-disable-next-line import/no-extraneous-dependencies
 const postcss = require('postcss');
-const scss = require('postcss-scss');
 
 const plugin = postcss.plugin('transform-custom-properties', () => {
   return root => {
     root.walkDecls(declaration => {
       const CUSTOM_PROPERTY_REGEX = /var\(--([a-z-0-9]+),\s\$([a-z-0-9]+)\)/g;
-      const { prop, parent, raws } = declaration;
+      const { prop, raws } = declaration;
       // We're most likely in a Sass variable map
       if (prop[0] === '$') {
         return;
@@ -26,6 +24,7 @@ const plugin = postcss.plugin('transform-custom-properties', () => {
       const values = [];
       let index = 0;
 
+      // eslint-disable-next-line no-restricted-syntax
       for (const line of lines) {
         if (!values[index]) {
           values[index] = '';


### PR DESCRIPTION
Closes #4001

Adds in a build step for our `scss` folder where we transform custom property usage with an appropriate fallback.

#### Changelog

**New**

- Custom postcss plugin to transform CSS Custom Properties into Sass variable fallbacks

**Changed**

- `gulp sass:source` now uses postcss and a custom plugin to transform source files to include an appropriate fallback

**Removed**

#### Testing / Reviewing

- Pull down PR
- Run `yarn build` in `components`
- View `scss/components/_accordion.scss` and verify this output:

```scss
/*/ Accordion styles*/
/*/ @access private*/
/*/ @group accordion*/
@mixin accordion {
  .#{$prefix}--accordion {
    @include reset;

    list-style: none;
    width: 100%;
  }

  .#{$prefix}--accordion__item {
    transition: all $duration--fast-02 motion(standard, productive);
    transition: all var(--c-duration-fast-02, $duration--fast-02)
      motion(standard, productive);
    border-top: 1px solid $ui-03;
    overflow: visible;

    &:last-child {
      border-bottom: 1px solid $ui-03;
      border-bottom: 1px solid var(--c-ui-03, $ui-03);
    }
  }

```