### PR TITLE
fix(skeleton-components): add className prop to all, allow extra props

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.Skeleton.js
+++ b/packages/react/src/components/Accordion/Accordion.Skeleton.js
@@ -7,6 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { ChevronRight16 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
 import SkeletonText from '../SkeletonText';
@@ -14,11 +15,21 @@ import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
-function AccordionSkeleton(props) {
-  const numSkeletonItems = props.open ? props.count - 1 : props.count;
+function AccordionSkeleton({
+  open,
+  count,
+  className: customClassName,
+  ...rest
+}) {
+  const className = cx(
+    `${prefix}--accordion`,
+    `${prefix}--skeleton`,
+    customClassName
+  );
+  const numSkeletonItems = open ? count - 1 : count;
   return (
-    <ul className={`${prefix}--accordion ${prefix}--skeleton`}>
-      {props.open && (
+    <ul className={className} {...rest}>
+      {open && (
         <li
           className={`${prefix}--accordion__item ${prefix}--accordion__item--active`}>
           <span className={`${prefix}--accordion__heading`}>
@@ -54,6 +65,11 @@ AccordionSkeleton.propTypes = {
    * Set unique identifier to generate unique item keys
    */
   uid: deprecate(PropTypes.any),
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 AccordionSkeleton.defaultProps = {

--- a/packages/react/src/components/Accordion/Accordion.Skeleton.js
+++ b/packages/react/src/components/Accordion/Accordion.Skeleton.js
@@ -15,20 +15,11 @@ import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
-function AccordionSkeleton({
-  open,
-  count,
-  className: customClassName,
-  ...rest
-}) {
-  const className = cx(
-    `${prefix}--accordion`,
-    `${prefix}--skeleton`,
-    customClassName
-  );
+function AccordionSkeleton({ open, count, className, ...rest }) {
+  const classes = cx(`${prefix}--accordion`, `${prefix}--skeleton`, className);
   const numSkeletonItems = open ? count - 1 : count;
   return (
-    <ul className={className} {...rest}>
+    <ul className={classes} {...rest}>
       {open && (
         <li
           className={`${prefix}--accordion__item ${prefix}--accordion__item--active`}>

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -16,14 +18,27 @@ const item = (
   </div>
 );
 
-function BreadcrumbSkeleton() {
+function BreadcrumbSkeleton({ className: customClassName, ...rest }) {
+  const className = cx(
+    `${prefix}--breadcrumb`,
+    `${prefix}--skeleton`,
+    customClassName
+  );
+
   return (
-    <div className={`${prefix}--breadcrumb ${prefix}--skeleton`}>
+    <div className={className} {...rest}>
       {item}
       {item}
       {item}
     </div>
   );
 }
+
+BreadcrumbSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default BreadcrumbSkeleton;

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -18,15 +18,11 @@ const item = (
   </div>
 );
 
-function BreadcrumbSkeleton({ className: customClassName, ...rest }) {
-  const className = cx(
-    `${prefix}--breadcrumb`,
-    `${prefix}--skeleton`,
-    customClassName
-  );
+function BreadcrumbSkeleton({ className, ...rest }) {
+  const classes = cx(`${prefix}--breadcrumb`, `${prefix}--skeleton`, className);
 
   return (
-    <div className={className} {...rest}>
+    <div className={classes} {...rest}>
       {item}
       {item}
       {item}

--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -7,20 +7,27 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const ButtonSkeleton = ({ small, href }) => {
-  const buttonClasses = classNames({
+const ButtonSkeleton = ({
+  className: customClassName,
+  small,
+  href,
+  ...rest
+}) => {
+  const buttonClasses = cx({
     [`${prefix}--skeleton`]: true,
     [`${prefix}--btn`]: true,
     [`${prefix}--btn--sm`]: small,
+    customClassName,
   });
 
   const commonProps = {
     className: buttonClasses,
+    ...rest,
   };
 
   const button = <div {...commonProps} />;
@@ -40,6 +47,11 @@ ButtonSkeleton.propTypes = {
    * Optionally specify an href for your Button to become an <a> element
    */
   href: PropTypes.string,
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 ButtonSkeleton.defaultProps = {

--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -13,11 +13,10 @@ import { settings } from 'carbon-components';
 const { prefix } = settings;
 
 const ButtonSkeleton = ({ className, small, href, ...rest }) => {
-  const buttonClasses = cx({
+  const buttonClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--btn`]: true,
     [`${prefix}--btn--sm`]: small,
-    className,
   });
 
   const commonProps = {

--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -12,17 +12,12 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const ButtonSkeleton = ({
-  className: customClassName,
-  small,
-  href,
-  ...rest
-}) => {
+const ButtonSkeleton = ({ className, small, href, ...rest }) => {
   const buttonClasses = cx({
     [`${prefix}--skeleton`]: true,
     [`${prefix}--btn`]: true,
     [`${prefix}--btn--sm`]: small,
-    customClassName,
+    className,
   });
 
   const commonProps = {

--- a/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
+++ b/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
@@ -5,15 +5,30 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const CheckboxSkeleton = () => (
-  <div className={`${prefix}--form-item ${prefix}--checkbox-wrapper`}>
+const CheckboxSkeleton = ({ className: customClassName, ...rest }) => (
+  <div
+    className={cx(
+      `${prefix}--form-item`,
+      `${prefix}--checkbox-wrapper`,
+      customClassName
+    )}
+    {...rest}>
     <span className={`${prefix}--checkbox-label ${prefix}--skeleton`} />
   </div>
 );
+
+CheckboxSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default CheckboxSkeleton;

--- a/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
+++ b/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
@@ -12,12 +12,12 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const CheckboxSkeleton = ({ className: customClassName, ...rest }) => (
+const CheckboxSkeleton = ({ className, ...rest }) => (
   <div
     className={cx(
       `${prefix}--form-item`,
       `${prefix}--checkbox-wrapper`,
-      customClassName
+      className
     )}
     {...rest}>
     <span className={`${prefix}--checkbox-label ${prefix}--skeleton`} />

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -18,9 +18,10 @@ const DataTableSkeleton = ({
   zebra,
   compact,
   headers,
-  ...other
+  className: customClassName,
+  ...rest
 }) => {
-  const dataTableSkeletonClasses = classNames({
+  const dataTableSkeletonClasses = cx(customClassName, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--data-table`]: true,
     [`${prefix}--data-table--zebra`]: zebra,
@@ -49,7 +50,7 @@ const DataTableSkeleton = ({
   }
 
   return (
-    <table className={dataTableSkeletonClasses} {...other}>
+    <table className={dataTableSkeletonClasses} {...rest}>
       <thead>
         <tr>
           {columnsArray.map(i => (
@@ -103,6 +104,11 @@ DataTableSkeleton.propTypes = {
       header: PropTypes.node,
     }),
   ]),
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 DataTableSkeleton.defaultProps = {

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -18,10 +18,10 @@ const DataTableSkeleton = ({
   zebra,
   compact,
   headers,
-  className: customClassName,
+  className,
   ...rest
 }) => {
-  const dataTableSkeletonClasses = cx(customClassName, {
+  const dataTableSkeletonClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--data-table`]: true,
     [`${prefix}--data-table--zebra`]: zebra,

--- a/packages/react/src/components/DatePicker/DatePicker.Skeleton.js
+++ b/packages/react/src/components/DatePicker/DatePicker.Skeleton.js
@@ -7,11 +7,17 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const DatePickerSkeleton = ({ range, id }) => {
+const DatePickerSkeleton = ({
+  range,
+  id,
+  className: customClassName,
+  ...rest
+}) => {
   const dateInput = (
     <div className={`${prefix}--date-picker-container`}>
       {
@@ -26,7 +32,13 @@ const DatePickerSkeleton = ({ range, id }) => {
     return (
       <div className={`${prefix}--form-item`}>
         <div
-          className={`${prefix}--date-picker ${prefix}--date-picker--range ${prefix}--skeleton`}>
+          className={cx(
+            `${prefix}--date-picker`,
+            `${prefix}--date-picker--range`,
+            `${prefix}--skeleton`,
+            customClassName
+          )}
+          {...rest}>
           {dateInput}
           {dateInput}
         </div>
@@ -37,7 +49,14 @@ const DatePickerSkeleton = ({ range, id }) => {
   return (
     <div className={`${prefix}--form-item`}>
       <div
-        className={`${prefix}--date-picker ${prefix}--date-picker--short ${prefix}--date-picker--simple ${prefix}--skeleton`}>
+        className={cx(
+          `${prefix}--date-picker`,
+          `${prefix}--date-picker--short`,
+          `${prefix}--date-picker--simple`,
+          `${prefix}--skeleton`,
+          customClassName
+        )}
+        {...rest}>
         {dateInput}
       </div>
     </div>
@@ -49,6 +68,11 @@ DatePickerSkeleton.propTypes = {
    * Specify whether the skeleton should be of range date picker.
    */
   range: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 export default DatePickerSkeleton;

--- a/packages/react/src/components/DatePicker/DatePicker.Skeleton.js
+++ b/packages/react/src/components/DatePicker/DatePicker.Skeleton.js
@@ -12,12 +12,7 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const DatePickerSkeleton = ({
-  range,
-  id,
-  className: customClassName,
-  ...rest
-}) => {
+const DatePickerSkeleton = ({ range, id, className, ...rest }) => {
   const dateInput = (
     <div className={`${prefix}--date-picker-container`}>
       {
@@ -36,7 +31,7 @@ const DatePickerSkeleton = ({
             `${prefix}--date-picker`,
             `${prefix}--date-picker--range`,
             `${prefix}--skeleton`,
-            customClassName
+            className
           )}
           {...rest}>
           {dateInput}
@@ -54,7 +49,7 @@ const DatePickerSkeleton = ({
           `${prefix}--date-picker--short`,
           `${prefix}--date-picker--simple`,
           `${prefix}--skeleton`,
-          customClassName
+          className
         )}
         {...rest}>
         {dateInput}

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
@@ -12,14 +12,15 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const DropdownSkeleton = ({ inline, className: customClassName, ...rest }) => {
-  const wrapperClasses = cx(customClassName, {
+const DropdownSkeleton = ({ inline, className, ...rest }) => {
+  const wrapperClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--dropdown-v2`]: true,
     [`${prefix}--list-box`]: true,
     [`${prefix}--form-item`]: true,
     [`${prefix}--list-box--inline`]: inline,
   });
+
   return (
     <div className={wrapperClasses} {...rest}>
       <div role="button" className={`${prefix}--list-box__field`}>

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
@@ -7,13 +7,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const DropdownSkeleton = ({ inline }) => {
-  const wrapperClasses = classNames({
+const DropdownSkeleton = ({ inline, className: customClassName, ...rest }) => {
+  const wrapperClasses = cx(customClassName, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--dropdown-v2`]: true,
     [`${prefix}--list-box`]: true,
@@ -21,7 +21,7 @@ const DropdownSkeleton = ({ inline }) => {
     [`${prefix}--list-box--inline`]: inline,
   });
   return (
-    <div className={wrapperClasses}>
+    <div className={wrapperClasses} {...rest}>
       <div role="button" className={`${prefix}--list-box__field`}>
         <span className={`${prefix}--list-box__label`} />
       </div>
@@ -34,6 +34,11 @@ DropdownSkeleton.propTypes = {
    * Specify whether you want the inline version of this control
    */
   inline: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 DropdownSkeleton.defaultProps = {

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
@@ -14,9 +14,9 @@ import ButtonSkeleton from '../Button/Button.Skeleton';
 
 const { prefix } = settings;
 
-function FileUploaderSkeleton({ className: customClassName, ...rest }) {
+function FileUploaderSkeleton({ className, ...rest }) {
   return (
-    <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+    <div className={cx(`${prefix}--form-item`, className)} {...rest}>
       <SkeletonText heading width="100px" />
       <SkeletonText width="225px" className={`${prefix}--label-description`} />
       <ButtonSkeleton />

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
@@ -5,21 +5,30 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 import SkeletonText from '../SkeletonText';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 
 const { prefix } = settings;
 
-function FileUploaderSkeleton() {
+function FileUploaderSkeleton({ className: customClassName, ...rest }) {
   return (
-    <div className={`${prefix}--form-item`}>
+    <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
       <SkeletonText heading width="100px" />
       <SkeletonText width="225px" className={`${prefix}--label-description`} />
       <ButtonSkeleton />
     </div>
   );
 }
+
+FileUploaderSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default FileUploaderSkeleton;

--- a/packages/react/src/components/Icon/Icon.Skeleton.js
+++ b/packages/react/src/components/Icon/Icon.Skeleton.js
@@ -12,17 +12,14 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const IconSkeleton = ({ style, className: customClassName, ...rest }) => {
+const IconSkeleton = ({ style, className, ...rest }) => {
   const props = {
     style,
     ...rest,
   };
 
   return (
-    <div
-      className={cx(`${prefix}--icon--skeleton`, customClassName)}
-      {...props}
-    />
+    <div className={cx(`${prefix}--icon--skeleton`, className)} {...props} />
   );
 };
 

--- a/packages/react/src/components/Icon/Icon.Skeleton.js
+++ b/packages/react/src/components/Icon/Icon.Skeleton.js
@@ -7,16 +7,23 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const IconSkeleton = ({ style }) => {
+const IconSkeleton = ({ style, className: customClassName, ...rest }) => {
   const props = {
     style,
+    ...rest,
   };
 
-  return <div className={`${prefix}--icon--skeleton`} {...props} />;
+  return (
+    <div
+      className={cx(`${prefix}--icon--skeleton`, customClassName)}
+      {...props}
+    />
+  );
 };
 
 IconSkeleton.propTypes = {
@@ -24,6 +31,11 @@ IconSkeleton.propTypes = {
    * The CSS styles.
    */
   style: PropTypes.object,
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 export default IconSkeleton;

--- a/packages/react/src/components/NumberInput/NumberInput.Skeleton.js
+++ b/packages/react/src/components/NumberInput/NumberInput.Skeleton.js
@@ -12,12 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const NumberInputSkeleton = ({
-  hideLabel,
-  className: customClassName,
-  ...rest
-}) => (
-  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+const NumberInputSkeleton = ({ hideLabel, className, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--number ${prefix}--skeleton`} />
   </div>

--- a/packages/react/src/components/NumberInput/NumberInput.Skeleton.js
+++ b/packages/react/src/components/NumberInput/NumberInput.Skeleton.js
@@ -7,12 +7,17 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const NumberInputSkeleton = ({ hideLabel }) => (
-  <div className={`${prefix}--form-item`}>
+const NumberInputSkeleton = ({
+  hideLabel,
+  className: customClassName,
+  ...rest
+}) => (
+  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--number ${prefix}--skeleton`} />
   </div>
@@ -23,6 +28,11 @@ NumberInputSkeleton.propTypes = {
    * Specify whether the label should be hidden, or not
    */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add to the form item wrapper.
+   */
+  className: PropTypes.string,
 };
 
 export default NumberInputSkeleton;

--- a/packages/react/src/components/Pagination/Pagination.Skeleton.js
+++ b/packages/react/src/components/Pagination/Pagination.Skeleton.js
@@ -13,14 +13,10 @@ import SkeletonText from '../SkeletonText';
 
 const { prefix } = settings;
 
-function PaginationSkeleton({ className: customClassName, ...rest }) {
+function PaginationSkeleton({ className, ...rest }) {
   return (
     <div
-      className={cx(
-        `${prefix}--pagination`,
-        `${prefix}--skeleton`,
-        customClassName
-      )}
+      className={cx(`${prefix}--pagination`, `${prefix}--skeleton`, className)}
       {...rest}>
       <div className={`${prefix}--pagination__left`}>
         <SkeletonText width="70px" />

--- a/packages/react/src/components/Pagination/Pagination.Skeleton.js
+++ b/packages/react/src/components/Pagination/Pagination.Skeleton.js
@@ -5,26 +5,41 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 import SkeletonText from '../SkeletonText';
 
 const { prefix } = settings;
 
-export default class PaginationSkeleton extends React.Component {
-  render() {
-    return (
-      <div className={`${prefix}--pagination ${prefix}--skeleton`}>
-        <div className={`${prefix}--pagination__left`}>
-          <SkeletonText width="70px" />
-          <SkeletonText width="35px" />
-          <SkeletonText width="105px" />
-        </div>
-        <div
-          className={`${prefix}--pagination__right ${prefix}--pagination--inline`}>
-          <SkeletonText width="70px" />
-        </div>
+function PaginationSkeleton({ className: customClassName, ...rest }) {
+  return (
+    <div
+      className={cx(
+        `${prefix}--pagination`,
+        `${prefix}--skeleton`,
+        customClassName
+      )}
+      {...rest}>
+      <div className={`${prefix}--pagination__left`}>
+        <SkeletonText width="70px" />
+        <SkeletonText width="35px" />
+        <SkeletonText width="105px" />
       </div>
-    );
-  }
+      <div
+        className={`${prefix}--pagination__right ${prefix}--pagination--inline`}>
+        <SkeletonText width="70px" />
+      </div>
+    </div>
+  );
 }
+
+PaginationSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
+
+export default PaginationSkeleton;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -26,14 +26,10 @@ const step = (
   </li>
 );
 
-function ProgressIndicatorSkeleton({ className: customClassName, ...rest }) {
+function ProgressIndicatorSkeleton({ className, ...rest }) {
   return (
     <ul
-      className={cx(
-        `${prefix}--progress`,
-        `${prefix}--skeleton`,
-        customClassName
-      )}
+      className={cx(`${prefix}--progress`, `${prefix}--skeleton`, className)}
       {...rest}>
       {step}
       {step}

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -24,9 +26,15 @@ const step = (
   </li>
 );
 
-function ProgressIndicatorSkeleton() {
+function ProgressIndicatorSkeleton({ className: customClassName, ...rest }) {
   return (
-    <ul className={`${prefix}--progress ${prefix}--skeleton`}>
+    <ul
+      className={cx(
+        `${prefix}--progress`,
+        `${prefix}--skeleton`,
+        customClassName
+      )}
+      {...rest}>
       {step}
       {step}
       {step}
@@ -34,5 +42,12 @@ function ProgressIndicatorSkeleton() {
     </ul>
   );
 }
+
+ProgressIndicatorSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default ProgressIndicatorSkeleton;

--- a/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
+++ b/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
@@ -5,18 +5,29 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-function RadioButtonSkeleton() {
+function RadioButtonSkeleton({ className: customClassName, ...rest }) {
   return (
-    <div className={`${prefix}--radio-button-wrapper`}>
+    <div
+      className={cx(`${prefix}--radio-button-wrapper`, customClassName)}
+      {...rest}>
       <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
       <span className={`${prefix}--radio-button__label ${prefix}--skeleton`} />
     </div>
   );
 }
+
+RadioButtonSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default RadioButtonSkeleton;

--- a/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
+++ b/packages/react/src/components/RadioButton/RadioButton.Skeleton.js
@@ -12,11 +12,9 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-function RadioButtonSkeleton({ className: customClassName, ...rest }) {
+function RadioButtonSkeleton({ className, ...rest }) {
   return (
-    <div
-      className={cx(`${prefix}--radio-button-wrapper`, customClassName)}
-      {...rest}>
+    <div className={cx(`${prefix}--radio-button-wrapper`, className)} {...rest}>
       <div className={`${prefix}--radio-button ${prefix}--skeleton`} />
       <span className={`${prefix}--radio-button__label ${prefix}--skeleton`} />
     </div>

--- a/packages/react/src/components/Search/Search.Skeleton.js
+++ b/packages/react/src/components/Search/Search.Skeleton.js
@@ -7,20 +7,20 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const SearchSkeleton = ({ small }) => {
-  const searchClasses = classNames({
+const SearchSkeleton = ({ small, className: customClassName, ...rest }) => {
+  const searchClasses = cx(customClassName, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--search--xl`]: !small,
     [`${prefix}--search--sm`]: small,
   });
 
   return (
-    <div className={searchClasses}>
+    <div className={searchClasses} {...rest}>
       <span className={`${prefix}--label`} />
       <div className={`${prefix}--search-input`} />
     </div>
@@ -32,6 +32,11 @@ SearchSkeleton.propTypes = {
    * Specify whether the Search should be a small variant
    */
   small: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 SearchSkeleton.defaultProps = {

--- a/packages/react/src/components/Search/Search.Skeleton.js
+++ b/packages/react/src/components/Search/Search.Skeleton.js
@@ -12,8 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const SearchSkeleton = ({ small, className: customClassName, ...rest }) => {
-  const searchClasses = cx(customClassName, {
+const SearchSkeleton = ({ small, className, ...rest }) => {
+  const searchClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--search--xl`]: !small,
     [`${prefix}--search--sm`]: small,

--- a/packages/react/src/components/Select/Select.Skeleton.js
+++ b/packages/react/src/components/Select/Select.Skeleton.js
@@ -7,12 +7,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const SelectSkeleton = ({ hideLabel }) => (
-  <div className={`${prefix}--form-item`}>
+const SelectSkeleton = ({ hideLabel, className: customClassName, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--select ${prefix}--skeleton`}>
       <div className={`${prefix}--select-input`} />
@@ -25,6 +26,11 @@ SelectSkeleton.propTypes = {
    * Specify whether the label should be hidden, or not
    */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add to the form item wrapper.
+   */
+  className: PropTypes.string,
 };
 
 export default SelectSkeleton;

--- a/packages/react/src/components/Select/Select.Skeleton.js
+++ b/packages/react/src/components/Select/Select.Skeleton.js
@@ -12,8 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const SelectSkeleton = ({ hideLabel, className: customClassName, ...rest }) => (
-  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+const SelectSkeleton = ({ hideLabel, className, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--select ${prefix}--skeleton`}>
       <div className={`${prefix}--select-input`} />

--- a/packages/react/src/components/Slider/Slider.Skeleton.js
+++ b/packages/react/src/components/Slider/Slider.Skeleton.js
@@ -12,8 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const SliderSkeleton = ({ hideLabel, className: customClassName, ...rest }) => (
-  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+const SliderSkeleton = ({ hideLabel, className, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--slider-container ${prefix}--skeleton`}>
       <span className={`${prefix}--slider__range-label`} />

--- a/packages/react/src/components/Slider/Slider.Skeleton.js
+++ b/packages/react/src/components/Slider/Slider.Skeleton.js
@@ -7,12 +7,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const SliderSkeleton = ({ hideLabel }) => (
-  <div className={`${prefix}--form-item`}>
+const SliderSkeleton = ({ hideLabel, className: customClassName, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--slider-container ${prefix}--skeleton`}>
       <span className={`${prefix}--slider__range-label`} />
@@ -31,6 +32,11 @@ SliderSkeleton.propTypes = {
    * Specify whether the label should be hidden, or not
    */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add to the form item wrapper.
+   */
+  className: PropTypes.string,
 };
 
 export default SliderSkeleton;

--- a/packages/react/src/components/StructuredList/StructuredList.Skeleton.js
+++ b/packages/react/src/components/StructuredList/StructuredList.Skeleton.js
@@ -7,13 +7,18 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const StructuredListSkeleton = ({ rowCount, border }) => {
-  const StructuredListSkeletonClasses = classNames({
+const StructuredListSkeleton = ({
+  rowCount,
+  border,
+  className: customClassName,
+  ...rest
+}) => {
+  const StructuredListSkeletonClasses = cx(customClassName, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--structured-list`]: true,
     [`${prefix}--structured-list--border`]: border,
@@ -31,7 +36,7 @@ const StructuredListSkeleton = ({ rowCount, border }) => {
   }
 
   return (
-    <section className={StructuredListSkeletonClasses}>
+    <section className={StructuredListSkeletonClasses} {...rest}>
       <div className={`${prefix}--structured-list-thead`}>
         <div
           className={`${prefix}--structured-list-row ${prefix}--structured-list-row--header-row`}>
@@ -61,6 +66,11 @@ StructuredListSkeleton.propTypes = {
    * Specify whether a border should be added to your StructuredListSkeleton
    */
   border: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
 };
 
 StructuredListSkeleton.defaultProps = {

--- a/packages/react/src/components/StructuredList/StructuredList.Skeleton.js
+++ b/packages/react/src/components/StructuredList/StructuredList.Skeleton.js
@@ -12,13 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const StructuredListSkeleton = ({
-  rowCount,
-  border,
-  className: customClassName,
-  ...rest
-}) => {
-  const StructuredListSkeletonClasses = cx(customClassName, {
+const StructuredListSkeleton = ({ rowCount, border, className, ...rest }) => {
+  const StructuredListSkeletonClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--structured-list`]: true,
     [`${prefix}--structured-list--border`]: border,

--- a/packages/react/src/components/Tabs/Tabs.Skeleton.js
+++ b/packages/react/src/components/Tabs/Tabs.Skeleton.js
@@ -18,10 +18,10 @@ const tab = (
   </li>
 );
 
-function TabsSkeleton({ className: customClassName, ...rest }) {
+function TabsSkeleton({ className, ...rest }) {
   return (
     <div
-      className={cx(`${prefix}--tabs`, `${prefix}--skeleton`, customClassName)}
+      className={cx(`${prefix}--tabs`, `${prefix}--skeleton`, className)}
       {...rest}>
       <div className={`${prefix}--tabs-trigger`}>
         <div className={`${prefix}--tabs-trigger-text`}>&nbsp;</div>

--- a/packages/react/src/components/Tabs/Tabs.Skeleton.js
+++ b/packages/react/src/components/Tabs/Tabs.Skeleton.js
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -16,9 +18,11 @@ const tab = (
   </li>
 );
 
-function TabsSkeleton() {
+function TabsSkeleton({ className: customClassName, ...rest }) {
   return (
-    <div className={`${prefix}--tabs ${prefix}--skeleton`}>
+    <div
+      className={cx(`${prefix}--tabs`, `${prefix}--skeleton`, customClassName)}
+      {...rest}>
       <div className={`${prefix}--tabs-trigger`}>
         <div className={`${prefix}--tabs-trigger-text`}>&nbsp;</div>
         <svg width="10" height="5" viewBox="0 0 10 5" fillRule="evenodd">
@@ -34,5 +38,12 @@ function TabsSkeleton() {
     </div>
   );
 }
+
+TabsSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default TabsSkeleton;

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -12,10 +12,10 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-function TagSkeleton({ className: customClassName, ...rest }) {
+function TagSkeleton({ className, ...rest }) {
   return (
     <span
-      className={cx(`${prefix}--tag`, `${prefix}--skeleton`, customClassName)}
+      className={cx(`${prefix}--tag`, `${prefix}--skeleton`, className)}
       {...rest}
     />
   );

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -5,13 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-function TagSkeleton() {
-  return <span className={`${prefix}--tag ${prefix}--skeleton`} />;
+function TagSkeleton({ className: customClassName, ...rest }) {
+  return (
+    <span
+      className={cx(`${prefix}--tag`, `${prefix}--skeleton`, customClassName)}
+      {...rest}
+    />
+  );
 }
+
+TagSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
 
 export default TagSkeleton;

--- a/packages/react/src/components/TextArea/TextArea.Skeleton.js
+++ b/packages/react/src/components/TextArea/TextArea.Skeleton.js
@@ -12,12 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const TextAreaSkeleton = ({
-  hideLabel,
-  className: customClassName,
-  ...rest
-}) => (
-  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+const TextAreaSkeleton = ({ hideLabel, className, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--skeleton ${prefix}--text-area`} />
   </div>

--- a/packages/react/src/components/TextArea/TextArea.Skeleton.js
+++ b/packages/react/src/components/TextArea/TextArea.Skeleton.js
@@ -7,12 +7,17 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const TextAreaSkeleton = ({ hideLabel }) => (
-  <div className={`${prefix}--form-item`}>
+const TextAreaSkeleton = ({
+  hideLabel,
+  className: customClassName,
+  ...rest
+}) => (
+  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--skeleton ${prefix}--text-area`} />
   </div>
@@ -23,6 +28,11 @@ TextAreaSkeleton.propTypes = {
    * Specify whether the label should be hidden, or not
    */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add to the form item wrapper.
+   */
+  className: PropTypes.string,
 };
 
 export default TextAreaSkeleton;

--- a/packages/react/src/components/TextInput/TextInput.Skeleton.js
+++ b/packages/react/src/components/TextInput/TextInput.Skeleton.js
@@ -7,12 +7,17 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const TextInputSkeleton = ({ hideLabel }) => (
-  <div className={`${prefix}--form-item`}>
+const TextInputSkeleton = ({
+  hideLabel,
+  className: customClassName,
+  ...rest
+}) => (
+  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--skeleton ${prefix}--text-input`} />
   </div>
@@ -23,6 +28,11 @@ TextInputSkeleton.propTypes = {
    * Specify whether the label should be hidden, or not
    */
   hideLabel: PropTypes.bool,
+
+  /**
+   * Specify an optional className to add to the form item wrapper.
+   */
+  className: PropTypes.string,
 };
 
 export default TextInputSkeleton;

--- a/packages/react/src/components/TextInput/TextInput.Skeleton.js
+++ b/packages/react/src/components/TextInput/TextInput.Skeleton.js
@@ -12,12 +12,8 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const TextInputSkeleton = ({
-  hideLabel,
-  className: customClassName,
-  ...rest
-}) => (
-  <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+const TextInputSkeleton = ({ hideLabel, className, ...rest }) => (
+  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
     {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
     <div className={`${prefix}--skeleton ${prefix}--text-input`} />
   </div>

--- a/packages/react/src/components/Toggle/Toggle.Skeleton.js
+++ b/packages/react/src/components/Toggle/Toggle.Skeleton.js
@@ -7,6 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -26,6 +27,11 @@ export default class ToggleSkeleton extends React.Component {
      */
     labelText: PropTypes.string,
     ['aria-label']: PropTypes.string.isRequired,
+
+    /**
+     * Specify an optional className to add to the form item wrapper.
+     */
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -33,10 +39,10 @@ export default class ToggleSkeleton extends React.Component {
   };
 
   render() {
-    const { id, labelText } = this.props;
+    const { id, labelText, className: customClassName, ...rest } = this.props;
 
     return (
-      <div className={`${prefix}--form-item`}>
+      <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
         <input
           type="checkbox"
           id={id}

--- a/packages/react/src/components/Toggle/Toggle.Skeleton.js
+++ b/packages/react/src/components/Toggle/Toggle.Skeleton.js
@@ -39,10 +39,10 @@ export default class ToggleSkeleton extends React.Component {
   };
 
   render() {
-    const { id, labelText, className: customClassName, ...rest } = this.props;
+    const { id, labelText, className, ...rest } = this.props;
 
     return (
-      <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+      <div className={cx(`${prefix}--form-item`, className)} {...rest}>
         <input
           type="checkbox"
           id={id}

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.Skeleton.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.Skeleton.js
@@ -39,9 +39,9 @@ export default class ToggleSmallSkeleton extends React.Component {
   };
 
   render() {
-    const { id, labelText, className: customClassName, ...rest } = this.props;
+    const { id, labelText, className, ...rest } = this.props;
     return (
-      <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
+      <div className={cx(`${prefix}--form-item`, className)} {...rest}>
         <input
           type="checkbox"
           id={id}

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.Skeleton.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.Skeleton.js
@@ -7,6 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -26,6 +27,11 @@ export default class ToggleSmallSkeleton extends React.Component {
      */
     labelText: PropTypes.string,
     ['aria-label']: PropTypes.string.isRequired,
+
+    /**
+     * Specify an optional className to add to the form item wrapper.
+     */
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -33,9 +39,9 @@ export default class ToggleSmallSkeleton extends React.Component {
   };
 
   render() {
-    const { id, labelText } = this.props;
+    const { id, labelText, className: customClassName, ...rest } = this.props;
     return (
-      <div className={`${prefix}--form-item`}>
+      <div className={cx(`${prefix}--form-item`, customClassName)} {...rest}>
         <input
           type="checkbox"
           id={id}


### PR DESCRIPTION
Closes #4601 

Added a `className` prop and also `...rest` to skeleton components so that they can accept a class name from consumers, plus extra props if necessary.

I tried to make minimal changes outside of this scope, but let me know if you notice anything you'd like for me to adjust. 👍 

I also made certain assumptions about structure/naming. For example, I've mostly seen the classnames package referred to as `cx` in the codebase so I used that. ~And I've seen the default `className: customClassName` used as well. But again, let me know if you want this changed!~

#### Changelog

**Changed**

Added `className` + `...rest` to the following:
- AccordionSkeleton
- BreadcrumbSkeleton
- ButtonSkeleton
- CheckboxSkeleton
- DataTableSkeleton
- DatePickerSkeleton
- DropdownSkeleton
- FileUploaderSkeleton
- IconSkeleton
- NumberInputSkeleton
- PaginationSkeleton
- ProgressIndicatorSkeleton
- RadioButtonSkeleton
- SearchSkeleton
- SelectSkeleton
- SliderSkeleton
- StructuredListSkeleton
- TabsSkeleton
- TagSkeleton
- TextAreaSkeleton
- TextInputSkeleton
- ToggleSkeleton
- ToggleSmallSkeleton