### PR TITLE
fix(text-input): allow empty string for size prop

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -148,7 +148,7 @@ TextInput.propTypes = {
   /**
    * Specify the size of the Text Input. Currently supports either `sm` or `xl` as an option.
    */
-  size: PropTypes.oneOf(['sm', 'xl']),
+  size: PropTypes.oneOf(['sm', 'xl', '']),
 
   /**
    * Specify the type of the <input>


### PR DESCRIPTION
Closes #5469 

Currently `size` is an empty string but default, but that is not allowed in the propTypes declaration. The generates errors where ever `TextInput` is used (including in storybook built off the latest).

#### Changelog

**Changed**

- allow empty string for `size` prop

#### Testing / Reviewing

See that there are no propTypes errors in the console when you view the storybook deploy, compared to the `master` branch (or canary) storybook environment.
