### PR TITLE
fix(dropdown): issues with activedescendant attribute

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -249,7 +249,10 @@
 
   // Don't want to allow multiple elements have a "selected" style. Not sure why active
   // had unique styles initially but creating an overwrite for the latest HTML markup for
-  // backwards compatibility
+  // backwards compatibility. For the next major release it would be possible to clean up
+  // the HTML structure to prevent the user of :active and :focus styles which is creating
+  // these duplicated styles in the list. The Carbon 10 version of dropdown is already
+  // supporting 2 very different HTML structures.
   .#{$prefix}--dropdown-list[aria-activedescendant]
     .#{$prefix}--dropdown-item:active {
     background-color: inherit;

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -229,6 +229,24 @@
     padding: rem(11px) rem(16px);
   }
 
+  // We don't want to apply focus styles via focus selector when using the aria-activedescendant structure
+  .#{$prefix}--dropdown-list[aria-activedescendant]
+    .#{$prefix}--dropdown-link:focus {
+    outline: none;
+    // Copied from .bx--dropdown-link styles
+    margin: 0 $carbon--spacing-05;
+    padding: rem(11px) 0;
+  }
+
+  // Need added weight for item that is :focused and .bx--dropdown--focused
+  .#{$prefix}--dropdown-list[aria-activedescendant]
+    .#{$prefix}--dropdown--focused:focus {
+    // copied from default focus styles
+    @include focus-outline('outline');
+    margin: 0;
+    padding: rem(11px) rem(16px);
+  }
+
   .#{$prefix}--dropdown-item:hover .#{$prefix}--dropdown-link {
     border-bottom-color: $hover-ui;
   }

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -247,6 +247,14 @@
     padding: rem(11px) rem(16px);
   }
 
+  // Don't want to allow multiple elements have a "selected" style. Not sure why active
+  // had unique styles initially but creating an overwrite for the latest HTML markup for
+  // backwards compatibility
+  .#{$prefix}--dropdown-list[aria-activedescendant]
+    .#{$prefix}--dropdown-item:active {
+    background-color: inherit;
+  }
+
   .#{$prefix}--dropdown-item:hover .#{$prefix}--dropdown-link {
     border-bottom-color: $hover-ui;
   }

