### PR TITLE
fix(Slider): fix slider position based on value min and range

### DIFF
--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -25,9 +25,9 @@ describe('Slider', () => {
       <Slider
         id={id}
         className="extra-class"
-        value={50}
-        min={0}
-        max={100}
+        value={1}
+        min={1}
+        max={3}
         step={1}
       />
     );
@@ -54,6 +54,10 @@ describe('Slider', () => {
     it('can set value via props', () => {
       wrapper.setProps({ value: 55 });
       expect(wrapper.props().value).toEqual(55);
+    });
+
+    it('should accurately position slider on mount', () => {
+      expect(wrapper.state().left).toEqual(0);
     });
 
     it('should specify light version as expected', () => {

--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -424,7 +424,7 @@ export default class Slider extends PureComponent {
       if (value == null) {
         value = this.state.value;
       }
-      leftPercent = value / (range - this.props.min);
+      leftPercent = (value - this.props.min) / range;
     }
 
     if (useRawValue) {


### PR DESCRIPTION
Closes #5945

This PR fixes the slider position for all min values and ranges

#### Changelog

**Changed**

- `leftPercent` calculation

#### Testing / Reviewing

Confirm the slider position is correct esp for nonzero min values
