### PR TITLE
fix(Tooltip): add focus trap behavior and fix focus management logic

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -121,11 +121,11 @@ export default class ComposedModal extends Component {
   }) => {
     const { open, selectorsFloatingMenus } = this.props;
     if (open && currentActiveNode && oldActiveNode) {
-      const { current: modalNode } = this.innerModal;
+      const { current: bodyNode } = this.innerModal;
       const { current: startSentinelNode } = this.startSentinel;
       const { current: endSentinelNode } = this.endSentinel;
       wrapFocus({
-        modalNode,
+        bodyNode,
         startSentinelNode,
         endSentinelNode,
         currentActiveNode,

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -215,11 +215,11 @@ export default class Modal extends Component {
   }) => {
     const { open, selectorsFloatingMenus } = this.props;
     if (open && currentActiveNode && oldActiveNode) {
-      const { current: modalNode } = this.innerModal;
+      const { current: bodyNode } = this.innerModal;
       const { current: startTrapNode } = this.startTrap;
       const { current: endTrapNode } = this.endTrap;
       wrapFocus({
-        modalNode,
+        bodyNode,
         startTrapNode,
         endTrapNode,
         currentActiveNode,

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -224,6 +224,15 @@ class Tooltip extends Component {
    */
   _triggerRef = React.createRef();
 
+  /**
+   * Unique tooltip ID that is user-provided or auto-generated
+   * Referenced in aria-labelledby attribute
+   * @type {string}
+   * @private
+   */
+  _tooltipId =
+    this.props.id || `__carbon-tooltip_${Math.random().toString(36).substr(2)}`;
+
   componentDidMount() {
     if (!this._debouncedHandleFocus) {
       this._debouncedHandleFocus = debounce(this._handleFocus, 200);
@@ -368,9 +377,6 @@ class Tooltip extends Component {
       triggerId = (this.triggerId =
         this.triggerId ||
         `__carbon-tooltip-trigger_${Math.random().toString(36).substr(2)}`),
-      tooltipId = (this.tooltipId =
-        this.tooltipId ||
-        `__carbon-tooltip_${Math.random().toString(36).substr(2)}`),
       tooltipBodyId,
       children,
       className,
@@ -413,9 +419,9 @@ class Tooltip extends Component {
       onMouseOut: this.handleMouse,
       onFocus: this.handleMouse,
       onBlur: this.handleMouse,
-      'aria-controls': !open ? undefined : tooltipId,
+      'aria-controls': !open ? undefined : this._tooltipId,
       'aria-expanded': open,
-      'aria-describedby': open ? tooltipId : null,
+      'aria-describedby': open ? this._tooltipId : null,
       // if the user provides property `triggerText`,
       // then the button should use aria-labelledby to point to its id,
       // if the user doesn't provide property `triggerText`,
@@ -463,7 +469,7 @@ class Tooltip extends Component {
               this._tooltipEl = node;
             }}>
             <div
-              id={tooltipId}
+              id={this._tooltipId}
               className={tooltipClasses}
               {...other}
               data-floating-menu-direction={direction}

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -435,8 +435,11 @@ class Tooltip extends Component {
           {showIcon ? (
             <div id={triggerId} className={triggerClasses}>
               {triggerText}
-              <div className={`${prefix}--tooltip__trigger`} {...properties}>
-                <IconCustomElement ref={refProp} {...iconProperties} />
+              <div
+                className={`${prefix}--tooltip__trigger`}
+                {...properties}
+                ref={refProp}>
+                <IconCustomElement {...iconProperties} />
               </div>
             </div>
           ) : (

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -300,9 +300,7 @@ class Tooltip extends Component {
       const { current: triggerEl } = this._triggerRef;
       const shouldPreventClose =
         relatedTarget &&
-        ((triggerEl &&
-          triggerEl.contains &&
-          triggerEl.contains(relatedTarget)) ||
+        ((triggerEl && triggerEl?.contains(relatedTarget)) ||
           (this._tooltipEl && this._tooltipEl.contains(relatedTarget)));
       if (!shouldPreventClose) {
         this._handleUserInputOpenClose(evt, { open: false });

--- a/packages/react/src/internal/__tests__/wrapFocus-test.js
+++ b/packages/react/src/internal/__tests__/wrapFocus-test.js
@@ -46,7 +46,7 @@ describe('wrapFocus', () => {
 
   it('runs forward focus-wrap when following outer node is focused on', () => {
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('#outer-following'),
@@ -57,7 +57,7 @@ describe('wrapFocus', () => {
 
   it('runs forward focus-wrap when following focus sentinel is focused on', () => {
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('#end-sentinel'),
@@ -68,7 +68,7 @@ describe('wrapFocus', () => {
 
   it('runs reverse focus-wrap when preceding outer node is focused on', () => {
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('#outer-preceding'),
@@ -79,7 +79,7 @@ describe('wrapFocus', () => {
 
   it('runs reverse focus-wrap when preceding focus sentinel is focused on', () => {
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('#start-sentinel'),
@@ -90,7 +90,7 @@ describe('wrapFocus', () => {
 
   it('does not run focus-wrap when a floating menu is focused on', () => {
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('.bx--tooltip'),
@@ -106,7 +106,7 @@ describe('wrapFocus', () => {
       '#inner-modal'
     ).innerHTML = `<div id="dummy-old-active-node"></div>`;
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('#outer-following'),
@@ -120,7 +120,7 @@ describe('wrapFocus', () => {
       '#inner-modal'
     ).innerHTML = `<div id="dummy-old-active-node"></div>`;
     wrapFocus({
-      modalNode: node.querySelector('#inner-modal'),
+      bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
       currentActiveNode: node.querySelector('#outer-preceding'),

--- a/packages/react/src/internal/wrapFocus.js
+++ b/packages/react/src/internal/wrapFocus.js
@@ -44,7 +44,7 @@ function elementOrParentIsFloatingMenu(
  * @param {Node} [options.selectorsFloatingMenus] The CSS selectors that matches floating menus.
  */
 function wrapFocus({
-  modalNode,
+  bodyNode,
   startTrapNode,
   endTrapNode,
   currentActiveNode,
@@ -52,10 +52,10 @@ function wrapFocus({
   selectorsFloatingMenus,
 }) {
   if (
-    modalNode &&
+    bodyNode &&
     currentActiveNode &&
     oldActiveNode &&
-    !modalNode.contains(currentActiveNode) &&
+    !bodyNode.contains(currentActiveNode) &&
     !elementOrParentIsFloatingMenu(currentActiveNode, selectorsFloatingMenus)
   ) {
     const comparisonResult = oldActiveNode.compareDocumentPosition(
@@ -66,26 +66,26 @@ function wrapFocus({
       comparisonResult & DOCUMENT_POSITION_BROAD_PRECEDING
     ) {
       const tabbable = findLast(
-        modalNode.querySelectorAll(selectorTabbable),
+        bodyNode.querySelectorAll(selectorTabbable),
         (elem) => Boolean(elem.offsetParent)
       );
       if (tabbable) {
         tabbable.focus();
-      } else if (modalNode !== oldActiveNode) {
-        modalNode.focus();
+      } else if (bodyNode !== oldActiveNode) {
+        bodyNode.focus();
       }
     } else if (
       currentActiveNode === endTrapNode ||
       comparisonResult & DOCUMENT_POSITION_BROAD_FOLLOWING
     ) {
       const tabbable = Array.prototype.find.call(
-        modalNode.querySelectorAll(selectorTabbable),
+        bodyNode.querySelectorAll(selectorTabbable),
         (elem) => Boolean(elem.offsetParent)
       );
       if (tabbable) {
         tabbable.focus();
-      } else if (modalNode !== oldActiveNode) {
-        modalNode.focus();
+      } else if (bodyNode !== oldActiveNode) {
+        bodyNode.focus();
       }
     }
   }


### PR DESCRIPTION
Closes #6443
Refs https://github.com/carbon-design-system/carbon/issues/1264#issuecomment-637159076
Refs https://github.com/carbon-design-system/carbon/issues/4414
Refs https://github.com/carbon-design-system/carbon/pull/5489

This PR implements optional focus trapping in the interactive tooltip and correctly places focus back on the trigger element after the tooltip is dismissed.

#### Changelog

**Changed**

- enable focus trap option in interactive tooltip
- place focus back on tooltip trigger element after tooltip dismissal rather than around elements where the tooltip portal is created/destroyed
- rename `wrapFocus` props to be more generic

#### Testing / Reviewing

Confirm that focus and blur behaves as expected within the interactive tooltip component as well as between interactive siblings to the tooltip. Ensure that focus management remains the same in other `wrapFocus` or `FloatingMenu` components like Modal, ComposedModal, and OverflowMenu
