### PR TITLE
fix(TableSelectRow): change the checked proptype to optional

### DIFF
--- a/packages/react/src/components/DataTable/TableSelectRow.js
+++ b/packages/react/src/components/DataTable/TableSelectRow.js
@@ -50,7 +50,7 @@ TableSelectRow.propTypes = {
   /**
    * Specify whether all items are selected, or not
    */
-  checked: PropTypes.bool.isRequired,
+  checked: PropTypes.bool,
 
   /**
    * Specify whether the control is disabled


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/4253

The `TableSelectRow` react component has a `checked` prop that is required. However, setting it to `true` or `false` makes it impossible to use that the component properly. 
So I (but I'm very likely not the only one doing so) have to omit this prop to be able to use the component. This leads to getting the following console error: 
```
Warning: Failed prop type: The prop `checked` is marked as required in `TableSelectRow`, but its value is `undefined`. in TableSelectRow
```

What I suggest in this PR is simply to make this `checked` prop optional so that we can use the component without getting a console error.

## Sandbox
Here is a sanbox to have a live example of the issue I'm talking about. Try unselecting a row:
https://codesandbox.io/s/codesandbox-y4umm