### PR TITLE
test: mock lodash.debounce and recreate component in async test

### DIFF
--- a/packages/components/tests/spec/tooltip--simple_spec.js
+++ b/packages/components/tests/spec/tooltip--simple_spec.js
@@ -1,4 +1,3 @@
-import Promise, { delay } from 'bluebird';
 import Tooltip from '../../src/components/tooltip/tooltip--simple';
 import TooltipDefinitionHTML from '../../html/tooltip/tooltip--definition.html';
 import TooltipIconHTML from '../../html/tooltip/tooltip--icon.html';
@@ -95,15 +94,14 @@ describe('Test simple tooltip', function() {
     });
 
     it('Should not have visible class after mouseleave', async function() {
-      await new Promise(resolve => {
-        resolve(
-          element.dispatchEvent(
-            new CustomEvent('mouseleave', { bubbles: true })
-          )
-        );
+      return Tooltip.__with__({
+        debounce: fn => fn,
+      })(() => {
+        tooltip.release();
+        tooltip = new Tooltip(element);
+        element.dispatchEvent(new CustomEvent('mouseleave', { bubbles: true }));
+        expect(element.classList.contains('bx--tooltip--visible')).toBe(false);
       });
-      await delay(100);
-      expect(element.classList.contains('bx--tooltip--visible')).toBe(false);
     });
 
     it('Should not have hidden class after focus', function() {


### PR DESCRIPTION
Closes #5537

This PR replaces a timer based test with a mock for `lodash.debounce`, and reinstantiates the component within the async test function to replace the debounce function with the mocked version.

#### Testing / Reviewing

Ensure that tests are consistently passing CI (this may be difficult to test given the nature of the original issue and how it is not consistently reproducible)
