### PR TITLE
fix(icons): include build-info.json in package

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -12,7 +12,8 @@
     "lib",
     "scss",
     "svg",
-    "metadata.json"
+    "metadata.json",
+    "build-info.json"
   ],
   "keywords": [
     "ibm",


### PR DESCRIPTION
Closes #4613

#### Changelog

**New**

**Changed**

- Include `build-info.json` in package output

**Removed**
