### PR TITLE
refactor(with-state, structured-list, combobox): replace unsafe lifecycle methods

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -187,6 +187,10 @@ export default class ComboBox extends React.Component {
     light: false,
   };
 
+  static getDerivedStateFromProps(nextProps, state) {
+    return { inputValue: getInputValue(nextProps, state) };
+  }
+
   constructor(props) {
     super(props);
 
@@ -197,12 +201,6 @@ export default class ComboBox extends React.Component {
     this.state = {
       inputValue: getInputValue(props, {}),
     };
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState(state => ({
-      inputValue: getInputValue(nextProps, state),
-    }));
   }
 
   filterItems = (items, itemToString, inputValue) =>

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import uid from '../../tools/uniqueId';
+import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
 
@@ -95,6 +95,8 @@ export class StructuredListHead extends Component {
   }
 }
 
+const getInstanceId = setupGetInstanceId();
+
 export class StructuredListInput extends Component {
   static propTypes = {
     /**
@@ -139,8 +141,9 @@ export class StructuredListInput extends Component {
     title: 'title',
   };
 
-  UNSAFE_componentWillMount() {
-    this.uid = this.props.id || uid();
+  constructor(props) {
+    super(props);
+    this.uid = this.props.id || getInstanceId();
   }
 
   render() {

--- a/packages/react/src/tools/withState.js
+++ b/packages/react/src/tools/withState.js
@@ -15,9 +15,7 @@ export default class WithState extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.state = {
-      initialState: this.props.initialState,
-    };
+    this.state = this.props.initialState;
   }
 
   boundSetState = (...args) => this.setState(...args);

--- a/packages/react/src/tools/withState.js
+++ b/packages/react/src/tools/withState.js
@@ -13,8 +13,11 @@ export default class WithState extends React.PureComponent {
     initialState: PropTypes.object,
   };
 
-  UNSAFE_componentWillMount() {
-    this.setState(this.props.initialState);
+  constructor(props) {
+    super(props);
+    this.state = {
+      initialState: this.props.initialState,
+    };
   }
 
   boundSetState = (...args) => this.setState(...args);


### PR DESCRIPTION
Refs #4902 

This removes and replaces the functionality of the unsafe lifecycle methods from `withState`, StructuredList, and Combobox. 

#### Changelog

**Removed**

- unsafe lifecycle methods 

#### Testing / Reviewing

Make sure that StructuredList, Combobox, and the components that use withState (Dropdown, DatePicker, and Combobox) work as expected
