### PR TITLE
fix(button): add aria-label when using anchor element

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -74,6 +74,7 @@ const Button = React.forwardRef(function Button(
   };
   const anchorProps = {
     role: 'button',
+    ['aria-label']: children,
     href,
   };
   const assistiveText = hasIconOnly ? (


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5112

Adds `aria-label` when using a button-as-link variant

#### Changelog

**New**

- adds an `aria-label` using the buttons text content

#### Testing / Reviewing

Ensure there are no DAP errors 
