### PR TITLE
fix(data-table): right align datatable sort icon

### DIFF
--- a/packages/components/src/components/data-table/_data-table-sort.scss
+++ b/packages/components/src/components/data-table/_data-table-sort.scss
@@ -62,6 +62,8 @@
   .#{$prefix}--data-table--sort th .#{$prefix}--table-sort__flex {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    width: 100%;
     height: 100%;
     min-height: 3rem;
   }
@@ -69,9 +71,6 @@
   .#{$prefix}--data-table--sort:not(.#{$prefix}--data-table--compact):not(.#{$prefix}--data-table--short):not(.#{$prefix}--data-table--tall)
     th
     .#{$prefix}--table-sort__flex {
-    justify-content: space-between;
-    width: 100%;
-
     /* IE11 workaround for align-items: center and min-height
         https://github.com/philipwalton/flexbugs/issues/231 */
     @media screen and (-ms-high-contrast: active),

--- a/packages/components/src/components/data-table/_data-table-sort.scss
+++ b/packages/components/src/components/data-table/_data-table-sort.scss
@@ -69,6 +69,9 @@
   .#{$prefix}--data-table--sort:not(.#{$prefix}--data-table--compact):not(.#{$prefix}--data-table--short):not(.#{$prefix}--data-table--tall)
     th
     .#{$prefix}--table-sort__flex {
+    justify-content: space-between;
+    width: 100%;
+
     /* IE11 workaround for align-items: center and min-height
         https://github.com/philipwalton/flexbugs/issues/231 */
     @media screen and (-ms-high-contrast: active),
@@ -111,7 +114,7 @@
   .#{$prefix}--table-sort__icon-unsorted {
     width: rem(20px);
     min-width: $layout-01;
-    margin-right: $spacing-05;
+    margin-right: $spacing-03;
     margin-left: $spacing-03;
     opacity: 0;
     fill: $ui-05;
@@ -140,7 +143,7 @@
   .#{$prefix}--table-sort__icon {
     width: rem(20px);
     min-width: $layout-01;
-    margin-right: $spacing-05;
+    margin-right: $spacing-03;
     margin-left: $spacing-03;
     transform: rotate(0);
     opacity: 1;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6577

Right aligns the `DataTable` sort icon 

#### Changelog

**Changed**

- Align sort icon `8px` from right edge of `DataTable` header

#### Testing / Reviewing

Ensure sort icon renders properly in all browsers
