### PR TITLE
fix(accordion): change accordion heading height to 40px

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -43,6 +43,7 @@
     padding: rem(6px) 0;
     flex-direction: $accordion-flex-direction;
     position: relative;
+    height: rem(40px);
     width: 100%;
     margin: 0;
     transition: background-color motion(standard, productive) $duration--fast-02;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5983

Changes Accordion Heading to `40px`, was `32px`

#### Changelog

**Changed**

- `bx--accordion__heading` height to `40px`

#### Testing / Reviewing

Ensure nothing is broken, and that Accordion looks correct 
