### PR TITLE
fix(data-table): require additional props in certain situations

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -868,10 +868,7 @@ Map {
     },
     "TableExpandHeader": Object {
       "propTypes": Object {
-        "ariaLabel": Object {
-          "isRequired": true,
-          "type": "string",
-        },
+        "ariaLabel": [Function],
         "children": Object {
           "type": "node",
         },
@@ -881,14 +878,8 @@ Map {
         "expandIconDescription": Object {
           "type": "string",
         },
-        "isExpanded": Object {
-          "isRequired": true,
-          "type": "bool",
-        },
-        "onExpand": Object {
-          "isRequired": true,
-          "type": "func",
-        },
+        "isExpanded": [Function],
+        "onExpand": [Function],
       },
     },
     "TableExpandRow": Object {
@@ -1453,10 +1444,7 @@ Map {
   },
   "TableExpandHeader" => Object {
     "propTypes": Object {
-      "ariaLabel": Object {
-        "isRequired": true,
-        "type": "string",
-      },
+      "ariaLabel": [Function],
       "children": Object {
         "type": "node",
       },
@@ -1466,14 +1454,8 @@ Map {
       "expandIconDescription": Object {
         "type": "string",
       },
-      "isExpanded": Object {
-        "isRequired": true,
-        "type": "bool",
-      },
-      "onExpand": Object {
-        "isRequired": true,
-        "type": "func",
-      },
+      "isExpanded": [Function],
+      "onExpand": [Function],
     },
   },
   "TableExpandRow" => Object {

--- a/packages/react/src/components/DataTable/TableExpandHeader.js
+++ b/packages/react/src/components/DataTable/TableExpandHeader.js
@@ -78,12 +78,12 @@ TableExpandHeader.propTypes = {
    * Specify whether this row is expanded or not. This helps coordinate data
    * attributes so that `TableExpandRow` and `TableExapndedRow` work together
    */
-  isExpanded: isRequiredIfPropExists('isExpanded'),
+  isExpanded: isRequiredIfPropExists('enableExpando'),
 
   /**
    * Hook for when a listener initiates a request to expand the given row
    */
-  onExpand: isRequiredIfPropExists('onExpand'),
+  onExpand: isRequiredIfPropExists('enableExpando'),
 
   /**
    * The description of the chevron right icon, to be put in its SVG `<title>` element.

--- a/packages/react/src/components/DataTable/TableExpandHeader.js
+++ b/packages/react/src/components/DataTable/TableExpandHeader.js
@@ -7,6 +7,7 @@
 
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+import requiredIfGivenPropExists from '../../prop-types/requiredIfGivenPropExists';
 import React from 'react';
 import { ChevronRight16 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
@@ -49,21 +50,6 @@ const TableExpandHeader = ({
   );
 };
 
-function isRequiredIfPropExists(requiredProp) {
-  function checker(props, propName, componentName) {
-    if (props[requiredProp] === undefined) {
-      return;
-    }
-    if (props[propName] === undefined) {
-      throw new Error(
-        `${componentName} requires ${propName} if ${requiredProp} is defined`
-      );
-    }
-  }
-
-  return checker;
-}
-
 TableExpandHeader.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
@@ -72,18 +58,18 @@ TableExpandHeader.propTypes = {
    * Specify the string read by a voice reader when the expand trigger is
    * focused
    */
-  ariaLabel: isRequiredIfPropExists('ariaLabel'),
+  ariaLabel: requiredIfGivenPropExists('enableExpando', PropTypes.string),
 
   /**
    * Specify whether this row is expanded or not. This helps coordinate data
    * attributes so that `TableExpandRow` and `TableExapndedRow` work together
    */
-  isExpanded: isRequiredIfPropExists('enableExpando'),
+  isExpanded: requiredIfGivenPropExists('enableExpando', PropTypes.bool),
 
   /**
    * Hook for when a listener initiates a request to expand the given row
    */
-  onExpand: isRequiredIfPropExists('enableExpando'),
+  onExpand: requiredIfGivenPropExists('enableExpando', PropTypes.func),
 
   /**
    * The description of the chevron right icon, to be put in its SVG `<title>` element.

--- a/packages/react/src/components/DataTable/TableExpandHeader.js
+++ b/packages/react/src/components/DataTable/TableExpandHeader.js
@@ -49,6 +49,21 @@ const TableExpandHeader = ({
   );
 };
 
+function isRequiredIfPropExists(requiredProp) {
+  function checker(props, propName, componentName) {
+    if (props[requiredProp] === undefined) {
+      return;
+    }
+    if (props[propName] === undefined) {
+      throw new Error(
+        `${componentName} requires ${propName} if ${requiredProp} is defined`
+      );
+    }
+  }
+
+  return checker;
+}
+
 TableExpandHeader.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
@@ -57,18 +72,18 @@ TableExpandHeader.propTypes = {
    * Specify the string read by a voice reader when the expand trigger is
    * focused
    */
-  ariaLabel: PropTypes.string.isRequired,
+  ariaLabel: isRequiredIfPropExists('ariaLabel'),
 
   /**
    * Specify whether this row is expanded or not. This helps coordinate data
    * attributes so that `TableExpandRow` and `TableExapndedRow` work together
    */
-  isExpanded: PropTypes.bool.isRequired,
+  isExpanded: isRequiredIfPropExists('isExpanded'),
 
   /**
    * Hook for when a listener initiates a request to expand the given row
    */
-  onExpand: PropTypes.func.isRequired,
+  onExpand: isRequiredIfPropExists('onExpand'),
 
   /**
    * The description of the chevron right icon, to be put in its SVG `<title>` element.


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5681

Adds in a `PropType` checker function to only require certain props in certain situations

#### Changelog

**New**

- Helper function to validate if a prop is required or not. 

#### Testing / Reviewing

Ensure Data Table w/ expansion does not throw any console warnings. 
