### PR TITLE
fix(TimePicker): set invalid outline on invalid focused text input

### DIFF
--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -176,6 +176,10 @@
 
     box-shadow: none;
 
+    &:focus {
+      @include focus-outline('invalid');
+    }
+
     .#{$prefix}--text-input--password__visibility,
     // TODO: remove selector above
     .#{$prefix}--text-input--password__visibility__toggle {

--- a/packages/components/src/components/time-picker/_time-picker.scss
+++ b/packages/components/src/components/time-picker/_time-picker.scss
@@ -28,6 +28,10 @@
     @include focus-outline('invalid');
   }
 
+  .#{$prefix}--time-picker--invalid + .#{$prefix}--form-requirement {
+    color: $text-error;
+  }
+
   .#{$prefix}--time-picker__select {
     justify-content: center;
 

--- a/packages/react/src/components/TimePicker/TimePicker.js
+++ b/packages/react/src/components/TimePicker/TimePicker.js
@@ -195,6 +195,7 @@ export default class TimePicker extends Component {
     const timePickerClasses = classNames({
       [`${prefix}--time-picker`]: true,
       [`${prefix}--time-picker--light`]: light,
+      [`${prefix}--time-picker--invalid`]: invalid,
       [className]: className,
     });
 

--- a/packages/react/src/components/TimePicker/TimePicker.js
+++ b/packages/react/src/components/TimePicker/TimePicker.js
@@ -222,7 +222,7 @@ export default class TimePicker extends Component {
             <input
               {...other}
               {...timePickerInputProps}
-              data-invalid={invalid ? invalid : undefined}
+              data-invalid={invalid || null}
             />
           </div>
           {children}


### PR DESCRIPTION
Closes #6518

This PR correctly sets the invalid outline on the invalid time picker's text input to match the behavior throughout the system and sets the correct invalid text color on the error message

#### Testing / Reviewing

Confirm the invalid time picker matches the component spec 