### PR TITLE
fix(dropdown): add a11y role='option' and aria-selected to menu options

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -293,13 +293,15 @@ export default class Dropdown extends React.Component {
                   <ListBox.Menu aria-labelledby={id} id={id}>
                     {items.map((item, index) => {
                       const itemProps = getItemProps({ item, index });
+                      const isHighlighted =
+                        highlightedIndex === index || selectedItem === item;
                       return (
                         <ListBox.MenuItem
                           key={itemProps.id}
                           isActive={selectedItem === item}
-                          isHighlighted={
-                            highlightedIndex === index || selectedItem === item
-                          }
+                          isHighlighted={isHighlighted}
+                          role="option"
+                          aria-selected={isHighlighted}
                           title={itemToElement ? item.text : itemToString(item)}
                           {...itemProps}>
                           {itemToElement ? (

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -350,6 +350,7 @@ exports[`Dropdown should render custom item components 1`] = `
               role="listbox"
             >
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-4-item-0"
                 isActive={false}
                 isHighlighted={false}
@@ -357,13 +358,16 @@ exports[`Dropdown should render custom item components 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-4-item-0"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                 >
                   <div
                     className="bx--list-box__menu-item__option"
@@ -384,6 +388,7 @@ exports[`Dropdown should render custom item components 1`] = `
                 </div>
               </ListBoxMenuItem>
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-4-item-1"
                 isActive={false}
                 isHighlighted={false}
@@ -391,13 +396,16 @@ exports[`Dropdown should render custom item components 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-4-item-1"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                 >
                   <div
                     className="bx--list-box__menu-item__option"
@@ -418,6 +426,7 @@ exports[`Dropdown should render custom item components 1`] = `
                 </div>
               </ListBoxMenuItem>
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-4-item-2"
                 isActive={false}
                 isHighlighted={false}
@@ -425,13 +434,16 @@ exports[`Dropdown should render custom item components 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-4-item-2"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                 >
                   <div
                     className="bx--list-box__menu-item__option"
@@ -452,6 +464,7 @@ exports[`Dropdown should render custom item components 1`] = `
                 </div>
               </ListBoxMenuItem>
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-4-item-3"
                 isActive={false}
                 isHighlighted={false}
@@ -459,13 +472,16 @@ exports[`Dropdown should render custom item components 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-4-item-3"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                 >
                   <div
                     className="bx--list-box__menu-item__option"
@@ -486,6 +502,7 @@ exports[`Dropdown should render custom item components 1`] = `
                 </div>
               </ListBoxMenuItem>
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-4-item-4"
                 isActive={false}
                 isHighlighted={false}
@@ -493,13 +510,16 @@ exports[`Dropdown should render custom item components 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-4-item-4"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                 >
                   <div
                     className="bx--list-box__menu-item__option"
@@ -682,6 +702,7 @@ exports[`Dropdown should render with strings as items 1`] = `
               role="listbox"
             >
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-3-item-0"
                 isActive={false}
                 isHighlighted={false}
@@ -689,14 +710,17 @@ exports[`Dropdown should render with strings as items 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
                 title="zar"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-3-item-0"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                   title="zar"
                 >
                   <div
@@ -707,6 +731,7 @@ exports[`Dropdown should render with strings as items 1`] = `
                 </div>
               </ListBoxMenuItem>
               <ListBoxMenuItem
+                aria-selected={false}
                 id="downshift-3-item-1"
                 isActive={false}
                 isHighlighted={false}
@@ -714,14 +739,17 @@ exports[`Dropdown should render with strings as items 1`] = `
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
+                role="option"
                 title="doz"
               >
                 <div
+                  aria-selected={false}
                   className="bx--list-box__menu-item"
                   id="downshift-3-item-1"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseMove={[Function]}
+                  role="option"
                   title="doz"
                 >
                   <div


### PR DESCRIPTION
Closes #5368

This is to fix the a11y issues with the dropdown options where
- Certain ARIA roles must contain particular children
- Required ARIA child role not present: option

#### Changelog

**Changed**

- added `role="option"` and `aria-selected` to the menu items
- updated the dropdown jest snapshots

#### Testing / Reviewing

Check on the accessibility panel that the critical issue is gone
