### PR TITLE
fix(type): add `font-family` import

### DIFF
--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -6,6 +6,7 @@
 //
 
 @import '@carbon/layout/scss/breakpoint';
+@import 'font-family';
 @import 'scale';
 
 /// @type Map


### PR DESCRIPTION
#### Changelog

**Changed**

- Add `font-family` import to `@carbon/type/scss/styles` to prevent `carbon--font-weight` not being found in isolation.