### PR TITLE
fix(Pagination): remove default value for pageInputDisabled

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3849,7 +3849,6 @@ Map {
       "itemText": [Function],
       "itemsPerPageText": "Items per page:",
       "page": 1,
-      "pageInputDisabled": false,
       "pageNumberText": "Page Number",
       "pageRangeText": [Function],
       "pageText": [Function],

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -25,7 +25,7 @@ const props = () => ({
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
   pageInputDisabled: boolean(
     '[Deprecated]: Disable page input (pageInputDisabled)',
-    false
+    undefined
   ),
   backwardText: text(
     'The description for the backward icon (backwardText)',

--- a/packages/react/src/components/Pagination/Pagination-test.js
+++ b/packages/react/src/components/Pagination/Pagination-test.js
@@ -313,11 +313,7 @@ describe('Pagination', () => {
 
         it('should hide text input if disabled', () => {
           const noTextInput = shallow(
-            <Pagination
-              pageSizes={[100]}
-              pagesUnknown={true}
-              pageInputDisabled={true}
-            />
+            <Pagination pageSizes={[100]} pagesUnknown={true} disabled={true} />
           );
           const right = noTextInput.find(
             `.${prefix}--pagination__right .${prefix}--text__input`
@@ -325,13 +321,13 @@ describe('Pagination', () => {
           expect(right.length).toEqual(0);
         });
 
-        it('should not append `pagination__button--no-index` class if input is disabled', () => {
+        it('should append `pagination__button--no-index` class if input is disabled', () => {
           const pagination = shallow(
             <Pagination
               page={2}
               pageSizes={[100]}
               pagesUnknown={true}
-              pageInputDisabled={true}
+              disabled={true}
             />
           );
           const forwardButton = pagination.find(
@@ -342,10 +338,10 @@ describe('Pagination', () => {
           );
           expect(
             backwardButton.hasClass(`${prefix}--pagination__button--no-index`)
-          ).toEqual(false);
+          ).toEqual(true);
           expect(
             forwardButton.hasClass(`${prefix}--pagination__button--no-index`)
-          ).toEqual(false);
+          ).toEqual(true);
         });
       });
 

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -145,7 +145,6 @@ export default class Pagination extends Component {
     page: 1,
     pagesUnknown: false,
     isLastPage: false,
-    pageInputDisabled: false,
     itemText: (min, max) => `${min}–${max} items`,
     pageText: (page) => `page ${page}`,
   };


### PR DESCRIPTION
Closes #6311

This PR prevents the deprecation warning on Pagination's `pageInputDisabled` prop from firing by default

#### Changelog

**Removed**

- default `pageInputDisabled` value

#### Testing / Reviewing

Confirm the deprecation warning does not appear by default when rendering `Pagination`
