### PR TITLE
fix(Tag): set button type to avoid form submissions

### DIFF
--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -67,6 +67,7 @@ const Tag = ({
         {children !== null && children !== undefined ? children : TYPES[type]}
       </span>
       <button
+        type="button"
         className={`${prefix}--tag__close-icon`}
         onClick={handleClose}
         disabled={disabled}


### PR DESCRIPTION
Closes #6603

This PR sets the filter tag button type so that it does not automatically submit a form if the tag is contained within a form element

#### Testing / Reviewing

Confirm that interacting with a filter tag within a form no longer automatically submits the form