### PR TITLE
fix(accordion): only target direct child p tags

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -109,7 +109,7 @@
       padding-right: 25%;
     }
 
-    p {
+    > p {
       @include type-style('body-long-01');
     }
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5285

We were incorrectly applying `body-long-01` text styles to ALL `p` elements inside of `bx--accordion__content`. This makes sure we only target direct child `p` tags

#### Changelog

**Changed**

- Only target direct child `p` tags instead of all `p` tags inside of `bx--accordion__content`

#### Testing / Reviewing

Add an inline-notification to an accordion and ensure the text is not altered. 
