### PR TITLE
fix: dynamic classes only now functional

### DIFF
--- a/packages/icons-vue/tasks/__tests__/createIconComponent-test.js
+++ b/packages/icons-vue/tasks/__tests__/createIconComponent-test.js
@@ -195,6 +195,23 @@ describe('createIconComponent', () => {
     expect(node.classList.contains(dynamicClass)).toBe(true);
   });
 
+  it('should support dynamic classes only', async () => {
+    const dynamicClass = 'bar';
+    const node = render({
+      components: {
+        [MockIconComponent.name]: MockIconComponent,
+      },
+      data() {
+        return {
+          myDynamicClass: dynamicClass,
+        };
+      },
+      template: `<MockIcon v-bind:class="myDynamicClass" />`,
+    });
+
+    expect(node.classList.contains(dynamicClass)).toBe(true);
+  });
+
   it('should be focusable if aria-label and tabindex is used', async () => {
     const label = 'custom-label';
     const node = render({

--- a/packages/icons-vue/tasks/createIconComponent.js
+++ b/packages/icons-vue/tasks/createIconComponent.js
@@ -55,6 +55,7 @@ export default {
       };
     }
     if (data.class) {
+      svgData.class = svgData.class || {}; // may be no static class
       svgData.class[data.class] = true;
     }
     return createElement('svg', svgData, [


### PR DESCRIPTION
Closes #4779

Add the ability to use dynamic classes only in @carbon/icons-vue

#### Changelog

m packages/icons-vue/tasks/__tests__/createIconComponent-test.js
m packages/icons-vue/tasks/createIconComponent.js

#### Testing / Reviewing

Without this I am unable to progress the use of carbon prefix for classes in some @carbon/vue components.
