### PR TITLE
fix(tooltip): add aria-labelledby and adjust aria-describedby attributes

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -412,13 +412,14 @@ class Tooltip extends Component {
       onBlur: this.handleMouse,
       'aria-haspopup': 'true',
       'aria-expanded': open,
+      'aria-describedby': tooltipId,
       // if the user provides property `triggerText`,
-      // then the button should use aria-describedby to point to its id,
+      // then the button should use aria-labelledby to point to its id,
       // if the user doesn't provide property `triggerText`,
       // then an aria-label will be provided via the `iconDescription` property.
       ...(triggerText
         ? {
-            'aria-describedby': triggerId,
+            'aria-labelledby': triggerId,
           }
         : {
             'aria-label': iconDescription,


### PR DESCRIPTION
Closes #2736 

Some aria fixes improving screen reader support for the component.

#### Changelog

- add `aria-describedby` (so the tooltip's content will be read)
- changed the attribute `aria-describedby` to `aria-labelledby` (so it will be announced)
- update the comment to reflect the changes

#### Testing / Reviewing

1. on a Mac hit `cmd-F5` to enable VoiceOver
2. click to focus the Storybook frame in browser
3. hit `tab` to move focus to the default tooltip icon

##### What you should hear

The tooltip should expand, the element should be announced, and the content should be read.
