### PR TITLE
fix(progress-indicator): left align text in progress step

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -181,6 +181,7 @@
   .#{$prefix}--progress-step-button {
     @include button-reset();
     display: flex;
+    text-align: left;
   }
 
   //unclickable button


### PR DESCRIPTION
Closes #6059

This PR overrides the default button text alignment to follow the component spec.

#### Testing / Reviewing

Confirm that progress step label text is left aligned in the vertical and horizontal progress indicator
