### PR TITLE
fix(DataTable): add the missing isSortable property

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.js
+++ b/packages/react/src/components/DataTable/DataTable.js
@@ -115,6 +115,11 @@ export default class DataTable extends React.Component {
      * Still experimental: may not work with every combination of table props
      */
     stickyHeader: PropTypes.bool,
+    
+    /**
+     * Specify whether the table should be able to be sorted by its headers
+     */
+    isSortable: PropTypes.bool,
   };
 
   static defaultProps = {

--- a/packages/react/src/components/DataTable/DataTable.js
+++ b/packages/react/src/components/DataTable/DataTable.js
@@ -115,7 +115,7 @@ export default class DataTable extends React.Component {
      * Still experimental: may not work with every combination of table props
      */
     stickyHeader: PropTypes.bool,
-    
+
     /**
      * Specify whether the table should be able to be sorted by its headers
      */


### PR DESCRIPTION
Added the missing isSortable property to DataTable.

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
