### PR TITLE
fix(DataTableSkeleton): add prop to hide header, toolbar

### DIFF
--- a/packages/components/src/components/data-table/_data-table-skeleton.scss
+++ b/packages/components/src/components/data-table/_data-table-skeleton.scss
@@ -13,6 +13,7 @@
   .#{$prefix}--data-table.#{$prefix}--skeleton {
     th {
       vertical-align: middle;
+      padding-left: 1rem;
     }
 
     th span,

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5825,6 +5825,8 @@ Map {
       "compact": false,
       "headers": Array [],
       "rowCount": 5,
+      "showHeader": true,
+      "showToolbar": true,
       "zebra": false,
     },
     "propTypes": Object {
@@ -5859,6 +5861,12 @@ Map {
       },
       "rowCount": Object {
         "type": "number",
+      },
+      "showHeader": Object {
+        "type": "bool",
+      },
+      "showToolbar": Object {
+        "type": "bool",
       },
       "zebra": Object {
         "type": "bool",

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton-story.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton-story.js
@@ -27,6 +27,8 @@ const props = () => ({
   ),
   zebra: boolean('Use zebra stripe (zebra)', false),
   compact: boolean('Compact variant (compact)', false),
+  showHeader: boolean('Show the Table Header (showHeader)', true),
+  showToolbar: boolean('Show the Table Toolbar (showToolbar)', true),
 });
 
 storiesOf('DataTableSkeleton', module)
@@ -43,7 +45,7 @@ storiesOf('DataTableSkeleton', module)
       info: {
         text: `
             Skeleton states are used as a progressive loading state while the user waits for content to load.
-    
+
             This example shows a skeleton state for a data table.
           `,
       },

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -18,6 +18,8 @@ const DataTableSkeleton = ({
   zebra,
   compact,
   className,
+  showHeader,
+  showToolbar,
   ...rest
 }) => {
   const dataTableSkeletonClasses = cx(className, {
@@ -44,18 +46,22 @@ const DataTableSkeleton = ({
 
   return (
     <div className={`${prefix}--skeleton ${prefix}--data-table-container`}>
-      <div className={`${prefix}--data-table-header`}>
-        <div className={`${prefix}--data-table-header__title`}></div>
-        <div className={`${prefix}--data-table-header__description`}></div>
-      </div>
-      <section
-        aria-label="data table toolbar"
-        className={`${prefix}--table-toolbar`}>
-        <div className={`${prefix}--toolbar-content`}>
-          <span
-            className={`${prefix}--skeleton ${prefix}--btn ${prefix}--btn--sm`}></span>
+      {showHeader ? (
+        <div className={`${prefix}--data-table-header`}>
+          <div className={`${prefix}--data-table-header__title`}></div>
+          <div className={`${prefix}--data-table-header__description`}></div>
         </div>
-      </section>
+      ) : null}
+      {showToolbar ? (
+        <section
+          aria-label="data table toolbar"
+          className={`${prefix}--table-toolbar`}>
+          <div className={`${prefix}--toolbar-content`}>
+            <span
+              className={`${prefix}--skeleton ${prefix}--btn ${prefix}--btn--sm`}></span>
+          </div>
+        </section>
+      ) : null}
       <table className={dataTableSkeletonClasses} {...rest}>
         <thead>
           <tr>
@@ -108,6 +114,16 @@ DataTableSkeleton.propTypes = {
    * Specify an optional className to add.
    */
   className: PropTypes.string,
+
+  /**
+   * Specify if the table header should be rendered as part of the skeleton.
+   */
+  showHeader: PropTypes.bool,
+
+  /**
+   * Specify if the table toolbar should be rendered as part of the skeleton.
+   */
+  showToolbar: PropTypes.bool,
 };
 
 DataTableSkeleton.defaultProps = {
@@ -116,6 +132,8 @@ DataTableSkeleton.defaultProps = {
   zebra: false,
   compact: false,
   headers: [],
+  showHeader: true,
+  showToolbar: true,
 };
 
 export default DataTableSkeleton;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/5993

After #5752 was merged, the DataTableSkeleton component always rendered a header and toolbar. This adds two props, `showHeader` and `showToolbar`, that optionally hide or show these parts of the component. They are set to `true` by default. 

#### Changelog

**New**

- `showHeader` prop that toggles the Table Header and description skeleton
- `showToolbar` prop that toggles the Table Toolbar skeleton

**Changed**

- Table headers were misaligned, so added some padding to the skeleton styles


#### Testing / Reviewing

Navigate to the `DataTableSkeleton` storybook page, change the knobs for `showHeader` and `showToolbar` and ensure it renders correctly. 
