### PR TITLE
feat(Multiselect): add NestedFilterableMultiselect to Multiselect

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -2660,6 +2660,7 @@ $carbon--spacing-04: carbon--mini-units(1.5);
   - [file-uploader [mixin]](#file-uploader-mixin)
   - [listbox [mixin]](#listbox-mixin)
   - [inline-notifications [mixin]](#inline-notifications-mixin)
+  - [toast-notifications [mixin]](#toast-notifications-mixin)
   - [tabs [mixin]](#tabs-mixin)
   - [text-area [mixin]](#text-area-mixin)
   - [tooltip--definition--legacy [mixin]](#tooltip--definition--legacy-mixin)
@@ -7427,6 +7428,7 @@ $interactive-04: if(
   - [inline-loading [mixin]](#inline-loading-mixin)
   - [loading [mixin]](#loading-mixin)
   - [slider [mixin]](#slider-mixin)
+  - [tabs [mixin]](#tabs-mixin)
 
 ### ✅ui-background [variable]
 
@@ -8767,6 +8769,7 @@ $hover-selected-ui: if(
   - [carbon--theme [mixin]](#carbon--theme-mixin)
   - [data-table-expandable [mixin]](#data-table-expandable-mixin)
   - [overflow-menu [mixin]](#overflow-menu-mixin)
+  - [tabs [mixin]](#tabs-mixin)
 
 ### ✅inverse-hover-ui [variable]
 
@@ -8966,6 +8969,7 @@ $disabled-02: if(
   - [pagination [mixin]](#pagination-mixin)
   - [select [mixin]](#select-mixin)
   - [slider [mixin]](#slider-mixin)
+  - [tabs [mixin]](#tabs-mixin)
   - [text-area [mixin]](#text-area-mixin)
   - [text-input [mixin]](#text-input-mixin)
   - [toggle [mixin]](#toggle-mixin)
@@ -8997,6 +9001,7 @@ $disabled-03: if(
   - [button [mixin]](#button-mixin)
   - [button-base [mixin]](#button-base-mixin)
   - [content-switcher [mixin]](#content-switcher-mixin)
+  - [tabs [mixin]](#tabs-mixin)
 
 ### ✅highlight [variable]
 
@@ -17010,6 +17015,7 @@ Dropdown styles
   }
 
   button.#{$prefix}--dropdown-text {
+    color: $text-01;
     // button-reset mixin contradicts with bx--dropdown-text styles
     background: none;
     border: none;
@@ -19124,7 +19130,6 @@ Inline notification styles
     @include reset;
 
     display: flex;
-    justify-content: space-between;
     position: relative;
     height: auto;
     min-height: rem(48px);
@@ -19238,6 +19243,7 @@ Inline notification styles
 
   .#{$prefix}--inline-notification__details {
     display: flex;
+    flex-grow: 1;
     margin: 0 $carbon--spacing-05;
   }
 
@@ -19299,8 +19305,6 @@ Inline notification styles
         $duration--fast-02 motion(standard, productive);
 
     .#{$prefix}--inline-notification__close-icon {
-      height: 1rem;
-      width: 1rem;
       fill: $inverse-01;
     }
   }
@@ -19505,7 +19509,7 @@ Toast notification styles
   .#{$prefix}--toast-notification__icon {
     flex-shrink: 0;
     margin-right: $carbon--spacing-05;
-    margin-top: $carbon--spacing-05;
+    margin-top: $carbon--spacing-04;
   }
 
   .#{$prefix}--toast-notification__details {
@@ -19530,8 +19534,6 @@ Toast notification styles
     }
 
     .#{$prefix}--toast-notification__close-icon {
-      height: 1rem;
-      width: 1rem;
       fill: $inverse-01;
     }
   }
@@ -19544,9 +19546,8 @@ Toast notification styles
 
   .#{$prefix}--toast-notification__title {
     @include type-style('productive-heading-01');
-
     font-weight: 600;
-    margin-top: 1rem;
+    margin-top: $carbon--spacing-04;
     word-break: break-word;
   }
 
@@ -19600,6 +19601,7 @@ Toast notification styles
   - [support-04 [variable]](#support-04-variable)
   - [inverse-support-03 [variable]](#inverse-support-03-variable)
   - [support-03 [variable]](#support-03-variable)
+  - [carbon--spacing-04 [variable]](#carbon--spacing-04-variable)
   - [carbon--spacing-06 [variable]](#carbon--spacing-06-variable)
 
 ## number-input
@@ -21887,6 +21889,12 @@ Tabs styles
     }
   }
 
+  .#{$prefix}--tabs--fixed {
+    @include carbon--breakpoint(md) {
+      min-height: rem(48px);
+    }
+  }
+
   .#{$prefix}--tabs-trigger {
     display: flex;
     align-items: center;
@@ -22008,6 +22016,23 @@ Tabs styles
     }
   }
 
+  .#{$prefix}--tabs--fixed .#{$prefix}--tabs__nav-item {
+    @include carbon--breakpoint(md) {
+      background-color: $ui-03;
+
+      & + .#{$prefix}--tabs__nav-item {
+        margin-left: 0;
+        // Draws the border without affecting the inner-content
+        box-shadow: -1px 0 0 0 $ui-04;
+      }
+
+      & + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
+      &.#{$prefix}--tabs__nav-item--selected + .#{$prefix}--tabs__nav-item {
+        box-shadow: none;
+      }
+    }
+  }
+
   .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
     transition: color $duration--fast-01 motion(standard, productive), border-bottom-color
         $duration--fast-01 motion(standard, productive),
@@ -22029,7 +22054,18 @@ Tabs styles
 
     @include carbon--breakpoint(md) {
       background-color: transparent;
-      box-shadow: none;
+
+      &,
+      & + .#{$prefix}--tabs__nav-item {
+        box-shadow: none;
+      }
+    }
+  }
+
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+    @include carbon--breakpoint(md) {
+      background-color: $hover-selected-ui;
     }
   }
 
@@ -22044,6 +22080,23 @@ Tabs styles
 
   .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
     pointer-events: none;
+  }
+
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled,
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
+    @include carbon--breakpoint(md) {
+      background-color: $disabled-02;
+    }
+  }
+
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item--disabled
+    .#{$prefix}--tabs__nav-link {
+    @include carbon--breakpoint(md) {
+      color: $disabled-03;
+    }
   }
 
   //-----------------------------
@@ -22066,6 +22119,26 @@ Tabs styles
       .#{$prefix}--tabs__nav-link:active {
         color: $text-01;
         border-bottom: 2px solid $interactive-01;
+      }
+    }
+  }
+
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled),
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item--selected:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+    @include carbon--breakpoint(md) {
+      background-color: $ui-01;
+
+      .#{$prefix}--tabs__nav-link {
+        // Draws the border without affecting the inner-content
+        box-shadow: inset 0 2px 0 0 $interactive-04;
+        border-bottom: none;
+      }
+
+      .#{$prefix}--tabs__nav-link:focus,
+      .#{$prefix}--tabs__nav-link:active {
+        box-shadow: none;
       }
     }
   }
@@ -22115,6 +22188,15 @@ Tabs styles
     }
   }
 
+  .#{$prefix}--tabs--fixed a.#{$prefix}--tabs__nav-link {
+    @include carbon--breakpoint(md) {
+      display: flex;
+      align-items: center;
+      height: rem(48px);
+      border-bottom: none;
+    }
+  }
+
   //-----------------------------
   //  Link Hover
   //-----------------------------
@@ -22124,6 +22206,14 @@ Tabs styles
     @include carbon--breakpoint(md) {
       color: $text-01;
       border-bottom: $tab-underline-color-hover;
+    }
+  }
+
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+    .#{$prefix}--tabs__nav-link {
+    @include carbon--breakpoint(md) {
+      border-bottom: none;
     }
   }
 
@@ -22144,6 +22234,14 @@ Tabs styles
   .#{$prefix}--tabs__nav-item--disabled a.#{$prefix}--tabs__nav-link:active {
     outline: none;
     border-bottom: $tab-underline-disabled;
+  }
+
+  .#{$prefix}--tabs--fixed
+    .#{$prefix}--tabs__nav-item--disabled
+    .#{$prefix}--tabs__nav-link {
+    @include carbon--breakpoint(md) {
+      border-bottom: none;
+    }
   }
 
   //-----------------------------
