### PR TITLE
docs(file-uploader): show legacy file uploader in vanilla docs

### DIFF
--- a/packages/components/src/components/file-uploader/file-uploader.config.js
+++ b/packages/components/src/components/file-uploader/file-uploader.config.js
@@ -29,5 +29,22 @@ module.exports = {
         exampleUploadStates: true,
       },
     },
+    {
+      name: 'legacy',
+      label: 'Legacy file uploader',
+      context: {
+        id: 'legacy-file-uploader',
+        legacy: true,
+      },
+    },
+    {
+      name: 'legacy with example upload states',
+      label: 'Legacy file uploader with example upload states',
+      context: {
+        id: 'legacy-file-uploader-states',
+        legacy: true,
+        exampleUploadStates: true,
+      },
+    },
   ],
 };

--- a/packages/components/src/components/file-uploader/file-uploader.hbs
+++ b/packages/components/src/components/file-uploader/file-uploader.hbs
@@ -5,6 +5,7 @@
   LICENSE file in the root directory of this source tree.
 -->
 
+{{#unless legacy}}
 <div class="{{prefix}}--form-item">
   <strong class="{{prefix}}--file--label">Account
     photo</strong>
@@ -57,3 +58,53 @@
     </div>
   </div>
 </div>
+{{else}}
+<div class="{{prefix}}--form-item">
+  <strong class="{{prefix}}--file--label">Account
+    photo</strong>
+  <p class="{{prefix}}--label-description">Only .jpg and .png files. 500kb max file size.</p>
+  <div class="{{prefix}}--file" data-file data-file-demo-state-manager>
+    <label for="legacy-file-uploader" class="{{prefix}}--file-btn {{prefix}}--btn {{prefix}}--btn--primary"
+      role="button" tabindex="0">Add file</label>
+    <input type="file" class="{{prefix}}--file-input" id="legacy-file-uploader" data-file-uploader
+      data-target="[data-file-container]" multiple />
+    <div data-file-container data-file-drop-container class="{{prefix}}--file-container">
+      {{#if exampleUploadStates}}
+      <div class="{{prefix}}--file__selected-file">
+        <p class="{{prefix}}--file-filename">Lorem ipsum dolor sit amet consectetur adipisicing elit. Libero vero
+          sapiente illum reprehenderit molestiae perferendis voluptatem temporibus laudantium ducimus magni voluptatum
+          veniam, odit nesciunt corporis numquam maxime sunt excepturi sint!</p>
+        <span data-for="{{id}}" class="{{prefix}}--file__state-container">
+          {{ carbon-icon 'CheckmarkFilled16' class=(add prefix '--file-complete') }}
+        </span>
+      </div>
+      <div class="{{prefix}}--file__selected-file {{prefix}}--file__selected-file--invalid" data-invalid>
+        <p class="{{prefix}}--file-filename">color.jpeg</p>
+        <span data-for="{{id}}" class="{{prefix}}--file__state-container">
+          {{ carbon-icon 'WarningFilled16' class=(add prefix '--file--invalid')}}
+          {{ carbon-icon 'Close16' class=(add prefix '--file-close') aria-label="Remove uploaded file" tabindex="0" }}
+        </span>
+        <div class="{{prefix}}--form-requirement">
+          <div class="{{prefix}}--form-requirement__title">File size exceeds limit.</div>
+          <p class="{{prefix}}--form-requirement__supplement">500 kb max file size. Select a new file and try
+            again.</p>
+        </div>
+      </div>
+      <div class="{{prefix}}--file__selected-file">
+        <p class="{{prefix}}--file-filename">color.jpeg</p>
+        <span data-for="{{id}}" class="{{prefix}}--file__state-container">
+          <div class="{{prefix}}--inline-loading__animation">
+            <div data-inline-loading-spinner="" class="{{prefix}}--loading {{prefix}}--loading--small">
+              <svg class="{{prefix}}--loading__svg" viewBox="-75 -75 150 150">
+                <circle class="{{prefix}}--loading__background" cx="0" cy="0" r="26.8125"></circle>
+                <circle class="{{prefix}}--loading__stroke" cx="0" cy="0" r="26.8125"></circle>
+              </svg>
+            </div>
+          </div>
+        </span>
+      </div>
+      {{/if}}
+    </div>
+  </div>
+</div>
+{{/unless}}


### PR DESCRIPTION
Closes #5247

This PR adds the legacy file uploader back into the vanilla docs

#### Testing / Reviewing

Ensure the file uploader functions as expected
