### PR TITLE
fix(ListBoxMenu): use arrayOf(Component) instead of childrenOfType

### DIFF
--- a/packages/react/src/components/ListBox/ListBoxMenu.js
+++ b/packages/react/src/components/ListBox/ListBoxMenu.js
@@ -40,6 +40,13 @@ ListBoxMenu.propTypes = {
    */
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(ListBoxMenuItem),
+    /**
+     * allow single item using the workaround for functional components
+     * https://github.com/facebook/react/issues/2979#issuecomment-222379916
+     */
+    PropTypes.shape({
+      type: PropTypes.oneOf([ListBoxMenuItem]),
+    }),
     PropTypes.bool, // used in Dropdown for closed state
   ]),
 

--- a/packages/react/src/components/ListBox/ListBoxMenu.js
+++ b/packages/react/src/components/ListBox/ListBoxMenu.js
@@ -9,7 +9,6 @@ import React from 'react';
 import { settings } from 'carbon-components';
 import PropTypes from 'prop-types';
 import ListBoxMenuItem from './ListBoxMenuItem';
-import childrenOfType from '../../prop-types/childrenOfType';
 
 const { prefix } = settings;
 
@@ -39,7 +38,10 @@ ListBoxMenu.propTypes = {
   /**
    * Provide the contents of your ListBoxMenu
    */
-  children: childrenOfType(ListBoxMenuItem),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(ListBoxMenuItem),
+    PropTypes.bool, // used in Dropdown for closed state
+  ]),
 
   /**
    * Specify a custom `id`


### PR DESCRIPTION
Relates to [#2785](https://github.com/carbon-design-system/carbon/pull/2785)

Fixes an issue where hot-loader changes the component's instance and === doesn't work properly.

#### Changelog

**Changed**

- ListBoxMenu prop types are validated with arrayOf instead of childrenOfType

#### Testing / Reviewing

- Make sure that no warning or error is thrown when using the ListBoxMenu with ListBoxMenuItem children

#### Screenshot

![image](https://user-images.githubusercontent.com/6061509/88960163-6426fb80-d2a3-11ea-8572-8e99c3aee4a5.png)
