### PR TITLE
fix(dropdown): revert id change to have stable identifier

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -13,7 +13,6 @@ import { settings } from 'carbon-components';
 import { WarningFilled16 } from '@carbon/icons-react';
 import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
 import { match, keys } from '../../internal/keyboard';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
 
@@ -24,8 +23,6 @@ const defaultItemToString = item => {
 
   return item ? item.label : '';
 };
-
-const getInstanceId = setupGetInstanceId();
 
 export default class Dropdown extends React.Component {
   static propTypes = {
@@ -152,10 +149,6 @@ export default class Dropdown extends React.Component {
     helperText: '',
   };
 
-  constructor(props) {
-    super(props);
-    this.dropdownInstanceId = getInstanceId();
-  }
   handleOnChange = selectedItem => {
     if (this.props.onChange) {
       this.props.onChange({ selectedItem });
@@ -197,10 +190,8 @@ export default class Dropdown extends React.Component {
       [`${prefix}--label--disabled`]: disabled,
     });
 
-    const dropdownId = `dropdown-${this.dropdownInstanceId}`;
-
     const title = titleText ? (
-      <label htmlFor={dropdownId} className={titleClasses}>
+      <label htmlFor={id} className={titleClasses}>
         {titleText}
       </label>
     ) : null;
@@ -247,7 +238,7 @@ export default class Dropdown extends React.Component {
             <ListBox
               type={type}
               size={size}
-              id={dropdownId}
+              id={id}
               aria-label={ariaLabel}
               className={className({ isOpen })}
               disabled={disabled}
@@ -286,7 +277,7 @@ export default class Dropdown extends React.Component {
                 />
               </ListBox.Field>
               {isOpen && (
-                <ListBox.Menu aria-labelledby={dropdownId} id={id}>
+                <ListBox.Menu aria-labelledby={id} id={id}>
                   {items.map((item, index) => (
                     <ListBox.MenuItem
                       key={itemToString(item)}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -67,7 +67,7 @@ exports[`Dropdown should render 1`] = `
       <ListBox
         className="bx--dropdown"
         disabled={false}
-        id="dropdown-1"
+        id="test-dropdown"
         innerRef={[Function]}
         isOpen={false}
         light={false}
@@ -75,7 +75,7 @@ exports[`Dropdown should render 1`] = `
       >
         <div
           className="bx--dropdown bx--list-box"
-          id="dropdown-1"
+          id="test-dropdown"
           onClick={[Function]}
           onKeyDown={[Function]}
           role="listbox"
@@ -242,7 +242,7 @@ exports[`Dropdown should render custom item components 1`] = `
       <ListBox
         className="bx--dropdown bx--dropdown--open"
         disabled={false}
-        id="dropdown-5"
+        id="test-dropdown"
         innerRef={[Function]}
         isOpen={true}
         light={false}
@@ -250,7 +250,7 @@ exports[`Dropdown should render custom item components 1`] = `
       >
         <div
           className="bx--dropdown bx--dropdown--open bx--list-box bx--list-box--expanded"
-          id="dropdown-5"
+          id="test-dropdown"
           onClick={[Function]}
           onKeyDown={[Function]}
           role="listbox"
@@ -344,11 +344,11 @@ exports[`Dropdown should render custom item components 1`] = `
             </div>
           </ListBoxField>
           <ListBoxMenu
-            aria-labelledby="dropdown-5"
+            aria-labelledby="test-dropdown"
             id="test-dropdown"
           >
             <div
-              aria-labelledby="dropdown-5"
+              aria-labelledby="test-dropdown"
               className="bx--list-box__menu"
               id="test-dropdown__menu"
               role="listbox"
@@ -576,7 +576,7 @@ exports[`Dropdown should render with strings as items 1`] = `
       <ListBox
         className="bx--dropdown bx--dropdown--open"
         disabled={false}
-        id="dropdown-4"
+        id="test-dropdown"
         innerRef={[Function]}
         isOpen={true}
         light={false}
@@ -584,7 +584,7 @@ exports[`Dropdown should render with strings as items 1`] = `
       >
         <div
           className="bx--dropdown bx--dropdown--open bx--list-box bx--list-box--expanded"
-          id="dropdown-4"
+          id="test-dropdown"
           onClick={[Function]}
           onKeyDown={[Function]}
           role="listbox"
@@ -678,11 +678,11 @@ exports[`Dropdown should render with strings as items 1`] = `
             </div>
           </ListBoxField>
           <ListBoxMenu
-            aria-labelledby="dropdown-4"
+            aria-labelledby="test-dropdown"
             id="test-dropdown"
           >
             <div
-              aria-labelledby="dropdown-4"
+              aria-labelledby="test-dropdown"
               className="bx--list-box__menu"
               id="test-dropdown__menu"
               role="listbox"


### PR DESCRIPTION
Updates some changes that removed a stable `id` for folks to hook into the underlying `ListBox` component.

[Reference (Internal Slack)](https://ibm-studios.slack.com/archives/C0M053VPT/p1577114116064800)

#### Changelog

**New**

**Changed**

- Remove instance id and prefer stable id from prop

**Removed**

#### Testing / Reviewing

-  There should be one expected a11y violation that exists already (accessible name does not match visible label) but it should not add any additional violations
