### PR TITLE
fix(multi-select): remove absolute positioning of filterable tag, update input spacing

### DIFF
--- a/packages/components/src/components/multi-select/_multi-select.scss
+++ b/packages/components/src/components/multi-select/_multi-select.scss
@@ -45,12 +45,9 @@
     color: $text-01;
   }
 
-  .#{$prefix}--multi-select--filterable {
-    .#{$prefix}--list-box__selection--multi {
-      position: absolute;
-      left: $carbon--spacing-03;
-      right: auto;
-    }
+  .#{$prefix}--multi-select--filterable.#{$prefix}--multi-select
+    .#{$prefix}--text-input {
+    padding-left: $carbon--spacing-03;
   }
 
   .#{$prefix}--multi-select--selected .#{$prefix}--text-input {

--- a/packages/components/src/components/multi-select/_multi-select.scss
+++ b/packages/components/src/components/multi-select/_multi-select.scss
@@ -50,6 +50,12 @@
     padding-left: $carbon--spacing-03;
   }
 
+  .#{$prefix}--multi-select--filterable
+    .#{$prefix}--list-box__selection--multi {
+    margin-left: $carbon--spacing-03;
+    margin-right: $carbon--spacing-01;
+  }
+
   .#{$prefix}--multi-select--selected .#{$prefix}--text-input {
     // this value will need to change based on the number of digits in
     // the number of items selected


### PR DESCRIPTION
Closes #4721 

#4721 appears to be caused by an absolutely positioned tag. The tag sits on top of the filter input, so as the number inside the tag grows it will continue to encroach on the filter input's text.

This fix removes absolute positioning for that selected items tag.

A side effect of this is that when you select the filter input now, the focus outline will no longer extend / wrap everything --

### Old (with 10+ selected items):

![Screen Shot 2019-11-22 at 1 13 34 PM](https://user-images.githubusercontent.com/9057921/69453631-ebda6480-0d29-11ea-8541-a756f1f18e6d.png)


### New (with 10+ selected items):

![Screen Shot 2019-11-22 at 1 13 17 PM](https://user-images.githubusercontent.com/9057921/69453653-fac11700-0d29-11ea-99b1-5b4ec5963119.png)

☝️ For the spacing above, I can definitely adjust the split between spacing inside the input and spacing between the input and the tag. Just let me know what you prefer!

But due to the structure of this component, this seems like the easiest fix. I imagine with a bigger refactor + involving some JS, you could possibly keep the tag on top of the input and just steadily adjust the input's left padding to accommodate a growing "selected items" number in the tag. That seems like a lot of overhead though 😅 **What do you all think?**

#### Changelog

**Changed**

- change absolutely positioned tag and distribute spacing between tag and input.
