### PR TITLE
fix(text-area): apply disabled text token to textarea content

### DIFF
--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -80,6 +80,7 @@
     outline: none;
     background-color: $disabled-background-color;
     border-bottom: 1px solid transparent;
+    color: $disabled-02;
   }
 
   .#{$prefix}--text-area:disabled::placeholder {


### PR DESCRIPTION
Closes #6474

This PR applies the disabled text color token to content in a disabled textarea

#### Testing / Reviewing

Confirm the disabled textarea is visually correct