### PR TITLE
docs(tabs): un-comment hidden proptype

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -36,6 +36,7 @@ export default class Tabs extends React.Component {
 
     /**
      * Specify whether the Tab content is hidden
+     */
     hidden: PropTypes.bool,
 
     /**


### PR DESCRIPTION
Closes #5105

#### Changelog

**Changed**

- un-comment the `hidden` proptype (see: https://github.com/carbon-design-system/carbon/issues/5105#issuecomment-576462576)
