### PR TITLE
fix(SideNav): detect child node for blur

### DIFF
--- a/packages/react/src/components/UIShell/SideNav.js
+++ b/packages/react/src/components/UIShell/SideNav.js
@@ -95,8 +95,16 @@ const SideNav = React.forwardRef(function SideNav(props, ref) {
   let eventHandlers = {};
 
   if (addFocusListeners) {
-    eventHandlers.onFocus = event => handleToggle(event, true);
-    eventHandlers.onBlur = event => handleToggle(event, false);
+    eventHandlers.onFocus = event => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        handleToggle(event, true);
+      }
+    };
+    eventHandlers.onBlur = event => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        handleToggle(event, false);
+      }
+    };
   }
 
   if (addMouseListeners && isRail) {


### PR DESCRIPTION
This changes fixes a logic in `<SideNav>` where it detects focus on a
nav item as side nav losing focus as a whole.

Fixes #6004.

#### Changelog

**Changed**

- A change to stop toggling on focus/blur upon a side nav item getting/losing focus.

#### Testing / Reviewing

Testing should make sure side nav is not broken.