### PR TITLE
fix(text-input): remove outline flicker during state transition

### DIFF
--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -141,8 +141,8 @@
   // Disabled
   //-----------------------------
   .#{$prefix}--text-input:disabled {
+    @include focus-outline('reset');
     cursor: not-allowed;
-    outline: none;
     background-color: $disabled-01;
     border-bottom: 1px solid transparent;
     color: $disabled-02;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5979

Sets outline to transparent when disabled so that there is not a visible state change when toggling between disabled/enabled. 

#### Changelog

**Changed**

- Instead of setting the outline to `none`, we set it to transparent. 

#### Testing / Reviewing

Check out the `TextInput` story, and toggle the disabled state a few times. You should not see any flicker around the input. 
