### PR TITLE
docs(Tabs): return text node in custom label example

### DIFF
--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -67,9 +67,7 @@ const props = {
   }),
 };
 
-const CustomLabel = ({ text }) => {
-  text;
-};
+const CustomLabel = ({ text }) => text;
 
 const CodeSnippetExample = () => (
   <CodeSnippet type="multi">


### PR DESCRIPTION
Closes #6402

This PR returns a value for a custom label function in the Tabs story so that React will render it. Unblocks #4758 

#### Testing / Reviewing

Confirm the tabs stories render correctly again
