### PR TITLE
fix(select): resolve Firefox specific alignment and invalid state issues

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -42,8 +42,7 @@ $css--helpers: true;
     grid-template-columns: auto 0;
   }
 
-  .#{$prefix}--select-input__wrapper,
-  .#{$prefix}--select-input--inline__wrapper {
+  .#{$prefix}--pagination .#{$prefix}--select-input--inline__wrapper {
     height: 100%;
   }
 

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -234,10 +234,6 @@
     color: $disabled;
     cursor: not-allowed;
 
-    &:hover {
-      background-color: transparent;
-    }
-
     ~ * {
       cursor: not-allowed;
     }

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -46,7 +46,7 @@
     width: rem(224px);
     min-width: rem(128px);
     max-width: rem(448px);
-    padding: 0 rem(42px) 0 $carbon--spacing-05; // 1.5rem + chevron width
+    padding: 0 $spacing-09 0 $spacing-05;
     color: $text-01;
     background-color: $field-01;
     border: none;
@@ -97,7 +97,7 @@
   }
 
   .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input {
-    padding-right: rem(64px); // 1rem + chevron width + invalid icon width
+    padding-right: carbon--mini-units(10);
   }
 
   .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input,
@@ -135,7 +135,7 @@
   .#{$prefix}--select__arrow {
     fill: $ui-05;
     position: absolute;
-    right: 1rem;
+    right: $spacing-05;
     pointer-events: none;
   }
 
@@ -143,7 +143,7 @@
     .#{$prefix}--select-input
     ~ .#{$prefix}--select__invalid-icon {
     position: absolute;
-    right: rem(34px); // 1.5rem + chevron width
+    right: $spacing-09;
   }
 
   .#{$prefix}--select-input__wrapper[data-invalid]
@@ -183,13 +183,13 @@
   .#{$prefix}--select--inline.#{$prefix}--select--invalid .#{$prefix}--label,
   .#{$prefix}--select--inline.#{$prefix}--select--invalid
     .#{$prefix}--form__helper-text {
-    margin-top: rem(13px);
+    margin-top: rem(13px); // offset label text margin
     align-self: flex-start;
   }
 
   .#{$prefix}--select--inline .#{$prefix}--form__helper-text {
     margin-bottom: 0;
-    margin-left: rem(8px);
+    margin-left: $spacing-03;
   }
 
   .#{$prefix}--select--inline .#{$prefix}--label {
@@ -202,7 +202,7 @@
     color: $text-01;
     border-bottom: none;
     padding-left: $carbon--spacing-03;
-    padding-right: rem(26px);
+    padding-right: $spacing-07;
 
     &:hover {
       background-color: $hover-ui;
@@ -215,13 +215,13 @@
 
   .#{$prefix}--select--inline.#{$prefix}--select--invalid
     .#{$prefix}--select-input {
-    padding-right: rem(50px);
+    padding-right: $spacing-09 + $spacing-03; // 3.5rem
   }
 
   .#{$prefix}--select--inline.#{$prefix}--select--invalid
     .#{$prefix}--select-input
     ~ .#{$prefix}--select__invalid-icon {
-    right: rem(24px);
+    right: $spacing-07;
   }
 
   .#{$prefix}--select--inline .#{$prefix}--select-input:disabled {

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -31,10 +31,6 @@
     position: relative;
     display: flex;
     align-items: center;
-
-    &:hover .#{$prefix}--select-input {
-      background-color: $hover-ui;
-    }
   }
 
   .#{$prefix}--select-input {
@@ -203,10 +199,11 @@
     border-bottom: none;
     padding-left: $carbon--spacing-03;
     padding-right: $spacing-07;
+  }
 
-    &:hover {
-      background-color: $hover-ui;
-    }
+  .#{$prefix}--select--inline .#{$prefix}--select-input[disabled],
+  .#{$prefix}--select--inline .#{$prefix}--select-input[disabled]:hover {
+    background-color: $disabled-background-color;
   }
 
   .#{$prefix}--select--inline .#{$prefix}--select__arrow {

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -216,8 +216,6 @@
   }
 
   .#{$prefix}--select--inline .#{$prefix}--select__arrow {
-    bottom: auto;
-    top: 1.125rem;
     right: $carbon--spacing-03;
   }
 

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -68,8 +68,6 @@
 
     // Select text renders a little high on Firefox
     @-moz-document url-prefix() {
-      padding-top: rem(4px);
-
       // Removes dotted inner focus
       &:-moz-focusring,
       &::-moz-focus-inner {
@@ -205,10 +203,6 @@
     border-bottom: none;
     padding-left: $carbon--spacing-03;
     padding-right: rem(26px);
-
-    @-moz-document url-prefix() {
-      padding-top: 0;
-    }
 
     &:hover {
       background-color: $hover-ui;

--- a/packages/components/src/components/select/select.config.js
+++ b/packages/components/src/components/select/select.config.js
@@ -60,7 +60,7 @@ module.exports = {
       notes: `
         Select displays a list below its title when selected. They are used primarily in forms,
         where a user chooses one option from a list. Once the user selects an item, the dropdown will
-        dissapear and the field will reflect the user's choice. Create Select Item components for each
+        disappear and the field will reflect the user's choice. Create Select Item components for each
         option in the list.
       `,
       context: {

--- a/packages/components/src/components/select/select.hbs
+++ b/packages/components/src/components/select/select.hbs
@@ -37,7 +37,7 @@
           {{/if}}
           {{/each}}
         </select>
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+        {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
         {{#if invalid}}
         {{ carbon-icon 'WarningFilled16' class=(add @root.prefix '--select__invalid-icon')}}
         {{/if}}

--- a/packages/components/src/components/select/select.hbs
+++ b/packages/components/src/components/select/select.hbs
@@ -79,7 +79,7 @@
             selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/each}} </optgroup> {{else}}
           <option class="{{@root.prefix}}--select-option" value="{{value}}" {{#if disabled}} disabled{{/if}}{{#if
             selected}} selected{{/if}}{{#if hidden}} hidden{{/if}}>{{label}} </option> {{/if}} {{/each}} </select>
-        {{ carbon-icon 'ChevronDownGlyph' class=(add @root.prefix '--select__arrow') }}
+        {{ carbon-icon 'ChevronDown16' class=(add @root.prefix '--select__arrow') }}
       </div>
       {{#if invalid}}
       <div class="{{@root.prefix}}--form-requirement">

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -37,6 +37,7 @@ const Select = React.forwardRef(function Select(
     [`${prefix}--select--inline`]: inline,
     [`${prefix}--select--light`]: light,
     [`${prefix}--select--invalid`]: invalid,
+    [`${prefix}--select--disabled`]: disabled,
     [className]: className,
   });
   const labelClasses = classNames(`${prefix}--label`, {

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -68,7 +68,6 @@ const Select = React.forwardRef(function Select(
           id={id}
           className={`${prefix}--select-input`}
           disabled={disabled || undefined}
-          data-invalid={invalid || undefined}
           aria-invalid={invalid || undefined}
           ref={ref}>
           {children}


### PR DESCRIPTION
Closes #4423

This PR removes a double invalid outline for inline select elements and also resolves some alignment and spacing issues in our `<select>` component caused by targeted rules for Firefox only

#### Testing / Reviewing

Ensure the Carbon Select component appears correct
