### PR TITLE
fix(text-input): use placeholder text as title attribute

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -56,6 +56,7 @@ const TextInput = React.forwardRef(function TextInput(
     type,
     ref,
     className: textInputClasses,
+    title: placeholder,
     ...other,
   };
   const labelClasses = classNames(`${prefix}--label`, {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5517

Sets the `title` attribute for `TextInput` to the `placeholder` value, so that long placeholder text can be read. One caveat being that the placeholder text will still be shown when there is text entered into the input, not just when the text input is empty.

#### Changelog

**New**

- Sets `title` attribute to the `placeholder` text

#### Testing / Reviewing

Hover over a text input and make sure you can read the placeholder
