### PR TITLE
test(checkbox): restore id and htmlFor tests

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox-test.js
+++ b/packages/react/src/components/Checkbox/Checkbox-test.js
@@ -29,12 +29,20 @@ describe('Checkbox', () => {
         expect(label.hasClass(`${prefix}--checkbox-label`)).toEqual(true);
       });
 
+      it('has the expected htmlFor value', () => {
+        expect(label.props().htmlFor).toEqual('testing');
+      });
+
       it('applies extra classes to label', () => {
         expect(label.hasClass('extra-class')).toEqual(true);
       });
 
       describe('input', () => {
         const input = () => wrapper.find('input');
+
+        it('has id set as expected', () => {
+          expect(input().props().id).toEqual('testing');
+        });
 
         it('defaultChecked prop sets defaultChecked on input', () => {
           expect(input().props().defaultChecked).toBeUndefined();


### PR DESCRIPTION
The PR restores the `Checkbox` tests for `id` and `htmlFor` that I mentioned here: https://github.com/carbon-design-system/carbon/pull/6049#issuecomment-625964072

Please let me know if you'd like to see any changes to the tests. I just grabbed them from the history.

#### Changelog

**New**

- restore tests for `id` and `htmlFor`