### PR TITLE
fix(type): update reset to use relative unit

### DIFF
--- a/packages/type/scss/_reset.scss
+++ b/packages/type/scss/_reset.scss
@@ -10,18 +10,18 @@
 @import 'styles';
 
 /// Include a type reset for a given body and mono font family
-/// @param {Number} $base-font-size [$carbon--base-font-size] - The base font size for your document
 /// @param {String} $body-font-family [carbon--font-family('sans')] - The font family used on the `<body>` element
 /// @param {String} $mono-font-family [carbon--font-family('mono')] - The font family used on elements that require mono fonts, like the `<code>` element
 /// @access public
 /// @group @carbon/type
 @mixin carbon--type-reset(
+  // TODO: remove in next major release. This has been replaced with 100%
   $base-font-size: $carbon--base-font-size,
   $body-font-family: carbon--font-family('sans'),
   $mono-font-family: carbon--font-family('mono')
 ) {
   html {
-    font-size: $base-font-size;
+    font-size: 100%;
   }
 
   body {

--- a/packages/type/scss/_reset.scss
+++ b/packages/type/scss/_reset.scss
@@ -16,7 +16,7 @@
 /// @group @carbon/type
 @mixin carbon--type-reset(
   // TODO: remove in next major release. This has been replaced with 100%
-  $base-font-size: $carbon--base-font-size,
+    $base-font-size: $carbon--base-font-size,
   $body-font-family: carbon--font-family('sans'),
   $mono-font-family: carbon--font-family('mono')
 ) {


### PR DESCRIPTION
We have used a fixed value for the font-size in `html` which incidentally causes text preferences to not be honored when set by the browser. This change updates the type reset to use a relative unit, `100%`, which should mean that our components respond appropriately when the user has browser preferences for text size.

#### Changelog

**New**

**Changed**

- `html` now has a base font-size of `100%`

**Removed**

#### Testing / Reviewing

- In your browser of choice, change your text size preferences to large and view the preview to verify that the components change instead of staying the same