### PR TITLE
fix(modal): prevent overflow indicator from blocking interactive content

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -284,6 +284,7 @@
     bottom: $spacing-09;
     // Safari interprets `transparent` differently, so make color token value transparent instead:
     background-image: linear-gradient(to bottom, rgba($ui-01, 0), $ui-01);
+    pointer-events: none;
   }
 
   .#{$prefix}--modal-content:focus


### PR DESCRIPTION
Closes #5809

This PR allows interactive content underneath the modal overflow indicator to remain interactable

#### Testing / Reviewing

Enable the `hasScrollingContent` prop in the Modal component and position an interactive element in the modal body so that it appears in the modal overflow indicator (the faded area). Confirm that the element is interactable as expected