### PR TITLE
fix(time-picker): support light theme styles in time picker select

### DIFF
--- a/packages/components/src/components/time-picker/_time-picker.scss
+++ b/packages/components/src/components/time-picker/_time-picker.scss
@@ -75,6 +75,7 @@
     &:disabled,
     &:hover:disabled {
       cursor: not-allowed;
+      background-color: transparent;
       border-bottom: 1px solid transparent;
       color: $disabled-02;
     }

--- a/packages/components/src/components/time-picker/_time-picker.scss
+++ b/packages/components/src/components/time-picker/_time-picker.scss
@@ -64,6 +64,21 @@
       color: $text-05;
     }
   }
+
+  .#{$prefix}--time-picker--light .#{$prefix}--select-input {
+    background-color: $field-02;
+
+    &:hover {
+      background-color: $hover-ui;
+    }
+
+    &:disabled,
+    &:hover:disabled {
+      cursor: not-allowed;
+      border-bottom: 1px solid transparent;
+      color: $disabled-02;
+    }
+  }
 }
 
 @include exports('time-picker') {


### PR DESCRIPTION
Closes #6090

This PR adds support back in for the light variation styles `<TimePickerSelect>`

#### Testing / Reviewing

Confirm that the light time picker styles are correct