### PR TITLE
fix(ui-shell): remove menu aria role

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -199,10 +199,7 @@ class HeaderMenu extends React.Component {
           {menuLinkName}
           <MenuContent />
         </a>
-        <ul
-          {...accessibilityLabel}
-          className={`${prefix}--header__menu`}
-          role="menu">
+        <ul {...accessibilityLabel} className={`${prefix}--header__menu`}>
           {React.Children.map(children, this._renderMenuItem)}
         </ul>
       </li>
@@ -210,9 +207,7 @@ class HeaderMenu extends React.Component {
   }
 
   /**
-   * Render an individual menuitem, passing along `role: 'none'` because the
-   * host node <li> doesn't apply when in a <ul> with `role="menu"` and so we
-   * need to revert the semantics.
+   * Render an individual menuitem.
    *
    * We also capture the `ref` for each child inside of `this.items` to properly
    * manage focus. In addition to this focus management, all items receive a
@@ -223,7 +218,6 @@ class HeaderMenu extends React.Component {
     if (React.isValidElement(item)) {
       return React.cloneElement(item, {
         ref: this.handleItemRef(index),
-        role: 'none',
       });
     }
   };

--- a/packages/react/src/components/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/UIShell/SideNavMenu.js
@@ -164,9 +164,7 @@ export class SideNavMenu extends React.Component {
             <ChevronDown20 />
           </SideNavIcon>
         </button>
-        <ul className={`${prefix}--side-nav__menu`} role="menu">
-          {children}
-        </ul>
+        <ul className={`${prefix}--side-nav__menu`}>{children}</ul>
       </li>
     );
   }

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
@@ -57,16 +57,12 @@ exports[`HeaderMenu should render 1`] = `
       </a>
       <ul
         className="bx--header__menu"
-        role="menu"
       >
         <ForwardRef(HeaderMenuItem)
           href="/a"
           key=".0"
-          role="none"
         >
-          <li
-            role="none"
-          >
+          <li>
             <Link
               className="bx--header__menu-item"
               element="a"
@@ -90,11 +86,8 @@ exports[`HeaderMenu should render 1`] = `
         <ForwardRef(HeaderMenuItem)
           href="/b"
           key=".1"
-          role="none"
         >
-          <li
-            role="none"
-          >
+          <li>
             <Link
               className="bx--header__menu-item"
               element="a"
@@ -118,11 +111,8 @@ exports[`HeaderMenu should render 1`] = `
         <ForwardRef(HeaderMenuItem)
           href="/c"
           key=".2"
-          role="none"
         >
-          <li
-            role="none"
-          >
+          <li>
             <Link
               className="bx--header__menu-item"
               element="a"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
@@ -129,7 +129,6 @@ exports[`SideNavMenu should render 1`] = `
     </button>
     <ul
       className="bx--side-nav__menu"
-      role="menu"
     >
       text
     </ul>


### PR DESCRIPTION
Closes #3583
Closes #3584
Closes #3590 

ref https://github.com/carbon-design-system/carbon/issues/3583#issuecomment-580438514 https://github.com/carbon-design-system/carbon/issues/3584#issuecomment-580438107 and https://github.com/carbon-design-system/carbon/issues/3590#issuecomment-580439214

This PR removes the aria-role from our UI shell menus due to our implementation of tab key navigation vs arrow key navigation