### PR TITLE
chore(grid): update test snapshots

### DIFF
--- a/packages/components/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
+++ b/packages/components/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
@@ -115,9 +115,11 @@ em {
   margin-right: -1rem;
   margin-left: -1rem; }
 
-.bx--grid--condensed [class*='bx--col'] {
-  padding-top: 0.0625rem;
-  padding-bottom: 0.0625rem; }
+.bx--grid--condensed .bx--row:not(:last-of-type) {
+  margin-bottom: 0.125rem; }
+
+.bx--row--condensed + .bx--row--condensed {
+  margin-top: 0.125rem; }
 
 .bx--col {
   width: 100%;


### PR DESCRIPTION
It looks like the grid snapshot test is failing when you run `yarn test` locally. I'm not sure why the CI test isn't catching this (or at least, I don't see it catching this in any output)

But when you run `yarn test` locally you will get the following error for a failed snapshot for the test `should generate grid code when the grid feature flag is on` --

```bash
 FAIL  packages/components/src/globals/grid/__tests__/grid-test.js
  ● _grid.scss › should generate grid code when the grid feature flag is on

    expect(received).toMatchSnapshot()

    Snapshot name: `_grid.scss should generate grid code when the grid feature flag is on 1`

    - Snapshot
    + Received

    @@ -110,13 +110,15 @@
        display: flex;
        flex-wrap: wrap;
        margin-right: -1rem;
        margin-left: -1rem; }
      
    - .bx--grid--condensed [class*='bx--col'] {
    -   padding-top: 0.0625rem;
    -   padding-bottom: 0.0625rem; }
    + .bx--grid--condensed .bx--row:not(:last-of-type) {
    +   margin-bottom: 0.125rem; }
    + 
    + .bx--row--condensed + .bx--row--condensed {
    +   margin-top: 0.125rem; }
      
      .bx--col {
        width: 100%;
        padding-right: 1rem;
        padding-left: 1rem; }

      27 | @import '../grid';
      28 | `);
    > 29 |     expect(result.css.toString()).toMatchSnapshot();
         |                                   ^
      30 |   });
      31 | 
      32 |   it('should export a 12 column grid by default', async () => {

      at toMatchSnapshot (packages/components/src/globals/grid/__tests__/grid-test.js:29:35)
      at tryCatch (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:271:22)
      at Generator.prototype.(anonymous function) [as next] (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:97:21)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
```

#### Changelog

**Changed**

- update grid test snapshot

#### Testing / Reviewing

I saw this error when running `yarn test` in local development, but for some reason I don't see it in Circle CI output. 🤔 
