### PR TITLE
fix(time-picker): remove extra css reset

### DIFF
--- a/packages/components/src/components/time-picker/_time-picker.scss
+++ b/packages/components/src/components/time-picker/_time-picker.scss
@@ -50,7 +50,6 @@
   }
 
   .#{$prefix}--time-picker__input-field {
-    @include reset;
     @include focus-outline('reset');
     @include type-style('code-02');
 


### PR DESCRIPTION
Closes #6482 

The `TimePicker` already gets reset styles from `.bx--text-input` here:
https://github.com/carbon-design-system/carbon/blob/d734a44594ef5648a414fb8a3dab1f30fd41d186/packages/components/src/components/text-input/_text-input.scss#L22-L24

I suggest removing the reset in `TimePicker` so that there aren't double the reset styles to override (which is currently causing the style regression described in #6482)

#### Changelog

**Removed**

- removed css-reset mixin
