### PR TITLE
docs(tooltip): add display name for storybook

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -58,6 +58,8 @@ const props = {
   }),
 };
 
+Tooltip.displayName = 'Tooltip';
+
 function UncontrolledTooltipExample() {
   const [value, setValue] = useState(true);
   return (


### PR DESCRIPTION
Right now if you look at the `Tooltip` stories, click on the blue "show info" button, and look at the "Story source" section, you'll see `[object Object]` in the source: http://react.carbondesignsystem.com/?path=/story/tooltip--default-bottom

![Screen Shot 2019-10-08 at 4 42 45 PM](https://user-images.githubusercontent.com/9057921/66435647-f1ceed00-e9ea-11e9-8d0b-0c2543a3af2b.png)

By adding a display name, you can make it say show the component's name `Tooltip` instead.

#### Changelog

**New**

- add a display name for `Tooltip` in storybook