### PR TITLE
fix(storybook): remove layer import

### DIFF
--- a/packages/components/docs/migration/migrate-to-10.x.md
+++ b/packages/components/docs/migration/migrate-to-10.x.md
@@ -74,11 +74,12 @@ initial `v10` release.
 **IMPORTANT NOTE**: Most of deprecated variables, mixins and functions will be
 _removed_ soon after the initial `v10` release.
 
-| `scss` path         | v10                                                                           |
-| ------------------- | ----------------------------------------------------------------------------- |
-| `src`               | Deprecated in v10, use `scss` instead [Migrate](../../src/migrate-to-10.x.md) |
-| `scss/globals`      | [Migrate](../../src/globals/scss/migrate-to-10.x.md)                          |
-| `scss/globals/grid` | [Migrate](../../src/globals/scss/grid/migrate-to-10.x.md)                     |
+| `scss` path          | v10                                                                           |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `src`                | Deprecated in v10, use `scss` instead [Migrate](../../src/migrate-to-10.x.md) |
+| `scss/globals`       | [Migrate](../../src/globals/scss/migrate-to-10.x.md)                          |
+| `scss/globals/grid`  | [Migrate](../../src/globals/scss/grid/migrate-to-10.x.md)                     |
+| `scss/globals/layer` | Deprecated in v10 [Migrate](../../src/globals/scss/migrate-to-10.x.md)        |
 
 ### Features
 
@@ -86,3 +87,4 @@ _removed_ soon after the initial `v10` release.
 | ------------------- | ------- |
 | `font-size` mixin   | Removed |
 | `line-height` mixin | Removed |
+| `layer` mixin       | Removed |

--- a/packages/components/src/globals/scss/migrate-to-10.x.md
+++ b/packages/components/src/globals/scss/migrate-to-10.x.md
@@ -140,7 +140,7 @@ No change
 
 ## `_layer.scss`
 
-No change
+- Removed, replaced with `box-shadow` mixin
 
 ### Internal
 

--- a/packages/react/.storybook/styles.scss
+++ b/packages/react/.storybook/styles.scss
@@ -18,7 +18,6 @@ $prefix: 'bx';
 @import '~carbon-components/scss/globals/scss/theme';
 @import '~carbon-components/scss/globals/scss/mixins';
 @import '~carbon-components/scss/globals/scss/layout';
-@import '~carbon-components/scss/globals/scss/layer';
 @import '~carbon-components/scss/globals/scss/spacing';
 @import '~carbon-components/scss/globals/scss/typography';
 @import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';


### PR DESCRIPTION
Removes an import that was causing build failures. 

#### Changelog

**Removed**

- `layer.scss` import in the storybook environment

#### Testing / Reviewing

Ensure storybook compiles
