### PR TITLE
fix(DataTableSkeleton): replace toolbar button skeletons with spans

### DIFF
--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -52,9 +52,8 @@ const DataTableSkeleton = ({
         aria-label="data table toolbar"
         className={`${prefix}--table-toolbar`}>
         <div className={`${prefix}--toolbar-content`}>
-          <button
-            className={`${prefix}--skeleton ${prefix}--btn ${prefix}--btn--sm`}
-            type="button"></button>
+          <span
+            className={`${prefix}--skeleton ${prefix}--btn ${prefix}--btn--sm`}></span>
         </div>
       </section>
       <table className={dataTableSkeletonClasses} {...rest}>


### PR DESCRIPTION
Closes #6026

This PR replaces the data table skeleton toolbar buttons with `span`s so the DAP form label requirement is not missing

#### Testing / Reviewing

Confirm the related DAP error is resolved and the data table skeleton still appears correct