### PR TITLE
fix(breadcrumb): change breadcrumb to an ordered list

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.js
@@ -25,9 +25,9 @@ const Breadcrumb = ({
   });
 
   return (
-    <nav className={className} {...rest}>
+    <ol className={className} {...rest}>
       {children}
-    </nav>
+    </ol>
   );
 };
 

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.js
@@ -25,9 +25,11 @@ const Breadcrumb = ({
   });
 
   return (
-    <ol className={className} {...rest}>
-      {children}
-    </ol>
+    <nav aria-label="breadcrumb">
+      <ol className={className} {...rest}>
+        {children}
+      </ol>
+    </nav>
   );
 };
 

--- a/packages/react/src/components/Breadcrumb/BreadcrumbItem.js
+++ b/packages/react/src/components/Breadcrumb/BreadcrumbItem.js
@@ -32,11 +32,11 @@ const BreadcrumbItem = ({
 
   if (typeof children === 'string' && href) {
     return (
-      <div className={className} {...rest}>
+      <li className={className} {...rest}>
         <Link href={href} aria-current={ariaCurrent}>
           {children}
         </Link>
-      </div>
+      </li>
     );
   }
 

--- a/packages/react/src/components/Breadcrumb/BreadcrumbItem.js
+++ b/packages/react/src/components/Breadcrumb/BreadcrumbItem.js
@@ -41,12 +41,12 @@ const BreadcrumbItem = ({
   }
 
   return (
-    <div className={className} {...rest}>
+    <li className={className} {...rest}>
       {React.cloneElement(children, {
         'aria-current': ariaCurrent,
         className: `${prefix}--link`,
       })}
-    </div>
+    </li>
   );
 };
 


### PR DESCRIPTION
Closes #1608 

**November Release PR**

Breadcrumb accessibility improvement. 

#### Changelog

**Changed**

- changed the Breadcrumb `<nav>` to `<ol>` and changed the BreadcrumbItem to from `<div>` to `<li>`
- nest Breadcrumb into `<nav>` [landmark region](https://aat.w3ibm.mybluemix.net/token/dcaf9b63-6731-42ae-a97e-f1bb1f9966c2/f58137a1-1d9f-4676-97fd-170855fe35fe/latest///doc/w3/help/en-US/idhi_accessibility_check_g1157.html)


#### Testing / Reviewing

Check breadcrumb is accessible and doesn't have violations. 
