### PR TITLE
fix(time-picker): update icon to chevrondown16

### DIFF
--- a/packages/react/src/components/TimePickerSelect/TimePickerSelect.js
+++ b/packages/react/src/components/TimePickerSelect/TimePickerSelect.js
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { ChevronDownGlyph } from '@carbon/icons-react';
+import { ChevronDown16 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -108,11 +108,11 @@ export default class TimePickerSelect extends Component {
           disabled={disabled}>
           {children}
         </select>
-        <ChevronDownGlyph
+        <ChevronDown16
           className={`${prefix}--select__arrow`}
           aria-label={iconDescription}>
           {iconDescription && <title>{iconDescription}</title>}
-        </ChevronDownGlyph>
+        </ChevronDown16>
       </div>
     );
   }


### PR DESCRIPTION
Closes #5114

Updates the icon from `<TimePicker />` from `<ChevronDownGlyph />` to `<ChevronDown16 />` to be consistent with the `<Select />` component.

#### Changelog

**Changed**

- import `<ChevronDown16 />` for `<TimePicker />`


#### Testing / Reviewing

Testing should ensure `<TimePicker />` icon is consistent with designs
