### PR TITLE
Revert "fix(dropdown): use itemToElement for selected label if not null"

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -282,11 +282,7 @@ export default class Dropdown extends React.Component {
                     id={fieldLabelId}
                     className={`${prefix}--list-box__label`}
                     {...getLabelProps()}>
-                    {selectedItem
-                      ? itemToElement
-                        ? itemToElement(selectedItem)
-                        : itemToString(selectedItem)
-                      : label}
+                    {selectedItem ? itemToString(selectedItem) : label}
                   </span>
                   <ListBox.MenuIcon
                     isOpen={isOpen}


### PR DESCRIPTION
Reverts carbon-design-system/carbon#4977

Per @joshblack's comment - https://github.com/carbon-design-system/carbon/pull/4977#issuecomment-573113469

> I think it should be meant only for rendering an option in a list. If we support custom rendering for the value on top of the field, we won't be able to control things like contrast or could end up with violations if people decide to put things other than text in that location.