### PR TITLE
fix(checkbox): add display name for forwardref

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.js
+++ b/packages/react/src/components/Checkbox/Checkbox.js
@@ -128,4 +128,6 @@ Checkbox.defaultProps = {
   indeterminate: false,
 };
 
+Checkbox.displayName = 'Checkbox';
+
 export default Checkbox;


### PR DESCRIPTION
Currently the `Checkbox` component has no display name. You can see this in both the story source (where it is listed as `object object`) and in the prop table (where it is listed as `Unknown  component`): http://react.carbondesignsystem.com/?path=/story/checkbox--checked

And if you inspect the component using the React plugin, it appears as `Anonymous`:

![Screen Shot 2019-11-01 at 10 36 20 AM](https://user-images.githubusercontent.com/9057921/68036783-5e5ca500-fc94-11e9-8c7f-3274de2b9bd5.png)

I think it would be best to set the display name in the component source. I realize in previous situations the display name was set in the story source, but this case is a bit different because the component is listed `Anonymous` as shown above.

#### Changelog

**New**

- set `Checkbox` component display name