### PR TITLE
docs(FileUploaderItem): add proptypes for size prop

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2549,6 +2549,16 @@ Map {
       "role": Object {
         "type": "string",
       },
+      "size": Object {
+        "args": Array [
+          Array [
+            "default",
+            "field",
+            "small",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "tabIndex": Object {
         "type": "number",
       },

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -116,6 +116,7 @@ const props = {
       'Error body (errorBody)',
       '500kb max file size. Select a new file and try again.'
     ),
+    size: select('FileUploaderItem height (size)', sizes, 'default'),
   }),
   fileUploaderDropContainer: () => ({
     size: select('Filename height (size)', sizes, 'default'),

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
@@ -183,6 +183,12 @@ FileUploaderDropContainer.propTypes = {
    * The event handler signature looks like `onAddFiles(evt, { addedFiles })`
    */
   onAddFiles: PropTypes.func,
+
+  /**
+   * Specify the size of the uploaded items, from a list of available
+   * sizes. For `default` size, this prop can remain unspecified.
+   */
+  size: PropTypes.oneOf(['default', 'field', 'small']),
 };
 
 FileUploaderDropContainer.defaultProps = {

--- a/packages/react/src/components/FileUploader/FileUploaderItem.js
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.js
@@ -88,8 +88,8 @@ FileUploaderItem.propTypes = {
   status: PropTypes.oneOf(['uploading', 'edit', 'complete']),
 
   /**
-   * Specify the size of the button, from a list of available sizes.
-   * For `default` buttons, this prop can remain unspecified.
+   * Specify the size of the uploaded items, from a list of available
+   * sizes. For `default` size, this prop can remain unspecified.
    */
   size: PropTypes.oneOf(['default', 'field', 'small']),
 


### PR DESCRIPTION
Closes #6322

This PR adds prop type definitions for the `size` prop in FileUploaderItem