### PR TITLE
feat(modal): stack modal buttons in small viewports

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -27,6 +27,7 @@
     width: 100%;
     // 196px from design kit
     max-width: rem(196px);
+    border-right: $button-separator;
   }
 
   .#{$prefix}--btn--secondary.#{$prefix}--btn--disabled

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -295,12 +295,17 @@
 
   .#{$prefix}--modal-footer {
     display: flex;
+    flex-direction: column;
 
     grid-row: -1/-1;
     grid-column: 1/-1;
     justify-content: flex-end;
     height: 4rem;
     margin-top: auto;
+
+    @include carbon--breakpoint(md) {
+      flex-direction: row;
+    }
 
     button.#{$prefix}--btn {
       flex: 0 1 50%;
@@ -309,6 +314,16 @@
       margin: 0;
       padding-top: $spacing-05;
       padding-bottom: $spacing-07;
+      border-bottom: $button-separator;
+
+      @include carbon--breakpoint(md) {
+        border-right: $button-separator;
+        border-bottom: 0;
+      }
+
+      &:last-of-type {
+        border: 0;
+      }
     }
   }
 

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -150,6 +150,11 @@ $button-outline-offset: -5px !default;
 /// @deprecated
 $button-outline: 1px solid $ibm-color__white-0 !default;
 
+/// @type Value
+/// @access public
+/// @group button
+$button-separator: 1px solid $gray-20;
+
 // Accordion
 
 /// @type Value


### PR DESCRIPTION
Ref #5638

This PR modifies buttons within modals to stack at smaller viewport sizes and include the button separators (depends on #6608). #6608 should be merged in first, but this PR will contain the changes from that PR

#### Changelog

**New**

- modal footer button separators

**Changed**

- modal footer button arrangement at smaller viewports

#### Testing / Reviewing

Confirm the modal footer buttons are styled and arranged correctly at all screen sizes