### PR TITLE
docs(storybook): add layout token switcher

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -40,7 +40,8 @@
     align-items: flex-start;
     justify-content: $accordion-justify-content;
     cursor: pointer;
-    padding: rem(6px) 0;
+    padding: calc((#{$container-02} - var(--cds-body-long-01-line-height)) / 2)
+      0;
     flex-direction: $accordion-flex-direction;
     position: relative;
     width: 100%;
@@ -72,12 +73,13 @@
 
   .#{$prefix}--accordion__arrow {
     @include focus-outline('reset');
-    // Without flex basis and flex shrink being set here, our icon width can go
-    // <16px and cause the icon to render in the incorrect artboard size
-    flex: 0 0 1rem;
-    width: 1rem;
-    height: 1rem;
+    flex: 0 0 $icon-size-01;
+    width: $icon-size-01;
+    height: $icon-size-01;
     margin: $accordion-arrow-margin;
+    margin-top: calc(
+      (var(--cds-body-long-01-line-height) - #{$icon-size-01}) / 2
+    );
     fill: $ui-05;
     // TODO: RTL rotate(180deg);
     transform: rotate(90deg);

--- a/packages/react/.storybook/addon-carbon-theme/components/Panel.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Panel.js
@@ -8,6 +8,7 @@
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@storybook/components';
+import Slider from './Slider';
 import {
   CARBON_CURRENT_THEME,
   CARBON_TYPE_TOKEN,
@@ -199,8 +200,9 @@ export const CarbonLayoutPanel = ({ api, active }) => {
     layoutTokenDefaults
   );
   const handleLayoutTokenChange = useCallback(
-    (event, { tokenType }) => {
-      const { name: tokenName, value: tokenValue } = event.target;
+    (event, { tokenType, tokenValuesArray }) => {
+      const { name: tokenName, value: tokenValueIndex } = event.target;
+      const tokenValue = tokenValuesArray[tokenValueIndex];
       setCurrentLayoutTokens({
         ...currentLayoutTokens,
         [tokenType]: {
@@ -210,28 +212,32 @@ export const CarbonLayoutPanel = ({ api, active }) => {
       });
       api.getChannel().emit(CARBON_LAYOUT_TOKEN, { tokenName, tokenValue });
     },
-    [api]
+    [currentLayoutTokens, api]
   );
   return (
     active && (
       <Form>
         {Object.keys(layoutTokenDefaults).map(tokenType => {
-          const tokenCategoryObj = layoutTokenDefaults[tokenType];
-          return Object.keys(tokenCategoryObj).map(tokenName => (
+          const tokenTypeObj = layoutTokenDefaults[tokenType];
+          const tokenValuesArray = Object.values(tokenTypeObj);
+          return Object.keys(tokenTypeObj).map(tokenName => (
             <Form.Field key={tokenName} label={`${tokenName}:`}>
-              <Form.Select
+              <Slider
+                values={tokenValuesArray}
                 name={tokenName}
+                value={tokenValuesArray.indexOf(
+                  currentLayoutTokens[tokenType][tokenName]
+                )}
+                min={0}
+                max={tokenValuesArray.length - 1}
+                step={1}
+                range
                 onChange={event =>
-                  handleLayoutTokenChange(event, { tokenType })
-                }
-                size="flex"
-                value={currentLayoutTokens[tokenType][tokenName]}>
-                {Object.values(tokenCategoryObj).map(tokenValue => (
-                  <option key={tokenValue} value={tokenValue}>
-                    {tokenValue}
-                  </option>
-                ))}
-              </Form.Select>
+                  handleLayoutTokenChange(event, {
+                    tokenType,
+                    tokenValuesArray,
+                  })
+                }></Slider>
             </Form.Field>
           ));
         })}

--- a/packages/react/.storybook/addon-carbon-theme/components/Panel.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Panel.js
@@ -232,6 +232,7 @@ export const CarbonLayoutPanel = ({ api, active }) => {
                 max={tokenValuesArray.length - 1}
                 step={1}
                 range
+                hashMarks
                 onChange={event =>
                   handleLayoutTokenChange(event, {
                     tokenType,

--- a/packages/react/.storybook/addon-carbon-theme/components/Panel.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Panel.js
@@ -8,7 +8,11 @@
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@storybook/components';
-import { CARBON_CURRENT_THEME, CARBON_TYPE_TOKEN } from '../shared';
+import {
+  CARBON_CURRENT_THEME,
+  CARBON_TYPE_TOKEN,
+  CARBON_LAYOUT_TOKEN,
+} from '../shared';
 
 const typeTokenPairings = [
   '12-16',
@@ -131,6 +135,112 @@ export const CarbonTypePanel = ({ api, active }) => {
 };
 
 CarbonTypePanel.propTypes = {
+  /**
+   * The Storybook API object.
+   */
+  api: PropTypes.shape({
+    getChannel: PropTypes.func,
+  }).isRequired,
+
+  /**
+   * `true` if this Storybook add-on panel is active.
+   */
+  active: PropTypes.bool.isRequired,
+};
+
+const layoutTokenDefaults = {
+  container: {
+    'container-01': '1.5rem',
+    'container-02': '2rem',
+    'container-03': '2.5rem',
+    'container-04': '3rem',
+    'container-05': '4rem',
+  },
+  'fluid-spacing': {
+    'fluid-spacing-01': '0',
+    'fluid-spacing-02': '2vw',
+    'fluid-spacing-03': '5vw',
+    'fluid-spacing-04': '10vw',
+  },
+  'icon-size': {
+    'icon-size-01': '1rem',
+    'icon-size-02': '1.25rem',
+  },
+  layout: {
+    'layout-01': '1rem',
+    'layout-02': '1.5rem',
+    'layout-03': '2rem',
+    'layout-04': '3rem',
+    'layout-05': '4rem',
+    'layout-06': '6rem',
+    'layout-07': '10rem',
+  },
+  spacing: {
+    'spacing-01': '0.125rem',
+    'spacing-02': '0.25rem',
+    'spacing-03': '0.5rem',
+    'spacing-04': '0.75rem',
+    'spacing-05': '1rem',
+    'spacing-06': '1.5rem',
+    'spacing-07': '2rem',
+    'spacing-08': '2.5rem',
+    'spacing-09': '3rem',
+    'spacing-10': '4rem',
+    'spacing-11': '5rem',
+    'spacing-12': '6rem',
+  },
+};
+
+/**
+ * Storybook add-on panel for Carbon layout token switcher.
+ */
+export const CarbonLayoutPanel = ({ api, active }) => {
+  const [currentLayoutTokens, setCurrentLayoutTokens] = useState(
+    layoutTokenDefaults
+  );
+  const handleLayoutTokenChange = useCallback(
+    (event, { tokenType }) => {
+      const { name: tokenName, value: tokenValue } = event.target;
+      setCurrentLayoutTokens({
+        ...currentLayoutTokens,
+        [tokenType]: {
+          ...currentLayoutTokens[tokenType],
+          [tokenName]: tokenValue,
+        },
+      });
+      api.getChannel().emit(CARBON_LAYOUT_TOKEN, { tokenName, tokenValue });
+    },
+    [api]
+  );
+  return (
+    active && (
+      <Form>
+        {Object.keys(layoutTokenDefaults).map(tokenType => {
+          const tokenCategoryObj = layoutTokenDefaults[tokenType];
+          return Object.keys(tokenCategoryObj).map(tokenName => (
+            <Form.Field key={tokenName} label={`${tokenName}:`}>
+              <Form.Select
+                name={tokenName}
+                onChange={event =>
+                  handleLayoutTokenChange(event, { tokenType })
+                }
+                size="flex"
+                value={currentLayoutTokens[tokenType][tokenName]}>
+                {Object.values(tokenCategoryObj).map(tokenValue => (
+                  <option key={tokenValue} value={tokenValue}>
+                    {tokenValue}
+                  </option>
+                ))}
+              </Form.Select>
+            </Form.Field>
+          ));
+        })}
+      </Form>
+    )
+  );
+};
+
+CarbonLayoutPanel.propTypes = {
   /**
    * The Storybook API object.
    */

--- a/packages/react/.storybook/addon-carbon-theme/components/Slider.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Slider.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Slider({
+  name,
+  min,
+  max,
+  step,
+  value,
+  values,
+  onChange,
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        width: '100%',
+      }}>
+      <span
+        style={{
+          paddingLeft: 5,
+          paddingRight: 5,
+          whiteSpace: 'nowrap',
+        }}>
+        {values[min] || min}
+      </span>
+      <input
+        style={{
+          flexGrow: 1,
+          padding: '5px',
+        }}
+        type="range"
+        name={name}
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={onChange}
+      />
+      <span>{`${values[value] || value} / ${values[max] || max}`}</span>
+    </div>
+  );
+}
+Slider.propTypes = {
+  /**
+   * String specifying the name for the slider
+   */
+  name: PropTypes.string,
+
+  /**
+   * Minimum possible value in the range
+   */
+  min: PropTypes.number.isRequired,
+
+  /**
+   * Maximum possible value in the range
+   */
+  max: PropTypes.number.isRequired,
+
+  /**
+   * Incremental values for the range slider
+   */
+  step: PropTypes.number.isRequired,
+
+  /**
+   * Current value of the range slider
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+  /**
+   * For custom labels, highlighting non-numerical values, etc.
+   *
+   * The range input's `value` represents the index of a highlighted element in
+   * the `values` array. This allows for the illusion of stepping through an
+   * array of values, which the standard `step` attribute may not cover, since
+   * `step` only accepts positive numbers or 'any' as a value
+   */
+  values: PropTypes.array,
+
+  /**
+   * The callback function for the `change` event,
+   * called when range slider value changes.
+   */
+  onChange: PropTypes.func.isRequired,
+};
+
+Slider.defaultProps = {
+  min: 0,
+  max: 10,
+  step: 1,
+  value: 5,
+  onChange: value => value,
+};

--- a/packages/react/.storybook/addon-carbon-theme/components/Slider.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Slider.js
@@ -1,6 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const SliderLabel = ({ children }) => (
+  <span
+    style={{
+      paddingLeft: 5,
+      paddingRight: 5,
+      whiteSpace: 'nowrap',
+    }}>
+    {children}
+  </span>
+);
+
 export default function Slider({
   name,
   min,
@@ -15,19 +26,13 @@ export default function Slider({
       style={{
         display: 'flex',
         alignItems: 'center',
-        width: '100%',
       }}>
-      <span
-        style={{
-          paddingLeft: 5,
-          paddingRight: 5,
-          whiteSpace: 'nowrap',
-        }}>
-        {values[min] || min}
-      </span>
+      <SliderLabel>{values[min] || min}</SliderLabel>
       <input
         style={{
           flexGrow: 1,
+          width: '100%',
+          maxWidth: '25rem',
           padding: '5px',
         }}
         type="range"
@@ -38,7 +43,9 @@ export default function Slider({
         value={value}
         onChange={onChange}
       />
-      <span>{`${values[value] || value} / ${values[max] || max}`}</span>
+      <SliderLabel>
+        {`${values[value] || value} / ${values[max] || max}`}
+      </SliderLabel>
     </div>
   );
 }

--- a/packages/react/.storybook/addon-carbon-theme/components/Slider.js
+++ b/packages/react/.storybook/addon-carbon-theme/components/Slider.js
@@ -14,6 +14,7 @@ const SliderLabel = ({ children }) => (
 
 export default function Slider({
   name,
+  hashMarks,
   min,
   max,
   step,
@@ -37,12 +38,20 @@ export default function Slider({
         }}
         type="range"
         name={name}
+        list={name}
         min={min}
         max={max}
         step={step}
         value={value}
         onChange={onChange}
       />
+      {hashMarks && (
+        <datalist id={name}>
+          {values.map((value, i) => (
+            <option key={`${value}${i}`} value={i}></option>
+          ))}
+        </datalist>
+      )}
       <SliderLabel>
         {`${values[value] || value} / ${values[max] || max}`}
       </SliderLabel>
@@ -53,7 +62,12 @@ Slider.propTypes = {
   /**
    * String specifying the name for the slider
    */
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
+
+  /**
+   * Boolean value for displaying hash marks along the slider
+   */
+  hashMarks: PropTypes.bool,
 
   /**
    * Minimum possible value in the range
@@ -93,6 +107,7 @@ Slider.propTypes = {
 };
 
 Slider.defaultProps = {
+  name: 'Slider',
   min: 0,
   max: 10,
   step: 1,

--- a/packages/react/.storybook/addon-carbon-theme/register.js
+++ b/packages/react/.storybook/addon-carbon-theme/register.js
@@ -7,12 +7,18 @@
 
 import React from 'react';
 import addons from '@storybook/addons';
-import { CarbonThemesPanel, CarbonTypePanel } from './components/Panel';
+import {
+  CarbonThemesPanel,
+  CarbonTypePanel,
+  CarbonLayoutPanel,
+} from './components/Panel';
 import {
   CARBON_THEMES_ADDON_ID,
   CARBON_THEME_PANEL_ID,
   CARBON_TYPE_ADDON_ID,
   CARBON_TYPE_PANEL_ID,
+  CARBON_LAYOUT_ADDON_ID,
+  CARBON_LAYOUT_PANEL_ID,
 } from './shared';
 
 addons.register(CARBON_THEMES_ADDON_ID, api => {
@@ -29,6 +35,15 @@ addons.register(CARBON_TYPE_ADDON_ID, api => {
     title: 'Carbon type',
     render: ({ active, key }) => (
       <CarbonTypePanel api={api} key={key} active={active} />
+    ),
+  });
+});
+
+addons.register(CARBON_LAYOUT_ADDON_ID, api => {
+  addons.addPanel(CARBON_LAYOUT_PANEL_ID, {
+    title: 'Carbon layout',
+    render: ({ active, key }) => (
+      <CarbonLayoutPanel api={api} key={key} active={active} />
     ),
   });
 });

--- a/packages/react/.storybook/addon-carbon-theme/shared.js
+++ b/packages/react/.storybook/addon-carbon-theme/shared.js
@@ -11,3 +11,6 @@ export const CARBON_THEME_PANEL_ID = `${CARBON_THEMES_ADDON_ID}/panel`;
 export const CARBON_TYPE_ADDON_ID = 'carbon-type';
 export const CARBON_TYPE_TOKEN = `${CARBON_TYPE_ADDON_ID}/type`;
 export const CARBON_TYPE_PANEL_ID = `${CARBON_TYPE_ADDON_ID}/panel`;
+export const CARBON_LAYOUT_ADDON_ID = 'carbon-layout';
+export const CARBON_LAYOUT_TOKEN = `${CARBON_LAYOUT_ADDON_ID}/layout`;
+export const CARBON_LAYOUT_PANEL_ID = `${CARBON_LAYOUT_ADDON_ID}/panel`;

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -14,6 +14,7 @@ import { configureActions } from '@storybook/addon-actions';
 import {
   CARBON_CURRENT_THEME,
   CARBON_TYPE_TOKEN,
+  CARBON_LAYOUT_TOKEN,
 } from './addon-carbon-theme/shared';
 import Container from './Container';
 
@@ -66,6 +67,11 @@ addons.getChannel().on(CARBON_TYPE_TOKEN, ({ tokenName, tokenValue }) => {
     `--${customPropertyPrefix}-${tokenName}-line-height`,
     rem(lineHeight)
   );
+});
+
+addons.getChannel().on(CARBON_LAYOUT_TOKEN, ({ tokenName, tokenValue }) => {
+  const root = document.documentElement;
+  root.style.setProperty(`--${customPropertyPrefix}-${tokenName}`, tokenValue);
 });
 
 function loadStories() {


### PR DESCRIPTION
Closes #4661

This PR creates a storybook addon for modifying Carbon layout tokens. This includes container tokens, fluid spacing tokens, icon size tokens, layout tokens, and spacing tokens. The token values are controlled by a new Slider component for our addon panels (which may be preferable to dropdowns)

The accordion changes serve to show that the tokens are being used and changed at runtime. Alternatively we can remove the component level changes and just merge in the storybook portion. then we can split the component work out into separate tickets

#### Changelog

**New**

- Carbon Layout storybook addon
- Slider component for addon panels

**Changed**

- integrate layout tokens in accordion