### PR TITLE
feat(sketch): add pictogram support to plugin

### DIFF
--- a/packages/sketch/package.json
+++ b/packages/sketch/package.json
@@ -28,6 +28,7 @@
     "@carbon/colors": "^10.8.1",
     "@carbon/icon-helpers": "^10.6.0",
     "@carbon/icons": "^10.9.3",
+    "@carbon/pictograms": "^10.9.2",
     "@carbon/themes": "^10.10.3",
     "@carbon/type": "^10.9.3",
     "@skpm/builder": "^0.7.0",

--- a/packages/sketch/src/commands/index.js
+++ b/packages/sketch/src/commands/index.js
@@ -14,6 +14,7 @@ import '@babel/polyfill';
 export { sync as syncColors, generate as generateColors } from './colors';
 export { generate as generateIcons } from './icons';
 export { syncSmallIcons, syncLargeIcons } from './icons';
+export { sync as syncPictograms } from './pictograms';
 export { sync as syncThemes, generate as generateThemes } from './themes';
 export { sync as syncType, generate as generateType } from './type';
 

--- a/packages/sketch/src/commands/index.js
+++ b/packages/sketch/src/commands/index.js
@@ -14,6 +14,7 @@ import '@babel/polyfill';
 export { sync as syncColors, generate as generateColors } from './colors';
 export { generate as generateIcons } from './icons';
 export { syncSmallIcons, syncLargeIcons } from './icons';
+export { generate as generatePictograms } from './pictograms';
 export { sync as syncPictograms } from './pictograms';
 export { sync as syncThemes, generate as generateThemes } from './themes';
 export { sync as syncType, generate as generateType } from './type';

--- a/packages/sketch/src/commands/pictograms/generate.js
+++ b/packages/sketch/src/commands/pictograms/generate.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Document, Text, Rectangle, Group } from 'sketch/dom';
+import { command } from '../command';
+import { findOrCreatePage, selectPage } from '../../tools/page';
+
+const { categories } = require('@carbon/pictograms/metadata.json');
+
+export function generate() {
+  command('commands/pictograms/generate', () => {
+    const document = Document.getSelectedDocument();
+    const symbols = document.getSymbols();
+    const page = selectPage(findOrCreatePage(document, 'pictograms'));
+    const groups = [];
+    let PAGE_X_OFFSET = 0;
+    let PAGE_Y_OFFSET = 0;
+
+    for (const category of categories) {
+      const categoryText = new Text({
+        text: category.name,
+        style: {
+          fontFamily: 'IBM Plex Sans',
+          fontSize: 32,
+          fontWeight: 4,
+          lineHeight: 40,
+        },
+      });
+      const group = new Group({
+        name: category.name,
+        frame: new Rectangle(PAGE_X_OFFSET, PAGE_Y_OFFSET),
+        layers: [categoryText],
+      });
+
+      const layers = [];
+      const MARGIN = 4;
+      let PICTOGRAM_X_OFFSET = 0;
+      let PICTOGRAM_Y_OFFSET = categoryText.frame.height + 8;
+      let COLUMN_COUNT = 0;
+
+      for (const pictogram of category.members) {
+        const symbol = symbols.find(symbol => {
+          const parts = symbol.name.split('/').map(string => string.trim());
+          const [_type, name] = parts;
+          return name === pictogram;
+        });
+
+        if (!symbol) {
+          throw new Error(`Unable to find symbol for pictogram ${pictogram}!`);
+        }
+
+        const instance = symbol.createNewInstance();
+        instance.frame.offset(PICTOGRAM_X_OFFSET, PICTOGRAM_Y_OFFSET);
+
+        layers.push(instance);
+        PICTOGRAM_X_OFFSET = PICTOGRAM_X_OFFSET + 32 + MARGIN;
+        COLUMN_COUNT = COLUMN_COUNT + 1;
+
+        // 8 column layout
+        if (COLUMN_COUNT > 7) {
+          PICTOGRAM_X_OFFSET = 0;
+          COLUMN_COUNT = 0;
+          PICTOGRAM_Y_OFFSET = PICTOGRAM_Y_OFFSET + 32 + MARGIN;
+        }
+      }
+
+      group.layers.push(...layers);
+      group.adjustToFit();
+      PAGE_Y_OFFSET = PAGE_Y_OFFSET + group.frame.height;
+
+      groups.push(group);
+    }
+
+    page.layers.push(...groups);
+  });
+}

--- a/packages/sketch/src/commands/pictograms/index.js
+++ b/packages/sketch/src/commands/pictograms/index.js
@@ -5,4 +5,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export { generate } from './generate';
 export { sync } from './sync';

--- a/packages/sketch/src/commands/pictograms/index.js
+++ b/packages/sketch/src/commands/pictograms/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { sync } from './sync';

