### PR TITLE
fix(Modal): selectorPrimaryFocus will work,regardless of focusTrap Value

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -249,7 +249,7 @@ export default class Modal extends Component {
     if (!this.props.open) {
       return;
     }
-    if (!this.props.focusTrap) {
+    if (this.props.selectorPrimaryFocus || !this.props.focusTrap) {
       this.focusButton(this.innerModal.current);
     }
   }
@@ -382,7 +382,7 @@ export default class Modal extends Component {
       </div>
     );
 
-    return !focusTrap ? (
+    return this.props.selectorPrimaryFocus || !focusTrap ? (
       modal
     ) : (
       // `<FocusTrap>` has `active: true` in its `defaultProps`


### PR DESCRIPTION
Closes #

Modal: `selectorPrimaryFocus` doesn't work, when used together with `focusTrap` [#4088](https://github.com/carbon-design-system/carbon/issues/4088) 

#### Changelog

**Changed**

- Added condition to check if selectorPrimaryFocus is present then it should take priority over to focusTrap as mentioned in the issue.
