### PR TITLE
feat(button): add separator in button sets

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -196,6 +196,7 @@
   - [✅highlight [variable]](#highlight-variable)
   - [✅decorative-01 [variable]](#decorative-01-variable)
   - [✅hover-light-ui [variable]](#hover-light-ui-variable)
+  - [✅button-separator [variable]](#button-separator-variable)
   - [✅skeleton-01 [variable]](#skeleton-01-variable)
   - [✅skeleton-02 [variable]](#skeleton-02-variable)
   - [✅⚠️brand-01 [variable]](#brand-01-variable)
@@ -4227,6 +4228,7 @@ Define theme variables from a map of tokens
   $highlight: map-get($theme, 'highlight') !global;
   $decorative-01: map-get($theme, 'decorative-01') !global;
   $hover-light-ui: map-get($theme, 'hover-light-ui') !global;
+  $button-separator: map-get($theme, 'button-separator') !global;
   $skeleton-01: map-get($theme, 'skeleton-01') !global;
   $skeleton-02: map-get($theme, 'skeleton-02') !global;
   $brand-01: map-get($theme, 'brand-01') !global;
@@ -4538,6 +4540,10 @@ Define theme variables from a map of tokens
     $hover-light-ui: var(
       --#{$custom-property-prefix}-hover-light-ui,
       map-get($theme, 'hover-light-ui')
+    ) !global;
+    $button-separator: var(
+      --#{$custom-property-prefix}-button-separator,
+      map-get($theme, 'button-separator')
     ) !global;
     $skeleton-01: var(
       --#{$custom-property-prefix}-skeleton-01,
@@ -5229,6 +5235,19 @@ Define theme variables from a map of tokens
       @include custom-property(
         'hover-light-ui',
         map-get($theme, 'hover-light-ui')
+      );
+    }
+
+    @if should-emit(
+      $theme,
+      $parent-carbon-theme,
+      'button-separator',
+      $emit-difference
+    )
+    {
+      @include custom-property(
+        'button-separator',
+        map-get($theme, 'button-separator')
       );
     }
 
@@ -6015,6 +6034,7 @@ Define theme variables from a map of tokens
   - [highlight [variable]](#highlight-variable)
   - [decorative-01 [variable]](#decorative-01-variable)
   - [hover-light-ui [variable]](#hover-light-ui-variable)
+  - [button-separator [variable]](#button-separator-variable)
   - [skeleton-01 [variable]](#skeleton-01-variable)
   - [skeleton-02 [variable]](#skeleton-02-variable)
   - [brand-01 [variable]](#brand-01-variable)
@@ -6171,6 +6191,7 @@ $carbon--theme--g90: map-merge(
     highlight: #0043ce,
     decorative-01: #6f6f6f,
     hover-light-ui: #6f6f6f,
+    button-separator: #161616,
     skeleton-01: #353535,
     skeleton-02: #525252,
     brand-02: #6f6f6f,
@@ -6246,6 +6267,7 @@ $carbon--theme--g100: map-merge(
     highlight: #002d9c,
     decorative-01: #525252,
     hover-light-ui: #525252,
+    button-separator: #161616,
     skeleton-01: #353535,
     skeleton-02: #393939,
     brand-02: #6f6f6f,
@@ -6412,6 +6434,7 @@ $carbon--theme: (
   highlight: if(global-variable-exists('highlight'), $highlight, map-get($carbon--theme--white, 'highlight')),
   decorative-01: if(global-variable-exists('decorative-01'), $decorative-01, map-get($carbon--theme--white, 'decorative-01')),
   hover-light-ui: if(global-variable-exists('hover-light-ui'), $hover-light-ui, map-get($carbon--theme--white, 'hover-light-ui')),
+  button-separator: if(global-variable-exists('button-separator'), $button-separator, map-get($carbon--theme--white, 'button-separator')),
   skeleton-01: if(global-variable-exists('skeleton-01'), $skeleton-01, map-get($carbon--theme--white, 'skeleton-01')),
   skeleton-02: if(global-variable-exists('skeleton-02'), $skeleton-02, map-get($carbon--theme--white, 'skeleton-02')),
   brand-01: if(global-variable-exists('brand-01'), $brand-01, map-get($carbon--theme--white, 'brand-01')),
@@ -8326,6 +8349,30 @@ $hover-light-ui: if(
 - **Used by**:
   - [carbon--theme [mixin]](#carbon--theme-mixin)
   - [content-switcher [mixin]](#content-switcher-mixin)
+
+### ✅button-separator [variable]
+
+<details>
+<summary>Source code</summary>
+
+```scss
+$button-separator: if(
+  global-variable-exists('carbon--theme') and map-has-key(
+      $carbon--theme,
+      'button-separator'
+    ),
+  map-get($carbon--theme, 'button-separator'),
+  #e0e0e0
+);
+```
+
+</details>
+
+- **Group**: [@carbon/themes](#carbonthemes)
+- **Type**: `{undefined}`
+- **Used by**:
+  - [carbon--theme [mixin]](#carbon--theme-mixin)
+  - [button [mixin]](#button-mixin)
 
 ### ✅skeleton-01 [variable]
 
@@ -13823,17 +13870,43 @@ Button styles
     display: flex;
   }
 
-  .#{$prefix}--btn-set > .#{$prefix}--btn {
+  .#{$prefix}--btn-set--stacked {
+    flex-direction: column;
+  }
+
+  .#{$prefix}--btn-set .#{$prefix}--btn {
     width: 100%;
     // 196px from design kit
     max-width: rem(196px);
+
+    &:not(:first-of-type):not(:focus) {
+      box-shadow: rem(-1px) 0 0 0 $button-separator;
+    }
   }
 
-  .#{$prefix}--btn--secondary.#{$prefix}--btn--disabled
-    + .#{$prefix}--btn--primary.#{$prefix}--btn--disabled,
-  .#{$prefix}--btn--tertiary.#{$prefix}--btn--disabled
-    + .#{$prefix}--btn--danger.#{$prefix}--btn--disabled {
+  .#{$prefix}--btn-set .#{$prefix}--btn:focus + .#{$prefix}--btn {
+    box-shadow: inherit;
+  }
+
+  .#{$prefix}--btn-set--stacked
+    .#{$prefix}--btn:not(:first-of-type):not(:focus) {
+    box-shadow: 0 rem(-1px) 0 0 $button-separator;
+  }
+
+  .#{$prefix}--btn-set .#{$prefix}--btn.#{$prefix}--btn--disabled {
     box-shadow: rem(-1px) 0 0 0 $disabled-03;
+
+    &:first-of-type {
+      box-shadow: none;
+    }
+  }
+
+  .#{$prefix}--btn-set--stacked .#{$prefix}--btn.#{$prefix}--btn--disabled {
+    box-shadow: 0 rem(-1px) 0 0 $disabled-03;
+
+    &:first-of-type {
+      box-shadow: none;
+    }
   }
 
   .#{$prefix}--btn {
@@ -14091,6 +14164,7 @@ Button styles
   - [button-base [mixin]](#button-base-mixin)
   - [button-theme [mixin]](#button-theme-mixin)
   - [prefix [variable]](#prefix-variable)
+  - [button-separator [variable]](#button-separator-variable)
   - [disabled-03 [variable]](#disabled-03-variable)
   - [interactive-01 [variable]](#interactive-01-variable)
   - [text-04 [variable]](#text-04-variable)

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -32,8 +32,12 @@
     // 196px from design kit
     max-width: rem(196px);
 
-    &:not(:first-of-type):not(:focus) {
+    &:not(:focus) {
       box-shadow: rem(-1px) 0 0 0 $button-separator;
+    }
+
+    &:first-of-type:not(:focus) {
+      box-shadow: inherit;
     }
   }
 
@@ -41,9 +45,12 @@
     box-shadow: inherit;
   }
 
-  .#{$prefix}--btn-set--stacked
-    .#{$prefix}--btn:not(:first-of-type):not(:focus) {
+  .#{$prefix}--btn-set--stacked .#{$prefix}--btn:not(:focus) {
     box-shadow: 0 rem(-1px) 0 0 $button-separator;
+  }
+
+  .#{$prefix}--btn-set--stacked .#{$prefix}--btn:first-of-type:not(:focus) {
+    box-shadow: inherit;
   }
 
   .#{$prefix}--btn-set .#{$prefix}--btn.#{$prefix}--btn--disabled {

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -27,6 +27,7 @@
     width: 100%;
     // 196px from design kit
     max-width: rem(196px);
+    border-right: $button-separator;
   }
 
   .#{$prefix}--btn--secondary.#{$prefix}--btn--disabled

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -37,6 +37,10 @@
     }
   }
 
+  .#{$prefix}--btn-set .#{$prefix}--btn:focus + .#{$prefix}--btn {
+    box-shadow: inherit;
+  }
+
   .#{$prefix}--btn-set--stacked
     .#{$prefix}--btn:not(:first-of-type):not(:focus) {
     box-shadow: 0 rem(-1px) 0 0 $button-separator;

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -23,11 +23,23 @@
     display: flex;
   }
 
+  .#{$prefix}--btn-set--stacked {
+    flex-direction: column;
+  }
+
   .#{$prefix}--btn-set > .#{$prefix}--btn {
     width: 100%;
     // 196px from design kit
     max-width: rem(196px);
     border-right: $button-separator;
+
+    &:last-of-type {
+      border-right: 0;
+    }
+  }
+
+  .#{$prefix}--btn-set--stacked > .#{$prefix}--btn {
+    border-bottom: $button-separator;
 
     &:last-of-type {
       border-right: 0;

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -27,30 +27,39 @@
     flex-direction: column;
   }
 
-  .#{$prefix}--btn-set > .#{$prefix}--btn {
+  .#{$prefix}--btn-set .#{$prefix}--btn {
     width: 100%;
     // 196px from design kit
     max-width: rem(196px);
-    border-right: $button-separator;
+    box-shadow: rem(-1px) 0 0 0 $button-separator;
 
-    &:last-of-type {
-      border-right: 0;
+    &:first-of-type {
+      box-shadow: none;
     }
   }
 
-  .#{$prefix}--btn-set--stacked > .#{$prefix}--btn {
-    border-bottom: $button-separator;
+  .#{$prefix}--btn-set--stacked .#{$prefix}--btn {
+    box-shadow: 0 rem(-1px) 0 0 $button-separator;
 
-    &:last-of-type {
-      border-right: 0;
+    &:first-of-type {
+      box-shadow: none;
     }
   }
 
-  .#{$prefix}--btn--secondary.#{$prefix}--btn--disabled
-    + .#{$prefix}--btn--primary.#{$prefix}--btn--disabled,
-  .#{$prefix}--btn--tertiary.#{$prefix}--btn--disabled
-    + .#{$prefix}--btn--danger.#{$prefix}--btn--disabled {
+  .#{$prefix}--btn-set .#{$prefix}--btn.#{$prefix}--btn--disabled {
     box-shadow: rem(-1px) 0 0 0 $disabled-03;
+
+    &:first-of-type {
+      box-shadow: none;
+    }
+  }
+
+  .#{$prefix}--btn-set--stacked .#{$prefix}--btn.#{$prefix}--btn--disabled {
+    box-shadow: 0 rem(-1px) 0 0 $disabled-03;
+
+    &:first-of-type {
+      box-shadow: none;
+    }
   }
 
   .#{$prefix}--btn {

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -31,19 +31,15 @@
     width: 100%;
     // 196px from design kit
     max-width: rem(196px);
-    box-shadow: rem(-1px) 0 0 0 $button-separator;
 
-    &:first-of-type {
-      box-shadow: none;
+    &:not(:first-of-type):not(:focus) {
+      box-shadow: rem(-1px) 0 0 0 $button-separator;
     }
   }
 
-  .#{$prefix}--btn-set--stacked .#{$prefix}--btn {
+  .#{$prefix}--btn-set--stacked
+    .#{$prefix}--btn:not(:first-of-type):not(:focus) {
     box-shadow: 0 rem(-1px) 0 0 $button-separator;
-
-    &:first-of-type {
-      box-shadow: none;
-    }
   }
 
   .#{$prefix}--btn-set .#{$prefix}--btn.#{$prefix}--btn--disabled {

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -28,6 +28,10 @@
     // 196px from design kit
     max-width: rem(196px);
     border-right: $button-separator;
+
+    &:last-of-type {
+      border-right: 0;
+    }
   }
 
   .#{$prefix}--btn--secondary.#{$prefix}--btn--disabled

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -153,7 +153,7 @@ $button-outline: 1px solid $ibm-color__white-0 !default;
 /// @type Value
 /// @access public
 /// @group button
-$button-separator: 1px solid $gray-20;
+$button-separator: $gray-20;
 
 // Accordion
 

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -150,6 +150,11 @@ $button-outline-offset: -5px !default;
 /// @deprecated
 $button-outline: 1px solid $ibm-color__white-0 !default;
 
+/// @type Value
+/// @access public
+/// @group button
+$button-separator: 1px solid $gray-20;
+
 // Accordion
 
 /// @type Value

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -153,7 +153,7 @@ $button-outline: 1px solid $ibm-color__white-0 !default;
 /// @type Color
 /// @access public
 /// @group button
-$button-separator: $gray-20 !default;
+$button-separator: $gray-100 !default;
 
 // Accordion
 

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -150,10 +150,10 @@ $button-outline-offset: -5px !default;
 /// @deprecated
 $button-outline: 1px solid $ibm-color__white-0 !default;
 
-/// @type Value
+/// @type Color
 /// @access public
 /// @group button
-$button-separator: $gray-20;
+$button-separator: $gray-20 !default;
 
 // Accordion
 

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -150,11 +150,6 @@ $button-outline-offset: -5px !default;
 /// @deprecated
 $button-outline: 1px solid $ibm-color__white-0 !default;
 
-/// @type Color
-/// @access public
-/// @group button
-$button-separator: $gray-100 !default;
-
 // Accordion
 
 /// @type Value

--- a/packages/elements/docs/sass.md
+++ b/packages/elements/docs/sass.md
@@ -196,6 +196,7 @@
   - [✅highlight [variable]](#highlight-variable)
   - [✅decorative-01 [variable]](#decorative-01-variable)
   - [✅hover-light-ui [variable]](#hover-light-ui-variable)
+  - [✅button-separator [variable]](#button-separator-variable)
   - [✅skeleton-01 [variable]](#skeleton-01-variable)
   - [✅skeleton-02 [variable]](#skeleton-02-variable)
   - [✅⚠️brand-01 [variable]](#brand-01-variable)
@@ -3848,6 +3849,7 @@ Define theme variables from a map of tokens
   $highlight: map-get($theme, 'highlight') !global;
   $decorative-01: map-get($theme, 'decorative-01') !global;
   $hover-light-ui: map-get($theme, 'hover-light-ui') !global;
+  $button-separator: map-get($theme, 'button-separator') !global;
   $skeleton-01: map-get($theme, 'skeleton-01') !global;
   $skeleton-02: map-get($theme, 'skeleton-02') !global;
   $brand-01: map-get($theme, 'brand-01') !global;
@@ -4159,6 +4161,10 @@ Define theme variables from a map of tokens
     $hover-light-ui: var(
       --#{$custom-property-prefix}-hover-light-ui,
       map-get($theme, 'hover-light-ui')
+    ) !global;
+    $button-separator: var(
+      --#{$custom-property-prefix}-button-separator,
+      map-get($theme, 'button-separator')
     ) !global;
     $skeleton-01: var(
       --#{$custom-property-prefix}-skeleton-01,
@@ -4850,6 +4856,19 @@ Define theme variables from a map of tokens
       @include custom-property(
         'hover-light-ui',
         map-get($theme, 'hover-light-ui')
+      );
+    }
+
+    @if should-emit(
+      $theme,
+      $parent-carbon-theme,
+      'button-separator',
+      $emit-difference
+    )
+    {
+      @include custom-property(
+        'button-separator',
+        map-get($theme, 'button-separator')
       );
     }
 
@@ -5636,6 +5655,7 @@ Define theme variables from a map of tokens
   - [highlight [variable]](#highlight-variable)
   - [decorative-01 [variable]](#decorative-01-variable)
   - [hover-light-ui [variable]](#hover-light-ui-variable)
+  - [button-separator [variable]](#button-separator-variable)
   - [skeleton-01 [variable]](#skeleton-01-variable)
   - [skeleton-02 [variable]](#skeleton-02-variable)
   - [brand-01 [variable]](#brand-01-variable)
@@ -5792,6 +5812,7 @@ $carbon--theme--g90: map-merge(
     highlight: #0043ce,
     decorative-01: #6f6f6f,
     hover-light-ui: #6f6f6f,
+    button-separator: #161616,
     skeleton-01: #353535,
     skeleton-02: #525252,
     brand-02: #6f6f6f,
@@ -5867,6 +5888,7 @@ $carbon--theme--g100: map-merge(
     highlight: #002d9c,
     decorative-01: #525252,
     hover-light-ui: #525252,
+    button-separator: #161616,
     skeleton-01: #353535,
     skeleton-02: #393939,
     brand-02: #6f6f6f,
@@ -6033,6 +6055,7 @@ $carbon--theme: (
   highlight: if(global-variable-exists('highlight'), $highlight, map-get($carbon--theme--white, 'highlight')),
   decorative-01: if(global-variable-exists('decorative-01'), $decorative-01, map-get($carbon--theme--white, 'decorative-01')),
   hover-light-ui: if(global-variable-exists('hover-light-ui'), $hover-light-ui, map-get($carbon--theme--white, 'hover-light-ui')),
+  button-separator: if(global-variable-exists('button-separator'), $button-separator, map-get($carbon--theme--white, 'button-separator')),
   skeleton-01: if(global-variable-exists('skeleton-01'), $skeleton-01, map-get($carbon--theme--white, 'skeleton-01')),
   skeleton-02: if(global-variable-exists('skeleton-02'), $skeleton-02, map-get($carbon--theme--white, 'skeleton-02')),
   brand-01: if(global-variable-exists('brand-01'), $brand-01, map-get($carbon--theme--white, 'brand-01')),
@@ -7594,6 +7617,29 @@ $hover-light-ui: if(
     ),
   map-get($carbon--theme, 'hover-light-ui'),
   #e5e5e5
+);
+```
+
+</details>
+
+- **Group**: [@carbon/themes](#carbonthemes)
+- **Type**: `{undefined}`
+- **Used by**:
+  - [carbon--theme [mixin]](#carbon--theme-mixin)
+
+### ✅button-separator [variable]
+
+<details>
+<summary>Source code</summary>
+
+```scss
+$button-separator: if(
+  global-variable-exists('carbon--theme') and map-has-key(
+      $carbon--theme,
+      'button-separator'
+    ),
+  map-get($carbon--theme, 'button-separator'),
+  #e0e0e0
 );
 ```
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -216,6 +216,22 @@ Map {
     },
     "render": [Function],
   },
+  "ButtonSet" => Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "ButtonSet",
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "stacked": Object {
+        "type": "bool",
+      },
+    },
+    "render": [Function],
+  },
   "Checkbox" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -22,6 +22,7 @@ describe('Carbon Components React', () => {
         "BreadcrumbItem",
         "BreadcrumbSkeleton",
         "Button",
+        "ButtonSet",
         "ButtonSkeleton",
         "Checkbox",
         "CheckboxSkeleton",

--- a/packages/react/src/components/Button/Button-story.js
+++ b/packages/react/src/components/Button/Button-story.js
@@ -6,17 +6,14 @@
  */
 
 import React from 'react';
-import classNames from 'classnames';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
-import { settings } from 'carbon-components';
 import { iconAddSolid, iconSearch } from 'carbon-icons';
 import { Add16, AddFilled16, Search16 } from '@carbon/icons-react';
 import Button from '../Button';
 import ButtonSkeleton from '../Button/Button.Skeleton';
-
-const { prefix } = settings;
+import ButtonSet from '../ButtonSet';
 
 const icons = {
   None: 'None',
@@ -199,25 +196,22 @@ storiesOf('Button', module)
   .add(
     'Sets of Buttons',
     () => {
-      const { stacked, ...setProps } = props.set();
-      const buttonSetClasses = classNames(`${prefix}--btn-set`, {
-        [`${prefix}--btn-set--stacked`]: stacked,
-      });
+      const { stacked, ...buttonProps } = props.set();
       return (
-        <div className={buttonSetClasses}>
-          <Button kind="secondary" {...setProps}>
+        <ButtonSet stacked={stacked}>
+          <Button kind="secondary" {...buttonProps}>
             Secondary button
           </Button>
-          <Button kind="primary" {...setProps}>
+          <Button kind="primary" {...buttonProps}>
             Primary button
           </Button>
-        </div>
+        </ButtonSet>
       );
     },
     {
       info: {
         text: `
-          When an action required by the user has more than one option, always use a a negative action button (secondary) paired with a positive action button (primary) in that order. Negative action buttons will be on the left. Positive action buttons should be on the right. When these two types buttons are paired in the correct order, they will automatically space themselves apart.
+          When an action required by the user has more than one option, always use a negative action button (secondary) paired with a positive action button (primary) in that order. Negative action buttons will be on the left. Positive action buttons should be on the right. When these two types buttons are paired in the correct order, they will automatically space themselves apart.
         `,
       },
     }

--- a/packages/react/src/components/Button/Button-story.js
+++ b/packages/react/src/components/Button/Button-story.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
@@ -109,6 +110,7 @@ const props = {
         'Icon description (iconDescription)',
         'Button icon'
       ),
+      stacked: boolean('Stack buttons vertically (stacked)', false),
       onClick: action('onClick'),
       onFocus: action('onFocus'),
     };
@@ -197,9 +199,12 @@ storiesOf('Button', module)
   .add(
     'Sets of Buttons',
     () => {
-      const setProps = props.set();
+      const { stacked, ...setProps } = props.set();
+      const buttonSetClasses = classNames(`${prefix}--btn-set`, {
+        [`${prefix}--btn-set--stacked`]: stacked,
+      });
       return (
-        <div className={`${prefix}--btn-set`}>
+        <div className={buttonSetClasses}>
           <Button kind="secondary" {...setProps}>
             Secondary button
           </Button>

--- a/packages/react/src/components/ButtonSet/ButtonSet-test.js
+++ b/packages/react/src/components/ButtonSet/ButtonSet-test.js
@@ -19,36 +19,31 @@ describe('ButtonSet', () => {
     wrapper = shallow(<ButtonSet className="extra-class" />);
   });
 
-  describe('Renders as expected', () => {
-    describe('renders children as expected', () => {
-      it('empty set', () => {
-        expect(wrapper.find('.child').length).toBe(0);
-      });
+  it('should render empty set as expected', () => {
+    expect(wrapper.find('.child').length).toBe(0);
+  });
 
-      it('nonempty set', () => {
-        wrapper = shallow(
-          <ButtonSet>
-            <div className="test-child" />
-            <div className="test-child" />
-          </ButtonSet>
-        );
-        expect(wrapper.find('.test-child').length).toBe(2);
-      });
-    });
-    it('renders wrapper as expected', () => {
-      expect(wrapper.length).toBe(1);
-    });
+  it('should render nonempty set as expected', () => {
+    wrapper = shallow(
+      <ButtonSet>
+        <div className="test-child" />
+        <div className="test-child" />
+      </ButtonSet>
+    );
+    expect(wrapper.find('.test-child').length).toBe(2);
+  });
 
-    describe('has the expected classes', () => {
-      it('horizontal set', () => {
-        expect(wrapper.hasClass(`${prefix}--btn-set`)).toEqual(true);
-      });
+  it('should render wrapper as expected', () => {
+    expect(wrapper.length).toBe(1);
+  });
 
-      it('vertical set', () => {
-        wrapper.setProps({ stacked: true });
-        expect(wrapper.hasClass(`${prefix}--btn-set`)).toEqual(true);
-        expect(wrapper.hasClass(`${prefix}--btn-set--stacked`)).toEqual(true);
-      });
-    });
+  it('should have the expected classes in a horizontal set', () => {
+    expect(wrapper.hasClass(`${prefix}--btn-set`)).toEqual(true);
+  });
+
+  it('should have the expected classes in a vertical set', () => {
+    wrapper.setProps({ stacked: true });
+    expect(wrapper.hasClass(`${prefix}--btn-set`)).toEqual(true);
+    expect(wrapper.hasClass(`${prefix}--btn-set--stacked`)).toEqual(true);
   });
 });

--- a/packages/react/src/components/ButtonSet/ButtonSet-test.js
+++ b/packages/react/src/components/ButtonSet/ButtonSet-test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ButtonSet from '../ButtonSet';
+import { shallow } from 'enzyme';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
+
+describe('ButtonSet', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<ButtonSet className="extra-class" />);
+  });
+
+  describe('Renders as expected', () => {
+    describe('renders children as expected', () => {
+      it('empty set', () => {
+        expect(wrapper.find('.child').length).toBe(0);
+      });
+
+      it('nonempty set', () => {
+        wrapper = shallow(
+          <ButtonSet>
+            <div className="test-child" />
+            <div className="test-child" />
+          </ButtonSet>
+        );
+        expect(wrapper.find('.test-child').length).toBe(2);
+      });
+    });
+    it('renders wrapper as expected', () => {
+      expect(wrapper.length).toBe(1);
+    });
+
+    describe('has the expected classes', () => {
+      it('horizontal set', () => {
+        expect(wrapper.hasClass(`${prefix}--btn-set`)).toEqual(true);
+      });
+
+      it('vertical set', () => {
+        wrapper.setProps({ stacked: true });
+        expect(wrapper.hasClass(`${prefix}--btn-set`)).toEqual(true);
+        expect(wrapper.hasClass(`${prefix}--btn-set--stacked`)).toEqual(true);
+      });
+    });
+  });
+});

--- a/packages/react/src/components/ButtonSet/ButtonSet.js
+++ b/packages/react/src/components/ButtonSet/ButtonSet.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
+const ButtonSet = React.forwardRef(function ButtonSet(
+  { children, className, stacked, ...rest },
+  ref
+) {
+  const buttonSetClasses = classNames(className, `${prefix}--btn-set`, {
+    [`${prefix}--btn-set--stacked`]: stacked,
+  });
+  return (
+    <div {...rest} className={buttonSetClasses} ref={ref}>
+      {children}
+    </div>
+  );
+});
+
+ButtonSet.displayName = 'ButtonSet';
+ButtonSet.propTypes = {
+  /**
+   * Specify the content of your ButtonSet
+   */
+  children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be added to your ButtonSet
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the button arrangement of the set (vertically stacked or
+   * horizontal)
+   */
+  stacked: PropTypes.bool,
+};
+
+export default ButtonSet;

--- a/packages/react/src/components/ButtonSet/index.js
+++ b/packages/react/src/components/ButtonSet/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default from './ButtonSet';

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -8,6 +8,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Button';
+import ButtonSet from '../ButtonSet';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import { Close20 } from '@carbon/icons-react';
@@ -575,7 +576,7 @@ export class ModalFooter extends Component {
     });
 
     return (
-      <div className={footerClass} {...other}>
+      <ButtonSet className={footerClass} {...other}>
         {secondaryButtonText && (
           <Button
             className={secondaryClass}
@@ -597,7 +598,7 @@ export class ModalFooter extends Component {
         )}
 
         {children}
-      </div>
+      </ButtonSet>
     );
   }
 }

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -12,6 +12,7 @@ import { settings } from 'carbon-components';
 import { Close20 } from '@carbon/icons-react';
 import toggleClass from '../../tools/toggleClass';
 import Button from '../Button';
+import ButtonSet from '../ButtonSet';
 import deprecate from '../../prop-types/deprecate';
 import requiredIfGivenPropIsTruthy from '../../prop-types/requiredIfGivenPropIsTruthy';
 import wrapFocus, {
@@ -419,7 +420,7 @@ export default class Modal extends Component {
           <div className={`${prefix}--modal-content--overflow-indicator`} />
         )}
         {!passiveModal && (
-          <div className={`${prefix}--modal-footer`}>
+          <ButtonSet className={`${prefix}--modal-footer`}>
             <Button kind="secondary" onClick={onSecondaryButtonClick}>
               {secondaryButtonText}
             </Button>
@@ -430,7 +431,7 @@ export default class Modal extends Component {
               ref={this.button}>
               {primaryButtonText}
             </Button>
-          </div>
+          </ButtonSet>
         )}
       </div>
     );

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -149,46 +149,50 @@ exports[`ModalWrapper should render 1`] = `
               Text
             </p>
           </div>
-          <div
+          <ButtonSet
             className="bx--modal-footer"
           >
-            <Button
-              disabled={false}
-              kind="secondary"
-              onClick={[Function]}
-              size="default"
-              tabIndex={0}
-              type="button"
+            <div
+              className="bx--modal-footer bx--btn-set"
             >
-              <button
-                className="bx--btn bx--btn--secondary"
+              <Button
                 disabled={false}
+                kind="secondary"
                 onClick={[Function]}
+                size="default"
                 tabIndex={0}
                 type="button"
               >
-                Cancel
-              </button>
-            </Button>
-            <Button
-              disabled={false}
-              kind="primary"
-              onClick={[Function]}
-              size="default"
-              tabIndex={0}
-              type="button"
-            >
-              <button
-                className="bx--btn bx--btn--primary"
+                <button
+                  className="bx--btn bx--btn--secondary"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  Cancel
+                </button>
+              </Button>
+              <Button
                 disabled={false}
+                kind="primary"
                 onClick={[Function]}
+                size="default"
                 tabIndex={0}
                 type="button"
               >
-                Save
-              </button>
-            </Button>
-          </div>
+                <button
+                  className="bx--btn bx--btn--primary"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  Save
+                </button>
+              </Button>
+            </div>
+          </ButtonSet>
         </div>
         <span
           className="bx--visually-hidden"

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -9,6 +9,7 @@ export Accordion from './components/Accordion';
 export AccordionItem from './components/AccordionItem';
 export { Breadcrumb, BreadcrumbItem } from './components/Breadcrumb';
 export Button from './components/Button';
+export ButtonSet from './components/ButtonSet';
 export Checkbox from './components/Checkbox';
 export CodeSnippet from './components/CodeSnippet';
 export ComboBox from './components/ComboBox';

--- a/packages/themes/docs/sass.md
+++ b/packages/themes/docs/sass.md
@@ -78,6 +78,7 @@
   - [✅highlight [variable]](#highlight-variable)
   - [✅decorative-01 [variable]](#decorative-01-variable)
   - [✅hover-light-ui [variable]](#hover-light-ui-variable)
+  - [✅button-separator [variable]](#button-separator-variable)
   - [✅skeleton-01 [variable]](#skeleton-01-variable)
   - [✅skeleton-02 [variable]](#skeleton-02-variable)
   - [✅⚠️brand-01 [variable]](#brand-01-variable)
@@ -284,6 +285,7 @@ Define theme variables from a map of tokens
   $highlight: map-get($theme, 'highlight') !global;
   $decorative-01: map-get($theme, 'decorative-01') !global;
   $hover-light-ui: map-get($theme, 'hover-light-ui') !global;
+  $button-separator: map-get($theme, 'button-separator') !global;
   $skeleton-01: map-get($theme, 'skeleton-01') !global;
   $skeleton-02: map-get($theme, 'skeleton-02') !global;
   $brand-01: map-get($theme, 'brand-01') !global;
@@ -595,6 +597,10 @@ Define theme variables from a map of tokens
     $hover-light-ui: var(
       --#{$custom-property-prefix}-hover-light-ui,
       map-get($theme, 'hover-light-ui')
+    ) !global;
+    $button-separator: var(
+      --#{$custom-property-prefix}-button-separator,
+      map-get($theme, 'button-separator')
     ) !global;
     $skeleton-01: var(
       --#{$custom-property-prefix}-skeleton-01,
@@ -1286,6 +1292,19 @@ Define theme variables from a map of tokens
       @include custom-property(
         'hover-light-ui',
         map-get($theme, 'hover-light-ui')
+      );
+    }
+
+    @if should-emit(
+      $theme,
+      $parent-carbon-theme,
+      'button-separator',
+      $emit-difference
+    )
+    {
+      @include custom-property(
+        'button-separator',
+        map-get($theme, 'button-separator')
       );
     }
 
@@ -2072,6 +2091,7 @@ Define theme variables from a map of tokens
   - [highlight [variable]](#highlight-variable)
   - [decorative-01 [variable]](#decorative-01-variable)
   - [hover-light-ui [variable]](#hover-light-ui-variable)
+  - [button-separator [variable]](#button-separator-variable)
   - [skeleton-01 [variable]](#skeleton-01-variable)
   - [skeleton-02 [variable]](#skeleton-02-variable)
   - [brand-01 [variable]](#brand-01-variable)
@@ -2228,6 +2248,7 @@ $carbon--theme--g90: map-merge(
     highlight: #0043ce,
     decorative-01: #6f6f6f,
     hover-light-ui: #6f6f6f,
+    button-separator: #161616,
     skeleton-01: #353535,
     skeleton-02: #525252,
     brand-02: #6f6f6f,
@@ -2303,6 +2324,7 @@ $carbon--theme--g100: map-merge(
     highlight: #002d9c,
     decorative-01: #525252,
     hover-light-ui: #525252,
+    button-separator: #161616,
     skeleton-01: #353535,
     skeleton-02: #393939,
     brand-02: #6f6f6f,
@@ -2469,6 +2491,7 @@ $carbon--theme: (
   highlight: if(global-variable-exists('highlight'), $highlight, map-get($carbon--theme--white, 'highlight')),
   decorative-01: if(global-variable-exists('decorative-01'), $decorative-01, map-get($carbon--theme--white, 'decorative-01')),
   hover-light-ui: if(global-variable-exists('hover-light-ui'), $hover-light-ui, map-get($carbon--theme--white, 'hover-light-ui')),
+  button-separator: if(global-variable-exists('button-separator'), $button-separator, map-get($carbon--theme--white, 'button-separator')),
   skeleton-01: if(global-variable-exists('skeleton-01'), $skeleton-01, map-get($carbon--theme--white, 'skeleton-01')),
   skeleton-02: if(global-variable-exists('skeleton-02'), $skeleton-02, map-get($carbon--theme--white, 'skeleton-02')),
   brand-01: if(global-variable-exists('brand-01'), $brand-01, map-get($carbon--theme--white, 'brand-01')),
@@ -4030,6 +4053,29 @@ $hover-light-ui: if(
     ),
   map-get($carbon--theme, 'hover-light-ui'),
   #e5e5e5
+);
+```
+
+</details>
+
+- **Group**: [@carbon/themes](#carbonthemes)
+- **Type**: `{undefined}`
+- **Used by**:
+  - [carbon--theme [mixin]](#carbon--theme-mixin)
+
+### ✅button-separator [variable]
+
+<details>
+<summary>Source code</summary>
+
+```scss
+$button-separator: if(
+  global-variable-exists('carbon--theme') and map-has-key(
+      $carbon--theme,
+      'button-separator'
+    ),
+  map-get($carbon--theme, 'button-separator'),
+  #e0e0e0
 );
 ```
 

--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -130,6 +130,8 @@ export const decorative01 = gray20;
 
 export const hoverLightUI = '#e5e5e5';
 
+export const buttonSeparator = '#e0e0e0';
+
 export const skeleton01 = '#e5e5e5';
 export const skeleton02 = gray30;
 

--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -129,6 +129,8 @@ export const decorative01 = gray70;
 
 export const hoverLightUI = '#525252';
 
+export const buttonSeparator = '#161616';
+
 export const skeleton01 = '#353535';
 export const skeleton02 = gray80;
 

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -131,6 +131,8 @@ export const decorative01 = gray60;
 
 export const hoverLightUI = '#6f6f6f';
 
+export const buttonSeparator = '#161616';
+
 export const skeleton01 = '#353535';
 export const skeleton02 = gray70;
 

--- a/packages/themes/src/tokens.js
+++ b/packages/themes/src/tokens.js
@@ -99,6 +99,8 @@ const colors = [
 
   'hoverLightUI',
 
+  'buttonSeparator',
+
   'skeleton01',
   'skeleton02',
 
@@ -233,6 +235,7 @@ export const unstable__meta = {
         'hoverField',
         'decorative01',
         'hoverLightUI',
+        'buttonSeparator',
       ],
     },
   ],

--- a/packages/themes/src/v9.js
+++ b/packages/themes/src/v9.js
@@ -94,6 +94,8 @@ export const decorative01 = '#EEF4FC';
 
 export const hoverLightUI = '#EEF4FC';
 
+export const buttonSeparator = '#e0e0e0';
+
 export const skeleton01 = 'rgba(61, 112, 178, .1)';
 export const skeleton02 = 'rgba(61, 112, 178, .1)';
 

--- a/packages/themes/src/white.js
+++ b/packages/themes/src/white.js
@@ -130,6 +130,8 @@ export const decorative01 = gray20;
 
 export const hoverLightUI = '#e5e5e5';
 
+export const buttonSeparator = '#e0e0e0';
+
 export const skeleton01 = '#e5e5e5';
 export const skeleton02 = gray30;
 


### PR DESCRIPTION
Ref #5638

This PR adds a separator between buttons (in button sets only) with a new `$button-separator` token

#### Changelog

**New**

- `ButtonSet` wrapper component
- `$button-separator` token for button sets
- support for vertically stacked button set orientation

**Changed**

- refactor styles and selectors to allow for sets to contain more than two buttons

#### Testing / Reviewing

Confirm the separators appear correct and for button sets only
