### PR TITLE
fix(type): add missing units to carbon--rem calls

### DIFF
--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -186,7 +186,7 @@ $productive-heading-07: (
 $expressive-heading-01: map-merge(
   $heading-01,
   (
-    line-height: carbon--rem(20),
+    line-height: carbon--rem(20px),
   )
 ) !default;
 
@@ -196,7 +196,7 @@ $expressive-heading-01: map-merge(
 $expressive-heading-02: map-merge(
   $heading-02,
   (
-    line-height: carbon--rem(24),
+    line-height: carbon--rem(24px),
   )
 ) !default;
 


### PR DESCRIPTION
Closes #4926 

This PR adds missing px units to `carbon--rem` usage within the `expressive-heading-01` & `expressive-heading-02` maps.

#### Changelog

**Changed**

- add missing px units
