### PR TITLE
fix(select): apply text color to focussed select for firefox

### DIFF
--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -80,6 +80,7 @@
 
     &:focus {
       @include focus-outline('outline');
+      color: $text-01;
     }
 
     &:disabled,


### PR DESCRIPTION
Closes #4241

It looks like Firefox expects there to be a `color` set on the `select:focus` 😲 
This style rule appears to fix the issue identified in #4241 

#### Changelog

**Changed**

- set `color: $text-01` when `select` is focussed

#### Testing / Reviewing

- open the `carbon-components-react` deployment in Firefox: https://deploy-preview-4343--the-carbon-components.netlify.com
- set the theme to a dark theme like `g100`
- select options in the `Select` component and see that the select option text color stays white (and readable)
