### PR TITLE
feat(modal): introduce size variants

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -71,8 +71,9 @@
 
   .#{$prefix}--modal-container {
     position: relative;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    grid-template-columns: auto;
     background-color: $ui-01;
     width: 100%;
     height: 100%;
@@ -83,31 +84,98 @@
     transition: transform $duration--moderate-02 motion(exit, expressive);
 
     @include carbon--breakpoint(md) {
-      width: 50%;
+      width: 84%;
       max-width: 768px;
       max-height: 90%;
       height: auto;
     }
 
     @include carbon--breakpoint(lg) {
-      max-height: 80%;
+      width: 60%;
+      max-height: 84%;
+    }
+
+    @include carbon--breakpoint(xlg) {
+      width: 48%;
+    }
+  }
+
+  .#{$prefix}--modal-container--xs {
+    @include carbon--breakpoint(md) {
+      width: 48%;
+    }
+
+    @include carbon--breakpoint(lg) {
+      width: 32%;
+      max-height: 48%;
+    }
+
+    @include carbon--breakpoint(xlg) {
+      width: 24%;
+
+      .#{$prefix}--modal-header,
+      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content__regular-content {
+        padding-right: rem(16px);
+      }
+    }
+  }
+
+  .#{$prefix}--modal-container--sm {
+    @include carbon--breakpoint(md) {
+      width: 60%;
+    }
+
+    @include carbon--breakpoint(lg) {
+      width: 42%;
+      max-height: 72%;
+    }
+
+    @include carbon--breakpoint(xlg) {
+      width: 36%;
+    }
+  }
+
+  .#{$prefix}--modal-container--lg {
+    @include carbon--breakpoint(md) {
+      width: 96%;
+    }
+
+    @include carbon--breakpoint(lg) {
+      width: 84%;
+      max-height: 96%;
+    }
+
+    @include carbon--breakpoint(xlg) {
+      width: 72%;
     }
   }
 
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content {
-    padding-right: 25%;
     padding-left: 1rem;
   }
 
   .#{$prefix}--modal-header,
-  .#{$prefix}--modal-footer {
-    flex-shrink: 0;
+  .#{$prefix}--modal-content,
+  .#{$prefix}--modal-content__regular-content {
+    padding-right: 20%;
+  }
+
+  .#{$prefix}--modal-content--with-form {
+    padding-right: 1rem;
+
+    @include carbon--breakpoint(xlg) {
+      padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+    }
   }
 
   .#{$prefix}--modal-header {
     padding-top: 1rem;
     margin-bottom: $carbon--spacing-03;
+
+    grid-row: 1/1;
+    grid-column: 1/-1;
   }
 
   .#{$prefix}--modal-header__label {
@@ -126,6 +194,9 @@
   .#{$prefix}--modal-content {
     @include type-style('body-long-01');
 
+    grid-row: 2/-2;
+    grid-column: 1/-1;
+
     overflow-y: auto;
     margin-bottom: $carbon--spacing-08;
     color: $text-01;
@@ -140,8 +211,28 @@
     }
   }
 
-  .#{$prefix}--modal-content > * {
-    @include type-style('body-long-01');
+  .#{$prefix}--modal-content {
+    > * {
+      @include type-style('body-long-01');
+    }
+  }
+
+  .#{$prefix}--modal-content--overflow-indicator {
+    grid-row: 2/-2;
+    grid-column: 1/-1;
+    width: 100%;
+    height: rem(16px);
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: $carbon--spacing-08;
+    background-image: linear-gradient(to bottom, transparent, $ui-01);
+  }
+
+  .#{$prefix}--modal-content:focus
+    ~ .#{$prefix}--modal-content--overflow-indicator {
+    width: calc(100% - 4px);
+    margin: 0 2px 2px 2px;
   }
 
   .#{$prefix}--modal-footer {
@@ -149,6 +240,9 @@
     margin-top: auto;
     height: 4rem;
     background-color: $modal-footer-background-color;
