### PR TITLE
docs(Switch): add explicit disabled prop type

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4555,6 +4555,9 @@ Map {
       "className": Object {
         "type": "string",
       },
+      "disabled": Object {
+        "type": "bool",
+      },
       "index": Object {
         "type": "number",
       },

--- a/packages/react/src/components/Switch/Switch.js
+++ b/packages/react/src/components/Switch/Switch.js
@@ -15,6 +15,7 @@ const { prefix } = settings;
 const Switch = React.forwardRef(function Switch(props, tabRef) {
   const {
     className,
+    disabled,
     index,
     name,
     onClick,
@@ -43,6 +44,7 @@ const Switch = React.forwardRef(function Switch(props, tabRef) {
     onClick: handleClick,
     onKeyDown: handleKeyDown,
     className: classes,
+    disabled,
   };
 
   return (
@@ -65,6 +67,11 @@ Switch.propTypes = {
    * Specify an optional className to be added to your Switch
    */
   className: PropTypes.string,
+
+  /**
+   * Specify whether or not the Switch should be disabled
+   */
+  disabled: PropTypes.bool,
 
   /**
    * The index of your Switch in your ContentSwitcher that is used for event handlers.


### PR DESCRIPTION
Closes #6594

This PR adds the `disabled` prop to the list of proptypes so that it is explicitly shown in the generated prop table