### PR TITLE
fix(data-table): use unselectAll translation key if selection checkbox is indeterminate

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.js
+++ b/packages/react/src/components/DataTable/DataTable.js
@@ -315,9 +315,10 @@ export default class DataTable extends React.Component {
     const checked = rowCount > 0 && selectedRowCount === rowCount;
     const indeterminate =
       rowCount > 0 && selectedRowCount > 0 && selectedRowCount !== rowCount;
-    const translationKey = checked
-      ? translationKeys.unselectAll
-      : translationKeys.selectAll;
+    const translationKey =
+      checked || indeterminate
+        ? translationKeys.unselectAll
+        : translationKeys.selectAll;
     return {
       ...rest,
       ariaLabel: t(translationKey),


### PR DESCRIPTION
Closes #4556 

#### Changelog

**Changed**

- check for `indeterminate` checkbox (as well as `checked` to determinate if `translationKeys.unselectAll` is used

#### Testing / Reviewing

Open the `carbon-components-react` deploy and follow the steps in #4556 -- directly select only a few rows, and then check the `aria-label` of the indeterminate icon. It *should* say "unselect all rows" instead of "select all rows"
