### PR TITLE
fix(DataTable): address spacing and alignment issues

### DIFF
--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -265,9 +265,8 @@
     transition: background-color $duration--fast-01 motion(entrance, productive);
   }
 
-  .#{$prefix}--data-table td.#{$prefix}--table-column-checkbox {
-    padding-top: rem(11px);
-    padding-bottom: 0;
+  .#{$prefix}--date-table tbody th.#{$prefix}--table-column-checkbox:hover {
+    background: $data-table-column-hover;
   }
 
   .#{$prefix}--date-table tbody th.#{$prefix}--table-column-checkbox:hover {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -87,7 +87,7 @@
 
   .#{$prefix}--data-table th,
   .#{$prefix}--data-table td {
-    vertical-align: top;
+    vertical-align: middle;
     text-align: left;
   }
 
@@ -430,6 +430,11 @@
   .#{$prefix}--data-table--tall td,
   .#{$prefix}--data-table--tall tbody tr th {
     padding-top: 1rem;
+  }
+
+  .#{$prefix}--data-table--tall th,
+  .#{$prefix}--data-table--tall td {
+    vertical-align: top;
   }
 
   .#{$prefix}--data-table--cell-secondary-text {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -269,8 +269,11 @@
     background: $data-table-column-hover;
   }
 
-  .#{$prefix}--date-table tbody th.#{$prefix}--table-column-checkbox:hover {
-    background: $data-table-column-hover;
+  //----------------------------------------------------------------------------
+  // Radio
+  //----------------------------------------------------------------------------
+  .#{$prefix}--table-column-radio {
+    width: 48px;
   }
 
   // default selected row + zebra select - even child

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -108,7 +108,8 @@
   }
 
   .#{$prefix}--data-table .#{$prefix}--table-header-label {
-    padding: rem(14px) $spacing-05;
+    padding-left: $spacing-05;
+    padding-right: $spacing-05;
     text-align: left;
   }
 
@@ -118,8 +119,8 @@
     color: $text-02;
     border-top: 1px solid $ui-01;
     border-bottom: 1px solid $ui-03;
-    padding: rem(14px) $spacing-05;
-    padding-bottom: rem(13px);
+    padding-left: $spacing-05;
+    padding-right: $spacing-05;
 
     + td:first-of-type {
       padding-left: $spacing-04;
@@ -258,11 +259,20 @@
     // Do not use `position: relative`, as its behavior is undefined for many table elements: https://www.w3.org/TR/CSS21/visuren.html#propdef-position
     position: static;
     background: $ui-03;
-    padding: rem(12px) $spacing-03 0 $spacing-05;
+    padding-left: $spacing-05;
+    padding-right: $spacing-05;
     width: rem(
       44px
     ); // 16px padding left + 8px padding right + 20px checkbox width
     transition: background-color $duration--fast-01 motion(entrance, productive);
+  }
+
+  .#{$prefix}--data-table--tall .#{$prefix}--table-column-checkbox {
+    padding-top: rem(13px);
+  }
+
+  .#{$prefix}--data-table--tall .#{$prefix}--table-column-radio {
+    padding-top: $spacing-05;
   }
 
   .#{$prefix}--date-table tbody th.#{$prefix}--table-column-checkbox:hover {
@@ -439,11 +449,6 @@
 
   .#{$prefix}--data-table--cell-secondary-text {
     @include type-style('label-01');
-  }
-
-  .#{$prefix}--data-table.#{$prefix}--data-table--tall
-    .#{$prefix}--table-column-checkbox {
-    padding-top: rem(12px);
   }
 
   //----------------------------------------------------------------------------

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -108,7 +108,6 @@
   }
 
   .#{$prefix}--data-table .#{$prefix}--table-header-label {
-    display: block;
     padding: rem(14px) $spacing-05;
     text-align: left;
   }

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -160,10 +160,30 @@
   .#{$prefix}--data-table td.#{$prefix}--table-expand {
     width: 2.5rem;
     min-width: 2.5rem;
