### PR TITLE
FIX: 32/settings--adjust.svg new geometry

### DIFF
--- a/packages/icons/svg/16/settings--adjust.svg
+++ b/packages/icons/svg/16/settings--adjust.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="16px" height="16px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<path d="M15,4h-2.1c-0.2-1.1-1.2-2-2.4-2S8.3,2.9,8.1,4H1v1h7.1c0.2,1.1,1.2,2,2.4,2s2.2-0.9,2.4-2H15V4z M10.5,6C9.7,6,9,5.3,9,4.5
-	S9.7,3,10.5,3S12,3.7,12,4.5S11.3,6,10.5,6z"/>
-<path d="M1,12h2.1c0.2,1.1,1.2,2,2.4,2s2.2-0.9,2.4-2H15v-1H7.9C7.7,9.9,6.7,9,5.5,9s-2.2,0.9-2.4,2H1V12z M5.5,10
-	C6.3,10,7,10.7,7,11.5S6.3,13,5.5,13S4,12.3,4,11.5S4.7,10,5.5,10z"/>
-</svg>

--- a/packages/icons/svg/32/settings--adjust.svg
+++ b/packages/icons/svg/32/settings--adjust.svg
@@ -1,1 +1,14 @@
-<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><style>.cls-1{fill:none;}</style></defs><title>settings--adjust</title><path d="M30,7H24.9a5,5,0,0,0-9.8,0H2V9H15.1a5,5,0,0,0,9.8,0H30ZM20,11a3,3,0,1,1,3-3A3,3,0,0,1,20,11Z" transform="translate(0 0)"/><path d="M2,25H7.1a5,5,0,0,0,9.8,0H30V23H16.9a5,5,0,0,0-9.8,0H2Zm7-1a3,3,0,1,1,3,3A3,3,0,0,1,9,24Z" transform="translate(0 0)"/><rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="32px" height="32px" viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<title>settings--adjust</title>
+<path d="M30,8h-4.1c-0.5-2.3-2.5-4-4.9-4s-4.4,1.7-4.9,4H2v2h14.1c0.5,2.3,2.5,4,4.9,4s4.4-1.7,4.9-4H30V8z M21,12c-1.7,0-3-1.3-3-3
+	s1.3-3,3-3s3,1.3,3,3S22.7,12,21,12z"/>
+<path d="M2,24h4.1c0.5,2.3,2.5,4,4.9,4s4.4-1.7,4.9-4H30v-2H15.9c-0.5-2.3-2.5-4-4.9-4s-4.4,1.7-4.9,4H2V24z M11,20c1.7,0,3,1.3,3,3
+	s-1.3,3-3,3s-3-1.3-3-3S9.3,20,11,20z"/>
+<rect id="_Transparent_Rectangle_" class="st0" width="32" height="32"/>
+</svg>


### PR DESCRIPTION
Adjustments to geometry of 32/settings--adjust.svg to improve quality of scaled assets and eliminate the need for 16/settings--adjust.svg 

#### Changelog

**Changed**

- Adjustments to geometry of 32/settings--adjust.svg to improve quality of scaled assets

**Removed**

- 16/settings--adjust.svg

#### Testing / Reviewing

Consider
https://deploy-preview-5361--carbon-elements.netlify.com/icons/examples/preview/#32%2Fsettings--adjust
https://deploy-preview-5361--carbon-elements.netlify.com/icons/examples/preview/#32%2Fsettings--adjust%20(Downsized%20to%2024)
https://deploy-preview-5361--carbon-elements.netlify.com/icons/examples/preview/#32%2Fsettings--adjust%20(Downsized%20to%2020)
https://deploy-preview-5361--carbon-elements.netlify.com/icons/examples/preview/#32%2Fsettings--adjust%20(Downsized%20to%2016)

on @2x and @1x displays.

Will require re-generation of Sketch Icon Libraries.