### PR TITLE
fix(list): correct list alignment and numbering

### DIFF
--- a/packages/components/src/components/list/_list.scss
+++ b/packages/components/src/components/list/_list.scss
@@ -23,88 +23,49 @@
   .#{$prefix}--list--ordered {
     @include reset;
     @include type-style('body-short-01');
-
-    counter-reset: listitem;
   }
 
   .#{$prefix}--list__item {
-    font-weight: 400;
     color: $text-01;
-    list-style-type: none;
-    counter-increment: listitem;
-    margin-left: $carbon--spacing-03;
-    padding-left: $carbon--spacing-03;
-    position: relative;
-  }
-
-  .#{$prefix}--list__item:before {
-    position: absolute;
-    left: -#{$carbon--spacing-03};
+    margin-bottom: #{$carbon--spacing-02};
   }
 
   .#{$prefix}--list--nested {
-    margin-bottom: rem(4px);
-    margin-left: $carbon--spacing-07;
+    margin-top: #{$carbon--spacing-02};
+    margin-left: #{$carbon--spacing-06};
   }
 
-  .#{$prefix}--list--unordered > .#{$prefix}--list__item:before,
-  .#{$prefix}--list--ordered > .#{$prefix}--list__item:before {
-    display: inline-block;
-    margin-right: $carbon--spacing-03;
-    margin-bottom: rem(4px);
+  .#{$prefix}--list--nested > .#{$prefix}--list__item {
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
-  .#{$prefix}--list--unordered
-    .#{$prefix}--list--nested
-    > .#{$prefix}--list__item:before,
-  .#{$prefix}--list--ordered
-    .#{$prefix}--list--nested
-    > .#{$prefix}--list__item:before {
-    margin-right: $carbon--spacing-03;
-    display: inline-block;
+  .#{$prefix}--list--nested .#{$prefix}--list--nested {
+    margin-top: 0;
   }
 
-  .#{$prefix}--list--unordered > .#{$prefix}--list__item:before {
-    content: '\002013';
+  .#{$prefix}--list--ordered {
+    list-style-type: decimal;
   }
 
-  .#{$prefix}--list--unordered
-    ul.#{$prefix}--list--nested
-    > .#{$prefix}--list__item:before {
-    content: '\0025AA';
+  .#{$prefix}--list--ordered.#{$prefix}--list--nested {
+    list-style-type: lower-latin;
   }
 
-  .#{$prefix}--list--unordered
-    ol.#{$prefix}--list--nested
-    > .#{$prefix}--list__item:before {
-    content: counter(listitem, lower-alpha) '.';
+  .#{$prefix}--list--unordered > .#{$prefix}--list__item {
+    position: relative;
+
+    &::before {
+      position: absolute;
+      left: -#{$carbon--spacing-05};
+      content: '\002013'; // – en dash
+    }
   }
 
-  .#{$prefix}--list--ordered > .#{$prefix}--list__item:before {
-    content: counter(listitem) '.';
-  }
-
-  .#{$prefix}--list--ordered ol.#{$prefix}--list--nested {
-    counter-reset: ol-counter;
-  }
-
-  .#{$prefix}--list--ordered
-    ol.#{$prefix}--list--nested
-    > .#{$prefix}--list__item {
-    counter-increment: ol-counter;
-  }
-
-  .#{$prefix}--list--ordered
-    ol.#{$prefix}--list--nested
-    > .#{$prefix}--list__item:before {
-    content: counter(ol-counter, lower-alpha) '.';
-    width: 0.6rem;
-  }
-
-  .#{$prefix}--list--ordered
-    ul.#{$prefix}--list--nested
-    > .#{$prefix}--list__item:before {
-    content: '\0025AA';
+  .#{$prefix}--list--unordered.#{$prefix}--list--nested
+    > .#{$prefix}--list__item::before {
+    left: -#{$carbon--spacing-04}; // offset to account for smaller ▪ vs –
+    content: '\0025AA'; // ▪ square
   }
 }
 

--- a/packages/components/src/components/list/_list.scss
+++ b/packages/components/src/components/list/_list.scss
@@ -27,12 +27,12 @@
 
   .#{$prefix}--list__item {
     color: $text-01;
