### PR TITLE
fix(tabs): automatically add scrollbar when content overflows

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -134,7 +134,7 @@
     @include carbon--breakpoint(md) {
       display: flex;
       transition: inherit;
-      overflow-x: scroll;
+      overflow-x: auto;
       max-width: 100%;
       max-height: none;
     }


### PR DESCRIPTION
Closes #6277

This PR changes the fixed 100% overflow-x to only apply when the content is overflowing

#### Testing / Reviewing

Confirm that scroll bars only appear when content overflows and not otherwise