### PR TITLE
fix(Modal): remove scroller class on unmount

### DIFF
--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -119,6 +119,10 @@ describe('Modal', () => {
       expect(
         document.body.classList.contains('bx--body--with-modal-open')
       ).toEqual(true);
+      wrapper.unmount();
+      expect(
+        document.body.classList.contains('bx--body--with-modal-open')
+      ).toEqual(false);
     });
 
     it('should set state to open when trigger button is clicked', () => {

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -236,6 +236,10 @@ export default class Modal extends Component {
     }
   };
 
+  componentWillUnmount() {
+    toggleClass(document.body, `${prefix}--body--with-modal-open`, false);
+  }
+
   componentDidMount() {
     toggleClass(
       document.body,


### PR DESCRIPTION
Fixes #4064.

#### Changelog

**New**

- Code to remove body scroller class when `<Modal>` gets unmounted.

#### Testing / Reviewing

Testing should make sure `<Modal>` is not broken.