### PR TITLE
docs(readme): use helpful link text and update 404ing URL

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -37,8 +37,7 @@ subject to breaking changes. Please use `es`/`umd`/`scss` directories instead)
 
 # :books: Documentation
 
-- See our documentation site
-  [here](http://carbondesignsystem.com/getting-started/developers) for full
+- See our [documentation site](https://www.carbondesignsystem.com/get-started/develop/vanilla) for full
   how-to docs and guidelines
 - [Contributing](/.github/CONTRIBUTING.md): Guidelines for making contributions
   to this repo.


### PR DESCRIPTION
The "Getting Started" link on the vanilla repo's README is 404ing, so this PR updates that link to be https://www.carbondesignsystem.com/get-started/develop/vanilla

Also I suggest changing the link text from "here" to "documentation site" so it's more accessible (i.e., when using a screen reader and tabbing/skipping to this link, the text "here" isn't as helpful as something like "documentation site")

#### Changelog

**Changed**

- update documentation site link & link text