### PR TITLE
fix(modal): update oneOf prop type to use array

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -135,7 +135,7 @@ export default class Modal extends Component {
     /**
      * Specify the size variant.
      */
-    size: PropTypes.oneOf('xs', 'sm', 'lg'),
+    size: PropTypes.oneOf(['xs', 'sm', 'lg']),
 
     /**
      * Specify whether the modal should use 3rd party `focus-trap-react` for the focus-wrap feature.


### PR DESCRIPTION
Noticed that `oneOf` for `Modal` in a recent change wasn't using the array syntax. This causes the following error to occur:

```
Warning: Invalid arguments supplied to oneOf, expected an array, got 3 arguments. A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).
```

#### Changelog

**New**

**Changed**

- Update `oneOf` to `oneOf` with an array argument

**Removed**
