### PR TITLE
fix(TooltipDefinition): update prop-types

### DIFF
--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -91,10 +91,10 @@ const TooltipDefinition = ({
 
 TooltipDefinition.propTypes = {
   /**
-   * Specify the tooltip trigger text that is rendered to the UI for the user to
+   * Specify the tooltip trigger that is rendered to the UI for the user to
    * interact with in order to display the tooltip.
    */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 
   /**
    * Specify an optional className to be applied to the container node


### PR DESCRIPTION
Closes #6489

This changes the children prop-type to `PropTypes.node` to allow for the use of span, p, or icon/svg elements to be support without prop-type errors.