### PR TITLE
chore: simplify developer onboarding with gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN bash -cl ". .nvm/nvm.sh \
+  && nvm install 12 \
+  && nvm use 12 \
+  && npm install -g prettier yarn cross-env jest \
+  && echo -e \"\nnvm use 12\" >> ~/.bashrc"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: |
+      yarn install
+      yarn build
+      yarn test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   <a href="https://lernajs.io/">
     <img src="https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg" alt="Maintained with Lerna" />
   </a>
+  <a href="https://gitpod.io/#https://github.com/carbon-design-system/carbon"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"></a>
   <a href="https://github.com/carbon-design-system/carbon/blob/master/.github/CONTRIBUTING.md">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
   </a>
@@ -32,7 +33,7 @@
 
 ## Getting started
 
-If you're just getting started, check out
+If you're getting started, check out
 [`carbon-components`](./packages/components). If you're looking for React
 components, take a look at [`carbon-components-react`](./packages/react).
 
@@ -74,6 +75,8 @@ We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
 [Developer Guide](./docs/developer-handbook.md)! 👀
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/carbon-design-system/carbon)
 
 ## 📝 License
 


### PR DESCRIPTION
Closes #5540

![image](https://user-images.githubusercontent.com/50386709/76098747-a582db80-5f8f-11ea-8ca7-3ca01ac60008.png)

Simplifies contributor onboarding with Gitpod by creating an in the browser coding experience with all the tooling that they need. And will build and test the code on workspace start or even before see [the prebuild docs](https://www.gitpod.io/docs/prebuilds/)

#### Changelog

- Added a `.gitpod.yml` to define the experience
- Added a `.gitpod.Dockerfile` to define dependencies and what tooling to install

**Changed**

- Added a button so that people can see the readme, click the button, and just code without friction

**Removed**

- Nothing!

#### Testing / Reviewing
Please note that as I have prebuilds enabled on my account it will have prebuilds enabled which in the case of this repository save 15 minutes!

Try it in the browser

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/carbon)
