### PR TITLE
feat(tile-group): add option to set class around RadioTile wrapper

### DIFF
--- a/packages/react/src/components/Tile/Tile-story.js
+++ b/packages/react/src/components/Tile/Tile-story.js
@@ -56,6 +56,7 @@ const props = {
       ''
     ),
     onChange: action('onChange'),
+    wrapperClassName: text('wrapperClassName', ''),
   }),
   radio: () => ({
     name: text('Form item name (name in <RadioTile>)', 'tiles'),

--- a/packages/react/src/components/TileGroup/TileGroup-test.js
+++ b/packages/react/src/components/TileGroup/TileGroup-test.js
@@ -31,6 +31,11 @@ describe('TileGroup', () => {
         expect(div.hasClass('extra-class'));
       });
 
+      it('sets classes that are passed via wrapperClassName prop', () => {
+        wrapper.setProps({ wrapperClassName: 'extra-class' });
+        expect(div.first('div').hasClass('extra-class'));
+      });
+
       it('sets disabled attribute if disabled prop is set', () => {
         wrapper.setProps({ disabled: true });
         expect(wrapper.first().props().disabled).toEqual(true);

--- a/packages/react/src/components/TileGroup/TileGroup.js
+++ b/packages/react/src/components/TileGroup/TileGroup.js
@@ -31,6 +31,11 @@ export default class TileGroup extends React.Component {
     className: PropTypes.string,
 
     /**
+     * Provide an optional className to be applied to the node wrapping around the RadioTiles
+     */
+    wrapperClassName: PropTypes.string,
+
+    /**
      * Specify the the value of <RadioTile> to be selected by default
      */
     defaultSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -122,12 +127,13 @@ export default class TileGroup extends React.Component {
       disabled,
       className = `${prefix}--tile-group`,
       legend,
+      wrapperClassName,
     } = this.props;
 
     return (
       <fieldset className={className} disabled={disabled}>
         {this.renderLegend(legend)}
-        <div>{this.getRadioTiles()}</div>
+        <div className={wrapperClassName}>{this.getRadioTiles()}</div>
       </fieldset>
     );
   }


### PR DESCRIPTION
Adds a prop (`wrapperClassName`) to the `TileGroup` component which allows to specify a class that will be applied to the div wrapping the RadioTiles inside the group.

#### Changelog

**New**

- `wrapperClassName` prop in `TileGroup`

#### Testing / Reviewing

1. `cd packages/react`
2. `yarn storybook`
3. In Storybook: Tile -> Selectable, set `wrapperClassName`
4. Verify by inspect element that the class name is set to the `<div>` surrounding the RadioTile components.

![image](https://user-images.githubusercontent.com/28265588/71971575-2bdaa580-320b-11ea-94e3-dcb9ff5c1ef4.png)

#### Two notes to the devs
1. I am not too happy with the name `wrapperClassName` but couldn't come up with something better, any input is highly appreciated 😄 
2. I added this extra class in order to be able to layout the tiles on the carbon grid. If there is a better way without adding an extra prop to this component, please let me know. Right now, the issue is that `RadioTile` needs to be a direct child of `TileGroup`. In order to have the tiles aligned with the columns of the grid though, they need the `.bx--col` class and must be directly under a `.bx--row`. Those two requirements conflict at the moment since `TileGroup` adds a div surrounding all the RadioTiles.