### PR TITLE
fix(ComposedModal): remove scroller class on unmount

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -168,10 +168,14 @@ describe('<ComposedModal />', () => {
   });
 
   it('should change class of <body> upon open state', () => {
-    mount(<ComposedModal open />);
+    const wrapper = mount(<ComposedModal open />);
     expect(
       document.body.classList.contains('bx--body--with-modal-open')
     ).toEqual(true);
+    wrapper.unmount();
+    expect(
+      document.body.classList.contains('bx--body--with-modal-open')
+    ).toEqual(false);
     mount(<ComposedModal open={false} />);
     expect(
       document.body.classList.contains('bx--body--with-modal-open')

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -148,6 +148,10 @@ export default class ComposedModal extends Component {
     }
   };
 
+  componentWillUnmount() {
+    toggleClass(document.body, `${prefix}--body--with-modal-open`, false);
+  }
+
   componentDidMount() {
     toggleClass(
       document.body,

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -122,16 +122,16 @@ export default class ComposedModal extends Component {
     }
   };
 
-  componentDidUpdate(prevProps) {
-    if (!prevProps.open && this.props.open) {
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.open && this.state.open) {
       this.beingOpen = true;
-    } else if (prevProps.open && !this.props.open) {
+    } else if (prevState.open && !this.state.open) {
       this.beingOpen = false;
     }
     toggleClass(
       document.body,
       `${prefix}--body--with-modal-open`,
-      this.props.open
+      this.state.open
     );
   }
 


### PR DESCRIPTION
Ports #4066.
Fixes #3945.

#### Changelog

**New**

- Code to remove scroller CSS class on ummounting `<ComposedModal>`.

#### Testing / Reviewing

Testing should make sure `<ComposedModal>` is not broken.