+
+    grid-row: -1/-1;
+    grid-column: 1/-1;
 
     button.#{$prefix}--btn {
       max-width: none;

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -85,9 +85,14 @@
 
     @include carbon--breakpoint(md) {
       width: 84%;
-      max-width: 768px;
       max-height: 90%;
       height: auto;
+
+      .#{$prefix}--modal-header,
+      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content__regular-content {
+        padding-right: 20%;
+      }
     }
 
     @include carbon--breakpoint(lg) {
@@ -100,7 +105,33 @@
     }
   }
 
+  .#{$prefix}--modal-header,
+  .#{$prefix}--modal-content {
+    padding-left: 1rem;
+  }
+
+  .#{$prefix}--modal-header,
+  .#{$prefix}--modal-content,
+  .#{$prefix}--modal-content__regular-content {
+    padding-right: 1rem;
+  }
+
+  .#{$prefix}--modal-content--with-form {
+    padding-right: 1rem;
+
+    @include carbon--breakpoint(md) {
+      padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+    }
+  }
+
   .#{$prefix}--modal-container--xs {
+    .#{$prefix}--modal-header,
+    .#{$prefix}--modal-content,
+    .#{$prefix}--modal-content__regular-content,
+    .#{$prefix}--modal-content--with-form {
+      padding-right: 1rem;
+    }
+
     @include carbon--breakpoint(md) {
       width: 48%;
     }
@@ -112,16 +143,17 @@
 
     @include carbon--breakpoint(xlg) {
       width: 24%;
-
-      .#{$prefix}--modal-header,
-      .#{$prefix}--modal-content,
-      .#{$prefix}--modal-content__regular-content {
-        padding-right: 1rem;
-      }
     }
   }
 
   .#{$prefix}--modal-container--sm {
+    .#{$prefix}--modal-header,
+    .#{$prefix}--modal-content,
+    .#{$prefix}--modal-content__regular-content,
+    .#{$prefix}--modal-content--with-form {
+      padding-right: 1rem;
+    }
+
     @include carbon--breakpoint(md) {
       width: 60%;
     }
@@ -133,12 +165,39 @@
 
     @include carbon--breakpoint(xlg) {
       width: 36%;
+
+      .#{$prefix}--modal-header,
+      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content__regular-content {
+        padding-right: 20%;
+      }
+
+      .#{$prefix}--modal-content--with-form {
+        padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+      }
     }
   }
 
   .#{$prefix}--modal-container--lg {
+    .#{$prefix}--modal-header,
+    .#{$prefix}--modal-content,
+    .#{$prefix}--modal-content__regular-content,
+    .#{$prefix}--modal-content--with-form {
+      padding-right: 1rem;
+    }
+
     @include carbon--breakpoint(md) {
       width: 96%;
+
+      .#{$prefix}--modal-header,
+      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content__regular-content {
+        padding-right: 20%;
+      }
+
+      .#{$prefix}--modal-content--with-form {
+        padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+      }
     }
 
     @include carbon--breakpoint(lg) {
@@ -148,25 +207,6 @@
 
     @include carbon--breakpoint(xlg) {
       width: 72%;
-    }
-  }
-
-  .#{$prefix}--modal-header,
-  .#{$prefix}--modal-content {
-    padding-left: 1rem;
-  }
-
-  .#{$prefix}--modal-header,
-  .#{$prefix}--modal-content,
-  .#{$prefix}--modal-content__regular-content {
-    padding-right: 20%;
-  }
-
-  .#{$prefix}--modal-content--with-form {
-    padding-right: 1rem;
-
-    @include carbon--breakpoint(xlg) {
-      padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
     }
   }
 
@@ -221,7 +261,7 @@
     grid-row: 2/-2;
     grid-column: 1/-1;
     width: 100%;
-    height: rem(16px);
+    height: rem(32px);
     content: '';
     position: absolute;
     left: 0;

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -116,7 +116,7 @@
       .#{$prefix}--modal-header,
       .#{$prefix}--modal-content,
       .#{$prefix}--modal-content__regular-content {
-        padding-right: rem(16px);
+        padding-right: 1rem;
       }
     }
   }

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -107,20 +107,20 @@
 
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content {
-    padding-left: 1rem;
+    padding-left: $carbon--spacing-05;
   }
 
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content,
   .#{$prefix}--modal-content__regular-content {
-    padding-right: 1rem;
+    padding-right: $carbon--spacing-05;
   }
 
   .#{$prefix}--modal-content--with-form {
