### PR TITLE
fix(progress-indicator): import button styles for button elements in steps

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -10,6 +10,7 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+@import '../button/button';
 
 /// Progress indicator styles
 /// @access private


### PR DESCRIPTION
The `ProgressIndicator` now uses a button element for steps, but it does not import button styles.

For users importing individual SCSS stylesheets, they can't import just the `ProgressIndicator` styles & get it to look correctly. Without imported button styles, in these situations, user agent styles show & make buttons appear unstyled.

#### Changelog

**New**

- import button styles into progress indicator styles
