### PR TITLE
fix(text-input): rename sizing props

### DIFF
--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -44,11 +44,11 @@
     }
   }
 
-  .#{$prefix}--text-input--large {
+  .#{$prefix}--text-input--xl {
     height: rem(48px);
   }
 
-  .#{$prefix}--text-input--small {
+  .#{$prefix}--text-input--sm {
     height: rem(32px);
   }
 

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -20,9 +20,9 @@ const types = {
 };
 
 const sizes = {
-  Large: 'large',
-  Default: '',
-  Small: 'small',
+  'Extra large size (xl)': 'xl',
+  'Regular size (lg)': '',
+  'Small size (sm)': 'sm',
 };
 
 function ControlledPasswordInputApp(props) {

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -148,7 +148,7 @@ TextInput.propTypes = {
   /**
    * Specify the size of the Text Input. Currently supports either `sm` or `xl` as an option.
    */
-  size: PropTypes.string,
+  size: PropTypes.oneOf(['sm', 'xl']),
 
   /**
    * Specify the type of the <input>

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -146,7 +146,7 @@ TextInput.propTypes = {
   placeholder: PropTypes.string,
 
   /**
-   * Specify the size of the Text Input. Currently supports either `small` or `large` as an option. If omitted, defaults to standard size
+   * Specify the size of the Text Input. Currently supports either `sm` or `xl` as an option.
    */
   size: PropTypes.string,
 


### PR DESCRIPTION
Matches Text Input `size` prop naming to Dropdown `size` prop naming

<img width="350" alt="Screen Shot 2020-01-23 at 3 55 01 PM" src="https://user-images.githubusercontent.com/11928039/73034149-021fa200-3df9-11ea-86fc-2f203dd6d104.png">


#### Changelog

**Changed**

- changes prop `small` to `sm `
- changes prop `large` to `xl`

#### Testing / Reviewing

Change knob for size and ensure text input changes to correct size
