### PR TITLE
refactor(code-snippet): update test suite for CodeSnippet.Skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,8 @@
       "/es/",
       "/examples/",
       "/lib/",
-      "/storybook/"
+      "/storybook/",
+      "/results/"
     ]
   }
 }

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.Skeleton.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.Skeleton.js
@@ -5,61 +5,58 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const { prefix } = settings;
 
-export default class CodeSnippetSkeleton extends Component {
-  static propTypes = {
-    /**
-     * The type of code snippet
-     * can be single or multi
-     */
-    type: PropTypes.oneOf(['single', 'multi']),
+function CodeSnippetSkeleton({
+  className: containerClassName,
+  type = 'single',
+  ...rest
+}) {
+  const className = cx(containerClassName, {
+    [`${prefix}--snippet`]: true,
+    [`${prefix}--skeleton`]: true,
+    [`${prefix}--snippet--single`]: type === 'single',
+    [`${prefix}--snippet--multi`]: type === 'multi',
+  });
 
-    /**
-     * Specify an optional className to be applied to the container node
-     */
-    className: PropTypes.string,
-  };
-
-  static defaultProps = {
-    type: 'single',
-  };
-
-  render() {
-    const { className, type, ...other } = this.props;
-
-    const codeSnippetClasses = classNames(className, {
-      [`${prefix}--snippet`]: true,
-      [`${prefix}--skeleton`]: true,
-      [`${prefix}--snippet--single`]: type === 'single',
-      [`${prefix}--snippet--multi`]: type === 'multi',
-    });
-
-    if (type === 'single') {
-      return (
-        <div className={codeSnippetClasses} {...other}>
-          <div className={`${prefix}--snippet-container`}>
-            <span />
-          </div>
+  if (type === 'single') {
+    return (
+      <div className={className} {...rest}>
+        <div className={`${prefix}--snippet-container`}>
+          <span />
         </div>
-      );
-    }
+      </div>
+    );
+  }
 
-    if (type === 'multi') {
-      return (
-        <div className={codeSnippetClasses} {...other}>
-          <div className={`${prefix}--snippet-container`}>
-            <span />
-            <span />
-            <span />
-          </div>
+  if (type === 'multi') {
+    return (
+      <div className={className} {...rest}>
+        <div className={`${prefix}--snippet-container`}>
+          <span />
+          <span />
+          <span />
         </div>
-      );
-    }
+      </div>
+    );
   }
 }
+
+CodeSnippetSkeleton.propTypes = {
+  /**
+   * The type of the code snippet, including single or multi
+   */
+  type: PropTypes.oneOf(['single', 'multi']),
+
+  /**
+   * Specify an optional className to be applied to the container node
+   */
+  className: PropTypes.string,
+};
+
+export default CodeSnippetSkeleton;

--- a/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js
+++ b/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js
@@ -6,10 +6,9 @@
  */
 
 import React from 'react';
-import CodeSnippet from '../CodeSnippet';
-import CodeSnippetSkeleton from '../CodeSnippet/CodeSnippet.Skeleton';
-import Copy from '../Copy';
-import CopyButton from '../CopyButton';
+import CodeSnippet from '../';
+import Copy from '../../Copy';
+import CopyButton from '../../CopyButton';
 import { shallow, mount } from 'enzyme';
 import { settings } from 'carbon-components';
 
@@ -52,18 +51,6 @@ describe('Code Snippet', () => {
       );
       clickWrapper.find(Copy).simulate('click');
       expect(onClick).toBeCalled();
-    });
-  });
-});
-
-describe('CodeSnippetSkeleton', () => {
-  describe('Renders as expected', () => {
-    const wrapper = shallow(<CodeSnippetSkeleton type="single" />);
-
-    it('Has the expected classes', () => {
-      expect(wrapper.hasClass(`${prefix}--skeleton`)).toEqual(true);
-      expect(wrapper.hasClass(`${prefix}--snippet`)).toEqual(true);
-      expect(wrapper.hasClass(`${prefix}--snippet--single`)).toEqual(true);
     });
   });
 });

--- a/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet.Skeleton-test.js
+++ b/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet.Skeleton-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { render, cleanup } from '@carbon/test-utils/react';
+import { settings } from 'carbon-components';
+import React from 'react';
+import { CodeSnippetSkeleton } from '../';
+
+const { prefix } = settings;
+const snippetTypes = ['single', 'multi'];
+
+describe('CodeSnippetSkeleton', () => {
+  afterEach(cleanup);
+
+  describe('automated accessibility testing', () => {
+    it.each(snippetTypes)(
+      'should have no Axe violations with type="%s"',
+      async type => {
+        const { container } = render(<CodeSnippetSkeleton type={type} />);
+        await expect(container).toHaveNoAxeViolations();
+      }
+    );
+
+    it.each(snippetTypes)(
+      'should have no DAP violations with type="%s"',
+      async type => {
+        const { container } = render(<CodeSnippetSkeleton type={type} />);
+        await expect(container).toHaveNoDAPViolations(
+          `CodeSnippetSkeleton-${type}`
+        );
+      }
+    );
+  });
+
+  it('should default to type="single"', () => {
+    const { container } = render(<CodeSnippetSkeleton />);
+    expect(
+      container.querySelector(`.${prefix}--snippet--single`)
+    ).toBeInstanceOf(HTMLElement);
+  });
+
+  it('should support a custom `className` on the outer-most element', () => {
+    const className = 'test';
+    const { container } = render(<CodeSnippetSkeleton className={className} />);
+    expect(container.firstChild.classList.contains(className)).toBe(true);
+  });
+});

--- a/packages/react/src/components/CodeSnippet/index.js
+++ b/packages/react/src/components/CodeSnippet/index.js
@@ -5,5 +5,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './CodeSnippet.Skeleton';
+export { default as CodeSnippetSkeleton } from './CodeSnippet.Skeleton';
 export default from './CodeSnippet';


### PR DESCRIPTION
Updates tests for `CodeSnippet.Skeleton`. Also fixes some project-related issues with Jest and DAP causing an infinite loop (FYI @dakahn), in addition to an export issue where the skeleton export was being overridden.

#### Changelog

**New**

- Add `CodeSnippet.Skeleton-test.js` and use existing tests plus helpers for AVT

**Changed**

- `CodeSnippet/index.js` now has the default export and a `CodeSnippetSkeleton` export
- Move code snippet tests to a `__tests__` folder

**Removed**
