### PR TITLE
fix(date-picker): update selected range background colors

### DIFF
--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -327,7 +327,7 @@
   .#{$prefix}--date-picker__day.today,
   .flatpickr-day.today {
     position: relative;
-    color: $interactive-01;
+    color: $link-01;
     font-weight: 600;
 
     &::after {
@@ -339,7 +339,7 @@
       transform: translateX(-50%);
       height: rem(4px);
       width: rem(4px);
-      background: $interactive-01;
+      background-color: $link-01;
     }
   }
 
@@ -367,14 +367,14 @@
 
   .#{$prefix}--date-picker__day.inRange,
   .flatpickr-day.inRange {
-    background: $date-picker-in-range-background-color;
+    background-color: $highlight;
     color: $text-01;
   }
 
   .#{$prefix}--date-picker__day.selected,
   .flatpickr-day.selected {
     color: $text-04;
-    background: $interactive-01;
+    background-color: $interactive-01;
 
     &:focus {
       outline: rem(1px) solid $ui-02;

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -245,6 +245,7 @@ $data-table-column-hover: $hover-selected-ui !default;
 /// @type Color
 /// @access public
 /// @group date-picker
+/// @deprecated
 $date-picker-in-range-background-color: $ibm-color__blue-20 !default;
 
 // Modal


### PR DESCRIPTION
Closes #6214

This PR updates date picker token usage to better accommodate dark themes

#### Testing / Reviewing

Confirm that the date picker colors are correct, particularly on the G90 and G100 themes
