### PR TITLE
fix(InlineLoading): update success svg color

### DIFF
--- a/packages/components/src/components/inline-loading/_inline-loading.scss
+++ b/packages/components/src/components/inline-loading/_inline-loading.scss
@@ -46,7 +46,7 @@
   }
 
   .#{$prefix}--inline-loading__checkmark-container {
-    fill: $interactive-04;
+    fill: $support-02;
 
     // For deprecated older markup
     &.#{$prefix}--inline-loading__svg {


### PR DESCRIPTION
Closes #6330

This PR updates the InlineLoading checkmark SVG to use the `support-02` color token

#### Testing / Reviewing

Confirm the inline loading success state matches the updated component spec