### PR TITLE
fix(OverflowMenu): fix of excessive onClose prop calls in OverflowMenu

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -266,9 +266,9 @@ class OverflowMenu extends Component {
     }
   };
 
-  componentDidUpdate() {
+  componentDidUpdate(_, prevState) {
     const { onClose } = this.props;
-    if (!this.state.open) {
+    if (!this.state.open && prevState.isOpen) {
       onClose();
     }
   }


### PR DESCRIPTION
This fixes the case when the `OverflowMenu` calls `onClose` prop callback although it has not been previously open and, as a result, there's no actual state change.

#### Changelog

- Added a check whether the `OverflowMenu` have previously been open before calling `onClose`.

#### Testing / Reviewing
After the change, `onClose` should be called only in case when the menu changes its state from 'open' to 'closed'.
