### PR TITLE
fix(NumberInput): add top offset to fix vertical controls alignment IE11

### DIFF
--- a/packages/components/src/components/number-input/_number-input.scss
+++ b/packages/components/src/components/number-input/_number-input.scss
@@ -77,6 +77,7 @@
   .#{$prefix}--number__input-wrapper {
     display: flex;
     align-items: center;
+    position: relative;
 
     ~ .#{$prefix}--form-requirement {
       color: $support-01;
@@ -98,6 +99,9 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    // vertically center controls within parent container on IE11
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   .#{$prefix}--number__control-btn {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/2069

This PR adds a top offset of 50% with transform: translateY(-50%), to vertically center the number input controls in IE11. position: relative is also added to `--number__input-wrapper`, so then `--number__controls` will be positioned relative to `--number__input-wrapper` which will now be its nearest positioned ancestor.

#### Changelog

**New**

- add `position: relative` to `--number__input-wrapper` to position `--number__controls` relative to `--number__input-wrapper`.
- add `top: 50%` and `transform: translateY(-50%)` to `--number__controls` to vertically center the controls in IE11.

#### Testing / Reviewing

go to http://localhost:9000/?path=/story/numberinput--default in IE11
