### PR TITLE
fix(code-snippet): set max-height to 100% and add bottom padding to expanded multi-line

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -114,8 +114,9 @@
   // expanded snippet container
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
     .#{$prefix}--snippet-container {
-    max-height: rem(1500px);
+    max-height: 100%;
     transition: max-height $duration--moderate-01 motion(standard, productive);
+    padding-bottom: $spacing-05;
   }
 
   // closed pre


### PR DESCRIPTION
Closes #4903 

The problem identified in #4903 is caused by a fixed max-height being set on the expanded multi-line code snippet. While this max-height is very large, there are situations where a code snippet may be even longer and would therefore be cut off.

This PR proposes making the max-height of an expanded multi-line code snippet 100%, so that all expanded snippets can be fully visible no matter how long they are. I don't think there's a reason to cut off this text (even with a scroll) when a user chooses to expand the snippet to see entire snippet.

I also added some bottom padding to this container because I noticed that the "Show more"/"Show less" button was overlapping the last line of code.

#### Changelog

**New**

- add bottom padding to the expanded multi-line snippet (so as not to cover last line of code when button)

**Changed**

- change max-height of expanded multi-line snippet to 100%

**Removed**

- {{removed thing}}

#### Testing / Reviewing

To test this, I used the Cupcake Ipsum generator to create 50 long paragraph of text to place into the multi-line code snippet. I suggest using that generator (not copy + pasting text repeatedly) or a similar generator so that it's easier to tell that the component is showing ALL available text when you expand it.
