### PR TITLE
fix(TableToolbarSearch): fix focus management

### DIFF
--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -80,7 +80,7 @@ const TableToolbarSearch = ({
   const handleExpand = (event, value = !expanded) => {
     if (!controlled && (!persistent || (!persistent && !persistant))) {
       setExpandedState(value);
-      if (value) {
+      if (value && !expanded) {
         setFocusTarget(searchRef);
       }
     }


### PR DESCRIPTION
This change checks if there was actual change in the expanded state of `<TableToolbarSearch>`, to set the focus upon expanding.

Fixes #5852.

#### Changelog

**Changed**

- Change to ensure the logic to moving focus to search input when `<TableToolbarSearch>` is expanded runs only when there is a change in expanded state.

#### Testing / Reviewing

Testing should make sure `<TableToolbarSearch>` is not broken.