### PR TITLE
fix(storybook): use productive-heading-03 and 04 instead of expressive

### DIFF
--- a/packages/react/.storybook/addon-carbon-theme/components/Panel.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Panel.js
@@ -32,8 +32,8 @@ const typeTokenDefaults = {
   'code-02': '14-20',
   'productive-heading-01': '14-18',
   'productive-heading-02': '16-22',
-  'expressive-heading-01': '14-18',
-  'expressive-heading-02': '16-22',
+  'productive-heading-03': '20-26',
+  'productive-heading-04': '28-36',
 };
 
 /**


### PR DESCRIPTION
Closes #4386 according to feedback in #4330

This PR removes the expressive heading tokens and adds `productive-heading-03` and `productive-heading-04` to the Carbon Type panel in the React storybook

#### Changelog

**New**

- `productive-heading-03` and `productive-heading-04` type token knobs

**Removed**

- `expressive-heading-01` and `expressive-heading-2` type token knobs

#### Testing / Reviewing

ensure the Carbon Type storybook panel functions as expected