### PR TITLE
fix(icon): normalize minimize/maximize

### DIFF
--- a/packages/icons/svg/16/maximize.svg
+++ b/packages/icons/svg/16/maximize.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="16px" height="16px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}
 </style>
 <title>maximize</title>
-<polygon points="10,1 10,2 13.3,2 8.5,6.8 9.2,7.5 14,2.7 14,6 15,6 15,1 "/>
-<polygon points="7.5,9.2 6.8,8.5 2,13.3 2,10 1,10 1,15 6,15 6,14 2.7,14 "/>
-<rect id="_Transparent_Rectangle_" class="st0" width="16" height="16"/>
+<polygon points="6,15 6,14 2.7,14 7,9.7 6.3,9 2,13.3 2,10 1,10 1,15 "/>
+<polygon points="10,1 10,2 13.3,2 9,6.3 9.7,7 14,2.7 14,6 15,6 15,1 "/>
+<polyline id="_Transparent_Rectangle__1_" class="st0" points="-0.2,-0.1 15.8,-0.1 15.8,15.9 "/>
 </svg>

--- a/packages/icons/svg/16/minimize.svg
+++ b/packages/icons/svg/16/minimize.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="16px" height="16px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}
 </style>
 <title>minimize</title>
-<polygon points="3,9 3,10 5.3,10 1,14.3 1.7,15 6,10.7 6,13 7,13 7,9 "/>
-<polygon points="13,7 13,6 10.7,6 15,1.7 14.3,1 10,5.3 10,3 9,3 9,7 "/>
+<polygon points="2,9 2,10 5.3,10 1,14.3 1.7,15 6,10.7 6,14 7,14 7,9 "/>
+<polygon points="14,7 14,6 10.7,6 15,1.7 14.3,1 10,5.3 10,2 9,2 9,7 "/>
 <rect id="_Transparent_Rectangle_" class="st0" width="16" height="16"/>
 </svg>


### PR DESCRIPTION
normalize size and spacing for 16/minimize.svg and 16/maximize.svg

#### Changelog

**Changed**

- 16/maximize.svg
- 16/minimize.svg


#### Testing / Reviewing

verify arrows for 16/minimize.svg and 16/maximize.svg are the same size, spacing, but opposite directions.
