### PR TITLE
feat(accordion): add resize rules for type theming

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -16,6 +16,8 @@
 /// @access private
 /// @group accordion
 @mixin accordion {
+  $line-height: rem(get-theme-value('body-long-01', 'line-height'));
+
   .#{$prefix}--accordion {
     @include reset;
 
@@ -34,13 +36,18 @@
   }
 
   .#{$prefix}--accordion__heading {
+    // With the target heading height, we can subtract out the line-height of
+    // the type token to figure out how much padding is needed to match the
+    // heading height
+    $heading-padding: (get-heading-height($line-height) - $line-height) / 2;
+
     @include button-reset;
     color: $text-01;
     display: flex;
     align-items: flex-start;
     justify-content: $accordion-justify-content;
     cursor: pointer;
-    padding: rem(6px) 0;
+    padding: $heading-padding 0;
     flex-direction: $accordion-flex-direction;
     position: relative;
     width: 100%;
@@ -71,12 +78,14 @@
   }
 
   .#{$prefix}--accordion__arrow {
+    $icon-size: get-icon-size($line-height);
+
     @include focus-outline('reset');
     // Without flex basis and flex shrink being set here, our icon width can go
     // <16px and cause the icon to render in the incorrect artboard size
-    flex: 0 0 1rem;
-    width: 1rem;
-    height: 1rem;
+    flex: 0 0 $icon-size;
+    width: $icon-size;
+    height: $icon-size;
     margin: $accordion-arrow-margin;
     fill: $ui-05;
     // TODO: RTL rotate(180deg);
@@ -173,6 +182,54 @@
   .#{$prefix}--accordion__title.#{$prefix}--skeleton__text {
     margin-bottom: 0;
   }
+}
+
+@function px($value) {
+  @if unit($value) == 'px' {
+    @return $value;
+  }
+  @if unit($value) == 'rem' {
+    @return ($value / ($value * 0 + 1)) * 16px;
+  }
+  @error "Unable to convert unit #{unit($value)} to px";
+}
+
+@function rem($value) {
+  @if unit($value) == 'rem' {
+    @return $value;
+  }
+  @if unit($value) == 'px' {
+    @return ($value / 16px) * 1rem;
+  }
+  @error "Unable to convert unit #{unit($value)} to px";
+}
+
+@function get-theme-value($token, $field) {
+  @return map-get(map-get($carbon--theme, $token), $field);
+}
+
+/// Get the heading height for the accordion
+/// @access private
+/// @group accordion
+/// @param {px | rem} $line-height
+/// @return {rem}
+@function get-heading-height($line-height) {
+  @if px($line-height) <= 20px {
+    @return 2rem;
+  }
+  @return 3rem;
+}
+
+/// Get the icon size for the accordion heading
+/// @access private
+/// @group accordion
+/// @param {px | rem} $line-height
+/// @return {rem}
+@function get-icon-size($line-height) {
+  @if px($line-height) <= 20px {
+    @return 1rem;
+  }
+  @return 1.25rem;
 }
 
 @include exports('accordion') {


### PR DESCRIPTION
Closes #4401 

Add resize rules for accordion where `body-long-01` may grow and the heading size and icon size should grow as a result.

#### Changelog

**New**

**Changed**

- Add resize rule for icon size based on `body-long-01`
- Add resize rule for heading based on `body-long-01`

**Removed**

#### Testing / Reviewing

- Verify default style works as expected
- Update `_container.scss` with the following map before the carbon import

```scss
$carbon--theme: map-merge(
  $carbon--theme--white,
  (
    body-long-01: (
      font-size: 1rem,
      line-height: 1.5rem,
    ),
  )
);
@include carbon--theme();
```

- Verify that new styles match specs as noted in #4401 