@@ -22196,7 +22294,11 @@ Tabs styles
   - [field-02 [variable]](#field-02-variable)
   - [ui-01 [variable]](#ui-01-variable)
   - [hover-ui [variable]](#hover-ui-variable)
+  - [hover-selected-ui [variable]](#hover-selected-ui-variable)
+  - [disabled-02 [variable]](#disabled-02-variable)
+  - [disabled-03 [variable]](#disabled-03-variable)
   - [interactive-01 [variable]](#interactive-01-variable)
+  - [interactive-04 [variable]](#interactive-04-variable)
   - [text-02 [variable]](#text-02-variable)
   - [carbon--spacing-04 [variable]](#carbon--spacing-04-variable)
   - [carbon--spacing-03 [variable]](#carbon--spacing-03-variable)

--- a/packages/react/src/components/GroupLabel/GroupLabel-story.js
+++ b/packages/react/src/components/GroupLabel/GroupLabel-story.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import GroupLabel from './GroupLabel';
+import { Tooltip } from 'carbon-components-react';
+
+const additionalProps = {
+  className: 'some-class',
+};
+
+storiesOf('GroupLabel', module)
+  .add(
+    'Default',
+    withInfo({
+      text: 'Group label.',
+    })(() => <GroupLabel {...additionalProps}>Label</GroupLabel>)
+  )
+  .add(
+    'With tooltip',
+    withInfo({
+      text: 'Form label with tooltip.',
+    })(() => (
+      <GroupLabel {...additionalProps}>
+        <Tooltip triggerText="Label">
+          This is the content of the tooltip.
+        </Tooltip>
+      </GroupLabel>
+    ))
+  );

--- a/packages/react/src/components/GroupLabel/GroupLabel.js
+++ b/packages/react/src/components/GroupLabel/GroupLabel.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+
+const categoryLabel = {
+  color: '#5A6872',
+  fontSize: '12px',
+  fontWeight: '600',
+  letterSpacing: '0.2px',
+  margin: '8px 16px',
+};
+
+const GroupLabel = ({ className, children, id, ...other }) => {
+  const classNames = classnames('bx--group-label', className);
+
+  return (
+    <label htmlFor={id} className={classNames} style={categoryLabel} {...other}>
+      {children}
+    </label>
+  );
+};
+
+GroupLabel.propTypes = {
+  /**
+   * Specify the content of the form label
+   */
+  children: PropTypes.node,
+
+  /**
+   * Provide a custom className to be applied to the containing <label> node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Provide a unique id for the given <GroupLabel>
+   */
+  id: PropTypes.string,
+};
+
+export default GroupLabel;

--- a/packages/react/src/components/GroupLabel/index.js
+++ b/packages/react/src/components/GroupLabel/index.js
@@ -1,0 +1,1 @@
+export default from './GroupLabel';

--- a/packages/react/src/components/MultiSelect/MultiSelect-story.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect-story.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
 import {
   withKnobs,
   boolean,
@@ -43,6 +44,340 @@ const items = [
   },
 ];
 
+const nestedItems = [
+  {
+    id: 'item-1',
+    text: 'Item 1',
+    category: 'Europe',
+  },
+  {
+    id: 'item-2',
+    text: 'Item 2',
+    category: 'Europe',
+    options: [
+      {
+        id: 'opt-3',
+        text: 'Option 3',
+      },
+      {
+        id: 'opt-4',
+        text: 'Option 4',
+        options: [
+          {
+            id: 'subopt-25',
+            text: 'SubOption 25',
+          },
+          {
+            id: 'subopt-30',
+            text: 'SubOption 30',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'item-3',
+    text: 'Item 3',
+    category: 'Asia',
+    options: [
+      {
+        id: 'opt-5',
+        text: 'Option 5',
+      },
+      {
+        id: 'opt-6',
+        text: 'Option 6',
+      },
+    ],
+  },
+  {
+    id: 'item-4',
+    text: 'Item 4',
+    category: 'America',
+    options: [
+      {
+        id: 'opt-7',
+        text: 'Option 7',
+        options: [
+          {
+            id: 'subopt-20',
+            text: 'SubOption 20',
+          },
+          {
+            id: 'subopt-15',
+            text: 'SubOption 15',
+          },
+          {
+            id: 'subopt-18',
+            text: 'SubOption 18',
+          },
+        ],
+      },
+      {
+        id: 'opt-8',
+        text: 'Option 8',
+        options: [
+          {
+            id: 'subopt-5',
+            text: 'SubOption 5',
+          },
+          {
+            id: 'subopt-10',
+            text: 'SubOption 10',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'item-5',
+    text: 'Item 5',
+    category: 'America',
+    options: [
+      {
+        id: 'opt-9',
+        text: 'Option 9',
+      },
+      {
+        id: 'opt-10',
+        text: 'Option 10',
+      },
+    ],
+  },
+];
+const selectedItems = [
+  {
+    id: 'item-2',
+    text: 'Item 2',
+    category: 'Europe',
+    options: [
+      {
+        id: 'opt-3',
+        text: 'Option 3',
+        checked: true,
+      },
+      {
+        id: 'opt-4',
+        text: 'Option 4',
+        options: [
+          {
+            id: 'subopt-25',
+            text: 'SubOption 25',
+          },
+          {
+            id: 'subopt-30',
+            text: 'SubOption 30',
+            checked: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'item-3',
+    text: 'Item 3',
+    category: 'Asia',
+    options: [
+      {
+        id: 'opt-5',
+        text: 'Option 5',
+      },
+      {
+        id: 'opt-6',
+        text: 'Option 6',
+        checked: true,
+      },
+    ],
+  },
+  {
+    id: 'item-4',
+    text: 'Item 4',
+    category: 'America',
+    options: [
+      {
+        id: 'opt-7',
+        text: 'Option 7',
+        checked: true,
+        options: [
+          {
+            id: 'subopt-20',
+            text: 'SubOption 20',
+          },
+          {
+            id: 'subopt-15',
+            text: 'SubOption 15',
+          },
+          {
+            id: 'subopt-18',
+            text: 'SubOption 18',
+          },
+        ],
+      },
+      {
+        id: 'opt-8',
+        text: 'Option 8',
+        options: [
+          {
+            id: 'subopt-5',
+            text: 'SubOption 5',
+          },
+          {
+            id: 'subopt-10',
+            text: 'SubOption 10',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const flattenItems = [
+  {
+    id: 'item-1',
+    text: 'Item 1',
+    category: 'Europe',
+    level: 0,
+  },
+  {
+    id: 'item-2',
+    text: 'Item 2',
+    category: 'Europe',
+    level: 0,
+    hasChildren: true,
+  },
+  {
+    id: 'opt-3',
+    text: 'Option 3',
+    category: 'Europe',
+    level: 1,
+    parentId: 'item-2',
+  },
+  {
+    id: 'opt-4',
+    text: 'Option 4',
+    category: 'Europe',
+    level: 1,
+    hasChildren: true,
+    parentId: 'item-2',
+  },
+  {
+    id: 'subopt-25',
+    text: 'SubOption 25',
+    category: 'Europe',
+    level: 2,
+    parentId: 'opt-4',
+  },
+  {
+    id: 'subopt-30',
+    text: 'SubOption 30',
+    category: 'Europe',
+    level: 2,
+    parentId: 'opt-4',
+  },
+  {
+    id: 'item-3',
+    text: 'Item 3',
+    category: 'Asia',
+    level: 0,
+    hasChildren: true,
+  },
+  {
+    id: 'opt-5',
+    text: 'Option 5',
+    category: 'Asia',
+    level: 1,
+    parentId: 'item-3',
+  },
+  {
+    id: 'item-4',
+    text: 'Item 4',
+    category: 'America',
+    level: 0,
+    hasChildren: true,
+  },
+  {
+    id: 'opt-7',
+    text: 'Option 7',
+    category: 'America',
+    level: 1,
+    hasChildren: true,
+    parentId: 'item-4',
+  },
+  {
+    id: 'subopt-20',
+    text: 'SubOption 20',
+    category: 'America',
+    level: 2,
+    parentId: 'opt-7',
+  },
+  {
+    id: 'subopt-15',
+    text: 'SubOption 15',
+    category: 'America',
+    level: 2,
+    parentId: 'opt-7',
+  },
+  {
+    id: 'opt-8',
+    text: 'Option 8',
+    category: 'America',
+    level: 1,
+    parentId: 'item-4',
+  },
+];
+const flattenSelectedItems = [
+  {
+    id: 'item-2',
+    text: 'Item 2',
+    category: 'Europe',
+    level: 0,
+    hasChildren: true,
+  },
+  {
+    id: 'opt-3',
+    text: 'Option 3',
+    category: 'Europe',
+    level: 1,
+    parentId: 'item-2',
+  },
+  {
+    id: 'subopt-30',
+    text: 'SubOption 30',
+    category: 'Europe',
+    level: 2,
+    parentId: 'opt-4',
+  },
+  {
+    id: 'item-3',
+    text: 'Item 3',
+    category: 'Asia',
+    level: 0,
+    hasChildren: true,
+  },
+  {
+    id: 'opt-5',
+    text: 'Option 5',
+    category: 'Asia',
+    level: 1,
+    parentId: 'item-3',
+  },
+  {
+    id: 'item-4',
+    text: 'Item 4',
+    category: 'America',
+    level: 0,
+    hasChildren: true,
+  },
+  {
+    id: 'opt-7',
+    text: 'Option 7',
+    category: 'America',
+    level: 1,
+    hasChildren: true,
+    parentId: 'item-4',
+  },
+];
+
 const defaultLabel = 'MultiSelect Label';
 const defaultPlaceholder = 'Filter';
 
@@ -59,6 +394,7 @@ const props = () => ({
     'Filterable (`<MultiSelect.Filterable>` instead of `<MultiSelect>`)',
     false
   ),
+  flatList: boolean('Flat list', false),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
   useTitleInItem: boolean('Show tooltip on hover', false),
@@ -153,4 +489,28 @@ storiesOf('MultiSelect', module)
           `,
       },
     }
+  )
+  .add(
+    'with nested selected items',
+    withInfo({
+      text: `
+        Nested Filterable Multiselect
+      `,
+    })(() => {
+      const { flatList, ...multiSelectProps } = props();
+      return (
+        <div style={{ width: 300 }}>
+          <MultiSelect.NestedFilterable
+            {...multiSelectProps}
+            key={flatList ? 'flat' : 'hierarchy'}
+            items={flatList ? flattenItems : nestedItems}
+            itemToString={item => (item ? item.text : '')}
+            initialSelectedItems={
+              flatList ? flattenSelectedItems : selectedItems
+            }
+            placeholder={defaultPlaceholder}
+          />
+        </div>
+      );
+    })
   );

--- a/packages/react/src/components/MultiSelect/NestedFilterableMultiselect.js
+++ b/packages/react/src/components/MultiSelect/NestedFilterableMultiselect.js
@@ -1,0 +1,764 @@
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import Downshift from 'downshift';
+import debounce from 'lodash.debounce';
+import isEqual from 'lodash.isequal';
+import ListBox from '../ListBox';
+import Checkbox from '../Checkbox';
+import GroupLabel from '../GroupLabel';
+import Selection from '../../internal/Selection';
+import { sortingPropTypes } from './MultiSelectPropTypes';
+import { defaultItemToString } from './tools/itemToString';
+import { groupedByCategory } from './tools/groupedByCategory';
+import {
+  buildHierarchy,
+  defaultSortItems,
+  defaultCompareItems,
+  findParent,
+} from './tools/sorting';
+import { defaultFilterItems, getAllChildren } from './tools/filter';
+
+export default class NestedFilterableMultiselect extends React.Component {
+  static propTypes = {
+    ...sortingPropTypes,
+
+    /**
+     * Disable the control
+     */
+    disabled: PropTypes.bool,
+
+    /**
+     * We try to stay as generic as possible here to allow individuals to pass
+     * in a collection of whatever kind of data structure they prefer
+     */
+    items: PropTypes.array.isRequired,
+
+    /**
+     * Allow users to pass in arbitrary items from their collection that are
+     * pre-selected
+     */
+    initialSelectedItems: PropTypes.array,
+
+    /**
+     * Helper function passed to downshift that allows the library to render a
+     * given item to a string label. By default, it extracts the `label` field
+     * from a given item to serve as the item label in the list.
+     */
+    itemToString: PropTypes.func,
+
+    /**
+     * Specify the locale of the control. Used for the default `compareItems`
+     * used for sorting the list of items in the control.
+     */
+    locale: PropTypes.string,
+
+    /**
+     * `onChange` is a utility for this controlled component to communicate to a
+     * consuming component what kind of internal state changes are occuring.
+     */
+    onChange: PropTypes.func,
+
+    /**
+     * Generic `placeholder` that will be used as the textual representation of
+     * what this field is for
+     */
+    placeholder: PropTypes.string.isRequired,
+
+    /**
+     * `true` to use the light version.
+     */
+    light: PropTypes.bool,
+
+    /**
+     * `customCategorySorting` is use to sort the items by category, aphabetic order if not specify
+     */
+    customCategorySorting: PropTypes.func,
+
+    /**
+     * `true` to show tooltip.
+     */
+    showTooltip: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    compareItems: defaultCompareItems,
+    disabled: false,
+    filterItems: defaultFilterItems,
+    initialSelectedItems: [],
+    itemToString: defaultItemToString,
+    locale: 'en',
+    sortItems: defaultSortItems,
+    light: false,
+    showTooltip: true,
+  };
+
+  static find(items = [], target) {
+    let found;
+    items.some(item => {
+      if (item.id === target.id) {
+        found = item;
+        return true;
+      }
+      return false;
+    });
+    return found;
+  }
+
+  static computeId({ item, itemToString = defaultItemToString, parentId }) {
+    return `${parentId ? `${parentId}-` : ''}${item.id || itemToString(item)}`;
+  }
+
+  static flatten({
+    category,
+    items = [],
+    level,
+    parentId,
+    itemToString = defaultItemToString,
+  }) {
+    return items.reduce((list, item) => {
+      const mappedItem = {
+        ...item,
+        id: NestedFilterableMultiselect.computeId({
+          item,
+          itemToString,
+          parentId,
+        }),
+        category: category || item.category,
+        level: level || 0,
+        hasChildren: !!item.options,
+        parentId,
+      };
+      list.push(mappedItem);
+      if (Array.isArray(item.options) && item.options.length > 0) {
+        list.push(
+          ...NestedFilterableMultiselect.flatten({
+            category: mappedItem.category,
+            items: item.options,
+            level: mappedItem.level + 1,
+            parentId: mappedItem.id,
+            itemToString,
+          })
+        );
+      }
+      return list;
+    }, []);
+  }
+
+  static cleanItem(item) {
+    const result = { ...item };
+    delete result.options;
+    delete result.checked;
+    return result;
+  }
+
+  static getDerivedStateFromProps(nextProps, currentState) {
+    const { items, initialSelectedItems, itemToString } = nextProps;
+    const { flattenedItems, flattenedSelectedItems } = currentState;
+
+    const itemsToProcess = initialSelectedItems
+      ? items.map(obj => initialSelectedItems.find(o => o.id === obj.id) || obj)
+      : items;
+    const isHierarchical = items.some(item => !!item.options);
+    const updatedItems = isHierarchical
+      ? NestedFilterableMultiselect.flatten({
+          items: itemsToProcess,
+          itemToString,
+        }).map(NestedFilterableMultiselect.cleanItem)
+      : itemsToProcess;
+
+    if (!isEqual(updatedItems, flattenedItems)) {
+      const updatedSelectedItems = isHierarchical
+        ? NestedFilterableMultiselect.flatten({
+            items: initialSelectedItems,
+            itemToString,
+          })
+            .filter((item, index, itemArray) => {
+              if (!item.parentId || item.checked) {
+                return true;
+              }
+
+              // Any parent checked will make all its children checked
+              const hierarchy = buildHierarchy(item, itemArray);
+              const parentChecked = hierarchy.some(parent => parent.checked);
+              if (parentChecked) {
+                return true;
+              }
+
+              // Any child checked will make its parent checked
+              const allChildren = getAllChildren(item, itemArray);
+              const childChecked = allChildren.some(child => child.checked);
+              if (childChecked) {
+                return true;
+              }
+
+              // If none of the children has the `checked` flag,
+              // all children are considered checked.
+              const rootAllChildren = getAllChildren(hierarchy[0], itemArray);
+              return (
+                rootAllChildren.length > 0 &&
+                !rootAllChildren.some(child => child.checked)
+              );
+            })
+            .map(NestedFilterableMultiselect.cleanItem)
+        : initialSelectedItems.reduce(
+            (list, item) => {
+              // Any parent checked will make all its children checked
+              const hierarchy = buildHierarchy(item, updatedItems);
+              hierarchy.forEach(parent => {
+                if (!NestedFilterableMultiselect.find(list, parent)) {
+                  list.push({ ...parent });
+                }
+              });
+
+              // If none of the children has the `checked` flag,
+              // all children are considered checked.
+              const allChildren = getAllChildren(item, updatedItems);
+              if (
+                !allChildren.some(child =>
+                  NestedFilterableMultiselect.find(list, child)
+                )
+              ) {
+                list.push(...allChildren.map(child => ({ ...child })));
+              }
+
+              return list;
+            },
+            [...initialSelectedItems]
+          );
+
+      flattenedItems.splice(0, flattenedItems.length, ...updatedItems);
+      flattenedSelectedItems.splice(
+        0,
+        flattenedSelectedItems.length,
+        ...updatedSelectedItems
+      );
+
+      return {
+        ...currentState,
+        flattenedItems,
+        flattenedSelectedItems,
+      };
+    }
+
+    return null;
+  }
+
+  static updateCheckedState({
+    options = [],
+    itemToString = defaultItemToString,
+    parentId,
+    selectedItems,
+  }) {
+    return options.map(option => {
+      const optionId = NestedFilterableMultiselect.computeId({
+        item: option,
+        itemToString,
+        parentId,
+      });
+      const result = { ...option };
+      if (result.options) {
+        result.options = NestedFilterableMultiselect.updateCheckedState({
+          options: result.options,
+          itemToString,
+          parentId: optionId,
+          selectedItems,
+        });
+        // The parent is checked only if all its children is checked
+        result.checked = !result.options.some(option => !option.checked);
+      } else {
+        result.checked = selectedItems.some(
+          selectedItem => selectedItem.id === optionId
+        );
+      }
+      return result;
+    });
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      highlightedIndex: null,
+      isOpen: false,
+      inputValue: '',
+      flattenedItems: [],
+      flattenedSelectedItems: [],
+      expandedItems: [],
+    };
+  }
+
+  handleOnChange = changes => {
+    const { items, itemToString, onChange } = this.props;
+
+    if (onChange) {
+      const { selectedItems = [] } = changes;
+
+      const isHierarchical = items.some(item => !!item.options);
+      const mappedSelectedItems = isHierarchical
+        ? items.reduce((list, item) => {
+            if (NestedFilterableMultiselect.find(selectedItems, item)) {
+              const selectedItem = { ...item };
+              if (item.options) {
+                selectedItem.options = NestedFilterableMultiselect.updateCheckedState(
+                  {
+                    options: item.options,
+                    itemToString,
+                    parentId: NestedFilterableMultiselect.computeId({
+                      item,
+                      itemToString,
+                    }),
+                    selectedItems,
+                  }
+                );
+              }
+              list.push(selectedItem);
+            }
+            return list;
+          }, [])
+        : selectedItems;
+
+      onChange({ selectedItems: mappedSelectedItems });
+    }
+  };
+
+  onToggle = item => {
+    const isExpanded = NestedFilterableMultiselect.find(
+      this.state.expandedItems,
+      item
+    );
+    !isExpanded
+      ? this.setState({ expandedItems: [...this.state.expandedItems, item] })
+      : this.setState(prevState => ({
+          expandedItems: prevState.expandedItems.filter(
+            expandedItem => expandedItem.id !== item.id
+          ),
+        }));
+  };
+
+  handleOnOuterClick = () => {
+    this.setState({
+      isOpen: false,
+      inputValue: '',
+    });
+  };
+
+  handleOnStateChange = changes => {
+    const { type } = changes;
+    switch (type) {
+      case Downshift.stateChangeTypes.changeInput:
+        this.setState({ inputValue: changes.inputValue });
+        break;
+      case Downshift.stateChangeTypes.keyDownArrowUp:
+      case Downshift.stateChangeTypes.itemMouseEnter:
+        this.setState({ highlightedIndex: changes.highlightedIndex });
+        break;
+      case Downshift.stateChangeTypes.keyDownArrowDown:
+        this.setState({
+          highlightedIndex: changes.highlightedIndex,
+          isOpen: true,
+        });
+        break;
+      case Downshift.stateChangeTypes.keyDownEscape:
+      case Downshift.stateChangeTypes.mouseUp:
+        this.setState({ isOpen: false });
+        break;
+      // Opt-in to some cases where we should be toggling the menu based on
+      // a given key press or mouse handler
+      // Reference: https://github.com/paypal/downshift/issues/206
+      case Downshift.stateChangeTypes.clickButton:
+      case Downshift.stateChangeTypes.keyDownSpaceButton:
+        this.setState(() => {
+          let nextIsOpen = changes.isOpen || false;
+          if (changes.isOpen === false) {
+            // If Downshift is trying to close the menu, but we know the input
+            // is the active element in thedocument, then keep the menu open
+            if (this.inputNode === document.activeElement) {
+              nextIsOpen = true;
+            }
+          }
+          return {
+            isOpen: nextIsOpen,
+          };
+        });
+        break;
+    }
+  };
+
+  handleOnInputValueChange = debounce((value, { type }) => {
+    if (type === Downshift.stateChangeTypes.changeInput) {
+      const { filterItems, itemToString } = this.props;
+      const {
+        expandedItems,
+        flattenedItems: items,
+        inputValue: prevInputValue,
+      } = this.state;
+
+      const inputValue = Array.isArray(value) ? prevInputValue : value;
+
+      const itemsToExpand = items.reduce((toExpand, item) => {
+        const allChildren = getAllChildren(item, items);
+        if (allChildren.length > 0) {
+          const filteredChildren = filterItems(allChildren, {
+            itemToString,
+            inputValue,
+          });
+          if (filteredChildren.length > 0) {
+            if (
+              !inputValue ||
+              NestedFilterableMultiselect.find(expandedItems, item)
+            ) {
+              return toExpand;
+            }
+            if (!NestedFilterableMultiselect.find(toExpand, item)) {
+              toExpand.push(item);
+            }
+          }
+        }
+        return toExpand;
+      }, []);
+
+      this.setState(() => {
+        return {
+          expandedItems: [...expandedItems, ...itemsToExpand],
+          inputValue: inputValue || '',
+        };
+      });
+    }
+  }, 200).bind(this);
+
+  clearInputValue = event => {
+    event.stopPropagation();
+    this.setState({ inputValue: '' });
+    this.inputNode && this.inputNode.focus && this.inputNode.focus();
+  };
+
+  getParentItem = item => {
+    const { flattenedItems: items } = this.state;
+    return findParent(item, items);
+  };
+
+  onItemChange = (item, selectedItems, onItemChange) => {
+    const { flattenedItems: items } = this.state;
+
+    const toRemove = !!NestedFilterableMultiselect.find(selectedItems, item);
+
+    const itemsChanged = [item];
+
+    if (item.parentId) {
+      // Walk parents
+      const parents = buildHierarchy(item, items).reverse();
+      parents.shift();
+      parents.some(parent => {
+        const isSelected = !!NestedFilterableMultiselect.find(
+          selectedItems,
+          parent
+        );
+        const children = selectedItems.filter(
+          selectedItem => selectedItem.parentId === parent.id
+        );
+        if (children.length === 1 && toRemove && isSelected) {
+          // Uncheck parent too and keep walking up
+          itemsChanged.push(parent);
+          return false;
+        } else if (!toRemove && !isSelected) {
+          // Check parent too
+          itemsChanged.push(parent);
+          return false;
+        }
+        // If selecting a new item, we need to keep going up to
+        // make sure all parents are checked.
+        // If unselecting an item, we will break out when the
+        // current parent does not need to be removed
+        return toRemove;
+      });
+    }
+
+    // Walk children
+    const children = getAllChildren(item, items);
+    if (children.length > 0) {
+      children.forEach(child => {
+        const isSelected = !!NestedFilterableMultiselect.find(
+          selectedItems,
+          child
+        );
+        if (toRemove && isSelected) {
+          // Uncheck the child too
+          itemsChanged.push(child);
+        } else if (!toRemove && !isSelected) {
+          // Check the child too
+          itemsChanged.push(child);
+        }
+      });
+    }
+
+    onItemChange(itemsChanged);
+  };
+
+  render() {
+    const {
+      highlightedIndex,
+      isOpen,
+      inputValue,
+      expandedItems,
+      flattenedItems: items,
+      flattenedSelectedItems: initialSelectedItems,
+    } = this.state;
+    const {
+      className: containerClassName,
+      disabled,
+      filterItems,
+      itemToString,
+      id,
+      locale,
+      placeholder,
+      sortItems,
+      compareItems,
+      light,
+      customCategorySorting,
+      showTooltip,
+    } = this.props;
+
+    const className = cx(
+      'bx--multi-select',
+      'bx--combo-box',
+      containerClassName,
+      {
+        'bx--list-box--light': light,
+      }
+    );
+
+    let currentIndex = -1;
+    let highlighted;
+
+    return (
+      <Selection
+        onChange={this.handleOnChange}
+        initialSelectedItems={initialSelectedItems}
+        render={({ selectedItems, onItemChange, clearSelection }) => (
+          <Downshift
+            highlightedIndex={highlightedIndex}
+            isOpen={isOpen}
+            inputValue={inputValue}
+            onInputValueChange={this.handleOnInputValueChange}
+            onChange={item => {
+              this.onItemChange(item, selectedItems, onItemChange);
+            }}
+            itemToString={itemToString}
+            onStateChange={this.handleOnStateChange}
+            onOuterClick={this.handleOnOuterClick}
+            selectedItem={selectedItems}
+            render={({
+              getButtonProps,
+              getInputProps,
+              getItemProps,
+              getRootProps,
+              isOpen,
+              inputValue,
+              selectedItem,
+            }) => (
+              <ListBox
+                className={className}
+                disabled={disabled}
+                {...getRootProps({ refKey: 'innerRef' })}>
+                <ListBox.Field tabIndex="-1" {...getButtonProps({ disabled })}>
+                  {selectedItem.length > 0 && (
+                    <ListBox.Selection
+                      clearSelection={clearSelection}
+                      selectionCount={
+                        selectedItem.filter(item => !item.hasChildren).length
+                      }
+                    />
+                  )}
+                  <input
+                    className="bx--text-input"
+                    aria-label={placeholder}
+                    ref={el => (this.inputNode = el)}
+                    {...getInputProps({
+                      disabled,
+                      id,
+                      placeholder,
+                      onKeyDown: e => {
+                        e.stopPropagation();
+                        const highlightedItem = highlighted && highlighted.item;
+                        if (highlightedItem) {
+                          if (e.which === 40) {
+                            // Down arrow
+                            if (
+                              highlightedItem.hasChildren &&
+                              !expandedItems.includes(highlightedItem)
+                            ) {
+                              this.onToggle(highlightedItem);
+                            }
+                          } else if (e.which === 38) {
+                            // Up arrow
+                            const parentItem = this.getParentItem(
+                              highlightedItem
+                            );
+                            if (
+                              parentItem &&
+                              highlighted.parentIndex > -1 &&
+                              highlighted.index ===
+                                highlighted.parentIndex + 1 &&
+                              expandedItems.includes(parentItem)
+                            ) {
+                              this.onToggle(parentItem);
+                            }
+                          }
+                        }
+                      },
+                      onKeyUp: e => {
+                        const which = e.which;
+                        if (which === 27) {
+                          this.setState({ isOpen: false });
+                        }
+                      },
+                    })}
+                  />
+                  {inputValue && isOpen && (
+                    <ListBox.Selection clearSelection={this.clearInputValue} />
+                  )}
+                  <ListBox.MenuIcon isOpen={isOpen} />
+                </ListBox.Field>
+                {isOpen && (
+                  <ListBox.Menu
+                    style={{
+                      maxHeight: '424px',
+                      overflowX: 'hidden',
+                      paddingTop: '8px',
+                    }}>
+                    {groupedByCategory(items, customCategorySorting).map(
+                      (group, index) => {
+                        const hasGroups =
+                          group[0] !== 'undefined' ? true : false;
+                        const filteredItems = filterItems(group[1], {
+                          itemToString,
+                          inputValue,
+                          expandedItems,
+                        });
+                        let categoryName = '';
+                        hasGroups
+                          ? (categoryName = group[0].toUpperCase())
+                          : null;
+
+                        return (
+                          <Fragment key={group[0] || index}>
+                            {hasGroups && filteredItems.length > 0 && (
+                              <div>
+                                <GroupLabel key={index}>
+                                  {categoryName}
+                                </GroupLabel>
+                              </div>
+                            )}
+                            {sortItems(filteredItems, {
+                              selectedItems,
+                              itemToString,
+                              compareItems,
+                              locale,
+                            }).map((item, itemIndex, itemArr) => {
+                              currentIndex++;
+
+                              if (highlightedIndex === currentIndex) {
+                                const parentItem = this.getParentItem(item);
+                                highlighted = {
+                                  item,
+                                  index: itemIndex,
+                                  parentIndex: parentItem
+                                    ? itemArr.indexOf(parentItem)
+                                    : -1,
+                                };
+                              }
+
+                              const itemProps = getItemProps({
+                                item,
+                                index: currentIndex,
+                              });
+                              const itemText = itemToString(item);
+
+                              const isChecked =
+                                selectedItem.filter(
+                                  selected => selected.id == item.id
+                                ).length > 0;
+                              const subOptions = getAllChildren(item, items);
+                              const groupIsOpen = !!NestedFilterableMultiselect.find(
+                                expandedItems,
+                                item
+                              );
+
+                              const myCheckedOptions = subOptions.filter(
+                                subOption =>
+                                  selectedItem.filter(
+                                    selected => selected.id === subOption.id
+                                  ).length > 0
+                              );
+                              const myUncheckedOptions = subOptions.filter(
+                                subOption =>
+                                  selectedItem.filter(
+                                    selected => selected.id === subOption.id
+                                  ).length === 0
+                              );
+
+                              const itemStyle = item.level
+                                ? {
+                                    paddingLeft: `${item.level * 19 + 16}px`,
+                                  }
+                                : undefined;
+
+                              return (
+                                <ListBox.MenuItem
+                                  style={itemStyle}
+                                  isActive={isChecked}
+                                  isHighlighted={
+                                    highlightedIndex === currentIndex
+                                  }
+                                  {...itemProps}
+                                  onClick={e => {
+                                    {
+                                      const clickOutOfCheckBox =
+                                        subOptions.length > 0 &&
+                                        (e.target.localName !== 'label' &&
+                                          e.target.localName !== 'input');
+                                      if (clickOutOfCheckBox) {
+                                        this.onToggle(item);
+                                      } else {
+                                        this.onItemChange(
+                                          item,
+                                          selectedItems,
+                                          onItemChange
+                                        );
+                                      }
+                                    }
+                                  }}>
+                                  <Checkbox
+                                    id={itemProps.id}
+                                    name={itemText}
+                                    checked={isChecked}
+                                    indeterminate={
+                                      myCheckedOptions &&
+                                      myUncheckedOptions &&
+                                      myCheckedOptions.length > 0 &&
+                                      myUncheckedOptions.length > 0
+                                    }
+                                    readOnly={true}
+                                    tabIndex="-1"
+                                    labelText={itemText}
+                                    tooltipText={showTooltip && itemText}
+                                    hasGroups={subOptions.length > 0}
+                                    isExpanded={groupIsOpen}
+                                  />
+                                </ListBox.MenuItem>
+                              );
+                            })}
+                          </Fragment>
+                        );
+                      }
+                    )}
+                  </ListBox.Menu>
+                )}
+              </ListBox>
+            )}
+          />
+        )}
+      />
+    );
+  }
+}

--- a/packages/react/src/components/MultiSelect/__tests__/NestedFilterableMultiselect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/NestedFilterableMultiselect-test.js
@@ -1,0 +1,1678 @@
+import React from 'react';
+import debounce from 'lodash.debounce';
+import { mount } from 'enzyme';
+import Downshift from 'downshift';
+import NestedFilterableMultiselect from '../NestedFilterableMultiselect';
+import {
+  assertMenuClosed,
+  assertMenuOpen,
+  findMenuIconNode,
+  openMenu,
+  generateItems,
+} from '../../ListBox/test-helpers';
+
+const listItemName = 'ListBoxMenuItem';
+
+jest.mock('lodash.debounce');
+
+debounce.mockImplementation(fn => fn);
+
+describe('NestedFilterableMultiselect', () => {
+  let mockProps;
+
+  describe('Simple multiselect', () => {
+    beforeEach(() => {
+      mockProps = {
+        disabled: false,
+        items: generateItems(5, index => ({
+          id: `id-${index}`,
+          label: `Item ${index}`,
+          value: index,
+        })),
+        initialSelectedItems: [],
+        onChange: jest.fn(),
+        placeholder: 'Placeholder...',
+      };
+    });
+
+    it('should render', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render without showing tooltip', () => {
+      const thisProps = {
+        ...mockProps,
+        showTooltip: false,
+      };
+      const wrapper = mount(<NestedFilterableMultiselect {...thisProps} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should display all items when the menu is open initially', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+    });
+
+    it('should let the user toggle the menu by the menu icon', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      findMenuIconNode(wrapper).simulate('click');
+      assertMenuOpen(wrapper, mockProps);
+      findMenuIconNode(wrapper).simulate('click');
+      assertMenuClosed(wrapper);
+    });
+
+    it('should close the menu by hitting Esc in search field', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 40,
+        key: 'ArrowDown',
+      });
+      assertMenuOpen(wrapper, mockProps);
+      wrapper.find('.bx--text-input').simulate('keyUp', { which: 27 });
+      assertMenuClosed(wrapper);
+    });
+
+    it('should not close the menu after a user makes a selection', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      wrapper
+        .find(listItemName)
+        .at(0)
+        .simulate('click');
+      assertMenuOpen(wrapper, mockProps);
+    });
+
+    it('should filter a list of items by the input value', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+      wrapper.find('Downshift').prop('onInputValueChange')('3', {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+      expect(wrapper.find(listItemName).length).toBe(1);
+      expect(wrapper.state().inputValue).toEqual('3');
+      expect(wrapper.state().expandedItems).toEqual([]);
+    });
+
+    it('should call `onChange` with each update to selected items via mouse click', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // Select the first two items
+      wrapper
+        .find(listItemName)
+        .at(0)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[0]],
+      });
+
+      wrapper
+        .find(listItemName)
+        .at(1)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[0], mockProps.items[1]],
+      });
+
+      // Un-select the next two items
+      wrapper
+        .find(listItemName)
+        .at(0)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[1]],
+      });
+
+      wrapper
+        .find(listItemName)
+        .at(1)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(4);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [],
+      });
+    });
+
+    it('should call `onChange` with each update to selected items via keyboard', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      wrapper.setState({
+        highlightedIndex: 0,
+      });
+
+      // Select the first item
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 13,
+        key: 'Enter',
+      });
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[0]],
+      });
+
+      // Select the second item
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 40,
+        key: 'ArrowDown',
+      });
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 13,
+        key: 'Enter',
+      });
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[0], mockProps.items[1]],
+      });
+
+      // Unselect the first item
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 38,
+        key: 'ArrowUp',
+      });
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 13,
+        key: 'Enter',
+      });
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[1]],
+      });
+    });
+  });
+
+  describe('multiselect with categories', () => {
+    const customCategorySorting = jest.fn((a, b) => a[0].localeCompare(b[0]));
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockProps = {
+        disabled: false,
+        items: generateItems(5, index => ({
+          id: `id-${index}`,
+          label: `Item ${index}`,
+          value: index,
+          category: `category-${index % 2 === 0 ? 1 : 2}`,
+        })),
+        initialSelectedItems: [],
+        customCategorySorting,
+        onChange: jest.fn(),
+        placeholder: 'Placeholder...',
+      };
+    });
+
+    it('should render', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      expect(wrapper).toMatchSnapshot();
+      openMenu(wrapper);
+      expect(
+        wrapper.containsAllMatchingElements([
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label className="bx--group-label">CATEGORY-1</label>,
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label className="bx--group-label">CATEGORY-2</label>,
+        ])
+      ).toBe(true);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+      expect(customCategorySorting).toHaveBeenCalled();
+    });
+
+    it('should clear all selections', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // Select the first two items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .simulate('click');
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [mockProps.items[0], mockProps.items[2]],
+      });
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(2);
+
+      // Clear all selection
+      wrapper.find('.bx--list-box__selection--multi').simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [],
+      });
+      expect(wrapper.find('ListBoxSelection').exists()).toBe(false);
+    });
+  });
+
+  describe('multiselect with suboptions', () => {
+    beforeEach(() => {
+      mockProps = {
+        disabled: false,
+        items: generateItems(3, index => ({
+          id: `id-${index}`,
+          label: `Nested item ${index}`,
+          value: index,
+          category: `category-${index % 2 === 0 ? 1 : 2}`,
+          options: [
+            {
+              id: 'option-id-1',
+              label: 'Sub item 1',
+              options:
+                index > 0
+                  ? [
+                      {
+                        id: 'suboption-id-11',
+                        label: 'Sub-child item 11',
+                      },
+                      {
+                        id: 'suboption-id-12',
+                        label: 'Sub-child item 12',
+                      },
+                    ]
+                  : undefined,
+            },
+            {
+              id: 'option-id-2',
+              label: 'Sub item 2',
+              options:
+                index === 1
+                  ? [
+                      {
+                        id: 'suboption-id-21',
+                        label: 'Sub-child item 21',
+                      },
+                      {
+                        id: 'suboption-id-22',
+                        label: 'Sub-child item 22',
+                      },
+                    ]
+                  : undefined,
+            },
+          ],
+        })),
+        onChange: jest.fn(),
+        placeholder: 'Placeholder...',
+      };
+    });
+
+    it('should render', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      expect(wrapper).toMatchSnapshot();
+      openMenu(wrapper);
+      expect(
+        wrapper.containsAllMatchingElements([
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label className="bx--group-label">CATEGORY-1</label>,
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label className="bx--group-label">CATEGORY-2</label>,
+        ])
+      ).toBe(true);
+      // Expand the child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(5);
+      // Expand the sub-child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(7);
+      // Collapse the sub-child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(5);
+      // Collapse the child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(3);
+    });
+
+    it('should filter a list of items by the input value (level=0)', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+      // Type 'Nested item 2'
+      wrapper.find('Downshift').prop('onInputValueChange')('Nested item 2', {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+      expect(wrapper.find(listItemName).length).toBe(1);
+      expect(wrapper.state().inputValue).toEqual('Nested item 2');
+      expect(wrapper.state().expandedItems).toEqual([]);
+      // An array input persists the current value
+      wrapper.find('Downshift').prop('onInputValueChange')([], {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+      expect(wrapper.find(listItemName).length).toBe(1);
+      expect(wrapper.state().inputValue).toEqual('Nested item 2');
+      expect(wrapper.state().expandedItems).toEqual([]);
+
+      // Expand the child items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(3);
+
+      // Expand the sub-child items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(5);
+    });
+
+    it('should filter a list of sub items by the input value (level=1)', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+      wrapper.find('Downshift').prop('onInputValueChange')('Sub item 2', {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+
+      const expectedExpandedItems = mockProps.items.map(item => ({
+        ...item,
+        level: 0,
+        options: undefined,
+        checked: undefined,
+        hasChildren: true,
+      }));
+
+      expect(wrapper.find(listItemName).length).toBe(6);
+      expect(wrapper.state().inputValue).toEqual('Sub item 2');
+      expect(wrapper.state().expandedItems).toEqual(expectedExpandedItems);
+
+      // Expand the sub-child items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(5)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find(listItemName).length).toBe(8);
+    });
+
+    it('should filter a list of sub child items by the input value (level=2)', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+      wrapper.find('Downshift').prop('onInputValueChange')('Sub-child item 1', {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+
+      const expectedExpandedItems = [
+        {
+          ...mockProps.items[1],
+          level: 0,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...mockProps.items[1].options[0],
+          level: 1,
+          category: mockProps.items[1].category,
+          parentId: mockProps.items[1].id,
+          id: `${mockProps.items[1].id}-${mockProps.items[1].options[0].id}`,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...mockProps.items[2],
+          level: 0,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...mockProps.items[2].options[0],
+          level: 1,
+          category: mockProps.items[2].category,
+          parentId: mockProps.items[2].id,
+          id: `${mockProps.items[2].id}-${mockProps.items[2].options[0].id}`,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+      ];
+
+      expect(wrapper.find(listItemName).length).toBe(8);
+      expect(wrapper.state().inputValue).toEqual('Sub-child item 1');
+      expect(wrapper.state().expandedItems).toEqual(expectedExpandedItems);
+
+      wrapper.find('Downshift').prop('onInputValueChange')('Sub-child item 2', {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+
+      expect(wrapper.find(listItemName).length).toBe(4);
+      expect(wrapper.state().inputValue).toEqual('Sub-child item 2');
+      expect(wrapper.state().expandedItems).toEqual([
+        ...expectedExpandedItems,
+        {
+          ...mockProps.items[1].options[1],
+          level: 1,
+          category: mockProps.items[1].category,
+          parentId: mockProps.items[1].id,
+          id: `${mockProps.items[1].id}-${mockProps.items[1].options[1].id}`,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+      ]);
+    });
+
+    it('should filter all items by the input value', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      expect(wrapper.find(listItemName).length).toBe(mockProps.items.length);
+      wrapper.find('Downshift').prop('onInputValueChange')('xxx', {
+        type: Downshift.stateChangeTypes.changeInput,
+      });
+      wrapper.update();
+      expect(wrapper.find(listItemName).length).toBe(0);
+      expect(wrapper.state().inputValue).toEqual('xxx');
+      expect(wrapper.state().expandedItems).toEqual([]);
+
+      // No group should exist
+      expect(
+        wrapper.containsAllMatchingElements([
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label className="bx--group-label">CATEGORY-1</label>,
+          // eslint-disable-next-line jsx-a11y/label-has-associated-control
+          <label className="bx--group-label">CATEGORY-2</label>,
+        ])
+      ).toBe(false);
+    });
+
+    it('should clear the input value', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+      wrapper.setState({ inputValue: 'xxx' });
+
+      wrapper.find('ListBoxSelection').prop('clearSelection')({
+        stopPropagation: jest.fn(),
+      });
+      expect(wrapper.state().inputValue).toEqual('');
+    });
+
+    it('should call `onChange` with each update to selected items', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // Select the first item
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map(o => ({
+              ...o,
+              checked: true,
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(0)
+          .prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(2);
+
+      // Select the second item
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map(o => ({
+              ...o,
+              checked: true,
+            })),
+          },
+          {
+            ...mockProps.items[2],
+            options: mockProps.items[2].options.map(o => ({
+              ...o,
+              checked: true,
+              options:
+                o.options &&
+                o.options.map(p => ({
+                  ...p,
+                  checked: true,
+                })),
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(1)
+          .prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(5);
+
+      // Un-select the next two items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[2],
+            options: mockProps.items[2].options.map(o => ({
+              ...o,
+              checked: true,
+              options:
+                o.options &&
+                o.options.map(p => ({
+                  ...p,
+                  checked: true,
+                })),
+            })),
+          },
+        ],
+      });
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(3);
+
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(4);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [],
+      });
+      expect(wrapper.find('ListBoxSelection').exists()).toBe(false);
+    });
+
+    it('should call `onChange` with each update to selected sub items', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // Expand the child items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      // Check the first suboption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map((o, i) => ({
+              ...o,
+              checked: i === 0,
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(0)
+          .prop('indeterminate')
+      ).toBe(true);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(1);
+
+      // Check the second suboption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map(o => ({
+              ...o,
+              checked: true,
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(1)
+          .prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(2);
+
+      // Un-select the first suboption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map((o, i) => ({
+              ...o,
+              checked: i !== 0,
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(0)
+          .prop('indeterminate')
+      ).toBe(true);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(1);
+
+      // Un-select the second suboption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(4);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(0)
+          .prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('ListBoxSelection').exists()).toBe(false);
+    });
+
+    it('should call `onChange` with each update to selected sub child items', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // Expand the child items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      // Check child item 1
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[1],
+            options: mockProps.items[1].options.map((o, i) => ({
+              ...o,
+              checked: i === 0,
+              options: o.options.map(p => ({
+                ...p,
+                checked: i === 0,
+              })),
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper.find('Checkbox[name="Nested item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(2);
+
+      // Expand sub child items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .find('span')
+        .simulate('click');
+
+      // Uncheck sub child 1
+      wrapper
+        .find('Checkbox[name="Sub-child item 11"]')
+        .find('.bx--checkbox-label')
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[1],
+            options: mockProps.items[1].options.map((o, i) => ({
+              ...o,
+              checked: false,
+              options: o.options.map((p, j) => ({
+                ...p,
+                checked: i !== 0 ? false : j !== 0,
+              })),
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(1);
+
+      // Uncheck sub child 2
+      wrapper
+        .find('Checkbox[name="Sub-child item 12"]')
+        .find('.bx--checkbox-label')
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [],
+      });
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(false);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 1"]').prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('ListBoxSelection').exists()).toBe(false);
+
+      // Check sub child 1
+      wrapper
+        .find('Checkbox[name="Sub-child item 11"]')
+        .find('.bx--checkbox-label')
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(4);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[1],
+            options: mockProps.items[1].options.map((o, i) => ({
+              ...o,
+              checked: false,
+              options: o.options.map((p, j) => ({
+                ...p,
+                checked: i !== 0 ? false : j === 0,
+              })),
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(1);
+    });
+
+    it('should clear all selections', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // Select the first two items
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .simulate('click');
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+
+      expect(mockProps.onChange).toHaveBeenCalledTimes(2);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map(o => ({
+              ...o,
+              checked: true,
+            })),
+          },
+          {
+            ...mockProps.items[2],
+            options: mockProps.items[2].options.map(o => ({
+              ...o,
+              checked: true,
+              options:
+                o.options &&
+                o.options.map(p => ({
+                  ...p,
+                  checked: true,
+                })),
+            })),
+          },
+        ],
+      });
+      expect(
+        wrapper
+          .find('Checkbox')
+          .at(1)
+          .prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('ListBoxSelection').prop('selectionCount')).toBe(5);
+
+      // Clear all selection
+      wrapper.find('.bx--list-box__selection--multi').simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(3);
+      expect(mockProps.onChange).toHaveBeenCalledWith({
+        selectedItems: [],
+      });
+      expect(wrapper.find('ListBoxSelection').exists()).toBe(false);
+    });
+
+    it('should set parent item as indeterminate if not all suboptions are checked', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // checked the item with multiple levels
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(false);
+      // expand suboptions
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(false);
+      // unselect subOption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(true);
+      // expand subChild
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(false);
+      // unselect subChild
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(true);
+    });
+
+    it('should unselect parent if all suboptions are unselect', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // checked the item with multiple levels
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(true);
+      // expand suboptions
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+      // unselect 1 subOption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(true);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(true);
+      // unselect 2 subOption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(false);
+    });
+
+    it('should unselect parent if the suboptions at all levels are unselect', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      // checked the item with multiple levels
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(true);
+      // expand suboptions
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+      // unselect 1 subOption
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(true);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(true);
+      // expand subChild
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      // unselect 1 subChild
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(3)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(true);
+      expect(wrapper.find('Checkbox[name="Sub item 1"]').prop('checked')).toBe(
+        true
+      );
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(true);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(true);
+      // unselect 2 subChild
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(4)
+        .simulate('click');
+      expect(
+        wrapper.find('Checkbox[name="Sub item 1"]').prop('indeterminate')
+      ).toBe(false);
+      expect(wrapper.find('Checkbox[name="Sub item 1"]').prop('checked')).toBe(
+        false
+      );
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('indeterminate')
+      ).toBe(false);
+      expect(
+        wrapper.find('Checkbox[name="Nested item 2"]').prop('checked')
+      ).toBe(false);
+    });
+
+    it('should expand when element is clicked out of CheckBox', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      //expand suboptions
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find('.bx--checkbox-label').length).toEqual(5);
+    });
+
+    it('should expand suboptions via keyboard', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      wrapper.setState({
+        highlightedIndex: 0,
+      });
+      //expand suboptions
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 40,
+        key: 'ArrowDown',
+      });
+      expect(wrapper.find('.bx--checkbox-label').length).toEqual(5);
+      expect(wrapper.state().highlightedIndex).toEqual(1);
+      // collapse suboptions
+      wrapper.find('.bx--text-input').simulate('keyDown', {
+        which: 38,
+        key: 'ArrowUp',
+      });
+      expect(wrapper.find('.bx--checkbox-label').length).toEqual(3);
+      expect(wrapper.state().highlightedIndex).toEqual(0);
+    });
+
+    it('should not expand subOptions when parent is selected', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .simulate('click');
+      expect(mockProps.onChange).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('.bx--checkbox-label').length).toEqual(3);
+    });
+
+    it('should highlight suboption when mouse enter', () => {
+      const wrapper = mount(<NestedFilterableMultiselect {...mockProps} />);
+      openMenu(wrapper);
+
+      //expand suboptions
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      expect(wrapper.find('.bx--checkbox-label').length).toEqual(5);
+
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('mousemove');
+      expect(wrapper.state().highlightedIndex).toEqual(1);
+    });
+  });
+
+  describe('multiselect with initial selections', () => {
+    beforeEach(() => {
+      mockProps = {
+        disabled: false,
+        items: generateItems(3, index => ({
+          id: `id-${index}`,
+          label: `Nested item ${index}`,
+          value: index,
+          category: `category-${index % 2 === 0 ? 1 : 2}`,
+          options:
+            index === 0
+              ? [
+                  {
+                    id: 'option-id-1',
+                    label: 'Sub item 1',
+                    options: [
+                      {
+                        id: 'suboption-id-11',
+                        label: 'Sub-child item 11',
+                      },
+                      {
+                        id: 'suboption-id-12',
+                        label: 'Sub-child item 12',
+                      },
+                    ],
+                  },
+                  {
+                    id: 'option-id-2',
+                    label: 'Sub item 2',
+                    options: [
+                      {
+                        id: 'suboption-id-21',
+                        label: 'Sub-child item 21',
+                      },
+                      {
+                        id: 'suboption-id-22',
+                        label: 'Sub-child item 22',
+                      },
+                    ],
+                  },
+                ]
+              : undefined,
+        })),
+        placeholder: 'Placeholder...',
+      };
+    });
+
+    it('preselect item at level 0', () => {
+      const props = {
+        ...mockProps,
+        initialSelectedItems: [
+          {
+            ...mockProps.items[0],
+          },
+          {
+            ...mockProps.items[2],
+          },
+        ],
+      };
+
+      const wrapper = mount(<NestedFilterableMultiselect {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      openMenu(wrapper);
+      // Expand the child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      // Expand the sub-child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+
+      const checked = wrapper
+        .find('Checkbox')
+        .filterWhere(node => !!node.prop('checked'));
+      expect(checked.length).toEqual(8);
+      expect(wrapper.instance().state.flattenedSelectedItems).toEqual([
+        {
+          ...props.initialSelectedItems[0],
+          level: 0,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0],
+          level: 1,
+          parentId: props.initialSelectedItems[0].id,
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1',
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0].options[0],
+          level: 2,
+          parentId: 'id-0-option-id-1',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1-suboption-id-11',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0].options[1],
+          level: 2,
+          parentId: 'id-0-option-id-1',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1-suboption-id-12',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1],
+          level: 1,
+          parentId: props.initialSelectedItems[0].id,
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2',
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1].options[0],
+          level: 2,
+          parentId: 'id-0-option-id-2',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2-suboption-id-21',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1].options[1],
+          level: 2,
+          parentId: 'id-0-option-id-2',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2-suboption-id-22',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[1],
+          level: 0,
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+      ]);
+    });
+
+    it('preselect item at level 1', () => {
+      const props = {
+        ...mockProps,
+        initialSelectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map(o => ({
+              ...o,
+              checked: true,
+            })),
+          },
+        ],
+      };
+
+      const wrapper = mount(<NestedFilterableMultiselect {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      openMenu(wrapper);
+      // Expand the child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      // Expand the sub-child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+
+      const checked = wrapper
+        .find('Checkbox')
+        .filterWhere(node => !!node.prop('checked'));
+      expect(checked.length).toEqual(7);
+      expect(wrapper.instance().state.flattenedSelectedItems).toEqual([
+        {
+          ...props.initialSelectedItems[0],
+          level: 0,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0],
+          level: 1,
+          parentId: props.initialSelectedItems[0].id,
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1',
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0].options[0],
+          level: 2,
+          parentId: 'id-0-option-id-1',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1-suboption-id-11',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0].options[1],
+          level: 2,
+          parentId: 'id-0-option-id-1',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1-suboption-id-12',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1],
+          level: 1,
+          parentId: props.initialSelectedItems[0].id,
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2',
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1].options[0],
+          level: 2,
+          parentId: 'id-0-option-id-2',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2-suboption-id-21',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1].options[1],
+          level: 2,
+          parentId: 'id-0-option-id-2',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2-suboption-id-22',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+      ]);
+    });
+
+    it('preselect item at level 2', () => {
+      const props = {
+        ...mockProps,
+        initialSelectedItems: [
+          {
+            ...mockProps.items[0],
+            options: mockProps.items[0].options.map(o => ({
+              ...o,
+              options: o.options.map((p, i) => ({
+                ...p,
+                checked: i === 0,
+              })),
+            })),
+          },
+        ],
+      };
+
+      const wrapper = mount(<NestedFilterableMultiselect {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      openMenu(wrapper);
+      // Expand the child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(0)
+        .find('span')
+        .simulate('click');
+      // Expand the sub-child items via mouse click
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(2)
+        .find('span')
+        .simulate('click');
+      wrapper
+        .find('.bx--checkbox-label')
+        .at(1)
+        .find('span')
+        .simulate('click');
+
+      const checked = wrapper
+        .find('Checkbox')
+        .filterWhere(node => !!node.prop('checked'));
+      expect(checked.length).toEqual(5);
+      expect(wrapper.instance().state.flattenedSelectedItems).toEqual([
+        {
+          ...props.initialSelectedItems[0],
+          level: 0,
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0],
+          level: 1,
+          parentId: props.initialSelectedItems[0].id,
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1',
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[0].options[0],
+          level: 2,
+          parentId: 'id-0-option-id-1',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-1-suboption-id-11',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1],
+          level: 1,
+          parentId: props.initialSelectedItems[0].id,
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2',
+          options: undefined,
+          checked: undefined,
+          hasChildren: true,
+        },
+        {
+          ...props.initialSelectedItems[0].options[1].options[0],
+          level: 2,
+          parentId: 'id-0-option-id-2',
+          category: props.initialSelectedItems[0].category,
+          id: 'id-0-option-id-2-suboption-id-21',
+          options: undefined,
+          checked: undefined,
+          hasChildren: false,
+        },
+      ]);
+    });
+  });
+
+  describe('multiselect with flat list', () => {
+    beforeEach(() => {
+      mockProps = {
+        disabled: false,
+        items: [
+          {
+            id: 'id-0',
+            label: 'Flat item 1',
+            value: 0,
+            category: 'category-0',
+            level: 0,
+            hasChildren: true,
+          },
+          {
+            id: 'id-1',
+            label: 'Child item 1',
+            value: 1,
+            category: 'category-0',
+            level: 1,
+            hasChildren: true,
+            parentId: 'id-0',
+          },
+          {
+            id: 'id-2',
+            label: 'Subchild item 2',
+            value: 2,
+            category: 'category-0',
+            level: 2,
+            parentId: 'id-1',
+          },
+          {
+            id: 'id-3',
+            label: 'Subchild item 3',
+            value: 3,
+            category: 'category-0',
+            level: 2,
+            parentId: 'id-1',
+          },
+          {
+            id: 'id-4',
+            label: 'Child item 4',
+            value: 4,
+            category: 'category-0',
+            level: 1,
+            parentId: 'id-0',
+          },
+          {
+            id: 'id-5',
+            label: 'Flat item 5',
+            value: 5,
+            category: 'category-0',
+            level: 0,
+          },
+          {
+            id: 'id-6',
+            label: 'Flat item 6',
+            value: 6,
+            category: 'category-1',
+            level: 0,
+            hasChildren: true,
+          },
+          {
+            id: 'id-7',
+            label: 'Child item 7',
+            value: 7,
+            category: 'category-1',
+            level: 1,
+            parentId: 'id-6',
+          },
+          {
+            id: 'id-8',
+            label: 'Child item 8',
+            value: 8,
+            category: 'category-1',
+            level: 1,
+            parentId: 'id-6',
+          },
+        ],
+        placeholder: 'Placeholder...',
+      };
+    });
+
+    it('preselect item at level 0', () => {
+      const props = {
+        ...mockProps,
+        initialSelectedItems: [
+          {
+            ...mockProps.items[0],
+          },
+          {
+            ...mockProps.items[6],
+          },
+        ],
+      };
+
+      const wrapper = mount(<NestedFilterableMultiselect {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.instance().state.flattenedSelectedItems).toEqual([
+        mockProps.items[0],
+        mockProps.items[6],
+        mockProps.items[1],
+        mockProps.items[4],
+        mockProps.items[2],
+        mockProps.items[3],
+        mockProps.items[7],
+        mockProps.items[8],
+      ]);
+    });
+
+    it('preselect item at level 1', () => {
+      const props = {
+        ...mockProps,
+        initialSelectedItems: [
+          {
+            ...mockProps.items[1],
+          },
+          {
+            ...mockProps.items[5],
+          },
+          {
+            ...mockProps.items[7],
+          },
+        ],
+      };
+
+      const wrapper = mount(<NestedFilterableMultiselect {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.instance().state.flattenedSelectedItems).toEqual([
+        mockProps.items[1],
+        mockProps.items[5],
+        mockProps.items[7],
+        mockProps.items[0],
+        mockProps.items[2],
+        mockProps.items[3],
+        mockProps.items[6],
+      ]);
+    });
+
+    it('preselect item at level 2', () => {
+      const props = {
+        ...mockProps,
+        initialSelectedItems: [
+          {
+            ...mockProps.items[2],
+          },
+        ],
+      };
+
+      const wrapper = mount(<NestedFilterableMultiselect {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.instance().state.flattenedSelectedItems).toEqual([
+        mockProps.items[2],
+        mockProps.items[0],
+        mockProps.items[1],
+      ]);
+    });
+  });
+});

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/NestedFilterableMultiselect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/NestedFilterableMultiselect-test.js.snap
@@ -1,0 +1,3478 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NestedFilterableMultiselect Simple multiselect should render 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={Array []}
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "id": "id-0",
+        "label": "Item 0",
+        "value": 0,
+      },
+      Object {
+        "id": "id-1",
+        "label": "Item 1",
+        "value": 1,
+      },
+      Object {
+        "id": "id-2",
+        "label": "Item 2",
+        "value": 2,
+      },
+      Object {
+        "id": "id-3",
+        "label": "Item 3",
+        "value": 3,
+      },
+      Object {
+        "id": "id-4",
+        "label": "Item 4",
+        "value": 4,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  onChange={[MockFunction]}
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={Array []}
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={Array []}
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-0-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect Simple multiselect should render without showing tooltip 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={Array []}
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "id": "id-0",
+        "label": "Item 0",
+        "value": 0,
+      },
+      Object {
+        "id": "id-1",
+        "label": "Item 1",
+        "value": 1,
+      },
+      Object {
+        "id": "id-2",
+        "label": "Item 2",
+        "value": 2,
+      },
+      Object {
+        "id": "id-3",
+        "label": "Item 3",
+        "value": 3,
+      },
+      Object {
+        "id": "id-4",
+        "label": "Item 4",
+        "value": 4,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  onChange={[MockFunction]}
+  placeholder="Placeholder..."
+  showTooltip={false}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={Array []}
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={Array []}
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-1-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with categories should render 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  customCategorySorting={[MockFunction]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={Array []}
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Item 0",
+        "value": 0,
+      },
+      Object {
+        "category": "category-2",
+        "id": "id-1",
+        "label": "Item 1",
+        "value": 1,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-2",
+        "label": "Item 2",
+        "value": 2,
+      },
+      Object {
+        "category": "category-2",
+        "id": "id-3",
+        "label": "Item 3",
+        "value": 3,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-4",
+        "label": "Item 4",
+        "value": 4,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  onChange={[MockFunction]}
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={Array []}
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={Array []}
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-9-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with flat list preselect item at level 0 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={
+    Array [
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-0",
+        "label": "Flat item 1",
+        "level": 0,
+        "value": 0,
+      },
+      Object {
+        "category": "category-1",
+        "hasChildren": true,
+        "id": "id-6",
+        "label": "Flat item 6",
+        "level": 0,
+        "value": 6,
+      },
+    ]
+  }
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-0",
+        "label": "Flat item 1",
+        "level": 0,
+        "value": 0,
+      },
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-1",
+        "label": "Child item 1",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 1,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-2",
+        "label": "Subchild item 2",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 2,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-3",
+        "label": "Subchild item 3",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 3,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-4",
+        "label": "Child item 4",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 4,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-5",
+        "label": "Flat item 5",
+        "level": 0,
+        "value": 5,
+      },
+      Object {
+        "category": "category-1",
+        "hasChildren": true,
+        "id": "id-6",
+        "label": "Flat item 6",
+        "level": 0,
+        "value": 6,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-7",
+        "label": "Child item 7",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 7,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-8",
+        "label": "Child item 8",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 8,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={
+      Array [
+        Object {
+          "category": "category-0",
+          "hasChildren": true,
+          "id": "id-0",
+          "label": "Flat item 1",
+          "level": 0,
+          "value": 0,
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-6",
+          "label": "Flat item 6",
+          "level": 0,
+          "value": 6,
+        },
+        Object {
+          "category": "category-0",
+          "hasChildren": true,
+          "id": "id-1",
+          "label": "Child item 1",
+          "level": 1,
+          "parentId": "id-0",
+          "value": 1,
+        },
+        Object {
+          "category": "category-0",
+          "id": "id-4",
+          "label": "Child item 4",
+          "level": 1,
+          "parentId": "id-0",
+          "value": 4,
+        },
+        Object {
+          "category": "category-0",
+          "id": "id-2",
+          "label": "Subchild item 2",
+          "level": 2,
+          "parentId": "id-1",
+          "value": 2,
+        },
+        Object {
+          "category": "category-0",
+          "id": "id-3",
+          "label": "Subchild item 3",
+          "level": 2,
+          "parentId": "id-1",
+          "value": 3,
+        },
+        Object {
+          "category": "category-1",
+          "id": "id-7",
+          "label": "Child item 7",
+          "level": 1,
+          "parentId": "id-6",
+          "value": 7,
+        },
+        Object {
+          "category": "category-1",
+          "id": "id-8",
+          "label": "Child item 8",
+          "level": 1,
+          "parentId": "id-6",
+          "value": 8,
+        },
+      ]
+    }
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={
+        Array [
+          Object {
+            "category": "category-0",
+            "hasChildren": true,
+            "id": "id-0",
+            "label": "Flat item 1",
+            "level": 0,
+            "value": 0,
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-6",
+            "label": "Flat item 6",
+            "level": 0,
+            "value": 6,
+          },
+          Object {
+            "category": "category-0",
+            "hasChildren": true,
+            "id": "id-1",
+            "label": "Child item 1",
+            "level": 1,
+            "parentId": "id-0",
+            "value": 1,
+          },
+          Object {
+            "category": "category-0",
+            "id": "id-4",
+            "label": "Child item 4",
+            "level": 1,
+            "parentId": "id-0",
+            "value": 4,
+          },
+          Object {
+            "category": "category-0",
+            "id": "id-2",
+            "label": "Subchild item 2",
+            "level": 2,
+            "parentId": "id-1",
+            "value": 2,
+          },
+          Object {
+            "category": "category-0",
+            "id": "id-3",
+            "label": "Subchild item 3",
+            "level": 2,
+            "parentId": "id-1",
+            "value": 3,
+          },
+          Object {
+            "category": "category-1",
+            "id": "id-7",
+            "label": "Child item 7",
+            "level": 1,
+            "parentId": "id-6",
+            "value": 7,
+          },
+          Object {
+            "category": "category-1",
+            "id": "id-8",
+            "label": "Child item 8",
+            "level": 1,
+            "parentId": "id-6",
+            "value": 8,
+          },
+        ]
+      }
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <ListBoxSelection
+                clearSelection={[Function]}
+                selectionCount={5}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__selection bx--list-box__selection--multi"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="0"
+                  title="Clear all selected items"
+                >
+                  5
+                  <Icon
+                    description="Clear all selected items"
+                    fillRule="evenodd"
+                    focusable="false"
+                    icon={
+                      Object {
+                        "height": "10",
+                        "id": "icon--close",
+                        "name": "icon--close",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--close",
+                        "viewBox": "0 0 10 10",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--close"
+                    role="img"
+                  >
+                    <svg
+                      alt="Clear all selected items"
+                      aria-label="Clear all selected items"
+                      fillRule="evenodd"
+                      focusable="false"
+                      height="10"
+                      name="icon--close"
+                      role="img"
+                      viewBox="0 0 10 10"
+                      width="10"
+                    >
+                      <title>
+                        Clear all selected items
+                      </title>
+                      <path
+                        d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxSelection>
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-31-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with flat list preselect item at level 1 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={
+    Array [
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-1",
+        "label": "Child item 1",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 1,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-5",
+        "label": "Flat item 5",
+        "level": 0,
+        "value": 5,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-7",
+        "label": "Child item 7",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 7,
+      },
+    ]
+  }
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-0",
+        "label": "Flat item 1",
+        "level": 0,
+        "value": 0,
+      },
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-1",
+        "label": "Child item 1",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 1,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-2",
+        "label": "Subchild item 2",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 2,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-3",
+        "label": "Subchild item 3",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 3,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-4",
+        "label": "Child item 4",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 4,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-5",
+        "label": "Flat item 5",
+        "level": 0,
+        "value": 5,
+      },
+      Object {
+        "category": "category-1",
+        "hasChildren": true,
+        "id": "id-6",
+        "label": "Flat item 6",
+        "level": 0,
+        "value": 6,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-7",
+        "label": "Child item 7",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 7,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-8",
+        "label": "Child item 8",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 8,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={
+      Array [
+        Object {
+          "category": "category-0",
+          "hasChildren": true,
+          "id": "id-1",
+          "label": "Child item 1",
+          "level": 1,
+          "parentId": "id-0",
+          "value": 1,
+        },
+        Object {
+          "category": "category-0",
+          "id": "id-5",
+          "label": "Flat item 5",
+          "level": 0,
+          "value": 5,
+        },
+        Object {
+          "category": "category-1",
+          "id": "id-7",
+          "label": "Child item 7",
+          "level": 1,
+          "parentId": "id-6",
+          "value": 7,
+        },
+        Object {
+          "category": "category-0",
+          "hasChildren": true,
+          "id": "id-0",
+          "label": "Flat item 1",
+          "level": 0,
+          "value": 0,
+        },
+        Object {
+          "category": "category-0",
+          "id": "id-2",
+          "label": "Subchild item 2",
+          "level": 2,
+          "parentId": "id-1",
+          "value": 2,
+        },
+        Object {
+          "category": "category-0",
+          "id": "id-3",
+          "label": "Subchild item 3",
+          "level": 2,
+          "parentId": "id-1",
+          "value": 3,
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-6",
+          "label": "Flat item 6",
+          "level": 0,
+          "value": 6,
+        },
+      ]
+    }
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={
+        Array [
+          Object {
+            "category": "category-0",
+            "hasChildren": true,
+            "id": "id-1",
+            "label": "Child item 1",
+            "level": 1,
+            "parentId": "id-0",
+            "value": 1,
+          },
+          Object {
+            "category": "category-0",
+            "id": "id-5",
+            "label": "Flat item 5",
+            "level": 0,
+            "value": 5,
+          },
+          Object {
+            "category": "category-1",
+            "id": "id-7",
+            "label": "Child item 7",
+            "level": 1,
+            "parentId": "id-6",
+            "value": 7,
+          },
+          Object {
+            "category": "category-0",
+            "hasChildren": true,
+            "id": "id-0",
+            "label": "Flat item 1",
+            "level": 0,
+            "value": 0,
+          },
+          Object {
+            "category": "category-0",
+            "id": "id-2",
+            "label": "Subchild item 2",
+            "level": 2,
+            "parentId": "id-1",
+            "value": 2,
+          },
+          Object {
+            "category": "category-0",
+            "id": "id-3",
+            "label": "Subchild item 3",
+            "level": 2,
+            "parentId": "id-1",
+            "value": 3,
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-6",
+            "label": "Flat item 6",
+            "level": 0,
+            "value": 6,
+          },
+        ]
+      }
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <ListBoxSelection
+                clearSelection={[Function]}
+                selectionCount={4}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__selection bx--list-box__selection--multi"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="0"
+                  title="Clear all selected items"
+                >
+                  4
+                  <Icon
+                    description="Clear all selected items"
+                    fillRule="evenodd"
+                    focusable="false"
+                    icon={
+                      Object {
+                        "height": "10",
+                        "id": "icon--close",
+                        "name": "icon--close",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--close",
+                        "viewBox": "0 0 10 10",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--close"
+                    role="img"
+                  >
+                    <svg
+                      alt="Clear all selected items"
+                      aria-label="Clear all selected items"
+                      fillRule="evenodd"
+                      focusable="false"
+                      height="10"
+                      name="icon--close"
+                      role="img"
+                      viewBox="0 0 10 10"
+                      width="10"
+                    >
+                      <title>
+                        Clear all selected items
+                      </title>
+                      <path
+                        d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxSelection>
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-32-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with flat list preselect item at level 2 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={
+    Array [
+      Object {
+        "category": "category-0",
+        "id": "id-2",
+        "label": "Subchild item 2",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 2,
+      },
+    ]
+  }
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-0",
+        "label": "Flat item 1",
+        "level": 0,
+        "value": 0,
+      },
+      Object {
+        "category": "category-0",
+        "hasChildren": true,
+        "id": "id-1",
+        "label": "Child item 1",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 1,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-2",
+        "label": "Subchild item 2",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 2,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-3",
+        "label": "Subchild item 3",
+        "level": 2,
+        "parentId": "id-1",
+        "value": 3,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-4",
+        "label": "Child item 4",
+        "level": 1,
+        "parentId": "id-0",
+        "value": 4,
+      },
+      Object {
+        "category": "category-0",
+        "id": "id-5",
+        "label": "Flat item 5",
+        "level": 0,
+        "value": 5,
+      },
+      Object {
+        "category": "category-1",
+        "hasChildren": true,
+        "id": "id-6",
+        "label": "Flat item 6",
+        "level": 0,
+        "value": 6,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-7",
+        "label": "Child item 7",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 7,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-8",
+        "label": "Child item 8",
+        "level": 1,
+        "parentId": "id-6",
+        "value": 8,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={
+      Array [
+        Object {
+          "category": "category-0",
+          "id": "id-2",
+          "label": "Subchild item 2",
+          "level": 2,
+          "parentId": "id-1",
+          "value": 2,
+        },
+        Object {
+          "category": "category-0",
+          "hasChildren": true,
+          "id": "id-0",
+          "label": "Flat item 1",
+          "level": 0,
+          "value": 0,
+        },
+        Object {
+          "category": "category-0",
+          "hasChildren": true,
+          "id": "id-1",
+          "label": "Child item 1",
+          "level": 1,
+          "parentId": "id-0",
+          "value": 1,
+        },
+      ]
+    }
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={
+        Array [
+          Object {
+            "category": "category-0",
+            "id": "id-2",
+            "label": "Subchild item 2",
+            "level": 2,
+            "parentId": "id-1",
+            "value": 2,
+          },
+          Object {
+            "category": "category-0",
+            "hasChildren": true,
+            "id": "id-0",
+            "label": "Flat item 1",
+            "level": 0,
+            "value": 0,
+          },
+          Object {
+            "category": "category-0",
+            "hasChildren": true,
+            "id": "id-1",
+            "label": "Child item 1",
+            "level": 1,
+            "parentId": "id-0",
+            "value": 1,
+          },
+        ]
+      }
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <ListBoxSelection
+                clearSelection={[Function]}
+                selectionCount={1}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__selection bx--list-box__selection--multi"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="0"
+                  title="Clear all selected items"
+                >
+                  1
+                  <Icon
+                    description="Clear all selected items"
+                    fillRule="evenodd"
+                    focusable="false"
+                    icon={
+                      Object {
+                        "height": "10",
+                        "id": "icon--close",
+                        "name": "icon--close",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--close",
+                        "viewBox": "0 0 10 10",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--close"
+                    role="img"
+                  >
+                    <svg
+                      alt="Clear all selected items"
+                      aria-label="Clear all selected items"
+                      fillRule="evenodd"
+                      focusable="false"
+                      height="10"
+                      name="icon--close"
+                      role="img"
+                      viewBox="0 0 10 10"
+                      width="10"
+                    >
+                      <title>
+                        Clear all selected items
+                      </title>
+                      <path
+                        d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxSelection>
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-33-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with initial selections preselect item at level 0 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 0,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-2",
+        "label": "Nested item 2",
+        "options": undefined,
+        "value": 2,
+      },
+    ]
+  }
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 0,
+      },
+      Object {
+        "category": "category-2",
+        "id": "id-1",
+        "label": "Nested item 1",
+        "options": undefined,
+        "value": 1,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-2",
+        "label": "Nested item 2",
+        "options": undefined,
+        "value": 2,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={
+      Array [
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0",
+          "label": "Nested item 0",
+          "level": 0,
+          "parentId": undefined,
+          "value": 0,
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0-option-id-1",
+          "label": "Sub item 1",
+          "level": 1,
+          "parentId": "id-0",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-1-suboption-id-11",
+          "label": "Sub-child item 11",
+          "level": 2,
+          "parentId": "id-0-option-id-1",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-1-suboption-id-12",
+          "label": "Sub-child item 12",
+          "level": 2,
+          "parentId": "id-0-option-id-1",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0-option-id-2",
+          "label": "Sub item 2",
+          "level": 1,
+          "parentId": "id-0",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-2-suboption-id-21",
+          "label": "Sub-child item 21",
+          "level": 2,
+          "parentId": "id-0-option-id-2",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-2-suboption-id-22",
+          "label": "Sub-child item 22",
+          "level": 2,
+          "parentId": "id-0-option-id-2",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-2",
+          "label": "Nested item 2",
+          "level": 0,
+          "parentId": undefined,
+          "value": 2,
+        },
+      ]
+    }
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={
+        Array [
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0",
+            "label": "Nested item 0",
+            "level": 0,
+            "parentId": undefined,
+            "value": 0,
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0-option-id-1",
+            "label": "Sub item 1",
+            "level": 1,
+            "parentId": "id-0",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-1-suboption-id-11",
+            "label": "Sub-child item 11",
+            "level": 2,
+            "parentId": "id-0-option-id-1",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-1-suboption-id-12",
+            "label": "Sub-child item 12",
+            "level": 2,
+            "parentId": "id-0-option-id-1",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0-option-id-2",
+            "label": "Sub item 2",
+            "level": 1,
+            "parentId": "id-0",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-2-suboption-id-21",
+            "label": "Sub-child item 21",
+            "level": 2,
+            "parentId": "id-0-option-id-2",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-2-suboption-id-22",
+            "label": "Sub-child item 22",
+            "level": 2,
+            "parentId": "id-0-option-id-2",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-2",
+            "label": "Nested item 2",
+            "level": 0,
+            "parentId": undefined,
+            "value": 2,
+          },
+        ]
+      }
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <ListBoxSelection
+                clearSelection={[Function]}
+                selectionCount={5}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__selection bx--list-box__selection--multi"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="0"
+                  title="Clear all selected items"
+                >
+                  5
+                  <Icon
+                    description="Clear all selected items"
+                    fillRule="evenodd"
+                    focusable="false"
+                    icon={
+                      Object {
+                        "height": "10",
+                        "id": "icon--close",
+                        "name": "icon--close",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--close",
+                        "viewBox": "0 0 10 10",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--close"
+                    role="img"
+                  >
+                    <svg
+                      alt="Clear all selected items"
+                      aria-label="Clear all selected items"
+                      fillRule="evenodd"
+                      focusable="false"
+                      height="10"
+                      name="icon--close"
+                      role="img"
+                      viewBox="0 0 10 10"
+                      width="10"
+                    >
+                      <title>
+                        Clear all selected items
+                      </title>
+                      <path
+                        d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxSelection>
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-28-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with initial selections preselect item at level 1 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "checked": true,
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "checked": true,
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 0,
+      },
+    ]
+  }
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 0,
+      },
+      Object {
+        "category": "category-2",
+        "id": "id-1",
+        "label": "Nested item 1",
+        "options": undefined,
+        "value": 1,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-2",
+        "label": "Nested item 2",
+        "options": undefined,
+        "value": 2,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={
+      Array [
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0",
+          "label": "Nested item 0",
+          "level": 0,
+          "parentId": undefined,
+          "value": 0,
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0-option-id-1",
+          "label": "Sub item 1",
+          "level": 1,
+          "parentId": "id-0",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-1-suboption-id-11",
+          "label": "Sub-child item 11",
+          "level": 2,
+          "parentId": "id-0-option-id-1",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-1-suboption-id-12",
+          "label": "Sub-child item 12",
+          "level": 2,
+          "parentId": "id-0-option-id-1",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0-option-id-2",
+          "label": "Sub item 2",
+          "level": 1,
+          "parentId": "id-0",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-2-suboption-id-21",
+          "label": "Sub-child item 21",
+          "level": 2,
+          "parentId": "id-0-option-id-2",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-2-suboption-id-22",
+          "label": "Sub-child item 22",
+          "level": 2,
+          "parentId": "id-0-option-id-2",
+        },
+      ]
+    }
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={
+        Array [
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0",
+            "label": "Nested item 0",
+            "level": 0,
+            "parentId": undefined,
+            "value": 0,
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0-option-id-1",
+            "label": "Sub item 1",
+            "level": 1,
+            "parentId": "id-0",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-1-suboption-id-11",
+            "label": "Sub-child item 11",
+            "level": 2,
+            "parentId": "id-0-option-id-1",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-1-suboption-id-12",
+            "label": "Sub-child item 12",
+            "level": 2,
+            "parentId": "id-0-option-id-1",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0-option-id-2",
+            "label": "Sub item 2",
+            "level": 1,
+            "parentId": "id-0",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-2-suboption-id-21",
+            "label": "Sub-child item 21",
+            "level": 2,
+            "parentId": "id-0-option-id-2",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-2-suboption-id-22",
+            "label": "Sub-child item 22",
+            "level": 2,
+            "parentId": "id-0-option-id-2",
+          },
+        ]
+      }
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <ListBoxSelection
+                clearSelection={[Function]}
+                selectionCount={4}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__selection bx--list-box__selection--multi"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="0"
+                  title="Clear all selected items"
+                >
+                  4
+                  <Icon
+                    description="Clear all selected items"
+                    fillRule="evenodd"
+                    focusable="false"
+                    icon={
+                      Object {
+                        "height": "10",
+                        "id": "icon--close",
+                        "name": "icon--close",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--close",
+                        "viewBox": "0 0 10 10",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--close"
+                    role="img"
+                  >
+                    <svg
+                      alt="Clear all selected items"
+                      aria-label="Clear all selected items"
+                      fillRule="evenodd"
+                      focusable="false"
+                      height="10"
+                      name="icon--close"
+                      role="img"
+                      viewBox="0 0 10 10"
+                      width="10"
+                    >
+                      <title>
+                        Clear all selected items
+                      </title>
+                      <path
+                        d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxSelection>
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-29-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with initial selections preselect item at level 2 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "checked": true,
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "checked": false,
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "checked": true,
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "checked": false,
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 0,
+      },
+    ]
+  }
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 0,
+      },
+      Object {
+        "category": "category-2",
+        "id": "id-1",
+        "label": "Nested item 1",
+        "options": undefined,
+        "value": 1,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-2",
+        "label": "Nested item 2",
+        "options": undefined,
+        "value": 2,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={
+      Array [
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0",
+          "label": "Nested item 0",
+          "level": 0,
+          "parentId": undefined,
+          "value": 0,
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0-option-id-1",
+          "label": "Sub item 1",
+          "level": 1,
+          "parentId": "id-0",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-1-suboption-id-11",
+          "label": "Sub-child item 11",
+          "level": 2,
+          "parentId": "id-0-option-id-1",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": true,
+          "id": "id-0-option-id-2",
+          "label": "Sub item 2",
+          "level": 1,
+          "parentId": "id-0",
+        },
+        Object {
+          "category": "category-1",
+          "hasChildren": false,
+          "id": "id-0-option-id-2-suboption-id-21",
+          "label": "Sub-child item 21",
+          "level": 2,
+          "parentId": "id-0-option-id-2",
+        },
+      ]
+    }
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={
+        Array [
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0",
+            "label": "Nested item 0",
+            "level": 0,
+            "parentId": undefined,
+            "value": 0,
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0-option-id-1",
+            "label": "Sub item 1",
+            "level": 1,
+            "parentId": "id-0",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-1-suboption-id-11",
+            "label": "Sub-child item 11",
+            "level": 2,
+            "parentId": "id-0-option-id-1",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": true,
+            "id": "id-0-option-id-2",
+            "label": "Sub item 2",
+            "level": 1,
+            "parentId": "id-0",
+          },
+          Object {
+            "category": "category-1",
+            "hasChildren": false,
+            "id": "id-0-option-id-2-suboption-id-21",
+            "label": "Sub-child item 21",
+            "level": 2,
+            "parentId": "id-0-option-id-2",
+          },
+        ]
+      }
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <ListBoxSelection
+                clearSelection={[Function]}
+                selectionCount={2}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__selection bx--list-box__selection--multi"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="0"
+                  title="Clear all selected items"
+                >
+                  2
+                  <Icon
+                    description="Clear all selected items"
+                    fillRule="evenodd"
+                    focusable="false"
+                    icon={
+                      Object {
+                        "height": "10",
+                        "id": "icon--close",
+                        "name": "icon--close",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                              "fill-rule": "nonzero",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--close",
+                        "viewBox": "0 0 10 10",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--close"
+                    role="img"
+                  >
+                    <svg
+                      alt="Clear all selected items"
+                      aria-label="Clear all selected items"
+                      fillRule="evenodd"
+                      focusable="false"
+                      height="10"
+                      name="icon--close"
+                      role="img"
+                      viewBox="0 0 10 10"
+                      width="10"
+                    >
+                      <title>
+                        Clear all selected items
+                      </title>
+                      <path
+                        d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxSelection>
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-30-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
+exports[`NestedFilterableMultiselect multiselect with suboptions should render 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={Array []}
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "category": "category-1",
+        "id": "id-0",
+        "label": "Nested item 0",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": undefined,
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": undefined,
+          },
+        ],
+        "value": 0,
+      },
+      Object {
+        "category": "category-2",
+        "id": "id-1",
+        "label": "Nested item 1",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": Array [
+              Object {
+                "id": "suboption-id-21",
+                "label": "Sub-child item 21",
+              },
+              Object {
+                "id": "suboption-id-22",
+                "label": "Sub-child item 22",
+              },
+            ],
+          },
+        ],
+        "value": 1,
+      },
+      Object {
+        "category": "category-1",
+        "id": "id-2",
+        "label": "Nested item 2",
+        "options": Array [
+          Object {
+            "id": "option-id-1",
+            "label": "Sub item 1",
+            "options": Array [
+              Object {
+                "id": "suboption-id-11",
+                "label": "Sub-child item 11",
+              },
+              Object {
+                "id": "suboption-id-12",
+                "label": "Sub-child item 12",
+              },
+            ],
+          },
+          Object {
+            "id": "option-id-2",
+            "label": "Sub item 2",
+            "options": undefined,
+          },
+        ],
+        "value": 2,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  onChange={[MockFunction]}
+  placeholder="Placeholder..."
+  showTooltip={true}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={Array []}
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={Array []}
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-11-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;

--- a/packages/react/src/components/MultiSelect/index.js
+++ b/packages/react/src/components/MultiSelect/index.js
@@ -7,7 +7,9 @@
 
 import MultiSelect from './MultiSelect';
 import FilterableMultiSelect from './FilterableMultiSelect';
+import NestedFilterableMultiselect from './NestedFilterableMultiselect';
 
 MultiSelect.Filterable = FilterableMultiSelect;
+MultiSelect.NestedFilterable = NestedFilterableMultiselect;
 
 export default MultiSelect;

--- a/packages/react/src/components/MultiSelect/tools/__tests__/sorting-test.js
+++ b/packages/react/src/components/MultiSelect/tools/__tests__/sorting-test.js
@@ -22,39 +22,51 @@ describe('defaultSortItems', () => {
   });
 
   it('should sort un-selected options alphabetically', () => {
-    const mockItems = ['d', 'c', 'b', 'a'].map(label => ({ label }));
+    const mockItems = ['d', 'c', 'b', 'a'].map(label => ({ id: label, label }));
     expect(defaultSortItems(mockItems, mockOptions)).toEqual([
       {
+        id: 'a',
         label: 'a',
       },
       {
+        id: 'b',
         label: 'b',
       },
       {
+        id: 'c',
         label: 'c',
       },
       {
+        id: 'd',
         label: 'd',
       },
     ]);
   });
 
   it('should sort un-selected numbers in increasing order', () => {
-    const mockItems = ['1', '10', '11', '2', '3'].map(label => ({ label }));
+    const mockItems = ['1', '10', '11', '2', '3'].map(label => ({
+      id: label,
+      label,
+    }));
     expect(defaultSortItems(mockItems, mockOptions)).toEqual([
       {
+        id: '1',
         label: '1',
       },
       {
+        id: '2',
         label: '2',
       },
       {
+        id: '3',
         label: '3',
       },
       {
+        id: '10',
         label: '10',
       },
       {
+        id: '11',
         label: '11',
       },
     ]);
@@ -62,68 +74,163 @@ describe('defaultSortItems', () => {
 
   it('should sort un-selected alpha-numeric sequences with increasing order', () => {
     const mockItems = ['Option 1', 'Option 10', 'Option 11', 'Option 2'].map(
-      label => ({ label })
+      label => ({ id: label, label })
     );
     expect(defaultSortItems(mockItems, mockOptions)).toEqual([
       {
+        id: 'Option 1',
         label: 'Option 1',
       },
       {
+        id: 'Option 2',
         label: 'Option 2',
       },
       {
+        id: 'Option 10',
         label: 'Option 10',
       },
       {
+        id: 'Option 11',
         label: 'Option 11',
       },
     ]);
   });
 
-  it('should order a selected item before all other options', () => {
-    const mockItems = ['Option 1', 'Option 10', 'Option 11', 'Option 2'].map(
-      label => ({ label })
-    );
-
-    // Set `selectedItems` to ['Option 11']
-    mockOptions.selectedItems = [mockItems[2]];
-
+  it('should sort parent and child', () => {
+    const mockItems = [
+      {
+        id: 'x-a',
+        label: 'a',
+        parentId: 'x',
+      },
+      {
+        id: 'x',
+        label: 'x',
+      },
+      {
+        id: 'z-d-m',
+        label: 'm',
+        parentId: 'z-d',
+      },
+      {
+        id: 'z-1',
+        label: 'z',
+      },
+      {
+        id: 'x-b',
+        label: 'b',
+        parentId: 'x',
+      },
+      {
+        id: 'y',
+        label: 'y',
+      },
+      {
+        id: 'z-c',
+        label: 'c',
+        parentId: 'z',
+      },
+      {
+        id: 'z-d',
+        label: 'd',
+        parentId: 'z',
+      },
+      {
+        id: 'z',
+        label: 'z',
+      },
+      {
+        id: 'z-c-k',
+        label: 'k',
+        parentId: 'z-c',
+      },
+      {
+        id: 'z-e',
+        label: 'e',
+        parentId: 'z',
+      },
+      {
+        id: 'z-a',
+        label: 'a',
+        parentId: 'z',
+      },
+      {
+        id: 'z-c-l',
+        label: 'l',
+        parentId: 'z-c',
+      },
+      {
+        id: 'z-d-n',
+        label: 'n',
+        parentId: 'z-d',
+      },
+    ];
     expect(defaultSortItems(mockItems, mockOptions)).toEqual([
       {
-        label: 'Option 11',
+        id: 'x',
+        label: 'x',
       },
       {
-        label: 'Option 1',
+        id: 'x-a',
+        label: 'a',
+        parentId: 'x',
       },
       {
-        label: 'Option 2',
+        id: 'x-b',
+        label: 'b',
+        parentId: 'x',
       },
       {
-        label: 'Option 10',
-      },
-    ]);
-  });
-
-  it('should sort selected items and order them before all other options', () => {
-    const mockItems = ['Option 1', 'Option 10', 'Option 11', 'Option 2'].map(
-      label => ({ label })
-    );
-
-    // Set `selectedItems` to ['Option 11', 'Option 2']
-    mockOptions.selectedItems = [mockItems[2], mockItems[3]];
-
-    expect(defaultSortItems(mockItems, mockOptions)).toEqual([
-      {
-        label: 'Option 2',
+        id: 'y',
+        label: 'y',
       },
       {
-        label: 'Option 11',
+        id: 'z-1',
+        label: 'z',
       },
       {
-        label: 'Option 1',
+        id: 'z',
+        label: 'z',
       },
       {
-        label: 'Option 10',
+        id: 'z-a',
+        label: 'a',
+        parentId: 'z',
+      },
+      {
+        id: 'z-c',
+        label: 'c',
+        parentId: 'z',
+      },
+      {
+        id: 'z-c-k',
+        label: 'k',
+        parentId: 'z-c',
+      },
+      {
+        id: 'z-c-l',
+        label: 'l',
+        parentId: 'z-c',
+      },
+      {
+        id: 'z-d',
+        label: 'd',
+        parentId: 'z',
+      },
+      {
+        id: 'z-d-m',
+        label: 'm',
+        parentId: 'z-d',
+      },
+      {
+        id: 'z-d-n',
+        label: 'n',
+        parentId: 'z-d',
+      },
+      {
+        id: 'z-e',
+        label: 'e',
+        parentId: 'z',
       },
     ]);
   });

--- a/packages/react/src/components/MultiSelect/tools/filter.js
+++ b/packages/react/src/components/MultiSelect/tools/filter.js
@@ -1,0 +1,68 @@
+import { buildHierarchy } from './sorting';
+
+export const getAllChildren = (item, items) => {
+  const results = [];
+  const children = items.filter(
+    theItem => theItem.parentId && theItem.parentId === item.id
+  );
+
+  if (children.length > 0) {
+    results.push(...children);
+
+    children.forEach(child => {
+      results.push(...getAllChildren(child, items));
+    });
+  }
+
+  return results;
+};
+
+export const defaultFilterItems = (
+  items,
+  { itemToString, inputValue, expandedItems }
+) =>
+  items.filter(item => {
+    const parents = buildHierarchy(item, items);
+    parents.pop();
+
+    if (parents.length > 0 && expandedItems) {
+      // If any parent item is not expanded, the child item should not be shown
+      const isExpanded = !parents.some(
+        parent =>
+          !expandedItems.some(expandedItem => expandedItem.id === parent.id)
+      );
+      if (!isExpanded) {
+        return false;
+      }
+    }
+
+    if (!inputValue) {
+      return true;
+    }
+
+    const children = getAllChildren(item, items).filter(theItem =>
+      itemToString(theItem)
+        .toLowerCase()
+        .includes(inputValue.toLowerCase())
+    );
+    if (children.length > 0) {
+      // if any of the child item matches, the parent item should be shown
+      return true;
+    }
+
+    if (parents.length > 0) {
+      const isVisible = parents.some(parent =>
+        itemToString(parent)
+          .toLowerCase()
+          .includes(inputValue.toLowerCase())
+      );
+      if (isVisible) {
+        // if it matches any of the parents, all sub items should be shown
+        return true;
+      }
+    }
+
+    return itemToString(item)
+      .toLowerCase()
+      .includes(inputValue.toLowerCase());
+  });

--- a/packages/react/src/components/MultiSelect/tools/groupedByCategory.js
+++ b/packages/react/src/components/MultiSelect/tools/groupedByCategory.js
@@ -1,0 +1,24 @@
+function AlphabeticSort(a, b) {
+  return a[0].localeCompare(b[0]);
+}
+
+export const groupedByCategory = (items, customCategorySorting) => {
+  const result = items.reduce((groupedArray, currentItem) => {
+    groupedArray[currentItem.category] =
+      groupedArray[currentItem.category] || [];
+    groupedArray[currentItem.category].push(currentItem);
+    return groupedArray;
+  }, Object.create(null));
+
+  const finalResult = Object.keys(result).reduce((array, key) => {
+    const elementArr = [key, result[key]];
+    array.push(elementArr);
+    return array;
+  }, []);
+  const comparator = customCategorySorting
+    ? customCategorySorting
+    : AlphabeticSort;
+  finalResult.sort(comparator);
+
+  return finalResult;
+};

--- a/packages/react/src/internal/Selection.js
+++ b/packages/react/src/internal/Selection.js
@@ -45,34 +45,60 @@ export default class Selection extends React.Component {
   };
 
   handleSelectItem = item => {
-    this.internalSetState(state => ({
-      selectedItems: state.selectedItems.concat(item),
+    const items = Array.isArray(item) ? item : [item];
+    this.internalSetState(prevState => ({
+      selectedItems: [...prevState.selectedItems, ...items],
     }));
   };
 
-  handleRemoveItem = index => {
-    this.internalSetState(state => ({
-      selectedItems: removeAtIndex(state.selectedItems, index),
-    }));
+  handleRemoveItem = item => {
+    const items = Array.isArray(item) ? item : [item];
+    this.internalSetState(prevState => {
+      const newState = {
+        selectedItems: prevState.selectedItems.filter(
+          itemOnState => items.indexOf(itemOnState) === -1
+        ),
+      };
+      return newState;
+    });
   };
+
   handleOnItemChange = item => {
     if (this.props.disabled) {
       return;
     }
     const { selectedItems } = this.state;
 
-    let selectedIndex;
-    selectedItems.forEach((selectedItem, index) => {
-      if (isEqual(selectedItem, item)) {
-        selectedIndex = index;
+    const itemsToProcess = Array.isArray(item) ? item : [item];
+    const result = itemsToProcess.reduce(
+      (acc, theItem) => {
+        let selectedIndex;
+        selectedItems.some((selectedItem, index) => {
+          if (isEqual(selectedItem, theItem)) {
+            selectedIndex = index;
+            return true;
+          }
+          return false;
+        });
+        if (selectedIndex === undefined) {
+          acc.itemsToSelect.push(theItem);
+        } else {
+          acc.itemsToRemove.push(selectedItems[selectedIndex]);
+        }
+        return acc;
+      },
+      {
+        itemsToSelect: [],
+        itemsToRemove: [],
       }
-    });
+    );
 
-    if (selectedIndex === undefined) {
-      this.handleSelectItem(item);
-      return;
+    if (result.itemsToSelect.length > 0) {
+      this.handleSelectItem(result.itemsToSelect);
     }
-    this.handleRemoveItem(selectedIndex);
+    if (result.itemsToRemove.length > 0) {
+      this.handleRemoveItem(result.itemsToRemove);
+    }
   };
 
   render() {
@@ -98,7 +124,7 @@ export default class Selection extends React.Component {
 
 // Generic utility for safely removing an element at a given index from an
 // array.
-const removeAtIndex = (array, index) => {
+export const removeAtIndex = (array, index) => {
   const result = array.slice();
   result.splice(index, 1);
   return result;


### PR DESCRIPTION
Move from carbon-design-system/carbon-addons-cloud-react

Fixes #2580.

Move filterable multi-select component to Carbon from https://github.com/carbon-design-system/carbon-addons-cloud-react/tree/master/src/components/MultiSelect 

#### Changelog

**New**

- src/components/GroupLabel/GroupLabel-story.js
- src/components/GroupLabel/GroupLabel.js
- src/components/GroupLabel/index.js
- src/components/MultiSelect/NestedFilterableMultiselect.js
- src/components/MultiSelect/__tests__/NestedFilterableMultiselect-test.js
- src/components/MultiSelect/__tests__/__snapshots__/NestedFilterableMultiselect-test.js.snap
- src/components/MultiSelect/tools/filter.js
- src/components/MultiSelect/tools/groupedByCategory.js

**Changed**

- ../components/docs/sass.md
- src/components/MultiSelect/MultiSelect-story.js
- src/components/MultiSelect/index.js
- src/components/MultiSelect/tools/__tests__/sorting-test.js
- src/components/MultiSelect/tools/sorting.js
- modified:   src/internal/Selection.js

**Removed**

none

#### Testing / Reviewing

use `yarn storybook`
