### PR TITLE
fix(pagination): hide scrollbars

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -35,6 +35,14 @@ $css--helpers: true;
     justify-content: space-between;
     border-top: 1px solid $ui-03;
     height: rem(48px);
+
+    // Browser overrides to hide scrollbar
+    scrollbar-width: none;    // Firefox
+    -ms-overflow-style: none; // Edge
+    &::-webkit-scrollbar {    // WebKit
+      width: 0;
+      height: 0;
+    }
   }
 
   .#{$prefix}--pagination .#{$prefix}--select {


### PR DESCRIPTION
After the latest change that allowed Pagination to horizontally scroll on small screens, scrollbars were present on Windows and MacOS when scrollbar visibility was set to always. This uses vendor prefixes to target each browser and hide them. 

#### Changelog

**New**

- Browser specific selectors to hide the scrollbar on `Pagination`

#### Testing / Reviewing

Ensure no scrollbars are present on Windows 10, or MacOS with scroll bar visibility set to 'Always' in System --> General.

Ensure Pagination can still scroll on mobile viewport
