### PR TITLE
fix(button): ensure rem in variable definition level

### DIFF
--- a/packages/components/src/components/button/_mixins.scss
+++ b/packages/components/src/components/button/_mixins.scss
@@ -20,7 +20,7 @@
   justify-content: space-between;
   vertical-align: top;
   flex-shrink: 0;
-  min-height: rem($button-height);
+  min-height: $button-height;
   padding: $button-padding;
   border-radius: $button-border-radius;
   text-align: left;

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -88,7 +88,7 @@ $button-border-radius: 0 !default;
 /// @type Number
 /// @access public
 /// @group button
-$button-height: 48px !default;
+$button-height: 3rem !default;
 
 /// @type Value
 /// @access public


### PR DESCRIPTION
This change makes sure `rem` unit is used in variable definition level (as it's done for other variables).

Fixes #6469.

#### Changelog

**Changed**

- `$button-height` definition to use `rem` unit, as it's done for other variables.
- The corresponding change to `button/_mixins.scss`.

#### Testing / Reviewing

Testing should make sure our button is not broken.