### PR TITLE
feat(scss-generator): add additional types for AST

### DIFF
--- a/packages/scss-generator/__tests__/scss-test.js
+++ b/packages/scss-generator/__tests__/scss-test.js
@@ -414,6 +414,17 @@ describe('@carbon/scss', () => {
   $test: 1;
 };`,
       ],
+      [
+        'function in assignment',
+        t.Assignment(
+          t.Identifier('value'),
+          t.SassFunctionCall(t.Identifier('map-get'), [
+            t.Identifier('map'),
+            t.SassString('key'),
+          ])
+        ),
+        `$value: map-get($map, 'key');`,
+      ],
     ];
 
     test.each(calls)('%s', (_, ast, expected) => {

--- a/packages/scss-generator/__tests__/scss-test.js
+++ b/packages/scss-generator/__tests__/scss-test.js
@@ -515,4 +515,16 @@ describe('@carbon/scss', () => {
       expect(code.trim()).toEqual(expected.trim());
     });
   });
+
+  describe('formatting', () => {
+    test('newline', () => {
+      const { code } = generate(
+        t.StyleSheet([t.Comment('start'), t.Newline(), t.Comment('end')])
+      );
+      expect(code).toBe(`//start
+
+//end
+`);
+    });
+  });
 });

--- a/packages/scss-generator/src/types/definitions.js
+++ b/packages/scss-generator/src/types/definitions.js
@@ -298,6 +298,47 @@ const SassValue = defineType('SassValue', {
 //-------------------------------------------------------------------------------
 // Calls
 //-------------------------------------------------------------------------------
+const SassFunctionCall = defineType('SassFunctionCall', {
+  fields: {
+    id: {
+      validate: assertType(Identifier),
+    },
+    params: {
+      optional: true,
+      validate: () =>
+        arrayOf(
+          assertOneOf([
+            assertType(Identifier),
+            assertType(SassBoolean),
+            assertType(SassList),
+            assertType(SassMap),
+            assertType(SassNumber),
+            assertType(SassString),
+          ])
+        ),
+    },
+  },
+  generate(printer, node) {
+    printer.space();
+    printer.print(node.id);
+    printer.token('(');
+    if (Array.isArray(node.params)) {
+      for (let i = 0; i < node.params.length; i++) {
+        const param = node.params[i];
+        if (param.type === Identifier.type) {
+          printer.token('$');
+        }
+        printer.print(param, node);
+        if (i !== node.params.length - 1) {
+          printer.token(',');
+          printer.space();
+        }
+      }
+    }
+    printer.token(')');
+  },
+});
+
 const SassMixinCall = defineType('SassMixinCall', {
   fields: {
     id: {
@@ -478,6 +519,7 @@ const Assignment = defineType('Assignment', {
           assertType(SassMap),
           assertType(SassNumber),
           assertType(SassString),
+          assertType(SassFunctionCall),
         ]),
     },
     default: {
@@ -731,6 +773,7 @@ module.exports = {
   SassBoolean,
   SassColor,
   SassFunction,
+  SassFunctionCall,
   SassImport,
   SassNumber,
   SassString,

--- a/packages/scss-generator/src/types/definitions.js
+++ b/packages/scss-generator/src/types/definitions.js
@@ -371,8 +371,13 @@ const SassMixinCall = defineType('SassMixinCall', {
     printer.token('(');
     if (Array.isArray(node.params)) {
       for (let i = 0; i < node.params.length; i++) {
-        printer.token('$');
-        printer.print(node.params[i], node);
+        const param = node.params[i];
+
+        if (param.type === Identifier.type) {
+          printer.token('$');
+        }
+
+        printer.print(param, node);
         if (i !== node.params.length - 1) {
           printer.token(',');
           printer.space();

--- a/packages/scss-generator/src/types/definitions.js
+++ b/packages/scss-generator/src/types/definitions.js
@@ -282,6 +282,19 @@ const SassString = defineType('SassString', {
   },
 });
 
+// Allow ability to shortcircuit AST builder limitations and embed raw values
+// into the Sass source code
+const SassValue = defineType('SassValue', {
+  fields: {
+    value: {
+      validate: assertAny,
+    },
+  },
+  generate(printer, node) {
+    printer.token(node.value);
+  },
+});
+
 //-------------------------------------------------------------------------------
 // Calls
 //-------------------------------------------------------------------------------
@@ -724,6 +737,7 @@ module.exports = {
   SassList,
   SassMap,
   SassMapProperty,
+  SassValue,
   SassMixin,
   SassMixinCall,
   StyleSheet,

--- a/packages/scss-generator/src/types/definitions.js
+++ b/packages/scss-generator/src/types/definitions.js
@@ -663,19 +663,21 @@ const CallExpression = defineType('CallExpression', {
 const StyleSheet = defineType('StyleSheet', {
   fields: {
     children: {
-      validate: arrayOf(
-        assertOneOf([
-          assertType(Assignment),
-          assertType(AtRule),
-          assertType(Comment),
-          assertType(IfStatement),
-          assertType(Rule),
-          assertType(SassFunction),
-          assertType(SassImport),
-          assertType(SassMixin),
-          assertType(SassMixinCall),
-        ])
-      ),
+      validate: () =>
+        arrayOf(
+          assertOneOf([
+            assertType(Assignment),
+            assertType(AtRule),
+            assertType(Comment),
+            assertType(IfStatement),
+            assertType(Rule),
+            assertType(SassFunction),
+            assertType(SassImport),
+            assertType(SassMixin),
+            assertType(SassMixinCall),
+            assertType(Newline),
+          ])
+        ),
     },
   },
   generate(printer, node) {
@@ -686,6 +688,15 @@ const StyleSheet = defineType('StyleSheet', {
         printer.newline();
       }
     }
+  },
+});
+
+//-------------------------------------------------------------------------------
+// Formatting
+//-------------------------------------------------------------------------------
+const Newline = defineType('Newline', {
+  generate(printer) {
+    printer.newline();
   },
 });
 
@@ -716,4 +727,7 @@ module.exports = {
   SassMixin,
   SassMixinCall,
   StyleSheet,
+
+  // Formatting
+  Newline,
 };


### PR DESCRIPTION
Adds in additional AST node types for our theme generation logic, namely `SassValue` for bypassing the AST builder, `SassFunctionCall` for specifying function calls, and `Newline` for formatting.

#### Changelog

**New**

**Changed**

- Types have been updating to include `Newline`, `SassValue`, and `SassFunctionCall`
- `SassMixinCall` no longer assumes `Identifier` in params position

**Removed**

#### Testing / Reviewing

- Verify test cases handle additions (if needed)
