### PR TITLE
fix(HeaderMenu): support escape key

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -95,6 +95,16 @@ class HeaderMenu extends React.Component {
 
       return;
     }
+    if (matches(event, [keys.Escape])) {
+      event.stopPropagation();
+      event.preventDefault();
+
+      this.setState({
+        expanded: false,
+      });
+
+      return;
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes #3661.

#### Changelog

**New**

- Escape key support for `<HeaderMenu>`.

#### Testing / Reviewing

Testing should make sure `<HeaderMenu>` is not broken.