### PR TITLE
chore: use loose option for class property transpilation

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -129,7 +129,12 @@
       "dev-expression",
       "@babel/plugin-syntax-dynamic-import",
       "@babel/plugin-syntax-import-meta",
-      "@babel/plugin-proposal-class-properties",
+      [
+        "@babel/plugin-proposal-class-properties",
+        {
+          "loose": false
+        }
+      ],
       "@babel/plugin-proposal-export-namespace-from",
       "@babel/plugin-proposal-export-default-from"
     ]


### PR DESCRIPTION
Closes #4633

This only changes class components using `static propTypes`. It doesn't impact functional components or classes which assign `propTypes` outside of the class.

### before
```javascript
_defineProperty(CodeSnippet, "propTypes", {
  /**
   * Provide the type of Code Snippet
   */
  type: PropTypes.oneOf(['single', 'inline', 'multi']),

  /**
   * Specify an optional className to be applied to the container node
   */
  className: PropTypes.string
}
```

### after
```javascript
CodeSnippet.propTypes = {
  /**
   * Provide the type of Code Snippet
   */
  type: PropTypes.oneOf(['single', 'inline', 'multi']),

  /**
   * Specify an optional className to be applied to the container node
   */
  className: PropTypes.string,
}
```