### PR TITLE
fix(inline-notification): update close btn focus outline & action btn specificity

### DIFF
--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -166,7 +166,7 @@
     word-break: break-word;
   }
 
-  .#{$prefix}--inline-notification__action-button {
+  .#{$prefix}--inline-notification__action-button.#{$prefix}--btn--ghost {
     height: rem(32px);
     margin: $carbon--spacing-03 0;
 
@@ -198,6 +198,10 @@
     max-width: rem(48px);
     transition: outline $duration--fast-02 motion(standard, productive),
       background-color $duration--fast-02 motion(standard, productive);
+
+    &:focus {
+      @include focus-outline('outline');
+    }
 
     .#{$prefix}--inline-notification__close-icon {
       fill: $inverse-01;

--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -177,6 +177,12 @@
       color: $inverse-link;
     }
 
+    &:focus {
+      border-color: transparent;
+      outline: 2px solid $inverse-focus-ui;
+      outline-offset: -2px;
+    }
+
     &:hover {
       background-color: $inverse-hover-ui;
     }
@@ -200,7 +206,8 @@
       background-color $duration--fast-02 motion(standard, productive);
 
     &:focus {
-      @include focus-outline('outline');
+      outline: 2px solid $inverse-focus-ui;
+      outline-offset: -2px;
     }
 
     .#{$prefix}--inline-notification__close-icon {

--- a/packages/components/src/components/notification/_toast-notification.scss
+++ b/packages/components/src/components/notification/_toast-notification.scss
@@ -111,6 +111,10 @@
 
   .#{$prefix}--toast-notification__close-button {
     @include focus-outline('reset');
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     background-color: transparent;
     border: none;
     cursor: pointer;
@@ -123,7 +127,8 @@
     transition: outline $transition--base, background-color $transition--base;
 
     &:focus {
-      @include focus-outline('outline');
+      outline: 2px solid $inverse-focus-ui;
+      outline-offset: -2px;
     }
 
     .#{$prefix}--toast-notification__close-icon {

--- a/packages/components/src/components/notification/_toast-notification.scss
+++ b/packages/components/src/components/notification/_toast-notification.scss
@@ -145,7 +145,7 @@
   .#{$prefix}--toast-notification__title {
     @include type-style('productive-heading-01');
     font-weight: 600;
-    margin-top: $carbon--spacing-04;
+    margin-top: $carbon--spacing-05;
     word-break: break-word;
   }
 


### PR DESCRIPTION
Closes #4561
Closes #4567 

#### Changelog

**New**

- add focus state for ~close~ all buttons in `InlineNotification` & `ToastNotification`

**Changed**

- add a level of specificity to the action button styles in the `InlineNotification` so they aren't overridden by recent updates
- adjusted the svg position of the close button icon for the `ToastNotification`, as it looked a little too high 🤔 