### PR TITLE
docs: remove deprecated `small` button prop usage from React stories

### DIFF
--- a/packages/react/src/components/Button/Button-story.js
+++ b/packages/react/src/components/Button/Button-story.js
@@ -58,7 +58,6 @@ const props = {
       ),
       onClick: action('onClick'),
       onFocus: action('onFocus'),
-      small: boolean('Small (small) - Deprecated in favor of `size`', false),
     };
   },
   iconOnly: () => {
@@ -92,7 +91,6 @@ const props = {
     return {
       className: 'some-class',
       disabled: boolean('Disabled (disabled)', false),
-      small: boolean('Small (small)', false),
       size: select('Button size (size)', sizes, 'default'),
       renderIcon: !iconToUse || iconToUse.svgData ? undefined : iconToUse,
       iconDescription: text(

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -142,7 +142,7 @@ storiesOf('FileUploader', module)
           />
           <Button
             kind="secondary"
-            small
+            size="small"
             style={{ marginTop: '1rem' }}
             onClick={() => {
               fileUploader.clearFiles();


### PR DESCRIPTION
There are two instances where the deprecated `Button` prop `small` is still used in storybook -- in the `Button` stories and in a `FileUploader` story.

The presence of this deprecated prop generates console errors in local development, so I wanted to suggest removing their usage in storybook. I understand the next to keep them in existing tests, but in this case I think it would be beneficial to remove them from demos.

Please let me know what you think -- thank you! 👍 

#### Changelog

**Removed**

- remove deprecated `Button` prop `small` usage from stories

#### Testing / Reviewing

Best way to view the console errors, in my experience, is to run the storybook environment locally & view the dev console in Chrome.