-    height: 3rem;
-    vertical-align: top;
-    padding: 0;
     border-bottom: 1px solid $ui-03;
+  }
+
+  .#{$prefix}--data-table td.#{$prefix}--table-expand,
+  th.#{$prefix}--table-expand {
+    padding: rem(14px) $spacing-05;
+  }
+
+  .#{$prefix}--data-table--compact td.#{$prefix}--table-expand,
+  .#{$prefix}--data-table--compact th.#{$prefix}--table-expand {
+    padding-top: rem(2px);
+    padding-bottom: rem(2px);
+  }
+
+  .#{$prefix}--data-table--short td.#{$prefix}--table-expand,
+  .#{$prefix}--data-table--short th.#{$prefix}--table-expand {
+    padding-top: rem(7px);
+    padding-bottom: rem(6px);
+  }
+
+  .#{$prefix}--data-table--tall td.#{$prefix}--table-expand,
+  .#{$prefix}--data-table--tall th.#{$prefix}--table-expand {
+    padding-top: rem(16px);
+    padding-bottom: rem(16px);
   }
 
   .#{$prefix}--data-table
@@ -179,11 +199,7 @@
 
   .#{$prefix}--table-expand__button {
     @include button-reset('false');
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    height: 100%;
-    width: 100%;
+    height: rem(16px);
   }
 
   .#{$prefix}--data-table--short .#{$prefix}--table-expand__button {
@@ -202,17 +218,6 @@
     fill: $ui-05;
     transform: rotate(90deg);
     transition: transform $duration--moderate-01 motion(standard, productive);
-  }
-
-  th.#{$prefix}--table-expand {
-    position: relative;
-    vertical-align: middle;
-    padding-left: $spacing-05;
-    padding-right: $spacing-05;
-  }
-
-  th.#{$prefix}--table-expand + th.#{$prefix}--table-column-checkbox {
-    padding-left: $spacing-03;
   }
 
   // fix expanded parent separating border length

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -165,19 +165,7 @@
 
   .#{$prefix}--data-table td.#{$prefix}--table-expand,
   th.#{$prefix}--table-expand {
-    padding: $spacing-05;
-  }
-
-  .#{$prefix}--data-table--compact td.#{$prefix}--table-expand,
-  .#{$prefix}--data-table--compact th.#{$prefix}--table-expand {
-    padding-top: rem(2px);
-    padding-bottom: rem(2px);
-  }
-
-  .#{$prefix}--data-table--short td.#{$prefix}--table-expand,
-  .#{$prefix}--data-table--short th.#{$prefix}--table-expand {
-    padding-top: rem(7px);
-    padding-bottom: rem(6px);
+    padding: 0 $spacing-05;
   }
 
   .#{$prefix}--data-table--tall td.#{$prefix}--table-expand,
@@ -200,10 +188,7 @@
   .#{$prefix}--table-expand__button {
     @include button-reset('false');
     height: rem(16px);
-  }
-
-  .#{$prefix}--data-table--short .#{$prefix}--table-expand__button {
-    height: auto;
+    vertical-align: inherit;
   }
 
   .#{$prefix}--table-expand__button:focus {

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -165,7 +165,7 @@
 
   .#{$prefix}--data-table td.#{$prefix}--table-expand,
   th.#{$prefix}--table-expand {
-    padding: rem(14px) $spacing-05;
+    padding: $spacing-05;
   }
 
   .#{$prefix}--data-table--compact td.#{$prefix}--table-expand,

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -120,7 +120,7 @@
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover td:first-of-type {
-    border-bottom: 1px solid transparent; // first td doesn't have a visible border
+    border-bottom: 1px solid $hover-ui; // first td doesn't have a visible border
   }
 
   // child row when hovering on expanded parent

