### PR TITLE
fix(button): update focus styles to use box-shadow

### DIFF
--- a/packages/components/src/components/button/_mixins.scss
+++ b/packages/components/src/components/button/_mixins.scss
@@ -26,8 +26,7 @@
   text-align: left;
   text-decoration: none;
   transition: all $duration--fast-01 motion(entrance, productive);
-  outline: $button-outline-width solid transparent;
-  outline-offset: -4px;
+  outline: none;
   position: relative;
   max-width: rem(320px);
 
@@ -72,7 +71,7 @@
 
   &:focus {
     border-color: $focus;
-    outline-color: $ui-02;
+    box-shadow: inset 0 0 0 $button-outline-width $ui-02;
   }
 
   &:disabled:hover,
@@ -83,7 +82,7 @@
     background-color: $disabled-02;
     border-color: $disabled-02;
     text-decoration: none;
-    outline-color: $disabled-02;
+    box-shadow: none;
   }
 
   &:active {


### PR DESCRIPTION
Closes #3919
Closes #3560

#### Changelog

**New**

**Changed**

- Update button focus styles to use `box-shadow` instead of `outline` as the offset for outline is unsupported in IE11

**Removed**

#### Testing / Reviewing

- Run environment in IE11 and verify focus styles are applied
