### PR TITLE
chore(notification): fix variable typo in component

### DIFF
--- a/packages/react/src/components/Notification/Notification.js
+++ b/packages/react/src/components/Notification/Notification.js
@@ -70,7 +70,7 @@ export function NotificationButton({
   notificationType,
   ...rest
 }) {
-  const buttonClasName = cx(className, {
+  const buttonClassName = cx(className, {
     [`${prefix}--toast-notification__close-button`]:
       notificationType === 'toast',
     [`${prefix}--inline-notification__close-button`]:
@@ -88,7 +88,7 @@ export function NotificationButton({
       type={type}
       aria-label={iconDescription}
       title={iconDescription}
-      className={buttonClasName}>
+      className={buttonClassName}>
       {IconTag && (
         <IconTag aria-label={ariaLabel} className={iconClassName} name={name} />
       )}


### PR DESCRIPTION
Small typo in a variable used within the `Notification` component. It shouldn't affect end users at all, because the variable is only used privately inside the component.

I named this a `chore` because of the nature of the change but let me know if you want it named something else 👍 

#### Changelog

**Changed**

- fix typo in private variable name
