### PR TITLE
fix(code-snippet): re-introduce bx--snippet-button class to copy button

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -78,6 +78,7 @@ function CodeSnippet({
         </code>
       </div>
       <CopyButton
+        className={`${prefix}--snippet-button`}
         onClick={onClick}
         feedback={feedback}
         iconDescription={copyButtonDescription}


### PR DESCRIPTION
Closes #4772

Recent changes have left out the `bx--snippet-button` class that was previously added to the copy button inside the `CodeSnippet` component.

This class adds necessary positioning styles etc.

The regression that this PR resolves is only visible if you run the latest `master` branch locally, or if you view a recent PR deployment like this one: https://deploy-preview-4760--carbon-components-react.netlify.com/?path=/story/codesnippet--multi-line

#### Changelog

**New**

- re-introduce `bx--snippet-button` class for copy button style & positioning

#### Testing / Reviewing

Compare this PR's React storybook deployment (where the copy button position is fixed) to the another PR's storybook deployment like this one: https://deploy-preview-4760--carbon-components-react.netlify.com/?path=/story/codesnippet--multi-line
