### PR TITLE
fix(TooltipDefinition): change children proptype check to allow a node

### DIFF
--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-test.js
@@ -40,4 +40,14 @@ describe('TooltipDefinition', () => {
     const wrapper = mount(<TooltipDefinition {...mockProps} direction="top" />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should allow passing a node to the children prop', () => {
+    console.error = jest.fn();
+    const childNode = <div>This is the Child</div>;
+    const props = { ...mockProps, children: childNode };
+
+    mount(<TooltipDefinition {...props} />);
+
+    expect(console.error).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -56,10 +56,10 @@ const TooltipDefinition = ({
 
 TooltipDefinition.propTypes = {
   /**
-   * Specify the tooltip trigger text that is rendered to the UI for the user to
+   * Specify the tooltip trigger text or node that is rendered to the UI for the user to
    * interact with in order to display the tooltip.
    */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 
   /**
    * The CSS class name of the trigger element


### PR DESCRIPTION
I just changed the proptypes rule in the TooltipDefinition react component to allow its child to be a node and not only a string.
This is needed to prevent getting the console error:
```
Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `TooltipDefinition`, expected `string`. in TooltipDefinition
```

And then obviously, a little test to make sure the changes work. I'm not sure that test is really needed, but I thought better testing too much than not enough. 
Feel free to tell me if you think I should get rid of it.

---

Here are 2 screenshots of my main usecase when needing a node instead of a plain string as TooltipDefinition child:

An `<img />`:
<img width="265" alt="Bildschirmfoto 2019-10-04 um 16 37 22" src="https://user-images.githubusercontent.com/15985745/66216417-b9b36b80-e6c5-11e9-8f25-32b1e0820843.png">

A `<Checkbox />`:
<img width="269" alt="Bildschirmfoto 2019-10-04 um 16 38 06" src="https://user-images.githubusercontent.com/15985745/66216421-bb7d2f00-e6c5-11e9-974f-10c468584a11.png">
