### PR TITLE
fix(link): set default type styles to body-short-01

### DIFF
--- a/packages/components/src/components/link/_link.scss
+++ b/packages/components/src/components/link/_link.scss
@@ -23,7 +23,7 @@
 @mixin link {
   .#{$prefix}--link {
     @include reset;
-    @include type-style('body-long-01');
+    @include type-style('body-short-01');
     color: $link-01;
     text-decoration: none;
     outline: none;
@@ -62,7 +62,7 @@
 
   .#{$prefix}--link--disabled {
     @include reset;
-    @include type-style('body-long-01');
+    @include type-style('body-short-01');
     display: inline;
     color: $disabled-02;
     font-weight: 400;


### PR DESCRIPTION
Closes #4402

~~This PR sets the default breadcrumb type styles to `body-long-01`. Previously it was `body-short-01` but since the breadcrumb links inherit styles from the Carbon Link component it ended up as `body-long-01`. The separator was still `body-short-01` though, which meant it wasn't changing together with the breadcrumb link text~~

This PR sets the default link type styles to `body-short-01` in accordance to https://github.com/carbon-design-system/carbon/pull/4407#issuecomment-544679150

#### Testing / Reviewing

Ensure the link appears correct and scales with the correct type token changes (and all of its consumers including breadcrumb)