### PR TITLE
chore: fix PR labeler syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,94 +1,123 @@
 'squad: system':
-  - '**'
-  - '.*'
-  - '.*/**'
+  - '*'
+  - '**/*'
 
 'package: browserslist-config-carbon':
+  - packages/browserslist-config-carbon/*
   - packages/browserslist-config-carbon/**/*
 
 'package: bundler':
+  - packages/bundler/*
   - packages/bundler/**/*
 
 'package: cli':
+  - packages/cli/*
   - packages/cli/**/*
 
 'package: cli-reporter':
+  - packages/cli-reporter/*
   - packages/cli-reporter/**/*
 
 'package: colors':
+  - packages/colors/*
   - packages/colors/**/*
 
 'package: components':
+  - packages/components/*
   - packages/components/**/*
 
 'package: elements':
+  - packages/elements/*
   - packages/elements/**/*
 
 'package: eslint-config-carbon':
+  - packages/eslint-config-carbon/*
   - packages/eslint-config-carbon/**/*
 
 'package: grid':
+  - packages/grid/*
   - packages/grid/**/*
 
 'package: icon-build-helpers':
+  - packages/icon-build-helpers/*
   - packages/icon-build-helpers/**/*
 
 'package: icon-helpers':
+  - packages/icon-helpers/*
   - packages/icon-helpers/**/*
 
 'package: icons':
+  - packages/icons/*
   - packages/icons/**/*
 
 'package: icons-angular':
+  - packages/icons-angular/*
   - packages/icons-angular/**/*
 
 'package: icons-handlebars':
+  - packages/icons-handlebars/*
   - packages/icons-handlebars/**/*
 
 'package: icons-react':
+  - packages/icons-react/*
   - packages/icons-react/**/*
 
 'package: icons-vue':
+  - packages/icons-vue/*
   - packages/icons-vue/**/*
 
 'package: import-once':
+  - packages/import-once/*
   - packages/import-once/**/*
 
 'package: layout':
+  - packages/layout/*
   - packages/layout/**/*
 
 'package: motion':
+  - packages/motion/*
   - packages/motion/**/*
 
 'package: pictograms':
+  - packages/pictograms/*
   - packages/pictograms/**/*
 
 'package: pictograms-react':
+  - packages/pictograms-react/*
   - packages/pictograms-react/**/*
 
 'package: react':
+  - packages/react/*
   - packages/react/**/*
 
 'package: react-hooks':
+  - packages/react-hooks/*
   - packages/react-hooks/**/*
 
 'package: scss-generator':
+  - packages/scss-generator/*
   - packages/scss-generator/**/*
 
 'package: sketch':
+  - packages/sketch/*
   - packages/sketch/**/*
 
 'package: stylelint-config-elements':
+  - packages/stylelint-config-elements/*
   - packages/stylelint-config-elements/**/*
 
 'package: text-utils':
+  - packages/text-utils/*
   - packages/text-utils/**/*
 
 'package: themes':
+  - packages/themes/*
   - packages/themes/**/*
 
 'package: type':
+  - packages/type/*
   - packages/type/**/*
 
 'package: upgrade':
+  - packages/upgrade/*
   - packages/upgrade/**/*


### PR DESCRIPTION
This is a continuation of https://github.com/carbon-design-system/carbon/pull/4946 with fixed syntax. I verified this in a private repo that has GH actions enabled. Also, per the [official docs](https://github.com/actions/labeler#common-examples), it's looking for this syntax:

```
'package: components':
  - packages/components/*
  - packages/components/**/*
```