### PR TITLE
fix(components): make sure font weight is loaded

### DIFF
--- a/packages/components/src/globals/scss/_typography.scss
+++ b/packages/components/src/globals/scss/_typography.scss
@@ -37,6 +37,7 @@ $base-font-size: 16px !default;
 }
 
 // 🔬 Experimental
+@import '../../globals/scss/vendor/@carbon/elements/scss/type/font-family';
 @import '../../globals/scss/vendor/@carbon/elements/scss/type/styles';
 
 /// Different type styles per token


### PR DESCRIPTION
Closes #4062

Addresses load order bug where `carbon--font-weight` was not being loaded.

#### Changelog

**New**

**Changed**

- Import `font-family` before `styles` in `_typography.scss`

**Removed**
