### PR TITLE
fix(tile): adds onChange call to handlers in selectable tile

### DIFF
--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -202,7 +202,7 @@ describe('Tile', () => {
       expect(wrapper.childAt(1).hasClass('bx--tile--light')).toEqual(true);
     });
 
-    it.only('should call onChange when the checkbox value changes', () => {
+    it('should call onChange when the checkbox value changes', () => {
       const onChange = jest.fn();
       const wrapper = mount(
         <SelectableTile onChange={onChange}>

--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -129,14 +129,15 @@ describe('Tile', () => {
   });
 
   describe('Renders selectable tile as expected', () => {
-    const wrapper = mount(
-      <SelectableTile className="extra-class">
-        <div className="child">Test</div>
-      </SelectableTile>
-    );
+    let wrapper;
     let label;
 
     beforeEach(() => {
+      wrapper = mount(
+        <SelectableTile className="extra-class">
+          <div className="child">Test</div>
+        </SelectableTile>
+      );
       wrapper.state().selected = false;
       label = wrapper.find('label');
     });
@@ -199,6 +200,25 @@ describe('Tile', () => {
       wrapper.setProps({ light: true });
       expect(wrapper.props().light).toEqual(true);
       expect(wrapper.childAt(1).hasClass('bx--tile--light')).toEqual(true);
+    });
+
+    it.only('should call onChange when the checkbox value changes', () => {
+      const onChange = jest.fn();
+      const wrapper = mount(
+        <SelectableTile onChange={onChange}>
+          <span id="test-id">test</span>
+        </SelectableTile>
+      );
+
+      const content = wrapper.find('#test-id');
+
+      // Tile becomes selected
+      content.simulate('click');
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      // Tile becomes un-selected
+      content.simulate('click');
+      expect(onChange).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -334,9 +334,9 @@ export class SelectableTile extends Component {
           id={id}
           className={`${prefix}--tile-input`}
           value={value}
+          onChange={this.handleOnChange}
           type="checkbox"
           name={name}
-          onChange={this.handleOnChange}
           title={title}
           checked={this.state.selected}
         />

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -261,19 +261,15 @@ export class SelectableTile extends Component {
   handleClick = evt => {
     evt.preventDefault();
     evt.persist();
-    const isInput = evt.target === this.input;
-    if (!isInput) {
-      this.setState(
-        {
-          selected: !this.state.selected,
-        },
-        () => {
-          this.props.handleClick(evt);
-        }
-      );
-    } else {
-      this.props.handleClick(evt);
-    }
+    this.setState(
+      {
+        selected: !this.state.selected,
+      },
+      () => {
+        this.props.handleClick(evt);
+        this.props.onChange(evt);
+      }
+    );
   };
 
   handleKeyDown = evt => {
@@ -286,16 +282,12 @@ export class SelectableTile extends Component {
         },
         () => {
           this.props.handleKeyDown(evt);
+          this.props.onChange(evt);
         }
       );
     } else {
       this.props.handleKeyDown(evt);
     }
-  };
-
-  handleOnChange = event => {
-    this.setState({ selected: event.target.checked });
-    this.props.onChange(event);
   };
 
   render() {
@@ -337,11 +329,11 @@ export class SelectableTile extends Component {
           id={id}
           className={`${prefix}--tile-input`}
           value={value}
-          onChange={this.handleOnChange}
           type="checkbox"
           name={name}
           title={title}
           checked={this.state.selected}
+          readOnly
         />
         <label
           htmlFor={id}

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -339,7 +339,6 @@ export class SelectableTile extends Component {
           onChange={this.handleOnChange}
           title={title}
           checked={this.state.selected}
-          readOnly
         />
         <label
           htmlFor={id}

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -290,6 +290,11 @@ export class SelectableTile extends Component {
     }
   };
 
+  handleOnChange = event => {
+    this.setState({ selected: event.target.checked });
+    this.props.onChange(event);
+  };
+
   render() {
     const {
       children,
@@ -331,6 +336,7 @@ export class SelectableTile extends Component {
           value={value}
           type="checkbox"
           name={name}
+          onChange={this.handleOnChange}
           title={title}
           checked={this.state.selected}
           readOnly


### PR DESCRIPTION
Closes #5130 

This PR adds a call to `onChange` on `handleClick` and `handleKeydown` so that it's called when people select a tile through the traditional methods. This removes the `isInput` check from `handleClick` because the input is a 1x1 square behind the label and can not be clicked.  It also adds a test to make sure the `onChange` handler is called 

#### Changelog
**New** 

- test for `onChange` prop

**Changed**

- adds `onChange` call to handlers

**Removed**

-  `isInput` from `handleClick` 

#### Testing / Reviewing

Pull down the PR, add a console.log to the onChange prop and verify that onChange is called when a tile is selected. 
