### PR TITLE
fix(Dropdown): rely on list-box height closes #4916

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -16293,6 +16293,11 @@ Dropdown styles
     }
   }
 
+  // when implemented as a listbox (react), rely on the list-box height
+  .#{$prefix}--dropdown[role='listbox'] {
+    height: 100%;
+  }
+
   .#{$prefix}--dropdown--xl {
     height: rem(48px);
   }

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -51,7 +51,6 @@
     border: none;
     border-bottom: 1px solid $ui-04;
     width: 100%;
-    height: rem(40px);
     cursor: pointer;
     color: $text-01;
     outline: 2px solid transparent;

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -68,7 +68,7 @@
   // Dropdown isn't implemented as a listbox in vanilla but _is_ in React.
   // In React we rely on the list box height for things like size.
   // Vanilla can't rely on listbox height so we define it here.
-  .#{$prefix}--dropdown:not([role='listbox']) {
+  .#{$prefix}--dropdown:not(.#{$prefix}--list-box) {
     height: rem(40px);
   }
 

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -51,6 +51,7 @@
     border: none;
     border-bottom: 1px solid $ui-04;
     width: 100%;
+    height: rem(40px);
     cursor: pointer;
     color: $text-01;
     outline: 2px solid transparent;
@@ -63,6 +64,11 @@
     &:hover {
       background-color: $hover-ui;
     }
+  }
+
+  // when implemented as a listbox (react), rely on the list-box height
+  .#{$prefix}--dropdown[role='listbox'] {
+    height: 100%;
   }
 
   .#{$prefix}--dropdown--xl {

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -51,7 +51,6 @@
     border: none;
     border-bottom: 1px solid $ui-04;
     width: 100%;
-    height: rem(40px);
     cursor: pointer;
     color: $text-01;
     outline: 2px solid transparent;
@@ -66,9 +65,11 @@
     }
   }
 
-  // when implemented as a listbox (react), rely on the list-box height
-  .#{$prefix}--dropdown[role='listbox'] {
-    height: 100%;
+  // Dropdown isn't implemented as a listbox in vanilla but _is_ in React.
+  // In React we rely on the list box height for things like size.
+  // Vanilla can't rely on listbox height so we define it here.
+  .#{$prefix}--dropdown:not([role='listbox']) {
+    height: rem(40px);
   }
 
   .#{$prefix}--dropdown--xl {


### PR DESCRIPTION
Testing: test all the possible sizes for dropdown using the storybook knob
- also check vanilla ;)


Dropdown isn't implemented as a listbox in vanilla but _is_ in React. In React we rely on the list box height for things like size. Vanilla can't rely on listbox height so we define it here.