### PR TITLE
chore(pictograms-react): update example storybook name

### DIFF
--- a/packages/pictograms-react/examples/storybook/package.json
+++ b/packages/pictograms-react/examples/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-icons-react-storybook",
+  "name": "carbon-pictograms-react-storybook",
   "license": "Apache-2.0",
   "scripts": {
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
When you run `yarn test` you get a `jest-haste-map` naming collision --

```
jest-haste-map: Haste module naming collision: carbon-icons-react-storybook
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/packages/pictograms-react/examples/storybook/package.json
    * <rootDir>/packages/icons-react/examples/storybook/package.json
```

So this PR changes the duplicate name in `@carbon/pictograms-react`'s storybook example to avoid the collision.

#### Changelog

**Changed**

- update example storybook name in `@carbon/pictograms-react

