### PR TITLE
fix: pictogram rendering bugs

### DIFF
--- a/packages/icon-build-helpers/src/builders/vanilla/svgo.js
+++ b/packages/icon-build-helpers/src/builders/vanilla/svgo.js
@@ -44,7 +44,7 @@ const plugins = [
           }
         }
 
-        const sizes = ['16', '20', '24', '32'];
+        const sizes = ['16', '20', '24', '32', '48'];
 
         for (const size of sizes) {
           if (
@@ -170,9 +170,6 @@ const plugins = [
   },
   {
     cleanupNumericValues: true,
-  },
-  {
-    moveElemsAttrsToGroup: true,
   },
   {
     moveGroupAttrsToElems: true,


### PR DESCRIPTION
Closes #4080 

white boxes: We were both moving attributes to group elements while trying to take them away, this prevented us from adequately stripping/collapsing wrapper groups with more than one layer.

black boxes: we were only removing rectangles that matched the icon sizes: `['16', '20', '24', '32']`. Since we're not gonna need bespoke pictogram sizes, extending this again shouldn't be necessary.


Preview link: https://carbon-pictograms.now.sh/guidelines/iconography/pictograms