### PR TITLE
fix(unstable-pagination): use size 16 icons

### DIFF
--- a/packages/react/src/components/Pagination/Unstable_Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Unstable_Pagination/Pagination.js
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
-import { CaretRight24, CaretLeft24 } from '@carbon/icons-react';
+import { CaretRight16, CaretLeft16 } from '@carbon/icons-react';
 import Button from '../../Button';
 import Select from '../../Select';
 import SelectItem from '../../SelectItem';
@@ -144,7 +144,7 @@ function Unstable_Pagination({
           onClick={() => setCurrentPage(currentPage - 1)}
           disabled={backButtonDisabled}
           hasIconOnly
-          renderIcon={CaretLeft24}
+          renderIcon={CaretLeft16}
           tooltipAlignment="center"
           tooltipPosition="top"
           iconDescription={backwardText}
@@ -160,7 +160,7 @@ function Unstable_Pagination({
           onClick={() => setCurrentPage(currentPage + 1)}
           disabled={forwardButtonDisabled}
           hasIconOnly
-          renderIcon={CaretRight24}
+          renderIcon={CaretRight16}
           tooltipAlignment="center"
           tooltipPosition="top"
           iconDescription={forwardText}


### PR DESCRIPTION
Follow-on from #6058 - I noticed @jendowns initial PR for the unstable pagination was in flight at the same time as mine for the stable pagination and figured we should update this to be consistent.

#### Changelog

**Changed**

- Update unstable pagination icon size to 16

#### Testing / Reviewing

The forward/reverse icons should render at size 16 in the storybook deploy preview
