### PR TITLE
fix(FilterableMultiSelect): match label IDs with downshift

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -294,7 +294,7 @@ export default class FilterableMultiSelect extends React.Component {
     const helperId = !helperText
       ? undefined
       : `filterablemultiselect-helper-text-${this.filterableMultiSelectInstanceId}`;
-    const labelId = `filterablemultiselect-label-${this.filterableMultiSelectInstanceId}`;
+    const labelId = `${id}-label`;
     const titleClasses = cx(`${prefix}--label`, {
       [`${prefix}--label--disabled`]: disabled,
     });
@@ -323,6 +323,7 @@ export default class FilterableMultiSelect extends React.Component {
           <Downshift
             {...downshiftProps}
             highlightedIndex={highlightedIndex}
+            id={id}
             isOpen={isOpen}
             inputValue={inputValue}
             onInputValueChange={this.handleOnInputValueChange}

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -60,6 +60,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
         defaultIsOpen={false}
         environment={[Window]}
         getA11yStatusMessage={[Function]}
+        id="test-filterable-multiselect"
         inputValue=""
         isOpen={false}
         itemToString={[Function]}
@@ -78,7 +79,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
         <ListBox
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="downshift-0-label"
+          aria-labelledby="test-filterable-multiselect-label"
           aria-owns={null}
           className="bx--multi-select bx--combo-box bx--multi-select--filterable"
           disabled={false}
@@ -90,7 +91,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
           <div
             aria-expanded={false}
             aria-haspopup="listbox"
-            aria-labelledby="downshift-0-label"
+            aria-labelledby="test-filterable-multiselect-label"
             aria-owns={null}
             className="bx--multi-select bx--combo-box bx--multi-select--filterable bx--list-box"
             onClick={[Function]}
@@ -99,7 +100,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
           >
             <ListBoxField
               aria-haspopup={true}
-              aria-labelledby="filterablemultiselect-label-1"
+              aria-labelledby="test-filterable-multiselect-label"
               data-toggle={true}
               disabled={false}
               id="test-filterable-multiselect"
@@ -113,7 +114,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
               <div
                 aria-controls={null}
                 aria-haspopup={true}
-                aria-labelledby="filterablemultiselect-label-1"
+                aria-labelledby="test-filterable-multiselect-label"
                 aria-owns={null}
                 className="bx--list-box__field"
                 data-toggle={true}
@@ -129,7 +130,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
                   aria-activedescendant={null}
                   aria-autocomplete="list"
                   aria-controls={null}
-                  aria-labelledby="downshift-0-label"
+                  aria-labelledby="test-filterable-multiselect-label"
                   autoComplete="off"
                   className="bx--text-input bx--text-input--empty"
                   disabled={false}


### PR DESCRIPTION
Closes #6066

This PR passes the filterable multiselect IDs into downshift to validate the label references to the listbox field and input

#### Changelog

**Changed**

- `labelId` value
- pass `id` into downshift component

#### Testing / Reviewing

Confirm that no DAP errors are thrown for filterable multiselect
