### PR TITLE
Enable clicking/highlighting inside inline notifications

### DIFF
--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -62,6 +62,7 @@
       filter: opacity(0.4);
       border-style: solid;
       border-width: 1px 1px 1px 0;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
This is related to https://github.com/carbon-design-system/carbon-website/issues/655

### Steps to reproduce
1. Navigate to https://www.carbondesignsystem.com/data-visualization/basic-charts
2. Click on the links inside this box or try highlighting the text
![image](https://user-images.githubusercontent.com/14989804/70451529-86011300-1a73-11ea-9dc3-271f98e661ef.png)

The box drawn for the stroke in `::before` seems to be blocking pointer events.

Feel free to suggest other ways of fixing this. 🙂 