### PR TITLE
chore(tile-group): remove unrecognized prop from tests

### DIFF
--- a/packages/react/src/components/TileGroup/TileGroup-test.js
+++ b/packages/react/src/components/TileGroup/TileGroup-test.js
@@ -14,8 +14,8 @@ describe('TileGroup', () => {
   describe('renders as expected', () => {
     const wrapper = mount(
       <TileGroup defaultSelected="female" name="gender">
-        <RadioTile labelText="Male" value="male" />
-        <RadioTile labelText="Female" value="female" />
+        <RadioTile value="male" />
+        <RadioTile value="female" />
       </TileGroup>
     );
 


### PR DESCRIPTION
The following error is generated in tests for `TileGroup` --

```
  ● Console

    console.error node_modules/react-dom/cjs/react-dom.development.js:545
      Warning: React does not recognize the `labelText` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attri
bute, spell it as lowercase `labeltext` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in input (created by RadioTile)
          in RadioTile (created by TileGroup)
          in div (created by TileGroup)
          in fieldset (created by TileGroup)
          in TileGroup (created by WrapperComponent)
          in WrapperComponent
```

It doesn't look like `labelText` is a valid prop for the component anymore.

#### Changelog

**Removed**

- remove unrecognized `labelText` prop from `TileGroup` tests