--- a/packages/components/src/components/dropdown/dropdown.js
+++ b/packages/components/src/components/dropdown/dropdown.js
@@ -65,6 +65,7 @@ class Dropdown extends mixin(
     // we want the focus class to move as the user hovers over items. This also updates the location of focus based on
     // the last hovered item if the user switches back to using the keyboard.
     if (
+      // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
       this.element.querySelector(this.options.selectorTrigger) &&
       this.element.querySelector(this.options.selectorMenu)
     ) {
@@ -120,6 +121,7 @@ class Dropdown extends mixin(
    * @private
    */
   _focusCleanup() {
+    // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
     const triggerNode = this.element.querySelector(
       this.options.selectorTrigger
     );
@@ -145,6 +147,7 @@ class Dropdown extends mixin(
    * @param {HTMLElement} itemToFocus The element to be focused.
    */
   _updateFocus(itemToFocus) {
+    // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
     const triggerNode = this.element.querySelector(
       this.options.selectorTrigger
     );
@@ -179,6 +182,7 @@ class Dropdown extends mixin(
       return;
     }
 
+    // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
     const triggerNode = this.element.querySelector(
       this.options.selectorTrigger
     );
@@ -275,6 +279,7 @@ class Dropdown extends mixin(
 
     // Using the latest semantic markup structure where trigger is a button
     // @todo remove conditional once legacy structure is depreciated
+    // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
     if (this.element.querySelector(this.options.selectorTrigger)) {
       const listNode = this.element.querySelector(this.options.selectorMenu);
       const focusedId = listNode.getAttribute('aria-activedescendant');
@@ -329,6 +334,7 @@ class Dropdown extends mixin(
       ) {
         // Using the latest semantic markup structure where trigger is a button
         // @todo remove conditional once legacy structure is depreciated
+        // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
         if (this.element.querySelector(this.options.selectorTrigger)) {
           this._updateFocus(current);
         } else {
@@ -355,6 +361,7 @@ class Dropdown extends mixin(
 
     if (this.element.dispatchEvent(eventStart)) {
       if (this.element.dataset.dropdownType !== 'navigation') {
+        // NOTE: `selectorTrigger` does NOT match the trigger button in older markup
         const selectorText =
           !this.element.querySelector(this.options.selectorTrigger) &&
           this.element.dataset.dropdownType !== 'inline'
@@ -408,7 +415,9 @@ class Dropdown extends mixin(
    * @member Dropdown.options
    * @type {object}
    * @property {string} selectorInit The CSS selector to find selectors.
-   * @property {string} [selectorTrigger] The CSS selector to find trigger button when using a11y compliant markup.
+   * @property {string} [selectorTrigger]
+   *   The CSS selector to find the trigger button when using a11y compliant markup.
+   *   NOTE: Does NOT match the trigger button in older markup.
    * @property {string} [selectorMenu] The CSS selector to find menu list when using a11y compliant markup.
    * @property {string} [selectorText] The CSS selector to find the element showing the selected item.
    * @property {string} [selectorTextInner] The CSS selector to find the element showing the selected item, used for inline mode.
@@ -433,7 +442,7 @@ class Dropdown extends mixin(
     const { prefix } = settings;
     return {
       selectorInit: '[data-dropdown]',
-      selectorTrigger: `button.${prefix}--dropdown-text`,
+      selectorTrigger: `button.${prefix}--dropdown-text`, // NOTE: Does NOT match the trigger button in older markup.
       selectorMenu: `.${prefix}--dropdown-list`,
       selectorText: `.${prefix}--dropdown-text`,
       selectorTextInner: `.${prefix}--dropdown-text__inner`,

--- a/packages/components/src/components/dropdown/dropdown.js
+++ b/packages/components/src/components/dropdown/dropdown.js
@@ -58,6 +58,15 @@ class Dropdown extends mixin(
         }
       })
     );
+
+    this.manage(
+      on(this.element, 'mouseover', event => {
+        const item = eventMatches(event, this.options.selectorItem);
+        if (item) {
+          this._updateFocus(item);
+        }
+      })
+    );
   }
 
   /**
@@ -95,12 +104,11 @@ class Dropdown extends mixin(
   }
 
   /**
-   * When using aria-activedescendent we want to make sure attributes and classes
+   * When using aria-activedescendant we want to make sure attributes and classes
    * are properly cleaned up when the dropdown is closed
    * @private
    */
   _focusCleanup() {
-    console.log('in focusClean up');
     const triggerNode = this.element.querySelector(
       this.options.selectorTrigger
     );
@@ -118,6 +126,30 @@ class Dropdown extends mixin(
       if (focusedItem) {
         focusedItem.classList.remove(this.options.classFocused);
       }
+    }
+  }
+
+  /**
+   * Update focus using aria-activedescendant HTML structure
+   * @param {HTMLElement} itemToFocus The element to be focused.
+   */
+  _updateFocus(itemToFocus) {
+    const triggerNode = this.element.querySelector(
+      this.options.selectorTrigger
+    );
+
+    // only want to grab the listNode IF it's using the latest a11y HTML structure
+    const listNode = triggerNode
+      ? this.element.querySelector(this.options.selectorMenu)
+      : null;
+
+    const previouslyFocused = listNode.querySelector(
+      this.options.selectorItemFocused
+    );
+    itemToFocus.classList.add(this.options.classFocused);
+    listNode.setAttribute('aria-activedescendant', itemToFocus.id);
+    if (previouslyFocused) {
+      previouslyFocused.classList.remove(this.options.classFocused);
     }
   }
 
@@ -287,15 +319,7 @@ class Dropdown extends mixin(
         // Using the latest semantic markup structure where trigger is a button
         // @todo remove conditional once legacy structure is depreciated
         if (this.element.querySelector(this.options.selectorTrigger)) {
-          const listNode = this.element.querySelector(
-            this.options.selectorMenu
-          );
-          const previouslyFocused = listNode.querySelector(
-            this.options.selectorItemFocused
-          );
-          current.classList.add(this.options.classFocused);
-          listNode.setAttribute('aria-activedescendant', current.id);
-          previouslyFocused.classList.remove(this.options.classFocused);
+          this._updateFocus(current);
         } else {
           current.focus();
         }

--- a/packages/components/src/components/dropdown/dropdown.js
+++ b/packages/components/src/components/dropdown/dropdown.js
@@ -59,14 +59,25 @@ class Dropdown extends mixin(
       })
     );
 
-    this.manage(
-      on(this.element, 'mouseover', event => {
-        const item = eventMatches(event, this.options.selectorItem);
-        if (item) {
-          this._updateFocus(item);
-        }
-      })
-    );
+    // When using the active descendant approach we use a class to give focus styles during keyboard (up/down arrows)
+    // navigation instead of relying on the :focus selector. This leaves the potential to have multiple items when
+    // switching interactions between keyboard and mouse users. To more closely align with Carbon React implementation,
+    // we want the focus class to move as the user hovers over items. This also updates the location of focus based on
+    // the last hovered item if the user switches back to using the keyboard.
+    if (
+      this.element.querySelector(this.options.selectorTrigger) &&
+      this.element.querySelector(this.options.selectorMenu)
+    ) {
+      // Using the latest HTML structure that supports the aria-activedescendant attribute
+      this.manage(
+        on(this.element, 'mouseover', event => {
+          const item = eventMatches(event, this.options.selectorItem);
+          if (item) {
+            this._updateFocus(item);
+          }
+        })
+      );
+    }
   }
 
   /**

--- a/packages/components/src/components/dropdown/dropdown.js
+++ b/packages/components/src/components/dropdown/dropdown.js
@@ -95,6 +95,33 @@ class Dropdown extends mixin(
   }
 
   /**
+   * When using aria-activedescendent we want to make sure attributes and classes
+   * are properly cleaned up when the dropdown is closed
+   * @private
+   */
+  _focusCleanup() {
+    console.log('in focusClean up');
+    const triggerNode = this.element.querySelector(
+      this.options.selectorTrigger
+    );
+
+    // only want to grab the listNode IF it's using the latest a11y HTML structure
+    const listNode = triggerNode
+      ? this.element.querySelector(this.options.selectorMenu)
+      : null;
+
+    if (listNode) {
+      listNode.removeAttribute('aria-activedescendant');
+      const focusedItem = this.element.querySelector(
+        this.options.selectorItemFocused
+      );
+      if (focusedItem) {
+        focusedItem.classList.remove(this.options.classFocused);
+      }
+    }
+  }
+
+  /**
    * Opens and closes the dropdown menu.
    * @param {Event} [event] The event triggering this method.
    *
@@ -181,15 +208,7 @@ class Dropdown extends mixin(
         if (triggerNode) {
           triggerNode.setAttribute('aria-expanded', 'false');
         }
-        if (listNode) {
-          listNode.removeAttribute('aria-activedescendant');
-          const focusedItem = this.element.querySelector(
-            this.options.selectorItemFocused
-          );
-          if (focusedItem) {
-            focusedItem.classList.remove(this.options.classFocused);
-          }
-        }
+        this._focusCleanup();
       }
 
       // @todo remove once legacy structure is depreciated
@@ -337,6 +356,7 @@ class Dropdown extends mixin(
    */
   handleBlur() {
     this.element.classList.remove(this.options.classOpen);
+    this._focusCleanup();
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/4031

clean up focus classes and activedescendant attribute when dropdown is blurred.  Also fixed issued @emyarod found in #4406 where it was possible to have multiple focus indicators at once.  To resolve this issue I carried over the functionality of having the focus move with the mouse hover a behavior that is in the React version.  The styling is different than the react version since it's a much bigger undertaking and would most likely require some HTML changes to not create spaghetti CSS. (much better suited for a major change)

#### Changelog

**Changed**

- update Dropdown JavaScript to clean up focus and active descendant when blurred
- update Dropdown JavaScript and styles so focus also moves with the mouse creating a more similar experience to what's in Carbon React.

#### Testing / Reviewing

Shouldn't be able to reproduce the bug in #4406 and the focus moves with the mouse user (@carbon-design-system/design).  When you `blur` the dropdown the active descendent attribute should no longer be on the list.
