### PR TITLE
chore(react): update storybook to re-enable theming panels

### DIFF
--- a/packages/react/.storybook/addon-carbon-theme/register.js
+++ b/packages/react/.storybook/addon-carbon-theme/register.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import addons from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 import { CarbonThemesPanel, CarbonTypePanel } from './components/Panel';
 import {
   CARBON_THEMES_ADDON_ID,
@@ -15,20 +15,22 @@ import {
   CARBON_TYPE_PANEL_ID,
 } from './shared';
 
-addons.register(CARBON_THEMES_ADDON_ID, api => {
-  addons.addPanel(CARBON_THEME_PANEL_ID, {
-    title: 'Carbon theme',
-    render: ({ active, key }) => (
-      <CarbonThemesPanel api={api} key={key} active={active} />
-    ),
+if (process.env.CARBON_REACT_STORYBOOK_USE_CUSTOM_PROPERTIES === 'true') {
+  addons.register(CARBON_THEMES_ADDON_ID, api => {
+    addons.addPanel(CARBON_THEME_PANEL_ID, {
+      title: 'Carbon theme',
+      render: ({ active, key }) => (
+        <CarbonThemesPanel api={api} key={key} active={active} />
+      ),
+    });
   });
-});
 
-addons.register(CARBON_TYPE_ADDON_ID, api => {
-  addons.addPanel(CARBON_TYPE_PANEL_ID, {
-    title: 'Carbon type',
-    render: ({ active, key }) => (
-      <CarbonTypePanel api={api} key={key} active={active} />
-    ),
+  addons.register(CARBON_TYPE_ADDON_ID, api => {
+    addons.addPanel(CARBON_TYPE_PANEL_ID, {
+      title: 'Carbon type',
+      render: ({ active, key }) => (
+        <CarbonTypePanel api={api} key={key} active={active} />
+      ),
+    });
   });
-});
+}

--- a/packages/react/.storybook/addons.js
+++ b/packages/react/.storybook/addons.js
@@ -14,11 +14,8 @@ import '@storybook/addon-a11y/register';
 // Community addons
 import 'storybook-readme/register';
 
-if (process.env.CARBON_REACT_STORYBOOK_USE_CUSTOM_PROPERTIES === 'true') {
-  import('./addon-carbon-theme/register').catch(error => {
-    console.error(error);
-  });
-}
+// Custom addons
+import './addon-carbon-theme/register';
 
 // These options used by storybook often conflict with developer tools,
 // conditional panels, or other things that get in the way of our workflow


### PR DESCRIPTION
Closes #5331 

Update storybook config to remove dynamic import and update call signature for addons registration.

#### Changelog

**New**

**Changed**

- Update how our custom addon is registered

**Removed**

#### Testing / Reviewing

- Verify the netlify preview includes the theme and type panels
- Pull down locally and verify:
  - Running `yarn storybook` does *not* include the theme and type panels
  - Running `CARBON_REACT_STORYBOOK_USE_CUSTOM_PROPERTIES=true yarn storybook` *does* include the theme and type panels
