### PR TITLE
fix(UIShell): eliminate duplicate main

### DIFF
--- a/packages/components/src/components/ui-shell/_header.scss
+++ b/packages/components/src/components/ui-shell/_header.scss
@@ -303,6 +303,7 @@
   // Header - Skip to content
   //--------------------------------------------------------------------------
   .#{$prefix}--skip-to-content {
+    color: $shell-header-text-01;
     position: absolute;
     width: 1px;
     height: 1px;
@@ -326,7 +327,6 @@
     border: 4px solid $ibm-color__blue-60;
     z-index: 9999;
     background-color: $shell-header-bg-01;
-    color: $shell-header-text-01;
     outline: none;
     padding: 0 1rem;
   }

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -13,7 +13,7 @@ import React, { useEffect } from 'react';
 
 const { prefix } = settings;
 
-function Container({ story }) {
+function Container({ story, hasMainContent }) {
   useEffect(() => {
     const originalDirection = document.documentElement.dir;
     if (process.env.CARBON_REACT_STORYBOOK_USE_RTL === 'true') {
@@ -28,7 +28,9 @@ function Container({ story }) {
     <React.StrictMode>
       <div
         data-floating-menu-container
-        role="main"
+        id={!hasMainContent ? 'main-content' : undefined}
+        role={!hasMainContent ? 'main' : 'region'}
+        aria-label={!hasMainContent ? undefined : 'UI Shell container'}
         style={{
           padding: '3em',
           display: 'flex',
@@ -37,9 +39,10 @@ function Container({ story }) {
         }}>
         {story()}
       </div>
-      <input
+      <a
         aria-label="input-text-offleft"
         type="text"
+        href="main-content"
         className={`${prefix}--visually-hidden`}
       />
     </React.StrictMode>

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -45,7 +45,9 @@ configureActions({
   limit: 10,
 });
 
-addDecorator(story => <Container story={story} />);
+addDecorator((story, { parameters = {} }) => (
+  <Container story={story} hasMainContent={parameters.hasMainContent} />
+));
 // addDecorator(checkA11y);
 
 addons.getChannel().on(CARBON_CURRENT_THEME, theme => {

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -392,7 +392,8 @@ storiesOf('UI Shell', module)
           </>
         )}
       />
-    ))
+    )),
+    { hasMainContent: true }
   )
   .add(
     'Header Base w/ SideNav',


### PR DESCRIPTION
This change eliminates duplicated `<main>` (one from UI shell story) and `<div role="main">` (one from the Storybook decorator for all stories) by telling the existence of former to the latter.

This change also does:

* Defines the color of non-focused state of skip-to-content element, given our a11y test tool cannot detect "shown for screen reader only" element
* Make focus sentinel point to the main content for better navigation

Refs #3576.

#### Changelog

**Changed**

- Change to eliminate duplicated `<main>` and `<div role="main">`
- Color of non-focused skip-to-content element
- Change to make focus sentinel point to the main content for better navigation

#### Testing / Reviewing

Testing should make sure skip-to-content element is not broken. All other changes are of Storybook environment.
