### PR TITLE
fix(tooltip): wrap icon tooltip content

### DIFF
--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -29,6 +29,8 @@
 @mixin tooltip--content($tooltip-type: 'icon') {
   @include box-shadow;
   width: max-content;
+  min-width: rem(24px);
+  max-width: rem(208px);
   height: auto;
   padding: if(
     $tooltip-type == 'definition',


### PR DESCRIPTION
According to the design guidelines, tooltips should wrap their content when they reach their maximum width. This was initially introduced in #2783 but seems to have been missed in the new styles when refactoring the tooltips in #2781.

#### Changelog

**New**

- Added minimum and maximum width to tooltip styling

#### Testing / Reviewing

1. Run react storybook
2. Try out long texts in DefintionTooltip and IconTooltip
