### PR TITLE
feat(FloatingMenu): conditionally set focus in floating menu on menu open

### DIFF
--- a/packages/components/src/components/link/_link.scss
+++ b/packages/components/src/components/link/_link.scss
@@ -27,7 +27,7 @@
     color: $link-01;
     text-decoration: none;
     outline: none;
-    transition: $duration--fast-01 motion(standard, productive);
+    transition: color $duration--fast-01 motion(standard, productive);
 
     &:hover {
       color: $hover-primary-text;

--- a/packages/components/src/globals/js/settings.js
+++ b/packages/components/src/globals/js/settings.js
@@ -21,9 +21,13 @@
  * // @todo given that the default value is so long, is it appropriate to put in the JSDoc?
  * @property {string} [selectorTabbable]
  *   A selector selecting tabbable/focusable nodes.
- *   By default selectorTabbable refereneces links, areas, inputs, buttons, selects, textareas,
+ *   By default selectorTabbable references links, areas, inputs, buttons, selects, textareas,
  *   iframes, objects, embeds, or elements explicitly using tabindex or contenteditable attributes
  *   as long as the element is not `disabled` or the `tabindex="-1"`.
+ * @property {string} [selectorFocusable]
+ *   CSS selector that selects major nodes that are click focusable
+ *   This property is identical to selectorTabbable with the exception of
+ *   the `:not([tabindex='-1'])` pseudo class
  */
 const settings = {
   prefix: 'bx',

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3830,9 +3830,7 @@ Map {
       "onMouseUp": Object {
         "type": "func",
       },
-      "primaryFocus": Object {
-        "type": "bool",
-      },
+      "primaryFocus": [Function],
       "requireTitle": Object {
         "type": "bool",
       },

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2397,6 +2397,7 @@ exports[`DataTable should render 1`] = `
                         "render": [Function],
                       }
                     }
+                    selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                     tabIndex={0}
                     title="Settings"
                   >
@@ -3373,6 +3374,7 @@ exports[`DataTable sticky header should render 1`] = `
                         "render": [Function],
                       }
                     }
+                    selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
                     tabIndex={0}
                     title="Settings"
                   >

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
@@ -45,6 +45,7 @@ exports[`DataTable.TableToolbarMenu should render 1`] = `
           "render": [Function],
         }
       }
+      selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
       tabIndex={0}
       title="Add"
     >

--- a/packages/react/src/components/DataTable/stories/with-overflow-menu.js
+++ b/packages/react/src/components/DataTable/stories/with-overflow-menu.js
@@ -55,7 +55,7 @@ export default props => (
                 ))}
                 <TableCell className="bx--table-column-menu">
                   <OverflowMenu flipped>
-                    <OverflowMenuItem primaryFocus>Action 1</OverflowMenuItem>
+                    <OverflowMenuItem>Action 1</OverflowMenuItem>
                     <OverflowMenuItem>Action 2</OverflowMenuItem>
                     <OverflowMenuItem>Action 3</OverflowMenuItem>
                   </OverflowMenu>

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -55,11 +55,7 @@ storiesOf('OverflowMenu', module)
     'basic',
     withReadme(OverflowREADME, () => (
       <OverflowMenu {...props.menu()}>
-        <OverflowMenuItem
-          {...props.menuItem()}
-          itemText="Option 1"
-          primaryFocus
-        />
+        <OverflowMenuItem {...props.menuItem()} itemText="Option 1" />
         <OverflowMenuItem
           {...props.menuItem()}
           itemText="Option 2 is an example of a really long string and how we recommend handling this"
@@ -94,7 +90,6 @@ storiesOf('OverflowMenu', module)
             href: 'https://www.ibm.com',
           }}
           itemText="Option 1"
-          primaryFocus
         />
         <OverflowMenuItem
           {...{
@@ -150,11 +145,7 @@ storiesOf('OverflowMenu', module)
           style: { width: 'auto' },
           renderIcon: () => <div style={{ padding: '0 1rem' }}>Menu</div>,
         }}>
-        <OverflowMenuItem
-          {...props.menuItem()}
-          itemText="Option 1"
-          primaryFocus
-        />
+        <OverflowMenuItem {...props.menuItem()} itemText="Option 1" />
         <OverflowMenuItem
           {...props.menuItem()}
           itemText="Option 2 is an example of a really long string and how we recommend handling this"

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -26,6 +26,10 @@ const props = {
     iconDescription: text('Icon description (iconDescription)', ''),
     flipped: boolean('Flipped (flipped)', false),
     light: boolean('Light (light)', false),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      ''
+    ),
     onClick: action('onClick'),
     onFocus: action('onFocus'),
     onKeyDown: action('onKeyDown'),

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -429,7 +429,7 @@ class OverflowMenu extends Component {
       iconClass,
       onClick, // eslint-disable-line
       onOpen, // eslint-disable-line
-      selectorPrimaryFocus, // eslint-disable-line
+      selectorPrimaryFocus = '[data-floating-menu-primary-focus]', // eslint-disable-line
       renderIcon: IconElement,
       innerRef: ref,
       menuOptionsClass,

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -208,6 +208,12 @@ class OverflowMenu extends Component {
      * Don't use this to make OverflowMenu background color same as container background color.
      */
     light: PropTypes.bool,
+
+    /**
+     * Specify a CSS selector that matches the DOM element that should
+     * be focused when the OverflowMenu opens
+     */
+    selectorPrimaryFocus: PropTypes.string,
   };
 
   static defaultProps = {
@@ -225,6 +231,7 @@ class OverflowMenu extends Component {
     menuOffset: getMenuOffset,
     menuOffsetFlip: getMenuOffset,
     light: false,
+    selectorPrimaryFocus: '[data-overflow-menu-primary-focus]',
   };
 
   /**
@@ -245,26 +252,6 @@ class OverflowMenu extends Component {
    * @private
    */
   _triggerRef = React.createRef();
-
-  getPrimaryFocusableElement = () => {
-    const { current: triggerEl } = this._triggerRef;
-    if (triggerEl) {
-      const primaryFocusPropEl = triggerEl.querySelector(
-        '[data-floating-menu-primary-focus]'
-      );
-      if (primaryFocusPropEl) {
-        return primaryFocusPropEl;
-      }
-    }
-    const firstItem = this.overflowMenuItem0;
-    if (
-      firstItem &&
-      firstItem.overflowMenuItem &&
-      firstItem.overflowMenuItem.current
-    ) {
-      return firstItem.overflowMenuItem.current;
-    }
-  };
 
   componentDidUpdate(_, prevState) {
     const { onClose } = this.props;
@@ -393,10 +380,6 @@ class OverflowMenu extends Component {
   _handlePlace = menuBody => {
     if (menuBody) {
       this._menuBody = menuBody;
-      const primaryFocus =
-        menuBody.querySelector('[data-floating-menu-primary-focus]') ||
-        menuBody;
-      primaryFocus.focus();
       const hasFocusin = 'onfocusin' in window;
       const focusinEventName = hasFocusin ? 'focusin' : 'focus';
       this._hFocusIn = on(
@@ -446,6 +429,7 @@ class OverflowMenu extends Component {
       iconClass,
       onClick, // eslint-disable-line
       onOpen, // eslint-disable-line
+      selectorPrimaryFocus, // eslint-disable-line
       renderIcon: IconElement,
       innerRef: ref,
       menuOptionsClass,
@@ -509,7 +493,8 @@ class OverflowMenu extends Component {
         menuRef={this._bindMenuBody}
         flipped={this.props.flipped}
         target={this._getTarget}
-        onPlace={this._handlePlace}>
+        onPlace={this._handlePlace}
+        selectorPrimaryFocus={this.props.selectorPrimaryFocus}>
         {React.cloneElement(menuBody, {
           'data-floating-menu-direction': direction,
         })}

--- a/packages/react/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/packages/react/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -120,7 +120,6 @@ export default class OverflowMenuItem extends React.Component {
       onClick, // eslint-disable-line
       handleOverflowMenuItemFocus, // eslint-disable-line
       onKeyDown,
-      primaryFocus,
       wrapperClassName,
       requireTitle,
       index,
@@ -149,9 +148,6 @@ export default class OverflowMenuItem extends React.Component {
       },
       wrapperClassName
     );
-    const primaryFocusProp = primaryFocus
-      ? { 'data-floating-menu-primary-focus': true }
-      : {};
     const TagToUse = href ? 'a' : 'button';
     const OverflowMenuItemContent = (() => {
       if (typeof itemText !== 'string') {
@@ -167,7 +163,6 @@ export default class OverflowMenuItem extends React.Component {
       <li className={overflowMenuItemClasses} role="menuitem">
         <TagToUse
           {...other}
-          {...primaryFocusProp}
           href={href}
           className={overflowMenuBtnClasses}
           disabled={disabled}

--- a/packages/react/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/packages/react/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import warning from 'warning';
 import { settings } from 'carbon-components';
 import { match, keys } from '../../internal/keyboard';
+import deprecate from '../../prop-types/deprecate.js';
 
 const { prefix } = settings;
 
@@ -72,7 +73,13 @@ export default class OverflowMenuItem extends React.Component {
     /**
      * `true` if this menu item should get focus when the menu gets open.
      */
-    primaryFocus: PropTypes.bool,
+    primaryFocus: deprecate(
+      PropTypes.bool,
+      'The `primaryFocus` prop has been deprecated as it is no longer used. ' +
+        'Feel free to remove this prop from <OverflowMenuItem>. This prop will ' +
+        'be removed in the next major release of `carbon-components-react`. ' +
+        'Opt for `selectorPrimaryFocus` in `<OverflowMenu>` instead'
+    ),
 
     /**
      * `true` if this menu item has long text and requires a browser tooltip
@@ -120,6 +127,7 @@ export default class OverflowMenuItem extends React.Component {
       onClick, // eslint-disable-line
       handleOverflowMenuItemFocus, // eslint-disable-line
       onKeyDown,
+      primaryFocus,
       wrapperClassName,
       requireTitle,
       index,
@@ -163,6 +171,7 @@ export default class OverflowMenuItem extends React.Component {
       <li className={overflowMenuItemClasses} role="menuitem">
         <TagToUse
           {...other}
+          {...{ 'data-floating-menu-primary-focus': primaryFocus || null }}
           href={href}
           className={overflowMenuBtnClasses}
           disabled={disabled}

--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -25,18 +25,30 @@ const props = {
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      ''
+    ),
   }),
   withoutIcon: () => ({
     showIcon: false,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      ''
+    ),
   }),
   customIcon: () => ({
     showIcon: true,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      ''
+    ),
     renderIcon: React.forwardRef((props, ref) => (
       <div ref={ref}>
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
@@ -52,6 +64,10 @@ const props = {
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
     iconDescription: 'Helpful Information',
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      ''
+    ),
     renderIcon: OverflowMenuVertical16,
   }),
 };

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -133,6 +133,12 @@ class Tooltip extends Component {
     direction: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
 
     /**
+     * Specify a CSS selector that matches the DOM element that should
+     * be focused when the Tooltip opens
+     */
+    selectorPrimaryFocus: PropTypes.string,
+
+    /**
      * The adjustment of the tooltip position.
      */
     menuOffset: PropTypes.oneOfType([
@@ -201,6 +207,7 @@ class Tooltip extends Component {
     showIcon: true,
     triggerText: null,
     menuOffset: getMenuOffset,
+    selectorPrimaryFocus: '[data-tooltip-primary-focus]',
   };
 
   /**
@@ -381,6 +388,7 @@ class Tooltip extends Component {
       menuOffset,
       tabIndex = 0,
       innerRef: ref,
+      selectorPrimaryFocus, // eslint-disable-line
       ...other
     } = this.props;
 
@@ -447,6 +455,7 @@ class Tooltip extends Component {
         </ClickListener>
         {open && (
           <FloatingMenu
+            selectorPrimaryFocus={this.props.selectorPrimaryFocus}
             target={this._getTarget}
             triggerRef={this._triggerRef}
             menuDirection={direction}

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -321,7 +321,7 @@ class FloatingMenu extends React.Component {
       warning(
         focusableNode === null,
         'Floating Menus must have at least a programmatically focusable child. ' +
-          'This can be accomplished by adding tabindex="-1" to the content element.'
+          'This can be accomplished by adding tabIndex="-1" to the content element.'
       );
     }
   };

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -307,7 +307,7 @@ class FloatingMenu extends React.Component {
    */
   _focusMenuContent = menuBody => {
     const primaryFocusNode = menuBody.querySelector(
-      this.props.selectorPrimaryFocus
+      this.props.selectorPrimaryFocus || null
     );
     const tabbableNode = menuBody.querySelector(selectorTabbable);
     const focusableNode = menuBody.querySelector(selectorFocusable);

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 import window from 'window-or-global';
 import { settings } from 'carbon-components';
 import OptimizedResize from './OptimizedResize';
+import { selectorFocusable, selectorTabbable } from './keyboard/navigation';
 
 const { prefix } = settings;
 
@@ -299,17 +300,41 @@ class FloatingMenu extends React.Component {
       this._updateMenuSize();
     });
   }
+  /**
+   * Set focus on floating menu content after menu placement.
+   * @param {Element} menuBody The DOM element of the menu body.
+   * @private
+   */
+  _focusMenuContent = menuBody => {
+    const primaryFocusNode = menuBody.querySelector(
+      this.props.selectorPrimaryFocus
+    );
+    const tabbableNode = menuBody.querySelector(selectorTabbable);
+    const focusableNode = menuBody.querySelector(selectorFocusable);
+    const focusTarget =
+      primaryFocusNode || // User defined focusable node
+      tabbableNode || // First sequentially focusable node
+      focusableNode || // First programmatic focusable node
+      menuBody;
+    focusTarget.focus();
+    if (focusTarget === menuBody && __DEV__) {
+      warning(
+        focusableNode === null,
+        'Floating Menus must have at least a programmatically focusable child. ' +
+          'This can be accomplished by adding tabindex="-1" to the content element.'
+      );
+    }
+  };
 
   componentDidUpdate(prevProps) {
     this._updateMenuSize(prevProps);
     const { onPlace } = this.props;
-    if (
-      this._placeInProgress &&
-      this.state.floatingPosition &&
-      typeof onPlace === 'function'
-    ) {
-      onPlace(this._menuBody);
-      this._placeInProgress = false;
+    if (this._placeInProgress && this.state.floatingPosition) {
+      this._focusMenuContent(this._menuBody);
+      if (typeof onPlace === 'function') {
+        onPlace(this._menuBody);
+        this._placeInProgress = false;
+      }
     }
   }
 

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -330,7 +330,9 @@ class FloatingMenu extends React.Component {
     this._updateMenuSize(prevProps);
     const { onPlace } = this.props;
     if (this._placeInProgress && this.state.floatingPosition) {
-      this._focusMenuContent(this._menuBody);
+      if (this._menuBody && !this._menuBody.contains(document.activeElement)) {
+        this._focusMenuContent(this._menuBody);
+      }
       if (typeof onPlace === 'function') {
         onPlace(this._menuBody);
         this._placeInProgress = false;

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -176,6 +176,12 @@ class FloatingMenu extends React.Component {
     ]),
 
     /**
+     * Specify a CSS selector that matches the DOM element that should
+     * be focused when the Modal opens
+     */
+    selectorPrimaryFocus: PropTypes.string,
+
+    /**
      * The additional styles to put to the floating menu.
      */
     styles: PropTypes.object,

--- a/packages/react/src/internal/keyboard/navigation.js
+++ b/packages/react/src/internal/keyboard/navigation.js
@@ -52,11 +52,21 @@ export const DOCUMENT_POSITION_BROAD_FOLLOWING =
   Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_CONTAINED_BY;
 
 /**
- * CSS selector that selects major nodes that is sequential-focusable.
+ * CSS selector that selects major nodes that are sequential-focusable.
  */
 export const selectorTabbable = `
   a[href], area[href], input:not([disabled]):not([tabindex='-1']),
   button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
   textarea:not([disabled]):not([tabindex='-1']),
   iframe, object, embed, *[tabindex]:not([tabindex='-1']), *[contenteditable=true]
+`;
+
+/**
+ * CSS selector that selects major nodes that are click focusable
+ */
+export const selectorFocusable = `
+  a[href], area[href], input:not([disabled]),
+  button:not([disabled]),select:not([disabled]),
+  textarea:not([disabled]),
+  iframe, object, embed, *[tabindex], *[contenteditable=true]
 `;


### PR DESCRIPTION
Closes #1264
Closes #5365
Closes #5488
related #4414

depends on #5456

This PR adds keyboard navigation features to our floating menus within the confines of the current component architecture.

#### Changelog

**New**

- `selectorPrimaryFocus` in floating menu to select custom targets (ref carbon-design-system/carbon-components-react#980)
- `selectorFocusable` constant to help with default focus targeting when `selectorPrimaryFocus` and `selectorTabbable` do not select any elements (ref #4268)

**Changed**

- consolidate shared keyboard navigation logic for overflow menu and interactive tooltip in floating menu code
- deprecate `primaryFocus` in OverflowMenuItem (which followed vanilla library pattern) in favor of CCR backwards compatible `selectorPrimaryFocus`

#### Testing / Reviewing

Ensure floating menu contents are keyboard navigable. Ensure keyboard navigation flow in floating menu components is as expected.