### PR TITLE
docs(modal-wrapper): remove invalid prop, fix renderTriggerButtonIcon knob

### DIFF
--- a/packages/react/src/components/ModalWrapper/ModalWrapper-story.js
+++ b/packages/react/src/components/ModalWrapper/ModalWrapper-story.js
@@ -52,8 +52,8 @@ const props = () => {
       'Modal contains scrollable content (hasScrollingContent)',
       true
     ),
-    renderTriggerButtonIcon: typeof iconToUse === 'function' && iconToUse,
-    triggerButtonIcon: typeof iconToUse !== 'function' && iconToUse,
+    renderTriggerButtonIcon:
+      typeof iconToUse === 'function' ? iconToUse : undefined,
     modalLabel: text('The modal label (optional) (modalLabel)', 'Label'),
     modalHeading: text('The modal heading (modalHeading)', 'Modal'),
     selectorPrimaryFocus: text(


### PR DESCRIPTION
The `ModalWrapper` demo in the React storybook environment has an invalid prop `triggerButtonIcon` being passed to it.


![Screen Shot 2019-12-06 at 2 22 17 PM](https://user-images.githubusercontent.com/9057921/70353806-da1db480-1833-11ea-9258-8fb990cf47b6.png)

Error text:

```
Warning: React does not recognize the `triggerButtonIcon` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `triggerbuttonicon` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

---------

This demo also has a default value of `'none'` for the `renderTriggerButtonIcon` **on page load**, which is an invalid value & generates a console error in local development. (The error goes away when you use knobs to select an icon, because then the value being passed changes from `'none'` to a valid icon).

![Screen Shot 2019-12-06 at 2 22 09 PM](https://user-images.githubusercontent.com/9057921/70353840-f1f53880-1833-11ea-9857-9a7ae1af5660.png)

Text of two console errors **on page load**:

```
Warning: Failed prop type: Invalid prop `renderTriggerButtonIcon` supplied to `ModalWrapper`.
    in ModalWrapper (created by Container)
    in Container (created by storyFn)
    in storyFn
    in ErrorBoundary

Warning: Failed prop type: Invalid prop `renderIcon` supplied to `Button`.
    in Button (created by ModalWrapper)
    in ModalWrapper (created by Container)
    in div (created by Story)
    in Story (created by Container)
    in div (created by Container)
    in StrictMode (created by Container)
    in Container (created by storyFn)
    in storyFn
    in ErrorBoundary
```

----------

This PR proposes removing the invalid prop `triggerButtonIcon` and also updating the `renderTriggerButtonIcon` prop's knob logic so that, on page load, `renderTriggerButtonIcon={undefined}` (valid) and not `renderTriggerButtonIco='none'` (invalid)

#### Changelog

**Changed**

- change default value for `renderTriggerButtonIcon` prop knob. Now it will be `renderTriggerButtonIcon={undefined}` (valid) on page load, and not `renderTriggerButtonIco='none'` (invalid)

**Removed**

- remove `triggerButtonIcon` (not a valid prop)

#### Testing / Reviewing

I suggest running the storybook locally, and viewing the console in Chrome.
