### PR TITLE
fix(icons-build-helpers): remove will-change: transform from react icons

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/components/Icon.js
+++ b/packages/icon-build-helpers/src/builders/react/components/Icon.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const Icon = React.forwardRef(function Icon(
-  { className, children, style = {}, tabIndex, ...rest },
+  { className, children, tabIndex, ...rest },
   ref
 ) {
   const { tabindex, ...props } = getAttributes({
@@ -29,10 +29,6 @@ const Icon = React.forwardRef(function Icon(
   if (ref) {
     props.ref = ref;
   }
-
-  props.style = {
-    ...style,
-  };
 
   return React.createElement('svg', props, children);
 });

--- a/packages/icon-build-helpers/src/builders/react/components/Icon.js
+++ b/packages/icon-build-helpers/src/builders/react/components/Icon.js
@@ -9,10 +9,6 @@ import { getAttributes } from '@carbon/icon-helpers';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const defaultStyle = {
-  willChange: 'transform',
-};
-
 const Icon = React.forwardRef(function Icon(
   { className, children, style = {}, tabIndex, ...rest },
   ref
@@ -35,7 +31,6 @@ const Icon = React.forwardRef(function Icon(
   }
 
   props.style = {
-    ...defaultStyle,
     ...style,
   };
 

--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -52,11 +52,6 @@ exports[`Accordion should render 1`] = `
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
                   role="img"
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
                   viewBox="0 0 16 16"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -125,11 +120,6 @@ exports[`Accordion should render 1`] = `
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
                   role="img"
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
                   viewBox="0 0 16 16"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"
@@ -198,11 +188,6 @@ exports[`Accordion should render 1`] = `
                   height={16}
                   preserveAspectRatio="xMidYMid meet"
                   role="img"
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
                   viewBox="0 0 16 16"
                   width={16}
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion.Skeleton-test.js.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/Accordion.Skeleton-test.js.snap
@@ -32,11 +32,6 @@ exports[`AccordionSkeleton should render 1`] = `
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 16 16"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -140,11 +135,6 @@ exports[`AccordionSkeleton should render 1`] = `
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 16 16"
                 width={16}
                 xmlns="http://www.w3.org/2000/svg"
@@ -200,11 +190,6 @@ exports[`AccordionSkeleton should render 1`] = `
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 16 16"
                 width={16}
                 xmlns="http://www.w3.org/2000/svg"
@@ -260,11 +245,6 @@ exports[`AccordionSkeleton should render 1`] = `
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 16 16"
                 width={16}
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/Accordion/__tests__/__snapshots__/AccordionItem-test.js.snap
+++ b/packages/react/src/components/Accordion/__tests__/__snapshots__/AccordionItem-test.js.snap
@@ -45,11 +45,6 @@ exports[`AccordionItem should render 1`] = `
               height={16}
               preserveAspectRatio="xMidYMid meet"
               role="img"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 16 16"
               width={16}
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2040,11 +2040,6 @@ exports[`DataTable should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -2112,11 +2107,6 @@ exports[`DataTable should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -2184,11 +2174,6 @@ exports[`DataTable should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -2292,11 +2277,6 @@ exports[`DataTable should render 1`] = `
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            style={
-                              Object {
-                                "willChange": "transform",
-                              }
-                            }
                             viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
@@ -2345,11 +2325,6 @@ exports[`DataTable should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -2454,11 +2429,6 @@ exports[`DataTable should render 1`] = `
                               onKeyDown={[Function]}
                               preserveAspectRatio="xMidYMid meet"
                               role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 16 16"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -3043,11 +3013,6 @@ exports[`DataTable sticky header should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -3115,11 +3080,6 @@ exports[`DataTable sticky header should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -3187,11 +3147,6 @@ exports[`DataTable sticky header should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -3295,11 +3250,6 @@ exports[`DataTable sticky header should render 1`] = `
                             focusable="false"
                             height={16}
                             preserveAspectRatio="xMidYMid meet"
-                            style={
-                              Object {
-                                "willChange": "transform",
-                              }
-                            }
                             viewBox="0 0 16 16"
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
@@ -3348,11 +3298,6 @@ exports[`DataTable sticky header should render 1`] = `
                               focusable="false"
                               height={16}
                               preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 32 32"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
@@ -3457,11 +3402,6 @@ exports[`DataTable sticky header should render 1`] = `
                               onKeyDown={[Function]}
                               preserveAspectRatio="xMidYMid meet"
                               role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
                               viewBox="0 0 16 16"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableBatchAction-test.js.snap
@@ -54,11 +54,6 @@ exports[`DataTable.TableBatchAction should render 1`] = `
             height={16}
             preserveAspectRatio="xMidYMid meet"
             role="img"
-            style={
-              Object {
-                "willChange": "transform",
-              }
-            }
             viewBox="0 0 32 32"
             width={16}
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -54,11 +54,6 @@ exports[`DataTable.TableExpandRow should render 1`] = `
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
                         viewBox="0 0 16 16"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
@@ -91,11 +91,6 @@ exports[`DataTable.TableToolbarMenu should render 1`] = `
                 onKeyDown={[Function]}
                 preserveAspectRatio="xMidYMid meet"
                 role="img"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 16 16"
                 width={16}
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -51,11 +51,6 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 16 16"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -104,11 +99,6 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 32 32"
                 width={16}
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -145,11 +145,6 @@ exports[`Dropdown should render 1`] = `
                         name="chevron--down"
                         preserveAspectRatio="xMidYMid meet"
                         role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
                         viewBox="0 0 16 16"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"
@@ -319,11 +314,6 @@ exports[`Dropdown should render custom item components 1`] = `
                         name="chevron--down"
                         preserveAspectRatio="xMidYMid meet"
                         role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
                         viewBox="0 0 16 16"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"
@@ -652,11 +642,6 @@ exports[`Dropdown should render with strings as items 1`] = `
                         name="chevron--down"
                         preserveAspectRatio="xMidYMid meet"
                         role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
                         viewBox="0 0 16 16"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -38,11 +38,6 @@ exports[`ListBoxField should render 1`] = `
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"
@@ -99,11 +94,6 @@ exports[`ListBoxField should set \`aria-owns\` based when expanded 1`] = `
               focusable="false"
               height={16}
               preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 32 32"
               width={16}
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
@@ -28,11 +28,6 @@ exports[`ListBoxMenuIcon should render 1`] = `
           name="chevron--down"
           preserveAspectRatio="xMidYMid meet"
           role="img"
-          style={
-            Object {
-              "willChange": "transform",
-            }
-          }
           viewBox="0 0 16 16"
           width={16}
           xmlns="http://www.w3.org/2000/svg"
@@ -78,11 +73,6 @@ exports[`ListBoxMenuIcon should render 2`] = `
           name="chevron--down"
           preserveAspectRatio="xMidYMid meet"
           role="img"
-          style={
-            Object {
-              "willChange": "transform",
-            }
-          }
           viewBox="0 0 16 16"
           width={16}
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -48,11 +48,6 @@ exports[`ListBoxSelection should render 1`] = `
           focusable="false"
           height={16}
           preserveAspectRatio="xMidYMid meet"
-          style={
-            Object {
-              "willChange": "transform",
-            }
-          }
           viewBox="0 0 32 32"
           width={16}
           xmlns="http://www.w3.org/2000/svg"
@@ -117,11 +112,6 @@ exports[`ListBoxSelection should render 2`] = `
           focusable="false"
           height={16}
           preserveAspectRatio="xMidYMid meet"
-          style={
-            Object {
-              "willChange": "transform",
-            }
-          }
           viewBox="0 0 32 32"
           width={16}
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -123,11 +123,6 @@ exports[`ModalWrapper should render 1`] = `
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
                     role="img"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
                     viewBox="0 0 32 32"
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -162,11 +162,6 @@ exports[`MultiSelect.Filterable should render 1`] = `
                           name="chevron--down"
                           preserveAspectRatio="xMidYMid meet"
                           role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
                           viewBox="0 0 16 16"
                           width={16}
                           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -155,11 +155,6 @@ exports[`MultiSelect should render 1`] = `
                           name="chevron--down"
                           preserveAspectRatio="xMidYMid meet"
                           role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
                           viewBox="0 0 16 16"
                           width={16}
                           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderGlobalAction-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderGlobalAction-test.js.snap
@@ -26,11 +26,6 @@ exports[`HeaderGlobalAction should render 1`] = `
           focusable="false"
           height={32}
           preserveAspectRatio="xMidYMid meet"
-          style={
-            Object {
-              "willChange": "transform",
-            }
-          }
           viewBox="0 0 32 32"
           width={32}
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
@@ -38,11 +38,6 @@ exports[`HeaderMenu should render 1`] = `
                 focusable="false"
                 height={16}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 16 16"
                 width={16}
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenuButton-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenuButton-test.js.snap
@@ -27,11 +27,6 @@ exports[`HeaderMenuButton should render 1`] = `
           focusable="false"
           height={20}
           preserveAspectRatio="xMidYMid meet"
-          style={
-            Object {
-              "willChange": "transform",
-            }
-          }
           viewBox="0 0 20 20"
           width={20}
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavFooter-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavFooter-test.js.snap
@@ -31,11 +31,6 @@ exports[`SideNavFooter should render 1`] = `
               focusable="false"
               height={20}
               preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 32 32"
               width={20}
               xmlns="http://www.w3.org/2000/svg"
@@ -89,11 +84,6 @@ exports[`SideNavFooter should render 2`] = `
               focusable="false"
               height={20}
               preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
               viewBox="0 0 32 32"
               width={20}
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
@@ -32,7 +32,6 @@ exports[`SideNavMenu should render 1`] = `
                 focusable="false"
                 height="20"
                 preserveAspectRatio="xMidYMid meet"
-                style="will-change: transform;"
                 viewBox="0 0 32 32"
                 width="20"
                 xmlns="http://www.w3.org/2000/svg"
@@ -109,11 +108,6 @@ exports[`SideNavMenu should render 1`] = `
                 focusable="false"
                 height={20}
                 preserveAspectRatio="xMidYMid meet"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
                 viewBox="0 0 32 32"
                 width={20}
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavSwitcher-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNavSwitcher-test.js.snap
@@ -75,11 +75,6 @@ exports[`SideNavSwitcher should render 1`] = `
             focusable="false"
             height={20}
             preserveAspectRatio="xMidYMid meet"
-            style={
-              Object {
-                "willChange": "transform",
-              }
-            }
             viewBox="0 0 32 32"
             width={20}
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/5274

Our react SVG's were still adding the `will-change: transform` style, which was causing weird interaction errors. This removes that property from each icon that is generated in `icon-build-helpers`

#### Changelog

**Removed**

- SVG's will no longer add `will-change: transform` to each icon processed in `icons-react` 

#### Testing / Reviewing

Ensure the SVG's are not adding this property anymore. May need to run locally and build from the root directory. 
