### PR TITLE
fix(list-box): update background, border colors

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -135,8 +135,16 @@ $list-box-menu-width: rem(300px);
     background-color: $field-02;
   }
 
+  .#{$prefix}--list-box--light .#{$prefix}--list-box__menu {
+    background: $field-02;
+  }
+
+  .#{$prefix}--list-box--light .#{$prefix}--list-box__menu-item__option {
+    border-top-color: $decorative-01;
+  }
+
   .#{$prefix}--list-box--light.#{$prefix}--list-box--expanded {
-    border-bottom-width: 0;
+    border-bottom-color: $decorative-01;
   }
 
   // Disabled state for `list-box`
@@ -578,6 +586,13 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box__menu-item--active
     .#{$prefix}--list-box__menu-item__option {
     color: $text-01;
+  }
+
+  // Hide top border if previous list item is selected
+  .#{$prefix}--list-box__menu-item--active
+    + .#{$prefix}--list-box__menu-item
+    > .#{$prefix}--list-box__menu-item__option {
+    border-top-color: transparent;
   }
 
   .#{$prefix}--list-box__menu-item__selected-icon {

--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -64,7 +64,7 @@
   .#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open,
   .#{$prefix}--overflow-menu--light.#{$prefix}--overflow-menu--open
     .#{$prefix}--overflow-menu__trigger {
-    background-color: $ui-02;
+    background-color: $field-02;
   }
 
   .#{$prefix}--overflow-menu__icon {
@@ -167,6 +167,10 @@
     border-top: 1px solid $ui-03;
   }
 
+  .#{$prefix}--overflow-menu--light .#{$prefix}--overflow-menu--divider {
+    border-top: 1px solid $decorative-01;
+  }
+
   a.#{$prefix}--overflow-menu-options__btn::before {
     content: '';
     height: 100%;
@@ -226,6 +230,11 @@
 
   .#{$prefix}--overflow-menu-options__option--danger {
     border-top: 1px solid $ui-03;
+  }
+
+  .#{$prefix}--overflow-menu--light
+    .#{$prefix}--overflow-menu-options__option--danger {
+    border-top: 1px solid $decorative-01;
   }
 
   .#{$prefix}--overflow-menu-options__option--danger


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5705

Updates a few colors and uses the new `decorative-01` token so horizontal rules (`border-top`) correctly show in dark themes on components that have a `light` prop

#### Changelog

**Changed**

- Listbox components (MultiSelect, ComboBox) use `field-02` as the menu background when `light` prop is applied
- OverflowMenu uses `field-02` as the menu background when `light` prop is applied
- Any horizontal rule (`border-top`) is now using `decorative-01` when `light` prop is applied

#### Testing / Reviewing

View these components in all 4 themes, and check that the rules show up when the `light` prop is applied
