### PR TITLE
feat(date-picker): add size variants

### DIFF
--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -119,6 +119,15 @@
     }
   }
 
+  // Size variant styles
+  .#{$prefix}--date-picker__input--xl {
+    height: rem(48px);
+  }
+
+  .#{$prefix}--date-picker__input--sm {
+    height: rem(32px);
+  }
+
   .#{$prefix}--date-picker__icon {
     position: absolute;
     right: 1rem;

--- a/packages/react/src/components/DatePicker/DatePicker-story.js
+++ b/packages/react/src/components/DatePicker/DatePicker-story.js
@@ -28,7 +28,7 @@ const patterns = {
 
 const sizes = {
   'Extra large size (xl)': 'xl',
-  'Regular size (lg)': undefined,
+  'Default size': undefined,
   'Small size (sm)': 'sm',
 };
 

--- a/packages/react/src/components/DatePicker/DatePicker-story.js
+++ b/packages/react/src/components/DatePicker/DatePicker-story.js
@@ -26,6 +26,12 @@ const patterns = {
   'Regular (d{1,2}/d{1,2}/d{4})': '\\d{1,2}/\\d{1,2}/\\d{4}',
 };
 
+const sizes = {
+  'Extra large size (xl)': 'xl',
+  'Regular size (lg)': '',
+  'Small size (sm)': 'sm',
+};
+
 const props = {
   datePicker: () => ({
     id: 'date-picker',
@@ -36,6 +42,7 @@ const props = {
   datePickerInput: () => ({
     id: 'date-picker-input-id',
     className: 'some-class',
+    size: select('Field size (size)', sizes, '') || undefined,
     labelText: text(
       'Label text (labelText in <DatePickerInput>)',
       'Date Picker label'

--- a/packages/react/src/components/DatePicker/DatePicker-story.js
+++ b/packages/react/src/components/DatePicker/DatePicker-story.js
@@ -28,7 +28,7 @@ const patterns = {
 
 const sizes = {
   'Extra large size (xl)': 'xl',
-  'Regular size (lg)': '',
+  'Regular size (lg)': undefined,
   'Small size (sm)': 'sm',
 };
 
@@ -42,7 +42,7 @@ const props = {
   datePickerInput: () => ({
     id: 'date-picker-input-id',
     className: 'some-class',
-    size: select('Field size (size)', sizes, '') || undefined,
+    size: select('Field size (size)', sizes, undefined) || undefined,
     labelText: text(
       'Label text (labelText in <DatePickerInput>)',
       'Date Picker label'

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.js
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.js
@@ -32,6 +32,11 @@ export default class DatePickerInput extends Component {
     labelText: PropTypes.node.isRequired,
 
     /**
+     * Specify the size of the Text Input. Currently supports either `sm` or `xl` as an option.
+     */
+    size: PropTypes.oneOf(['sm', 'xl']),
+
+    /**
      * Provide a regular expression that the input value must match
      */
     pattern: (props, propName, componentName) => {
@@ -99,6 +104,7 @@ export default class DatePickerInput extends Component {
       pattern,
       iconDescription,
       openCalendar,
+      size,
       ...other
     } = this.props;
 
@@ -122,6 +128,10 @@ export default class DatePickerInput extends Component {
     const labelClasses = classNames(`${prefix}--label`, {
       [`${prefix}--visually-hidden`]: hideLabel,
       [`${prefix}--label--disabled`]: disabled,
+    });
+
+    const inputClasses = classNames(`${prefix}--date-picker__input`, {
+      [`${prefix}--date-picker__input--${size}`]: size,
     });
 
     const datePickerIcon = (() => {
@@ -162,7 +172,7 @@ export default class DatePickerInput extends Component {
           this.input = input;
         }}
         data-invalid
-        className={`${prefix}--date-picker__input`}
+        className={inputClasses}
       />
     ) : (
       <input
@@ -172,7 +182,7 @@ export default class DatePickerInput extends Component {
         {...other}
         {...datePickerInputProps}
         disabled={disabled}
-        className={`${prefix}--date-picker__input`}
+        className={inputClasses}
       />
     );
 

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.js
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.js
@@ -32,9 +32,9 @@ export default class DatePickerInput extends Component {
     labelText: PropTypes.node.isRequired,
 
     /**
-     * Specify the size of the Text Input. Currently supports either `sm` or `xl` as an option.
+     * Specify the size of the Date Picker Input. Currently supports either `sm` or `xl` as an option. Defaults to ''.
      */
-    size: PropTypes.oneOf(['sm', 'xl']),
+    size: PropTypes.oneOf(['sm', 'xl', '']),
 
     /**
      * Provide a regular expression that the input value must match
@@ -86,6 +86,7 @@ export default class DatePickerInput extends Component {
     invalid: false,
     onClick: () => {},
     onChange: () => {},
+    size: '',
   };
 
   render() {

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.js
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.js
@@ -32,9 +32,9 @@ export default class DatePickerInput extends Component {
     labelText: PropTypes.node.isRequired,
 
     /**
-     * Specify the size of the Date Picker Input. Currently supports either `sm` or `xl` as an option. Defaults to ''.
+     * Specify the size of the Date Picker Input. Currently supports either `sm` or `xl` as an option.
      */
-    size: PropTypes.oneOf(['sm', 'xl', '']),
+    size: PropTypes.oneOf(['sm', 'xl']),
 
     /**
      * Provide a regular expression that the input value must match
@@ -86,7 +86,6 @@ export default class DatePickerInput extends Component {
     invalid: false,
     onClick: () => {},
     onChange: () => {},
-    size: '',
   };
 
   render() {


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/5448

Adds in `sm` and `xl` versions of `DatePicker`.

#### Changelog

**New**

- `xl` and `sm` styles for `DatePicker` 
- Knob to change sizes in the storybook

#### Testing / Reviewing

Go to `DatePicker` --> `knobs` and change the size. Ensure the valid/invalid states in various sizes are correct