### PR TITLE
docs(text-input): set display name and props for variations

### DIFF
--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -73,6 +73,8 @@ const props = {
   }),
 };
 
+TextInput.displayName = 'TextInput';
+
 storiesOf('TextInput', module)
   .addDecorator(withKnobs)
   .add(
@@ -112,12 +114,21 @@ storiesOf('TextInput', module)
   )
   .add(
     'Fully controlled toggle password visibility',
-    () => (
-      <ControlledPasswordInputApp
-        {...props.TextInputProps()}
-        {...props.PasswordInputProps()}
-      />
-    ),
+    () => {
+      ControlledPasswordInputApp.__docgenInfo = {
+        ...TextInput.PasswordInput.__docgenInfo,
+        props: {
+          ...TextInput.PasswordInput.__docgenInfo.props,
+        },
+      };
+
+      return (
+        <ControlledPasswordInputApp
+          {...props.TextInputProps()}
+          {...props.PasswordInputProps()}
+        />
+      );
+    },
     {
       info: {
         text: `


### PR DESCRIPTION
The default story for `TextInput` has an "Unknown" component (i.e., should be `TextInput`) that affects both the story source and the proptable. So this PR adds a display name for `TextInput` so that it isn't displayed as "Unknown"

Also, the `ControlledPasswordInputApp` story doesn't have a proptable. So this PR passes the `TextInput.PasswordInput` into the `ControlledPasswordInputApp` docgen info so that it can have a proptable.

#### Changelog

**Changed**

- add display name for default story - `TextInput`
- pass in props for `ControlledPasswordInputApp` story

#### Testing / Reviewing

Check out the React storybook deploy and compare to this live version --

Compare with default `TextInput` story (i.e., "Unknown" component): http://react.carbondesignsystem.com/?path=/story/textinput--default

Compare with fully controlled story (i.e., no props in proptable): 
 http://react.carbondesignsystem.com/?path=/story/textinput--fully-controlled-toggle-password-visibility