### PR TITLE
fix(icons): include build-info.json in files for svelte team

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -12,6 +12,7 @@
     "lib",
     "scss",
     "svg",
+    "build-info.json",
     "metadata.json"
   ],
   "keywords": [


### PR DESCRIPTION
Closes #5501

This change will expose an internal file `build-info.json` to be consumed by the svelte team for their icons.

#### Changelog

**New**

**Changed**

- Include `build-info.json` in `files` key of `package.json`

**Removed**
