### PR TITLE
fix(dropdown): restore default dropdown height

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -51,6 +51,7 @@
     border: none;
     border-bottom: 1px solid $ui-04;
     width: 100%;
+    height: rem(40px);
     cursor: pointer;
     color: $text-01;
     outline: 2px solid transparent;


### PR DESCRIPTION
Closes #5117

This PR restores the dropdown height rule for default dropdown sizes (ref #5041)

#### Testing / Reviewing

Ensure dropdown sizes appear correct