### PR TITLE
fix(dropdown): fix vanilla dropdown toggle in safari

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.js
+++ b/packages/components/src/components/dropdown/dropdown.js
@@ -233,7 +233,9 @@ class Dropdown extends mixin(
         if (triggerNode) {
           triggerNode.setAttribute('aria-expanded', 'true');
         }
-        (listNode || this.element).focus();
+
+        this.element.focus();
+
         if (listNode) {
           const selectedNode = listNode.querySelector(
             this.options.selectorLinkSelected


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6384

The menu should now close properly when clicked on directly in safari

#### Changelog

**Changed**

- Logic in `dropdown.js`

#### Testing / Reviewing

Ensure vanilla dropdown still works properly across all browsers 
