### PR TITLE
fix: Prevent Tooltip setState call if not open

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -331,7 +331,7 @@ class Tooltip extends Component {
       evt.target &&
       this._tooltipEl &&
       this._tooltipEl.contains(evt.target);
-    if (!shouldPreventClose) {
+    if (!shouldPreventClose && this.state.open) {
       this._handleUserInputOpenClose(evt, { open: false });
     }
   };


### PR DESCRIPTION
This PR prevents the `handleClickOutside` from calling `setState` if the ToolTip is already closed. This same [code change](https://github.com/carbon-design-system/carbon-components-react/pull/2424) was merged in the previous version of Carbon React.

The reason for this check is that, at scale, these calls create _**real**_ performance issues. 

Our app has over 1,000 `<Tooltip />`s. Each of these `<Tooltip />`s calls `setState({open: false})` for any click in the UI. The unnecessary calls to `setState` makes toggling radio buttons and opening Modals very, very slow. Up to two seconds in some cases in our UI. After adding this check the UI behaves normally.

#### Changelog
**Changed**
- Adds a check to the `handleClickOutside` method.

#### Testing / Reviewing
Below is a performance screenshot with current behavior.
<img width="623" alt="Screen Shot 2019-12-06 at 11 02 21 AM" src="https://user-images.githubusercontent.com/141877/70341230-193e0c80-1818-11ea-8219-658bfa606267.png">
