### PR TITLE
fix(number-input): use label for aria-label, deprecate ariaLabel prop

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -15,6 +15,7 @@ import {
   CaretUpGlyph,
 } from '@carbon/icons-react';
 import mergeRefs from '../../tools/mergeRefs';
+import deprecate from '../../prop-types/deprecate';
 import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
 import { useControlledStateWithValue } from '../../internal/FeatureFlags';
 
@@ -137,7 +138,10 @@ class NumberInput extends Component {
     /**
      * Provide a description that would be used to best describe the use case of the NumberInput component
      */
-    ariaLabel: PropTypes.string,
+    ariaLabel: deprecate(
+      PropTypes.string,
+      `\nThe prop \`ariaLabel\` for NumberInput has been deprecated in favor of \`label\`.`
+    ),
     /**
      * `true` to use the light version.
      */
@@ -164,7 +168,6 @@ class NumberInput extends Component {
     step: 1,
     invalid: false,
     invalidText: 'Provide invalidText',
-    ariaLabel: 'Numeric input field with increment and decrement buttons',
     helperText: '',
     light: false,
     allowEmpty: false,
@@ -266,7 +269,6 @@ class NumberInput extends Component {
       invalid,
       invalidText,
       helperText,
-      ariaLabel,
       light,
       allowEmpty,
       innerRef: ref,
@@ -298,7 +300,7 @@ class NumberInput extends Component {
           ? value
           : this.state.value,
       readOnly,
-      'aria-label': ariaLabel,
+      'aria-label': label,
     };
 
     const buttonProps = {


### PR DESCRIPTION
Closes #4499

My understanding is that the label text should match the `aria-label` attribute text on the input.

But in this case, both the label and the `aria-label` are populated by separate props, so they can differ if two different strings are provided.

To resolve this, I propose deprecating the `ariaLabel` prop that populates the `aria-label` attribute. And then, I propose making it so the `label` prop also populates the `aria-label` attribute. That way, both the label and `aria-label` will always match.

### Changelog

**Changed**

- use `label` prop to populate `aria-label` attribute text
- deprecate `ariaLabel` prop

**Removed**

- remove default value for `ariaLabel` since the prop is no longer used & is deprecated

#### Testing / Reviewing

View the the PR deployment for `carbon-components-react`, view the `NumberInput` component, and run the DAP tool. Make sure that you don't see a violation for mismatched label/aria-label text, as shown in the originating issue #4499.
