### PR TITLE
fix(multiselect): fix invalid inline multiselect error icon

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -121,10 +121,6 @@ $list-box-menu-width: rem(300px);
     transform: translateY(-50%);
   }
 
-  .#{$prefix}--list-box--inline .#{$prefix}--list-box__invalid-icon {
-    top: $carbon--spacing-03;
-  }
-
   .#{$prefix}--list-box[data-invalid] .#{$prefix}--list-box__field {
     border-bottom: 0;
     padding-right: carbon--mini-units(8);


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5073

Removes some extra positioning styles that were causing the inline variation to be misaligned. This block should be able to handle position on its own. 

```scss 
.#{$prefix}--list-box__invalid-icon {
   top: 50%;
   transform: translateY(-50%);
}
```

#### Changelog

**Removed**
- Extra position styles

#### Testing / Reviewing

- Create an inline multi-select 
- Add`type="inline"` on `L113` in `MultiSelect-story.js`
- In the storybook, enable error styles via the knob
- Ensure icon is centered 