### PR TITLE
fix(ui-shell): remove role='menu' from ui-shell

### DIFF
--- a/packages/components/src/components/ui-shell/_header.scss
+++ b/packages/components/src/components/ui-shell/_header.scss
@@ -167,7 +167,7 @@
     }
   }
 
-  .#{$prefix}--header__menu-bar[role='menubar'] {
+  .#{$prefix}--header__menu-bar {
     display: flex;
     height: 100%;
     list-style: none;
@@ -240,7 +240,7 @@
     transform: rotate(180deg);
   }
 
-  .#{$prefix}--header__menu[role='menu'] {
+  .#{$prefix}--header__menu {
     display: none;
     list-style: none;
     padding: 0;

--- a/packages/components/src/components/ui-shell/_side-nav.scss
+++ b/packages/components/src/components/ui-shell/_side-nav.scss
@@ -328,8 +328,8 @@
     > .#{$prefix}--side-nav__submenu:hover,
   .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
     > .#{$prefix}--side-nav__link:hover,
-  .#{$prefix}--side-nav__menu[role='menu']
-    a.#{$prefix}--side-nav__link[role='menuitem']:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover,
+  .#{$prefix}--side-nav__menu
+    a.#{$prefix}--side-nav__link:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover,
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item:hover,
   .#{$prefix}--side-nav
     .#{$prefix}--header__menu-title[aria-expanded='true']:hover {
@@ -433,20 +433,19 @@
     color: $ibm-color__gray-100;
   }
 
-  .#{$prefix}--side-nav__menu[role='menu'] {
+  .#{$prefix}--side-nav__menu {
     display: block;
     visibility: hidden;
     max-height: 0;
   }
 
   .#{$prefix}--side-nav__submenu[aria-expanded='true']
-    + .#{$prefix}--side-nav__menu[role='menu'] {
+    + .#{$prefix}--side-nav__menu {
     max-height: rem(1500px);
     visibility: inherit;
   }
 
-  .#{$prefix}--side-nav__menu[role='menu']
-    a.#{$prefix}--side-nav__link[role='menuitem'] {
+  .#{$prefix}--side-nav__menu a.#{$prefix}--side-nav__link {
     height: mini-units(4);
     min-height: mini-units(4);
     padding-left: mini-units(4);
@@ -454,13 +453,11 @@
   }
 
   .#{$prefix}--side-nav__item.#{$prefix}--side-nav__item--icon
-    a.#{$prefix}--side-nav__link[role='menuitem'] {
+    a.#{$prefix}--side-nav__link {
     padding-left: mini-units(9);
   }
-  .#{$prefix}--side-nav__menu[role='menu']
-    a.#{$prefix}--side-nav__link--current,
-  .#{$prefix}--side-nav__menu[role='menu']
-    a.#{$prefix}--side-nav__link[aria-current='page'],
+  .#{$prefix}--side-nav__menu a.#{$prefix}--side-nav__link--current,
+  .#{$prefix}--side-nav__menu a.#{$prefix}--side-nav__link[aria-current='page'],
   a.#{$prefix}--side-nav__link--current {
     background-color: $ibm-color__gray-20;
 
@@ -584,7 +581,7 @@
   }
 
   .#{$prefix}--side-nav--fixed
-    .#{$prefix}--side-nav__menu[role='menu']
+    .#{$prefix}--side-nav__menu
     a.#{$prefix}--side-nav__link {
     padding-left: mini-units(4);
   }

--- a/packages/components/src/components/ui-shell/header-nav.hbs
+++ b/packages/components/src/components/ui-shell/header-nav.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -17,27 +17,27 @@
   "0", while the rest should get "-1"
 -->
 <nav class="{{@root.prefix}}--header__nav" aria-label="Platform Name" data-header-nav>
