### PR TITLE
docs(themes): update link to color tokens in README

### DIFF
--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -26,7 +26,7 @@ are pre-defined for a specific theme. Currently, we offer the following color
 themes: white, gray 10, gray 90, gray 100 .
 
 You can preview all of the token values for this on the
-[Carbon Design System website](https://next.carbondesignsystem.com/guidelines/color/usage)
+[Carbon Design System website](https://www.carbondesignsystem.com/guidelines/color/usage)
 .
 
 ### Sass


### PR DESCRIPTION
Currently this link to color tokens on the `@carbon/themes` README just leads to the homepage, due to the deprecated `next` subdomain.

#### Changelog

**Changed**

- update link to color tokens on the Carbon website