### PR TITLE
fix(pagination): input wrapper alignment closes #4733

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -43,6 +43,7 @@ $css--helpers: true;
   }
 
   .#{$prefix}--pagination .#{$prefix}--select-input--inline__wrapper {
+    display: flex;
     height: 100%;
   }
 


### PR DESCRIPTION
Regression was likely due to IE fixes, test in all browsers