### PR TITLE
fix(code-snippet): set multi-line snippet overflow-x to auto

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -137,7 +137,7 @@
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
     .#{$prefix}--snippet-container
     pre {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {


### PR DESCRIPTION
Currently if you click on the "expand" / "view more" button for the multi-line `CodeSnippet`, it will always show a horizontal scrollbar even if there isn't any content overflowing horizontally... (you can see it in action here when you expand the `CodeSnippet`: http://react.carbondesignsystem.com/?path=/story/codesnippet--multi-line)

This can be fixed by changing `overflow-x: scroll` (aka "always show a scrollbar") to `overflow-x: auto` (aka "default behavior / show a scrollbar if needed")

#### Changelog
**Changed**

- change `overflow-x: scroll` to `overflow-x: auto`
**Removed**