### PR TITLE
fix(skeleton-components): convert Breadcrumb, Fileuploader, ProgressIndicator, RadioButton, Tabs, and Tag skeletons to function declarations

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -10,13 +10,13 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const BreadcrumbSkeleton = () => {
-  const item = (
-    <div className={`${prefix}--breadcrumb-item`}>
-      <span className={`${prefix}--link`}>&nbsp;</span>
-    </div>
-  );
+const item = (
+  <div className={`${prefix}--breadcrumb-item`}>
+    <span className={`${prefix}--link`}>&nbsp;</span>
+  </div>
+);
 
+function BreadcrumbSkeleton() {
   return (
     <div className={`${prefix}--breadcrumb ${prefix}--skeleton`}>
       {item}
@@ -24,6 +24,6 @@ const BreadcrumbSkeleton = () => {
       {item}
     </div>
   );
-};
+}
 
 export default BreadcrumbSkeleton;

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -10,19 +10,20 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-export default class BreadcrumbSkeleton extends React.Component {
-  render() {
-    const item = (
-      <div className={`${prefix}--breadcrumb-item`}>
-        <span className={`${prefix}--link`}>&nbsp;</span>
-      </div>
-    );
-    return (
-      <div className={`${prefix}--breadcrumb ${prefix}--skeleton`}>
-        {item}
-        {item}
-        {item}
-      </div>
-    );
-  }
-}
+const BreadcrumbSkeleton = () => {
+  const item = (
+    <div className={`${prefix}--breadcrumb-item`}>
+      <span className={`${prefix}--link`}>&nbsp;</span>
+    </div>
+  );
+
+  return (
+    <div className={`${prefix}--breadcrumb ${prefix}--skeleton`}>
+      {item}
+      {item}
+      {item}
+    </div>
+  );
+};
+
+export default BreadcrumbSkeleton;

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
@@ -12,17 +12,12 @@ import ButtonSkeleton from '../Button/Button.Skeleton';
 
 const { prefix } = settings;
 
-export default class FileUploaderSkeleton extends React.Component {
-  render() {
-    return (
-      <div className={`${prefix}--form-item`}>
-        <SkeletonText heading width="100px" />
-        <SkeletonText
-          width="225px"
-          className={`${prefix}--label-description`}
-        />
-        <ButtonSkeleton />
-      </div>
-    );
-  }
-}
+const FileUploaderSkeleton = () => (
+  <div className={`${prefix}--form-item`}>
+    <SkeletonText heading width="100px" />
+    <SkeletonText width="225px" className={`${prefix}--label-description`} />
+    <ButtonSkeleton />
+  </div>
+);
+
+export default FileUploaderSkeleton;

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
@@ -12,12 +12,14 @@ import ButtonSkeleton from '../Button/Button.Skeleton';
 
 const { prefix } = settings;
 
-const FileUploaderSkeleton = () => (
-  <div className={`${prefix}--form-item`}>
-    <SkeletonText heading width="100px" />
-    <SkeletonText width="225px" className={`${prefix}--label-description`} />
-    <ButtonSkeleton />
-  </div>
-);
+function FileUploaderSkeleton() {
+  return (
+    <div className={`${prefix}--form-item`}>
+      <SkeletonText heading width="100px" />
+      <SkeletonText width="225px" className={`${prefix}--label-description`} />
+      <ButtonSkeleton />
+    </div>
+  );
+}
 
 export default FileUploaderSkeleton;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -10,33 +10,33 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-export default class ProgressIndicatorSkeleton extends React.Component {
-  render() {
-    const currentSvg = (
-      <svg>
-        <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
-      </svg>
-    );
+const ProgressIndicatorSkeleton = () => {
+  const currentSvg = (
+    <svg>
+      <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
+    </svg>
+  );
 
-    const step = (
-      <li
-        className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
-        <div
-          className={`${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable`}>
-          {currentSvg}
-          <p className={`${prefix}--progress-label`} />
-          <span className={`${prefix}--progress-line`} />
-        </div>
-      </li>
-    );
+  const step = (
+    <li
+      className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
+      <div
+        className={`${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable`}>
+        {currentSvg}
+        <p className={`${prefix}--progress-label`} />
+        <span className={`${prefix}--progress-line`} />
+      </div>
+    </li>
+  );
 
-    return (
-      <ul className={`${prefix}--progress ${prefix}--skeleton`}>
-        {step}
-        {step}
-        {step}
-        {step}
-      </ul>
-    );
-  }
-}
+  return (
+    <ul className={`${prefix}--progress ${prefix}--skeleton`}>
+      {step}
+      {step}
+      {step}
+      {step}
+    </ul>
+  );
+};
+
+export default ProgressIndicatorSkeleton;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -10,25 +10,21 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const ProgressIndicatorSkeleton = () => {
-  const currentSvg = (
-    <svg>
-      <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
-    </svg>
-  );
+const step = (
+  <li
+    className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
+    <div
+      className={`${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable`}>
+      <svg>
+        <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
+      </svg>
+      <p className={`${prefix}--progress-label`} />
+      <span className={`${prefix}--progress-line`} />
+    </div>
+  </li>
+);
 
-  const step = (
-    <li
-      className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
-      <div
-        className={`${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable`}>
-        {currentSvg}
-        <p className={`${prefix}--progress-label`} />
-        <span className={`${prefix}--progress-line`} />
-      </div>
-    </li>
-  );
-
+function ProgressIndicatorSkeleton() {
   return (
     <ul className={`${prefix}--progress ${prefix}--skeleton`}>
       {step}
@@ -37,6 +33,6 @@ const ProgressIndicatorSkeleton = () => {
       {step}
     </ul>
   );
-};
+}
 
 export default ProgressIndicatorSkeleton;

--- a/packages/react/src/components/RadioButton/RadioButton-test.js
+++ b/packages/react/src/components/RadioButton/RadioButton-test.js
@@ -151,7 +151,7 @@ describe('RadioButtonSkeleton', () => {
   describe('Renders as expected', () => {
     const wrapper = shallow(<RadioButtonSkeleton />);
 
-    const label = wrapper.find('label');
+    const label = wrapper.find('span');
 
     it('Has the expected classes', () => {
       expect(label.hasClass(`${prefix}--skeleton`)).toEqual(true);

--- a/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
+++ b/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
@@ -10,11 +10,13 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const RadioButtonSkeleton = () => (
-  <div className={`${prefix}--radio-button-wrapper`}>
-    <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
-    <span className={`${prefix}--radio-button__label ${prefix}--skeleton`} />
-  </div>
-);
+function RadioButtonSkeleton() {
+  return (
+    <div className={`${prefix}--radio-button-wrapper`}>
+      <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
+      <span className={`${prefix}--radio-button__label ${prefix}--skeleton`} />
+    </div>
+  );
+}
 
 export default RadioButtonSkeleton;

--- a/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
+++ b/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
@@ -10,20 +10,11 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-export default class RadioButtonSkeleton extends React.Component {
-  render() {
-    const { id } = this.props;
-    return (
-      <div className={`${prefix}--radio-button-wrapper`}>
-        <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
-        {
-          /* eslint-disable jsx-a11y/label-has-for,jsx-a11y/label-has-associated-control */
-          <label
-            className={`${prefix}--radio-button__label ${prefix}--skeleton`}
-            htmlFor={id}
-          />
-        }
-      </div>
-    );
-  }
-}
+const RadioButtonSkeleton = () => (
+  <div className={`${prefix}--radio-button-wrapper`}>
+    <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
+    <span className={`${prefix}--radio-button__label ${prefix}--skeleton`} />
+  </div>
+);
+
+export default RadioButtonSkeleton;

--- a/packages/react/src/components/Tabs/Tabs.Skeleton.js
+++ b/packages/react/src/components/Tabs/Tabs.Skeleton.js
@@ -10,13 +10,13 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const TabsSkeleton = () => {
-  const tab = (
-    <li className={`${prefix}--tabs__nav-item`}>
-      <div className={`${prefix}--tabs__nav-link`}>&nbsp;</div>
-    </li>
-  );
+const tab = (
+  <li className={`${prefix}--tabs__nav-item`}>
+    <div className={`${prefix}--tabs__nav-link`}>&nbsp;</div>
+  </li>
+);
 
+function TabsSkeleton() {
   return (
     <div className={`${prefix}--tabs ${prefix}--skeleton`}>
       <div className={`${prefix}--tabs-trigger`}>
@@ -33,6 +33,6 @@ const TabsSkeleton = () => {
       </ul>
     </div>
   );
-};
+}
 
 export default TabsSkeleton;

--- a/packages/react/src/components/Tabs/Tabs.Skeleton.js
+++ b/packages/react/src/components/Tabs/Tabs.Skeleton.js
@@ -10,31 +10,29 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-export default class TabsSkeleton extends React.Component {
-  render() {
-    const tab = (
-      <li className={`${prefix}--tabs__nav-item`}>
-        <div className={`${prefix}--tabs__nav-link`}>&nbsp;</div>
-      </li>
-    );
-    return (
-      <div className={`${prefix}--tabs ${prefix}--skeleton`}>
-        <div className={`${prefix}--tabs-trigger`}>
-          <div className={`${prefix}--tabs-trigger-text`}>&nbsp;</div>
-          <svg width="10" height="5" viewBox="0 0 10 5" fillRule="evenodd">
-            <path d="M10 0L5 5 0 0z" />
-          </svg>
-        </div>
-        <ul className={`${prefix}--tabs__nav ${prefix}--tabs__nav--hidden`}>
-          <li
-            className={`${prefix}--tabs__nav-item ${prefix}--tabs__nav-item--selected`}>
-            <div className={`${prefix}--tabs__nav-link`}> &nbsp;</div>
-          </li>
-          {tab}
-          {tab}
-          {tab}
-        </ul>
+const TabsSkeleton = () => {
+  const tab = (
+    <li className={`${prefix}--tabs__nav-item`}>
+      <div className={`${prefix}--tabs__nav-link`}>&nbsp;</div>
+    </li>
+  );
+
+  return (
+    <div className={`${prefix}--tabs ${prefix}--skeleton`}>
+      <div className={`${prefix}--tabs-trigger`}>
+        <div className={`${prefix}--tabs-trigger-text`}>&nbsp;</div>
+        <svg width="10" height="5" viewBox="0 0 10 5" fillRule="evenodd">
+          <path d="M10 0L5 5 0 0z" />
+        </svg>
       </div>
-    );
-  }
-}
+      <ul className={`${prefix}--tabs__nav ${prefix}--tabs__nav--hidden`}>
+        {tab}
+        {tab}
+        {tab}
+        {tab}
+      </ul>
+    </div>
+  );
+};
+
+export default TabsSkeleton;

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -10,8 +10,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-export default class TagSkeleton extends React.Component {
-  render() {
-    return <span className={`${prefix}--tag ${prefix}--skeleton`} />;
-  }
-}
+const TagSkeleton = () => (
+  <span className={`${prefix}--tag ${prefix}--skeleton`} />
+);
+
+export default TagSkeleton;

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -10,8 +10,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const TagSkeleton = () => (
-  <span className={`${prefix}--tag ${prefix}--skeleton`} />
-);
+function TagSkeleton() {
+  return <span className={`${prefix}--tag ${prefix}--skeleton`} />;
+}
 
 export default TagSkeleton;


### PR DESCRIPTION
Partially addresses #4398

I was looking at some of the skeleton components noted to have missing props in #4398, including:

- [x] `BreadcrumbSkeleton`
- [x] `FileuploaderSkeleton`
- [x] `ProgressIndicatorSkeleton`
- [x] `RadioButtonSkeleton`
- [x] `TabsSkeleton`
- [x] `TagSkeleton`

 ... but I didn't find any undocumented or missing props in those. (Unless the purpose is to add `className` props to each?)

Only `RadioButtonSkeleton` had a prop, `id`, but in that case the prop was unnecessary because it was assigned to `label` element that was untied to any `input`. (Which I propose removing)

In the process of checking these components, I took the opportunity to convert them from classes to ~functional components~ function declarations & follow patterns used in other skeleton components. This conversion may also help with auditing these components in the future.

Please let me know if you have questions or concerns about this -- thank you!


#### Changelog

**Changed**

- convert `BreadcrumbSkeleton` to functional component
- convert `FileuploaderSkeleton` to functional component
- convert `ProgressIndicatorSkeleton` to functional component
- convert `RadioButtonSkeleton` to functional component
- convert `TabsSkeleton` to functional component
- convert `TagSkeleton` to functional component

**Removed**

- removed `id` prop from `RadioButtonSkeleton` & updated the `label` to a `span` instead
