### PR TITLE
fix(inline-notification): fix inline-notification styles on mobile

### DIFF
--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -24,6 +24,7 @@
     @include reset;
 
     display: flex;
+    flex-wrap: wrap;
     position: relative;
     height: auto;
     min-height: rem(48px);
@@ -36,6 +37,7 @@
 
     @include carbon--breakpoint(md) {
       max-width: rem(608px);
+      flex-wrap: nowrap;
     }
 
     @include carbon--breakpoint(lg) {
@@ -158,7 +160,11 @@
   .#{$prefix}--inline-notification__details {
     display: flex;
     flex-grow: 1;
-    margin: 0 $carbon--spacing-05;
+    margin: 0 $carbon--spacing-09 0 $carbon--spacing-05;
+
+    @include carbon--breakpoint(md) {
+      margin: 0 $carbon--spacing-05;
+    }
   }
 
   .#{$prefix}--inline-notification__icon {
@@ -186,6 +192,11 @@
   .#{$prefix}--inline-notification__action-button.#{$prefix}--btn--ghost {
     height: rem(32px);
     margin: $carbon--spacing-03 0;
+    margin-left: $carbon--spacing-08;
+
+    @include carbon--breakpoint(md) {
+      margin: $carbon--spacing-03 0;
+    }
 
     &,
     &:hover,
@@ -212,6 +223,9 @@
 
   .#{$prefix}--inline-notification__close-button {
     @include focus-outline('reset');
+    position: absolute;
+    top: 0;
+    right: 0;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -234,6 +248,10 @@
 
     .#{$prefix}--inline-notification__close-icon {
       fill: $inverse-01;
+    }
+
+    @include carbon--breakpoint(md) {
+      position: initial;
     }
   }
 

--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -191,7 +191,7 @@
 
   .#{$prefix}--inline-notification__action-button.#{$prefix}--btn--ghost {
     height: rem(32px);
-    margin: $carbon--spacing-03 0;
+    margin-bottom: $carbon--spacing-03;
     margin-left: $carbon--spacing-08;
 
     @include carbon--breakpoint(md) {

--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -251,7 +251,7 @@
     }
 
     @include carbon--breakpoint(md) {
-      position: initial;
+      position: static;
     }
   }
 

--- a/packages/react/src/components/Notification/Notification-story.js
+++ b/packages/react/src/components/Notification/Notification-story.js
@@ -26,11 +26,7 @@ const notificationProps = () => ({
   lowContrast: boolean('Use low contrast variant (lowContrast)', false),
   role: text('ARIA role (role)', 'alert'),
   title: text('Title (title)', 'Notification title'),
-  subtitle: (
-    <span>
-      Subtitle text goes here. <a href="#example">Example link</a>
-    </span>
-  ),
+  subtitle: text('Subtitle (subtitle)', 'Subtitle text goes here.'),
   iconDescription: text(
     'Icon description (iconDescription)',
     'describes the close button'


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5730

Fixes mobile related issues with `inline-notification`. CTA on `inline-notification` now wraps on mobile and is placed under the subtitle text. On larger screens, it will appear adjacent to the notification text. 

<img width="334" alt="Screen Shot 2020-03-31 at 12 43 14 PM" src="https://user-images.githubusercontent.com/11928039/78068912-167aa080-734e-11ea-87c3-44f5d26737f0.png">

<img width="643" alt="Screen Shot 2020-03-31 at 12 43 20 PM" src="https://user-images.githubusercontent.com/11928039/78068928-1b3f5480-734e-11ea-805c-dfa4d2692d7a.png">

#### Changelog

**New**

- Subtitle text can now be changed via a knob on the storybook
- Mobile styles that are reset to their previous values once they reach the first breakpoint (`md`)

#### Testing / Reviewing

Ensure that inline notification looks correct at all sizes in all browsers. 
 