### PR TITLE
docs(migration): update scss migration guide links

### DIFF
--- a/packages/components/src/globals/scss/migrate-to-10.x.md
+++ b/packages/components/src/globals/scss/migrate-to-10.x.md
@@ -40,7 +40,7 @@ _removed_ soon after the initial `v10` release.
 ## `_colors.scss`
 
 `$color__` variables are deprecated. Migration table available
-[here](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-color.md).
+[here](https://github.com/IBM/carbon/blob/master/docs/migration/10.x-color.md).
 
 ## `_css--body.scss`
 
@@ -106,7 +106,7 @@ if you would still like to use the classes.
 | Paragraph  | 16px | `body-long-02`          |
 
 For full details, please check our
-[our v10 migration guide for type.](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-type.md)
+[our v10 migration guide for type.](https://github.com/IBM/carbon/blob/master/docs/migration/10.x-type.md)
 
 ## `_feature-flags.scss`
 
@@ -168,12 +168,12 @@ No change
 ## `_motion.scss`
 
 New in v10. For full details, please check out our
-[migration guide](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-motion.md).
+[migration guide](https://github.com/IBM/carbon/blob/master/docs/migration/10.x-motion.md).
 
 ## `_spacing.scss`
 
 Spacing scale no longer uses t-shirt sizing, instead uses a scale approach (ref:
-https://github.com/IBM/carbon-elements/blob/v0.0.1-beta.1/docs/migration/10.x-layout.md#migrating).
+https://github.com/IBM/carbon/blob/v0.0.1-beta.1/docs/migration/10.x-layout.md#migrating).
 
 | v9          | v10 (spacing scale step) |
 | ----------- | ------------------------ |
@@ -198,7 +198,7 @@ https://github.com/IBM/carbon-elements/blob/v0.0.1-beta.1/docs/migration/10.x-la
 ## `_theme-tokens.scss`
 
 Migration table available
-[here](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-color.md).
+[here](https://github.com/IBM/carbon/blob/master/docs/migration/10.x-color.md).
 
 ## `_theme.scss`
 
@@ -223,7 +223,7 @@ No change
 | `font-size` mixin      | ☠️ Deprecated                                               |
 
 For full details, please check our
-[our v10 migration guide for type.](https://github.com/IBM/carbon-elements/blob/master/docs/migration/10.x-type.md)
+[our v10 migration guide for type.](https://github.com/IBM/carbon/blob/master/docs/migration/10.x-type.md)
 
 ## `_vars.scss`
 


### PR DESCRIPTION
Update the migration guide links to point to the mono repo links instead of carbon-elements.