### PR TITLE
fix(accordion): update accordion breakpoints

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -101,11 +101,11 @@
     padding-right: $carbon--spacing-05;
 
     // Custom breakpoints based on issue #4993
-    @media (min-width: 480px) {
+    @include carbon--breakpoint-up(480px) {
       padding-right: $carbon--spacing-09;
     }
 
-    @media (min-width: 640px) {
+    @include carbon--breakpoint-up(640px) {
       padding-right: 25%;
     }
 

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -98,10 +98,15 @@
     // Transition property for when the accordion closes
     transition: padding motion(standard, productive) $duration--fast-02;
     padding-left: $carbon--spacing-05;
-    padding-right: 25%;
+    padding-right: $carbon--spacing-05;
 
-    @include carbon--breakpoint-down('md') {
+    // Custom breakpoints based on issue #4993
+    @media (min-width: 480px) {
       padding-right: $carbon--spacing-09;
+    }
+
+    @media (min-width: 640px) {
+      padding-right: 25%;
     }
 
     p {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/4993

Updates Accordion to only use `16px` of padding when the screen is below `480px` Based on updated specs [found here](https://github.com/carbon-design-system/carbon/issues/4993#issuecomment-573199723) 

![image](https://user-images.githubusercontent.com/11928039/72558125-f101ee80-3856-11ea-918f-83a139edcde9.png)

![image](https://user-images.githubusercontent.com/11928039/72558139-f7906600-3856-11ea-868b-9a89b10a1583.png)

![image](https://user-images.githubusercontent.com/11928039/72558144-fa8b5680-3856-11ea-8dde-67744f789b9b.png)


#### Changelog

**New**

- Breakpoints at `480px` and `640px`

#### Testing / Reviewing

See that the Accordion content shifts from `1rem` padding, to `3rem` padding, to `25%` padding as the screen size increases. 
