### PR TITLE
fix(pagination): adds scroll to  mobile pagination

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -53,11 +53,7 @@ $css--helpers: true;
     width: auto;
     min-width: auto;
     height: 100%;
-    padding: 0 2.5rem 0 $spacing-05;
-    @include carbon--breakpoint('md') {
-      padding-right: carbon--mini-units(4.5);
-      margin-right: 0;
-    }
+    padding: 0 2.25rem 0 $spacing-05;
   }
 
   .#{$prefix}--pagination .#{$prefix}--select-input:hover {

--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -28,6 +28,7 @@ $css--helpers: true;
     @include reset;
     @include type-style('body-short-01');
     width: 100%;
+    overflow-x: scroll;
     background-color: $ui-01;
     display: flex;
     align-items: center;
@@ -53,7 +54,6 @@ $css--helpers: true;
     min-width: auto;
     height: 100%;
     padding: 0 2.5rem 0 $spacing-05;
-    margin-right: -0.65rem;
     @include carbon--breakpoint('md') {
       padding-right: carbon--mini-units(4.5);
       margin-right: 0;
@@ -66,10 +66,7 @@ $css--helpers: true;
 
   .#{$prefix}--pagination .#{$prefix}--select__arrow {
     top: 50%;
-    transform: translateY(-50%);
-    @include carbon--breakpoint('md') {
-      right: $carbon--spacing-05;
-    }
+    transform: translate(-0.5rem, -50%);
   }
 
   .#{$prefix}--pagination
@@ -94,6 +91,11 @@ $css--helpers: true;
   .#{$prefix}--pagination__left > .#{$prefix}--form-item,
   .#{$prefix}--pagination__right > .#{$prefix}--form-item {
     height: 100%;
+  }
+
+  .#{$prefix}--pagination__left .#{$prefix}--pagination__text,
+  .#{$prefix}--pagination__right .#{$prefix}--pagination__text {
+    white-space: nowrap;
   }
 
   .#{$prefix}--pagination__left .#{$prefix}--pagination__text {

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -43,7 +43,7 @@ const props = () => ({
 
 storiesOf('Pagination', module)
   .addDecorator(withKnobs)
-  .addDecorator(story => <div style={{ width: '800px' }}>{story()}</div>)
+  .addDecorator(story => <div style={{ maxWidth: '800px' }}>{story()}</div>)
   .add('Pagination', () => <Pagination {...props()} />, {
     info: {
       text: `


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/5953

Previously, when our `Pagination` component hit a mobile breakpoint, it would overflow off the page. This PR (similar to  #6096) adds in an overflow scrolling functionality. Also cleans up a few other visual bugs in Pagination
 
#### Changelog

**New**

- `overflow-x: scroll` to `Pagination` component

**Changed**
- All text now has `white-space: nowrap` to prevent text from stacking outside the top and bottom of the Pagination component. Now the text will scroll. 
- Changed arrow positioning logic to use `transform`, rather than using a negative margin on the input itself that was causing alignment issues. 

**Removed**

- Unnecessary code 

#### Testing / Reviewing

Verify Pagination still renders correctly at all breakpoints / all browsers 
