### PR TITLE
fix(react): add use-resize-observer to dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,6 +49,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "react-is": "^16.8.6",
+    "use-resize-observer": "^6.0.0",
     "warning": "^3.0.0",
     "window-or-global": "^1.0.1"
   },
@@ -115,7 +116,6 @@
     "storybook-readme": "^5.0.8",
     "string-replace-loader": "^2.1.0",
     "terser-webpack-plugin": "^2.3.2",
-    "use-resize-observer": "^6.0.0",
     "webpack": "^4.41.5",
     "whatwg-fetch": "^2.0.3"
   },


### PR DESCRIPTION
Hotfix to add `use-resize-observer` to dependencies