### PR TITLE
feat(number-input): respect min, max, and step attributes

### DIFF
--- a/packages/components/src/components/number-input/number-input.js
+++ b/packages/components/src/components/number-input/number-input.js
@@ -51,17 +51,21 @@ class NumberInput extends mixin(
     const max = Number(numberInput.max);
     const step = Number(numberInput.step) || 1;
 
-    if (target.indexOf('up-icon') >= 0) {
+    if (target.indexOf('up-icon') >= 0 && numberInput.value < max) {
       const nextValue = Number(numberInput.value) + step;
       if (nextValue > max) {
         numberInput.value = max;
+      } else if (nextValue < min) {
+        numberInput.value = min;
       } else {
         numberInput.value = nextValue;
       }
-    } else if (target.indexOf('down-icon') >= 0) {
+    } else if (target.indexOf('down-icon') >= 0 && numberInput.value > min) {
       const nextValue = Number(numberInput.value) - step;
       if (nextValue < min) {
         numberInput.value = min;
+      } else if (nextValue > max) {
+        numberInput.value = max;
       } else {
         numberInput.value = nextValue;
       }

--- a/packages/components/src/components/number-input/number-input.js
+++ b/packages/components/src/components/number-input/number-input.js
@@ -47,11 +47,24 @@ class NumberInput extends mixin(
   _handleClick(event) {
     const numberInput = this.element.querySelector(this.options.selectorInput);
     const target = event.currentTarget.getAttribute('class').split(' ');
+    const min = Number(numberInput.min);
+    const max = Number(numberInput.max);
+    const step = Number(numberInput.step) || 1;
 
     if (target.indexOf('up-icon') >= 0) {
-      ++numberInput.value;
+      const nextValue = Number(numberInput.value) + step;
+      if (nextValue > max) {
+        numberInput.value = max;
+      } else {
+        numberInput.value = nextValue;
+      }
     } else if (target.indexOf('down-icon') >= 0) {
-      --numberInput.value;
+      const nextValue = Number(numberInput.value) - step;
+      if (nextValue < min) {
+        numberInput.value = min;
+      } else {
+        numberInput.value = nextValue;
+      }
     }
 
     // Programmatic change in value (including `stepUp()`/`stepDown()`) won't fire change event

--- a/packages/components/tests/spec/number-input_spec.js
+++ b/packages/components/tests/spec/number-input_spec.js
@@ -130,6 +130,21 @@ describe('Test Number Input', function() {
       expect(inputNode.value).toBe('0');
     });
 
+    it('Should not decrease the value past the min', async function() {
+      inputNode.value = 3;
+      inputNode.step = 5;
+      const downArrowNode = document.querySelector('.down-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        downArrowNode.dispatchEvent(
+          new CustomEvent('click', { bubbles: true })
+        );
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('0');
+    });
+
     afterEach(function() {
       events.reset();
     });

--- a/packages/components/tests/spec/number-input_spec.js
+++ b/packages/components/tests/spec/number-input_spec.js
@@ -116,6 +116,18 @@ describe('Test Number Input', function() {
       expect(inputNode.value).toBe('1');
     });
 
+    it('Should increase the value by the step amount', async function() {
+      inputNode.step = 5;
+      const upArrowNode = document.querySelector('.up-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        upArrowNode.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('5');
+    });
+
     it('Should not increase the value past the max', async function() {
       inputNode.step = 5;
       inputNode.max = 3;
@@ -132,6 +144,21 @@ describe('Test Number Input', function() {
     it('Should decrease the value', async function() {
       const downArrowNode = document.querySelector('.down-icon');
       inputNode.value = '1';
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        downArrowNode.dispatchEvent(
+          new CustomEvent('click', { bubbles: true })
+        );
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('0');
+    });
+
+    it('Should decrease the value by the step amount', async function() {
+      inputNode.value = 5;
+      inputNode.step = 5;
+      const downArrowNode = document.querySelector('.down-icon');
       const e = await new Promise(resolve => {
         events.on(document.body, 'change', resolve);
         downArrowNode.dispatchEvent(

--- a/packages/components/tests/spec/number-input_spec.js
+++ b/packages/components/tests/spec/number-input_spec.js
@@ -116,6 +116,19 @@ describe('Test Number Input', function() {
       expect(inputNode.value).toBe('1');
     });
 
+    it('Should not increase the value past the max', async function() {
+      inputNode.step = 5;
+      inputNode.max = 3;
+      const upArrowNode = document.querySelector('.up-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        upArrowNode.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('3');
+    });
+
     it('Should decrease the value', async function() {
       const downArrowNode = document.querySelector('.down-icon');
       inputNode.value = '1';

--- a/packages/components/tests/spec/number-input_spec.js
+++ b/packages/components/tests/spec/number-input_spec.js
@@ -141,6 +141,64 @@ describe('Test Number Input', function() {
       expect(inputNode.value).toBe('3');
     });
 
+    it('Should ignore increment when current value is above maximum', async function() {
+      inputNode.value = 1000;
+      inputNode.step = 10;
+      inputNode.max = 100;
+      const upArrowNode = document.querySelector('.up-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        upArrowNode.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('1000');
+    });
+
+    it('Should set value to maximum on decrement when current value is above maximum', async function() {
+      inputNode.value = inputNode.max + 1;
+      inputNode.step = 10;
+      const downArrowNode = document.querySelector('.down-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        downArrowNode.dispatchEvent(
+          new CustomEvent('click', { bubbles: true })
+        );
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe(inputNode.max);
+    });
+
+    it('Should ignore decrement when current value is below minimum', async function() {
+      inputNode.value = -100;
+      inputNode.step = 10;
+      inputNode.min = 0;
+      const downArrowNode = document.querySelector('.down-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        downArrowNode.dispatchEvent(
+          new CustomEvent('click', { bubbles: true })
+        );
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('-100');
+    });
+
+    it('Should set value to minimum on increment when current value is below minimum', async function() {
+      inputNode.value = inputNode.min - 100;
+      inputNode.step = 10;
+      const upArrowNode = document.querySelector('.up-icon');
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        upArrowNode.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe(inputNode.min);
+    });
+
     it('Should decrease the value', async function() {
       const downArrowNode = document.querySelector('.down-icon');
       inputNode.value = '1';


### PR DESCRIPTION
Closes #5885

This PR adds support for the `min`, `max`, and `step` attributes in the number input component

#### Testing / Reviewing

Confirm the `min`, `max`, and `step` values are respected when incrementing and decrementing the number input