### PR TITLE
refactor(react): revert rollup ESM and CJS entrypoints

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -88,28 +88,25 @@ const umdBundleConfig = {
 };
 
 module.exports = [
+  // TODO: update configuration to correctly support tree-shaking for React
+  // components. See:
+  // https://github.com/carbon-design-system/carbon/issues/5442
   // Generates the following bundles:
   // ESM:       es/index.js
   // CommonJS: lib/index.js
-  {
-    ...baseConfig,
-    plugins: [
-      ...baseConfig.plugins,
-      replace({
-        'process.env.NODE_ENV': JSON.stringify('development'),
-      }),
-    ],
-    output: [
-      {
-        format: 'esm',
-        file: 'es/index.js',
-      },
-      {
-        format: 'cjs',
-        file: 'lib/index.js',
-      },
-    ],
-  },
+  // {
+  //   ...baseConfig,
+  //   output: [
+  //     {
+  //       format: 'esm',
+  //       file: 'es/index.js',
+  //     },
+  //     {
+  //       format: 'cjs',
+  //       file: 'lib/index.js',
+  //     },
+  //   ],
+  // },
 
   // Generate the development UMD bundle:
   // UMD: umd/carbon-components-react.js


### PR DESCRIPTION
This PR reverts our rollup changes that generated an entrypoint for ESM and CJS. The issues are documented over in: https://github.com/carbon-design-system/carbon/issues/5442

#### Changelog

**New**

**Changed**

- `rollup.config.js` no longer outputs ESM and CJS entrypoints

**Removed**

#### Testing / Reviewing

- Checkout PR
- Run build in `react`
- Verify that `es/index.js` and `lib/index.js` no longer are flat bundles and instead export components from relative paths