### PR TITLE
feat(DataTable): add light prop

### DIFF
--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -249,9 +249,20 @@
     border-top: 1px solid $data-table-zebra-color;
   }
 
-  .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra td,
-  .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra tbody th {
+  .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra
+    tbody
+    tr:nth-child(even)
+    td {
     background: $ui-01;
+  }
+
+  .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra
+    tbody
+    tr:nth-child(odd)
+    td {
+    background: $ui-background;
+    border-bottom-color: $ui-background;
+    border-top-color: $ui-background;
   }
 
   .#{$prefix}--data-table--zebra tbody tr:hover td {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -32,7 +32,7 @@
   }
 
   .#{$prefix}--data-table-header--light {
-    background: $ui-02;
+    background: $ui-background;
   }
 
   .#{$prefix}--data-table-header__title {
@@ -66,7 +66,7 @@
   }
 
   .#{$prefix}--data-table--light tbody {
-    background-color: $ui-02;
+    background-color: $ui-background;
   }
 
   .#{$prefix}--data-table tr {
@@ -248,10 +248,6 @@
     border-bottom: 1px solid $data-table-zebra-color;
     border-top: 1px solid $data-table-zebra-color;
   }
-
-  // .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra tbody tr:nth-child(odd) td {
-  //   background-color: $data-table-zebra-color;
-  // }
 
   .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra td,
   .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra tbody th {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -31,6 +31,10 @@
     padding: $spacing-05 0 $spacing-06 $spacing-05;
   }
 
+  .#{$prefix}--data-table-header--light {
+    background: $ui-02;
+  }
+
   .#{$prefix}--data-table-header__title {
     @include type-style('productive-heading-03');
     color: $text-01;
@@ -59,6 +63,10 @@
     @include type-style('body-short-01');
     background-color: $ui-01;
     width: 100%;
+  }
+
+  .#{$prefix}--data-table--light tbody {
+    background-color: $ui-02;
   }
 
   .#{$prefix}--data-table tr {
@@ -125,6 +133,11 @@
     & + td:first-of-type {
       padding-left: $spacing-04;
     }
+  }
+
+  .#{$prefix}--data-table--light td,
+  .#{$prefix}--data-table--light tbody th {
+    background: $ui-02;
   }
 
   @supports (-moz-appearance: none) {
@@ -234,6 +247,15 @@
     background-color: $data-table-zebra-color;
     border-bottom: 1px solid $data-table-zebra-color;
     border-top: 1px solid $data-table-zebra-color;
+  }
+
+  // .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra tbody tr:nth-child(odd) td {
+  //   background-color: $data-table-zebra-color;
+  // }
+
+  .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra td,
+  .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra tbody th {
+    background: $ui-01;
   }
 
   .#{$prefix}--data-table--zebra tbody tr:hover td {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -32,7 +32,7 @@
   }
 
   .#{$prefix}--data-table-header--light {
-    background: $ui-02;
+    background-color: $ui-02;
   }
 
   .#{$prefix}--data-table-header__title {
@@ -137,7 +137,7 @@
 
   .#{$prefix}--data-table--light td,
   .#{$prefix}--data-table--light tbody th {
-    background: $ui-02;
+    background-color: $ui-02;
   }
 
   @supports (-moz-appearance: none) {
@@ -253,14 +253,14 @@
     tbody
     tr:nth-child(even)
     td {
-    background: $ui-01;
+    background-color: $ui-01;
   }
 
   .#{$prefix}--data-table--light.#{$prefix}--data-table--zebra
     tbody
     tr:nth-child(odd)
     td {
-    background: $ui-02;
+    background-color: $ui-02;
     border-bottom-color: $ui-02;
     border-top-color: $ui-02;
   }

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -32,7 +32,7 @@
   }
 
   .#{$prefix}--data-table-header--light {
-    background: $ui-background;
+    background: $ui-02;
   }
 
   .#{$prefix}--data-table-header__title {
@@ -66,7 +66,7 @@
   }
 
   .#{$prefix}--data-table--light tbody {
-    background-color: $ui-background;
+    background-color: $ui-02;
   }
 
   .#{$prefix}--data-table tr {
@@ -137,7 +137,7 @@
 
   .#{$prefix}--data-table--light td,
   .#{$prefix}--data-table--light tbody th {
-    background: $ui-background;
+    background: $ui-02;
   }
 
   @supports (-moz-appearance: none) {
@@ -260,9 +260,9 @@
     tbody
     tr:nth-child(odd)
     td {
-    background: $ui-background;
-    border-bottom-color: $ui-background;
-    border-top-color: $ui-background;
+    background: $ui-02;
+    border-bottom-color: $ui-02;
+    border-top-color: $ui-02;
   }
 
   .#{$prefix}--data-table--zebra tbody tr:hover td {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -137,7 +137,7 @@
 
   .#{$prefix}--data-table--light td,
   .#{$prefix}--data-table--light tbody th {
-    background: $ui-02;
+    background: $ui-background;
   }
 
   @supports (-moz-appearance: none) {

--- a/packages/react/src/components/DataTable/DataTable-story.js
+++ b/packages/react/src/components/DataTable/DataTable-story.js
@@ -20,6 +20,7 @@ const props = () => ({
     null
   ),
   stickyHeader: boolean('Sticky header (experimental)', false),
+  light: boolean('Light variant (light)', false),
 });
 
 storiesOf('DataTable', module)

