### PR TITLE
fix(OverflowMenu): prevent page scroll on menu navigation and selection

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -319,6 +319,10 @@ class OverflowMenu extends Component {
   };
 
   handleKeyPress = evt => {
+    if (!keyCodeMatches(evt, [keys.Enter, keys.Space])) {
+      evt.preventDefault();
+    }
+
     // only respond to key events when the menu is closed, so that menu items still respond to key events
     if (!this.state.open) {
       if (keyCodeMatches(evt, [keys.Enter, keys.Space])) {
@@ -331,7 +335,6 @@ class OverflowMenu extends Component {
       this.closeMenu();
       // Stop the esc keypress from bubbling out and closing something it shouldn't
       evt.stopPropagation();
-      evt.preventDefault();
     }
   };
 


### PR DESCRIPTION
Closes #4333

This PR prevents the page from scrolling when a user navigates or selects an item from an overflow menu with the keyboard

#### Testing / Reviewing

Ensure that using the keyboard to navigate menus or select items does not scroll the page

Ensure overflow menu item selection functions as expected
