### PR TITLE
fix(date-picker): use correct background for date picker in modal

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -56,7 +56,8 @@
     .#{$prefix}--select-input,
     .#{$prefix}--dropdown,
     .#{$prefix}--dropdown-list,
-    .#{$prefix}--number input[type='number'] {
+    .#{$prefix}--number input[type='number'],
+    .#{$prefix}--date-picker__input {
       background-color: $field-02;
     }
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5121

Adds `DatePicker` to the list of form items that should have inverse backgrounds when placed inside of a modal. 

#### Changelog

**New**

- `.#{$prefix}--date-picker__input` added to list of modal overrides 

#### Testing / Reviewing

Add a DatePicker to a Modal example and ensure it does not blend with the background

<img width="818" alt="Screen Shot 2020-01-21 at 11 30 28 AM" src="https://user-images.githubusercontent.com/11928039/72836441-7f081b80-3c41-11ea-9e71-edf27d33c9b0.png">
