### PR TITLE
docs: add NPE check for single file drag and drop upload

### DIFF
--- a/packages/react/examples/drag-and-drop-file-uploader/src/index.js
+++ b/packages/react/examples/drag-and-drop-file-uploader/src/index.js
@@ -100,7 +100,9 @@ function ExampleDropContainerApp(props) {
         invalid: true,
       };
       setFiles(files =>
-        files.map(file => (file === fileToUpload ? updatedFile : file))
+        files.map(file =>
+          file.uuid === fileToUpload.uuid ? updatedFile : file
+        )
       );
       console.log(error);
     }
@@ -118,7 +120,7 @@ function ExampleDropContainerApp(props) {
       if (props.multiple) {
         setFiles([...files, ...newFiles]);
         newFiles.forEach(uploadFile);
-      } else {
+      } else if (newFiles[0]) {
         setFiles([newFiles[0]]);
         uploadFile(newFiles[0]);
       }

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -91,7 +91,7 @@ function ExampleDropContainerApp(props) {
       if (props.multiple) {
         setFiles([...files, ...newFiles]);
         newFiles.forEach(uploadFile);
-      } else {
+      } else if (newFiles[0]) {
         setFiles([newFiles[0]]);
         uploadFile(newFiles[0]);
       }


### PR DESCRIPTION
Closes #5811

This PR prevents the drag and drop uploader examples from uploading `undefined` files when `multiple` is `false`

#### Testing / Reviewing

Ensure the storybook and code sandbox drag and drop uploaders examples function as expected