### PR TITLE
fix(breadcrumb): add reset for `ol`

### DIFF
--- a/packages/components/src/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/src/components/breadcrumb/_breadcrumb.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
+@import '../../globals/scss/css--reset';
 @import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/layout';
@@ -16,6 +17,7 @@
 /// @group breadcrumb
 @mixin breadcrumb {
   .#{$prefix}--breadcrumb {
+    @include reset;
     @include type-style('body-short-01');
     display: inline;
     @include carbon--breakpoint(md) {


### PR DESCRIPTION
## Changelog

**New**

Add reset to `Breadcrumb` to prevent browser defaults for containing `ol` when the CSS reset is toggled off