### PR TITLE
fix(react): stop passing selectionMode through as a prop

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -40,6 +40,10 @@ describe('ContentSwitcher', () => {
     it('should apply extra classes passed to it', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
+
+    it('should not have a selectionMode prop', () => {
+      expect('selectionMode' in wrapper.props()).toEqual(false);
+    });
   });
 
   describe('Allow initial state to draw from props', () => {

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -112,6 +112,7 @@ export default class ContentSwitcher extends React.Component {
       children,
       className,
       selectedIndex, // eslint-disable-line no-unused-vars
+      selectionMode, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
 

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -74,6 +74,12 @@ describe('Tabs', () => {
             .hasClass(`${prefix}--tabs--container`)
         ).toBe(true);
       });
+
+      it('has no selectionMode prop', () => {
+        expect(
+          'selectionMode' in wrapper.find(`.${prefix}--tabs`).props()
+        ).toBe(false);
+      });
     });
 
     describe('Trigger (<div>)', () => {

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -227,6 +227,7 @@ export default class Tabs extends React.Component {
       role,
       type,
       onSelectionChange,
+      selectionMode, // eslint-disable-line no-unused-vars
       tabContentClassName,
       ...other
     } = this.props;


### PR DESCRIPTION
Closes #5903.

In `<ContentSwitcher>` and `<Tabs>`, the `selectionMode` is no longer passed as a prop to the inner `<div>`.

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}

Unit tests have been added to demonstrate this issue. Reviewers can also view these components in Storybook and see that the errors in question have gone away. However, you might consider altering your unit testing so that all errors of this kind cause a failure automatically.