### PR TITLE
fix(progress-indicator): remove progress bar space on content wrap

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -296,6 +296,8 @@
   }
 
   .#{$prefix}--progress--vertical .#{$prefix}--progress-line {
+    position: absolute;
+    top: 0;
     left: 0;
     height: 100%;
     width: 1px;


### PR DESCRIPTION
Closes #6044

This PR removes extra spaces in the vertical progress bar when the label text wraps

#### Testing / Reviewing

Increase the length of the progress step label until the text wraps and confirm that there are no spaces in the vertical progress bar