### PR TITLE
feat(sketch): create shared styles for icon stroke

### DIFF
--- a/packages/sketch/src/commands/colors/generate.js
+++ b/packages/sketch/src/commands/colors/generate.js
@@ -20,7 +20,6 @@ export function generate() {
     const document = Document.getSelectedDocument();
     const page = selectPage(findOrCreatePage(document, 'color'));
     const sharedStyles = syncColorStyles(document, 'fill');
-    console.log(sharedStyles);
     const { black, white, colors, support } = groupByKey(
       sharedStyles,
       sharedStyle => {

--- a/packages/sketch/src/commands/colors/generate.js
+++ b/packages/sketch/src/commands/colors/generate.js
@@ -19,7 +19,7 @@ export function generate() {
   command('commands/colors/generate', () => {
     const document = Document.getSelectedDocument();
     const page = selectPage(findOrCreatePage(document, 'color'));
-    const sharedStyles = syncColorStyles(document);
+    const sharedStyles = syncColorStyles(document, 'fill');
     const { black, white, colors, support } = groupByKey(
       sharedStyles,
       sharedStyle => {

--- a/packages/sketch/src/commands/colors/generate.js
+++ b/packages/sketch/src/commands/colors/generate.js
@@ -20,11 +20,12 @@ export function generate() {
     const document = Document.getSelectedDocument();
     const page = selectPage(findOrCreatePage(document, 'color'));
     const sharedStyles = syncColorStyles(document, 'fill');
+    console.log(sharedStyles);
     const { black, white, colors, support } = groupByKey(
       sharedStyles,
       sharedStyle => {
         const { name } = sharedStyle;
-        const [_category, swatch] = name.split(' / ');
+        const [_category, _type, swatch] = name.split(' / ');
         switch (swatch) {
           case 'black':
             return 'black';
@@ -43,7 +44,7 @@ export function generate() {
     let Y_OFFSET = 0;
 
     const swatches = groupByKey(colors, sharedStyle => {
-      const [_category, swatch] = sharedStyle.name.split('/');
+      const [_category, _type, swatch] = sharedStyle.name.split('/');
       return swatch;
     });
 

--- a/packages/sketch/src/commands/colors/sync.js
+++ b/packages/sketch/src/commands/colors/sync.js
@@ -11,6 +11,6 @@ import { syncColorStyles } from '../../sharedStyles/colors';
 
 export function sync() {
   command('commands/colors/sync', () => {
-    syncColorStyles(Document.getSelectedDocument());
+    syncColorStyles(Document.getSelectedDocument(), 'fill');
   });
 }

--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -21,9 +21,9 @@ export function syncIconSymbols(
   sharedLayerStyles,
   sizes = [32, 24, 20, 16]
 ) {
-  const sharedStyles = syncColorStyles(document);
+  const sharedStyles = syncColorStyles(document, 'fill');
   const [sharedStyle] = sharedStyles.filter(
-    ({ name }) => name === 'color / black'
+    ({ name }) => name === 'color / fill / black'
   );
 
   if (!sharedStyle) {

--- a/packages/sketch/src/commands/test/sync-shared-styles.js
+++ b/packages/sketch/src/commands/test/sync-shared-styles.js
@@ -42,13 +42,13 @@ export function testSyncSharedStyles() {
     /**
      * Testing shared layer styles
      */
-    const sharedStyle = syncColorStyle(document, 'black', '#000000');
+    const sharedStyle = syncColorStyle(document, 'black', '#000000', 'fill');
 
     if (document.sharedLayerStyles.length !== 1) {
       throw new Error('Expected sync command to generate a shared layer style');
     }
 
-    syncColorStyle(document, 'black', '#000000');
+    syncColorStyle(document, 'black', '#000000', 'fill');
 
     if (document.sharedLayerStyles.length !== 1) {
       throw new Error(
@@ -118,7 +118,7 @@ export function testSyncSharedStyles() {
       throw new Error('The layer is not in sync with the shared style');
     }
 
-    syncColorStyle(document, 'black', '#dedede');
+    syncColorStyle(document, 'black', '#dedede', 'fill');
 
     if (getLayerFillColor() !== '#dededeff') {
       throw new Error('The layer did not update to the new shared style');

--- a/packages/sketch/src/commands/test/sync-symbol-id.js
+++ b/packages/sketch/src/commands/test/sync-symbol-id.js
@@ -26,14 +26,19 @@ export function testSyncSymbolId() {
   command('commands/test/sync-symbol-id', () => {
     const document = Document.getSelectedDocument();
 
-    syncSymbol(document, 'test-symbol', {
-      layers: [
-        new ShapePath({
-          name: 'Inner',
-          shapeType: ShapePath.ShapeType.Oval,
-          frame: new Rectangle(0, 0, 16, 16),
-        }),
-      ],
-    });
+    syncSymbol(
+      document.getSymbols(),
+      document.sharedLayerStyles,
+      'test-symbol',
+      {
+        layers: [
+          new ShapePath({
+            name: 'Inner',
+            shapeType: ShapePath.ShapeType.Oval,
+            frame: new Rectangle(0, 0, 16, 16),
+          }),
+        ],
+      }
+    );
   });
 }

--- a/packages/sketch/src/commands/themes/generate.js
+++ b/packages/sketch/src/commands/themes/generate.js
@@ -21,7 +21,7 @@ export function generate() {
   command('commands/themes/generate', () => {
     const document = Document.getSelectedDocument();
     const page = selectPage(findOrCreatePage(document, 'themes'));
-    const sharedStyles = syncThemeColorStyles(document);
+    const sharedStyles = syncThemeColorStyles(document, 'fill');
 
     const tokens = groupByKey(sharedStyles, sharedStyle => {
       const [_namespace, _category, _group, token] = sharedStyle.name.split(

--- a/packages/sketch/src/commands/themes/sync.js
+++ b/packages/sketch/src/commands/themes/sync.js
@@ -12,6 +12,6 @@ import { syncThemeColorStyles } from '../../sharedStyles/themes';
 export function sync() {
   command('commands/themes/sync', () => {
     const document = Document.getSelectedDocument();
-    syncThemeColorStyles(document);
+    syncThemeColorStyles(document, 'fill');
   });
 }

--- a/packages/sketch/src/sharedStyles/colors.js
+++ b/packages/sketch/src/sharedStyles/colors.js
@@ -18,14 +18,15 @@ const { black, white, orange, yellow, ...swatches } = colors;
  * @param {Document} document
  * @returns {Array<SharedStyle>}
  */
-export function syncColorStyles(document) {
+export function syncColorStyles(document, type) {
   const sharedStyles = Object.keys(swatches).flatMap(swatchName => {
     const name = formatTokenName(swatchName);
     const result = Object.keys(swatches[swatchName]).map(grade => {
       return syncColorStyle(
         document,
-        formatSharedStyleName(name, grade),
-        swatches[swatchName][grade]
+        formatSharedStyleName(name, type, grade),
+        swatches[swatchName][grade],
+        type
       );
     });
     return result;
@@ -37,7 +38,12 @@ export function syncColorStyles(document) {
     ['orange', orange['40']],
     ['yellow', yellow['30']],
   ].map(([name, value]) => {
-    return syncColorStyle(document, formatSharedStyleName(name), value);
+    return syncColorStyle(
+      document,
+      formatSharedStyleName(name, type),
+      value,
+      type
+    );
   });
 
   return sharedStyles.concat(singleColors);
@@ -45,13 +51,14 @@ export function syncColorStyles(document) {
 
 /**
  * Our shared style name will need to have the `color` namespace alongside a
- * name for the swatch and an optional grade.
+ * name for the swatch, the style type, and an optional grade.
  * @param {string} name
+ * @param {string} type
  * @param {string?} grade
  * @returns {string}
  */
-function formatSharedStyleName(name, grade) {
-  return ['color', name.split('-').join(' '), grade]
+function formatSharedStyleName(name, type, grade) {
+  return ['color', type, name.split('-').join(' '), grade]
     .filter(Boolean)
     .join(' / ');
 }

--- a/packages/sketch/src/sharedStyles/themes.js
+++ b/packages/sketch/src/sharedStyles/themes.js
@@ -21,9 +21,10 @@ const { colors } = tokens;
 /**
  * Sync theme color shared styles to the given document and return the result
  * @param {Document} document
+ * @param {string} styleType
  * @returns {Array<SharedStyle>}
  */
-export function syncThemeColorStyles(document) {
+export function syncThemeColorStyles(document, styleType) {
   const themes = {
     'White theme': white,
     'Gray 10 theme': g10,
@@ -43,7 +44,7 @@ export function syncThemeColorStyles(document) {
         const name = `theme / ${theme.toLowerCase()} / ${type} tokens / ${formatTokenName(
           token
         )}`;
-        return syncColorStyle(document, name, themes[theme][token]);
+        return syncColorStyle(document, name, themes[theme][token], styleType);
       });
   });
 

--- a/packages/sketch/src/tools/sharedStyles.js
+++ b/packages/sketch/src/tools/sharedStyles.js
@@ -61,15 +61,18 @@ export function syncSharedStyle(
  * @param {Document} document
  * @param {string} name
  * @param {string} value
+ * @param {string} type
  * @returns {SharedStyle}
  */
-export function syncColorStyle(document, name, value) {
-  return syncSharedStyle(document, name, {
-    fills: [
-      {
-        color: value,
-        fillType: Style.FillType.Color,
-      },
-    ],
-  });
+export function syncColorStyle(document, name, value, type) {
+  if (type === 'fill') {
+    return syncSharedStyle(document, name, {
+      fills: [
+        {
+          color: value,
+          fillType: Style.FillType.Color,
+        },
+      ],
+    });
+  }
 }

--- a/packages/sketch/src/tools/sharedStyles.js
+++ b/packages/sketch/src/tools/sharedStyles.js
@@ -75,4 +75,14 @@ export function syncColorStyle(document, name, value, type) {
       ],
     });
   }
+  if (type === 'border') {
+    return syncSharedStyle(document, name, {
+      borders: [
+        {
+          color: value,
+          fillType: Style.FillType.Color,
+        },
+      ],
+    });
+  }
 }


### PR DESCRIPTION
Closes #5692

This PR renames the fill shared style layers and lays the groundwork for specifying shared style type (currently "fill" or "border") to prepare for #4130/#5567 (branched off of #5569)

#### Changelog

**Changed**

- change shared sync command and generate commands for colors, themes, and icons to use new naming scheme
- fix symbol sync test

#### Testing / Reviewing

Ensure the sketch plugin works as expected and the new shared style names are correct

Plugin can be downloaded and tested here:

[carbon-elements.sketchplugin.zip](https://github.com/carbon-design-system/carbon/files/4404430/carbon-elements.sketchplugin.zip)

