### PR TITLE
fix(ui-shell): remove role banner from header ui-shell

### DIFF
--- a/packages/react/src/components/UIShell/Header.js
+++ b/packages/react/src/components/UIShell/Header.js
@@ -17,7 +17,7 @@ const Header = ({ className: customClassName, children, ...rest }) => {
   const className = cx(`${prefix}--header`, customClassName);
 
   return (
-    <header {...rest} className={className} role="banner">
+    <header {...rest} className={className}>
       {children}
     </header>
   );

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/Header-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/Header-test.js.snap
@@ -8,7 +8,6 @@ exports[`Header should render 1`] = `
   <header
     aria-label="label"
     className="bx--header custom-class"
-    role="banner"
   />
 </Header>
 `;


### PR DESCRIPTION
Closes #

After running DAP on `https://www.ibm.com/design/thinking` we noticed the following violation was introduced by the Carbon UI Shell: https://aat.w3ibm.mybluemix.net/token/07b25738-c5c6-4479-ad20-bead3e1aac6b/09148427-a9bf-417b-8d67-972cfa453cd3/latest///doc/w3/help/en-US/idhi_accessibility_check_g1146.html

#### Changelog

**New**

- We don't need `role=banner` on a header: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_role

**Changed**

- Deleted `role=banner` on the UI Shell
- Updated client component tests to account for deletion

**Removed**

- Deleted `role=banner` on the UI Shell

#### Testing / Reviewing

- Run `yarn test` and make sure all relevant tests pass. :) 