--- a/packages/sketch/src/commands/pictograms/shared.js
+++ b/packages/sketch/src/commands/pictograms/shared.js
@@ -1,0 +1,220 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* global MSSVGImporter, NSString, NSUTF8StringEncoding */
+
+import { toString } from '@carbon/icon-helpers';
+import { Artboard, Rectangle, Shape } from 'sketch/dom';
+import { syncColorStyles } from '../../sharedStyles/colors';
+import { syncSymbol } from '../../tools/symbols';
+
+const meta = require('@carbon/pictograms/build-info.json');
+const metadata = require('@carbon/pictograms/metadata.json');
+
+export function syncPictogramSymbols(
+  document,
+  symbols,
+  symbolsPage,
+  sharedLayerStyles
+) {
+  const sharedStyles = syncColorStyles(document, 'border');
+  const [sharedStyle] = sharedStyles.filter(
+    ({ name }) => name === 'color / border / black'
+  );
+
+  if (!sharedStyle) {
+    throw new Error(
+      'Unexpected error occurred, expected shared style but found none'
+    );
+  }
+
+  const pictograms = normalize(meta);
+  const pictogramNames = Object.keys(pictograms);
+
+  // To help with debugging, we have `start` and `end` values here to focus on
+  // specific pictogram ranges. You can also work on a specific pictogram by finding
+  // it's index and setting the value of start to the index and end to the
+  // index + 1.
+  //
+  // To find the index, you can use:
+  //   console.log(pictogramNames.findIndex(name === 'name-to-find')); // 50
+  // And use that value below like:
+  //  const start = 50;
+  //  const end = 51;
+  // This will allow you to focus only on the pictogram named 'name-to-find'
+  const start = 0;
+  const end = pictogramNames.length;
+
+  // We keep track of the current X and Y offsets at the top-level, each
+  // iteration of an pictogram set should reset the X_OFFSET and update the
+  // Y_OFFSET with the maximum size in the pictogram set.
+  const ARTBOARD_MARGIN = 32;
+  const INITIAL_Y_OFFSET =
+    symbolsPage.layers.reduce((acc, layer) => {
+      if (layer.frame.y + layer.frame.height > acc) {
+        return layer.frame.y + layer.frame.height;
+      }
+      return acc;
+    }, 0) + 32;
+  let X_OFFSET = 0;
+  let Y_OFFSET = INITIAL_Y_OFFSET;
+  let maxSize = -Infinity;
+
+  const symbolsToSync = pictogramNames.slice(start, end).flatMap((name, i) => {
+    const sizes = pictograms[name];
+
+    X_OFFSET = 0;
+    if (i !== 0) {
+      Y_OFFSET = Y_OFFSET + maxSize + ARTBOARD_MARGIN;
+    }
+    maxSize = -Infinity;
+
+    return sizes.map(pictogram => {
+      const size = 48;
+      const descriptor = Object.assign({}, pictogram.descriptor);
+
+      // We push a transparent rectangle to mirror the "bounding box" found in
+      // pictogram artboards that is stripped by our build process. Including this
+      // makes sure that our pictogram renders true to the path data
+      descriptor.content.push({
+        elem: 'rect',
+        attrs: {
+          width: size,
+          height: size,
+          fill: 'none',
+        },
+      });
+
+      const layer = createSVGLayer(pictogram.descriptor);
+
+      layer.name = pictogram.basename;
+      layer.rect = {
+        origin: {
+          x: 0,
+          y: 0,
+        },
+        size: {
+          width: size,
+          height: size,
+        },
+      };
+
+      const info = metadata.icons.find(pictogram => {
+        return pictogram.name === name;
+      });
+
+      let symbolName = name;
+
+      if (sizes.length !== 1) {
+        symbolName = `${name} / ${size}`;
+      }
+
+      if (info.category && info.subcategory) {
+        symbolName = `${info.category} / ${info.subcategory} / ${symbolName}`;
+      }
+
+      symbolName = `pictogram / ${symbolName}`;
+
+      const artboard = new Artboard({
+        name: symbolName,
+        frame: new Rectangle(X_OFFSET, Y_OFFSET, size, size),
+        layers: [layer],
+      });
+
+      if (size > maxSize) {
+        maxSize = size;
+      }
+
+      X_OFFSET = X_OFFSET + size + 8;
+
+      const [group] = artboard.layers;
+
+      // Last layer will be the transparent rectangle we added above
+      const strokePaths = group.layers
+        .slice(0, -1)
+        .map(layer => layer.duplicate());
+
+      let shape;
+      if (strokePaths.length === 1) {
+        shape = strokePaths[0];
+        shape.name = 'Border';
+        shape.style = sharedStyle.style;
+        shape.sharedStyleId = sharedStyle.id;
+      } else {
+        // If we have multiple fill paths, we need to consolidate them into a
+        // single Shape so that we can style the pictogram with one override in the
+        // symbol
+        shape = new Shape({
+          name: 'Border',
+          frame: new Rectangle(0, 0, size, size),
+          layers: strokePaths,
+          style: sharedStyle.style,
+          sharedStyleId: sharedStyle.id,
+        });
+      }
+
+      shape.style.fills = [];
+
+      artboard.layers.push(shape);
+      group.remove();
+
+      return syncSymbol(symbols, sharedLayerStyles, artboard.name, {
+        name: artboard.name,
+        frame: artboard.frame,
+        layers: artboard.layers,
+        background: artboard.background,
+        parent: symbolsPage,
+      });
+    });
+  });
+
+  return symbolsToSync;
+}
+
+/**
+ * Normalize a collection of pictograms by their basename
+ * @param {Array<Pictogram>} pictograms
+ * @returns {object}
+ */
+function normalize(pictograms) {
+  // Collect all pictograms and group them by their base names. The value of the
+  // basename key is the array of all sizes for that pictogram
+  const pictogramsByBasename = pictograms.reduce((acc, pictogram) => {
+    const name = pictogram.basename;
+    if (acc[name]) {
+      return {
+        ...acc,
+        [name]: acc[name].concat(pictogram),
+      };
+    }
+    return {
+      ...acc,
+      [name]: [pictogram],
+    };
+  }, {});
+
+  return pictogramsByBasename;
+}
+
+/**
+ * Create a layer from an SVG descriptor
+ *
+ * Reference:
+ * https://github.com/airbnb/react-sketchapp/blob/aa3070556c47883974edbc7f78978c421a8199f7/src/jsonUtils/sketchImpl/makeSvgLayer.js#L12
+ *
+ * @param {object} svg
+ * @returns {Layer}
+ */
+function createSVGLayer(svg) {
+  const svgString = NSString.stringWithString(toString(svg));
+  const svgData = svgString.dataUsingEncoding(NSUTF8StringEncoding);
+  const svgImporter = MSSVGImporter.svgImporter();
+  svgImporter.prepareToImportFromData(svgData);
+  const svgLayer = svgImporter.importAsLayer();
+
+  return svgLayer;
+}

