### PR TITLE
fix(progress-indicator): apply support-01 to warning icon inner paths

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -206,7 +206,7 @@
   }
 
   //ERROR STYLING
-  .#{$prefix}--progress__warning > path {
+  .#{$prefix}--progress__warning > * {
     fill: $support-01;
   }
 


### PR DESCRIPTION
Closes #5815

This PR applies support-01 fill to all inner paths in the progress indicator step warning SVG

#### Testing / Reviewing

Confirm that the warning icon is correct in all themes for the progress indicator 