### PR TITLE
fix(multiselect): close button for tags

### DIFF
--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -19,7 +19,6 @@
     @include type-style('label-01');
 
     display: inline-flex;
-    position: relative;
     align-items: center;
     padding: 0 $carbon--spacing-03;
     height: 1.5rem;

--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -96,16 +96,10 @@
     @include tag-theme($inverse-02, $inverse-01);
 
     cursor: pointer;
-    padding-right: calc(
-      #{$carbon--spacing-06} + #{rem(2px)}
-    ); // icon width + 2px space from right edge
+    padding-right: rem(2px);
   }
 
   .#{$prefix}--tag--filter > svg {
-    position: absolute;
-    right: rem(2px);
-    top: 50%;
-    transform: translateY(-50%);
     fill: $inverse-01;
     margin-left: rem(4px);
     padding: rem(2px);


### PR DESCRIPTION
Closes #4888

Close svg for tags was not aligned. 

#### Changelog

**Removed**

- absolute positioning for close svg 

#### Testing / Reviewing

Make sure tag filter and multi select tags are working and close button is positioned correctly. 