### PR TITLE
fix(tooltip): set trigger button margin only when descendent of label

### DIFF
--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -333,13 +333,15 @@
     cursor: pointer;
     font-size: 1rem;
 
-    // Override `margin: 0` from button-reset mixin:
-    margin-left: $carbon--spacing-03;
-
     &:focus {
       @include focus-outline('border');
       fill: $hover-primary;
     }
+  }
+
+  .#{$prefix}--tooltip__label .#{$prefix}--tooltip__trigger {
+    // Override `margin: 0` from button-reset mixin
+    margin-left: $carbon--spacing-03;
   }
 
   .#{$prefix}--tooltip__label--bold {


### PR DESCRIPTION
Closes #4671

This PR moves the left margin rule for non-icon-only tooltip trigger buttons to a new selector that only targets tool trigger buttons that are descendants of tooltip labels

#### Changelog

**Changed**

- change selector for tooltip trigger button left margin from `.bx--tooltip__trigger:not(.bx--btn--icon-only)` to `.bx--tooltip__label .bx--tooltip__trigger`

#### Testing / Reviewing

Ensure overflow menu trigger button has the correct size and no margins

Ensure labeled interactive tooltip trigger button has space between it and its label

Ensure all components that consume tooltip appear as expected
