### PR TITLE
fix(search): fix a11y structure

### DIFF
--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -96,6 +96,12 @@
 
   .#{$prefix}--toolbar-search-container-expandable
     .#{$prefix}--search
+    .#{$prefix}--label {
+    visibility: hidden;
+  }
+
+  .#{$prefix}--toolbar-search-container-expandable
+    .#{$prefix}--search
     .#{$prefix}--search-input {
     border: none;
     height: 100%;
@@ -131,9 +137,12 @@
 
   .#{$prefix}--toolbar-search-container-active
     .#{$prefix}--search
+    .#{$prefix}--label,
+  .#{$prefix}--toolbar-search-container-active
+    .#{$prefix}--search
     .#{$prefix}--search-input {
     padding-left: $spacing-3xl;
-    visibility: visible;
+    visibility: inherit;
   }
 
   .#{$prefix}--toolbar-search-container-active

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -80,7 +80,7 @@ const TableToolbarSearch = ({
   return (
     <div
       tabIndex={expandedState ? '-1' : '0'}
-      role="searchbox"
+      role="search"
       ref={searchRef}
       onClick={event => handleExpand(event, true)}
       onFocus={event => handleExpand(event, true)}

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2228,7 +2228,7 @@ exports[`DataTable should render 1`] = `
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  role="searchbox"
+                  role="search"
                   tabIndex="0"
                 >
                   <Search
@@ -2289,6 +2289,7 @@ exports[`DataTable should render 1`] = `
                         id="custom-id"
                         onChange={[Function]}
                         placeholder="Filter table"
+                        role="searchbox"
                         type="text"
                         value=""
                       />
@@ -3203,7 +3204,7 @@ exports[`DataTable sticky header should render 1`] = `
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  role="searchbox"
+                  role="search"
                   tabIndex="0"
                 >
                   <Search
@@ -3264,6 +3265,7 @@ exports[`DataTable sticky header should render 1`] = `
                         id="custom-id"
                         onChange={[Function]}
                         placeholder="Filter table"
+                        role="searchbox"
                         type="text"
                         value=""
                       />

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -13,7 +13,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    role="searchbox"
+    role="search"
     tabIndex="0"
   >
     <Search
@@ -75,6 +75,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
           id="custom-id"
           onChange={[Function]}
           placeholder="Filter table"
+          role="searchbox"
           type="text"
           value=""
         />

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -168,6 +168,7 @@ export default class Search extends Component {
           {labelText}
         </label>
         <input
+          role="searchbox"
           {...other}
           type={type}
           className={`${prefix}--search-input`}


### PR DESCRIPTION
This change does the following things:

* Ensures that the `<label>` in `<Search>` is hidden when `<TableToolbarSearch>` hides it. This fixes the orphaned relationship between `<input>` and `<label>` when search box is collpased and fixes "INPUT LABEL references must be valid" DAP error
* Changes the ARIA role of the search container in `<TableToolbarSearch>` to `search` rather than `searchbox`, to better reflect its "container" nature. Also added `searchbox` role to the underlying `<input>` to reflect where the search box is. This lets VoiceOver announce the `<input>` inside `<Search>` as a "search text field" rather than "edit text", and fixes "An interactive element/widget must have an accessible name" DAP error when search box is expanded

Fixes #3806.

#### Changelog

**Changed**

- Ensures that the `<label>` in `<Search>` is hidden when `<TableToolbarSearch>` hides it
- Changes the ARIA role of the search container in `<TableToolbarSearch>` to `search` rather than `searchbox`

#### Testing / Reviewing

Testing should make sure `<Search>` and `<TableToolbarSearch>` are not broken.