### PR TITLE
fix(cli): update to support new package versions

### DIFF
--- a/packages/cli/src/changelog.js
+++ b/packages/cli/src/changelog.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const parse = require('@commitlint/parse');
+const { default: parse } = require('@commitlint/parse');
 const execa = require('execa');
 
 // We keep a list of commits that are process-oriented that we never want to

--- a/packages/cli/src/workspace.js
+++ b/packages/cli/src/workspace.js
@@ -18,7 +18,7 @@ const packagePaths = fs
   .readdirSync(PACKAGES_DIR)
   .filter(basename => {
     const filename = path.join(PACKAGES_DIR, basename);
-    if (!denylist.has(filename)) {
+    if (denylist.has(filename)) {
       return false;
     }
 


### PR DESCRIPTION
Updates some issues in our CLI package related to an updated `@commitlint/parse` package and faulty logic in our filtering that ignored all packages in our workspace.

#### Changelog

**New**

**Changed**

- Update filter by denylist logic in workspace adapter
- Update `@commitlint/parse` package to use default import name

**Removed**
