### PR TITLE
fix(button): use currentColor as icon fill for all states

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -36,11 +36,6 @@
 
   .#{$prefix}--btn {
     @include button-base;
-
-    &.#{$prefix}--btn--disabled > svg.#{$prefix}--btn__icon,
-    &:disabled > svg.#{$prefix}--btn__icon {
-      fill: $disabled-03;
-    }
   }
 
   // Reset intrisic padding in Firefox (see #731)
@@ -113,14 +108,6 @@
       background: transparent;
       color: $disabled;
       outline: none;
-
-      > .#{$prefix}--btn__icon path {
-        fill: $disabled;
-      }
-    }
-
-    &:hover > .#{$prefix}--btn__icon path {
-      fill: $inverse-01;
     }
   }
 
@@ -156,10 +143,6 @@
     &:hover,
     &:active {
       color: $hover-primary-text;
-
-      .#{$prefix}--btn__icon path {
-        fill: $hover-primary-text;
-      }
     }
 
     &:active {
@@ -176,10 +159,6 @@
       background: transparent;
       border-color: transparent;
       outline: none;
-
-      .#{$prefix}--btn__icon path {
-        fill: $disabled;
-      }
     }
 
     &.#{$prefix}--btn--sm {
@@ -273,7 +252,7 @@
       $danger,
       $text-04,
       $hover-danger,
-      $icon-03,
+      currentColor,
       $active-danger
     );
 


### PR DESCRIPTION
I've noticed that in the button styles the icon path fill is initially set to `currentColor` but overwritten in most states (disabled, hover...) event hough the `color` value changes the same.

If this is intentional, I'd be interested in the reasoning behind it. Otherwise, this PR applies the same `currentColor` logic to the states.

#### Changelog

**Changed**

- removed explicit icon fill color in button states which were identical to color value

#### Testing / Reviewing

1. Run react storybook
2. Apply different button states
