### PR TITLE
docs(file-uploader): apply iconDescription values for storybook demo

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -75,11 +75,18 @@ const props = {
     accept: array('Accepted file extensions (accept)', ['.jpg', '.png'], ','),
     name: text('Form item name: (name)', ''),
     multiple: boolean('Supports multiple files (multiple)', true),
+    iconDescription: text(
+      'Close button icon description (iconDescription)',
+      'Clear file'
+    ),
   }),
   fileUploaderItem: () => ({
     name: text('Filename (name)', 'README.md'),
     status: select('Status for file name (status)', filenameStatuses, 'edit'),
-    iconDescription: text('(iconDescription)', 'Icon description'),
+    iconDescription: text(
+      'Close button icon description (iconDescription)',
+      'Clear file'
+    ),
     onDelete: action('onDelete'),
     invalid: boolean('Invalid (invalid)', false),
     errorSubject: text(


### PR DESCRIPTION
Closes #3438 

Based on the originating issue, this looks like a problem with the storybook demo, which wasn't providing an `iconDescription` value and presented a default label instead. I updated that plus a related text knob description.

#### Changelog

**New**

- add `iconDescription` value to storybook demo
#### Testing / Reviewing

Open the `carbon-components-react` deployment for this PR, go to the "FilterUploader" (second) story, and use VoiceOver on MacOS to add a file, then tab to the close button and listen to what VoiceOver announces. (You should hear it say "Clear file" instead of the default "Provide an icon description"
