### PR TITLE
fix(Tabs): allow keyboard event defaults

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -179,10 +179,10 @@ export default class Tabs extends React.Component {
       }
 
       if (window.matchMedia('(min-width: 42rem)').matches) {
-        evt.preventDefault();
         const nextIndex = this.getNextIndex(index, this.getDirection(evt));
         const tab = this.getTabAt(nextIndex);
-        if (tab) {
+        if (tab && matches(evt, [keys.ArrowLeft, keys.ArrowRight])) {
+          evt.preventDefault();
           this.selectTabAt(nextIndex, onSelectionChange);
           if (tab.tabAnchor) {
             tab.tabAnchor.focus();


### PR DESCRIPTION
Ref https://github.com/carbon-design-system/carbon/pull/4784#issuecomment-576879328

This PR allows default keyboard event behavior in the non-mobile Tabs component

#### Changelog

**Removed**

- `event.preventDefault` call

#### Testing / Reviewing

Place a tabbable element in the tab content panel and navigate to it using the keyboard from the tabs list, or scroll on a page with overflow using the arrow keys while a tab is focused
