### PR TITLE
fix(content-switcher): fix dap violations

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -110,7 +110,7 @@ export default class ContentSwitcher extends React.Component {
     const classes = classNames(`${prefix}--content-switcher`, className);
 
     return (
-      <div {...other} className={classes}>
+      <div {...other} className={classes} role="tablist">
         {React.Children.map(children, (child, index) =>
           React.cloneElement(child, {
             index,


### PR DESCRIPTION
Closes #4520 

When use role of tab, role of tablist is needed on container.

#### Changelog

**New**

- added `role="tablist"` to container

#### Testing / Reviewing

Make sure DAP violations are fixed