### PR TITLE
fix(dependencies): update icons dependency in vanilla

### DIFF
--- a/packages/components/docs/experimental.md
+++ b/packages/components/docs/experimental.md
@@ -155,7 +155,7 @@ For now, you can click the "expanded" viewing mode option and see the module
 name available for each icon in the second-to-last column. So if you are looking
 for the glyph version of an icon, you might see `/chevron--down` and in the far
 right-hand side of the table (when in expanded mode) you'd see
-`ChevronDownGlyph`. You can use this identifier alongside the `carbon-icons`
+`ChevronDownGlyph`. You can use this identifier alongside the `carbon-icon`
 helper by doing:
 
 ```hbs

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,10 +66,12 @@
     "freshy": ">= 1.0.3"
   },
   "dependencies": {
-    "carbon-icons": "^7.0.7",
     "flatpickr": "4.6.1",
     "lodash.debounce": "^4.0.8",
     "warning": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@carbon/icons": "^10.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Also moves the icon library dependency from `dependencies` to `peerDependencies` because icons in vanilla are something applications put in their HTML, rather than what vanilla library directly uses.

Fixes #5551.

#### Changelog

**New**

- `@carbon/icons` in `peerDependency` for vanilla `package.json`

**Removed**

- `carbon-icons` in `dependency` for vanilla `package.json`