### PR TITLE
fix(dropdown): use theme token for text color

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -123,6 +123,7 @@
   }
 
   button.#{$prefix}--dropdown-text {
+    color: $text-01;
     // button-reset mixin contradicts with bx--dropdown-text styles
     background: none;
     border: none;


### PR DESCRIPTION
Fixes #4323.

#### Changelog

**Changed**

- The color of dropdown trigger text.

#### Testing / Reviewing

Testing should make sure our dropdown component is not broken.