### PR TITLE
feat(PasswordInput): support translations for password visibility toggle

### DIFF
--- a/packages/react/src/components/TextInput/PasswordInput-test.js
+++ b/packages/react/src/components/TextInput/PasswordInput-test.js
@@ -14,6 +14,11 @@ describe('PasswordInput', () => {
         labelText="testlabel"
         helperText="testHelper"
         light
+        /**
+         * Simulates a condition where the translations for password visibility
+         * toggle button are not present
+         */
+        translateWithId={jest.fn(() => undefined)}
       />
     );
 
@@ -61,6 +66,18 @@ describe('PasswordInput', () => {
         expect(passwordInput().props().placeholder).not.toBeDefined();
         wrapper.setProps({ placeholder: 'Enter text' });
         expect(passwordInput().props().placeholder).toEqual('Enter text');
+      });
+
+      it('should call `translateWithId` with the id strings needed to translate', () => {
+        expect(wrapper.props().translateWithId).toHaveBeenCalledWith(
+          'show.password'
+        );
+        wrapper
+          .find('.bx--text-input--password__visibility__toggle')
+          .simulate('click');
+        expect(wrapper.props().translateWithId).toHaveBeenCalledWith(
+          'hide.password'
+        );
       });
     });
 

--- a/packages/react/src/components/TextInput/PasswordInput-test.js
+++ b/packages/react/src/components/TextInput/PasswordInput-test.js
@@ -14,11 +14,8 @@ describe('PasswordInput', () => {
         labelText="testlabel"
         helperText="testHelper"
         light
-        /**
-         * Simulates a condition where the translations for password visibility
-         * toggle button are not present
-         */
-        translateWithId={jest.fn(() => undefined)}
+        showPasswordLabel="Show password"
+        hidePasswordLabel="Hide password"
       />
     );
 
@@ -48,6 +45,8 @@ describe('PasswordInput', () => {
         expect(passwordInput().props().type).toEqual('password');
         wrapper.find('button').simulate('click');
         expect(passwordInput().props().type).toEqual('text');
+        wrapper.find('button').simulate('click');
+        expect(passwordInput().props().type).toEqual('password');
       });
 
       it('should set value as expected', () => {
@@ -68,16 +67,17 @@ describe('PasswordInput', () => {
         expect(passwordInput().props().placeholder).toEqual('Enter text');
       });
 
-      it('should call `translateWithId` with the id strings needed to translate', () => {
-        expect(wrapper.props().translateWithId).toHaveBeenCalledWith(
-          'show.password'
-        );
+      it('should set password visibility toggle text as expected', () => {
+        const { hidePasswordLabel, showPasswordLabel } = wrapper.props();
+        expect(
+          wrapper.find('.bx--text-input--password__visibility__toggle').text()
+        ).toEqual(showPasswordLabel);
         wrapper
           .find('.bx--text-input--password__visibility__toggle')
           .simulate('click');
-        expect(wrapper.props().translateWithId).toHaveBeenCalledWith(
-          'hide.password'
-        );
+        expect(
+          wrapper.find('.bx--text-input--password__visibility__toggle').text()
+        ).toEqual(hidePasswordLabel);
       });
     });
 

--- a/packages/react/src/components/TextInput/PasswordInput.js
+++ b/packages/react/src/components/TextInput/PasswordInput.js
@@ -7,6 +7,16 @@ import { textInputProps } from './util';
 
 const { prefix } = settings;
 
+export const translationIds = {
+  'hide.password': 'hide.password',
+  'show.password': 'show.password',
+};
+
+const defaultTranslations = {
+  [translationIds['hide.password']]: 'Hide password',
+  [translationIds['show.password']]: 'Show password',
+};
+
 export default function PasswordInput({
   labelText,
   className,
@@ -21,6 +31,7 @@ export default function PasswordInput({
   light,
   tooltipPosition = 'bottom',
   tooltipAlignment = 'center',
+  translateWithId: t,
   ...other
 }) {
   const [inputType, setInputType] = useState('password');
@@ -97,7 +108,7 @@ export default function PasswordInput({
         className={passwordVisibilityToggleClasses}
         onClick={togglePasswordVisibility}>
         <span className={`${prefix}--assistive-text`}>
-          {`${passwordIsVisible ? 'Hide' : 'Show'} password`}
+          {passwordIsVisible ? t('hide.password') : t('show.password')}
         </span>
         {passwordVisibilityIcon}
       </button>
@@ -222,4 +233,5 @@ PasswordInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  translateWithId: id => defaultTranslations[id],
 };

--- a/packages/react/src/components/TextInput/PasswordInput.js
+++ b/packages/react/src/components/TextInput/PasswordInput.js
@@ -7,16 +7,6 @@ import { textInputProps } from './util';
 
 const { prefix } = settings;
 
-export const translationIds = {
-  'hide.password': 'hide.password',
-  'show.password': 'show.password',
-};
-
-const defaultTranslations = {
-  [translationIds['hide.password']]: 'Hide password',
-  [translationIds['show.password']]: 'Show password',
-};
-
 export default function PasswordInput({
   labelText,
   className,
@@ -31,7 +21,8 @@ export default function PasswordInput({
   light,
   tooltipPosition = 'bottom',
   tooltipAlignment = 'center',
-  translateWithId: t,
+  hidePasswordLabel = 'Hide password',
+  showPasswordLabel = 'Show password',
   ...other
 }) {
   const [inputType, setInputType] = useState('password');
@@ -108,7 +99,7 @@ export default function PasswordInput({
         className={passwordVisibilityToggleClasses}
         onClick={togglePasswordVisibility}>
         <span className={`${prefix}--assistive-text`}>
-          {passwordIsVisible ? t('hide.password') : t('show.password')}
+          {passwordIsVisible ? hidePasswordLabel : showPasswordLabel}
         </span>
         {passwordVisibilityIcon}
       </button>
@@ -222,6 +213,16 @@ PasswordInput.propTypes = {
    * Can be one of: start, center, or end.
    */
   tooltipAlignment: PropTypes.oneOf(['start', 'center', 'end']),
+
+  /**
+   * "Hide password" tooltip text on password visibility toggle
+   */
+  hidePasswordLabel: PropTypes.string,
+
+  /**
+   * "Show password" tooltip text on password visibility toggle
+   */
+  showPasswordLabel: PropTypes.string,
 };
 
 PasswordInput.defaultProps = {
@@ -233,5 +234,4 @@ PasswordInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
-  translateWithId: id => defaultTranslations[id],
 };

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -8,7 +8,13 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  boolean,
+  select,
+  text,
+  object,
+} from '@storybook/addon-knobs';
 import TextInput from '../TextInput';
 import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
 
@@ -70,6 +76,13 @@ const props = {
       ['start', 'center', 'end'],
       'center'
     ),
+    togglePasswordVisibilityTranslationIds: object(
+      'Password visibility toggle button translation IDs (for translateWithId callback)',
+      {
+        'hide.password': 'Hide password',
+        'show.password': 'Show password',
+      }
+    ),
   }),
 };
 
@@ -98,12 +111,19 @@ storiesOf('TextInput', module)
   )
   .add(
     'Toggle password visibility',
-    () => (
-      <TextInput.PasswordInput
-        {...props.TextInputProps()}
-        {...props.PasswordInputProps()}
-      />
-    ),
+    () => {
+      const {
+        togglePasswordVisibilityTranslationIds,
+        ...passwordInputProps
+      } = props.PasswordInputProps();
+      return (
+        <TextInput.PasswordInput
+          {...props.TextInputProps()}
+          {...passwordInputProps}
+          translateWithId={id => togglePasswordVisibilityTranslationIds[id]}
+        />
+      );
+    },
     {
       info: {
         text: `
@@ -122,10 +142,16 @@ storiesOf('TextInput', module)
         },
       };
 
+      const {
+        togglePasswordVisibilityTranslationIds,
+        ...passwordInputProps
+      } = props.PasswordInputProps();
+
       return (
         <ControlledPasswordInputApp
           {...props.TextInputProps()}
-          {...props.PasswordInputProps()}
+          {...passwordInputProps}
+          translateWithId={id => togglePasswordVisibilityTranslationIds[id]}
         />
       );
     },

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -8,13 +8,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import {
-  withKnobs,
-  boolean,
-  select,
-  text,
-  object,
-} from '@storybook/addon-knobs';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import TextInput from '../TextInput';
 import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
 
@@ -76,12 +70,13 @@ const props = {
       ['start', 'center', 'end'],
       'center'
     ),
-    togglePasswordVisibilityTranslationIds: object(
-      'Password visibility toggle button translation IDs (for translateWithId callback)',
-      {
-        'hide.password': 'Hide password',
-        'show.password': 'Show password',
-      }
+    hidePasswordLabel: text(
+      '"Hide password" tooltip label for password visibility toggle (hidePasswordLabel)',
+      'Hide password'
+    ),
+    showPasswordLabel: text(
+      '"Show password" tooltip label for password visibility toggle (showPasswordLabel)',
+      'Show password'
     ),
   }),
 };
@@ -112,15 +107,10 @@ storiesOf('TextInput', module)
   .add(
     'Toggle password visibility',
     () => {
-      const {
-        togglePasswordVisibilityTranslationIds,
-        ...passwordInputProps
-      } = props.PasswordInputProps();
       return (
         <TextInput.PasswordInput
           {...props.TextInputProps()}
-          {...passwordInputProps}
-          translateWithId={id => togglePasswordVisibilityTranslationIds[id]}
+          {...props.PasswordInputProps()}
         />
       );
     },
@@ -142,16 +132,10 @@ storiesOf('TextInput', module)
         },
       };
 
-      const {
-        togglePasswordVisibilityTranslationIds,
-        ...passwordInputProps
-      } = props.PasswordInputProps();
-
       return (
         <ControlledPasswordInputApp
           {...props.TextInputProps()}
-          {...passwordInputProps}
-          translateWithId={id => togglePasswordVisibilityTranslationIds[id]}
+          {...props.PasswordInputProps()}
         />
       );
     },


### PR DESCRIPTION
Closes #4047

This PR adds support for translated text on the password visibility toggle button

#### Changelog

**New**

- `translateWithId` prop to support custom strings for "show password" and "hide password" tooltip

#### Testing / Reviewing

Ensure the translations appear as expected (storybook knob)