-    margin-bottom: #{$carbon--spacing-02};
+    margin-bottom: $carbon--spacing-02;
   }
 
   .#{$prefix}--list--nested {
-    margin-top: #{$carbon--spacing-02};
-    margin-left: #{$carbon--spacing-06};
+    margin-top: $carbon--spacing-02;
+    margin-left: $carbon--spacing-06;
   }
 
   .#{$prefix}--list--nested > .#{$prefix}--list__item {
@@ -57,14 +57,14 @@
 
     &::before {
       position: absolute;
-      left: -#{$carbon--spacing-05};
+      left: -$carbon--spacing-05;
       content: '\002013'; // – en dash
     }
   }
 
   .#{$prefix}--list--unordered.#{$prefix}--list--nested
     > .#{$prefix}--list__item::before {
-    left: -#{$carbon--spacing-04}; // offset to account for smaller ▪ vs –
+    left: -$carbon--spacing-04; // offset to account for smaller ▪ vs –
     content: '\0025AA'; // ▪ square
   }
 }

--- a/packages/components/src/components/list/list--nesting.hbs
+++ b/packages/components/src/components/list/list--nesting.hbs
@@ -7,21 +7,22 @@
 
 <ol class="{{@root.prefix}}--list--ordered">
   <li class="{{@root.prefix}}--list__item"> Ordered List level 1
-    <ul class="{{@root.prefix}}--list--nested">
+    <ul class="{{@root.prefix}}--list--unordered {{@root.prefix}}--list--nested">
       <li class="{{@root.prefix}}--list__item"> Unordered List level 2</li>
       <li class="{{@root.prefix}}--list__item"> Unordered List level 2
-        <ol class="bx--list--nested">
-          <li class="bx--list__item"> Ordered List level 3</li>
-          <li class="bx--list__item"> Ordered List level 3
-            <ul class="bx--list--nested">
-              <li class="bx--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam venenatis
+        <ol class="{{@root.prefix}}--list--ordered {{@root.prefix}}--list--nested">
+          <li class="{{@root.prefix}}--list__item"> Ordered List level 3</li>
+          <li class="{{@root.prefix}}--list__item"> Ordered List level 3
+            <ul class="{{@root.prefix}}--list--unordered {{@root.prefix}}--list--nested">
+              <li class="{{@root.prefix}}--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+                venenatis
                 aliquet odio ut viverra. Integer sollicitudin sed mi a finibus. Etiam massa ipsum, suscipit vitae nisl
                 ut, semper euismod ante.</li>
-              <li class="bx--list__item"> Unordered List level 4</li>
-              <li class="bx--list__item"> Unordered List level 4</li>
+              <li class="{{@root.prefix}}--list__item"> Unordered List level 4</li>
+              <li class="{{@root.prefix}}--list__item"> Unordered List level 4</li>
             </ul>
           </li>
-          <li class="bx--list__item"> Ordered List level 3</li>
+          <li class="{{@root.prefix}}--list__item"> Ordered List level 3</li>
         </ol>
       </li>
       <li class="{{@root.prefix}}--list__item"> Unordered List level 2</li>
@@ -33,22 +34,23 @@
 <br>
 <ul class="{{@root.prefix}}--list--unordered">
   <li class="{{@root.prefix}}--list__item">Unordered List level 1
-    <ol class="{{@root.prefix}}--list--nested">
+    <ol class="{{@root.prefix}}--list--ordered {{@root.prefix}}--list--nested">
       <li class="{{@root.prefix}}--list__item">Ordered List level 2</li>
       <li class="{{@root.prefix}}--list__item">Ordered
         List level 2
-        <ul class="bx--list--nested">
-          <li class="bx--list__item"> Unordered List level 3</li>
-          <li class="bx--list__item"> Unordered List level 3
-            <ol class="bx--list--nested">
-              <li class="bx--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam venenatis
+        <ul class="{{@root.prefix}}--list--unordered {{@root.prefix}}--list--nested">
+          <li class="{{@root.prefix}}--list__item"> Unordered List level 3</li>
+          <li class="{{@root.prefix}}--list__item"> Unordered List level 3
+            <ol class="{{@root.prefix}}--list--ordered {{@root.prefix}}--list--nested">
+              <li class="{{@root.prefix}}--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+                venenatis
                 aliquet odio ut viverra. Integer sollicitudin sed mi a finibus. Etiam massa ipsum, suscipit vitae nisl
                 ut, semper euismod ante.</li>
