### PR TITLE
fix(link): use hover color token for visited links

### DIFF
--- a/packages/components/src/components/link/_link.scss
+++ b/packages/components/src/components/link/_link.scss
@@ -30,7 +30,7 @@
     transition: $duration--fast-01 motion(standard, productive);
 
     &:hover {
-      color: $link-01;
+      color: $hover-primary-text;
       text-decoration: underline;
     }
 
@@ -57,7 +57,7 @@
     }
 
     &:visited:hover {
-      color: $link-01;
+      color: $hover-primary-text;
     }
   }
 


### PR DESCRIPTION
Closes #5549

This PR sets the link hover color tokens to `$hover-primary-text`

#### Testing / Reviewing

Verify that the link component matches the spec
