### PR TITLE
docs(tabs): add example CodeSnippet via renderContent to story

### DIFF
--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -117,7 +117,11 @@ storiesOf('Tabs', module)
           renderContent={TabContentRenderedOnlyWhenSelected}>
           <div className="some-content">
             <p>Content for fourth tab goes here.</p>
-            <p>This example uses the <CodeSnippet type="inline">renderContent</CodeSnippet> prop to re-render content when the tab is selected.</p>
+            <p>
+              This example uses the&nbsp;
+              <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
+              re-render content when the tab is selected.
+            </p>
             <CodeSnippetExample />
           </div>
         </Tab>
@@ -155,7 +159,12 @@ storiesOf('Tabs', module)
           renderContent={TabContentRenderedOnlyWhenSelected}>
           <div className="some-content">
             <p>Content for third tab goes here.</p>
-            <p>This example uses the <CodeSnippet type="inline">renderContent</CodeSnippet> prop to re-render content when the tab is selected.</p>            <CodeSnippetExample />
+            <p>
+              This example uses the&nbsp;
+              <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
+              re-render content when the tab is selected.
+            </p>
+            <CodeSnippetExample />
           </div>
         </Tab>
         <Tab

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -102,13 +102,19 @@ storiesOf('Tabs', module)
     () => (
       <Tabs {...props.tabs()}>
         <Tab id="tab-1" {...props.tab()} label="Tab label 1">
-          <div className="some-content">Content for first tab goes here.</div>
+          <div className="some-content">
+            <p>Content for first tab goes here.</p>
+          </div>
         </Tab>
         <Tab id="tab-2" {...props.tab()} label="Tab label 2">
-          <div className="some-content">Content for second tab goes here.</div>
+          <div className="some-content">
+            <p>Content for second tab goes here.</p>
+          </div>
         </Tab>
         <Tab id="tab-3" {...props.tab()} label="Tab label 3" disabled>
-          <div className="some-content">Content for third tab goes here.</div>
+          <div className="some-content">
+            <p>Content for third tab goes here.</p>
+          </div>
         </Tab>
         <Tab
           id="tab-4"
@@ -129,7 +135,9 @@ storiesOf('Tabs', module)
           id="tab-5"
           {...props.tab()}
           label={<CustomLabel text="Custom Label" />}>
-          <div className="some-content">Content for fifth tab goes here.</div>
+          <div className="some-content">
+            <p>Content for fifth tab goes here.</p>
+          </div>
         </Tab>
       </Tabs>
     ),
@@ -147,10 +155,14 @@ storiesOf('Tabs', module)
     () => (
       <Tabs type="container" {...props.tabs()}>
         <Tab id="tab-1" {...props.tab()} label="Tab label 1">
-          <div className="some-content">Content for first tab goes here.</div>
+          <div className="some-content">
+            <p>Content for first tab goes here.</p>
+          </div>
         </Tab>
         <Tab id="tab-2" {...props.tab()} label="Tab label 2">
-          <div className="some-content">Content for second tab goes here.</div>
+          <div className="some-content">
+            <p>Content for second tab goes here.</p>
+          </div>
         </Tab>
         <Tab
           id="tab-3"
@@ -171,7 +183,9 @@ storiesOf('Tabs', module)
           id="tab-4"
           {...props.tab()}
           label={<CustomLabel text="Custom Label" />}>
-          <div className="some-content">Content for fourth tab goes here.</div>
+          <div className="some-content">
+            <p>Content for fourth tab goes here.</p>
+          </div>
         </Tab>
       </Tabs>
     ),

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -12,6 +12,7 @@ import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import { settings } from 'carbon-components';
 import classNames from 'classnames';
 import './Tabs-story.scss';
+import CodeSnippet from '../CodeSnippet';
 import Tabs from '../Tabs';
 import Tab from '../Tab';
 import TabsSkeleton from '../Tabs/Tabs.Skeleton';
