### PR TITLE
fix(sketch): add undefined exception handler in icon generate script

### DIFF
--- a/packages/sketch/package.json
+++ b/packages/sketch/package.json
@@ -20,6 +20,7 @@
     "build": "cross-env NODE_ENV=production skpm-build",
     "clean": "rimraf carbon-elements.sketchplugin",
     "develop": "cross-env NODE_ENV=development skpm-build --watch",
+    "log": "skpm log -f",
     "skpm:link": "skpm-link"
   },
   "dependencies": {

--- a/packages/sketch/src/commands/command.js
+++ b/packages/sketch/src/commands/command.js
@@ -22,7 +22,7 @@ export function command(name, fn) {
     sketch.UI.message('Done! 🎉');
   } catch (error) {
     console.log(error);
-    sketch.UI.message('An error occured, please check the development logs');
+    sketch.UI.message('An error occurred, please check the development logs');
   }
 
   if (process.env.NODE_ENV === 'development') {

--- a/packages/sketch/src/commands/icons/generate.js
+++ b/packages/sketch/src/commands/icons/generate.js
@@ -68,6 +68,11 @@ export function generate() {
             const [_type, _category, _subcategory, name, size] = parts;
             return name === icon && size === '32';
           });
+
+          if (!symbol) {
+            throw new Error(`Unable to find symbol for icon ${icon}!`);
+          }
+
           const instance = symbol.createNewInstance();
           instance.frame.offset(ICON_X_OFFSET, ICON_Y_OFFSET);
 


### PR DESCRIPTION
Closes #5582

This PR avoid pushing `undefined` as a Layer object to Sketch in the icon page generation script and adds an npm script for viewing the development log

#### Changelog

**New**

- `log` npm script for viewing the development log

**Changed**

- `undefined` exception handler in icons/generate script

#### Testing / Reviewing

1. modify `carbon/packages/sketch/src/commands/icons/shared.js` to only deal with a subset of icons (either modify the `start` and `end` variables to be a subset of the full icons list or directly change the slice size in `symbolsToSync`)
2. `yarn build`
3. sync and generate the icons in Sketch
