### PR TITLE
chore(icons): add ignore for alex in README

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -90,6 +90,8 @@ svg [data-icon-path='inner-path'] {
 }
 ```
 
+<!-- alex ignore color -->
+
 In the code snippet above, we are targetting the inner path attribute with
 `[data-icon-path="inner-path"]`. The value of `fill` will be the custom color
 you would like to set for the inner path. We also need to set `opacity` to `1`


### PR DESCRIPTION
Alex was failing in CI with the use of the word color found in `icons/README.md`. This PR updates Alex to ignore it for this portion of our docs.

#### Changelog

**New**

**Changed**

- Add comment to disable Alex checking color in `icons/README.md`

**Removed**
