### PR TITLE
fix(DatePicker): explicitly update minDate and maxDate

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -307,17 +307,6 @@ export default class DatePicker extends Component {
   };
 
   UNSAFE_componentWillUpdate(nextProps) {
-    //Explicitly update minDate and maxDate
-    const extraProps = ['minDate', 'maxDate'];
-    extraProps.forEach(prop => {
-      if (nextProps[prop] !== this.props[prop]) {
-        if (this.cal) {
-          this.cal.set(prop, nextProps[prop]);
-        } else if (this.inputField) {
-          this.inputField[prop] = nextProps[prop];
-        }
-      }
-    });
     if (nextProps.value !== this.props.value) {
       if (this.cal) {
         this.cal.setDate(nextProps.value);
@@ -394,11 +383,17 @@ export default class DatePicker extends Component {
     }
   }
 
-  componentDidUpdate({ dateFormat: prevDateFormat }) {
-    const { dateFormat } = this.props;
-    if (this.cal && prevDateFormat !== dateFormat) {
-      this.cal.set({ dateFormat });
-    }
+  componentDidUpdate(prevProps) {
+    const extraProps = ['dateFormat', 'minDate', 'maxDate'];
+    extraProps.forEach(prop => {
+      if (prevProps[prop] !== this.props[prop]) {
+        if (this.cal) {
+          this.cal.set(prop, this.props[prop]);
+        } else if (this.inputField) {
+          this.inputField[prop] = this.props[prop];
+        }
+      }
+    });
   }
 
   componentWillUnmount() {

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -383,17 +383,23 @@ export default class DatePicker extends Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    const extraProps = ['dateFormat', 'minDate', 'maxDate'];
-    extraProps.forEach(prop => {
-      if (prevProps[prop] !== this.props[prop]) {
-        if (this.cal) {
-          this.cal.set(prop, this.props[prop]);
-        } else if (this.inputField) {
-          this.inputField[prop] = this.props[prop];
-        }
+  componentDidUpdate({
+    dateFormat: prevDateFormat,
+    minDate: prevMinDate,
+    maxDate: prevMaxDate,
+  }) {
+    const { dateFormat, minDate, maxDate } = this.props;
+    if (this.cal) {
+      if (prevDateFormat !== dateFormat) {
+        this.cal.set({ dateFormat });
       }
-    });
+      if (prevMinDate !== minDate) {
+        this.cal.set('minDate', minDate);
+      }
+      if (prevMaxDate !== maxDate) {
+        this.cal.set('maxDate', maxDate);
+      }
+    }
   }
 
   componentWillUnmount() {

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -307,6 +307,17 @@ export default class DatePicker extends Component {
   };
 
   UNSAFE_componentWillUpdate(nextProps) {
+    //Explicitly update minDate and maxDate
+    const extraProps = ['minDate', 'maxDate'];
+    extraProps.forEach(prop => {
+      if (nextProps[prop] !== this.props[prop]) {
+        if (this.cal) {
+          this.cal.set(prop, nextProps[prop]);
+        } else if (this.inputField) {
+          this.inputField[prop] = nextProps[prop];
+        }
+      }
+    });
     if (nextProps.value !== this.props.value) {
       if (this.cal) {
         this.cal.setDate(nextProps.value);


### PR DESCRIPTION
Since flatpickr does not automatically update minDate and maxDate,
we need to explicitly do it when the user makes any change in the props
by using set(option, value) method from flatpickr

Fixes #2500 

#### Changelog

**New**

**Changed**

- explicitly update minDate and maxDate when they are changed

**Removed**

#### Testing / Reviewing

Testing should make sure <DatePicker> is not broken.