-  <ul class="{{@root.prefix}}--header__menu-bar" role="menubar" aria-label="Platform Name">
+  <ul class="{{@root.prefix}}--header__menu-bar" aria-label="Platform Name">
     {{#each header.navLinks}}
     {{#if href}}
     <li>
-      <a class="{{@root.prefix}}--header__menu-item" href="javascript:void(0)" role="menuitem" tabindex="0">
+      <a class="{{@root.prefix}}--header__menu-item" href="javascript:void(0)" tabindex="0">
         {{this.title}}
       </a>
     </li>
     {{else}}
     <li class="{{@root.prefix}}--header__submenu" data-header-submenu>
-      <a class="{{@root.prefix}}--header__menu-item {{@root.prefix}}--header__menu-title" role="menuitem" aria-haspopup="true"
+      <a class="{{@root.prefix}}--header__menu-item {{@root.prefix}}--header__menu-title" aria-haspopup="true"
         aria-expanded="{{this.state.expanded}}" href="javascript:void(0)" tabindex="0">
         {{this.title}}
         <svg class="{{@root.prefix}}--header__menu-arrow" width="12" height="7" aria-hidden="true">
           <path d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
         </svg>
       </a>
-      <ul class="{{@root.prefix}}--header__menu" role="menu" aria-label="{{this.title}}">
+      <ul class="{{@root.prefix}}--header__menu" aria-label="{{this.title}}">
         {{#each this.items}}
         <li role="none">
-          <a class="{{@root.prefix}}--header__menu-item" role="menuitem" href="{{this.href}}" tabindex="-1">
+          <a class="{{@root.prefix}}--header__menu-item" href="{{this.href}}" tabindex="-1">
             <span class="{{@root.prefix}}--text-truncate--end">
               {{this.title}}
             </span>

--- a/packages/components/src/components/ui-shell/navigation-menu.hbs
+++ b/packages/components/src/components/ui-shell/navigation-menu.hbs
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright IBM Corp. 2016, 2018
 
   This source code is licensed under the Apache-2.0 license found in the
@@ -12,7 +12,8 @@
       {{#each this.items}}
       {{#if this.active}}
       {{#if this.hasIcon}}
-      <li class="{{@root.prefix}}--navigation-item {{@root.prefix}}--navigation-item--active {{@root.prefix}}--navigation-item--icon">
+      <li
+        class="{{@root.prefix}}--navigation-item {{@root.prefix}}--navigation-item--active {{@root.prefix}}--navigation-item--icon">
         {{else}}
       <li class="{{@root.prefix}}--navigation-item {{@root.prefix}}--navigation-item--active">
         {{/if}}
@@ -28,7 +29,8 @@
           {{#if this.hasIcon}}
           <div class="{{@root.prefix}}--navigation-icon">
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
-              <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+              <path
+                d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
           {{/if}}
@@ -47,7 +49,8 @@
               <div class="{{@root.prefix}}--navigation-icon">
 
                 <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-                  <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+                  <path
+                    d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
                 </svg>
               </div>
               {{/if}}
@@ -58,14 +61,15 @@
                 </svg>
               </div>
             </button>
-            <ul id="category-1-menu" class="{{@root.prefix}}--navigation__category-items" role="menu">
+            <ul id="category-1-menu" class="{{@root.prefix}}--navigation__category-items">
               {{#each this.links}}
               {{#if this.active}}
-              <li class="{{@root.prefix}}--navigation__category-item {{@root.prefix}}--navigation__category-item--active">
+              <li
+                class="{{@root.prefix}}--navigation__category-item {{@root.prefix}}--navigation__category-item--active">
                 {{else}}
               <li class="{{@root.prefix}}--navigation__category-item">
                 {{/if}}
-                <a class="{{@root.prefix}}--navigation-link" href="{{ this.href }}" role="menuitem">
+                <a class="{{@root.prefix}}--navigation-link" href="{{ this.href }}">
                   {{ this.title }}
                 </a>
               </li>

--- a/packages/components/src/components/ui-shell/side-nav-fixed.hbs
+++ b/packages/components/src/components/ui-shell/side-nav-fixed.hbs
@@ -20,19 +20,19 @@
             </svg>
           </div>
         </button>
-        <ul class="{{@root.prefix}}--side-nav__menu" role="menu" hidden="">
+        <ul class="{{@root.prefix}}--side-nav__menu" hidden="">
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">L0 menu item</span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">L0 menu item</span>
             </a>
           </li>
-          <li class="{{@root.prefix}}--side-nav__menu-item" role="menuitem">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+          <li class="{{@root.prefix}}--side-nav__menu-item">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">L0 menu item</span>
             </a>
           </li>
@@ -50,28 +50,28 @@
             </svg>
           </div>
         </button>
-        <ul class="{{@root.prefix}}--side-nav__menu" role="menu">
+        <ul class="{{@root.prefix}}--side-nav__menu">
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">
                 L0 menu item
               </span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem" aria-current="page">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" aria-current="page">
               <span class="{{@root.prefix}}--side-nav__link-text">
                 L0 menu item
               </span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">L0 menu item</span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">L0 menu item</span>
             </a>
           </li>

--- a/packages/components/src/components/ui-shell/side-nav.hbs
+++ b/packages/components/src/components/ui-shell/side-nav.hbs
@@ -13,7 +13,8 @@
         <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
           <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
-              <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+              <path
+                d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
           <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
@@ -23,7 +24,8 @@
         <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" aria-current="page">
           <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
-              <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+              <path
+                d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
           <span class="{{@root.prefix}}--side-nav__link-text">Link - active</span>
@@ -33,7 +35,8 @@
         <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
           <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
-              <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+              <path
+                d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
           <span class="{{@root.prefix}}--side-nav__link-text">
@@ -46,7 +49,8 @@
           aria-current="page">
           <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small">
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
-              <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+              <path
+                d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
           <span class="{{@root.prefix}}--side-nav__link-text">
@@ -58,40 +62,42 @@
         <button class="{{@root.prefix}}--side-nav__submenu" type="button" aria-haspopup="true" aria-expanded="true">
           <div class="{{@root.prefix}}--side-nav__icon">
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
-              <path d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
+              <path
+                d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12 12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86 23l1.73-1a11.9 11.9 0 0 1-1.4-3.93zm7.63-13.31l-.68-1.88A14 14 0 0 0 7 5.33l1.24 1.53a12 12 0 0 1 3.58-2.1zM5.59 10L3.86 9a13.89 13.89 0 0 0-1.64 4.54l2 .35A11.9 11.9 0 0 1 5.59 10zM16 2v2a12 12 0 0 1 0 24v2a14 14 0 0 0 0-28z" />
             </svg>
           </div>
           <span class="{{@root.prefix}}--side-nav__submenu-title">
             Category title that is really long and probably should overflow
           </span>
-          <div class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small {{@root.prefix}}--side-nav__submenu-chevron">
+          <div
+            class="{{@root.prefix}}--side-nav__icon {{@root.prefix}}--side-nav__icon--small {{@root.prefix}}--side-nav__submenu-chevron">
             <svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
               <path d="M16 22L6 12l1.414-1.414L16 19.172l8.586-8.586L26 12 16 22z" />
             </svg>
           </div>
         </button>
-        <ul class="{{@root.prefix}}--side-nav__menu" role="menu">
+        <ul class="{{@root.prefix}}--side-nav__menu">
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">
                 Link with really long text that probably should be truncated
               </span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem" aria-current="page">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" aria-current="page">
               <span class="{{@root.prefix}}--side-nav__link-text">
                 Link with really long text that probably should be truncated
               </span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)">
               <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
             </a>
           </li>
           <li class="{{@root.prefix}}--side-nav__menu-item" role="none">
-            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" role="menuitem" aria-current="page">
+            <a class="{{@root.prefix}}--side-nav__link" href="javascript:void(0)" aria-current="page">
               <span class="{{@root.prefix}}--side-nav__link-text">Link</span>
             </a>
           </li>

--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -206,11 +206,7 @@ class HeaderMenu extends React.Component {
   }
 
   /**
-   * Render an individual menuitem, passing along `role: 'none'` because the
-   * host node <li> doesn't apply when in a <ul> with `role="menu"` and so we
-   * need to revert the semantics.
-   *
-   * We also capture the `ref` for each child inside of `this.items` to properly
+   * We capture the `ref` for each child inside of `this.items` to properly
    * manage focus. In addition to this focus management, all items receive a
    * `tabIndex: -1` so the user won't hit a large number of items in their tab
    * sequence when they might not want to go through all the items.
@@ -219,7 +215,6 @@ class HeaderMenu extends React.Component {
     if (React.isValidElement(item)) {
       return React.cloneElement(item, {
         ref: this.handleItemRef(index),
-        role: 'none',
       });
     }
   };

--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -120,8 +120,7 @@ class HeaderMenu extends React.Component {
   };
 
   /**
-   * ref handler for our menu button. This node is represented by the
-   * `role="menu"` attribute. If we are supplied a `focusRef` prop, we also
+   * ref handler for our menu button. If we are supplied a `focusRef` prop, we also
    * forward along the node.
    *
    * This is useful when this component is a child in a
@@ -199,10 +198,7 @@ class HeaderMenu extends React.Component {
           {menuLinkName}
           <MenuContent />
         </a>
-        <ul
-          {...accessibilityLabel}
-          className={`${prefix}--header__menu`}
-          role="menu">
+        <ul {...accessibilityLabel} className={`${prefix}--header__menu`}>
           {React.Children.map(children, this._renderMenuItem)}
         </ul>
       </li>

--- a/packages/react/src/components/UIShell/SideNavMenu.js
+++ b/packages/react/src/components/UIShell/SideNavMenu.js
@@ -164,9 +164,7 @@ export class SideNavMenu extends React.Component {
             <ChevronDown20 />
           </SideNavIcon>
         </button>
-        <ul className={`${prefix}--side-nav__menu`} role="menu">
-          {children}
-        </ul>
+        <ul className={`${prefix}--side-nav__menu`}>{children}</ul>
       </li>
     );
   }

--- a/packages/react/src/components/UIShell/Switcher.js
+++ b/packages/react/src/components/UIShell/Switcher.js
@@ -31,7 +31,7 @@ const Switcher = React.forwardRef(function Switcher(props, ref) {
   });
 
   return (
-    <ul ref={ref} className={className} role="menu" {...accessibilityLabel}>
+    <ul ref={ref} className={className} {...accessibilityLabel}>
       {children}
     </ul>
   );

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -588,7 +588,7 @@ storiesOf('UI Shell', module)
           </HeaderGlobalAction>
         </HeaderGlobalBar>
         <HeaderPanel aria-label="Header Panel" expanded>
-          <Switcher role="menu" aria-label="Switcher Container">
+          <Switcher aria-label="Switcher Container">
             <SwitcherItem isSelected aria-label="Link 1" href="#">
               Link 1
             </SwitcherItem>

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
@@ -57,7 +57,6 @@ exports[`HeaderMenu should render 1`] = `
       </a>
       <ul
         className="bx--header__menu"
-        role="menu"
       >
         <ForwardRef(HeaderMenuItem)
           href="/a"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
@@ -61,11 +61,8 @@ exports[`HeaderMenu should render 1`] = `
         <ForwardRef(HeaderMenuItem)
           href="/a"
           key=".0"
-          role="none"
         >
-          <li
-            role="none"
-          >
+          <li>
             <Link
               className="bx--header__menu-item"
               element="a"
@@ -89,11 +86,8 @@ exports[`HeaderMenu should render 1`] = `
         <ForwardRef(HeaderMenuItem)
           href="/b"
           key=".1"
-          role="none"
         >
-          <li
-            role="none"
-          >
+          <li>
             <Link
               className="bx--header__menu-item"
               element="a"
@@ -117,11 +111,8 @@ exports[`HeaderMenu should render 1`] = `
         <ForwardRef(HeaderMenuItem)
           href="/c"
           key=".2"
-          role="none"
         >
-          <li
-            role="none"
-          >
+          <li>
             <Link
               className="bx--header__menu-item"
               element="a"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
@@ -129,7 +129,6 @@ exports[`SideNavMenu should render 1`] = `
     </button>
     <ul
       className="bx--side-nav__menu"
-      role="menu"
     >
       text
     </ul>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3583
Closes https://github.com/carbon-design-system/carbon/issues/3590
Closes https://github.com/carbon-design-system/carbon/issues/3584

We erroneously had role="menu" implying an application menu. 

#### Changelog

**Removed**

- All references to `role="menu"` and 'role="menuitem"`

#### Testing / Reviewing
 
Make sure UI Shell still looks the same, and there are no new DAP errors. 
