### PR TITLE
fix(sketch): update based on theme changes

### DIFF
--- a/packages/sketch/src/sharedStyles/colors.js
+++ b/packages/sketch/src/sharedStyles/colors.js
@@ -35,7 +35,7 @@ export function syncColorStyles(document) {
     ['black', black['100']],
     ['white', white['0']],
     ['orange', orange['40']],
-    ['yellow', yellow['20']],
+    ['yellow', yellow['30']],
   ].map(([name, value]) => {
     return syncColorStyle(document, formatSharedStyleName(name), value);
   });

--- a/packages/sketch/src/sharedStyles/themes.js
+++ b/packages/sketch/src/sharedStyles/themes.js
@@ -11,9 +11,12 @@ import {
   g90,
   g100,
   formatTokenName,
+  tokens,
   unstable__meta as meta,
 } from '@carbon/themes';
 import { syncColorStyle } from '../tools/sharedStyles';
+
+const { colors } = tokens;
 
 /**
  * Sync theme color shared styles to the given document and return the result
@@ -31,9 +34,10 @@ export function syncThemeColorStyles(document) {
   const sharedStyles = Object.keys(themes).flatMap(theme => {
     return Object.keys(themes[theme])
       .filter(token => {
-        return !meta.deprecated.includes(token);
+        return colors.includes(token) && !meta.deprecated.includes(token);
       })
       .map(token => {
+        console.log(token);
         const { type } = meta.colors.find(group => {
           return group.tokens.includes(token);
         });

--- a/packages/sketch/src/sharedStyles/themes.js
+++ b/packages/sketch/src/sharedStyles/themes.js
@@ -37,7 +37,6 @@ export function syncThemeColorStyles(document) {
         return colors.includes(token) && !meta.deprecated.includes(token);
       })
       .map(token => {
-        console.log(token);
         const { type } = meta.colors.find(group => {
           return group.tokens.includes(token);
         });


### PR DESCRIPTION
Update `sketch` plugin based on theme changes

#### Changelog

**New**

**Changed**

- Only sync color styles for themes
- Make sure yellow-30 is used instead of yellow-20 for yellow in colors

**Removed**
