### PR TITLE
fix(accessibility): set proper aria role on modal control

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -335,7 +335,6 @@ export default class Modal extends Component {
     const modalBody = (
       <div
         ref={this.innerModal}
-        role="dialog"
         className={`${prefix}--modal-container`}
         aria-label={
           modalLabel

--- a/packages/react/src/components/ModalWrapper/ModalWrapper.js
+++ b/packages/react/src/components/ModalWrapper/ModalWrapper.js
@@ -99,7 +99,7 @@ export default class ModalWrapper extends React.Component {
 
     return (
       <div
-        role="presentation"
+        role="dialog"
         onKeyDown={evt => {
           if (evt.which === 27) {
             this.handleClose();


### PR DESCRIPTION
Closes: https://github.com/carbon-design-system/carbon/issues/4557

Use correct aria role and move it to the wrapper.

#### Changelog

**Changed**

- aria role to `dialog` instead of `presentation` on ModalWrapper

**Removed**

- Role from Modal child elements 

#### Testing / Reviewing

Create an app that renders a modal and run pa11y against it.