### PR TITLE
fix(button): reduce small ghost button left/right padding

### DIFF
--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -126,7 +126,7 @@ $button-padding-ghost-field: calc(0.675rem - 3px) 12px !default;
 /// @access public
 /// @group button
 /// Uses the same padding-y as small buttons, but removes extra padding-right
-$button-padding-ghost-sm: calc(0.375rem - 3px) 1rem !default;
+$button-padding-ghost-sm: calc(0.375rem - 3px) 12px !default;
 
 /// @type Number
 /// @access public


### PR DESCRIPTION
Closes #5329
Closes #5387

This PR reduces the side padding for small ghost buttons to match the other small button variants