-              <li class="bx--list__item"> Ordered List level 4</li>
-              <li class="bx--list__item"> Ordered List level 4</li>
+              <li class="{{@root.prefix}}--list__item"> Ordered List level 4</li>
+              <li class="{{@root.prefix}}--list__item"> Ordered List level 4</li>
             </ol>
           </li>
-          <li class="bx--list__item"> Unordered List level 3</li>
+          <li class="{{@root.prefix}}--list__item"> Unordered List level 3</li>
         </ul>
       </li>
       <li class="{{@root.prefix}}--list__item">Ordered List level 2</li>

--- a/packages/components/src/components/list/list--nesting.hbs
+++ b/packages/components/src/components/list/list--nesting.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -14,7 +14,9 @@
           <li class="bx--list__item"> Ordered List level 3</li>
           <li class="bx--list__item"> Ordered List level 3
             <ul class="bx--list--nested">
-              <li class="bx--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam venenatis aliquet odio ut viverra. Integer sollicitudin sed mi a finibus. Etiam massa ipsum, suscipit vitae nisl ut, semper euismod ante.</li>
+              <li class="bx--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam venenatis
+                aliquet odio ut viverra. Integer sollicitudin sed mi a finibus. Etiam massa ipsum, suscipit vitae nisl
+                ut, semper euismod ante.</li>
               <li class="bx--list__item"> Unordered List level 4</li>
               <li class="bx--list__item"> Unordered List level 4</li>
             </ul>
@@ -33,13 +35,15 @@
   <li class="{{@root.prefix}}--list__item">Unordered List level 1
     <ol class="{{@root.prefix}}--list--nested">
       <li class="{{@root.prefix}}--list__item">Ordered List level 2</li>
-      <li class="{{@root.prefix}}--list__item">Ordered 
+      <li class="{{@root.prefix}}--list__item">Ordered
         List level 2
         <ul class="bx--list--nested">
           <li class="bx--list__item"> Unordered List level 3</li>
           <li class="bx--list__item"> Unordered List level 3
             <ol class="bx--list--nested">
-              <li class="bx--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam venenatis aliquet odio ut viverra. Integer sollicitudin sed mi a finibus. Etiam massa ipsum, suscipit vitae nisl ut, semper euismod ante.</li>
+              <li class="bx--list__item"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam venenatis
+                aliquet odio ut viverra. Integer sollicitudin sed mi a finibus. Etiam massa ipsum, suscipit vitae nisl
+                ut, semper euismod ante.</li>
               <li class="bx--list__item"> Ordered List level 4</li>
               <li class="bx--list__item"> Ordered List level 4</li>
             </ol>

--- a/packages/components/src/components/list/list.hbs
+++ b/packages/components/src/components/list/list.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -8,10 +8,10 @@
 <{{tag}} class="{{@root.prefix}}--list--{{type}}">
   <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1
     <{{tag}} class="{{@root.prefix}}--list--nested">
-      <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
-      <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
-    </{{tag}}>
-  </li>
-  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1</li>
-  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1</li>
+  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
+  <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
+</{{tag}}>
+</li>
+<li class="{{@root.prefix}}--list__item">{{displayType}} List level 1</li>
+<li class="{{@root.prefix}}--list__item">{{displayType}} List level 1</li>
 </{{tag}}>

--- a/packages/components/src/components/list/list.hbs
+++ b/packages/components/src/components/list/list.hbs
@@ -7,7 +7,7 @@
 
 <{{tag}} class="{{@root.prefix}}--list--{{type}}">
   <li class="{{@root.prefix}}--list__item">{{displayType}} List level 1
