### PR TITLE
fix(copy-button): add aria-label for the copy button

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet-story.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet-story.js
@@ -26,9 +26,12 @@ const props = {
     feedback: text('Feedback text (feedback)', 'Feedback Enabled 👍'),
     copyButtonDescription: text(
       'Copy icon description (copyButtonDescription)',
-      ''
+      'copyable code snippet'
     ),
-    ariaLabel: text('ARIA label of the container (ariaLabel)', ''),
+    ariaLabel: text(
+      'ARIA label of the container (ariaLabel)',
+      'Container label'
+    ),
     onClick: action('onClick'),
   }),
   multiline: () => ({

--- a/packages/react/src/components/CopyButton/CopyButton.js
+++ b/packages/react/src/components/CopyButton/CopyButton.js
@@ -92,6 +92,7 @@ export default class CopyButton extends Component {
         className={classNames}
         onClick={this.handleClick}
         aria-label={iconDescription}
+        title={iconDescription}
         {...other}>
         <Copy16 className={`${prefix}--snippet__icon`} />
         <div className={feedbackClassNames} data-feedback={feedback} />

--- a/packages/react/src/components/CopyButton/CopyButton.js
+++ b/packages/react/src/components/CopyButton/CopyButton.js
@@ -91,12 +91,9 @@ export default class CopyButton extends Component {
         type="button"
         className={classNames}
         onClick={this.handleClick}
-        title={iconDescription}
+        aria-label={iconDescription}
         {...other}>
-        <Copy16
-          className={`${prefix}--snippet__icon`}
-          aria-label={iconDescription}
-        />
+        <Copy16 className={`${prefix}--snippet__icon`} />
         <div className={feedbackClassNames} data-feedback={feedback} />
       </button>
     );


### PR DESCRIPTION
Closes #3734 

The originating issue identified a labeling problem with the `CopyButton`, and also with the `CopyButton` used inside the single-line and multi-line `CodeSnippet` variations.

* **For the `CopyButton`**, I added an `aria-label`. (The `aria-label` on the inner svg can be removed, in this case.) This removes the DAP violation for the `CopyButton`.

* **For the single- and multi-line `CodeSnippet`**, the fix for the `CopyButton` helps, plus I also made sure to include default values for the a11y-related props in those storybook demos. This removes the DAP violations identified in #3734 

#### Changelog

**Changed**

- use `aria-label` in the `CopyButton`
- add default values for a11y props in the `CodeSnippet` storybook demo
