### PR TITLE
fix(overflow-menu): update top-positioned menu's pseudo-element to prevent box-shadow overlap

### DIFF
--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -116,10 +116,10 @@
   }
 
   .#{$prefix}--overflow-menu-options[data-floating-menu-direction='top']::after {
-    bottom: rem(-6px);
+    bottom: rem(-8px);
     left: 0;
     width: rem(32px);
-    height: rem(6px);
+    height: rem(8px);
   }
 
   .#{$prefix}--overflow-menu-options[data-floating-menu-direction='left']::after {


### PR DESCRIPTION
Closes #4667 

Small fix to prevent a slight overlap in the `box-shadow` from the top-positioned menu. 👍 

#### Changelog

**Changed**

- update size & position of menu pseudo-element