### PR TITLE
fix(accordion): top align accordion headings

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -9872,7 +9872,7 @@ Accordion styles
     @include button-reset;
     color: $text-01;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: $accordion-justify-content;
     cursor: pointer;
     padding: rem(6px) 0;

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -36,7 +36,7 @@
     @include button-reset;
     color: $text-01;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: $accordion-justify-content;
     cursor: pointer;
     padding: rem(6px) 0;

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -162,7 +162,7 @@ $accordion-justify-content: flex-start !default;
 /// @type Value
 /// @access public
 /// @group accordion
-$accordion-arrow-margin: 0 $carbon--spacing-05 0 0 !default;
+$accordion-arrow-margin: 2px $carbon--spacing-05 0 0 !default;
 
 /// @type Value
 /// @access public

--- a/packages/react/src/components/Accordion/Accordion-story.js
+++ b/packages/react/src/components/Accordion/Accordion-story.js
@@ -67,9 +67,9 @@ storiesOf('Accordion', module)
         </AccordionItem>
         <AccordionItem
           title={
-            <h4>
+            <span>
               Section 4 title (<em>the title can be a node</em>)
-            </h4>
+            </span>
           }
           {...props}>
           <p>


### PR DESCRIPTION
Closes #4051

refs https://github.com/IBM-Design/idr/issues/98

This PR changes the accordion heading chevron alignment rules so that it is top aligned rather than center aligned. The `$accordion-arrow-margin` token is modified order to keep the chevron centered when the accordion heading is one line long. The React Accordion storybook example is also modified to follow the design guidelines (headings should remain 14px large)

#### Changelog

**Changed**

- accordion heading alignment
- `$accordion-arrow-margin` token (`margin-top` rule)
- React Accordion story

#### Testing / Reviewing

Ensure the accordion looks correct with multiline headings (this can be done by editing storybook knobs or directly changing the content in devtools directly)
