### PR TITLE
fix(modal): add transparent outline for high contrast themes

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -75,6 +75,7 @@
     width: 100%;
     height: 100%;
     max-height: 100%;
+    // make modal edge visible on high contrast themes (#3880)
     outline: 3px solid transparent;
     outline-offset: -3px;
     overflow: hidden;

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -75,6 +75,8 @@
     width: 100%;
     height: 100%;
     max-height: 100%;
+    outline: 3px solid transparent;
+    outline-offset: -3px;
     overflow: hidden;
     transform-origin: top center;
     transform: translate3d(0, -24px, 0);


### PR DESCRIPTION
Closes #3880

This PR adds a transparent outline to the modal container so that the edge of the modal is visible in high contrast environments

#### Changelog

**New**

- modal container outline and outline offset

#### Testing / Reviewing

Ensure the low contrast modal edge can be seen against the background

Ensure the normal modal views are unchanged
