### PR TITLE
docs(radio-tile): remove invalid labelText prop from story

### DIFF
--- a/packages/react/src/components/Tile/Tile-story.js
+++ b/packages/react/src/components/Tile/Tile-story.js
@@ -146,25 +146,13 @@ storiesOf('Tile', module)
           defaultSelected="default-selected"
           legend="Selectable Tile Group"
           {...props.group()}>
-          <RadioTile
-            value="standard"
-            id="tile-1"
-            labelText="Selectable Tile"
-            {...radioProps}>
+          <RadioTile value="standard" id="tile-1" {...radioProps}>
             Selectable Tile
           </RadioTile>
-          <RadioTile
-            value="default-selected"
-            labelText="Default selected tile"
-            id="tile-2"
-            {...radioProps}>
+          <RadioTile value="default-selected" id="tile-2" {...radioProps}>
             Selectable Tile
           </RadioTile>
-          <RadioTile
-            value="selected"
-            labelText="Selectable Tile"
-            id="tile-3"
-            {...radioProps}>
+          <RadioTile value="selected" id="tile-3" {...radioProps}>
             Selectable Tile
           </RadioTile>
         </TileGroup>


### PR DESCRIPTION
`labelText` is not a valid prop for the `RadioTile` component, so when it is used in the React storybook it generates the following console error (in local development) --

![Screen Shot 2019-12-06 at 1 28 59 PM](https://user-images.githubusercontent.com/9057921/70350642-b6a33b80-182c-11ea-8f45-794f7cf13f49.png)

Text of error:

```
Warning: React does not recognize the `labelText` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `labeltext` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in input (created by RadioTile)
    in RadioTile (created by TileGroup)
    in div (created by TileGroup)
    in fieldset (created by TileGroup)
    in TileGroup (created by Container)
    in div (created by Story)
    in Story (created by Container)
    in div (created by Container)
    in StrictMode (created by Container)
    in Container (created by storyFn)
    in storyFn
    in ErrorBoundary
```

This PR proposes removing usage of `labelText` prop in the storybook, which removes the console errors in local development. 👍 


#### Changelog

**Removed**

- remove `labelText` prop usage in `RadioTile` component story

#### Testing / Reviewing

I suggest running the storybook locally & then viewing the dev console in **Chrome**
Even without pulling down my remote, you could run the storybook, observe the console errors, and then remove the lines that I removed -- the usage of `labelText`
