### PR TITLE
fix(code-snippet): set correct width for feedback container in Safari

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -59,12 +59,14 @@
     }
 
     .#{$prefix}--copy-btn__feedback {
+      box-sizing: content-box;
       @include tooltip--content('icon');
       clip: auto;
       margin: auto;
       overflow: visible;
       display: none;
     }
+
     @include tooltip--placement('icon', 'bottom', 'center');
   }
 

--- a/packages/components/src/components/copy-button/_copy-button.scss
+++ b/packages/components/src/components/copy-button/_copy-button.scss
@@ -97,12 +97,14 @@
     }
 
     .#{$prefix}--copy-btn__feedback {
+      box-sizing: content-box;
       @include tooltip--content('icon');
       clip: auto;
       margin: auto;
       overflow: visible;
       display: none;
     }
+
     @include tooltip--placement('icon', 'bottom', 'center');
 
     &:focus {


### PR DESCRIPTION
Closes #5595

This PR resets the copy button feedback container `box-sizing` so that `max-content` works correctly in Safari. Not sure if this would be better in a Safari specific media query but the other browsers appear unaffected

#### Testing / Reviewing

Ensure that the copy button feedback has the correct width in code snippets and in the individual copy button component
