### PR TITLE
chore(project): update format:diff ignore pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "lerna run clean && lerna clean --yes && rimraf node_modules",
     "doctoc": "doctoc --title '## Table of Contents'",
     "format": "prettier --write '**/*.{js,md,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**'",
-    "format:diff": "prettier --list-different '**/*.{js,md,scss,ts}' '!**/{build,es,lib,storybook,ts,umd,components}/**'",
+    "format:diff": "prettier --list-different '**/*.{js,md,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**' '!packages/components/**'",
     "lint": "eslint packages",
     "lint:styles": "stylelint '**/*.{css,scss}' --config ./packages/stylelint-config-elements",
     "sync": "carbon-cli sync",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -37,8 +37,9 @@ subject to breaking changes. Please use `es`/`umd`/`scss` directories instead)
 
 # :books: Documentation
 
-- See our [documentation site](https://www.carbondesignsystem.com/get-started/develop/vanilla) for full
-  how-to docs and guidelines
+- See our
+  [documentation site](https://www.carbondesignsystem.com/get-started/develop/vanilla)
+  for full how-to docs and guidelines
 - [Contributing](/.github/CONTRIBUTING.md): Guidelines for making contributions
   to this repo.
 - [🏃‍♀️ Migration Guides](./docs/migration)

--- a/packages/components/docs/migration/migrate-to-10.x.md
+++ b/packages/components/docs/migration/migrate-to-10.x.md
@@ -31,7 +31,7 @@ initial `v10` release.
 | Combobox           | No breaking changes                                                   |
 | Content Switcher   | [Migrate](../../src/components/content-switcher/migrate-to-10.x.md)   |
 | Copy Button        | [Migrate](../../src/components/copy-button/migrate-to-10.x.md)        |
-| Data Table V2      | [Migrate](../../src/components/data-table/migrate-to-10.x.md)      |
+| Data Table V2      | [Migrate](../../src/components/data-table/migrate-to-10.x.md)         |
 | Data Table         | Removed                                                               |
 | Date Picker        | TODO                                                                  |
 | Dropdown           | [Migrate](../../src/components/dropdown/migrate-to-10.x.md)           |

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -162,7 +162,7 @@ export default class Pagination extends Component {
     return !pageSizesChanged && !pageChanged && !pageSizeChanged
       ? null
       : {
-          page: pageSizeChanged && 1 || pageChanged && page || currentPage,
+          page: (pageSizeChanged && 1) || (pageChanged && page) || currentPage,
           pageSize: pageSizeChanged ? pageSize : currentPageSize,
           prevPageSizes: pageSizes,
           prevPage: page,


### PR DESCRIPTION
Updates our `format:diff` to include `react`. The `components` pattern was mistakenly stopping this from occurring. Also updates failures from this change.

#### Changelog

**New**

**Changed**

- `format:diff` now uses a separate ignore pattern with `packages/components` instead of `components`
- Updated files according to prettier formatting

**Removed**
