### PR TITLE
fix(modal): add padding to last child only when scrolling is true

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -261,7 +261,7 @@
   }
 
   // Required so overflow-indicator disappears at end of content
-  .#{$prefix}--modal-content > *:last-child {
+  .#{$prefix}--modal-scroll-content > *:last-child {
     padding-bottom: $spacing-07;
   }
 


### PR DESCRIPTION
Closes #5254 
(Ref #4979)  

This PR adjusts the padding that is added to the last child in the modal so that it is only applied when `hasScrollingContent` is true. 
#### Changelog

**Changed**

- selector for `padding-bottom` on last child

#### Testing / Reviewing

Make sure that no scroll area exists on a Modal when `hasScrollingContent` is false. 
