### PR TITLE
fix(tooltip): change aria-describedby a11y

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -455,7 +455,6 @@ class Tooltip extends Component {
               this._tooltipEl = node;
             }}>
             <div
-              id={tooltipId}
               className={tooltipClasses}
               {...other}
               data-floating-menu-direction={direction}
@@ -467,6 +466,7 @@ class Tooltip extends Component {
               role="tooltip">
               <span className={`${prefix}--tooltip__caret`} />
               <div
+                id={tooltipId}
                 className={`${prefix}--tooltip__content`}
                 tabIndex="-1"
                 role="dialog"


### PR DESCRIPTION
Closes #5959

I tested the `Tooltip` element with VoiceOver on MacOS and couldn't get it to announce the contents of the tooltip upon focusing on the triggering button element. 

#### Changelog

**Changed**

- I moved the `tooltipId` to the element that has the `role="dialog"` attribute. That seems to fix the issue with VoiceOver

#### Testing / Reviewing

Open the Storybook and fire up VoiceIver to test it.

Important information: I tested the `Tooltip` component with NVDA on Windows and couldn't get it to work either way. I think there are further, more deep-rooted A11Y issues with `Tooltip` but PR #5489 seems to address those.