### PR TITLE
Fix(HeaderMenu + HeaderNavigation): handle null item

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -212,10 +212,12 @@ class HeaderMenu extends React.Component {
    * sequence when they might not want to go through all the items.
    */
   _renderMenuItem = (item, index) => {
-    return React.cloneElement(item, {
-      ref: this.handleItemRef(index),
-      role: 'none',
-    });
+    if (React.isValidElement(item)) {
+      return React.cloneElement(item, {
+        ref: this.handleItemRef(index),
+        role: 'none',
+      });
+    }
   };
 }
 

--- a/packages/react/src/components/UIShell/HeaderNavigation.js
+++ b/packages/react/src/components/UIShell/HeaderNavigation.js
@@ -81,8 +81,10 @@ export default class HeaderNavigation extends React.Component {
    * `this.items` to properly manage focus.
    */
   _renderNavItem = (child, index) => {
-    return React.cloneElement(child, {
-      ref: this.handleItemRef(index),
-    });
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, {
+        ref: this.handleItemRef(index),
+      });
+    }
   };
 }


### PR DESCRIPTION
Related to #4261 

Allows `<HeaderMenu>` and `<HeaderNavigation>` to handle a null item/child on render.

#### Changelog

**Changed**

- check if child/item is a valid React element before rendering

#### Testing / Reviewing

In `packages/react/src/components/UIShell/UIShell-story.js` pass a null `<HeaderMenuItem>` to a `<HeaderNavigation>` and `<HeaderMenu>` component.
ie change:
     line 158 to `{false && <HeaderMenuItem href="#">Link 1</HeaderMenuItem>}`
     line 162 to `{false &&<HeaderMenuItem href="#">Sub-link 1</HeaderMenuItem>}`

Link 1 should no longer be visible in the header, and sub-link 1 should disappear from the link 4 dropdown. 
