### PR TITLE
docs(type): update link to type styles in README

### DIFF
--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -84,8 +84,7 @@ Instead of using a type scale, `@carbon/type` provides tokens that represent
 what we call type styles. These tokens have a variety of properties for styling
 how text is rendered on a page.
 
-You can find a full reference of the type styles that are available
-[Carbon Design System website](https://www.carbondesignsystem.com/guidelines/typography/productive) .
+You can find a full reference of the type styles that are available on the [Carbon Design System website](https://www.carbondesignsystem.com/guidelines/typography/productive) .
 
 You can include a token in your Sass file by writing:
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -84,7 +84,9 @@ Instead of using a type scale, `@carbon/type` provides tokens that represent
 what we call type styles. These tokens have a variety of properties for styling
 how text is rendered on a page.
 
-You can find a full reference of the type styles that are available on the [Carbon Design System website](https://www.carbondesignsystem.com/guidelines/typography/productive) .
+You can find a full reference of the type styles that are available on the
+[Carbon Design System website](https://www.carbondesignsystem.com/guidelines/typography/productive)
+.
 
 You can include a token in your Sass file by writing:
 

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -85,7 +85,7 @@ what we call type styles. These tokens have a variety of properties for styling
 how text is rendered on a page.
 
 You can find a full reference of the type styles that are available
-[here](https://next.carbondesignsystem.com/guidelines/typography/productive) .
+[Carbon Design System website](https://www.carbondesignsystem.com/guidelines/typography/productive) .
 
 You can include a token in your Sass file by writing:
 


### PR DESCRIPTION
Currently this link to color tokens on the `@carbon/type` README just leads to the homepage, due to the deprecated next subdomain.

Also the use of "here" as link text is not very accessible, as someone using a screenreader who skips to the link won't have info in the link text about where the link goes.

#### Changelog

**Changed**

- update link to type styles on the Carbon website
- update link text to reference Carbon website as destination