### PR TITLE
fix(UIshell): adds story for SkipToContent and removes the tabIndex prop requirement

### DIFF
--- a/packages/react/src/components/UIShell/SkipToContent.js
+++ b/packages/react/src/components/UIShell/SkipToContent.js
@@ -29,7 +29,7 @@ const SkipToContent = ({
 
 SkipToContent.propTypes = {
   /**
-   * Provide an optional class to be applied to the containing node
+   * Provide text to display in the SkipToContent `a` tag
    */
   children: PropTypes.string.isRequired,
 
@@ -42,7 +42,7 @@ SkipToContent.propTypes = {
   /**
    * Optionally override the default tabindex of 0
    */
-  tabIndex: PropTypes.string.isRequired,
+  tabIndex: PropTypes.string,
 };
 
 SkipToContent.defaultProps = {

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -66,11 +66,12 @@ const StoryContent = () => {
           </h2>
           <p style={{ lineHeight: '20px' }}>
             The shell is perhaps the most crucial piece of any UI built with
-            Carbon. It contains the shared navigation framework for the entire
-            design system and ties the products in IBM’s portfolio together in a
-            cohesive and elegant way. The shell is the home of the topmost
-            navigation, where users can quickly and dependably gain their
-            bearings and move between pages.
+            <a href="www.carbondesignsystem.com"> Carbon</a>. It contains the
+            shared navigation framework for the entire design system and ties
+            the products in IBM’s portfolio together in a cohesive and elegant
+            way. The shell is the home of the topmost navigation, where users
+            can quickly and dependably gain their bearings and move between
+            pages.
             <br />
             <br />
             The shell was designed with maximum flexibility built in, to serve
@@ -216,6 +217,37 @@ storiesOf('UI Shell', module)
           </HeaderGlobalAction>
         </HeaderGlobalBar>
       </Header>
+    ))
+  )
+  .add(
+    'Header Base w/ SkipToContent',
+    withReadme(readme, () => (
+      <>
+        <Header aria-label="IBM Platform Name">
+          <SkipToContent />
+          <HeaderName href="#" prefix="IBM">
+            [Platform]
+          </HeaderName>
+          <HeaderGlobalBar>
+            <HeaderGlobalAction
+              aria-label="Search"
+              onClick={action('search click')}>
+              <Search20 />
+            </HeaderGlobalAction>
+            <HeaderGlobalAction
+              aria-label="Notifications"
+              onClick={action('notification click')}>
+              <Notification20 />
+            </HeaderGlobalAction>
+            <HeaderGlobalAction
+              aria-label="App Switcher"
+              onClick={action('app-switcher click')}>
+              <AppSwitcher20 />
+            </HeaderGlobalAction>
+          </HeaderGlobalBar>
+        </Header>
+        <StoryContent />
+      </>
     ))
   )
   .add(


### PR DESCRIPTION
Closes #4802

This PR adds a story that more explicitly shows the use of `SkipToContent`. Because we use render props in all of the current stories that use `SkipToContent`, the Story Source doesn't provide prop tables or component names for them.

Example from Header Base w/ Navigation, Actions, and SideNav:
 
![Screen Shot 2019-12-13 at 11 19 36 AM](https://user-images.githubusercontent.com/17281178/70818895-78f96200-1d9a-11ea-9877-941c2de1cb93.png)

The new story shows all of the components used and their prop tables and is the only story that shows the code example for SkipToContent. 

I'm waiting on confirmation from Sharon Sniders, but I believe the DAP violation related to SKipToContent is coming from when it is not visible and is not present when it is visible so it might not need to be addressed. If it does, #4865 will resolve the DAP violation. 

In the comment for the `tabIndex` proptype check, it is described as optional so I removed the `.isRequired` from the check and changed the comment for the `children` prop since it seemed to be describing the wrong thing. 

#### Changelog

**New**

- UIShell story to illustrate `SkipToContent` use

**Changed**

- A link added to `StoryContent` so there is something to tab to when `SkipToContent` is used. 
- Description of 'children' prop

**Removed**

- `.isRequired` from `tabIndex` proptype check 

#### Testing / Reviewing

Look at the story source for the new UIShell Story "Header Base w/ SkipToContent" and decide if we want this story included!
