### PR TITLE
chore: add build step to generate react docgen metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
       "/dist/",
       "/es/",
       "/lib/",
+      "/build/",
       "e2e",
       "examples",
       "/umd/"

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,2 +1,5 @@
 # Storybook
 storybook-static
+
+# Generated metadata
+react-docgen.json

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "yarn clean && node scripts/build.js",
     "build-storybook": "build-storybook",
-    "clean": "rimraf es lib umd storybook-static build",
+    "clean": "rimraf es lib umd storybook-static build react-docgen.json",
     "prepublish": "yarn build",
     "start": "yarn storybook",
     "storybook": "rimraf node_modules/.cache/storybook && start-storybook -p 9000"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "yarn clean && node scripts/build.js",
     "build-storybook": "build-storybook",
-    "clean": "rimraf es lib umd storybook-static",
+    "clean": "rimraf es lib umd storybook-static build",
     "prepublish": "yarn build",
     "start": "yarn storybook",
     "storybook": "rimraf node_modules/.cache/storybook && start-storybook -p 9000"

--- a/packages/react/scripts/build.js
+++ b/packages/react/scripts/build.js
@@ -3,6 +3,8 @@
 const { execSync } = require('child_process');
 const { inInstall } = require('in-publish');
 const path = require('path');
+const fs = require('fs');
+const mapValues = require('lodash/mapValues');
 
 if (inInstall()) {
   process.exit(0);
@@ -32,6 +34,10 @@ try {
   exec(`${babelPath} src -q -d lib --ignore "${ignoreGlobs}"`, {
     BABEL_ENV: 'cjs',
   });
+  exec(`${babelPath} src -q -d build/docgen --ignore "${ignoreGlobs}"`, {
+    BABEL_ENV: 'docgen',
+  });
+
   exec(
     `${rollupPath} -c scripts/rollup.config.js -o umd/carbon-components-react.js`,
     {
@@ -48,3 +54,9 @@ try {
   console.error('One of the commands failed:', error.stack); // eslint-disable-line no-console
   process.exit(1);
 }
+
+// Create docgen metadata
+fs.writeFileSync(
+  'react-docgen.json',
+  JSON.stringify(mapValues(require(`../build/docgen`), '__docgenInfo'))
+);

--- a/packages/react/scripts/build.js
+++ b/packages/react/scripts/build.js
@@ -34,9 +34,15 @@ try {
   exec(`${babelPath} src -q -d lib --ignore "${ignoreGlobs}"`, {
     BABEL_ENV: 'cjs',
   });
+
+  // Create docgen metadata
   exec(`${babelPath} src -q -d build/docgen --ignore "${ignoreGlobs}"`, {
     BABEL_ENV: 'docgen',
   });
+  fs.writeFileSync(
+    'react-docgen.json',
+    JSON.stringify(mapValues(require(`../build/docgen`), '__docgenInfo'))
+  );
 
   exec(
     `${rollupPath} -c scripts/rollup.config.js -o umd/carbon-components-react.js`,
@@ -54,9 +60,3 @@ try {
   console.error('One of the commands failed:', error.stack); // eslint-disable-line no-console
   process.exit(1);
 }
-
-// Create docgen metadata
-fs.writeFileSync(
-  'react-docgen.json',
-  JSON.stringify(mapValues(require(`../build/docgen`), '__docgenInfo'))
-);

--- a/packages/react/scripts/env.js
+++ b/packages/react/scripts/env.js
@@ -2,6 +2,17 @@
 
 const BABEL_ENV = process.env.BABEL_ENV;
 
+const docgenConfig = {
+  plugins: [
+    [
+      'babel-plugin-react-docgen',
+      {
+        removeMethods: true,
+      },
+    ],
+  ],
+};
+
 module.exports = () => ({
   presets: [
     [
@@ -14,5 +25,5 @@ module.exports = () => ({
       },
     ],
   ],
-  plugins: BABEL_ENV === 'docgen' ? ['react-docgen'] : [],
+  ...(BABEL_ENV === 'docgen' && docgenConfig),
 });

--- a/packages/react/scripts/env.js
+++ b/packages/react/scripts/env.js
@@ -14,4 +14,5 @@ module.exports = () => ({
       },
     ],
   ],
+  plugins: BABEL_ENV === 'docgen' ? ['react-docgen'] : [],
 });


### PR DESCRIPTION
Closes #4635 

**New:**
- BABEL_ENV `docgen`
	- includes `babel-plugin-react-docgen`
	- outputs a`build/docgen` (not published)
- Use `build/docgen` to generate a `react-docgen.json` file (published)

Testing:
- `yarn workspace carbon-components-react build`
- Should generate a `react-docgen.json` file with docgen data in the react package.
