### PR TITLE
fix(DatePicker): change VO cursor order

### DIFF
--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -201,10 +201,16 @@
     width: rem(40px);
     padding: 0;
     fill: $text-01;
+    border: none;
+    background-color: transparent;
     transition: background-color $duration--fast-01 motion(standard, productive);
 
     &:hover {
       background-color: $hover-ui;
+    }
+
+    &:focus {
+      @include focus-outline;
     }
   }
 

--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -19,6 +19,7 @@
 @mixin date-picker {
   .#{$prefix}--date-picker {
     display: flex;
+    position: relative;
   }
 
   .#{$prefix}--date-picker--light .#{$prefix}--date-picker__input {

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -533,6 +533,7 @@ describe('Focus management', () => {
 
   it('makes the focused day element sequential focusable', () => {
     const datePicker = wrapper.find('DatePicker').instance();
+    datePicker.cal.open();
     const dayElem = datePicker.cal.calendarContainer.querySelector(
       '.flatpickr-day'
     );

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -441,42 +441,8 @@ describe('Focus management', () => {
     );
   });
 
-  it('focuses on calendar dropdown when focus goes next to the date picker input', () => {
-    wrapper = mount(
-      <>
-        <input id="dummy-focus-node-before" type="text" />
-        <DatePicker
-          onChange={() => {}}
-          datePickerType="single"
-          className="extra-class"
-          appendTo={document.body}>
-          <div className="test-child">
-            <input type="text" className={`${prefix}--date-picker__input`} />
-          </div>
-        </DatePicker>
-        <input id="dummy-focus-node-after" type="text" />
-      </>
-    );
-
-    const datePicker = wrapper.find('DatePicker').instance();
-    datePicker.cal.open();
-    datePicker.cal.selectedDateElem = {
-      focus: jest.fn(),
-    };
-    const event = Object.assign(
-      new CustomEvent('focusout', { bubbles: true }),
-      {
-        relatedTarget: wrapper.find('#dummy-focus-node-after').getDOMNode(),
-      }
-    );
-    wrapper
-      .find('.bx--date-picker__input')
-      .getDOMNode()
-      .dispatchEvent(event);
-    expect(datePicker.cal.selectedDateElem.focus).toHaveBeenCalled();
-  });
-
   it('closes calendar dropdown when focus goes before next to the date picker input', () => {
+    jest.useFakeTimers();
     const datePicker = wrapper.find('DatePicker').instance();
     datePicker.cal.open();
     const event = Object.assign(
@@ -489,59 +455,7 @@ describe('Focus management', () => {
       .find('.bx--date-picker__input')
       .getDOMNode()
       .dispatchEvent(event);
-    expect(datePicker.cal.isOpen).toBe(false);
-  });
-
-  it('focuses on the date picker input when focus goes before next to calendar dropdown', () => {
-    jest.useFakeTimers();
-
-    const datePicker = wrapper.find('DatePicker').instance();
-    datePicker.cal.open();
-
-    const datePickerInput = wrapper
-      .find('.bx--date-picker__input')
-      .getDOMNode();
-    jest.spyOn(datePickerInput, 'focus');
-
-    const { calendarContainer } = datePicker.cal;
-    const dummyNodeBeforeCalendar = document.createElement('input');
-    calendarContainer.parentNode.insertBefore(
-      dummyNodeBeforeCalendar,
-      calendarContainer
-    );
-    addedNodes.push(dummyNodeBeforeCalendar);
-
-    const event = Object.assign(
-      new CustomEvent('focusout', { bubbles: true }),
-      {
-        relatedTarget: dummyNodeBeforeCalendar,
-      }
-    );
-    calendarContainer
-      .querySelector('button.flatpickr-prev-month')
-      .dispatchEvent(event);
     jest.runAllTimers();
-
-    expect(datePickerInput.focus).toHaveBeenCalled();
-  });
-
-  it('closes calendar dropdown when focus goes next to calendar dropdown', () => {
-    jest.useFakeTimers();
-
-    const datePicker = wrapper.find('DatePicker').instance();
-    datePicker.cal.open();
-
-    const event = Object.assign(
-      new CustomEvent('focusout', { bubbles: true }),
-      {
-        relatedTarget: wrapper.find('#dummy-focus-node-after').getDOMNode(),
-      }
-    );
-    datePicker.cal.calendarContainer
-      .querySelector('button.flatpickr-prev-month')
-      .dispatchEvent(event);
-    jest.runAllTimers();
-
     expect(datePicker.cal.isOpen).toBe(false);
   });
 

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -146,7 +146,7 @@ describe('DatePicker', () => {
         datePickerType="single"
         dateFormat="m/d/Y"
         value={'02/26/2017'}
-        appendTo={document.body.firstChild}
+        appendTo={document.body}
         onChange={() => {}}>
         <DatePickerInput
           key="label"
@@ -166,9 +166,7 @@ describe('DatePicker', () => {
     });
 
     it('sends appendTo to Flatpickr', () => {
-      expect(wrapper.instance().cal.config.appendTo).toBe(
-        document.body.firstChild
-      );
+      expect(wrapper.instance().cal.config.appendTo).toBe(document.body);
     });
   });
 
@@ -444,6 +442,22 @@ describe('Focus management', () => {
   });
 
   it('focuses on calendar dropdown when focus goes next to the date picker input', () => {
+    wrapper = mount(
+      <>
+        <input id="dummy-focus-node-before" type="text" />
+        <DatePicker
+          onChange={() => {}}
+          datePickerType="single"
+          className="extra-class"
+          appendTo={document.body}>
+          <div className="test-child">
+            <input type="text" className={`${prefix}--date-picker__input`} />
+          </div>
+        </DatePicker>
+        <input id="dummy-focus-node-after" type="text" />
+      </>
+    );
+
     const datePicker = wrapper.find('DatePicker').instance();
     datePicker.cal.open();
     datePicker.cal.selectedDateElem = {

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -247,7 +247,7 @@ export default class DatePicker extends Component {
 
   componentDidMount() {
     const {
-      appendTo,
+      appendTo = this._container.current,
       datePickerType,
       dateFormat,
       id = this._instanceId,
@@ -296,6 +296,7 @@ export default class DatePicker extends Component {
               container: this._container.current,
               inputFrom: this.inputField,
               inputTo: this.toInputField,
+              appendTo,
             }),
           ],
           clickOpens: true,

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -18,11 +18,8 @@ import carbonFlatpickrFocusPlugin from './plugins/focusPlugin';
 import carbonFlatpickrMonthSelectPlugin from './plugins/monthSelectPlugin';
 import carbonFlatpickrRangePlugin from './plugins/rangePlugin';
 import { match, keys } from '../../internal/keyboard';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
 
 const { prefix } = settings;
-
-const getInstanceId = setupGetInstanceId();
 
 // Weekdays shorthand for english locale
 l10n.en.weekdays.shorthand.forEach((day, index) => {
@@ -229,7 +226,6 @@ export default class DatePicker extends Component {
     locale: 'en',
   };
 
-  _instanceId = getInstanceId();
   _container = React.createRef();
 
   UNSAFE_componentWillUpdate(nextProps) {
@@ -250,7 +246,7 @@ export default class DatePicker extends Component {
       appendTo = this._container.current,
       datePickerType,
       dateFormat,
-      id = this._instanceId,
+      id,
       locale,
       minDate,
       maxDate,
@@ -488,7 +484,6 @@ export default class DatePicker extends Component {
       short,
       light,
       datePickerType,
-      id = this._instanceId,
       minDate, // eslint-disable-line
       maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
@@ -537,13 +532,7 @@ export default class DatePicker extends Component {
     });
     return (
       <div className={`${prefix}--form-item`}>
-        <div
-          ref={this._container}
-          className={datePickerClasses}
-          {...other}
-          aria-owns={
-            datePickerType === 'simple' ? undefined : `${id}__calendar`
-          }>
+        <div ref={this._container} className={datePickerClasses} {...other}>
           {childrenWithProps}
         </div>
       </div>

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -217,6 +217,16 @@ export default class DatePicker extends Component {
      * The maximum date that a user can pick to.
      */
     maxDate: PropTypes.string,
+
+    /**
+     * The assistive text for the previous month button.
+     */
+    prevMonthNavLabel: PropTypes.string,
+
+    /**
+     * The assistive text for the next month button.
+     */
+    nextMonthNavLabel: PropTypes.string,
   };
 
   static defaultProps = {
@@ -224,6 +234,8 @@ export default class DatePicker extends Component {
     light: false,
     dateFormat: 'm/d/Y',
     locale: 'en',
+    prevMonthNavLabel: 'Go to previous month',
+    nextMonthNavLabel: 'Go to next month',
   };
 
   _container = React.createRef();
@@ -251,6 +263,8 @@ export default class DatePicker extends Component {
       minDate,
       maxDate,
       value,
+      prevMonthNavLabel,
+      nextMonthNavLabel,
       onClose,
     } = this.props;
     if (datePickerType === 'single' || datePickerType === 'range') {
@@ -283,6 +297,8 @@ export default class DatePicker extends Component {
               selectorFlatpickrYearContainer: '.numInputWrapper',
               selectorFlatpickrCurrentMonth: '.cur-month',
               classFlatpickrCurrentMonth: 'cur-month',
+              prevMonthNavLabel,
+              nextMonthNavLabel,
             }),
             carbonFlatpickrFixEventsPlugin({
               inputFrom: this.inputField,

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -17,7 +17,6 @@ import carbonFlatpickrFixEventsPlugin from './plugins/fixEventsPlugin';
 import carbonFlatpickrFocusPlugin from './plugins/focusPlugin';
 import carbonFlatpickrMonthSelectPlugin from './plugins/monthSelectPlugin';
 import carbonFlatpickrRangePlugin from './plugins/rangePlugin';
-import { match, keys } from '../../internal/keyboard';
 
 const { prefix } = settings;
 
@@ -374,31 +373,11 @@ export default class DatePicker extends Component {
     }
   };
 
-  addKeyboardEvents = cal => {
+  addKeyboardEvents = () => {
     if (this.inputField) {
-      this.inputField.addEventListener('keydown', e => {
-        if (match(e, keys.ArrowDown)) {
-          (
-            cal.selectedDateElem ||
-            cal.todayDateElem ||
-            cal.calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
-            cal.calendarContainer
-          ).focus();
-        }
-      });
       this.inputField.addEventListener('change', this.onChange);
     }
     if (this.toInputField) {
-      this.toInputField.addEventListener('keydown', e => {
-        if (match(e, keys.ArrowDown)) {
-          (
-            cal.selectedDateElem ||
-            cal.todayDateElem ||
-            cal.calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
-            cal.calendarContainer
-          ).focus();
-        }
-      });
       this.toInputField.addEventListener('change', this.onChange);
     }
   };

--- a/packages/react/src/components/DatePicker/plugins/appendToPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/appendToPlugin.js
@@ -17,12 +17,8 @@ export default config => fp => {
    */
   const handlePreCalendarPosition = () => {
     Promise.resolve().then(() => {
-      const {
-        calendarContainer,
-        config: fpConfig,
-        _positionElement: positionElement,
-      } = fp;
-      const { appendTo } = fpConfig;
+      const { calendarContainer, _positionElement: positionElement } = fp;
+      const { appendTo } = config;
       const {
         left: containerLeft,
         top: containerTop,

--- a/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.js
@@ -27,9 +27,29 @@ export default config => fp => {
   };
 
   /**
+   * Cleans-up tab indices of prev/next month buttons.
+   */
+  const handleCloseCalendarDropdown = () => {
+    const { calendarContainer } = fp;
+    const prevMonthNav = calendarContainer.querySelector(
+      '.flatpickr-prev-month'
+    );
+    if (prevMonthNav) {
+      prevMonthNav.tabIndex = '0';
+    }
+    const nextMonthNav = calendarContainer.querySelector(
+      '.flatpickr-next-month'
+    );
+    if (nextMonthNav) {
+      nextMonthNav.tabIndex = '0';
+    }
+  };
+
+  /**
    * Handles `keydown` event.
    */
   const handleKeydown = event => {
+    const { calendarContainer } = fp;
     const { inputFrom, inputTo } = config;
     const { target } = event;
     if (inputFrom === target || inputTo === target) {
@@ -54,6 +74,20 @@ export default config => fp => {
         event.preventDefault();
         fp.open();
         setTimeout(() => {
+          // Makes prev/next month buttons not sequential-focusable
+          // when user hits down arrow keys to open calendar dropdown
+          const prevMonthNav = calendarContainer.querySelector(
+            '.flatpickr-prev-month'
+          );
+          if (prevMonthNav) {
+            prevMonthNav.tabIndex = '-1';
+          }
+          const nextMonthNav = calendarContainer.querySelector(
+            '.flatpickr-next-month'
+          );
+          if (nextMonthNav) {
+            nextMonthNav.tabIndex = '-1';
+          }
           focusOnCalendar();
         }, 100); // VO seems to attempt to steal focus back to `<input>` for unknown reason
       }
@@ -91,6 +125,7 @@ export default config => fp => {
   };
 
   return {
+    onClose: [handleCloseCalendarDropdown],
     onReady: [register, init],
     onDestroy: [release],
   };

--- a/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.js
@@ -12,6 +12,20 @@ import { match, keys } from '../../../internal/keyboard';
  * @returns {Plugin} A Flatpickr plugin to fix Flatpickr's behavior of certain events.
  */
 export default config => fp => {
+  const focusOnCalendar = () => {
+    const focusTarget =
+      fp.selectedDateElem ||
+      fp.todayDateElem ||
+      fp.calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
+      fp.calendarContainer;
+    if (focusTarget) {
+      if (focusTarget !== fp.calendarContainer) {
+        focusTarget.tabIndex = '0';
+      }
+      focusTarget.focus();
+    }
+  };
+
   /**
    * Handles `keydown` event.
    */
@@ -39,6 +53,9 @@ export default config => fp => {
       } else if (match(event, keys.ArrowDown)) {
         event.preventDefault();
         fp.open();
+        setTimeout(() => {
+          focusOnCalendar();
+        }, 100); // VO seems to attempt to steal focus back to `<input>` for unknown reason
       }
     }
   };

--- a/packages/react/src/components/DatePicker/plugins/focusPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/focusPlugin.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  DOCUMENT_POSITION_BROAD_PRECEDING,
+  DOCUMENT_POSITION_BROAD_FOLLOWING,
+} from '../../../internal/keyboard/navigation';
+
+/**
+ * @param config Plugin configuration.
+ * @returns A Flatpickr plugin to manage focus to align with the UX pattern in our design system.
+ */
+export default config => fp => {
+  /**
+   * Focuses on calendar dropdown.
+   */
+  const focusCalendar = () => {
+    const { calendarContainer, selectedDateElem, todayDateElem } = fp;
+    (selectedDateElem || todayDateElem || calendarContainer).focus();
+  };
+
+  /**
+   * Handles `focusin` event to ensure an day element in calendar dropdown is sequential-focusable
+   * when it gets focus.
+   * Doing so ensures the next sequential-focusable element of an day element won't be date picker `<input>`.
+   */
+  const handleFocusCalendarDropdown = ({ target: currentActiveNode }) => {
+    const currentDayElem =
+      currentActiveNode && currentActiveNode.closest('.flatpickr-day');
+    if (currentDayElem) {
+      currentDayElem.tabIndex = 0;
+    }
+  };
+
+  /**
+   * Handles `focusout` event to:
+   *
+   * * Ensure an day element in calendar dropdown is non-sequential-focusable when it loses focus
+   * * Move the focus back to the `<input>`
+   */
+  const handleBlurCalendarDropdown = ({
+    target: oldActiveNode,
+    relatedTarget: currentActiveNode,
+  }) => {
+    const oldDayElem = oldActiveNode && oldActiveNode.closest('.flatpickr-day');
+    if (oldDayElem) {
+      oldDayElem.tabIndex = -1;
+    }
+    const { inputFrom, inputTo } = config;
+    const { calendarContainer, isOpen } = fp;
+    if (
+      isOpen &&
+      calendarContainer.contains(oldActiveNode) &&
+      !calendarContainer.contains(currentActiveNode)
+    ) {
+      const comparisonResult = !currentActiveNode
+        ? DOCUMENT_POSITION_BROAD_FOLLOWING
+        : oldActiveNode.compareDocumentPosition(currentActiveNode);
+      setTimeout(() => {
+        // This `focusout` event handler can be called from Flatpickr's code cleaning up calenar dropdown's DOM,
+        // and changing focus in such condition causes removing an orphaned DOM node,
+        // because Flatpickr redraws the calendar dropdown when the `<input>` gets focus.
+        if (comparisonResult & DOCUMENT_POSITION_BROAD_PRECEDING) {
+          (inputTo || inputFrom).focus();
+        } else {
+          // When VO cursor moves onto the `<input>` for year, keyboard focus is temporary lost for some reason.
+          // Ensure we don't close the calanedar dropdown in such condition.
+          const lostFocusWasTemporary = calendarContainer.contains(
+            document.activeElement
+          );
+          if (!lostFocusWasTemporary) {
+            // Closing after moving focus. Reversing the order will cause re-opening calendar dropdown upon focusing
+            fp.close();
+          }
+        }
+      }, 0);
+    }
+  };
+
+  /**
+   * Handles `focusout` event on the date picker container to focus on the calendar dropdown or close the calendar dropdown.
+   */
+  const handleBlurContainer = ({
+    target: oldActiveNode,
+    relatedTarget: currentActiveNode,
+  }) => {
+    const { container } = config;
+    const { calendarContainer, isOpen } = fp;
+    let shouldFocusOnCalendarDropdown = false;
+    if (
+      isOpen &&
+      container &&
+      oldActiveNode &&
+      currentActiveNode &&
+      container.contains(oldActiveNode) &&
+      !container.contains(currentActiveNode)
+    ) {
+      const comparisonResult = oldActiveNode.compareDocumentPosition(
+        currentActiveNode
+      );
+      if (comparisonResult & DOCUMENT_POSITION_BROAD_FOLLOWING) {
+        shouldFocusOnCalendarDropdown = true;
+      }
+    }
+    if (shouldFocusOnCalendarDropdown) {
+      focusCalendar();
+    } else if (!calendarContainer.contains(currentActiveNode)) {
+      fp.close();
+    }
+  };
+
+  /**
+   * Releases event listeners used in this Flatpickr plugin.
+   */
+  const release = () => {
+    const { container } = config;
+    container.removeEventListener('focusout', handleBlurContainer);
+    fp.calendarContainer.removeEventListener(
+      'focusout',
+      handleBlurCalendarDropdown
+    );
+    fp.calendarContainer.removeEventListener(
+      'focusin',
+      handleFocusCalendarDropdown
+    );
+  };
+
+  /**
+   * Sets up event listeners used for this Flatpickr plugin.
+   */
+  const init = () => {
+    release();
+    const { container } = config;
+    fp.calendarContainer.addEventListener(
+      'focusin',
+      handleFocusCalendarDropdown
+    );
+    fp.calendarContainer.addEventListener(
+      'focusout',
+      handleBlurCalendarDropdown
+    );
+    container.addEventListener('focusout', handleBlurContainer);
+  };
+
+  /**
+   * Registers this Flatpickr plugin.
+   */
+  const register = () => {
+    fp.loadedPlugins.push('carbonFlatpickrFocusPlugin');
+  };
+
+  return {
+    onReady: [register, init],
+    onDestroy: release,
+  };
+};

--- a/packages/react/src/components/DatePicker/plugins/focusPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/focusPlugin.js
@@ -43,8 +43,11 @@ export default config => fp => {
    * Doing so ensures the next sequential-focusable element of an day element won't be date picker `<input>`.
    */
   const handleFocusCalendarDropdown = ({ target: currentActiveNode }) => {
+    const { selectedDateElem, todayDateElem } = fp;
     const currentDayElem =
-      currentActiveNode && currentActiveNode.closest('.flatpickr-day');
+      (currentActiveNode && currentActiveNode.closest('.flatpickr-day')) ||
+      selectedDateElem ||
+      todayDateElem;
     if (currentDayElem) {
       cleanDayElemTabIndices();
       currentDayElem.tabIndex = 0;
@@ -111,12 +114,13 @@ export default config => fp => {
     target: oldActiveNode,
     relatedTarget: currentActiveNode,
   }) => {
-    const { container } = config;
+    const { container, appendTo } = config;
     const { calendarContainer, isOpen } = fp;
     let shouldFocusOnCalendarDropdown = false;
     if (
       isOpen &&
       container &&
+      !container.contains(appendTo) &&
       oldActiveNode &&
       currentActiveNode &&
       container.contains(oldActiveNode) &&

--- a/packages/react/src/components/DatePicker/plugins/monthSelectPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/monthSelectPlugin.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright IBM Corp. 2019, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @param {number} monthNumber The month number.
+ * @param {boolean} shorthand `true` to use shorthand month.
+ * @param {Locale} locale The Flatpickr locale data.
+ * @returns {string} The month string.
+ */
+const monthToStr = (monthNumber, shorthand, locale) =>
+  locale.months[shorthand ? 'shorthand' : 'longhand'][monthNumber];
+
+/**
+ * @param {object} config Plugin configuration.
+ * @param {boolean} [config.shorthand] `true` to use shorthand month.
+ * @param {string} config.selectorFlatpickrMonthYearContainer The CSS selector for the container of month/year selection UI.
+ * @param {string} config.selectorFlatpickrYearContainer The CSS selector for the container of year selection UI.
+ * @param {string} config.selectorFlatpickrCurrentMonth The CSS selector for the text-based month selection UI.
+ * @param {string} config.classFlatpickrCurrentMonth The CSS class for the text-based month selection UI.
+ * @returns {Plugin} A Flatpickr plugin to use text instead of `<select>` for month picker.
+ */
+export default config => fp => {
+  const setupElements = () => {
+    if (fp.prevMonthNav) {
+      const prevMonthNav = document.createElement('button');
+      prevMonthNav.className = fp.prevMonthNav.className;
+      while (fp.prevMonthNav.firstChild) {
+        prevMonthNav.appendChild(fp.prevMonthNav.firstChild);
+      }
+      fp.prevMonthNav.parentNode.replaceChild(prevMonthNav, fp.prevMonthNav);
+    }
+    if (fp.nextMonthNav) {
+      const nextMonthNav = document.createElement('button');
+      nextMonthNav.className = fp.nextMonthNav.className;
+      while (fp.nextMonthNav.firstChild) {
+        nextMonthNav.appendChild(fp.nextMonthNav.firstChild);
+      }
+      fp.nextMonthNav.parentNode.replaceChild(nextMonthNav, fp.nextMonthNav);
+    }
+    if (fp.monthElements) {
+      fp.monthElements.forEach(elem => {
+        if (!elem.parentNode) return;
+        elem.parentNode.removeChild(elem);
+      });
+      fp.monthElements.splice(
+        0,
+        fp.monthElements.length,
+        ...fp.monthElements.map(() => {
+          // eslint-disable-next-line no-underscore-dangle
+          const monthElement = fp._createElement(
+            'span',
+            config.classFlatpickrCurrentMonth
+          );
+          monthElement.textContent = monthToStr(
+            fp.currentMonth,
+            config.shorthand === true,
+            fp.l10n
+          );
+          fp.yearElements[0]
+            .closest(config.selectorFlatpickrMonthYearContainer)
+            .insertBefore(
+              monthElement,
+              fp.yearElements[0].closest(config.selectorFlatpickrYearContainer)
+            );
+          return monthElement;
+        })
+      );
+    }
+  };
+
+  const updateCurrentMonth = () => {
+    const monthStr = monthToStr(
+      fp.currentMonth,
+      config.shorthand === true,
+      fp.l10n
+    );
+    fp.yearElements.forEach(elem => {
+      const currentMonthContainer = elem.closest(
+        config.selectorFlatpickrMonthYearContainer
+      );
+      Array.prototype.forEach.call(
+        currentMonthContainer.querySelectorAll('.cur-month'),
+        monthElement => {
+          monthElement.textContent = monthStr;
+        }
+      );
+    });
+  };
+
+  const register = () => {
+    fp.loadedPlugins.push('carbonFlatpickrMonthSelectPlugin');
+  };
+
+  return {
+    onMonthChange: updateCurrentMonth,
+    onValueUpdate: updateCurrentMonth,
+    onOpen: updateCurrentMonth,
+    onReady: [setupElements, updateCurrentMonth, register],
+  };
+};

--- a/packages/react/src/components/DatePicker/plugins/monthSelectPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/monthSelectPlugin.js
@@ -21,13 +21,17 @@ const monthToStr = (monthNumber, shorthand, locale) =>
  * @param {string} config.selectorFlatpickrYearContainer The CSS selector for the container of year selection UI.
  * @param {string} config.selectorFlatpickrCurrentMonth The CSS selector for the text-based month selection UI.
  * @param {string} config.classFlatpickrCurrentMonth The CSS class for the text-based month selection UI.
+ * @param {string} config.prevMonthNavLabel The assistive text for the previous month button.
+ * @param {string} config.nextMonthNavLabel The assistive text for the next month button.
  * @returns {Plugin} A Flatpickr plugin to use text instead of `<select>` for month picker.
  */
 export default config => fp => {
   const setupElements = () => {
+    const { prevMonthNavLabel, nextMonthNavLabel } = config;
     if (fp.prevMonthNav) {
       const prevMonthNav = document.createElement('button');
       prevMonthNav.className = fp.prevMonthNav.className;
+      prevMonthNav.setAttribute('aria-label', prevMonthNavLabel);
       while (fp.prevMonthNav.firstChild) {
         prevMonthNav.appendChild(fp.prevMonthNav.firstChild);
       }
@@ -36,6 +40,7 @@ export default config => fp => {
     if (fp.nextMonthNav) {
       const nextMonthNav = document.createElement('button');
       nextMonthNav.className = fp.nextMonthNav.className;
+      nextMonthNav.setAttribute('aria-label', nextMonthNavLabel);
       while (fp.nextMonthNav.firstChild) {
         nextMonthNav.appendChild(fp.nextMonthNav.firstChild);
       }


### PR DESCRIPTION
This change makes VO cursor moves to calendar dropdown as the next element to date picker input.

Also contains the following changes:

* Ensures hitting tab key on date picker input focuses on calendar dropdown, to align to the new VO cursor behavior
* Make the arrow for previous/next month focusable
* Moves an old Flatpickr plugin code to a separate file

Refs #5310.

#### Changelog

**New**

- An ARIA attribute to make VO cursor moves to calendar dropdown as the next element to date picker input.
- A Flatpick plugin to make tab/shift-tab key behaviors align to such new VO cursor behavior.

**Changed**

* Make the arrow for previous/next month focusable.
* Moves an old Flatpickr plugin code to a separate file.

#### Testing / Reviewing

Testing should make sure our date picker is not broken.