### PR TITLE
fix(header): reset default ul styling directly in header navigation menus

### DIFF
--- a/packages/components/src/components/ui-shell/_header.scss
+++ b/packages/components/src/components/ui-shell/_header.scss
@@ -170,6 +170,9 @@
   .#{$prefix}--header__menu-bar[role='menubar'] {
     display: flex;
     height: 100%;
+    list-style: none;
+    padding: 0;
+    margin: 0;
   }
 
   a.#{$prefix}--header__menu-item[role='menuitem'] {

--- a/packages/components/src/components/ui-shell/_header.scss
+++ b/packages/components/src/components/ui-shell/_header.scss
@@ -242,6 +242,9 @@
 
   .#{$prefix}--header__menu[role='menu'] {
     display: none;
+    list-style: none;
+    padding: 0;
+    margin: 0;
   }
 
   .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true']


### PR DESCRIPTION
Closes #4673 

This PR applies 3 missing style rules to the `HeaderNavigation` component's `ul.bx--header__menu-bar`  & `ul.bx--header__menu` elements.

Currently the component relies on global reset rules to render correctly, but for consumers who don't use those global resets (like us), the `ul.bx--header__menu-bar` & `ul.bx--header__menu` elements still have padding, margins, and default list-style rules applied. 

#### Changelog

**New**

- add rules to reset default list styles for `ul.bx--header__menu-bar`  & `ul.bx--header__menu`
