### PR TITLE
ci(actions): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install --offline
+      - name: Build project
+        run: yarn build
+      - name: Publish packages under the `next` dist tag
+        run: yarn lerna publish from-package --dist-tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Prepare artifacts for release
+        run: |
+          zip -r --junk-paths carbon-elements.sketchplugin.zip packages/sketch/carbon-elements.sketchplugin
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: true
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./carbon-elements.sketchplugin.zip
+          asset_name: carbon-elements.sketchplugin.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release
+name: Release
 
 on:
   push:
@@ -12,21 +12,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+
       - name: Install dependencies
         run: yarn install --offline
+
       - name: Build project
         run: yarn build
+
       - name: Publish packages under the `next` dist tag
         run: yarn lerna publish from-package --dist-tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Prepare artifacts for release
         run: |
           zip -r --junk-paths carbon-elements.sketchplugin.zip packages/sketch/carbon-elements.sketchplugin
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
@@ -37,6 +43,7 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: true
+
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build project
         run: yarn build
 
+      - name: Run Continuous Integration checks
+        run: yarn ci-check
+
       - name: Publish packages under the `next` dist tag
         run: yarn lerna publish from-package --dist-tag next
         env:


### PR DESCRIPTION
Sets up an automated release workflow that generates a GitHub Release, uploads artifacts for the release, and publishes our packages to npm using GitHub Actions.

This release workflow responds whenever we push up a `v*` tag to our project and performs the following steps:

- Clone, install, and build the project
- Publish changes packages under the `@next` tag
- Creates a GitHub release for the given tag
- Uploads `carbon-elements.sketch.zip` to the release

#### Changelog

**New**

- Add release workflow

**Changed**

**Removed**

#### Testing / Reviewing

- Hope it works? 😅 
