### PR TITLE
fix(progress-indicator): set title based on label attribute

### DIFF
--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -44,6 +44,7 @@ export function ProgressStep({
   onClick,
   renderLabel: ProgressStepLabel,
   translateWithId: t,
+  ...rest
 }) {
   const classes = classnames({
     [`${prefix}--progress-step`]: true,
@@ -109,7 +110,8 @@ export function ProgressStep({
         aria-disabled={disabled}
         tabIndex={!current && onClick && !disabled ? 0 : -1}
         onClick={!current ? onClick : undefined}
-        onKeyDown={handleKeyDown}>
+        onKeyDown={handleKeyDown}
+        {...rest}>
         <span className={`${prefix}--assistive-text`}>{message}</span>
         <SVGIcon
           complete={complete}

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -44,7 +44,6 @@ export function ProgressStep({
   onClick,
   renderLabel: ProgressStepLabel,
   translateWithId: t,
-  ...rest
 }) {
   const classes = classnames({
     [`${prefix}--progress-step`]: true,
@@ -111,7 +110,7 @@ export function ProgressStep({
         tabIndex={!current && onClick && !disabled ? 0 : -1}
         onClick={!current ? onClick : undefined}
         onKeyDown={handleKeyDown}
-        {...rest}>
+        title={label}>
         <span className={`${prefix}--assistive-text`}>{message}</span>
         <SVGIcon
           complete={complete}

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -44,6 +44,7 @@ export function ProgressStep({
   onClick,
   renderLabel: ProgressStepLabel,
   translateWithId: t,
+  ...rest
 }) {
   const classes = classnames({
     [`${prefix}--progress-step`]: true,
@@ -110,7 +111,8 @@ export function ProgressStep({
         tabIndex={!current && onClick && !disabled ? 0 : -1}
         onClick={!current ? onClick : undefined}
         onKeyDown={handleKeyDown}
-        title={label}>
+        title={label}
+        {...rest}>
         <span className={`${prefix}--assistive-text`}>{message}</span>
         <SVGIcon
           complete={complete}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6292

Sets the `title` for the  `ProgressStep` based on the `label` prop.

#### Changelog

**New**

- Extra props are spread to `ProgressStep` component

**Changed**

- `title` is automatically set by the `label` prop

#### Testing / Reviewing

Try hovering over a `ProgressStep` and ensure a tooltip is shown on hover 
