### PR TITLE
fix(list-box): increase specificity on closed menu

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -426,10 +426,15 @@ $list-box-menu-width: rem(300px);
     right: 0;
     width: $list-box-width;
     background-color: $ui-01;
-    max-height: 0;
     transition: max-height $duration--fast-02 motion(standard, productive);
     overflow-y: auto;
     z-index: z('dropdown');
+  }
+
+  .#{$prefix}--list-box
+    .#{$prefix}--list-box__field[aria-expanded='false']
+    + .#{$prefix}--list-box__menu {
+    max-height: 0;
   }
 
   .#{$prefix}--list-box--expanded .#{$prefix}--list-box__menu {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6002

When we added in the List Box animations, we set the `max-height` to 0 on closed list box menus. Some applications were overriding the max-height, which was causing the menus to be stuck open. This PR increases the selector specificity so that ours _should_ take precedent over an end-users selector. 

#### Changelog

**Changed**

- Increased selector specificity so that our styles should take precedence when the menu is closed 

#### Testing / Reviewing

Try to override the list-box menu `max-height` property in `.storybook/styles.scss` like so 

```scss
html body.sb-show-main .bx--list-box__menu {
  max-height: rem(340px);
}
```

The menu should remain closed but should have an increased size when opened. 
