### PR TITLE
fix(Slider): sync value in props and state in controlled mode

### DIFF
--- a/packages/react/src/components/Slider/Slider-story.js
+++ b/packages/react/src/components/Slider/Slider-story.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -47,6 +47,23 @@ storiesOf('Slider', module)
             Sliders provide a visual indication of adjustable content, where the user can move the handle along a horizontal track to increase or decrease the value.
           `,
     },
+  })
+  .add('controlled slider', () => {
+    const [val, setVal] = useState(87);
+    return (
+      <>
+        <button onClick={() => setVal(Math.round(Math.random() * 100))}>
+          randomize value
+        </button>
+        <Slider
+          max={100}
+          min={0}
+          value={val}
+          onChange={({ value }) => setVal(value)}
+        />
+        <h1>{val}</h1>
+      </>
+    );
   })
   .add(
     'skeleton',

--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -56,6 +56,15 @@ describe('Slider', () => {
       expect(wrapper.props().value).toEqual(55);
     });
 
+    it('should change the value upon change in props', () => {
+      wrapper.setProps({ value: 1 });
+      wrapper.setState({ value: 1 });
+      wrapper.update();
+      wrapper.setProps({ value: 2 });
+      expect(wrapper.state().value).toEqual(2);
+      wrapper.setProps({ value: 1 });
+    });
+
     it('should accurately position slider on mount', () => {
       expect(wrapper.state().left).toEqual(0);
     });

--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -19,9 +19,10 @@ throttle.mockImplementation(fn => Object.assign(fn, { throttled: true }));
 
 const { prefix } = settings;
 describe('Slider', () => {
-  describe('Renders as expected', () => {
-    const id = 'slider';
-    const wrapper = mount(
+  const id = 'slider';
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount(
       <Slider
         id={id}
         className="extra-class"
@@ -31,7 +32,9 @@ describe('Slider', () => {
         step={1}
       />
     );
+  });
 
+  describe('Renders as expected', () => {
     it('renders children as expected', () => {
       expect(wrapper.find(`.${prefix}--text-input`).length).toBe(1);
     });
@@ -62,7 +65,6 @@ describe('Slider', () => {
       wrapper.update();
       wrapper.setProps({ value: 2 });
       expect(wrapper.state().value).toEqual(2);
-      wrapper.setProps({ value: 1 });
     });
 
     it('should accurately position slider on mount', () => {

--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -193,6 +193,7 @@ export default class Slider extends PureComponent {
       prevState.value !== this.state.value &&
       typeof this.props.onChange === 'function'
     ) {
+      // TODO: pass event object as first param (breaking change/feat for v11)
       this.props.onChange({ value: this.state.value });
     }
 
@@ -201,6 +202,7 @@ export default class Slider extends PureComponent {
       this.state.needsOnRelease &&
       typeof this.props.onRelease === 'function'
     ) {
+      // TODO: pass event object as first param (breaking change/feat for v11)
       this.props.onRelease({ value: this.state.value });
       // Reset the flag
       this.setState({ needsOnRelease: false });

--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -14,8 +14,6 @@ import throttle from 'lodash.throttle';
 import * as keys from '../../internal/keyboard/keys';
 import { matches } from '../../internal/keyboard/match';
 import deprecate from '../../prop-types/deprecate';
-import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
-import { useControlledStateWithValue } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -58,9 +56,7 @@ export default class Slider extends PureComponent {
     /**
      * The callback to get notified of change in value.
      */
-    onChange: !useControlledStateWithValue
-      ? PropTypes.func
-      : requiredIfValueExists(PropTypes.func),
+    onChange: PropTypes.func,
 
     /**
      * The callback to get notified of value on handle release.
@@ -210,9 +206,9 @@ export default class Slider extends PureComponent {
       this.setState({ needsOnRelease: false });
     }
 
-    // If `useControlledStateWithValue` feature flag is on, do nothing here.
+    // If value from props does not change, do nothing here.
     // Otherwise, do prop -> state sync without "value capping".
-    if (useControlledStateWithValue || prevProps.value === this.props.value) {
+    if (prevProps.value === this.props.value) {
       return;
     }
     this.setState(


### PR DESCRIPTION
Closes #6039

This PR fixes a regression with the Slider component in controlled mode

#### Changelog

**New**

- controlled mode test case
- related storybook story

**Changed**

- props state sync logic in component lifecycle

#### Testing / Reviewing

Ensure controlled mode works as expected for the slider component, and no regressions are introduced