### PR TITLE
fix(tabs): updates role to tab and moves aria-selected to li

### DIFF
--- a/packages/components/src/components/tabs/tabs.hbs
+++ b/packages/components/src/components/tabs/tabs.hbs
@@ -14,9 +14,10 @@
     {{#each items}}
     <li
       class="{{@root.prefix}}--tabs__nav-item{{#if selected}} {{@root.prefix}}--tabs__nav-item--selected{{/if}} {{#if disabled}} {{@root.prefix}}--tabs__nav-item--disabled {{/if}}"
-      data-target=".{{panelClass}}" role="presentation">
+      data-target=".{{panelClass}}" role="tab" {{#if selected}} aria-selected="true" {{/if}} {{#if disabled}}
+      aria-disabled="true" {{/if}}>
       <a tabindex="0" id="{{linkId}}" class="{{@root.prefix}}--tabs__nav-link" href="javascript:void(0)" role="tab"
-        aria-controls="{{panelId}}" {{#if selected}} aria-selected="true" {{/if}}>{{label}}</a>
+        aria-controls="{{panelId}}">{{label}}</a>
     </li>
     {{/each}}
   </ul>


### PR DESCRIPTION
Closes #1942 

This was done during the mob programming by @aledavila and me! 🎉 
 It updates the role of the `li` in each tab to `tab` so that `aria-selected` becomes valid aria. It also adds `aria-disabled` on disabled tabs.   

#### Changelog

**Changed**

- `role="presentation"` -> `role="tab"` 

**Removed**

- `aria-selected` on the `a` 

#### Testing / Reviewing

Run DAP on the vanilla Tabs component and verify that there an no violations associated with the component (there will be some coming from the environment so ignore those) 