### PR TITLE
fix: replace heading-01 with productive-heading-01

### DIFF
--- a/packages/components/demo/scss/_markdown-page.scss
+++ b/packages/components/demo/scss/_markdown-page.scss
@@ -229,7 +229,7 @@
 
   ul,
   ol {
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     margin-left: 1.5rem;
     margin-bottom: 1rem;
     line-height: 1.75;
@@ -331,7 +331,7 @@
   }
 
   blockquote + p strong {
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     color: $brand-01;
   }
 

--- a/packages/components/demo/scss/_page.scss
+++ b/packages/components/demo/scss/_page.scss
@@ -92,7 +92,7 @@ td {
     }
 
     h1 {
-      @include type-style('heading-01');
+      @include type-style('productive-heading-01');
       font-weight: 300;
       line-height: 1.25;
 

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -51,7 +51,7 @@
   }
 
   .#{$prefix}--data-table thead {
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     background-color: $ui-03;
   }
 

--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -215,7 +215,7 @@
 
   .#{$prefix}--date-picker__month .flatpickr-current-month,
   .flatpickr-month .flatpickr-current-month {
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     padding: 0;
   }
 

--- a/packages/components/src/components/date-picker/_flatpickr.scss
+++ b/packages/components/src/components/date-picker/_flatpickr.scss
@@ -280,7 +280,7 @@
   opacity: 1;
 }
 .flatpickr-current-month {
-  @include type-style('heading-01');
+  @include type-style('productive-heading-01');
 
   color: inherit;
   position: absolute;

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -30,7 +30,7 @@
   // TODO: sync with type
   .#{$prefix}--file--label {
     @include reset;
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     color: $text-01;
     margin-bottom: $carbon--spacing-03;
   }

--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -126,7 +126,7 @@
   }
 
   .#{$prefix}--inline-notification__title {
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     margin: 0 $carbon--spacing-02 0 0;
     line-height: rem(24px);
   }

--- a/packages/components/src/components/notification/_toast-notification.scss
+++ b/packages/components/src/components/notification/_toast-notification.scss
@@ -139,7 +139,7 @@
   }
 
   .#{$prefix}--toast-notification__title {
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
 
     font-weight: 600;
     margin-top: 1rem;

--- a/packages/components/src/components/structured-list/_structured-list.scss
+++ b/packages/components/src/components/structured-list/_structured-list.scss
@@ -87,7 +87,7 @@
   .#{$prefix}--structured-list-th {
     @include reset;
     @include padding-th;
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     display: table-cell;
     font-weight: 600;
     height: rem(40px);

--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -203,7 +203,7 @@
       display: flex;
       .#{$prefix}--tabs__nav-link {
         color: $text-01;
-        @include type-style('heading-01');
+        @include type-style('productive-heading-01');
         border-bottom: 3px solid $interactive-01;
       }
 

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -448,7 +448,7 @@
   }
 
   .#{$prefix}--tooltip__heading {
-    @include carbon--type-style('heading-01');
+    @include carbon--type-style('productive-heading-01');
     margin-bottom: $spacing-03;
   }
 

--- a/packages/components/src/components/ui-shell/_side-nav.scss
+++ b/packages/components/src/components/ui-shell/_side-nav.scss
@@ -357,7 +357,7 @@
   //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__submenu[aria-haspopup='true'] {
     @include button-reset($width: true);
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     @include focus-outline('reset');
     padding: 0 mini-units(2);
     display: flex;
@@ -483,7 +483,7 @@
     .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true']
     + .#{$prefix}--header__menu {
     @include focus-outline('reset');
-    @include type-style('heading-01');
+    @include type-style('productive-heading-01');
     position: relative;
     display: flex;
     align-items: center;

--- a/packages/components/src/components/ui-shell/_switcher.scss
+++ b/packages/components/src/components/ui-shell/_switcher.scss
@@ -47,7 +47,7 @@
   }
 
   .#{$prefix}--switcher__item-link {
-    @include carbon--type-style('heading-01');
+    @include carbon--type-style('productive-heading-01');
     display: block;
     height: $spacing-07;
     text-decoration: none;


### PR DESCRIPTION
Closes #4391

This PR replaces references to the deprecated `heading-01` type token with `productive-heading-01`

#### Changelog

**Changed**

- vanilla demo page
- data table
- date picker (and flatpickr base)
- file uploader
- notification
- structured list
- tabs
- tooltip
- UI shell side nav and switcher

#### Testing / Reviewing

Ensure the affected components are visually correct
