### PR TITLE
fix(Modal): remove z-index transition

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -48,6 +48,7 @@
       transition: background-color $duration--slow-02
           motion(entrance, expressive),
         opacity $duration--moderate-02 motion(entrance, expressive),
+        z-index $duration--slow-02 motion(entrance, expressive),
         visibility $duration--moderate-02 motion(entrance, expressive);
     }
 

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -28,7 +28,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: z('hidden');
+    z-index: z('modal');
     display: flex;
     align-items: center;
     justify-content: center;
@@ -38,18 +38,16 @@
     visibility: hidden;
     transition: background-color $duration--slow-02 motion(exit, expressive),
       opacity $duration--moderate-02 motion(exit, expressive),
-      visibility $duration--moderate-02 motion(exit, expressive);
+      visibility 0ms linear $duration--moderate-02;
 
     &.is-visible {
-      z-index: z('modal');
       visibility: visible;
       opacity: 1;
       background-color: $overlay-01;
       transition: background-color $duration--slow-02
           motion(entrance, expressive),
         opacity $duration--moderate-02 motion(entrance, expressive),
-        z-index $duration--slow-02 motion(entrance, expressive),
-        visibility $duration--moderate-02 motion(entrance, expressive);
+        visibility 0ms linear;
     }
 
     .#{$prefix}--text-input,

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -38,7 +38,6 @@
     visibility: hidden;
     transition: background-color $duration--slow-02 motion(exit, expressive),
       opacity $duration--moderate-02 motion(exit, expressive),
-      z-index $duration--slow-02 motion(exit, expressive),
       visibility $duration--moderate-02 motion(exit, expressive);
 
     &.is-visible {
@@ -49,7 +48,6 @@
       transition: background-color $duration--slow-02
           motion(entrance, expressive),
         opacity $duration--moderate-02 motion(entrance, expressive),
-        z-index $duration--slow-02 motion(entrance, expressive),
         visibility $duration--moderate-02 motion(entrance, expressive);
     }
 


### PR DESCRIPTION
Closes #4690

Removes z-index transition on Modal component preventing visual and performance issues (see #4690 for more information).

Is there a reason why the `z-index` of the Modal needs to be `-1` when hidden? I needed to re-add the transition on one state to prevent the same visual bug to appear when closing the modal. As @sabov noted though, it'd be better if `z-index` wouldn't be transitioned at all.
