### PR TITLE
[WIP] fix(Tag): add `role=button` to filter variant for screen readers

### DIFF
--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -43,6 +43,7 @@ const Tag = ({
   return filter ? (
     <span
       className={tagClasses}
+      role="button"
       title={title || 'Clear filter'}
       tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
       {...other}>


### PR DESCRIPTION
Closes #4427

Adds a `role="button"` to our Tag with Filter for greater clarity when read through screen readers.

#### Testing / Reviewing

Open Safari and use VoiceOver to focus the Filter variant of Tag. You should hear "This is not a tag, clear selection, button" and then controls for activation.

#### Todo
- add tests