### PR TITLE
fix(pagination): alternate pagination scroll fix

### DIFF
--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -35,6 +35,14 @@ $css--helpers: true;
     justify-content: space-between;
     border-top: 1px solid $ui-03;
     height: rem(48px);
+
+    // Browser overrides to hide scrollbar
+    scrollbar-width: none;    // Firefox
+    -ms-overflow-style: none; // Edge
+    &::-webkit-scrollbar {    // WebKit
+      width: 0;
+      height: 0;
+    }
   }
 
   .#{$prefix}--pagination .#{$prefix}--select {

--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -28,21 +28,17 @@ $css--helpers: true;
     @include reset;
     @include type-style('body-short-01');
     width: 100%;
-    overflow-x: scroll;
     background-color: $ui-01;
+    overflow: hidden;
+    border-top: 1px solid $ui-03;
+    height: rem(48px);
+  }
+
+  .#{$prefix}--pagination--scroll-wrapper {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border-top: 1px solid $ui-03;
-    height: rem(48px);
-
-    // Browser overrides to hide scrollbar
-    scrollbar-width: none;    // Firefox
-    -ms-overflow-style: none; // Edge
-    &::-webkit-scrollbar {    // WebKit
-      width: 0;
-      height: 0;
-    }
+    overflow-x: auto;
   }
 
   .#{$prefix}--pagination .#{$prefix}--select {
@@ -60,7 +56,7 @@ $css--helpers: true;
     @include type-style('body-short-01');
     width: auto;
     min-width: auto;
-    height: 100%;
+    height: rem(48px);
     padding: 0 2.25rem 0 $spacing-05;
   }
 

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -264,78 +264,80 @@ export default class Pagination extends Component {
     const selectItems = this.renderSelectItems(totalPages);
     return (
       <div className={classNames} {...other}>
-        <div className={`${prefix}--pagination__left`}>
-          <label
-            id={`${prefix}-pagination-select-${inputId}-count-label`}
-            className={`${prefix}--pagination__text`}
-            htmlFor={`${prefix}-pagination-select-${inputId}`}>
-            {itemsPerPageText}
-          </label>
-          <Select
-            id={`${prefix}-pagination-select-${inputId}`}
-            className={`${prefix}--select__item-count`}
-            labelText=""
-            hideLabel
-            noLabel
-            inline
-            onChange={this.handleSizeChange}
-            value={statePageSize}>
-            {pageSizes.map((size) => (
-              <SelectItem key={size} value={size} text={String(size)} />
-            ))}
-          </Select>
-          <span className={`${prefix}--pagination__text`}>
-            {pagesUnknown
-              ? itemText(
-                  statePageSize * (statePage - 1) + 1,
-                  statePage * statePageSize
-                )
-              : itemRangeText(
-                  Math.min(statePageSize * (statePage - 1) + 1, totalItems),
-                  Math.min(statePage * statePageSize, totalItems),
-                  totalItems
-                )}
-          </span>
-        </div>
-        <div className={`${prefix}--pagination__right`}>
-          <Select
-            id={`${prefix}-pagination-select-${inputId}-right`}
-            className={`${prefix}--select__page-number`}
-            labelText={`Page number, of ${totalPages} pages`}
-            inline
-            hideLabel
-            onChange={this.handlePageInputChange}
-            value={statePage}
-            disabled={pageInputDisabled}>
-            {selectItems}
-          </Select>
-          <span className={`${prefix}--pagination__text`}>
-            {pagesUnknown
-              ? pageText(statePage)
-              : pageRangeText(statePage, totalPages)}
-          </span>
-          <Button
-            kind="ghost"
-            className={backButtonClasses}
-            hasIconOnly
-            renderIcon={CaretLeft16}
-            iconDescription={backwardText}
-            tooltipAlignment="center"
-            tooltipPosition="top"
-            onClick={this.decrementPage}
-            disabled={backButtonDisabled}
-          />
-          <Button
-            kind="ghost"
-            className={forwardButtonClasses}
-            hasIconOnly
-            renderIcon={CaretRight16}
-            iconDescription={forwardText}
-            tooltipAlignment="end"
-            tooltipPosition="top"
-            onClick={this.incrementPage}
-            disabled={forwardButtonDisabled || isLastPage}
-          />
+        <div className={`${prefix}--pagination--scroll-wrapper`}>
+          <div className={`${prefix}--pagination__left`}>
+            <label
+              id={`${prefix}-pagination-select-${inputId}-count-label`}
+              className={`${prefix}--pagination__text`}
+              htmlFor={`${prefix}-pagination-select-${inputId}`}>
+              {itemsPerPageText}
+            </label>
+            <Select
+              id={`${prefix}-pagination-select-${inputId}`}
+              className={`${prefix}--select__item-count`}
+              labelText=""
+              hideLabel
+              noLabel
+              inline
+              onChange={this.handleSizeChange}
+              value={statePageSize}>
+              {pageSizes.map((size) => (
+                <SelectItem key={size} value={size} text={String(size)} />
+              ))}
+            </Select>
+            <span className={`${prefix}--pagination__text`}>
+              {pagesUnknown
+                ? itemText(
+                    statePageSize * (statePage - 1) + 1,
+                    statePage * statePageSize
+                  )
+                : itemRangeText(
+                    Math.min(statePageSize * (statePage - 1) + 1, totalItems),
+                    Math.min(statePage * statePageSize, totalItems),
+                    totalItems
+                  )}
+            </span>
+          </div>
+          <div className={`${prefix}--pagination__right`}>
+            <Select
+              id={`${prefix}-pagination-select-${inputId}-right`}
+              className={`${prefix}--select__page-number`}
+              labelText={`Page number, of ${totalPages} pages`}
+              inline
+              hideLabel
+              onChange={this.handlePageInputChange}
+              value={statePage}
+              disabled={pageInputDisabled}>
+              {selectItems}
+            </Select>
+            <span className={`${prefix}--pagination__text`}>
+              {pagesUnknown
+                ? pageText(statePage)
+                : pageRangeText(statePage, totalPages)}
+            </span>
+            <Button
+              kind="ghost"
+              className={backButtonClasses}
+              hasIconOnly
+              renderIcon={CaretLeft16}
+              iconDescription={backwardText}
+              tooltipAlignment="center"
+              tooltipPosition="top"
+              onClick={this.decrementPage}
+              disabled={backButtonDisabled}
+            />
+            <Button
+              kind="ghost"
+              className={forwardButtonClasses}
+              hasIconOnly
+              renderIcon={CaretRight16}
+              iconDescription={forwardText}
+              tooltipAlignment="end"
+              tooltipPosition="top"
+              onClick={this.incrementPage}
+              disabled={forwardButtonDisabled || isLastPage}
+            />
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/6246

This is an alternate solution to #6246 that uses an extra container wrapper to scroll the Pagination component

#### Changelog

**New**

- `bx--pagination--scroll-wrapper` wraps the left and right pagination wrappers. The parent is set to `overflow: hidden` and this container is set to `overflow-x: auto`

**Changed**

- Moved some styes from `bx--pagination` to `bx--pagination--scroll-wrapper`


#### Testing / Reviewing

Ensure no scrollbars are present on Windows 10, or MacOS with scroll bar visibility set to 'Always' in System --> General.

Ensure Pagination can still scroll on mobile viewport


I recommend hiding whitespace changes, which makes this change seem larger than it is:
<img width="529" alt="Screen Shot 2020-06-10 at 2 01 14 PM" src="https://user-images.githubusercontent.com/11928039/84302162-c10afe80-ab09-11ea-823e-e2dcf833b2dd.png">
