### PR TITLE
fix(styles): add error handling for rem & em sass functions

### DIFF
--- a/packages/components/src/globals/scss/_typography.scss
+++ b/packages/components/src/globals/scss/_typography.scss
@@ -23,7 +23,7 @@ $base-font-size: 16px !default;
 /// @deprecated (For v10) Use `carbon--rem()`
 @function rem($px) {
   @if unit($px) != 'px' {
-    @error "Argument `#{$px}` must be a value in pixels.";
+    @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
   @return ($px / $base-font-size) * 1rem;
@@ -38,7 +38,7 @@ $base-font-size: 16px !default;
 /// @deprecated (For v10) Use `carbon--em()`
 @function em($px) {
   @if unit($px) != 'px' {
-    @error "Argument `#{$px}` must be a value in pixels.";
+    @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
   @return ($px / $base-font-size) * 1em;

--- a/packages/components/src/globals/scss/_typography.scss
+++ b/packages/components/src/globals/scss/_typography.scss
@@ -22,6 +22,10 @@ $base-font-size: 16px !default;
 /// @group global-typography
 /// @deprecated (For v10) Use `carbon--rem()`
 @function rem($px) {
+  @if unit($px) != 'px' {
+    @error "Argument `#{$px}` must be a value in pixels.";
+  }
+
   @return ($px / $base-font-size) * 1rem;
 }
 
@@ -33,6 +37,10 @@ $base-font-size: 16px !default;
 /// @group global-typography
 /// @deprecated (For v10) Use `carbon--em()`
 @function em($px) {
+  @if unit($px) != 'px' {
+    @error "Argument `#{$px}` must be a value in pixels.";
+  }
+
   @return ($px / $base-font-size) * 1em;
 }
 

--- a/packages/components/src/globals/scss/_typography.scss
+++ b/packages/components/src/globals/scss/_typography.scss
@@ -23,6 +23,7 @@ $base-font-size: 16px !default;
 /// @deprecated (For v10) Use `carbon--rem()`
 @function rem($px) {
   @if unit($px) != 'px' {
+    // TODO: update to @error in v11
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
@@ -38,6 +39,7 @@ $base-font-size: 16px !default;
 /// @deprecated (For v10) Use `carbon--em()`
 @function em($px) {
   @if unit($px) != 'px' {
+    // TODO: update to @error in v11
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 

--- a/packages/layout/scss/_convert.scss
+++ b/packages/layout/scss/_convert.scss
@@ -18,6 +18,7 @@ $carbon--base-font-size: 16px !default;
 /// @group @carbon/layout
 @function carbon--rem($px) {
   @if unit($px) != 'px' {
+    // TODO: update to @error in v11
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
@@ -31,6 +32,7 @@ $carbon--base-font-size: 16px !default;
 /// @group @carbon/layout
 @function carbon--em($px) {
   @if unit($px) != 'px' {
+    // TODO: update to @error in v11
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 

--- a/packages/layout/scss/_convert.scss
+++ b/packages/layout/scss/_convert.scss
@@ -18,7 +18,7 @@ $carbon--base-font-size: 16px !default;
 /// @group @carbon/layout
 @function carbon--rem($px) {
   @if unit($px) != 'px' {
-    @error "Argument `#{$px}` must be a value in pixels.";
+    @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
   @return ($px / $carbon--base-font-size) * 1rem;
@@ -31,7 +31,7 @@ $carbon--base-font-size: 16px !default;
 /// @group @carbon/layout
 @function carbon--em($px) {
   @if unit($px) != 'px' {
-    @error "Argument `#{$px}` must be a value in pixels.";
+    @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
   @return ($px / $carbon--base-font-size) * 1em;

--- a/packages/layout/scss/_convert.scss
+++ b/packages/layout/scss/_convert.scss
@@ -17,6 +17,10 @@ $carbon--base-font-size: 16px !default;
 /// @access public
 /// @group @carbon/layout
 @function carbon--rem($px) {
+  @if unit($px) != 'px' {
+    @error "Argument `#{$px}` must be a value in pixels.";
+  }
+
   @return ($px / $carbon--base-font-size) * 1rem;
 }
 
@@ -26,5 +30,9 @@ $carbon--base-font-size: 16px !default;
 /// @access public
 /// @group @carbon/layout
 @function carbon--em($px) {
+  @if unit($px) != 'px' {
+    @error "Argument `#{$px}` must be a value in pixels.";
+  }
+
   @return ($px / $carbon--base-font-size) * 1em;
 }


### PR DESCRIPTION
Related to https://github.com/carbon-design-system/carbon/issues/4926 & https://github.com/carbon-design-system/carbon/pull/4927

I think it would be a good idea to add a little bit of error handling to the `carbon--rem`/`carbon--em` functions (and their deprecated versions too).

Since these functions all require pixel values to output valid CSS, it would be nice to notify developers directly from these functions when a non-pixel value is received. (Without pixel values, the functions return invalid output -- see this CodePen for examples: https://codepen.io/jendowns/pen/PowpyQJ)

* Info on Sass's `@warn` rule: https://sass-lang.com/documentation/at-rules/warn
* CSS Tricks article on advanced type checking in Sass: https://css-tricks.com/snippets/sass/advanced-type-checking/

#### Changelog

**New**

- add ~`@error`~ `@warn` check to `carbon--rem`/`rem` and `carbon--em`/`em` functions