### PR TITLE
fix(Pictograms): remove `null` alias for soft ice cream

### DIFF
--- a/packages/pictograms/pictograms.yml
+++ b/packages/pictograms/pictograms.yml
@@ -3269,7 +3269,6 @@
     - soft ice cream
     - ice cream
     - food
-    - null
     - name: softlayer--enablement
       friendly_name: Softlayer enablement
       aliases:


### PR DESCRIPTION
closes #6552