### PR TITLE
fix(ProgressIndicator): set negative tabindex on disabled progress steps

### DIFF
--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -107,7 +107,7 @@ export function ProgressStep({
         })}
         disabled={disabled}
         aria-disabled={disabled}
-        tabIndex={!current && onClick ? 0 : -1}
+        tabIndex={!current && onClick && !disabled ? 0 : -1}
         onClick={!current ? onClick : undefined}
         onKeyDown={handleKeyDown}>
         <span className={`${prefix}--assistive-text`}>{message}</span>


### PR DESCRIPTION
Closes #6089

This PR removes disabled progress steps from the focus order according to WCAG 2.1

#### Testing / Reviewing

Confirm that disabled progress steps in the progress indicator do not receive focus when tabbing with the keyboard