### PR TITLE
chore(pictograms): correct berlin brandenburg name typo

### DIFF
--- a/packages/pictograms/categories.yml
+++ b/packages/pictograms/categories.yml
@@ -46,7 +46,7 @@ categories:
       - beijing--municipal
       - beijing--tower
       - berlin--brandenburg--gate
-      - berlin--brandenburg #DEPRECATED: use berlin--brandenberg--gate instead
+      - berlin--brandenburg #DEPRECATED: use berlin--brandenburg--gate instead
       - berlin--cathedral
       - berlin--tower
       - copenhagen--planetarium

--- a/packages/pictograms/metadata.yml
+++ b/packages/pictograms/metadata.yml
@@ -269,12 +269,12 @@ icons:
       - berlin
     variants:
       - name: berlin--brandenburg--gate
-        friendly_name: Berlin brandenberg gate
+        friendly_name: Berlin brandenburg gate
         usage: This is a description for usage
         categories:
           - name: Cities
-      - name: berlin--brandenburg # DEPRECATED: use berlin--brandenberg--gate instead
-        friendly_name: Berlin brandenberg
+      - name: berlin--brandenburg # DEPRECATED: use berlin--brandenburg--gate instead
+        friendly_name: Berlin brandenburg
         usage: This is a description for usage
         categories:
           - name: Cities

--- a/packages/pictograms/svg/berlin--brandenburg--gate.svg
+++ b/packages/pictograms/svg/berlin--brandenburg--gate.svg
@@ -2,10 +2,10 @@
 <!-- Generator: Adobe Illustrator 22.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
-<g id="berlin_brandenberg">
+<g id="berlin_brandenburg">
 	<rect style="fill:#FFFFFF;" width="48" height="48"/>
-	<g id="berlin_brandenberg_1_">
-		
+	<g id="berlin_brandenburg_1_">
+
 			<line style="fill:none;stroke:#000000;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;" x1="9" y1="36" x2="39" y2="36"/>
 		
 			<line style="fill:none;stroke:#000000;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;" x1="9" y1="18" x2="39" y2="18"/>

--- a/packages/pictograms/svg/berlin--brandenburg.svg
+++ b/packages/pictograms/svg/berlin--brandenburg.svg
@@ -3,9 +3,9 @@
 <!-- Generator: Adobe Illustrator 22.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
-<g id="berlin_brandenberg">
+<g id="berlin_brandenburg">
 	<rect style="fill:#FFFFFF;" width="48" height="48"/>
-	<g id="berlin_brandenberg_1_">
+	<g id="berlin_brandenburg_1_">
 			<line style="fill:none;stroke:#000000;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;" x1="9" y1="36" x2="39" y2="36"/>
 			<line style="fill:none;stroke:#000000;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;" x1="9" y1="18" x2="39" y2="18"/>
 			<line style="fill:none;stroke:#000000;stroke-width:0.72;stroke-linejoin:round;stroke-miterlimit:10;" x1="20" y1="16" x2="28" y2="16"/>


### PR DESCRIPTION
As noted in #4610, the gate in Berlin is called "Brandenburg Gate", not "Brandenberg Gate". This PR just fixes this typo.