### PR TITLE
chore(Search): deprecate custom buttons

### DIFF
--- a/packages/react/src/components/Search/Search-story.js
+++ b/packages/react/src/components/Search/Search-story.js
@@ -50,7 +50,7 @@ storiesOf('Search', module)
     },
   })
   .add(
-    'custom buttons',
+    '[Deprecated] custom buttons',
     () => (
       <div style={{ display: 'flex' }}>
         <Search {...props()} id="search-1" />

--- a/packages/react/src/components/SearchFilterButton/SearchFilterButton.js
+++ b/packages/react/src/components/SearchFilterButton/SearchFilterButton.js
@@ -7,27 +7,39 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import warning from 'warning';
 import { settings } from 'carbon-components';
 import { Filter16 } from '@carbon/icons-react';
 
 const { prefix } = settings;
 
+let didWarnAboutDeprecation = false;
+
 /**
  * The filter button for `<Search>`.
  */
-const SearchFilterButton = ({ labelText, iconDescription, ...other }) => (
-  <button
-    className={`${prefix}--search-button`}
-    type="button"
-    aria-label={labelText}
-    title={labelText}
-    {...other}>
-    <Filter16
-      className={`${prefix}--search-filter`}
-      aria-label={iconDescription}
-    />
-  </button>
-);
+const SearchFilterButton = ({ labelText, iconDescription, ...other }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'The SearchFilterButton component has been deprecated and will be removed in the next major release of `carbon-components-react`'
+    );
+    didWarnAboutDeprecation = true;
+  }
+  return (
+    <button
+      className={`${prefix}--search-button`}
+      type="button"
+      aria-label={labelText}
+      title={labelText}
+      {...other}>
+      <Filter16
+        className={`${prefix}--search-filter`}
+        aria-label={iconDescription}
+      />
+    </button>
+  );
+};
 
 SearchFilterButton.propTypes = {
   /**

--- a/packages/react/src/components/SearchLayoutButton/SearchLayoutButton.js
+++ b/packages/react/src/components/SearchLayoutButton/SearchLayoutButton.js
@@ -7,10 +7,13 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import warning from 'warning';
 import { settings } from 'carbon-components';
 import { ListBulleted16, Grid16 } from '@carbon/icons-react';
 
 const { prefix } = settings;
+
+let didWarnAboutDeprecation = false;
 
 /**
  * The layout button for `<Search>`.
@@ -60,6 +63,17 @@ class SearchLayoutButton extends Component {
           format: format || 'list',
           prevFormat: format,
         };
+  }
+
+  constructor(props) {
+    super(props);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The SearchLayoutButton component has been deprecated and will be removed in the next major release of `carbon-components-react`'
+      );
+      didWarnAboutDeprecation = true;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #4240.

#### Changelog

**Changed**

- Deprecated search custom buttons.

#### Testing / Reviewing

Testing should make sure our React search components are not broken.