### PR TITLE
fix(accordion): change skeleton buttons to spans for a11y

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.Skeleton.js
+++ b/packages/react/src/components/Accordion/Accordion.Skeleton.js
@@ -21,10 +21,10 @@ function AccordionSkeleton(props) {
       {props.open && (
         <li
           className={`${prefix}--accordion__item ${prefix}--accordion__item--active`}>
-          <button type="button" className={`${prefix}--accordion__heading`}>
+          <span className={`${prefix}--accordion__heading`}>
             <ChevronRight16 className={`${prefix}--accordion__arrow`} />
             <SkeletonText className={`${prefix}--accordion__title`} />
-          </button>
+          </span>
           <div className={`${prefix}--accordion__content`}>
             <SkeletonText width="90%" />
             <SkeletonText width="80%" />
@@ -64,10 +64,10 @@ AccordionSkeleton.defaultProps = {
 function AccordionSkeletonItem() {
   return (
     <li className={`${prefix}--accordion__item`}>
-      <button type="button" className={`${prefix}--accordion__heading`}>
+      <span className={`${prefix}--accordion__heading`}>
         <ChevronRight16 className={`${prefix}--accordion__arrow`} />
         <SkeletonText className={`${prefix}--accordion__title`} />
-      </button>
+      </span>
     </li>
   );
 }

--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion.Skeleton-test.js.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion.Skeleton-test.js.snap
@@ -11,9 +11,8 @@ exports[`AccordionSkeleton should render 1`] = `
     <li
       className="bx--accordion__item bx--accordion__item--active"
     >
-      <button
+      <span
         className="bx--accordion__heading"
-        type="button"
       >
         <ForwardRef(ChevronRight16)
           className="bx--accordion__arrow"
@@ -63,7 +62,7 @@ exports[`AccordionSkeleton should render 1`] = `
             }
           />
         </SkeletonText>
-      </button>
+      </span>
       <div
         className="bx--accordion__content"
       >
@@ -120,9 +119,8 @@ exports[`AccordionSkeleton should render 1`] = `
       <li
         className="bx--accordion__item"
       >
-        <button
+        <span
           className="bx--accordion__heading"
-          type="button"
         >
           <ForwardRef(ChevronRight16)
             className="bx--accordion__arrow"
@@ -172,7 +170,7 @@ exports[`AccordionSkeleton should render 1`] = `
               }
             />
           </SkeletonText>
-        </button>
+        </span>
       </li>
     </AccordionSkeletonItem>
     <AccordionSkeletonItem
@@ -181,9 +179,8 @@ exports[`AccordionSkeleton should render 1`] = `
       <li
         className="bx--accordion__item"
       >
-        <button
+        <span
           className="bx--accordion__heading"
-          type="button"
         >
           <ForwardRef(ChevronRight16)
             className="bx--accordion__arrow"
@@ -233,7 +230,7 @@ exports[`AccordionSkeleton should render 1`] = `
               }
             />
           </SkeletonText>
-        </button>
+        </span>
       </li>
     </AccordionSkeletonItem>
     <AccordionSkeletonItem
@@ -242,9 +239,8 @@ exports[`AccordionSkeleton should render 1`] = `
       <li
         className="bx--accordion__item"
       >
-        <button
+        <span
           className="bx--accordion__heading"
-          type="button"
         >
           <ForwardRef(ChevronRight16)
             className="bx--accordion__arrow"
@@ -294,7 +290,7 @@ exports[`AccordionSkeleton should render 1`] = `
               }
             />
           </SkeletonText>
-        </button>
+        </span>
       </li>
     </AccordionSkeletonItem>
   </ul>


### PR DESCRIPTION
Closes #4177 

Proposal to change the `button` elements inside the `AccordionSkeleton` and `AccordionSkeletonItem` components into `span`s. My reasoning: since these headings and items in the skeleton component are non-interactive, there shouldn't be a reason to mark them as `button` elements. This change would also remove the DAP violations.

#### Changelog

**Changed**

- change `button` elements into `span` elements

#### Testing / Reviewing

Open the React storybook deployment, view the `AccordionSkeleton`, and run the latest DAP ruleset (Sept 2019).
