### PR TITLE
fix(number-input): account for empty max and min attributes

### DIFF
--- a/packages/components/src/components/number-input/number-input.js
+++ b/packages/components/src/components/number-input/number-input.js
@@ -51,23 +51,31 @@ class NumberInput extends mixin(
     const max = Number(numberInput.max);
     const step = Number(numberInput.step) || 1;
 
-    if (target.indexOf('up-icon') >= 0 && numberInput.value < max) {
+    if (target.indexOf('up-icon') >= 0) {
       const nextValue = Number(numberInput.value) + step;
-      if (nextValue > max) {
-        numberInput.value = max;
-      } else if (nextValue < min) {
-        numberInput.value = min;
-      } else {
+      if (numberInput.max === '') {
         numberInput.value = nextValue;
+      } else if (numberInput.value < max) {
+        if (nextValue > max) {
+          numberInput.value = max;
+        } else if (nextValue < min) {
+          numberInput.value = min;
+        } else {
+          numberInput.value = nextValue;
+        }
       }
-    } else if (target.indexOf('down-icon') >= 0 && numberInput.value > min) {
+    } else if (target.indexOf('down-icon') >= 0) {
       const nextValue = Number(numberInput.value) - step;
-      if (nextValue < min) {
-        numberInput.value = min;
-      } else if (nextValue > max) {
-        numberInput.value = max;
-      } else {
+      if (numberInput.min === '') {
         numberInput.value = nextValue;
+      } else if (numberInput.value > min) {
+        if (nextValue < min) {
+          numberInput.value = min;
+        } else if (nextValue > max) {
+          numberInput.value = max;
+        } else {
+          numberInput.value = nextValue;
+        }
       }
     }
 

--- a/packages/components/tests/spec/number-input_spec.js
+++ b/packages/components/tests/spec/number-input_spec.js
@@ -118,6 +118,19 @@ describe('Test Number Input', function() {
       expect(inputNode.value).toBe('1');
     });
 
+    it('Should increase the value when no maximum is set', async function() {
+      const upArrowNode = document.querySelector('.up-icon');
+      inputNode.max = '';
+      inputNode.min = '';
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        upArrowNode.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('1');
+    });
+
     it('Should increase the value by the step amount', async function() {
       inputNode.step = 5;
       const upArrowNode = document.querySelector('.up-icon');
@@ -203,6 +216,23 @@ describe('Test Number Input', function() {
 
     it('Should decrease the value', async function() {
       const downArrowNode = document.querySelector('.down-icon');
+      inputNode.value = '1';
+      const e = await new Promise(resolve => {
+        events.on(document.body, 'change', resolve);
+        downArrowNode.dispatchEvent(
+          new CustomEvent('click', { bubbles: true })
+        );
+      });
+      await delay(0);
+      expect(e.cancelable).toBe(false);
+      expect(inputNode.value).toBe('0');
+    });
+
+    it('Should decrease the value when no minimum is set', async function() {
+      const downArrowNode = document.querySelector('.down-icon');
+      inputNode.min = '';
+      inputNode.max = '';
+      inputNode.step = 1;
       inputNode.value = '1';
       const e = await new Promise(resolve => {
         events.on(document.body, 'change', resolve);

--- a/packages/components/tests/spec/number-input_spec.js
+++ b/packages/components/tests/spec/number-input_spec.js
@@ -103,6 +103,8 @@ describe('Test Number Input', function() {
 
     beforeEach(function() {
       inputNode.value = '0';
+      inputNode.max = '100';
+      inputNode.min = '0';
     });
 
     it('Should increase the value', async function() {


### PR DESCRIPTION
Closes #6131

This PR fixes number input behavior when incrementing or decrementing the value while no `max` or `min` attributes are set

#### Changelog

**New**

- test cases

**Changed**

- number input increment and decrement behavior

#### Testing / Reviewing

Ensure the number input component works as expected with and without `min` or `max` attribute values set on the input