### PR TITLE
fix(checkbox): match label spacing in skeleton

### DIFF
--- a/packages/components/src/components/checkbox/_checkbox.scss
+++ b/packages/components/src/components/checkbox/_checkbox.scss
@@ -198,7 +198,7 @@
     @include skeleton;
     width: rem(100px);
     height: $spacing-05;
-    margin: auto 0;
+    margin: auto 0 auto rem(6px); // Add extra spacing when label is present
   }
 }
 


### PR DESCRIPTION
This PR adjusts the checkbox skeleton to match the label spacing from #5463

#### Testing / Reviewing

Ensure the checkbox skeleton is visually correct