-    padding-right: 1rem;
+    padding-right: $carbon--spacing-05;
 
     @include carbon--breakpoint(md) {
-      padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+      padding-right: $carbon--spacing-05; // Override for `.#{$prefix}--modal-content`
     }
   }
 
@@ -129,7 +129,7 @@
     .#{$prefix}--modal-content,
     .#{$prefix}--modal-content__regular-content,
     .#{$prefix}--modal-content--with-form {
-      padding-right: 1rem;
+      padding-right: $carbon--spacing-05;
     }
 
     @include carbon--breakpoint(md) {
@@ -151,7 +151,7 @@
     .#{$prefix}--modal-content,
     .#{$prefix}--modal-content__regular-content,
     .#{$prefix}--modal-content--with-form {
-      padding-right: 1rem;
+      padding-right: $carbon--spacing-05;
     }
 
     @include carbon--breakpoint(md) {
@@ -173,7 +173,7 @@
       }
 
       .#{$prefix}--modal-content--with-form {
-        padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+        padding-right: $carbon--spacing-05; // Override for `.#{$prefix}--modal-content`
       }
     }
   }
@@ -183,7 +183,7 @@
     .#{$prefix}--modal-content,
     .#{$prefix}--modal-content__regular-content,
     .#{$prefix}--modal-content--with-form {
-      padding-right: 1rem;
+      padding-right: $carbon--spacing-05;
     }
 
     @include carbon--breakpoint(md) {
@@ -196,7 +196,7 @@
       }
 
       .#{$prefix}--modal-content--with-form {
-        padding-right: 1rem; // Override for `.#{$prefix}--modal-content`
+        padding-right: $carbon--spacing-05; // Override for `.#{$prefix}--modal-content`
       }
     }
 
@@ -211,7 +211,7 @@
   }
 
   .#{$prefix}--modal-header {
-    padding-top: 1rem;
+    padding-top: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-03;
 
     grid-row: 1/1;
@@ -289,8 +289,8 @@
       flex: 1;
       height: 4rem;
       margin: 0;
-      padding-top: 1rem;
-      padding-bottom: 2rem;
+      padding-top: $carbon--spacing-05;
+      padding-bottom: $carbon--spacing-07;
     }
   }
 

