### PR TITLE
fix(code-snippet): adjust top + bottom of single-line variant gradient

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -124,11 +124,13 @@
 
   .#{$prefix}--snippet--single::after {
     width: rem(16px);
-    height: 100%;
     content: '';
     position: absolute;
-    top: 0;
     right: rem(56px);
+
+    // Prevents gradient from clipping focus outline:
+    top: 2px;
+    bottom: 2px;
 
     // Safari interprets `transparent` differently, so make color token value transparent instead:
     background-image: linear-gradient(to right, rgba($ui-01, 0), $ui-01);


### PR DESCRIPTION
Closes #5801 

I suggest adding a top/bottom value so account for the focus outline of the single-line `CodeSnippet` variant. That way, the gradient won't clip through the focus outline.

#### Changelog

**Changed**

- update `top` and `bottom` style rules for the single-line `CodeSnippet`'s scroll gradient so account for the 2px focus outline

**Removed**

- removed `height: 100%` because that was causing the gradient pseudo element to vertically overflow its container