### PR TITLE
fix(toggle-small): only emit onChange on keyUp if it exists

### DIFF
--- a/packages/react/src/components/ToggleSmall/ToggleSmall.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.js
@@ -58,7 +58,7 @@ const ToggleSmall = ({
         onKeyUp={evt => {
           if (match(evt, keys.Enter)) {
             input.checked = !input.checked;
-            onChange(evt);
+            onChange && onChange(evt);
             onToggle(input.checked, id, evt);
           }
         }}


### PR DESCRIPTION
Fixes #5930

#### Changelog

**Changed**

- Only emit `onChange` in `onKeyUp` handler if `onChange` is provided

#### Testing / Reviewing

1. Re-create test-case given in #5930 
2. Verify with changes from this PR
