### PR TITLE
chore: improve icon builder validation closes #6555

### DIFF
--- a/packages/icon-build-helpers/src/metadata/extensions/icons.js
+++ b/packages/icon-build-helpers/src/metadata/extensions/icons.js
@@ -30,7 +30,7 @@ const icons = () => {
           Joi.string().valid('glyph'),
           Joi.number().valid([16, 20, 24, 32])
         ),
-        aliases: Joi.array(),
+        aliases: Joi.array().items(Joi.string()),
       })
     ),
 

--- a/packages/icon-build-helpers/src/metadata/extensions/pictograms.js
+++ b/packages/icon-build-helpers/src/metadata/extensions/pictograms.js
@@ -22,7 +22,7 @@ const pictograms = () => {
       Joi.object().keys({
         name: Joi.string().required(),
         friendly_name: Joi.string().required(),
-        aliases: Joi.array().items(Joi.string(), Joi.number()),
+        aliases: Joi.array().items(Joi.string()),
       })
     ),
 

--- a/packages/icon-build-helpers/src/metadata/extensions/pictograms.js
+++ b/packages/icon-build-helpers/src/metadata/extensions/pictograms.js
@@ -22,7 +22,7 @@ const pictograms = () => {
       Joi.object().keys({
         name: Joi.string().required(),
         friendly_name: Joi.string().required(),
-        aliases: Joi.array(),
+        aliases: Joi.array().items(Joi.string(), Joi.number()),
       })
     ),
 

--- a/packages/pictograms/pictograms.yml
+++ b/packages/pictograms/pictograms.yml
@@ -3269,13 +3269,13 @@
     - soft ice cream
     - ice cream
     - food
-    - name: softlayer--enablement
-      friendly_name: Softlayer enablement
-      aliases:
-        - softlayer enablement
-        - enablement
-        - softlayer
-        - cloud
+- name: softlayer--enablement
+  friendly_name: Softlayer enablement
+  aliases:
+    - softlayer enablement
+    - enablement
+    - softlayer
+    - cloud
 - name: softlayer--enablement
   friendly_name: softlayer--enablement
   aliases: []

--- a/packages/pictograms/pictograms.yml
+++ b/packages/pictograms/pictograms.yml
@@ -3276,9 +3276,6 @@
     - enablement
     - softlayer
     - cloud
-- name: softlayer--enablement
-  friendly_name: softlayer--enablement
-  aliases: []
 - name: solar--field
   friendly_name: Solar field
   aliases:


### PR DESCRIPTION
Closes #6555 closes #6559


# whoop we caught a live one!
Issue: #6559 [(CI run)](https://app.circleci.com/pipelines/github/carbon-design-system/carbon/11105/workflows/547bf947-e592-481e-8f7b-b682ebec282e/jobs/13184)

### Description
Currently when an icon/pictogram fails validation, rely on joi's `error.annotate()` which prints out the entirety of our dataset without really pointing to the problem.

### Changelog

**New**
- Increased specificity of `aliases` property to exclude `null` values
- Enhanced error logging when validation fails


### Before
<img width="854" alt="Screen Shot 2020-07-24 at 4 34 20 PM" src="https://user-images.githubusercontent.com/4078018/88437744-c035df80-cdcc-11ea-8d42-7a51f45d0bb3.png">


### After
<img width="701" alt="Screen Shot 2020-07-24 at 4 35 10 PM" src="https://user-images.githubusercontent.com/4078018/88437287-c8414f80-cdcb-11ea-9c2e-468a99de3794.png">




