### PR TITLE
fix(accordion): disable focus on collapsed accordion item content

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -10,6 +10,7 @@
 @import '../../globals/scss/layout';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/css--reset';
+@import 'keyframes';
 
 /// Accordion styles
 /// @access private
@@ -93,15 +94,11 @@
   }
 
   .#{$prefix}--accordion__content {
+    display: none;
     // Transition property for when the accordion closes
-    transition: height motion(standard, productive) $duration--fast-02,
-      padding motion(standard, productive) $duration--fast-02;
+    transition: padding motion(standard, productive) $duration--fast-02;
     padding-left: $carbon--spacing-05;
-
     padding-right: 25%;
-    height: 0;
-    visibility: hidden;
-    opacity: 0;
 
     @include carbon--breakpoint-down('md') {
       padding-right: $carbon--spacing-09;
@@ -112,18 +109,29 @@
     }
   }
 
+  .#{$prefix}--accordion__item--collapsing .#{$prefix}--accordion__content,
+  .#{$prefix}--accordion__item--expanding .#{$prefix}--accordion__content {
+    display: block;
+  }
+
+  .#{$prefix}--accordion__item--collapsing .#{$prefix}--accordion__content {
+    animation: $duration--fast-02 motion(standard, productive)
+      collapse-accordion;
+  }
+
+  .#{$prefix}--accordion__item--expanding .#{$prefix}--accordion__content {
+    animation: $duration--fast-02 motion(standard, productive) expand-accordion;
+  }
+
   .#{$prefix}--accordion__item--active {
     overflow: visible;
 
     .#{$prefix}--accordion__content {
+      display: block;
       padding-bottom: $carbon--spacing-06;
       padding-top: $spacing-xs;
-      height: auto;
-      visibility: visible;
-      opacity: 1;
       // Transition property for when the accordion opens
-      transition: height motion(entrance, productive) $duration--fast-02,
-        padding-top motion(entrance, productive) $duration--fast-02,
+      transition: padding-top motion(entrance, productive) $duration--fast-02,
         padding-bottom motion(entrance, productive) $duration--fast-02;
     }
 

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -46,8 +46,8 @@
     margin: 0;
     transition: background-color motion(standard, productive) $duration--fast-02;
 
