### PR TITLE
fix(data-table): use box shadow for toolbar search focus outline

### DIFF
--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -155,6 +155,7 @@
     .#{$prefix}--search
     .#{$prefix}--search-input:focus {
     @include focus-outline('outline');
+    box-shadow: inset 0 0 0 2px $focus;
   }
 
   .#{$prefix}--toolbar-search-container-active


### PR DESCRIPTION
Closes #6063

This PR sets the focus outline for the data table toolbar search input using `box-shadow` rather than with the IE11-unsupported `outline-offset`

#### Testing / Reviewing

Expand and focus on the table toolbar search input and confirm that the focus outline appears correct in all browsers