### PR TITLE
fix(tabs): scroll tabs when width is larger than viewport

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -134,7 +134,8 @@
     @include carbon--breakpoint(md) {
       display: flex;
       transition: inherit;
-      overflow: visible;
+      overflow: scroll;
+      max-width: 100%;
       max-height: none;
     }
   }

--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -134,7 +134,7 @@
     @include carbon--breakpoint(md) {
       display: flex;
       transition: inherit;
-      overflow: scroll;
+      overflow-x: scroll;
       max-width: 100%;
       max-height: none;
     }


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/5624

Temporary workaround for the `Tabs` component until https://github.com/carbon-design-system/carbon/issues/4758 can be added in. Currently, if there are a large number of tabs and the window shrinks, the `overflow: visible` style on the tabs container causes the tabs to break off the right of the screen and cause an overflow. This change proposes that the container switch to  `overflow: scroll` so that the container does not break and there is no page overflow. 

#### Changelog

**Changed**

- `overflow: visible` changed to `overflow: scroll`

#### Testing / Reviewing

Ensure Tabs still render correctly in all browsers
