### PR TITLE
fix(accordion): set min height on accordion headings

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -40,7 +40,7 @@
     align-items: flex-start;
     justify-content: $accordion-justify-content;
     cursor: pointer;
-    padding: rem(6px) 0;
+    padding: rem(10px) 0;
     flex-direction: $accordion-flex-direction;
     position: relative;
     min-height: rem(40px);

--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -43,7 +43,7 @@
     padding: rem(6px) 0;
     flex-direction: $accordion-flex-direction;
     position: relative;
-    height: rem(40px);
+    min-height: rem(40px);
     width: 100%;
     margin: 0;
     transition: background-color motion(standard, productive) $duration--fast-02;


### PR DESCRIPTION
Closes #6127

This PR allows for accordion headings to grow past the minimum height of 40px

#### Testing / Reviewing

Increase the length of an accordion heading so that it wraps and confirm that the heading containers grow in size
