### PR TITLE
fix(pagination-nav): add data-page attributes

### DIFF
--- a/packages/react/src/components/PaginationNav/PaginationNav.js
+++ b/packages/react/src/components/PaginationNav/PaginationNav.js
@@ -104,6 +104,7 @@ function PaginationItem({
           [`${prefix}--pagination-nav__page--active`]: isActive,
         })}
         onClick={onClick}
+        data-page={page}
         aria-current={isActive ? 'page' : null}>
         <span className={`${prefix}--pagination-nav__accessibility-label`}>
           {isActive
@@ -139,6 +140,7 @@ function PaginationOverflow({
             {[...Array(count)].map((e, i) => (
               <option
                 value={(fromIndex + i).toString()}
+                data-page={fromIndex + i + 1}
                 key={`overflow-${fromIndex + i}`}>
                 {fromIndex + i + 1}
               </option>


### PR DESCRIPTION
Adds `data-page` attribute to the page buttons and select options in the PaginationNav component. This is to follow the vanilla implementation (https://the-carbon-components.netlify.app/?nav=pagination-nav) and to give developers better access for advanced behaviour that relies on handling the DOM node (such as adding a custom css rule or other `data-*` attributes.

I'm so sorry for the extra request, @joshblack @aledavila! Our intended implementation was counting on `data-page` and yet somehow it slipped through my first PR.

#### Changelog

**New**

- Added `data-page="<page-number>"` to `button.bx--pagination-nav__page` and `select.bx--pagination-nav__page option`

#### Testing / Reviewing

- Automated tests should make sure no behaviour is changed. Verify `data-page` attribute holds the actual page number, not the index.
