### PR TITLE
fix(pagination): prevent text from disappearing at certain sizes

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -106,14 +106,10 @@ $css--helpers: true;
   }
 
   .#{$prefix}--pagination__left {
-    @include carbon--breakpoint('md') {
-      padding: 0 $carbon--spacing-05;
-    }
+    padding: 0 $carbon--spacing-05;
   }
 
   .#{$prefix}--pagination__text {
-    display: none;
-
     @include carbon--breakpoint('md') {
       display: inline-block;
     }


### PR DESCRIPTION
Closes #4248

ref #1518

Pagination text was being hidden in a media query style block which is also triggered by zooming in on the page. This behavior does not seem to match the component spec

#### Changelog

**Changed**

- move component padding style rules out of media query block

**Removed**

- `display: none` on pagination component text

#### Testing / Reviewing

Ensure the component matches the spec and the original zoom/reflow issue is no longer present
