### PR TITLE
fix(ui-shell): allow custom classes on HeaderSideNavItems

### DIFF
--- a/packages/react/src/components/UIShell/HeaderSideNavItems.js
+++ b/packages/react/src/components/UIShell/HeaderSideNavItems.js
@@ -17,11 +17,13 @@ const HeaderSideNavItems = ({
   children,
   hasDivider,
 }) => {
-  const className = cx({
-    [`${prefix}--side-nav__header-navigation`]: true,
-    [`${prefix}--side-nav__header-divider`]: hasDivider,
-    customClassName,
-  });
+  const className = cx(
+    {
+      [`${prefix}--side-nav__header-navigation`]: true,
+      [`${prefix}--side-nav__header-divider`]: hasDivider,
+    },
+    customClassName
+  );
   return <div className={className}>{children}</div>;
 };
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5273

Ensures custom classes are properly passed down to `HeaderSideNavItems`

#### Changelog

**Changed**

- Moved `customClassName` out of the object so the custom class is correctly applied

#### Testing / Reviewing

Add `className="test"` to `HeaderSideNavItems` in the `Header Base w/ Navigation` story, and ensure the custom class is correctly applied
