### PR TITLE
refactor(global): replace yellow-20 with yellow-30

### DIFF
--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -272,7 +272,7 @@ $notification-error-background-color: $ibm-color__red-10 !default;
 /// @access public
 /// @group notification
 $notification-warning-background-color: mix(
-  $ibm-color__yellow-20,
+  $ibm-color__yellow-30,
   $ibm-color__white-0,
   15%
 ) !default;


### PR DESCRIPTION
Closes #4141

Since yellow-20 is being deprecated, this replaces `$ibm-color__yellow-20` with `$ibm-color__yellow-30` (#f1c21b). The alters the background color used in warning notifications.

#### Changelog

**Changed**

- `_theme-tokens.scss`

![image](https://user-images.githubusercontent.com/17458641/66531825-320d9880-eadb-11e9-9760-2f1e05d173cc.png)
