### PR TITLE
fix(header): remove negative margin on menu trigger

### DIFF
--- a/packages/components/src/components/ui-shell/_header.scss
+++ b/packages/components/src/components/ui-shell/_header.scss
@@ -87,10 +87,6 @@
     fill: $shell-header-icon-02;
   }
 
-  .#{$prefix}--header__menu-trigger {
-    margin-right: rem(-8px);
-  }
-
   .#{$prefix}--header__menu-trigger > svg {
     fill: $shell-header-icon-01;
   }


### PR DESCRIPTION
Closes #6215 

This PR removes the negative right margin on the header menu trigger so the system name no longer overlaps with it

#### Testing / Reviewing

Confirm the UI shell header elements no longer overlap