@@ -51,6 +52,32 @@ const props = {
 
 const CustomLabel = ({ text }) => <>{text}</>;
 
+const CodeSnippetExample = () => (
+  <CodeSnippet type="multi">
+    {`@mixin grid-container {
+      width: 100%;
+      padding-right: padding(mobile);
+      padding-left: padding(mobile);
+    
+      @include breakpoint(bp--xs--major) {
+        padding-right: padding(xs);
+        padding-left: padding(xs);
+      }
+    }
+    
+    $z-indexes: (
+      modal : 9000,
+      overlay : 8000,
+      dropdown : 7000,
+      header : 6000,
+      footer : 5000,
+      hidden : - 1,
+      overflowHidden: - 1,
+      floating: 10000
+    );`}
+  </CodeSnippet>
+);
+
 const TabContentRenderedOnlyWhenSelected = ({
   selected,
   children,
@@ -88,7 +115,10 @@ storiesOf('Tabs', module)
           {...props.tab()}
           label="Tab label 4"
           renderContent={TabContentRenderedOnlyWhenSelected}>
-          <div className="some-content">Content for fourth tab goes here.</div>
+          <div className="some-content">
+            <p>Content for fourth tab goes here.</p>
+            <CodeSnippetExample />
+          </div>
         </Tab>
         <Tab
           id="tab-5"
@@ -122,7 +152,10 @@ storiesOf('Tabs', module)
           {...props.tab()}
           label="Tab label 3"
           renderContent={TabContentRenderedOnlyWhenSelected}>
-          <div className="some-content">Content for third tab goes here.</div>
+          <div className="some-content">
+            <p>Content for third tab goes here.</p>
+            <CodeSnippetExample />
+          </div>
         </Tab>
         <Tab
           id="tab-4"

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -117,6 +117,7 @@ storiesOf('Tabs', module)
           renderContent={TabContentRenderedOnlyWhenSelected}>
           <div className="some-content">
             <p>Content for fourth tab goes here.</p>
+            <p>This example uses the <CodeSnippet type="inline">renderContent</CodeSnippet> prop to re-render content when the tab is selected.</p>
             <CodeSnippetExample />
           </div>
         </Tab>
@@ -154,7 +155,7 @@ storiesOf('Tabs', module)
           renderContent={TabContentRenderedOnlyWhenSelected}>
           <div className="some-content">
             <p>Content for third tab goes here.</p>
-            <CodeSnippetExample />
+            <p>This example uses the <CodeSnippet type="inline">renderContent</CodeSnippet> prop to re-render content when the tab is selected.</p>            <CodeSnippetExample />
           </div>
         </Tab>
         <Tab

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -55,26 +55,24 @@ const CustomLabel = ({ text }) => <>{text}</>;
 const CodeSnippetExample = () => (
   <CodeSnippet type="multi">
     {`@mixin grid-container {
-      width: 100%;
-      padding-right: padding(mobile);
-      padding-left: padding(mobile);
-    
-      @include breakpoint(bp--xs--major) {
-        padding-right: padding(xs);
-        padding-left: padding(xs);
-      }
-    }
-    
-    $z-indexes: (
-      modal : 9000,
-      overlay : 8000,
-      dropdown : 7000,
-      header : 6000,
-      footer : 5000,
-      hidden : - 1,
-      overflowHidden: - 1,
-      floating: 10000
-    );`}
+  width: 100%;
+  padding-right: padding(mobile);
+  padding-left: padding(mobile);
+  @include breakpoint(bp--xs--major) {
+    padding-right: padding(xs);
+    padding-left: padding(xs);
+  }
+}
+$z-indexes: (
+  modal : 9000,
+  overlay : 8000,
+  dropdown : 7000,
+  header : 6000,
+  footer : 5000,
+  hidden : - 1,
+  overflowHidden: - 1,
+  floating: 10000
+);`}
   </CodeSnippet>
 );
 

--- a/packages/react/src/components/Tabs/Tabs-story.scss
+++ b/packages/react/src/components/Tabs/Tabs-story.scss
@@ -10,6 +10,6 @@ $css--reset: false;
 @import '~carbon-components/src/globals/scss/css--helpers';
 
 .bx--tabs--container ~ div {
-  height: 320px;
+  min-height: 320px;
   background-color: $ui-01;
 }


### PR DESCRIPTION
Closes #5257

Originally I thought the best way to go about solving #5257 was to use the `selected` prop to force a rerender, but then I noticed that the storybook already had an example of that EXACT solution using `renderContent`

Anyway I think it would be beneficial to include a multi-line `CodeSnippet` example with `renderContent` in the `Tabs` story, to demonstrate how to force a rerender when a `Tab` is selected for tricky content that relies on refs etc.

Also, **please let me know if you'd like me to add any notes on the uses of `renderContent` in this context** 👍 (EDIT: I did add a little note to the example though)

#### Changelog

**New**

- add `CodeSnippet` example to demonstrate how to use `renderContent` to force a rerender of tab content

**Changed**

- change height of tab content in story to `min-height`, so that the code snippet doesn't look weird when expanded in the example.
