### PR TITLE
fix(multi-select): add display name for filterable version

### DIFF
--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MultiSelect.Filterable should render 1`] = `
-<FilterableMultiSelect
+<MultiSelect.Filterable
   ariaLabel="Choose an item"
   compareItems={[Function]}
   disabled={false}
@@ -192,5 +192,5 @@ exports[`MultiSelect.Filterable should render 1`] = `
       </Downshift>
     </Selection>
   </div>
-</FilterableMultiSelect>
+</MultiSelect.Filterable>
 `;

--- a/packages/react/src/components/MultiSelect/index.js
+++ b/packages/react/src/components/MultiSelect/index.js
@@ -8,6 +8,7 @@
 import MultiSelect from './MultiSelect';
 import FilterableMultiSelect from './FilterableMultiSelect';
 
+FilterableMultiSelect.displayName = 'MultiSelect.Filterable';
 MultiSelect.Filterable = FilterableMultiSelect;
 
 export default MultiSelect;


### PR DESCRIPTION
Addresses an issue raised in this comment: https://github.com/carbon-design-system/carbon/issues/4612#issuecomment-551263254

If you look at the `MultiSelect` story and select the "Filterable" option in the knobs, then you view the story source, you'll see that the source calls the components `FilterableMultiSelect` but that's not really the name of the component as it is exported and used -- it should be `MultiSelect.Filterable` --

![Screen Shot 2019-11-07 at 3 52 55 PM](https://user-images.githubusercontent.com/9057921/68430961-c1f44000-0176-11ea-895d-ff6bff3f9a71.png)

You also see it called `FilterableMultiSelect` if you inspect the component with the React plugin.

I propose adding a display name to change `FilterableMultiSelect` name to `MultiSelect.Filterable`, which is its exported name. This will fix the display name in storybook as well as elsewhere like in the React plugin/ dev tools.

Quick note: I applied this change to the `MultiSelect` component entry point because that's where the `MultiSelect.Filterable = FilterableMultiSelect` assignment is, but let me know if I should move it elsewhere! (IMO needs to be in the component source code or that entry point, since this isn't a storybook-specific issue)

#### Changelog

**New**

- add display name for `MultiSelect.Filterable`
