### PR TITLE
docs(number-input): add display name to the story source

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput-story.js
+++ b/packages/react/src/components/NumberInput/NumberInput-story.js
@@ -50,6 +50,8 @@ const props = () => ({
   ),
 });
 
+NumberInput.displayName = 'NumberInput';
+
 storiesOf('NumberInput', module)
   .addDecorator(withKnobs)
   .add(


### PR DESCRIPTION
### Summary

Storybook is not properly reading the `NumberInput`'s display name, even though it is set in the component. This affects the story source, where the component displays as `[object Ojbect]`. Go here and click on the "show info" button to see what I mean: http://react.carbondesignsystem.com/?path=/story/numberinput--default

An easy fix here is to set a display name in the story source, to help storybook out. Then that fixes the story source AND the prop types in the prop table.

### Context

This situation is slightly different from #4521  -- In *that* issue, the `Checkbox` shows up as `Anonymous` in the React component plugin, as a forwardRef without a name. *AND* storybook does not know it's name, so it cannot show a name in the story source or proptable.

However, for *this* `NumberInput`, you can see that the React component plugin knows the component's display name (NOTE: the `Anonymous` you see below is actually the caret up / down icons, which is a separate thing...)

![Screen Shot 2019-11-01 at 11 16 02 AM](https://user-images.githubusercontent.com/9057921/68038933-0aa08a80-fc99-11e9-9b67-b257285b1633.png)


And indeed, you can see the display name is set in the component source --
https://github.com/carbon-design-system/carbon/blob/86e76f645b5fea05d5b0040931485a39bcf836ae/packages/react/src/components/NumberInput/NumberInput.js#L436-L440


But storybook still does not understand the `NumberInput` display name. In the story source, it shows the component's name as `[object Object]`:

![Screen Shot 2019-11-01 at 11 17 37 AM](https://user-images.githubusercontent.com/9057921/68039060-4f2c2600-fc99-11e9-8112-61512fc10e6a.png)

**So that's why my proposed solution here is to change the display name in the storybook source, as opposed to elsewhere** -- this issue appears to be isolated to the way that storybook is interpreting the display name of the component. 🤔 Whereas the React component plugin knows the component's name.

### Changelog

**New**

- add display name for `NumberInput` in the story source.