-    &:hover:before,
-    &:focus:before {
+    &:hover::before,
+    &:focus::before {
       content: '';
       position: absolute;
       top: -1px;
@@ -56,7 +56,7 @@
       height: calc(100% + 2px);
     }
 
-    &:hover:before {
+    &:hover::before {
       background-color: $hover-ui;
     }
 

--- a/packages/components/src/components/accordion/_keyframes.scss
+++ b/packages/components/src/components/accordion/_keyframes.scss
@@ -1,0 +1,29 @@
+@mixin content-visible {
+  height: 100%;
+  visibility: visible;
+  opacity: 1;
+}
+
+@mixin content-hidden {
+  height: 0;
+  visibility: hidden;
+  opacity: 0;
+}
+
+@keyframes collapse-accordion {
+  0% {
+    @include content-visible;
+  }
+  100% {
+    @include content-hidden;
+  }
+}
+
+@keyframes expand-accordion {
+  0% {
+    @include content-hidden;
+  }
+  100% {
+    @include content-visible;
+  }
+}

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -16,6 +16,11 @@ import Container from './Container';
 
 addDecorator(
   withInfo({
+    styles: {
+      children: {
+        width: '100%',
+      },
+    },
     maxPropStringLength: 200, // Displays the first 200 characters in the default prop string
   })
 );

--- a/packages/react/src/components/Accordion/AccordionItem.js
+++ b/packages/react/src/components/Accordion/AccordionItem.js
@@ -61,12 +61,12 @@ function AccordionItem({
     }
   }
 
-  const handleAnimationEnd = event => {
+  function handleAnimationEnd(event) {
     if (rest.handleAnimationEnd) {
       rest.handleAnimationEnd(event);
     }
     setAnimation('');
-  };
+  }
 
   return (
     <li className={className} {...rest} onAnimationEnd={handleAnimationEnd}>

--- a/packages/react/src/components/Accordion/AccordionItem.js
+++ b/packages/react/src/components/Accordion/AccordionItem.js
@@ -27,9 +27,12 @@ function AccordionItem({
 }) {
   const [isOpen, setIsOpen] = useState(open);
   const [prevIsOpen, setPrevIsOpen] = useState(open);
+  const [animation, setAnimation] = useState('');
   const className = cx({
     [`${prefix}--accordion__item`]: true,
     [`${prefix}--accordion__item--active`]: isOpen,
+    [`${prefix}--accordion__item--collapsing`]: animation === 'collapsing',
+    [`${prefix}--accordion__item--expanding`]: animation === 'expanding',
     [customClassName]: !!customClassName,
   });
 
@@ -42,6 +45,7 @@ function AccordionItem({
   // panel
   function onClick(event) {
     const nextValue = !isOpen;
+    setAnimation(isOpen ? 'collapsing' : 'expanding');
     setIsOpen(nextValue);
     if (onHeadingClick) {
       // TODO: normalize signature, potentially:
@@ -57,8 +61,15 @@ function AccordionItem({
     }
   }
 
+  const handleAnimationEnd = event => {
+    if (rest.handleAnimationEnd) {
+      rest.handleAnimationEnd(event);
+    }
+    setAnimation('');
+  };
+
   return (
-    <li className={className} {...rest}>
+    <li className={className} {...rest} onAnimationEnd={handleAnimationEnd}>
       <Expando
         aria-expanded={isOpen}
         className={`${prefix}--accordion__heading`}

--- a/packages/react/src/components/Accordion/AccordionItem.js
+++ b/packages/react/src/components/Accordion/AccordionItem.js
@@ -31,8 +31,7 @@ function AccordionItem({
   const className = cx({
     [`${prefix}--accordion__item`]: true,
     [`${prefix}--accordion__item--active`]: isOpen,
-    [`${prefix}--accordion__item--collapsing`]: animation === 'collapsing',
-    [`${prefix}--accordion__item--expanding`]: animation === 'expanding',
+    [`${prefix}--accordion__item--${animation}`]: animation,
     [customClassName]: !!customClassName,
   });
 

--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -13,6 +13,7 @@ exports[`Accordion should render 1`] = `
     >
       <li
         className="bx--accordion__item child"
+        onAnimationEnd={[Function]}
       >
         <defaultRenderExpando
           aria-expanded={false}
@@ -85,6 +86,7 @@ exports[`Accordion should render 1`] = `
     >
       <li
         className="bx--accordion__item child"
+        onAnimationEnd={[Function]}
       >
         <defaultRenderExpando
           aria-expanded={false}
@@ -157,6 +159,7 @@ exports[`Accordion should render 1`] = `
     >
       <li
         className="bx--accordion__item child"
+        onAnimationEnd={[Function]}
       >
         <defaultRenderExpando
           aria-expanded={false}

--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/AccordionItem-test.js.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/AccordionItem-test.js.snap
@@ -7,6 +7,7 @@ exports[`AccordionItem should render 1`] = `
 >
   <li
     className="bx--accordion__item extra-class"
+    onAnimationEnd={[Function]}
   >
     <defaultRenderExpando
       aria-expanded={false}


### PR DESCRIPTION
Closes #3429

This PR disallows accordion item content to receive focus when the panel is collapsed. This sets `display` none on accordion content when the panel is collapsed.

Alternatively, we can refactor our `hidden` mixin (or each consumer of this mixin) to account for the situation where a typically visible `input` needs to inherit a hidden visibility rule

#### Changelog

**New**

- animations to preserve transitions when expanding and collapsing accordion items

**Changed**

- replace `height`, `visibility`, and `opacity` changes with `display` rule change to disable focus on collapsed panel content
- target CSS3 pseudo selectors
- storybook wrapper `div` styles to make the injected `div` function like a block level element inside our custom flexbox story wrapper (refs https://github.com/storybookjs/storybook/issues/5707)

#### Testing / Reviewing

Add a Toggle or Checkbox to an accordion item and tab through the accordion. The toggle should not receive focus while the panel is collapsed