--- a/packages/react/src/components/DataTable/DataTable.js
+++ b/packages/react/src/components/DataTable/DataTable.js
@@ -120,6 +120,12 @@ export default class DataTable extends React.Component {
      * Specify whether the table should be able to be sorted by its headers
      */
     isSortable: PropTypes.bool,
+
+    /**
+     * `true` to use the light version. For use on $ui-01 backgrounds only.
+     * Don't use this to make DataTable background color same as container background color.
+     */
+    light: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -127,6 +133,7 @@ export default class DataTable extends React.Component {
     filterRows: defaultFilterRows,
     locale: 'en',
     translateWithId,
+    light: false,
   };
 
   static translationKeys = Object.values(translationKeys);
@@ -350,6 +357,7 @@ export default class DataTable extends React.Component {
       useStaticWidth,
       shouldShowBorder,
       stickyHeader,
+      light,
     } = this.props;
     return {
       useZebraStyles,
@@ -358,6 +366,7 @@ export default class DataTable extends React.Component {
       useStaticWidth,
       shouldShowBorder,
       stickyHeader,
+      light,
     };
   };
 
@@ -365,10 +374,11 @@ export default class DataTable extends React.Component {
    * Helper utility to get the TableContainer Props.
    */
   getTableContainerProps = () => {
-    const { stickyHeader } = this.props;
+    const { stickyHeader, light } = this.props;
 
     return {
       stickyHeader,
+      light,
     };
   };
 

--- a/packages/react/src/components/DataTable/Table.js
+++ b/packages/react/src/components/DataTable/Table.js
@@ -21,6 +21,7 @@ export const Table = ({
   useStaticWidth,
   shouldShowBorder,
   stickyHeader,
+  light,
   ...other
 }) => {
   const componentClass = cx(`${prefix}--data-table`, className, {
@@ -32,6 +33,7 @@ export const Table = ({
     [`${prefix}--data-table--static`]: useStaticWidth,
     [`${prefix}--data-table--no-border`]: !shouldShowBorder,
     [`${prefix}--data-table--sticky-header`]: stickyHeader,
+    [`${prefix}--data-table--light`]: light,
   });
   const table = (
     <table {...other} className={componentClass}>
@@ -79,6 +81,12 @@ Table.propTypes = {
    * `false` If true, will keep the header sticky (only data rows will scroll)
    */
   stickyHeader: PropTypes.bool,
+
+  /**
+   * `true` to use the light version. For use on $ui-01 backgrounds only.
+   * Don't use this to make DataTable background color same as container background color.
+   */
+  light: PropTypes.bool,
 };
 
 Table.defaultProps = {

--- a/packages/react/src/components/DataTable/TableContainer.js
+++ b/packages/react/src/components/DataTable/TableContainer.js
@@ -18,6 +18,7 @@ const TableContainer = ({
   title,
   description,
   stickyHeader,
+  light,
   ...rest
 }) => {
   const tableContainerClasses = cx(
@@ -28,10 +29,14 @@ const TableContainer = ({
     }
   );
 
+  const tableHeaderClasses = cx(`${prefix}--data-table-header`, {
+    [`${prefix}--data-table-header--light`]: light,
+  });
+
   return (
     <div {...rest} className={tableContainerClasses}>
       {title && (
-        <div className={`${prefix}--data-table-header`}>
+        <div className={tableHeaderClasses}>
           <h4 className={`${prefix}--data-table-header__title`}>{title}</h4>
           <p className={`${prefix}--data-table-header__description`}>
             {description}
@@ -55,6 +60,12 @@ TableContainer.propTypes = {
    * Optional description text for the Table
    */
   description: PropTypes.node,
+
+  /**
+   * `true` to use the light version. For use on $ui-01 backgrounds only.
+   * Don't use this to make DataTable background color same as container background color.
+   */
+  light: PropTypes.bool,
 };
 
 export default TableContainer;

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -30,6 +30,9 @@ import DataTable, {
 } from '../';
 import { sortStates } from '../state/sorting';
 import { mount } from 'enzyme';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
 
 // Test helpers
 const getHeaderAt = (wrapper, index) =>
@@ -147,6 +150,33 @@ describe('DataTable', () => {
   it('should render', () => {
     const wrapper = mount(<DataTable {...mockProps} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('supports light version', () => {
+    const wrapper = mount(<DataTable {...mockProps} />);
+    expect(wrapper.props().light).toEqual(false);
+    expect(
+      wrapper
+        .find(`table.${prefix}--data-table`)
+        .hasClass(`${prefix}--data-table--light`)
+    ).toEqual(false);
+    expect(
+      wrapper
+        .find(`div.${prefix}--data-table-header`)
+        .hasClass(`${prefix}--data-table-header--light`)
+    ).toEqual(false);
+    wrapper.setProps({ light: true });
+    expect(wrapper.props().light).toEqual(true);
+    expect(
+      wrapper
+        .find(`table.${prefix}--data-table`)
+        .hasClass(`${prefix}--data-table--light`)
+    ).toEqual(true);
+    expect(
+      wrapper
+        .find(`div.${prefix}--data-table-header`)
+        .hasClass(`${prefix}--data-table-header--light`)
+    ).toEqual(true);
   });
 
   describe('sorting', () => {

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -15,6 +15,7 @@ exports[`DataTable selection -- radio buttons should not have select-all checkbo
       },
     ]
   }
+  light={false}
   locale="en"
   radio={true}
   render={
@@ -196,6 +197,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
       },
     ]
   }
+  light={false}
   locale="en"
   radio={true}
   render={
@@ -364,7 +366,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-14__select-row-b"
+                    id="data-table-15__select-row-b"
                     name="select-row-b"
                     onSelect={[Function]}
                     radio={true}
@@ -381,7 +383,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-14__select-row-a"
+                    id="data-table-15__select-row-a"
                     name="select-row-a"
                     onSelect={[Function]}
                     radio={true}
@@ -398,7 +400,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-14__select-row-c"
+                    id="data-table-15__select-row-c"
                     name="select-row-c"
                     onSelect={[Function]}
                     radio={true}
@@ -523,7 +525,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-14__select-row-b"
+                    id="data-table-15__select-row-b"
                     name="select-row-b"
                     onSelect={[Function]}
                     radio={true}
@@ -535,7 +537,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                         checked={false}
                         disabled={false}
                         hideLabel={true}
-                        id="data-table-14__select-row-b"
+                        id="data-table-15__select-row-b"
                         labelText="Select row"
                         name="select-row-b"
                         onClick={[Function]}
@@ -544,7 +546,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                           checked={false}
                           disabled={false}
                           hideLabel={true}
-                          id="data-table-14__select-row-b"
+                          id="data-table-15__select-row-b"
                           innerRef={null}
                           labelPosition="right"
                           labelText="Select row"
@@ -560,7 +562,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                               checked={false}
                               className="bx--radio-button"
                               disabled={false}
-                              id="data-table-14__select-row-b"
+                              id="data-table-15__select-row-b"
                               name="select-row-b"
                               onChange={[Function]}
                               onClick={[Function]}
@@ -570,7 +572,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                             <label
                               aria-label="Select row"
                               className="bx--radio-button__label"
-                              htmlFor="data-table-14__select-row-b"
+                              htmlFor="data-table-15__select-row-b"
                             >
                               <span
                                 className="bx--radio-button__appearance"
@@ -610,7 +612,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-14__select-row-a"
+                    id="data-table-15__select-row-a"
                     name="select-row-a"
                     onSelect={[Function]}
                     radio={true}
@@ -622,7 +624,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                         checked={false}
                         disabled={false}
                         hideLabel={true}
-                        id="data-table-14__select-row-a"
+                        id="data-table-15__select-row-a"
                         labelText="Select row"
                         name="select-row-a"
                         onClick={[Function]}
@@ -631,7 +633,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                           checked={false}
                           disabled={false}
                           hideLabel={true}
-                          id="data-table-14__select-row-a"
+                          id="data-table-15__select-row-a"
                           innerRef={null}
                           labelPosition="right"
                           labelText="Select row"
@@ -647,7 +649,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                               checked={false}
                               className="bx--radio-button"
                               disabled={false}
-                              id="data-table-14__select-row-a"
+                              id="data-table-15__select-row-a"
                               name="select-row-a"
                               onChange={[Function]}
                               onClick={[Function]}
@@ -657,7 +659,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                             <label
                               aria-label="Select row"
                               className="bx--radio-button__label"
-                              htmlFor="data-table-14__select-row-a"
+                              htmlFor="data-table-15__select-row-a"
                             >
                               <span
                                 className="bx--radio-button__appearance"
@@ -697,7 +699,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-14__select-row-c"
+                    id="data-table-15__select-row-c"
                     name="select-row-c"
                     onSelect={[Function]}
                     radio={true}
@@ -709,7 +711,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                         checked={false}
                         disabled={false}
                         hideLabel={true}
-                        id="data-table-14__select-row-c"
+                        id="data-table-15__select-row-c"
                         labelText="Select row"
                         name="select-row-c"
                         onClick={[Function]}
@@ -718,7 +720,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                           checked={false}
                           disabled={false}
                           hideLabel={true}
-                          id="data-table-14__select-row-c"
+                          id="data-table-15__select-row-c"
                           innerRef={null}
                           labelPosition="right"
                           labelText="Select row"
@@ -734,7 +736,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                               checked={false}
                               className="bx--radio-button"
                               disabled={false}
-                              id="data-table-14__select-row-c"
+                              id="data-table-15__select-row-c"
                               name="select-row-c"
                               onChange={[Function]}
                               onClick={[Function]}
@@ -744,7 +746,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                             <label
                               aria-label="Select row"
                               className="bx--radio-button__label"
-                              htmlFor="data-table-14__select-row-c"
+                              htmlFor="data-table-15__select-row-c"
                             >
                               <span
                                 className="bx--radio-button__appearance"
@@ -800,6 +802,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
       },
     ]
   }
+  light={false}
   locale="en"
   render={
     [MockFunction] {
@@ -828,6 +831,334 @@ exports[`DataTable selection should have select-all default to un-checked if no 
             "onInputChange": [Function],
             "radio": undefined,
             "rows": Array [],
+            "selectAll": [Function],
+            "selectRow": [Function],
+            "selectedRows": Array [],
+            "sortBy": [Function],
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": <TableContainer
+            title="DataTable with selection"
+          >
+            <Table
+              isSortable={false}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableSelectAll
+                    ariaLabel="Select all rows"
+                    checked={false}
+                    id="data-table-8__select-all"
+                    indeterminate={false}
+                    name="select-all"
+                    onSelect={[Function]}
+                  />
+                  <TableHeader
+                    isSortHeader={false}
+                    isSortable={false}
+                    onClick={[Function]}
+                    scope="col"
+                    sortDirection="NONE"
+                    translateWithId={[Function]}
+                  >
+                    Field A
+                  </TableHeader>
+                  <TableHeader
+                    isSortHeader={false}
+                    isSortable={false}
+                    onClick={[Function]}
+                    scope="col"
+                    sortDirection="NONE"
+                    translateWithId={[Function]}
+                  >
+                    Field B
+                  </TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody
+                aria-live="polite"
+              />
+            </Table>
+          </TableContainer>,
+        },
+      ],
+    }
+  }
+  rows={Array []}
+  sortRow={[Function]}
+  translateWithId={[Function]}
+>
+  <TableContainer
+    title="DataTable with selection"
+  >
+    <div
+      className="bx--data-table-container"
+    >
+      <div
+        className="bx--data-table-header"
+      >
+        <h4
+          className="bx--data-table-header__title"
+        >
+          DataTable with selection
+        </h4>
+        <p
+          className="bx--data-table-header__description"
+        />
+      </div>
+      <Table
+        isSortable={false}
+      >
+        <table
+          className="bx--data-table bx--data-table--no-border"
+        >
+          <TableHead>
+            <thead>
+              <TableRow>
+                <tr>
+                  <TableSelectAll
+                    ariaLabel="Select all rows"
+                    checked={false}
+                    id="data-table-8__select-all"
+                    indeterminate={false}
+                    name="select-all"
+                    onSelect={[Function]}
+                  >
+                    <th
+                      className="bx--table-column-checkbox"
+                      scope="col"
+                    >
+                      <ForwardRef(InlineCheckbox)
+                        ariaLabel="Select all rows"
+                        checked={false}
+                        id="data-table-8__select-all"
+                        indeterminate={false}
+                        name="select-all"
+                        onClick={[Function]}
+                      >
+                        <InlineCheckbox
+                          ariaLabel="Select all rows"
+                          checked={false}
+                          id="data-table-8__select-all"
+                          indeterminate={false}
+                          innerRef={null}
+                          name="select-all"
+                          onChange={[Function]}
+                          onClick={[Function]}
+                        >
+                          <input
+                            checked={false}
+                            className="bx--checkbox"
+                            id="data-table-8__select-all"
+                            name="select-all"
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            aria-label="Select all rows"
+                            className="bx--checkbox-label"
+                            htmlFor="data-table-8__select-all"
+                          />
+                        </InlineCheckbox>
+                      </ForwardRef(InlineCheckbox)>
+                    </th>
+                  </TableSelectAll>
+                  <TableHeader
+                    isSortHeader={false}
+                    isSortable={false}
+                    key="fieldA"
+                    onClick={[Function]}
+                    scope="col"
+                    sortDirection="NONE"
+                    translateWithId={[Function]}
+                  >
+                    <th
+                      scope="col"
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        Field A
+                      </span>
+                    </th>
+                  </TableHeader>
+                  <TableHeader
+                    isSortHeader={false}
+                    isSortable={false}
+                    key="fieldB"
+                    onClick={[Function]}
+                    scope="col"
+                    sortDirection="NONE"
+                    translateWithId={[Function]}
+                  >
+                    <th
+                      scope="col"
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        Field B
+                      </span>
+                    </th>
+                  </TableHeader>
+                </tr>
+              </TableRow>
+            </thead>
+          </TableHead>
+          <TableBody
+            aria-live="polite"
+          >
+            <tbody
+              aria-live="polite"
+            />
+          </TableBody>
+        </table>
+      </Table>
+    </div>
+  </TableContainer>
+</DataTable>
+`;
+
+exports[`DataTable selection should render 1`] = `
+<DataTable
+  filterRows={[Function]}
+  headers={
+    Array [
+      Object {
+        "header": "Field A",
+        "key": "fieldA",
+      },
+      Object {
+        "header": "Field B",
+        "key": "fieldB",
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  render={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "expandAll": [Function],
+            "expandRow": [Function],
+            "getBatchActionProps": [Function],
+            "getExpandHeaderProps": [Function],
+            "getHeaderProps": [Function],
+            "getRowProps": [Function],
+            "getSelectionProps": [Function],
+            "getTableContainerProps": [Function],
+            "getTableProps": [Function],
+            "headers": Array [
+              Object {
+                "header": "Field A",
+                "key": "fieldA",
+              },
+              Object {
+                "header": "Field B",
+                "key": "fieldB",
+              },
+            ],
+            "onInputChange": [Function],
+            "radio": undefined,
+            "rows": Array [
+              Object {
+                "cells": Array [
+                  Object {
+                    "errors": null,
+                    "id": "b:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
+                    "isEditable": false,
+                    "isEditing": false,
+                    "isValid": true,
+                    "value": "Field 2:A",
+                  },
+                  Object {
+                    "errors": null,
+                    "id": "b:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
+                    "isEditable": false,
+                    "isEditing": false,
+                    "isValid": true,
+                    "value": "Field 2:B",
+                  },
+                ],
+                "disabled": false,
+                "id": "b",
+                "isExpanded": false,
+                "isSelected": false,
+              },
+              Object {
+                "cells": Array [
+                  Object {
+                    "errors": null,
+                    "id": "a:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
+                    "isEditable": false,
+                    "isEditing": false,
+                    "isValid": true,
+                    "value": "Field 1:A",
+                  },
+                  Object {
+                    "errors": null,
+                    "id": "a:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
+                    "isEditable": false,
+                    "isEditing": false,
+                    "isValid": true,
+                    "value": "Field 1:B",
+                  },
+                ],
+                "disabled": false,
+                "id": "a",
+                "isExpanded": false,
+                "isSelected": false,
+              },
+              Object {
+                "cells": Array [
+                  Object {
+                    "errors": null,
+                    "id": "c:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
+                    "isEditable": false,
+                    "isEditing": false,
+                    "isValid": true,
+                    "value": "Field 3:A",
+                  },
+                  Object {
+                    "errors": null,
+                    "id": "c:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
+                    "isEditable": false,
+                    "isEditing": false,
+                    "isValid": true,
+                    "value": "Field 3:B",
+                  },
+                ],
+                "disabled": false,
+                "id": "c",
+                "isExpanded": false,
+                "isSelected": false,
+              },
+            ],
             "selectAll": [Function],
             "selectRow": [Function],
             "selectedRows": Array [],
@@ -878,14 +1209,84 @@ exports[`DataTable selection should have select-all default to un-checked if no 
               </TableHead>
               <TableBody
                 aria-live="polite"
-              />
+              >
+                <TableRow>
+                  <TableSelectRow
+                    ariaLabel="Select row"
+                    checked={false}
+                    disabled={false}
+                    id="data-table-7__select-row-b"
+                    name="select-row-b"
+                    onSelect={[Function]}
+                    radio={null}
+                  />
+                  <TableCell>
+                    Field 2:A
+                  </TableCell>
+                  <TableCell>
+                    Field 2:B
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableSelectRow
+                    ariaLabel="Select row"
+                    checked={false}
+                    disabled={false}
+                    id="data-table-7__select-row-a"
+                    name="select-row-a"
+                    onSelect={[Function]}
+                    radio={null}
+                  />
+                  <TableCell>
+                    Field 1:A
+                  </TableCell>
+                  <TableCell>
+                    Field 1:B
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableSelectRow
+                    ariaLabel="Select row"
+                    checked={false}
+                    disabled={false}
+                    id="data-table-7__select-row-c"
+                    name="select-row-c"
+                    onSelect={[Function]}
+                    radio={null}
+                  />
+                  <TableCell>
+                    Field 3:A
+                  </TableCell>
+                  <TableCell>
+                    Field 3:B
+                  </TableCell>
+                </TableRow>
+              </TableBody>
             </Table>
           </TableContainer>,
         },
       ],
     }
   }
-  rows={Array []}
+  rows={
+    Array [
+      Object {
+        "fieldA": "Field 2:A",
+        "fieldB": "Field 2:B",
+        "id": "b",
+      },
+      Object {
+        "fieldA": "Field 1:A",
+        "fieldB": "Field 1:B",
+        "id": "a",
+      },
+      Object {
+        "fieldA": "Field 3:A",
+        "fieldB": "Field 3:B",
+        "id": "c",
+      },
+    ]
+  }
   sortRow={[Function]}
   translateWithId={[Function]}
 >
@@ -1012,403 +1413,6 @@ exports[`DataTable selection should have select-all default to un-checked if no 
           >
             <tbody
               aria-live="polite"
-            />
-          </TableBody>
-        </table>
-      </Table>
-    </div>
-  </TableContainer>
-</DataTable>
-`;
-
-exports[`DataTable selection should render 1`] = `
-<DataTable
-  filterRows={[Function]}
-  headers={
-    Array [
-      Object {
-        "header": "Field A",
-        "key": "fieldA",
-      },
-      Object {
-        "header": "Field B",
-        "key": "fieldB",
-      },
-    ]
-  }
-  locale="en"
-  render={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          Object {
-            "expandAll": [Function],
-            "expandRow": [Function],
-            "getBatchActionProps": [Function],
-            "getExpandHeaderProps": [Function],
-            "getHeaderProps": [Function],
-            "getRowProps": [Function],
-            "getSelectionProps": [Function],
-            "getTableContainerProps": [Function],
-            "getTableProps": [Function],
-            "headers": Array [
-              Object {
-                "header": "Field A",
-                "key": "fieldA",
-              },
-              Object {
-                "header": "Field B",
-                "key": "fieldB",
-              },
-            ],
-            "onInputChange": [Function],
-            "radio": undefined,
-            "rows": Array [
-              Object {
-                "cells": Array [
-                  Object {
-                    "errors": null,
-                    "id": "b:fieldA",
-                    "info": Object {
-                      "header": "fieldA",
-                    },
-                    "isEditable": false,
-                    "isEditing": false,
-                    "isValid": true,
-                    "value": "Field 2:A",
-                  },
-                  Object {
-                    "errors": null,
-                    "id": "b:fieldB",
-                    "info": Object {
-                      "header": "fieldB",
-                    },
-                    "isEditable": false,
-                    "isEditing": false,
-                    "isValid": true,
-                    "value": "Field 2:B",
-                  },
-                ],
-                "disabled": false,
-                "id": "b",
-                "isExpanded": false,
-                "isSelected": false,
-              },
-              Object {
-                "cells": Array [
-                  Object {
-                    "errors": null,
-                    "id": "a:fieldA",
-                    "info": Object {
-                      "header": "fieldA",
-                    },
-                    "isEditable": false,
-                    "isEditing": false,
-                    "isValid": true,
-                    "value": "Field 1:A",
-                  },
-                  Object {
-                    "errors": null,
-                    "id": "a:fieldB",
-                    "info": Object {
-                      "header": "fieldB",
-                    },
-                    "isEditable": false,
-                    "isEditing": false,
-                    "isValid": true,
-                    "value": "Field 1:B",
-                  },
-                ],
-                "disabled": false,
-                "id": "a",
-                "isExpanded": false,
-                "isSelected": false,
-              },
-              Object {
-                "cells": Array [
-                  Object {
-                    "errors": null,
-                    "id": "c:fieldA",
-                    "info": Object {
-                      "header": "fieldA",
-                    },
-                    "isEditable": false,
-                    "isEditing": false,
-                    "isValid": true,
-                    "value": "Field 3:A",
-                  },
-                  Object {
-                    "errors": null,
-                    "id": "c:fieldB",
-                    "info": Object {
-                      "header": "fieldB",
-                    },
-                    "isEditable": false,
-                    "isEditing": false,
-                    "isValid": true,
-                    "value": "Field 3:B",
-                  },
-                ],
-                "disabled": false,
-                "id": "c",
-                "isExpanded": false,
-                "isSelected": false,
-              },
-            ],
-            "selectAll": [Function],
-            "selectRow": [Function],
-            "selectedRows": Array [],
-            "sortBy": [Function],
-          },
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": <TableContainer
-            title="DataTable with selection"
-          >
-            <Table
-              isSortable={false}
-            >
-              <TableHead>
-                <TableRow>
-                  <TableSelectAll
-                    ariaLabel="Select all rows"
-                    checked={false}
-                    id="data-table-6__select-all"
-                    indeterminate={false}
-                    name="select-all"
-                    onSelect={[Function]}
-                  />
-                  <TableHeader
-                    isSortHeader={false}
-                    isSortable={false}
-                    onClick={[Function]}
-                    scope="col"
-                    sortDirection="NONE"
-                    translateWithId={[Function]}
-                  >
-                    Field A
-                  </TableHeader>
-                  <TableHeader
-                    isSortHeader={false}
-                    isSortable={false}
-                    onClick={[Function]}
-                    scope="col"
-                    sortDirection="NONE"
-                    translateWithId={[Function]}
-                  >
-                    Field B
-                  </TableHeader>
-                </TableRow>
-              </TableHead>
-              <TableBody
-                aria-live="polite"
-              >
-                <TableRow>
-                  <TableSelectRow
-                    ariaLabel="Select row"
-                    checked={false}
-                    disabled={false}
-                    id="data-table-6__select-row-b"
-                    name="select-row-b"
-                    onSelect={[Function]}
-                    radio={null}
-                  />
-                  <TableCell>
-                    Field 2:A
-                  </TableCell>
-                  <TableCell>
-                    Field 2:B
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableSelectRow
-                    ariaLabel="Select row"
-                    checked={false}
-                    disabled={false}
-                    id="data-table-6__select-row-a"
-                    name="select-row-a"
-                    onSelect={[Function]}
-                    radio={null}
-                  />
-                  <TableCell>
-                    Field 1:A
-                  </TableCell>
-                  <TableCell>
-                    Field 1:B
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableSelectRow
-                    ariaLabel="Select row"
-                    checked={false}
-                    disabled={false}
-                    id="data-table-6__select-row-c"
-                    name="select-row-c"
-                    onSelect={[Function]}
-                    radio={null}
-                  />
-                  <TableCell>
-                    Field 3:A
-                  </TableCell>
-                  <TableCell>
-                    Field 3:B
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>,
-        },
-      ],
-    }
-  }
-  rows={
-    Array [
-      Object {
-        "fieldA": "Field 2:A",
-        "fieldB": "Field 2:B",
-        "id": "b",
-      },
-      Object {
-        "fieldA": "Field 1:A",
-        "fieldB": "Field 1:B",
-        "id": "a",
-      },
-      Object {
-        "fieldA": "Field 3:A",
-        "fieldB": "Field 3:B",
-        "id": "c",
-      },
-    ]
-  }
-  sortRow={[Function]}
-  translateWithId={[Function]}
->
-  <TableContainer
-    title="DataTable with selection"
-  >
-    <div
-      className="bx--data-table-container"
-    >
-      <div
-        className="bx--data-table-header"
-      >
-        <h4
-          className="bx--data-table-header__title"
-        >
-          DataTable with selection
-        </h4>
-        <p
-          className="bx--data-table-header__description"
-        />
-      </div>
-      <Table
-        isSortable={false}
-      >
-        <table
-          className="bx--data-table bx--data-table--no-border"
-        >
-          <TableHead>
-            <thead>
-              <TableRow>
-                <tr>
-                  <TableSelectAll
-                    ariaLabel="Select all rows"
-                    checked={false}
-                    id="data-table-6__select-all"
-                    indeterminate={false}
-                    name="select-all"
-                    onSelect={[Function]}
-                  >
-                    <th
-                      className="bx--table-column-checkbox"
-                      scope="col"
-                    >
-                      <ForwardRef(InlineCheckbox)
-                        ariaLabel="Select all rows"
-                        checked={false}
-                        id="data-table-6__select-all"
-                        indeterminate={false}
-                        name="select-all"
-                        onClick={[Function]}
-                      >
-                        <InlineCheckbox
-                          ariaLabel="Select all rows"
-                          checked={false}
-                          id="data-table-6__select-all"
-                          indeterminate={false}
-                          innerRef={null}
-                          name="select-all"
-                          onChange={[Function]}
-                          onClick={[Function]}
-                        >
-                          <input
-                            checked={false}
-                            className="bx--checkbox"
-                            id="data-table-6__select-all"
-                            name="select-all"
-                            onChange={[Function]}
-                            onClick={[Function]}
-                            type="checkbox"
-                          />
-                          <label
-                            aria-label="Select all rows"
-                            className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-all"
-                          />
-                        </InlineCheckbox>
-                      </ForwardRef(InlineCheckbox)>
-                    </th>
-                  </TableSelectAll>
-                  <TableHeader
-                    isSortHeader={false}
-                    isSortable={false}
-                    key="fieldA"
-                    onClick={[Function]}
-                    scope="col"
-                    sortDirection="NONE"
-                    translateWithId={[Function]}
-                  >
-                    <th
-                      scope="col"
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        Field A
-                      </span>
-                    </th>
-                  </TableHeader>
-                  <TableHeader
-                    isSortHeader={false}
-                    isSortable={false}
-                    key="fieldB"
-                    onClick={[Function]}
-                    scope="col"
-                    sortDirection="NONE"
-                    translateWithId={[Function]}
-                  >
-                    <th
-                      scope="col"
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        Field B
-                      </span>
-                    </th>
-                  </TableHeader>
-                </tr>
-              </TableRow>
-            </thead>
-          </TableHead>
-          <TableBody
-            aria-live="polite"
-          >
-            <tbody
-              aria-live="polite"
             >
               <TableRow
                 key="b"
@@ -1418,7 +1422,7 @@ exports[`DataTable selection should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-6__select-row-b"
+                    id="data-table-7__select-row-b"
                     name="select-row-b"
                     onSelect={[Function]}
                     radio={null}
@@ -1430,7 +1434,7 @@ exports[`DataTable selection should render 1`] = `
                         ariaLabel="Select row"
                         checked={false}
                         disabled={false}
-                        id="data-table-6__select-row-b"
+                        id="data-table-7__select-row-b"
                         name="select-row-b"
                         onClick={[Function]}
                       >
@@ -1438,7 +1442,7 @@ exports[`DataTable selection should render 1`] = `
                           ariaLabel="Select row"
                           checked={false}
                           disabled={false}
-                          id="data-table-6__select-row-b"
+                          id="data-table-7__select-row-b"
                           innerRef={null}
                           name="select-row-b"
                           onChange={[Function]}
@@ -1448,7 +1452,7 @@ exports[`DataTable selection should render 1`] = `
                             checked={false}
                             className="bx--checkbox"
                             disabled={false}
-                            id="data-table-6__select-row-b"
+                            id="data-table-7__select-row-b"
                             name="select-row-b"
                             onChange={[Function]}
                             onClick={[Function]}
@@ -1457,7 +1461,7 @@ exports[`DataTable selection should render 1`] = `
                           <label
                             aria-label="Select row"
                             className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-row-b"
+                            htmlFor="data-table-7__select-row-b"
                           />
                         </InlineCheckbox>
                       </ForwardRef(InlineCheckbox)>
@@ -1487,7 +1491,7 @@ exports[`DataTable selection should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-6__select-row-a"
+                    id="data-table-7__select-row-a"
                     name="select-row-a"
                     onSelect={[Function]}
                     radio={null}
@@ -1499,7 +1503,7 @@ exports[`DataTable selection should render 1`] = `
                         ariaLabel="Select row"
                         checked={false}
                         disabled={false}
-                        id="data-table-6__select-row-a"
+                        id="data-table-7__select-row-a"
                         name="select-row-a"
                         onClick={[Function]}
                       >
@@ -1507,7 +1511,7 @@ exports[`DataTable selection should render 1`] = `
                           ariaLabel="Select row"
                           checked={false}
                           disabled={false}
-                          id="data-table-6__select-row-a"
+                          id="data-table-7__select-row-a"
                           innerRef={null}
                           name="select-row-a"
                           onChange={[Function]}
@@ -1517,7 +1521,7 @@ exports[`DataTable selection should render 1`] = `
                             checked={false}
                             className="bx--checkbox"
                             disabled={false}
-                            id="data-table-6__select-row-a"
+                            id="data-table-7__select-row-a"
                             name="select-row-a"
                             onChange={[Function]}
                             onClick={[Function]}
@@ -1526,7 +1530,7 @@ exports[`DataTable selection should render 1`] = `
                           <label
                             aria-label="Select row"
                             className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-row-a"
+                            htmlFor="data-table-7__select-row-a"
                           />
                         </InlineCheckbox>
                       </ForwardRef(InlineCheckbox)>
@@ -1556,7 +1560,7 @@ exports[`DataTable selection should render 1`] = `
                     ariaLabel="Select row"
                     checked={false}
                     disabled={false}
-                    id="data-table-6__select-row-c"
+                    id="data-table-7__select-row-c"
                     name="select-row-c"
                     onSelect={[Function]}
                     radio={null}
@@ -1568,7 +1572,7 @@ exports[`DataTable selection should render 1`] = `
                         ariaLabel="Select row"
                         checked={false}
                         disabled={false}
-                        id="data-table-6__select-row-c"
+                        id="data-table-7__select-row-c"
                         name="select-row-c"
                         onClick={[Function]}
                       >
@@ -1576,7 +1580,7 @@ exports[`DataTable selection should render 1`] = `
                           ariaLabel="Select row"
                           checked={false}
                           disabled={false}
-                          id="data-table-6__select-row-c"
+                          id="data-table-7__select-row-c"
                           innerRef={null}
                           name="select-row-c"
                           onChange={[Function]}
@@ -1586,7 +1590,7 @@ exports[`DataTable selection should render 1`] = `
                             checked={false}
                             className="bx--checkbox"
                             disabled={false}
-                            id="data-table-6__select-row-c"
+                            id="data-table-7__select-row-c"
                             name="select-row-c"
                             onChange={[Function]}
                             onClick={[Function]}
@@ -1595,7 +1599,7 @@ exports[`DataTable selection should render 1`] = `
                           <label
                             aria-label="Select row"
                             className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-row-c"
+                            htmlFor="data-table-7__select-row-c"
                           />
                         </InlineCheckbox>
                       </ForwardRef(InlineCheckbox)>
@@ -1641,6 +1645,7 @@ exports[`DataTable should render 1`] = `
       },
     ]
   }
+  light={false}
   locale="en"
   render={
     [MockFunction] {
@@ -1771,6 +1776,7 @@ exports[`DataTable should render 1`] = `
         Object {
           "type": "return",
           "value": <TableContainer
+            light={false}
             title="DataTable with toolbar"
           >
             <TableToolbar
@@ -1863,6 +1869,7 @@ exports[`DataTable should render 1`] = `
             </TableToolbar>
             <Table
               isSortable={false}
+              light={false}
             >
               <TableHead>
                 <TableRow>
@@ -1945,6 +1952,7 @@ exports[`DataTable should render 1`] = `
   translateWithId={[Function]}
 >
   <TableContainer
+    light={false}
     title="DataTable with toolbar"
   >
     <div
@@ -2472,6 +2480,7 @@ exports[`DataTable should render 1`] = `
       </TableToolbar>
       <Table
         isSortable={false}
+        light={false}
       >
         <table
           className="bx--data-table bx--data-table--no-border"
@@ -2612,6 +2621,7 @@ exports[`DataTable sticky header should render 1`] = `
       },
     ]
   }
+  light={false}
   locale="en"
   render={
     [MockFunction] {
@@ -2742,6 +2752,7 @@ exports[`DataTable sticky header should render 1`] = `
         Object {
           "type": "return",
           "value": <TableContainer
+            light={false}
             stickyHeader={true}
             title="DataTable with toolbar"
           >
@@ -2835,6 +2846,7 @@ exports[`DataTable sticky header should render 1`] = `
             </TableToolbar>
             <Table
               isSortable={false}
+              light={false}
               stickyHeader={true}
             >
               <TableHead>
@@ -2919,6 +2931,7 @@ exports[`DataTable sticky header should render 1`] = `
   translateWithId={[Function]}
 >
   <TableContainer
+    light={false}
     stickyHeader={true}
     title="DataTable with toolbar"
   >
@@ -3447,6 +3460,7 @@ exports[`DataTable sticky header should render 1`] = `
       </TableToolbar>
       <Table
         isSortable={false}
+        light={false}
         stickyHeader={true}
       >
         <section


### PR DESCRIPTION
Closes #4120 

Add light prop to DataTable component for use on `$ui-01` container.
This is for the same reason as #4335 and #4347 

#### Changelog

**New**

- `light` prop in DataTable component

#### Testing / Reviewing

- Pull PR
- Make sure packages are built (`yarn build`)
- Run react storybook
```sh
cd packages/react
yarn storybook
```
- Activate light prop in knobs for DataTable. The DataTable rows background should change to the `$ui-02` equivalent color of the selected carbon theme.
