### PR TITLE
ci(github): add sync-generated-files workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,58 +25,8 @@ jobs:
             yarn ci-check
             yarn lerna run ci-check
 
-  artifacts:
-    docker:
-      - image: circleci/node:10.15-browsers
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - run:
-          name: Install yarn
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
-            # Reference:
-            # https://circleci.com/docs/2.0/env-vars/#example-configuration-of-environment-variables
-            echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> $BASH_ENV
-      - run:
-          name: Install dependencies
-          command: yarn install --offline --frozen-lockfile
-      - run:
-          name: Build packages
-          command: yarn build
-      - run:
-          name: Sync project dependency files
-          command: yarn sync
-      - run:
-          name: Push generated artifacts to GitHub
-          command: |
-            if [ -n "$(git status --porcelain)" ]; then
-              echo "Our git status is not clean. Checking in the following files:";
-              echo "$(git status --porcelain)";
-
-              git config --global credential.helper 'cache --timeout=120'
-              git config --global user.email "carbon@us.ibm.com"
-              git config --global user.name "carbon-bot"
-
-              git add -A
-              git commit -m "chore(project): sync generated files [skip ci]"
-
-              # Pipe to /dev/null to prevent any token leaks in CI output
-              git push -q \
-                https://${GH_TOKEN}:@github.com/carbon-design-system/carbon.git \
-                master \
-                > /dev/null 2>&1
-            fi
-
 workflows:
   version: 2
   main:
     jobs:
       - system
-      - artifacts:
-          requires:
-            - system
-          filters:
-            branches:
-              only:
-                - master

--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Use Node.js 10.x
         uses: actions/setup-node@v1
         with:
-          version: 10.x
+          node-version: '10.x'
       - name: Install dependencies
         run: yarn install --offline
       - name: Build project

--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -1,0 +1,38 @@
+name: Sync generated files
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          version: 10.x
+      - name: Install dependencies
+        run: yarn install --offline
+      - name: Build project
+        run: yarn build
+      - name: Sync project dependency files
+        run: yarn sync
+      - name: Push generated artifacts to GitHub
+        env:
+          NPM_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        command: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Our git status is not clean. Checking in the following files:";
+            echo "$(git status --porcelain)";
+            git config --global credential.helper 'cache --timeout=120'
+            git config --global user.email "carbon@us.ibm.com"
+            git config --global user.name "carbon-bot"
+            git add -A
+            git commit -m "chore(project): sync generated files [skip ci]"
+            # Pipe to /dev/null to prevent any token leaks in CI output
+            git push -q \
+              https://${GH_BOT_TOKEN}:@github.com/carbon-design-system/carbon.git \
+              master \
+              > /dev/null 2>&1
+          fi


### PR DESCRIPTION
Updates our CI config so that we use GitHub Actions to check-in generated artifacts instead of CircleCI

#### Changelog

**New**

- Add new GitHub workflow for syncing generated files

**Changed**

- CircleCI no longer has an artifacts workflow

**Removed**