-    <{{tag}} class="{{@root.prefix}}--list--nested">
+    <{{tag}} class="{{@root.prefix}}--list--{{type}} {{@root.prefix}}--list--nested">
   <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
   <li class="{{@root.prefix}}--list__item">{{displayType}} List level 2</li>
 </{{tag}}>

--- a/packages/react/src/components/OrderedList/OrderedList-story.js
+++ b/packages/react/src/components/OrderedList/OrderedList-story.js
@@ -8,9 +8,9 @@ storiesOf('OrderedList', module)
     'default',
     () => (
       <OrderedList>
-        <ListItem>Unordered List level 1</ListItem>
-        <ListItem>Unordered List level 1</ListItem>
-        <ListItem>Unordered List level 1</ListItem>
+        <ListItem>Ordered List level 1</ListItem>
+        <ListItem>Ordered List level 1</ListItem>
+        <ListItem>Ordered List level 1</ListItem>
       </OrderedList>
     ),
     {
@@ -23,17 +23,21 @@ storiesOf('OrderedList', module)
     'nested',
     () => (
       <OrderedList>
-        <ListItem>Unordered List level 1</ListItem>
-        <OrderedList nested>
-          <ListItem>Unordered List level 2</ListItem>
-          <ListItem>Unordered List level 2</ListItem>
+        <ListItem>
+          Ordered List level 1
           <OrderedList nested>
-            <ListItem>Unordered List level 2</ListItem>
-            <ListItem>Unordered List level 2</ListItem>
+            <ListItem>Ordered List level 2</ListItem>
+            <ListItem>
+              Ordered List level 2
+              <OrderedList nested>
+                <ListItem>Ordered List level 2</ListItem>
+                <ListItem>Ordered List level 2</ListItem>
+              </OrderedList>
+            </ListItem>
           </OrderedList>
-        </OrderedList>
-        <ListItem>Unordered List level 1</ListItem>
-        <ListItem>Unordered List level 1</ListItem>
+        </ListItem>
+        <ListItem>Ordered List level 1</ListItem>
+        <ListItem>Ordered List level 1</ListItem>
       </OrderedList>
     ),
     {

--- a/packages/react/src/components/UnorderedList/UnorderedList-story.js
+++ b/packages/react/src/components/UnorderedList/UnorderedList-story.js
@@ -34,11 +34,19 @@ storiesOf('UnorderedList', module)
     'nested',
     () => (
       <UnorderedList>
-        <ListItem>Unordered List level 1</ListItem>
-        <UnorderedList nested>
-          <ListItem>Unordered List level 2</ListItem>
-          <ListItem>Unordered List level 2</ListItem>
-        </UnorderedList>
+        <ListItem>
+          Unordered List level 1
+          <UnorderedList nested>
+            <ListItem>Unordered List level 2</ListItem>
+            <ListItem>
+              Unordered List level 2
+              <UnorderedList nested>
+                <ListItem>Unordered List level 2</ListItem>
+                <ListItem>Unordered List level 2</ListItem>
+              </UnorderedList>
+            </ListItem>
+          </UnorderedList>
+        </ListItem>
         <ListItem>Unordered List level 1</ListItem>
         <ListItem>Unordered List level 1</ListItem>
       </UnorderedList>


### PR DESCRIPTION
Closes #4433
Closes #3133

This PR adjusts ordered and unordered list spacing according to the updated spec and resolves a spacing issue for ordered lists with many list items. Previously we were using CSS counters and pseudo elements to replace the ordered list numbers, but since the spacing of these numbers was fixed they would overlap with the list item content if the number became large. We are no longer using pseudo elements for ordered lists and rely on the default implementation for ordered list numbering and spacing. (This may cause downstream changes for the Gatsby theme, website, and IDL site ref https://github.com/carbon-design-system/design-language-website/pull/229, https://github.com/carbon-design-system/gatsby-theme-carbon/pull/189)

#### Changelog

**Changed**

- update horizontal and vertical spacing according to updated component spec
- fix invalid markup in component examples

**Removed**

- CSS counter for ordered list numbering

#### Testing / Reviewing

Ensure the components match the latest spec (ordered, unordered, nested, etc)

Ensure that no content overlaps with the numbers for long ordered lists
