### PR TITLE
fix(progress-indicator): prevent progress step label SVG from shrinking

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -55,6 +55,7 @@
   .#{$prefix}--progress-step svg {
     position: relative;
     z-index: 1;
+    flex-shrink: 0;
     width: $carbon--spacing-05;
     height: $carbon--spacing-05;
     border-radius: 50%;

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator-story.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator-story.js
@@ -22,11 +22,11 @@ storiesOf('ProgressIndicator', module)
     'Default',
     () => (
       <ProgressIndicator
-        vertical={boolean('Vertical', false)}
+        vertical={boolean('Vertical (vertical)', false)}
         currentIndex={number('Current progress (currentIndex)', 1)}
-        spaceEqually={boolean('Space Equally', false)}>
+        spaceEqually={boolean('Space Equally (spaceEqually)', false)}>
         <ProgressStep
-          label={text('Label', 'First step')}
+          label={text('Label (label)', 'First step')}
           description="Step 1: Getting started with Carbon Design System"
           secondaryLabel="Optional label"
         />


### PR DESCRIPTION
Closes #6050

This PR prevents the progress step label SVGs from shrinking when the component width is reduced

#### Testing / Reviewing

- view the progress indicator story
- enable `spaceEqually` prop
- reduce component width
- confirm the progress step label SVGs are no longer shrinking