### PR TITLE
fix(pagination): add pageSizeInputDisabled prop to Pagination

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3852,6 +3852,7 @@ Map {
       "pageInputDisabled": false,
       "pageNumberText": "Page Number",
       "pageRangeText": [Function],
+      "pageSizeInputDisabled": false,
       "pageText": [Function],
       "pagesUnknown": false,
     },
@@ -3910,6 +3911,9 @@ Map {
       },
       "pageSize": Object {
         "type": "number",
+      },
+      "pageSizeInputDisabled": Object {
+        "type": "bool",
       },
       "pageSizes": Object {
         "args": Array [

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3852,7 +3852,6 @@ Map {
       "pageInputDisabled": false,
       "pageNumberText": "Page Number",
       "pageRangeText": [Function],
-      "pageSizeInputDisabled": false,
       "pageText": [Function],
       "pagesUnknown": false,
     },
@@ -3900,9 +3899,7 @@ Map {
       "page": Object {
         "type": "number",
       },
-      "pageInputDisabled": Object {
-        "type": "bool",
-      },
+      "pageInputDisabled": [Function],
       "pageNumberText": Object {
         "type": "string",
       },
@@ -3911,9 +3908,6 @@ Map {
       },
       "pageSize": Object {
         "type": "number",
-      },
-      "pageSizeInputDisabled": Object {
-        "type": "bool",
       },
       "pageSizes": Object {
         "args": Array [

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -19,11 +19,14 @@ import {
 import Pagination from '../Pagination';
 
 const props = () => ({
-  disabled: boolean('Disable backward/forward buttons (disabled)', false),
+  disabled: boolean('Disable page inputs (disabled)', false),
   page: number('The current page (page)', 1),
   totalItems: number('Total number of items (totalItems)', 103),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
-  pageInputDisabled: boolean('Disable page input (pageInputDisabled)', false),
+  pageInputDisabled: boolean(
+    '[Deprecated]: Disable page input (pageInputDisabled)',
+    false
+  ),
   backwardText: text(
     'The description for the backward icon (backwardText)',
     'Previous page'

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -23,10 +23,6 @@ const props = () => ({
   page: number('The current page (page)', 1),
   totalItems: number('Total number of items (totalItems)', 103),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
-  pageSizeInputDisabled: boolean(
-    'Disable page size input (pageSizeInputDisabled)',
-    false
-  ),
   pageInputDisabled: boolean('Disable page input (pageInputDisabled)', false),
   backwardText: text(
     'The description for the backward icon (backwardText)',

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -23,6 +23,10 @@ const props = () => ({
   page: number('The current page (page)', 1),
   totalItems: number('Total number of items (totalItems)', 103),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
+  pageSizeInputDisabled: boolean(
+    'Disable page size input (pageInputDisabled)',
+    false
+  ),
   pageInputDisabled: boolean('Disable page input (pageInputDisabled)', false),
   backwardText: text(
     'The description for the backward icon (backwardText)',

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -24,7 +24,7 @@ const props = () => ({
   totalItems: number('Total number of items (totalItems)', 103),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
   pageSizeInputDisabled: boolean(
-    'Disable page size input (pageInputDisabled)',
+    'Disable page size input (pageSizeInputDisabled)',
     false
   ),
   pageInputDisabled: boolean('Disable page input (pageInputDisabled)', false),

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -130,7 +130,7 @@ export default class Pagination extends Component {
      */
     pageInputDisabled: deprecate(
       PropTypes.bool,
-      `\nThe prop \`pageInputDisabled\` for Pagination has been deprecated, as the feature of \`pageInputDisabled\` has been combined with the general \`disabled\` prop.`
+      `The prop \`pageInputDisabled\` for Pagination has been deprecated, as the feature of \`pageInputDisabled\` has been combined with the general \`disabled\` prop.`
     ),
   };
 

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -14,6 +14,7 @@ import Select from '../Select';
 import SelectItem from '../SelectItem';
 import { equals } from '../../tools/array';
 import Button from '../Button';
+import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
@@ -99,7 +100,7 @@ export default class Pagination extends Component {
     totalItems: PropTypes.number,
 
     /**
-     * `true` if the backward/forward buttons should be disabled.
+     * `true` if the backward/forward buttons, as well as the page select elements,  should be disabled.
      */
     disabled: PropTypes.bool,
 
@@ -125,9 +126,12 @@ export default class Pagination extends Component {
     isLastPage: PropTypes.bool,
 
     /**
-     * `true` if the select box to change the page should be disabled.
+     * Deprecated; `true` if the select box to change the page should be disabled.
      */
-    pageInputDisabled: PropTypes.bool,
+    pageInputDisabled: deprecate(
+      PropTypes.bool,
+      `\nThe prop \`pageInputDisabled\` for Pagination has been deprecated, as the feature of \`pageInputDisabled\` has been combined with the general \`disabled\` prop.`
+    ),
   };
 
   static defaultProps = {
@@ -236,6 +240,7 @@ export default class Pagination extends Component {
       pageNumberText, // eslint-disable-line no-unused-vars
       pagesUnknown,
       isLastPage,
+      disabled,
       pageInputDisabled,
       totalItems,
       onChange, // eslint-disable-line no-unused-vars
@@ -247,7 +252,7 @@ export default class Pagination extends Component {
     const inputId = id || this.uniqueId;
     const { page: statePage, pageSize: statePageSize } = this.state;
     const totalPages = Math.max(Math.ceil(totalItems / statePageSize), 1);
-    const backButtonDisabled = this.props.disabled || statePage === 1;
+    const backButtonDisabled = disabled || statePage === 1;
     const backButtonClasses = classnames(
       `${prefix}--pagination__button`,
       `${prefix}--pagination__button--backward`,
@@ -255,8 +260,7 @@ export default class Pagination extends Component {
         [`${prefix}--pagination__button--no-index`]: backButtonDisabled,
       }
     );
-    const forwardButtonDisabled =
-      this.props.disabled || statePage === totalPages;
+    const forwardButtonDisabled = disabled || statePage === totalPages;
     const forwardButtonClasses = classnames(
       `${prefix}--pagination__button`,
       `${prefix}--pagination__button--forward`,
@@ -282,7 +286,7 @@ export default class Pagination extends Component {
             noLabel
             inline
             onChange={this.handleSizeChange}
-            disabled={pageInputDisabled}
+            disabled={pageInputDisabled || disabled}
             value={statePageSize}>
             {pageSizes.map((size) => (
               <SelectItem key={size} value={size} text={String(size)} />
@@ -310,7 +314,7 @@ export default class Pagination extends Component {
             hideLabel
             onChange={this.handlePageInputChange}
             value={statePage}
-            disabled={pageInputDisabled}>
+            disabled={pageInputDisabled || disabled}>
             {selectItems}
           </Select>
           <span className={`${prefix}--pagination__text`}>

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -128,11 +128,6 @@ export default class Pagination extends Component {
      * `true` if the select box to change the page should be disabled.
      */
     pageInputDisabled: PropTypes.bool,
-
-    /**
-     * `true` if the select box to change the page size should be disabled.
-     */
-    pageSizeInputDisabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -147,7 +142,6 @@ export default class Pagination extends Component {
     pagesUnknown: false,
     isLastPage: false,
     pageInputDisabled: false,
-    pageSizeInputDisabled: false,
     itemText: (min, max) => `${min}–${max} items`,
     pageText: (page) => `page ${page}`,
   };
@@ -243,7 +237,6 @@ export default class Pagination extends Component {
       pagesUnknown,
       isLastPage,
       pageInputDisabled,
-      pageSizeInputDisabled,
       totalItems,
       onChange, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
@@ -289,7 +282,7 @@ export default class Pagination extends Component {
             noLabel
             inline
             onChange={this.handleSizeChange}
-            disabled={pageSizeInputDisabled}
+            disabled={pageInputDisabled}
             value={statePageSize}>
             {pageSizes.map((size) => (
               <SelectItem key={size} value={size} text={String(size)} />

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -128,6 +128,11 @@ export default class Pagination extends Component {
      * `true` if the select box to change the page should be disabled.
      */
     pageInputDisabled: PropTypes.bool,
+
+    /**
+     * `true` if the select box to change the page size should be disabled.
+     */
+    pageSizeInputDisabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -142,6 +147,7 @@ export default class Pagination extends Component {
     pagesUnknown: false,
     isLastPage: false,
     pageInputDisabled: false,
+    pageSizeInputDisabled: false,
     itemText: (min, max) => `${min}–${max} items`,
     pageText: (page) => `page ${page}`,
   };
@@ -189,7 +195,10 @@ export default class Pagination extends Component {
         Math.max(Math.ceil(this.props.totalItems / this.state.pageSize), 1)
     ) {
       this.setState({ page });
-      this.props.onChange({ page, pageSize: this.state.pageSize });
+      this.props.onChange({
+        page,
+        pageSize: this.state.pageSize,
+      });
     }
   };
 
@@ -234,6 +243,7 @@ export default class Pagination extends Component {
       pagesUnknown,
       isLastPage,
       pageInputDisabled,
+      pageSizeInputDisabled,
       totalItems,
       onChange, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
@@ -279,6 +289,7 @@ export default class Pagination extends Component {
             noLabel
             inline
             onChange={this.handleSizeChange}
+            disabled={pageSizeInputDisabled}
             value={statePageSize}>
             {pageSizes.map((size) => (
               <SelectItem key={size} value={size} text={String(size)} />


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6055

This PR now ties all `Pagination` inputs / buttons to the `disabled` prop, rather than having 3 separate props ton control them individually. This also deprecates the `pageInputDisabled` prop.

#### Changelog

**Changed**

- `disabled` prop now controls both `select` elements, as well as the `back` and `forward` buttons.
- `pageInputDisabled` prop now will throw depraction warnings 

#### Testing / Reviewing

Go to `Pagination`, enable the `disabled` prop, and make sure all inputs are disabled 
