### PR TITLE
fix(select): add flex rule to accommodate long label text, update story

### DIFF
--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -25,6 +25,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .#{$prefix}--select-input__wrapper {

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -30,6 +30,7 @@ const props = {
       'Form validation UI content (invalidText in <Select>)',
       'A valid value is required'
     ),
+    labelText: text('Label text (helperText)', 'Select'),
     helperText: text('Helper text (helperText)', 'Optional helper text.'),
     onChange: action('onChange'),
   }),


### PR DESCRIPTION
Closes #4757 

In the [deployed storybook environment](http://react.carbondesignsystem.com/?path=/story/select--default), you can see that if the `Select` component's `labelText` is longer than the width of the inner `<select>` element, the caret icon's positioning is off:

<img width="358" alt="Screen Shot 2019-11-27 at 9 43 08 AM" src="https://user-images.githubusercontent.com/9057921/69738052-11d18180-10fb-11ea-82a0-e3bd28726986.png">

This PR adds a flex alignment rule to fix that issue & also adds `labelText` as a prop to the `Select` component story so that the label can be experimented with more easily:

<img width="361" alt="Screen Shot 2019-11-27 at 9 50 26 AM" src="https://user-images.githubusercontent.com/9057921/69738239-6248df00-10fb-11ea-9059-c8e0984747a2.png">


### Changelog

**New**

- add `align-items: flex-start` to `Select` component wrapper
- add `labelText` prop to knobs in `Select` story
