### PR TITLE
fix(modal): prevent modal from shifting when scrollbar appears

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -25,13 +25,13 @@
   .#{$prefix}--modal {
     position: fixed;
     top: 0;
-    right: 0;
-    bottom: 0;
     left: 0;
     z-index: z('modal');
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100vw;
+    height: 100vh;
     content: '';
     background-color: transparent;
     opacity: 0;


### PR DESCRIPTION
Closes #4435

This PR prevents the scroll bar from shifting modal position when opening or closing

#### Changelog

**Changed**

- modal positioning and dimensions

#### Testing / Reviewing

with scrollbars always displayed (default on Windows, instructions for macOS in original ticket), open and close the modal and observe that the modal position does not shift left/right due to the scrollbar being affected by the modal overlay