### PR TITLE
fix(ComposedModal): update `oneOf` signature

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -65,7 +65,7 @@ export default class ComposedModal extends Component {
     /**
      * Specify the size variant.
      */
-    size: PropTypes.oneOf('xs', 'sm', 'lg'),
+    size: PropTypes.oneOf(['xs', 'sm', 'lg']),
   };
 
   static getDerivedStateFromProps({ open }, state) {


### PR DESCRIPTION
Update signature of `oneOf` to use array signature. Without this, we will get a React prop type warning.

#### Changelog

**New**

**Changed**

- Update `oneOf` to array signature

**Removed**
