### PR TITLE
fix: prevent DatePicker from some unnecessary rerenders

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -15,6 +15,7 @@ import DatePickerInput from '../DatePickerInput';
 import carbonFlatpickrFixEventsPlugin from './plugins/fixEventsPlugin';
 import carbonFlatpickrRangePlugin from './plugins/rangePlugin';
 import { match, keys } from '../../internal/keyboard';
+import isEqual from 'lodash.isequal';
 
 const { prefix } = settings;
 
@@ -307,7 +308,7 @@ export default class DatePicker extends Component {
   };
 
   UNSAFE_componentWillUpdate(nextProps) {
-    if (nextProps.value !== this.props.value) {
+    if (!isEqual(nextProps.value, this.props.value)) {
       if (this.cal) {
         this.cal.setDate(nextProps.value);
         this.updateClassNames(this.cal);


### PR DESCRIPTION
Closes #
I originally set out to close https://github.com/carbon-design-system/carbon/issues/2546

What I noticed is that between the way that `DatePicker` consumes the selected date, and the way that Flatpickr parses the selected date, this error occurs during the `UNSAFE_componentWillUpdate` hook [here](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/DatePicker/DatePicker.js#L312) I was not able to determine exactly where this error was happening but did notice that the error yasotnik described seeing was most likely due to the fact that in [this hook](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/DatePicker/DatePicker.js#L312) multiple date arrays would not be compared properly, thus causing unnecessary re-renders.

**TL;DR** I don't believe this would solve the issue of parsing ranged dates on all 'fully controlled' inputs, but should solve the use case where yasotnik originally saw this error (when providing default values) and should prevent some unnecessary re-renders in general

#### Changelog

**Changed**

- the way `DatePicker` compares props to decide when to update

#### Testing / Reviewing

- Note that when comparing `nextProps.value` and `this.props.value` [here](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/DatePicker/DatePicker.js#L310) will return true (as in that they are not the same value) when `value` is an array of dates. This would not happen when using lodash [isEqual](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/DatePicker/DatePicker.js#L310)
