### PR TITLE
test(ComboBox): add required id to mockProps before each test

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -32,6 +32,7 @@ describe('ComboBox', () => {
 
   beforeEach(() => {
     mockProps = {
+      id: 'test-combobox',
       items: generateItems(5, generateGenericItem),
       onChange: jest.fn(),
       placeholder: 'Filter...',


### PR DESCRIPTION
Closes #4168

This PR addresses the issue where console warnings were being emitted due to missing required props in the Combobox tests

#### Testing / Reviewing

Ensure React Combobox tests do not emit any warnings for missing required props