### PR TITLE
fix(filename): remove added height for close button

### DIFF
--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -251,6 +251,7 @@
   }
 
   .#{$prefix}--file__state-container .#{$prefix}--file-close {
+    display: flex;
     height: $carbon--spacing-05;
     width: $carbon--spacing-05;
     background-color: transparent;


### PR DESCRIPTION
Closes #6021

On Firefox 77+ on Windows, the added `button` element to `Filename` is causing height mismatches which appear when the focus outline is visible. Originally missed this as the refactoring effort was combined with this change 

#### Testing / Reviewing

Ensure the `<Filename>` close button focus outline appears correct on all supported platforms
