### PR TITLE
fix(Button): unwind button proptype abstraction

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import { ButtonTypes } from '../../prop-types/types';
+import { ButtonKinds } from '../../prop-types/types';
 import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
@@ -142,7 +142,7 @@ Button.propTypes = {
   /**
    * Specify the kind of Button you want to create
    */
-  kind: ButtonTypes.buttonKind.isRequired,
+  kind: PropTypes.oneOf(ButtonKinds).isRequired,
 
   /**
    * Optionally specify an href for your Button to become an <a> element

--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -17,7 +17,7 @@ import {
 } from '@carbon/icons-react';
 import Loading from '../Loading';
 import uid from '../../tools/uniqueId';
-import { ButtonTypes } from '../../prop-types/types';
+import { ButtonKinds } from '../../prop-types/types';
 
 const { prefix } = settings;
 
@@ -88,7 +88,7 @@ export class FileUploaderButton extends Component {
     /**
      * Specify the type of underlying button
      */
-    buttonKind: ButtonTypes.buttonKind,
+    buttonKind: PropTypes.oneOf(ButtonKinds),
 
     /**
      * Specify the types of files that this input should be able to receive
@@ -269,7 +269,7 @@ export default class FileUploader extends Component {
     /**
      * Specify the type of the <FileUploaderButton>
      */
-    buttonKind: ButtonTypes.buttonKind,
+    buttonKind: PropTypes.oneOf(ButtonKinds),
 
     /**
      * Specify the status of the File Upload

--- a/packages/react/src/components/ModalWrapper/ModalWrapper.js
+++ b/packages/react/src/components/ModalWrapper/ModalWrapper.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import { ButtonTypes } from '../../prop-types/types';
+import { ButtonKinds } from '../../prop-types/types';
 
 export default class ModalWrapper extends React.Component {
   static propTypes = {
@@ -34,7 +34,7 @@ export default class ModalWrapper extends React.Component {
       PropTypes.object,
     ]),
     triggerButtonIconDescription: PropTypes.string,
-    triggerButtonKind: ButtonTypes.buttonKind,
+    triggerButtonKind: PropTypes.oneOf(ButtonKinds),
     shouldCloseAfterSubmit: PropTypes.bool,
   };
 

--- a/packages/react/src/prop-types/types.js
+++ b/packages/react/src/prop-types/types.js
@@ -5,15 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { oneOf } from 'prop-types';
-
-export const ButtonTypes = {
-  buttonKind: oneOf([
-    'primary',
-    'secondary',
-    'danger',
-    'ghost',
-    'danger--primary',
-    'tertiary',
-  ]),
-};
+export const ButtonKinds = [
+  'primary',
+  'secondary',
+  'danger',
+  'ghost',
+  'danger--primary',
+  'tertiary',
+];


### PR DESCRIPTION
Closes #4580

testing: note how our storybook prop-table for `Button` now reads 'oneOf ButtonKind' rather than just `custom`.

In the next version of docgen (5) and eventually storybook, docgen will be able to import and use types/arrays in prop-types rather than just give the name of the array.