### PR TITLE
docs(OverflowMenu): remove duplicate menu example and bad aria 

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -64,17 +64,6 @@ const OverflowMenuExample = ({ overflowMenuProps, overflowMenuItemProps }) => (
         isDelete
       />
     </OverflowMenu>
-    <OverflowMenu {...overflowMenuProps}>
-      <OverflowMenuItem
-        {...overflowMenuItemProps}
-        itemText="Option 1"
-        primaryFocus
-      />
-      <OverflowMenuItem
-        {...overflowMenuItemProps}
-        itemText="Option 2 is an example of a really long string and how we recommend handling this"
-      />
-    </OverflowMenu>
   </>
 );
 
@@ -125,10 +114,9 @@ storiesOf('OverflowMenu', module)
       <OverflowMenuExample
         overflowMenuProps={{
           ...props.menu(),
+          ariaLabel: null,
           style: { width: 'auto' },
-          renderIcon: () => (
-            <div style={{ padding: '0 1rem' }}>Custom trigger</div>
-          ),
+          renderIcon: () => <div style={{ padding: '0 1rem' }}>Menu</div>,
         }}
         overflowMenuItemProps={props.menuItem()}
       />


### PR DESCRIPTION
Closes #4200 

Our Storybook example had some bad aria causing a DAP violation. Easy clear with a prop override. 

#### Changelog

- added an override to the prop function that clears `aria-label` since our div button already has a built in label working fine
- also removed the duplicate storybook example we were using to illustrate focusing the first item in our menu. Having the stacked overflows is goofy and not our intended use case. 
- minor style change to `renderIcon` _(`ci-check` was bonkers, so if this is a discrepency with my Prettier install on Sublime vs. our Prettier, I'll fix it back)_

#### Notes

Do we want to expose props _in Story_ like we were doing with Overflow? Seems like it'd hurt copy-and-paste-ability and isn't communicating our intended usage. 

#### Testing / Reviewing

Make sure the OverflowMenu's Storybook is copacetic. 🏄 
