### PR TITLE
fix(search): remove role of image on icons to resolve DAP violations

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2246,13 +2246,11 @@ exports[`DataTable should render 1`] = `
                     >
                       <ForwardRef(Search16)
                         className="bx--search-magnifier"
-                        role="img"
                       >
                         <Icon
                           className="bx--search-magnifier"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
-                          role="img"
                           viewBox="0 0 16 16"
                           width={16}
                           xmlns="http://www.w3.org/2000/svg"
@@ -2263,7 +2261,6 @@ exports[`DataTable should render 1`] = `
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            role="img"
                             style={
                               Object {
                                 "willChange": "transform",
@@ -2300,25 +2297,19 @@ exports[`DataTable should render 1`] = `
                         onClick={[Function]}
                         type="button"
                       >
-                        <ForwardRef(Close16)
-                          aria-label="Clear search input"
-                          role="img"
-                        >
+                        <ForwardRef(Close16)>
                           <Icon
-                            aria-label="Clear search input"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            role="img"
                             viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-label="Clear search input"
+                              aria-hidden={true}
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              role="img"
                               style={
                                 Object {
                                   "willChange": "transform",
@@ -3225,13 +3216,11 @@ exports[`DataTable sticky header should render 1`] = `
                     >
                       <ForwardRef(Search16)
                         className="bx--search-magnifier"
-                        role="img"
                       >
                         <Icon
                           className="bx--search-magnifier"
                           height={16}
                           preserveAspectRatio="xMidYMid meet"
-                          role="img"
                           viewBox="0 0 16 16"
                           width={16}
                           xmlns="http://www.w3.org/2000/svg"
@@ -3242,7 +3231,6 @@ exports[`DataTable sticky header should render 1`] = `
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            role="img"
                             style={
                               Object {
                                 "willChange": "transform",
@@ -3279,25 +3267,19 @@ exports[`DataTable sticky header should render 1`] = `
                         onClick={[Function]}
                         type="button"
                       >
-                        <ForwardRef(Close16)
-                          aria-label="Clear search input"
-                          role="img"
-                        >
+                        <ForwardRef(Close16)>
                           <Icon
-                            aria-label="Clear search input"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            role="img"
                             viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <svg
-                              aria-label="Clear search input"
+                              aria-hidden={true}
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              role="img"
                               style={
                                 Object {
                                   "willChange": "transform",

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -33,13 +33,11 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
       >
         <ForwardRef(Search16)
           className="bx--search-magnifier"
-          role="img"
         >
           <Icon
             className="bx--search-magnifier"
             height={16}
             preserveAspectRatio="xMidYMid meet"
-            role="img"
             viewBox="0 0 16 16"
             width={16}
             xmlns="http://www.w3.org/2000/svg"
@@ -50,7 +48,6 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              role="img"
               style={
                 Object {
                   "willChange": "transform",
@@ -87,25 +84,19 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
           onClick={[Function]}
           type="button"
         >
-          <ForwardRef(Close16)
-            aria-label="Clear search input"
-            role="img"
-          >
+          <ForwardRef(Close16)>
             <Icon
-              aria-label="Clear search input"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              role="img"
               viewBox="0 0 16 16"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
             >
               <svg
-                aria-label="Clear search input"
+                aria-hidden={true}
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"
-                role="img"
                 style={
                   Object {
                     "willChange": "transform",

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -151,7 +151,7 @@ export default class Search extends Component {
 
     return (
       <div className={searchClasses}>
-        <Search16 className={`${prefix}--search-magnifier`} role="img" />
+        <Search16 className={`${prefix}--search-magnifier`} />
         <label htmlFor={id} className={`${prefix}--label`}>
           {labelText}
         </label>
@@ -171,7 +171,7 @@ export default class Search extends Component {
           onClick={this.clearInput}
           type="button"
           aria-label={closeButtonLabelText}>
-          <CloseIconX aria-label={closeButtonLabelText} role="img" />
+          <CloseIconX />
         </button>
       </div>
     );


### PR DESCRIPTION
Closes #4263

This PR removes `role="img"` from the icons in the Search component. Icons are aria-hidden by default but adding the `role-"img"` creates a DAP violation since it makes them visible. Just removing the role resolves the DAP violation and the screen reader is the same! Also removes the double use of the same aria label. 

#### Changelog

**Changed**

- removes `role="img"` from `CloseIconX` and `Search16` 
- removes extraneous arialabel from `CloseIconX`

#### Testing / Reviewing

Verify that there are no DAP violations and if you feel like it, check to make sure the VoiceOver experience is the same as before! 
