### PR TITLE
fix(tooltip): change default styles

### DIFF
--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -499,7 +499,13 @@
   .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition {
     @include type-style('label-01');
 
-    border-bottom: rem(1px) dotted $interactive-01;
+    border-bottom: rem(1px) dotted $text-02;
+    transition: border-color $duration--fast-02;
+  }
+
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition:hover,
+  .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition:focus {
+    border-bottom-color: $interactive-01;
   }
 
   .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition.#{$prefix}--tooltip--top {

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -505,7 +505,7 @@
 
   .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition:hover,
   .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition:focus {
-    border-bottom-color: $interactive-01;
+    border-bottom-color: $interactive-04;
   }
 
   .#{$prefix}--tooltip__trigger.#{$prefix}--tooltip__trigger--definition.#{$prefix}--tooltip--top {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6450

Updates default styles for `DefinitionTooltip` so that it is `text-02` by default and  `interactive-04` on focus / hover

#### Changelog

**Changed**

- `text-02` by default and  `interactive-04` on focus / hover


#### Testing / Reviewing

`DefinitionTooltip` renders properly 
