### PR TITLE
fix(notification): inline notification fits parent container

### DIFF
--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -29,6 +29,7 @@
     min-height: rem(48px);
     min-width: rem(288px);
     max-width: rem(288px);
+    width: 100%;
     color: $inverse-01;
     margin-top: $carbon--spacing-05;
     margin-bottom: $carbon--spacing-05;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/4554

Sets `width: 100%` so that `InlineNotification` fills its parent container, up to it's `max-width`

#### Changelog

**New**

- `width: 100%` on `InlineNotification`