--- a/packages/react/src/components/DataTable/TableHeader.js
+++ b/packages/react/src/components/DataTable/TableHeader.js
@@ -70,7 +70,7 @@ const TableHeader = React.forwardRef(function TableHeader(
         scope={scope}
         colSpan={colSpan}
         ref={ref}>
-        <span className={`${prefix}--table-header-label`}>{children}</span>
+        <div className={`${prefix}--table-header-label`}>{children}</div>
       </th>
     );
   }
@@ -92,7 +92,7 @@ const TableHeader = React.forwardRef(function TableHeader(
       ref={ref}
       scope={scope}>
       <button className={className} onClick={onClick} {...rest}>
-        <span className={`${prefix}--table-header-label`}>{children}</span>
+        <div className={`${prefix}--table-header-label`}>{children}</div>
         <Arrow
           className={`${prefix}--table-sort__icon`}
           aria-label={t('carbon.table.header.icon.description', {

--- a/packages/react/src/components/DataTable/TableSelectRow.js
+++ b/packages/react/src/components/DataTable/TableSelectRow.js
@@ -33,6 +33,7 @@ const TableSelectRow = ({
   const InlineInputComponent = radio ? RadioButton : InlineCheckbox;
   const tableSelectRowClasses = classNames(`${prefix}--table-column-checkbox`, {
     [className]: className,
+    [`${prefix}--table-column-radio`]: radio,
   });
   return (
     <td className={tableSelectRowClasses}>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -142,11 +142,11 @@ exports[`DataTable selection -- radio buttons should not have select-all checkbo
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field A
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                   <TableHeader
@@ -161,11 +161,11 @@ exports[`DataTable selection -- radio buttons should not have select-all checkbo
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field B
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                 </tr>
@@ -489,11 +489,11 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field A
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                   <TableHeader
@@ -508,11 +508,11 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field B
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                 </tr>
@@ -539,7 +539,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     radio={true}
                   >
                     <td
-                      className="bx--table-column-checkbox"
+                      className="bx--table-column-checkbox bx--table-column-radio"
                     >
                       <ForwardRef(RadioButton)
                         checked={false}
@@ -625,7 +625,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     radio={true}
                   >
                     <td
-                      className="bx--table-column-checkbox"
+                      className="bx--table-column-checkbox bx--table-column-radio"
                     >
                       <ForwardRef(RadioButton)
                         checked={false}
@@ -711,7 +711,7 @@ exports[`DataTable selection -- radio buttons should render 1`] = `
                     radio={true}
                   >
                     <td
-                      className="bx--table-column-checkbox"
+                      className="bx--table-column-checkbox bx--table-column-radio"
                     >
                       <ForwardRef(RadioButton)
                         checked={false}
@@ -989,11 +989,11 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field A
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                   <TableHeader
@@ -1008,11 +1008,11 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field B
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                 </tr>
@@ -1391,11 +1391,11 @@ exports[`DataTable selection should render 1`] = `
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field A
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                   <TableHeader
@@ -1410,11 +1410,11 @@ exports[`DataTable selection should render 1`] = `
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field B
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                 </tr>
@@ -2523,11 +2523,11 @@ exports[`DataTable should render 1`] = `
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field A
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                   <TableHeader
@@ -2542,11 +2542,11 @@ exports[`DataTable should render 1`] = `
                     <th
                       scope="col"
                     >
-                      <span
+                      <div
                         className="bx--table-header-label"
                       >
                         Field B
-                      </span>
+                      </div>
                     </th>
                   </TableHeader>
                 </tr>
@@ -3516,11 +3516,11 @@ exports[`DataTable sticky header should render 1`] = `
                       <th
                         scope="col"
                       >
-                        <span
+                        <div
                           className="bx--table-header-label"
                         >
                           Field A
-                        </span>
+                        </div>
                       </th>
                     </TableHeader>
                     <TableHeader
@@ -3535,11 +3535,11 @@ exports[`DataTable sticky header should render 1`] = `
                       <th
                         scope="col"
                       >
-                        <span
+                        <div
                           className="bx--table-header-label"
                         >
                           Field B
-                        </span>
+                        </div>
                       </th>
                     </TableHeader>
                   </tr>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
@@ -23,11 +23,11 @@ exports[`DataTable.TableHeader should have an active and ascending class if sort
               <th
                 scope="col"
               >
-                <span
+                <div
                   className="bx--table-header-label"
                 >
                   Header
-                </span>
+                </div>
               </th>
             </TableHeader>
           </tr>
@@ -61,11 +61,11 @@ exports[`DataTable.TableHeader should have an active class if it is the sort hea
               <th
                 scope="col"
               >
-                <span
+                <div
                   className="bx--table-header-label"
                 >
                   Header
-                </span>
+                </div>
               </th>
             </TableHeader>
           </tr>
@@ -99,11 +99,11 @@ exports[`DataTable.TableHeader should render 1`] = `
               <th
                 scope="col"
               >
-                <span
+                <div
                   className="bx--table-header-label"
                 >
                   Header
-                </span>
+                </div>
               </th>
             </TableHeader>
           </tr>
@@ -137,11 +137,11 @@ exports[`DataTable.TableHeader should render 2`] = `
               <th
                 scope="col"
               >
-                <span
+                <div
                   className="bx--table-header-label"
                 >
                   Header
-                </span>
+                </div>
               </th>
             </TableHeader>
           </tr>

--- a/packages/react/src/components/DataTable/stories/with-batch-expansion.js
+++ b/packages/react/src/components/DataTable/stories/with-batch-expansion.js
@@ -19,6 +19,7 @@ import DataTable, {
   TableRow,
 } from '../../DataTable';
 import { initialRows, headers } from './shared';
+import './with-expansion-story.scss';
 
 export default (props) => (
   <DataTable
@@ -60,9 +61,11 @@ export default (props) => (
                     <TableCell key={cell.id}>{cell.value}</TableCell>
                   ))}
                 </TableExpandRow>
-                <TableExpandedRow colSpan={headers.length + 1}>
-                  <h1>Expandable row content</h1>
-                  <p>Description here</p>
+                <TableExpandedRow
+                  colSpan={headers.length + 1}
+                  className="demo-expanded-td">
+                  <h6>Expandable row content</h6>
+                  <div>Description here</div>
                 </TableExpandedRow>
               </React.Fragment>
             ))}

--- a/packages/react/src/components/DataTable/stories/with-boolean-column-story.scss
+++ b/packages/react/src/components/DataTable/stories/with-boolean-column-story.scss
@@ -1,0 +1,3 @@
+.bx--data-table .bx--form-item.bx--checkbox-wrapper:last-of-type {
+  margin: 0;
+}

--- a/packages/react/src/components/DataTable/stories/with-boolean-column.js
+++ b/packages/react/src/components/DataTable/stories/with-boolean-column.js
@@ -122,7 +122,7 @@ export default (props) => (
                         <Checkbox
                           id={'check-' + cell.id}
                           checked={cell.value}
-                          labelText=""
+                          hideLabel
                         />
                       </TableCell>
                     );

--- a/packages/react/src/components/DataTable/stories/with-boolean-column.js
+++ b/packages/react/src/components/DataTable/stories/with-boolean-column.js
@@ -16,7 +16,7 @@ import DataTable, {
   TableHeader,
   TableRow,
 } from '../../DataTable';
-// import { initialRows, headers } from './shared';
+import './with-boolean-column-story.scss';
 
 const initialRows = [
   {

--- a/packages/react/src/components/DataTable/stories/with-dynamic-content-story.scss
+++ b/packages/react/src/components/DataTable/stories/with-dynamic-content-story.scss
@@ -1,0 +1,5 @@
+.demo-expanded-td td {
+  padding-left: 4rem;
+  padding-bottom: 1.5rem;
+  padding-top: 1rem;
+}

--- a/packages/react/src/components/DataTable/stories/with-dynamic-content.js
+++ b/packages/react/src/components/DataTable/stories/with-dynamic-content.js
@@ -34,6 +34,7 @@ import DataTable, {
   TableToolbarMenu,
 } from '../../DataTable';
 import { batchActionClick, initialRows, headers } from './shared';
+import './with-dynamic-content-story.scss';
 
 export default (props) => {
   const insertInRandomPosition = (array, element) => {
@@ -175,9 +176,11 @@ export default (props) => {
                           <TableCell key={cell.id}>{cell.value}</TableCell>
                         ))}
                       </TableExpandRow>
-                      <TableExpandedRow colSpan={headers.length + 3}>
-                        <h1>Expandable row content</h1>
-                        <p>Description here</p>
+                      <TableExpandedRow
+                        colSpan={headers.length + 3}
+                        className="demo-expanded-td">
+                        <h6>Expandable row content</h6>
+                        <div>Description here</div>
                       </TableExpandedRow>
                     </React.Fragment>
                   ))}

--- a/packages/react/src/components/DataTable/stories/with-expansion-story.scss
+++ b/packages/react/src/components/DataTable/stories/with-expansion-story.scss
@@ -1,0 +1,18 @@
+@import '~@carbon/type/scss/type';
+@import '~@carbon/themes/scss/themes';
+
+.demo-expanded-td td {
+  padding-left: 4rem;
+  padding-bottom: 1.5rem;
+  padding-top: 1rem;
+}
+
+.demo-inner-container-header {
+  @include carbon--type-style('productive-heading-01');
+  color: $text-01;
+}
+
+.demo-inner-container-content {
+  @include carbon--type-style('body-long-01');
+  color: $text-02;
+}

--- a/packages/react/src/components/DataTable/stories/with-expansion.js
+++ b/packages/react/src/components/DataTable/stories/with-expansion.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import './datatable-story.scss';
+import './with-expansion-story.scss';
 
 import React from 'react';
 import DataTable, {
@@ -61,12 +61,8 @@ export default (props) => (
                 <TableExpandedRow
                   colSpan={headers.length + 1}
                   className="demo-expanded-td">
-                  <h1 className="demo-inner-container-header">
-                    Expandable row content
-                  </h1>
-                  <p className="demo-inner-container-content">
-                    Description here
-                  </p>
+                  <h6>Expandable row content</h6>
+                  <div>Description here</div>
                 </TableExpandedRow>
               </React.Fragment>
             ))}

--- a/packages/react/src/components/DataTable/stories/with-options.js
+++ b/packages/react/src/components/DataTable/stories/with-options.js
@@ -21,6 +21,7 @@ import DataTable, {
   TableSelectRow,
 } from '..';
 import { headers, initialRows } from './shared';
+import './with-expansion-story.scss';
 
 export default (props) => (
   <DataTable
@@ -65,9 +66,11 @@ export default (props) => (
                     <TableCell key={cell.id}>{cell.value}</TableCell>
                   ))}
                 </TableExpandRow>
-                <TableExpandedRow colSpan={headers.length + 2}>
-                  <h1>Expandable row content</h1>
-                  <p>Description here</p>
+                <TableExpandedRow
+                  colSpan={headers.length + 2}
+                  className="demo-expanded-td">
+                  <h6>Expandable row content</h6>
+                  <div>Description here</div>
                 </TableExpandedRow>
               </React.Fragment>
             ))}


### PR DESCRIPTION
Closes #6184

This PR addresses several spacing and alignment issues in the data table:

* Expansion column style rules should be consistent in all table variants
* selection (checkbox) cells are now correctly aligned and spaced
* Changing the `size` no longer breaks cell height for expansion cells and selection (checkbox) cells
* radio button selection cells are now aligned and sized according to spec
* some documentation-only changes to correct the appearance of expanded row content

#### Testing / Reviewing

Confirm all table sizes and variants appear correct