### PR TITLE
fix(date-picker): use inset outline for focused selected day

### DIFF
--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -375,6 +375,11 @@
   .flatpickr-day.selected {
     color: $text-04;
     background: $interactive-01;
+
+    &:focus {
+      outline: rem(1px) solid $ui-02;
+      outline-offset: rem(-3px);
+    }
   }
 
   .#{$prefix}--date-picker__day.startRange.selected,


### PR DESCRIPTION
Closes #5308

This PR adds an inset focus outline to the selected day in the date picker calendar

#### Testing / Reviewing

Confirm the selected, focused day in the date picker with calendar appears correct