### PR TITLE
fix(date-picker): increase range input field spacing

### DIFF
--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -150,7 +150,7 @@
 
   .#{$prefix}--date-picker--range
     > .#{$prefix}--date-picker-container:first-child {
-    margin-right: rem(1px);
+    margin-right: rem(2px);
   }
 
   .#{$prefix}--date-picker--range .#{$prefix}--date-picker-container,


### PR DESCRIPTION
Closes #6265

After confirming that the fuzzy border problem is no longer present, this PR resolves the remaining spacing issue between inputs in the date range picker

#### Testing / Reviewing

Confirm the date range pickers have the correct spacing between the inputs
