### PR TITLE
fix(modal): use focus theme token for close button border color on focus

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -175,7 +175,7 @@
 
     &:focus {
       outline: none;
-      border-color: $interactive-01;
+      border-color: $focus;
     }
   }
 


### PR DESCRIPTION
Closes #4077

#### Changelog

**Changed**

- change `$interactive-01` theme token (which is `blue60` all for themes) to `focus` (which is `white` for dark UIs, like other focus states throughout the library)