### PR TITLE
fix(Slider): use value from input as-is

### DIFF
--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -228,8 +228,8 @@ describe('Slider', () => {
         },
       };
       wrapper.instance().onChange(evt);
-      expect(wrapper.state().value).toEqual(100);
-      expect(handleChange).lastCalledWith({ value: 100 });
+      expect(wrapper.state().value).toEqual(999);
+      expect(handleChange).lastCalledWith({ value: 999 });
     });
   });
 


### PR DESCRIPTION
This change ensures that `<Slider>` won't force changing the value that user types in the `<input>`. For example, if we set 3 to `min` and user wants to type 100 in the `<input>`, this change ensures `<input>` won't become 3 (the minimum value) as soon as user types 1 (the first
character in 100).

Fixes #3107.

#### Testing / Reviewing

Testing should make sure `<Slider>` is not broken.