### PR TITLE
fix(box-shadow): update box-shadow value

### DIFF
--- a/packages/components/src/globals/scss/_helper-mixins.scss
+++ b/packages/components/src/globals/scss/_helper-mixins.scss
@@ -54,7 +54,7 @@
 /// @example @include box-shadow;
 /// @group global-helpers
 @mixin box-shadow {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
 /// Adds outline styles depending on specific type


### PR DESCRIPTION
Box shadow value was incorrect

#### Changelog

**Changed**

- Reduced opacity to `.2`

#### Testing / Reviewing

Ensure the correct box-shadow is being applied to the components. If we are not using the correct value somewhere, please point it out so we can refactor it to use the `box-shadow` mixin. 