--- a/packages/sketch/src/commands/pictograms/sync.js
+++ b/packages/sketch/src/commands/pictograms/sync.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Document } from 'sketch/dom';
+import { command } from '../command';
+import { syncPictogramSymbols } from './shared';
+import { findOrCreateSymbolPage } from '../../tools/page';
+
+export function sync() {
+  command('commands/pictograms/sync', () => {
+    const document = Document.getSelectedDocument();
+    const symbolsPage = findOrCreateSymbolPage(document);
+    const symbols = document.getSymbols();
+    syncPictogramSymbols(
+      document,
+      Array.from(symbols),
+      symbolsPage,
+      document.sharedLayerStyles
+    );
+  });
+}

--- a/packages/sketch/src/manifest.json
+++ b/packages/sketch/src/manifest.json
@@ -69,6 +69,12 @@
       "identifier": "carbon.elements.icons.fixture.shared-styles-sync",
       "script": "commands/index.js",
       "handler": "testSyncSharedStyles"
+    },
+    {
+      "name": "Sync pictogram symbols",
+      "identifier": "carbon.elements.pictograms.sync",
+      "script": "commands/index.js",
+      "handler": "syncPictograms"
     }
   ],
   "menu": {
@@ -96,8 +102,18 @@
         ]
       },
       {
+        "title": "Pictograms",
+        "items": [
+          "carbon.elements.pictograms.sync",
+          "carbon.elements.pictograms.generate"
+        ]
+      },
+      {
         "title": "Type",
-        "items": ["carbon.elements.type.sync", "carbon.elements.type.generate"]
+        "items": [
+          "carbon.elements.type.sync",
+          "carbon.elements.type.generate"
+        ]
       },
       {
         "title": "Test",

--- a/packages/sketch/src/manifest.json
+++ b/packages/sketch/src/manifest.json
@@ -71,6 +71,12 @@
       "handler": "testSyncSharedStyles"
     },
     {
+      "name": "Generate pictogram page",
+      "identifier": "carbon.elements.pictograms.generate",
+      "script": "commands/index.js",
+      "handler": "generatePictograms"
+    },
+    {
       "name": "Sync pictogram symbols",
       "identifier": "carbon.elements.pictograms.sync",
       "script": "commands/index.js",


### PR DESCRIPTION
not sure what level of symbol editing we need to support/if we need to split up the shared layer style between Fills and Borders