### PR TITLE
chore: fix labeler action globs and add auto add package labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,94 @@
 'squad: system':
-  - ./**/*
+  - '**'
+  - '.*'
+  - '.*/**'
+
+'package: browserslist-config-carbon':
+  - packages/browserslist-config-carbon/**
+
+'package: bundler':
+  - packages/bundler/**
+
+'package: cli':
+  - packages/cli/**
+
+'package: cli-reporter':
+  - packages/cli-reporter/**
+
+'package: colors':
+  - packages/colors/**
+
+'package: components':
+  - packages/components/**
+
+'package: elements':
+  - packages/elements/**
+
+'package: eslint-config-carbon':
+  - packages/eslint-config-carbon/**
+
+'package: grid':
+  - packages/grid/**
+
+'package: icon-build-helpers':
+  - packages/icon-build-helpers/**
+
+'package: icon-helpers':
+  - packages/icon-helpers/**
+
+'package: icons':
+  - packages/icons/**
+
+'package: icons-angular':
+  - packages/icons-angular/**
+
+'package: icons-handlebars':
+  - packages/icons-handlebars/**
+
+'package: icons-react':
+  - packages/icons-react/**
+
+'package: icons-vue':
+  - packages/icons-vue/**
+
+'package: import-once':
+  - packages/import-once/**
+
+'package: layout':
+  - packages/layout/**
+
+'package: motion':
+  - packages/motion/**
+
+'package: pictograms':
+  - packages/pictograms/**
+
+'package: pictograms-react':
+  - packages/pictograms-react/**
+
+'package: react':
+  - packages/react/**
+
+'package: react-hooks':
+  - packages/react-hooks/**
+
+'package: scss-generator':
+  - packages/scss-generator/**
+
+'package: sketch':
+  - packages/sketch/**
+
+'package: stylelint-config-elements':
+  - packages/stylelint-config-elements/**
+
+'package: text-utils':
+  - packages/text-utils/**
+
+'package: themes':
+  - packages/themes/**
+
+'package: type':
+  - packages/type/**
+
+'package: upgrade':
+  - packages/upgrade/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,91 +4,91 @@
   - '.*/**'
 
 'package: browserslist-config-carbon':
-  - packages/browserslist-config-carbon/**
+  - packages/browserslist-config-carbon/**/*
 
 'package: bundler':
-  - packages/bundler/**
+  - packages/bundler/**/*
 
 'package: cli':
-  - packages/cli/**
+  - packages/cli/**/*
 
 'package: cli-reporter':
-  - packages/cli-reporter/**
+  - packages/cli-reporter/**/*
 
 'package: colors':
-  - packages/colors/**
+  - packages/colors/**/*
 
 'package: components':
-  - packages/components/**
+  - packages/components/**/*
 
 'package: elements':
-  - packages/elements/**
+  - packages/elements/**/*
 
 'package: eslint-config-carbon':
-  - packages/eslint-config-carbon/**
+  - packages/eslint-config-carbon/**/*
 
 'package: grid':
-  - packages/grid/**
+  - packages/grid/**/*
 
 'package: icon-build-helpers':
-  - packages/icon-build-helpers/**
+  - packages/icon-build-helpers/**/*
 
 'package: icon-helpers':
-  - packages/icon-helpers/**
+  - packages/icon-helpers/**/*
 
 'package: icons':
-  - packages/icons/**
+  - packages/icons/**/*
 
 'package: icons-angular':
-  - packages/icons-angular/**
+  - packages/icons-angular/**/*
 
 'package: icons-handlebars':
-  - packages/icons-handlebars/**
+  - packages/icons-handlebars/**/*
 
 'package: icons-react':
-  - packages/icons-react/**
+  - packages/icons-react/**/*
 
 'package: icons-vue':
-  - packages/icons-vue/**
+  - packages/icons-vue/**/*
 
 'package: import-once':
-  - packages/import-once/**
+  - packages/import-once/**/*
 
 'package: layout':
-  - packages/layout/**
+  - packages/layout/**/*
 
 'package: motion':
-  - packages/motion/**
+  - packages/motion/**/*
 
 'package: pictograms':
-  - packages/pictograms/**
+  - packages/pictograms/**/*
 
 'package: pictograms-react':
-  - packages/pictograms-react/**
+  - packages/pictograms-react/**/*
 
 'package: react':
-  - packages/react/**
+  - packages/react/**/*
 
 'package: react-hooks':
-  - packages/react-hooks/**
+  - packages/react-hooks/**/*
 
 'package: scss-generator':
-  - packages/scss-generator/**
+  - packages/scss-generator/**/*
 
 'package: sketch':
-  - packages/sketch/**
+  - packages/sketch/**/*
 
 'package: stylelint-config-elements':
-  - packages/stylelint-config-elements/**
+  - packages/stylelint-config-elements/**/*
 
 'package: text-utils':
-  - packages/text-utils/**
+  - packages/text-utils/**/*
 
 'package: themes':
-  - packages/themes/**
+  - packages/themes/**/*
 
 'package: type':
-  - packages/type/**
+  - packages/type/**/*
 
 'package: upgrade':
-  - packages/upgrade/**
+  - packages/upgrade/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,12 +1,13 @@
-name: 'Label pull request'
-
+name: 'Label pull requests'
 on:
-  - pull_request
-
+  schedule:
+    - cron: '*/5 * * * *'
 jobs:
-  triage:
+  labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v2
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
Fixes the GitHub action that labels every new PR with `squad: system` so we can consolidate ZenHub workspaces. Glob syntax from https://github.com/actions/labeler/issues/28#issuecomment-552362351.

Adds package labels as well to get a better feel for "splash zone" for each PR - better see which packages are affected by the PR. New package labels will also allow us to run analysis for reporting in the future.

## Update

The default action doesn't work when the PR originated from a fork, due to read-only permissions of the GH token. (See https://github.com/actions/labeler/issues/12#issuecomment-549901347.) This new approach adds a cron job that runs every 5 minutes on the master branch to label open PRs based on file patterns: https://github.com/marketplace/actions/periodic-labeler