### PR TITLE
fix(search): reposition clear input button

### DIFF
--- a/packages/components/src/components/search/_search.scss
+++ b/packages/components/src/components/search/_search.scss
@@ -119,6 +119,7 @@
     @include button-reset(false);
     @include focus-outline('reset');
     position: absolute;
+    top: 0;
     right: 0;
 
     &::before {


### PR DESCRIPTION
Closes #4579 

This PR fixes the positioning of the clear input button in the search component in IE11

#### Testing / Reviewing

View the `<Search>` component and ensure the clear input button is positioned correctly in all browsers
