### PR TITLE
fix(radio-button): use scale instead of px values for checked

### DIFF
--- a/packages/components/src/components/radio-button/_radio-button.scss
+++ b/packages/components/src/components/radio-button/_radio-button.scss
@@ -86,10 +86,11 @@
       content: '';
       display: inline-block;
       position: relative;
-      width: 0.5rem;
-      height: 0.5rem;
+      width: 100%;
+      height: 100%;
       border-radius: 50%;
       background-color: $icon-01;
+      transform: scale(0.5);
 
       // Allow the selected button to be seen in Windows HCM for IE/Edge
       @media screen and (-ms-high-contrast: active) {


### PR DESCRIPTION
Closes #5163 

Addresses some issues when using zoom for Radio button styles. Instead of using px values, this PR adds in the use of `scale` to correctly size to 8px. It seems like when using exact pixel values the browser will downsize it from 8x8 to nearly 8x8 (7.997 x 7.997) for rastering, which ends up causing the visual regression at certain zoom perspectives.

#### Changelog

**New**

**Changed**

- Use `scale` instead of explicit px values for radio buttons

**Removed**
