### PR TITLE
fix(tag): prevent focused close button icon from shrinking

### DIFF
--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -107,7 +107,7 @@
   }
 
   .#{$prefix}--tag--filter:focus > svg {
-    border: 2px solid $inverse-01;
+    box-shadow: inset 0 0 0 2px $inverse-focus-ui;
     border-radius: 50%;
   }
 


### PR DESCRIPTION
Fixes #4289.

#### Changelog

**Changed**

- Changed the tag's focus outline from `border` to `box-shadow` to make sure it doesn't affect the inner-content (icon) size.

#### Testing / Reviewing

Testing should make sure our tag component is not broken.