### PR TITLE
fix(number-input): allow value & defaultvalue to be string or number

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -113,11 +113,11 @@ class NumberInput extends Component {
     /**
      * Optional starting value for uncontrolled state
      */
-    defaultValue: PropTypes.number,
+    defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
      * Specify the value of the input
      */
-    value: PropTypes.number,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
      * Specify if the component should be read-only
      */


### PR DESCRIPTION
Closes #4996 

In order to allow `defaultValue` or `value` to be empty (for `allowEmpty` option), their proptypes need to be `string` or `number`.

#### Changelog

**Changed**

- set propTypes of `defaultValue` and `value` to be one of type `string` or `number`