### PR TITLE
fix(fileUploader): add aria label to span for upload button

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -180,7 +180,9 @@ export class FileUploaderButton extends Component {
           }}
           htmlFor={this.uid}
           {...other}>
-          <span role={role}>{this.state.labelText}</span>
+          <span role={role} aria-label={this.state.labelText}>
+            {this.state.labelText}
+          </span>
         </label>
         <input
           className={`${prefix}--visually-hidden`}


### PR DESCRIPTION
Closes #5726 

This PR adds an aria-label of the label text to the span.

#### Changelog

**New**

- adds aria label to span for FileUploader button

#### Testing / Reviewing

Make sure that the FileUploader reads well for screenreaders and that there are no DAP violations