### PR TITLE
fix(list-box): update chevron position for IE11

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -327,7 +327,9 @@ $list-box-menu-width: rem(300px);
   // Menu status inside of a `list-box__field`
   .#{$prefix}--list-box__menu-icon {
     position: absolute;
+    top: 0;
     right: $carbon--spacing-05;
+    bottom: 0;
     height: 100%;
     transition: transform $duration--fast-01 motion(standard, productive);
     cursor: pointer;


### PR DESCRIPTION
Update chevron position to work in IE11

Observed this while doing release audits for v10.9.0

![image](https://user-images.githubusercontent.com/3901764/71020192-7a3fcd00-20c1-11ea-9ce2-3243b8777041.png)


#### Changelog

**New**

**Changed**

- Update position for menu icon

**Removed**
