### PR TITLE
fix(icon-build-helpers): add default stroke="currentColor" for pictograms

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/builder.js
+++ b/packages/icon-build-helpers/src/builders/react/builder.js
@@ -154,7 +154,7 @@ async function builder(metadata, { output }) {
  */
 function createIconComponent(moduleName, descriptor, isDeprecated = false) {
   const { attrs, content } = descriptor;
-  const { width, height, viewBox } = attrs;
+  const { width, height, viewBox, ...rest } = attrs;
 
   const deprecatedTopLevel = isDeprecated
     ? 'let didWarnAboutDeprecation = false;'
@@ -179,7 +179,13 @@ function createIconComponent(moduleName, descriptor, isDeprecated = false) {
       function ${moduleName}({ children, ...rest }, ref) {
         ${deprecatedBlock}
         return (
-          <Icon width={${width}} height={${height}} viewBox="${viewBox}" ref={ref} {...rest}>
+          <Icon
+            width={${width}}
+            height={${height}}
+            viewBox="${viewBox}"
+            ${formatAttributes(rest)}
+            ref={ref}
+            {...rest}>
             ${content.map(convertToJSX).join('\n')}
             {children}
           </Icon>

--- a/packages/icon-build-helpers/src/metadata/extensions/output/index.js
+++ b/packages/icon-build-helpers/src/metadata/extensions/output/index.js
@@ -152,6 +152,7 @@ async function createDescriptor(name, data, size, original) {
     const [width, height] = info.attrs.viewBox.split(' ').slice(2);
     descriptor.attrs.width = width;
     descriptor.attrs.height = height;
+    descriptor.attrs.stroke = 'currentColor';
   }
 
   return descriptor;


### PR DESCRIPTION
Closes #6107

This is a hotfix for our latest release. It seems like in previous builds we were shipping improperly optimized SVG code that included hard-coded hex values for `stroke`. When we updated our optimizer, it correctly stripped these values out but unfortunately meant that pictograms had no default stroke so they appeared to render incorrectly.

The proposed hotfix here adds `stroke="currentColor"` to the default attributes for a pictogram. In the future we could similar do `fill="currentColor"` for icons. It also updates the React icon builder to appropriately place extra attributes from the icon descriptor on the React component itself.

#### Changelog

**New**


**Changed**

- Add `stroke="currentColor"` to `createDescriptor` for our pictograms
- Update React builder to include extra attributes when building the icon component

**Removed**

#### Testing / Reviewing

- Visit the pictogram storybook at packages/pictograms-react/examples/storybook
- Run `yarn` to install dependencies
- Run `yarn storybook` to run storybook
- Verify pictogram renders as intended