### PR TITLE
fix(dropdown): add `list-box` import as dependency

### DIFF
--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -15,6 +15,8 @@
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/layout';
 
+@import '../list-box/list-box';
+
 /// Dropdown styles
 /// @access private
 /// @group dropdown


### PR DESCRIPTION
## Changelog

Add `list-box` as style dependency for `dropdown` - Otherwise, if imported in isolation, the following occurs:

<img width="272" alt="Screenshot 2020-07-07 at 3 42 14 AM" src="https://user-images.githubusercontent.com/11292081/86869809-d9fcd480-c0f4-11ea-8d76-9bea8cafd561.png">