### PR TITLE
chore: add system squad label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility-issue.md
+++ b/.github/ISSUE_TEMPLATE/accessibility-issue.md
@@ -2,7 +2,7 @@
 name: Accessibility Issue ♿
 about: Report an accessibility or usability issue
 title: ''
-labels: 'type: a11y ♿'
+labels: 'type: a11y ♿', 'squad: system'
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,8 @@
 ---
-name: "Bug Report \U0001F41B"
+name: "Bug Report 🐛"
 about: Something isn't working as expected? Here is the right place to report.
 title: ''
-labels: "type: bug \U0001F41B"
+labels: "type: bug 🐛", "squad: system"
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
@@ -1,8 +1,8 @@
 ---
-name: "Feature request or enhancement \U0001F4A1"
+name: "Feature request or enhancement 💡"
 about: Suggest an idea for this project
 title: ''
-labels: "type: enhancement \U0001F4A1"
+labels: "type: enhancement 💡", "squad: system"
 assignees: ''
 ---
 
@@ -15,8 +15,8 @@ If you are reporting a bug or problem, please use the bug template instead.
 
 Please describe your request in one or two sentences.
 
-Clarify if you are asking for both design and development, or just design, or
-just development.
+Clarify if you are asking for design, development, or both design and
+development.
 
 ### Justification
 
@@ -24,8 +24,12 @@ Provide the business reasons for this request.
 
 ### Desired UX and success metrics
 
+<!--alex disable failure-->
+
 Describe the full user experience for this feature. Also define the metrics by
 which we can measure success/failure for the user.
+
+<!--alex enable failure-->
 
 ### "Must have" functionality
 
@@ -36,8 +40,12 @@ you to define functionality based on the desired UX.
 
 ### Specific timeline issues / requests
 
+<!--alex disable period-->
+
 Do you want this work within a specific time period? Is it related to an
 upcoming release?
+
+<!--alex enable period-->
 
 _NB: The Carbon team will try to work with your timeline, but it's not
 guaranteed. The earlier you make a request in advance of a desired delivery

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,8 @@
 ---
 name: Question ❓
-about: Usage question or discussion about Carbon Components.
+about: Usage question or discussion about Carbon components
 title: ''
-labels: 'type: question :question:'
+labels: 'type: question ❓', 'squad: system'
 assignees: ''
 ---
 


### PR DESCRIPTION
Adds system squad labels to issue templates so we can filter by squads going forward in ZenHub workspaces.