### PR TITLE
docs(theme): filter out non-color variables when generating theme table

### DIFF
--- a/packages/themes/examples/preview/index.js
+++ b/packages/themes/examples/preview/index.js
@@ -23,7 +23,17 @@ const colorNameLookup = Object.keys(colors).reduce(
   }),
   {}
 );
-const tokens = Object.keys(themes[Object.keys(themes)[0]]);
+const allTokens = themes[Object.keys(themes)[0]];
+const filteredTokens = {};
+
+// Filter out non-color variables:
+Object.entries(allTokens).forEach(([key, value]) => {
+  if (typeof value === 'string' && value.startsWith('#')) {
+    filteredTokens[key] = value;
+  }
+});
+
+const tokens = Object.keys(filteredTokens);
 
 function App() {
   return (

--- a/packages/themes/examples/preview/index.js
+++ b/packages/themes/examples/preview/index.js
@@ -9,7 +9,7 @@ import cx from 'classnames';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import * as colors from '@carbon/colors';
-import { themes, formatTokenName } from '@carbon/themes';
+import { themes, formatTokenName, unstable__meta as meta } from '@carbon/themes';
 
 const mountNode = document.getElementById('root');
 function render(element) {
@@ -23,17 +23,8 @@ const colorNameLookup = Object.keys(colors).reduce(
   }),
   {}
 );
-const allTokens = themes[Object.keys(themes)[0]];
-const filteredTokens = {};
 
-// Filter out non-color variables:
-Object.entries(allTokens).forEach(([key, value]) => {
-  if (typeof value === 'string' && value.startsWith('#')) {
-    filteredTokens[key] = value;
-  }
-});
-
-const tokens = Object.keys(filteredTokens);
+const tokens = meta.colors.flatMap(color => color.tokens);
 
 function App() {
   return (


### PR DESCRIPTION
Currently the themes page includes non-color variables in the table: https://carbon-elements.netlify.app/themes/examples/preview/ (scroll down)

This PR filtered out non-color variables before generating the table.

#### Changelog

**Changed**

- filter out non-color variables before generating theme table

#### Testing / Reviewing

Compare to https://carbon-elements.netlify.app/themes/examples/preview/
