### PR TITLE
feat(ComboBox): focus input after clearing selection

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -249,6 +249,12 @@ export default class ComboBox extends React.Component {
     );
   };
 
+  handleSelectionClear = () => {
+    if (this.textInput?.current) {
+      this.textInput.current.focus();
+    }
+  };
+
   handleOnStateChange = (newState, { setHighlightedIndex }) => {
     if (Object.prototype.hasOwnProperty.call(newState, 'inputValue')) {
       const { inputValue } = newState;
@@ -383,6 +389,8 @@ export default class ComboBox extends React.Component {
                     clearSelection={clearSelection}
                     translateWithId={translateWithId}
                     disabled={disabled}
+                    onClick={this.handleSelectionClear}
+                    onKeyDown={this.handleSelectionClear}
                   />
                 )}
                 <ListBox.MenuIcon

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -389,8 +389,7 @@ export default class ComboBox extends React.Component {
                     clearSelection={clearSelection}
                     translateWithId={translateWithId}
                     disabled={disabled}
-                    onClick={this.handleSelectionClear}
-                    onKeyDown={this.handleSelectionClear}
+                    onClearSelection={this.handleSelectionClear}
                   />
                 )}
                 <ListBox.MenuIcon

--- a/packages/react/src/components/ListBox/ListBoxSelection.js
+++ b/packages/react/src/components/ListBox/ListBoxSelection.js
@@ -24,8 +24,7 @@ const ListBoxSelection = ({
   selectionCount,
   translateWithId: t,
   disabled,
-  onClick,
-  onKeyDown,
+  onClearSelection,
 }) => {
   const className = cx(`${prefix}--list-box__selection`, {
     [`${prefix}--tag--filter`]: selectionCount,
@@ -37,8 +36,8 @@ const ListBoxSelection = ({
       return;
     }
     clearSelection(event);
-    if (onClick) {
-      onClick(event);
+    if (onClearSelection) {
+      onClearSelection(event);
     }
   };
   const handleOnKeyDown = event => {
@@ -50,8 +49,8 @@ const ListBoxSelection = ({
     // When a user hits ENTER, we'll clear the selection
     if (match(event, keys.Enter)) {
       clearSelection(event);
-      if (onKeyDown) {
-        onKeyDown(event);
+      if (onClearSelection) {
+        onClearSelection(event);
       }
     }
   };

--- a/packages/react/src/components/ListBox/ListBoxSelection.js
+++ b/packages/react/src/components/ListBox/ListBoxSelection.js
@@ -24,6 +24,8 @@ const ListBoxSelection = ({
   selectionCount,
   translateWithId: t,
   disabled,
+  onClick,
+  onKeyDown,
 }) => {
   const className = cx(`${prefix}--list-box__selection`, {
     [`${prefix}--tag--filter`]: selectionCount,
@@ -35,6 +37,9 @@ const ListBoxSelection = ({
       return;
     }
     clearSelection(event);
+    if (onClick) {
+      onClick(event);
+    }
   };
   const handleOnKeyDown = event => {
     event.stopPropagation();
@@ -45,6 +50,9 @@ const ListBoxSelection = ({
     // When a user hits ENTER, we'll clear the selection
     if (match(event, keys.Enter)) {
       clearSelection(event);
+      if (onKeyDown) {
+        onKeyDown(event);
+      }
     }
   };
   const description = selectionCount ? t('clear.all') : t('clear.selection');
@@ -75,6 +83,11 @@ const defaultTranslations = {
 
 ListBoxSelection.propTypes = {
   /**
+   * Specify whether or not the clear selection element should be disabled
+   */
+  disabled: PropTypes.bool,
+
+  /**
    * Specify a function to be invoked when a user interacts with the clear
    * selection element.
    */
@@ -92,6 +105,18 @@ ListBoxSelection.propTypes = {
    * return a string message for that given message id.
    */
   translateWithId: PropTypes.func.isRequired,
+
+  /**
+   * Specify an optional `onClick` handler that is called when the underlying
+   * clear selection element is clicked
+   */
+  onClick: PropTypes.func,
+
+  /**
+   * Specify an optional `onKeyDown` handler that is called when the underlying
+   * clear selection element fires a keydown event
+   */
+  onKeyDown: PropTypes.func,
 };
 
 ListBoxSelection.defaultProps = {


### PR DESCRIPTION
Closes #6030

This PR focuses the combobox input after the clear selection button is activated (via click or <kbd>Enter</kbd> keydown) so that focus remains within the component after user interaction

#### Testing / Reviewing

Confirm that focus is not lost when the clear selection button is triggered via mouse click or <kbd>Enter</kbd> keypress