--- a/packages/components/src/components/modal/modal.config.js
+++ b/packages/components/src/components/modal/modal.config.js
@@ -30,6 +30,45 @@ module.exports = {
       },
     },
     {
+      name: 'xs',
+      label: 'Transactional Modal (XS)',
+      context: {
+        idSuffix: Math.random()
+          .toString(36)
+          .substr(2),
+        hasFooter: true,
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
+        size: 'xs',
+      },
+    },
+    {
+      name: 'sm',
+      label: 'Transactional Modal (Small)',
+      context: {
+        idSuffix: Math.random()
+          .toString(36)
+          .substr(2),
+        hasFooter: true,
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
+        size: 'sm',
+      },
+    },
+    {
+      name: 'lg',
+      label: 'Transactional Modal (Large)',
+      context: {
+        idSuffix: Math.random()
+          .toString(36)
+          .substr(2),
+        hasFooter: true,
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
+        size: 'lg',
+      },
+    },
+    {
       name: 'nofooter',
       label: 'Passive Modal',
       notes: 'Passive Modals are modals without footers.',
@@ -40,6 +79,45 @@ module.exports = {
         hasFooter: false,
         classPrimaryButton: `${prefix}--btn--primary`,
         classCloseButton: `${prefix}--btn--secondary`,
+      },
+    },
+    {
+      name: 'nofooter-xs',
+      label: 'Passive Modal (XS)',
+      context: {
+        idSuffix: Math.random()
+          .toString(36)
+          .substr(2),
+        hasFooter: false,
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
+        size: 'xs',
+      },
+    },
+    {
+      name: 'nofooter-sm',
+      label: 'Passive Modal (Small)',
+      context: {
+        idSuffix: Math.random()
+          .toString(36)
+          .substr(2),
+        hasFooter: false,
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
+        size: 'sm',
+      },
+    },
+    {
+      name: 'nofooter-lg',
+      label: 'Passive Modal (Large)',
+      context: {
+        idSuffix: Math.random()
+          .toString(36)
+          .substr(2),
+        hasFooter: false,
+        classPrimaryButton: `${prefix}--btn--primary`,
+        classCloseButton: `${prefix}--btn--secondary`,
+        size: 'lg',
       },
     },
     {

--- a/packages/components/src/components/modal/modal.hbs
+++ b/packages/components/src/components/modal/modal.hbs
@@ -10,7 +10,7 @@
 
 <div data-modal id="modal-{{idSuffix}}" class="{{@root.prefix}}--modal {{classModalSupplemental}}" role="dialog"
   aria-modal="true" aria-labelledby="modal-{{idSuffix}}-label" aria-describedby="modal-{{idSuffix}}-heading" tabindex="-1">
-  <div class="{{@root.prefix}}--modal-container">
+  <div class="{{@root.prefix}}--modal-container{{#if size}} {{@root.prefix}}--modal-container--{{size}}{{/if}}">
     <div class="{{@root.prefix}}--modal-header">
       <p class="{{@root.prefix}}--modal-header__label {{@root.prefix}}--type-delta" id="modal-{{idSuffix}}-label">Optional label</p>
       <p class="{{@root.prefix}}--modal-header__heading {{@root.prefix}}--type-beta" id="modal-{{idSuffix}}-heading">Modal heading</p>
@@ -20,7 +20,8 @@
     </div>
 
     <!-- Note: Modals with content that scrolls, at any viewport, requires `tabindex="0"` on the `bx--modal-content` element -->
-    <div class="{{@root.prefix}}--modal-content" {{#if hasScrollingContent}}tabindex="0"{{/if}}>
+
+    <div class="{{@root.prefix}}--modal-content{{#if hasInput}} {{@root.prefix}}--modal-content--with-form{{/if}}" {{#if hasScrollingContent}}tabindex="0"{{/if}}>
       {{#if hasInput}}
       <div class="{{@root.prefix}}--form-item">
         <label for="text-input-{{idSuffix}}" class="{{@root.prefix}}--label">Text Input label</label>
@@ -71,9 +72,10 @@
         tellus tincidunt posuere. Curabitur justo urna, consectetur vel elit iaculis, ultrices condimentum risus. Nulla
         facilisi.
         Etiam venenatis molestie tellus. Quisque consectetur non risus eu rutrum. </p>
-        {{/if}}
+      {{/if}}
       {{/if}}
     </div>
+    <div class="{{@root.prefix}}--modal-content--overflow-indicator"></div>
 
     {{#if hasFooter}}
     <div class="{{@root.prefix}}--modal-footer">

--- a/packages/react/src/components/ComposedModal/ComposedModal-story.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-story.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import ComposedModal, {
   ModalHeader,
   ModalBody,
@@ -19,6 +19,13 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
+const sizes = {
+  Default: '',
+  'Extra small (xs)': 'xs',
+  'Small (sm)': 'sm',
+  'Large (lg)': 'lg',
+};
+
 const props = {
   composedModal: (includeOpen = true) => ({
     open: includeOpen ? boolean('Open (open in <ComposedModal>)', true) : null,
@@ -28,6 +35,7 @@ const props = {
       'Primary focus element selector (selectorPrimaryFocus)',
       '[data-modal-primary-focus]'
     ),
+    size: select('Size (size)', sizes),
   }),
   modalHeader: () => ({
     label: text('Optional Label (label in <ModalHeader>)', 'Optional Label'),
@@ -60,18 +68,21 @@ storiesOf('ComposedModal', module)
   .addDecorator(withKnobs)
   .add(
     'Using Header / Footer Props',
-    () => (
-      <ComposedModal {...props.composedModal()}>
-        <ModalHeader {...props.modalHeader()} />
-        <ModalBody>
-          <p className={`${prefix}--modal-content__text}`}>
-            Please see ModalWrapper for more examples and demo of the
-            functionality.
-          </p>
-        </ModalBody>
-        <ModalFooter {...props.modalFooter()} />
-      </ComposedModal>
-    ),
+    () => {
+      const { size, ...rest } = props.composedModal();
+      return (
+        <ComposedModal {...rest} size={size || undefined}>
+          <ModalHeader {...props.modalHeader()} />
+          <ModalBody>
+            <p className={`${prefix}--modal-content__text}`}>
+              Please see ModalWrapper for more examples and demo of the
+              functionality.
+            </p>
+          </ModalBody>
+          <ModalFooter {...props.modalFooter()} />
+        </ComposedModal>
+      );
+    },
     {
       info: {
         text: `
@@ -86,25 +97,28 @@ storiesOf('ComposedModal', module)
   )
   .add(
     'Using child nodes',
-    () => (
-      <ComposedModal {...props.composedModal()}>
-        <ModalHeader {...props.modalHeader()}>
-          <h1>Testing</h1>
-        </ModalHeader>
-        <ModalBody>
-          <p>
-            Please see ModalWrapper for more examples and demo of the
-            functionality.
-          </p>
-        </ModalBody>
-        <ModalFooter>
-          <Button kind="secondary">Cancel</Button>
-          <Button kind={props.composedModal().danger ? 'danger' : 'primary'}>
-            Save
-          </Button>
-        </ModalFooter>
-      </ComposedModal>
-    ),
+    () => {
+      const { size, ...rest } = props.composedModal();
+      return (
+        <ComposedModal {...rest} size={size || undefined}>
+          <ModalHeader {...props.modalHeader()}>
+            <h1>Testing</h1>
+          </ModalHeader>
+          <ModalBody>
+            <p>
+              Please see ModalWrapper for more examples and demo of the
+              functionality.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button kind="secondary">Cancel</Button>
+            <Button kind={props.composedModal().danger ? 'danger' : 'primary'}>
+              Save
+            </Button>
+          </ModalFooter>
+        </ComposedModal>
+      );
+    },
     {
       info: {
         text: `
@@ -121,14 +135,16 @@ storiesOf('ComposedModal', module)
         toggleModal = open => this.setState({ open });
         render() {
           const { open } = this.state;
+          const { size, ...rest } = props.composedModal();
           return (
             <>
               <Button onClick={() => this.toggleModal(true)}>
                 Launch composed modal
               </Button>
               <ComposedModal
-                {...props.composedModal()}
+                {...rest}
                 open={open}
+                size={size || undefined}
                 onClose={() => this.toggleModal(false)}>
                 <ModalHeader {...props.modalHeader()} />
                 <ModalBody>

--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -61,15 +61,13 @@ describe('<ModalBody />', () => {
     });
 
     it('renders wrapper as expected', () => {
-      expect(wrapper.length).toBe(1);
-    });
-
-    it('has the expected classes', () => {
-      expect(wrapper.hasClass(`${prefix}--modal-content`)).toEqual(true);
+      expect(wrapper.find(`.${prefix}--modal-content`).length).toBe(1);
     });
 
     it('renders extra classes passed in via className', () => {
-      expect(wrapper.hasClass('extra-class')).toEqual(true);
+      expect(
+        wrapper.find(`.${prefix}--modal-content`).hasClass('extra-class')
+      ).toEqual(true);
     });
   });
 });

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -399,7 +399,9 @@ export function ModalBody(props) {
       <div className={contentClass} {...hasScrollingContentProps} {...other}>
         {children}
       </div>
-      <div className={`${prefix}--modal-content--overflow-indicator`} />
+      {hasScrollingContent && (
+        <div className={`${prefix}--modal-content--overflow-indicator`} />
+      )}
     </>
   );
 }

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -60,6 +60,11 @@ export default class ComposedModal extends Component {
      * focused when the Modal opens
      */
     selectorPrimaryFocus: PropTypes.string,
+
+    /**
+     * Specify the size variant.
+     */
+    size: PropTypes.oneOf('xs', 'sm', 'lg'),
   };
 
   static getDerivedStateFromProps({ open }, state) {
@@ -192,6 +197,7 @@ export default class ComposedModal extends Component {
       children,
       danger,
       selectorPrimaryFocus, // eslint-disable-line
+      size,
       ...other
     } = this.props;
 
@@ -204,6 +210,7 @@ export default class ComposedModal extends Component {
 
     const containerClass = classNames({
       [`${prefix}--modal-container`]: true,
+      [`${prefix}--modal-container--${size}`]: size,
       [containerClassName]: containerClassName,
     });
 
@@ -379,20 +386,30 @@ export class ModalBody extends Component {
      * Specify an optional className to be added to the Modal Body node
      */
     className: PropTypes.string,
+
+    /**
+     * Provide whether the modal content has a form element.
+     * If `true` is used here, non-form child content should have `bx--modal-content__regular-content` class.
+     */
+    hasForm: PropTypes.bool,
   };
 
   render() {
-    const { className, children, ...other } = this.props;
+    const { className, children, hasForm, ...other } = this.props;
 
     const contentClass = classNames({
       [`${prefix}--modal-content`]: true,
+      [`${prefix}--modal-content--with-form`]: hasForm,
       [className]: className,
     });
 
     return (
-      <div className={contentClass} {...other}>
-        {children}
-      </div>
+      <>
+        <div className={contentClass} {...other}>
+          {children}
+        </div>
+        <div className={`${prefix}--modal-content--overflow-indicator`} />
+      </>
     );
   }
 }

--- a/packages/react/src/components/Modal/Modal-story.js
+++ b/packages/react/src/components/Modal/Modal-story.js
@@ -9,12 +9,19 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import Modal from '../Modal';
 import TextInput from '../TextInput';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
+
+const sizes = {
+  Default: '',
+  'Extra small (xs)': 'xs',
+  'Small (sm)': 'sm',
+  'Large (lg)': 'lg',
+};
 
 const props = () => ({
   className: 'some-class',
@@ -44,6 +51,7 @@ const props = () => ({
     'Primary focus element selector (selectorPrimaryFocus)',
     '[data-modal-primary-focus]'
   ),
+  size: select('Size (size)', sizes),
   iconDescription: text(
     'Close icon description (iconDescription)',
     'Close the modal'
@@ -60,14 +68,17 @@ storiesOf('Modal', module)
   .addDecorator(withKnobs)
   .add(
     'Default',
-    () => (
-      <Modal {...props()}>
-        <p className={`${prefix}--modal-content__text`}>
-          Please see ModalWrapper for more examples and demo of the
-          functionality.
-        </p>
-      </Modal>
-    ),
+    () => {
+      const { size, ...rest } = props();
+      return (
+        <Modal {...rest} size={size || undefined}>
+          <p className={`${prefix}--modal-content__text`}>
+            Please see ModalWrapper for more examples and demo of the
+            functionality.
+          </p>
+        </Modal>
+      );
+    },
     {
       info: {
         text: `
@@ -79,23 +90,30 @@ storiesOf('Modal', module)
   )
   .add(
     'Trap Focus',
-    () => (
-      <>
-        <Modal {...props()} selectorPrimaryFocus="#text-input-2">
-          <TextInput
-            id="text-input-1"
-            labelText="Text Input 1"
-            placeholder="Enter text..."
-            style={{ marginBottom: '1rem' }}
-          />
-          <TextInput
-            id="text-input-2"
-            labelText="Text Input 2"
-            placeholder="Enter text..."
-          />
-        </Modal>
-      </>
-    ),
+    () => {
+      const { size, ...rest } = props();
+      return (
+        <>
+          <Modal
+            {...rest}
+            hasForm
+            size={size || undefined}
+            selectorPrimaryFocus="#text-input-2">
+            <TextInput
+              id="text-input-1"
+              labelText="Text Input 1"
+              placeholder="Enter text..."
+              style={{ marginBottom: '1rem' }}
+            />
+            <TextInput
+              id="text-input-2"
+              labelText="Text Input 2"
+              placeholder="Enter text..."
+            />
+          </Modal>
+        </>
+      );
+    },
     {
       info: {
         text: `

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -401,7 +401,9 @@ export default class Modal extends Component {
           aria-labelledby={getAriaLabelledBy}>
           {this.props.children}
         </div>
-        <div className={`${prefix}--modal-content--overflow-indicator`} />
+        {hasScrollingContent && (
+          <div className={`${prefix}--modal-content--overflow-indicator`} />
+        )}
         {!passiveModal && (
           <div className={`${prefix}--modal-footer`}>
             <Button kind="secondary" onClick={onSecondaryButtonClick}>

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -319,7 +319,7 @@ export default class Modal extends Component {
       [this.props.className]: this.props.className,
     });
 
-    const contaienrClasses = classNames(`${prefix}--modal-container`, {
+    const containerClasses = classNames(`${prefix}--modal-container`, {
       [`${prefix}--modal-container--${size}`]: size,
     });
 

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -35,6 +35,12 @@ export default class Modal extends Component {
     passiveModal: PropTypes.bool,
 
     /**
+     * Provide whether the modal content has a form element.
+     * If `true` is used here, non-form child content should have `bx--modal-content__regular-content` class.
+     */
+    hasForm: PropTypes.bool,
+
+    /**
      * Specify a handler for closing modal.
      * The handler should care of closing modal, e.g. changing `open` prop.
      */
@@ -123,6 +129,11 @@ export default class Modal extends Component {
      * be focused when the Modal opens
      */
     selectorPrimaryFocus: PropTypes.string,
+
+    /**
+     * Specify the size variant.
+     */
+    size: PropTypes.oneOf('xs', 'sm', 'lg'),
 
     /**
      * Specify whether the modal should use 3rd party `focus-trap-react` for the focus-wrap feature.
@@ -278,6 +289,7 @@ export default class Modal extends Component {
       modalLabel,
       modalAriaLabel,
       passiveModal,
+      hasForm,
       secondaryButtonText,
       primaryButtonText,
       open,
@@ -290,6 +302,7 @@ export default class Modal extends Component {
       selectorPrimaryFocus, // eslint-disable-line
       selectorsFloatingMenus, // eslint-disable-line
       shouldSubmitOnEnter, // eslint-disable-line
+      size,
       focusTrap,
       ...other
     } = this.props;
@@ -304,6 +317,14 @@ export default class Modal extends Component {
       'is-visible': open,
       [`${prefix}--modal--danger`]: this.props.danger,
       [this.props.className]: this.props.className,
+    });
+
+    const contaienrClasses = classNames(`${prefix}--modal-container`, {
+      [`${prefix}--modal-container--${size}`]: size,
+    });
+
+    const contentClasses = classNames(`${prefix}--modal-content`, {
+      [`${prefix}--modal-content--with-form`]: hasForm,
     });
 
     const modalButton = (
@@ -336,7 +357,7 @@ export default class Modal extends Component {
       <div
         ref={this.innerModal}
         role="dialog"
-        className={`${prefix}--modal-container`}
+        className={contaienrClasses}
         aria-label={
           modalLabel
             ? null
@@ -352,7 +373,8 @@ export default class Modal extends Component {
           <h3 className={`${prefix}--modal-header__heading`}>{modalHeading}</h3>
           {!passiveModal && modalButton}
         </div>
-        <div className={`${prefix}--modal-content`}>{this.props.children}</div>
+        <div className={contentClasses}>{this.props.children}</div>
+        <div className={`${prefix}--modal-content--overflow-indicator`} />
         {!passiveModal && (
           <div className={`${prefix}--modal-footer`}>
             <Button kind="secondary" onClick={onSecondaryButtonClick}>

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -357,7 +357,7 @@ export default class Modal extends Component {
       <div
         ref={this.innerModal}
         role="dialog"
-        className={contaienrClasses}
+        className={containerClasses}
         aria-label={
           modalLabel
             ? null

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -158,6 +158,9 @@ exports[`ModalWrapper should render 1`] = `
               </p>
             </div>
             <div
+              className="bx--modal-content--overflow-indicator"
+            />
+            <div
               className="bx--modal-footer"
             >
               <ForwardRef(Button)


### PR DESCRIPTION
Refs #4607.

#### Changelog

**New**

- Size variants, with `bx--modal-container--xs`, `bx--modal-container--sm` and `bx--modal-container--lg` classes (enabled via `size` prop of `<Modal>`/`<ComposedModal>`).
- `bx--modal-content--with-form` class (enabled via `hasForm` prop of `<Modal>`/`<ModalBody>`), which removes the right margin. Non-form contents in there should use `bx--modal-content__regular-content` class.
- The UI in modal content for scroll overflow.

**Changed**

- Modal sizes with different variants with different breakpoints.

#### Testing / Reviewing

Testing should make sure our modal is not broken.