### PR TITLE
fix(react): pin downshift dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@carbon/icons-react": "^10.11.0",
     "classnames": "2.2.6",
-    "downshift": "^5.0.5",
+    "downshift": "5.0.5",
     "flatpickr": "4.6.1",
     "invariant": "^2.2.3",
     "lodash.debounce": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8868,12 +8868,7 @@ dotnet-deps-parser@4.9.0:
     tslib "^1.10.0"
     xml2js "0.4.19"
 
-downshift@^1.31.14:
-  version "1.31.16"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
-  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
-
-downshift@^5.0.5:
+downshift@5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.0.5.tgz#1cc90dc09ae62998ce28a4ce457e0f1cdd0bfcfa"
   integrity sha512-V1idov3Rkvz1YWA1K67aIx51EgokIDvep4x6KmU7HhsayI8DvTEZBeH4O92zeFVGximKujRO7ChBzBAf4PKWFA==
@@ -8882,6 +8877,11 @@ downshift@^5.0.5:
     compute-scroll-into-view "^1.0.9"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+downshift@^1.31.14:
+  version "1.31.16"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
+  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
 
 duplexer2@^0.1.2, duplexer2@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
When PR'ing into the website, we noticed that there was an error showing up that wasn't created locally in the monorepo.

After taking a look, it seems like newer versions of downshift (the version tested was 5.4.2) seem to pass a `ref` to `ListBox.MenuItem` from `getItemProps` which triggered the warning.

This PR pins the downshift version to `5.0.5` until we can update the dependency and `ListBox.MenuItem` component to accept refs

#### Changelog

**New**

**Changed**

- Pin `downshift` to `5.0.5`

**Removed**
