### PR TITLE
fix(sketch): filter correct layer name when generating icon symbols

### DIFF
--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -24,7 +24,7 @@ export function syncIconSymbols(
 ) {
   const sharedStyles = syncColorStyles(document);
   const [sharedStyle] = sharedStyles.filter(
-    ({ name }) => name === 'color/black'
+    ({ name }) => name === 'color / black'
   );
 
   if (!sharedStyle) {


### PR DESCRIPTION
Closes #5701

This PR changes the icon shared color style filter logic to match the changes in #5692