### PR TITLE
fix(tabs): revert input background changes

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -408,32 +408,6 @@
     padding: $carbon--spacing-05;
   }
 
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--text-input,
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--text-area,
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--search-input,
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--select-input,
-  .#{$prefix}--tabs--container ~ .#{$prefix}--tab-content .#{$prefix}--dropdown,
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--dropdown-list,
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--number
-    input[type='number'],
-  .#{$prefix}--tabs--container
-    ~ .#{$prefix}--tab-content
-    .#{$prefix}--date-picker__input {
-    background-color: $field-02;
-  }
-
   //-----------------------------
   // Skeleton state
   //-----------------------------

--- a/packages/components/src/components/tile/_tile.scss
+++ b/packages/components/src/components/tile/_tile.scss
@@ -33,17 +33,6 @@
     }
   }
 
-  .#{$prefix}--tile .#{$prefix}--text-input,
-  .#{$prefix}--tile .#{$prefix}--text-area,
-  .#{$prefix}--tile .#{$prefix}--search-input,
-  .#{$prefix}--tile .#{$prefix}--select-input,
-  .#{$prefix}--tile .#{$prefix}--dropdown,
-  .#{$prefix}--tile .#{$prefix}--dropdown-list,
-  .#{$prefix}--tile .#{$prefix}--number input[type='number'],
-  .#{$prefix}--tile .#{$prefix}--date-picker__input {
-    background-color: $field-02;
-  }
-
   .#{$prefix}--tile--light {
     background-color: $ui-02;
   }

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -200,7 +200,7 @@ storiesOf('Tabs', module)
           label={<CustomLabel text="Custom Label" />}>
           <div className="some-content">
             <p>Content for fourth tab goes here.</p>
-            <TextInput id="sample-input" labelText="text input label" />
+            <TextInput light id="sample-input" labelText="Text Input Label" />
           </div>
         </Tab>
       </Tabs>


### PR DESCRIPTION
Refs #5598 

Based on a conversation in Slack, these changes were causing unintended consequences. We'll have to postpone this until v11 and also make sure we target inputs that are using the `light` prop. 

https://ibm-studios.slack.com/archives/C046Y0YUD/p1587564854319500

<img width="482" alt="Screen Shot 2020-04-22 at 10 56 20 AM" src="https://user-images.githubusercontent.com/11928039/80016702-53870e00-8488-11ea-930a-2fe4dfd349e0.png">


#### Changelog

**Changed**

- Left the story change intact, but used `light` prop to achieve the same effect

**Removed**

- Container Tab + Tile specific styles setting all input backgrounds to `field-02`

#### Testing / Reviewing

Verify nothing is broken
