### PR TITLE
fix(combobox): fix initial selected item

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -339,7 +339,7 @@ export default class ComboBox extends React.Component {
         onStateChange={this.handleOnStateChange}
         inputValue={this.state.inputValue || ''}
         itemToString={itemToString}
-        defaultSelectedItem={initialSelectedItem}
+        initialSelectedItem={initialSelectedItem}
         inputId={id}
         selectedItem={selectedItem}>
         {({


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6420

Pre-selecting an item in the `ComboBox` component via the `initialSelectedItem` prop does not work.

#### Changelog

**New**

- {{new thing}}

**Changed**

- Seems like the component is passing the `initialSelectedItem` to `Downshift` with the wrong prop. Changing `defaultSelectedItem` to `initialSelectedItem` seems fixing the issue.

**Removed**

- {{removed thing}}

#### Testing / Reviewing

In `ComboBox-story.js`, you can reproduce the original problem if you add the initialSelectedItem prop like below:

```diff
        <ComboBox
          items={items}
          itemToString={(item) => (item ? item.text : '')}
+          initialSelectedItem={items[2]}
          {...props()}
        />
```
