### PR TITLE
fix(search): remove role attr and label from skeleton

### DIFF
--- a/packages/react/src/components/Search/Search.Skeleton.js
+++ b/packages/react/src/components/Search/Search.Skeleton.js
@@ -6,38 +6,36 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-export default class SearchSkeleton extends Component {
-  static propTypes = {
-    /**
-     * Specify whether the Search should be a small variant
-     */
-    small: PropTypes.bool,
-  };
+const SearchSkeleton = ({ small }) => {
+  const searchClasses = classNames({
+    [`${prefix}--skeleton`]: true,
+    [`${prefix}--search--xl`]: !small,
+    [`${prefix}--search--sm`]: small,
+  });
 
-  static defaultProps = {
-    small: false,
-  };
+  return (
+    <div className={searchClasses}>
+      <span className={`${prefix}--label`} />
+      <div className={`${prefix}--search-input`} />
+    </div>
+  );
+};
 
-  render() {
-    const { small } = this.props;
+SearchSkeleton.propTypes = {
+  /**
+   * Specify whether the Search should be a small variant
+   */
+  small: PropTypes.bool,
+};
 
-    const searchClasses = classNames({
-      [`${prefix}--skeleton`]: true,
-      [`${prefix}--search--xl`]: !small,
-      [`${prefix}--search--sm`]: small,
-    });
+SearchSkeleton.defaultProps = {
+  small: false,
+};
 
-    return (
-      <div className={searchClasses}>
-        <span className={`${prefix}--label`} />
-        <div className={`${prefix}--search-input`} />
-      </div>
-    );
-  }
-}
+export default SearchSkeleton;

--- a/packages/react/src/components/Search/Search.Skeleton.js
+++ b/packages/react/src/components/Search/Search.Skeleton.js
@@ -25,7 +25,7 @@ export default class SearchSkeleton extends Component {
   };
 
   render() {
-    const { small, id } = this.props;
+    const { small } = this.props;
 
     const searchClasses = classNames({
       [`${prefix}--skeleton`]: true,
@@ -34,11 +34,8 @@ export default class SearchSkeleton extends Component {
     });
 
     return (
-      <div className={searchClasses} role="search">
-        {
-          /* eslint-disable jsx-a11y/label-has-for,jsx-a11y/label-has-associated-control */
-          <label htmlFor={id} className={`${prefix}--label`} />
-        }
+      <div className={searchClasses}>
+        <span className={`${prefix}--label`} />
         <div className={`${prefix}--search-input`} />
       </div>
     );


### PR DESCRIPTION
Closes #4179 

Proposal to remove the `role="search"` attribute from this component and replace the `label` element with a simple `span`.  My reasoning here is that there doesn't appear to be a real need for the role attribute and a `label` element since this is a non-interactive `div`. This would also remove the DAP violations.

#### Changelog

**Changed**

- change `label` element to a `span` 

**Removed**

- remove `role="search"` attribute
- remove `htmlFor` attribute
