### PR TITLE
fix(progress-indicator): prevent onChange events on disabled items

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -205,6 +205,7 @@
   //DISABLED STYLING
   .#{$prefix}--progress-step--disabled {
     cursor: not-allowed;
+    pointer-events: none;
 
     svg {
       fill: $disabled;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -105,6 +105,7 @@ export function ProgressStep({
         className={classnames(`${prefix}--progress-step-button`, {
           [`${prefix}--progress-step-button--unclickable`]: !onClick || current,
         })}
+        disabled={disabled}
         aria-disabled={disabled}
         tabIndex={!current && onClick ? 0 : -1}
         onClick={!current ? onClick : undefined}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5913

Prevent disabled items from firing the `onChange` of `ProgressIndicator`

#### Changelog

**New**

- Made button elements disabled if the prop is added
- Sets `pointer-events: none` on disabled elements

#### Testing / Reviewing

Add `onChange` handler to `ProgressIndicator` and click on a disabled item. Make sure the index is not logged. 
