### PR TITLE
feat(eslint): enable button-has-type rule

### DIFF
--- a/config/eslint-config-carbon/plugins/react.js
+++ b/config/eslint-config-carbon/plugins/react.js
@@ -26,6 +26,7 @@ module.exports = {
   },
   rules: {
     // react
+    'react/button-has-type': 'error',
     'react/jsx-uses-vars': 1,
     'react/jsx-uses-react': 1,
     'react/no-find-dom-node': 1,

--- a/packages/react-hooks/src/__tests__/useAnnouncer-test.js
+++ b/packages/react-hooks/src/__tests__/useAnnouncer-test.js
@@ -55,7 +55,10 @@ describe('useAnnouncer', () => {
     function Component({ mode, message, testId }) {
       const announce = useAnnouncer();
       return (
-        <button data-test-id={testId} onClick={() => announce(mode, message)}>
+        <button
+          type="button"
+          data-test-id={testId}
+          onClick={() => announce(mode, message)}>
           Announce
         </button>
       );

--- a/packages/react-hooks/src/__tests__/useDebounce-test.js
+++ b/packages/react-hooks/src/__tests__/useDebounce-test.js
@@ -25,7 +25,9 @@ describe('useDebounce', () => {
       [debouncedValue] = useDebounce(count, 100);
 
       return (
-        <button onClick={() => updateCount(count + 1)}>{debouncedValue}</button>
+        <button type="button" onClick={() => updateCount(count + 1)}>
+          {debouncedValue}
+        </button>
       );
     }
 
@@ -53,7 +55,9 @@ describe('useDebounce', () => {
       [debouncedValue] = useDebounce(count, 100);
 
       return (
-        <button onClick={() => updateCount(count + 1)}>{debouncedValue}</button>
+        <button type="button" onClick={() => updateCount(count + 1)}>
+          {debouncedValue}
+        </button>
       );
     }
 
@@ -90,7 +94,9 @@ describe('useDebounce', () => {
       });
 
       return (
-        <button onClick={() => updateCount(count + 1)}>{debouncedValue}</button>
+        <button type="button" onClick={() => updateCount(count + 1)}>
+          {debouncedValue}
+        </button>
       );
     }
 

--- a/packages/react-hooks/src/useAnnouncer-story.js
+++ b/packages/react-hooks/src/useAnnouncer-story.js
@@ -45,7 +45,9 @@ storiesOf('useAnnouncer', module)
               onChange={onAnnouncementChange}
             />
           </div>
-          <button onClick={() => announce(mode, announcement)}>Announce</button>
+          <button type="button" onClick={() => announce(mode, announcement)}>
+            Announce
+          </button>
         </>
       );
     }
@@ -59,7 +61,11 @@ storiesOf('useAnnouncer', module)
         setCount(count + 1);
         announce(`Polite message ${count}`);
       }
-      return <button onClick={onClick}>Send polite alert</button>;
+      return (
+        <button type="button" onClick={onClick}>
+          Send polite alert
+        </button>
+      );
     }
     return <DemoComponent />;
   })
@@ -71,7 +77,11 @@ storiesOf('useAnnouncer', module)
         setCount(count + 1);
         announce(`Assertive message ${count}`);
       }
-      return <button onClick={onClick}>Send assertive alert</button>;
+      return (
+        <button type="button" onClick={onClick}>
+          Send assertive alert
+        </button>
+      );
     }
     return <DemoComponent />;
   })
@@ -92,7 +102,11 @@ storiesOf('useAnnouncer', module)
         setCount(count + 1);
         announce('assertive', `Assertive message ${count}`);
       }
-      return <button onClick={onClick}>Send assertive alert</button>;
+      return (
+        <button type="button" onClick={onClick}>
+          Send assertive alert
+        </button>
+      );
     }
 
     function Polite() {
@@ -102,7 +116,11 @@ storiesOf('useAnnouncer', module)
         setCount(count + 1);
         announce('polite', `Polite message ${count}`);
       }
-      return <button onClick={onClick}>Send polite alert</button>;
+      return (
+        <button type="button" onClick={onClick}>
+          Send polite alert
+        </button>
+      );
     }
 
     return <DemoComponent />;

--- a/packages/react/src/components/Accordion/AccordionItem.js
+++ b/packages/react/src/components/Accordion/AccordionItem.js
@@ -15,7 +15,7 @@ import { useId } from '../../internal/useId';
 import deprecate from '../../prop-types/deprecate.js';
 
 const { prefix } = settings;
-const defaultRenderExpando = (props) => <button {...props} />;
+const defaultRenderExpando = (props) => <button type="button" {...props} />;
 
 function AccordionItem({
   children,

--- a/packages/react/src/components/DataTable/TableExpandHeader.js
+++ b/packages/react/src/components/DataTable/TableExpandHeader.js
@@ -35,6 +35,7 @@ const TableExpandHeader = ({
       {...rest}>
       {!enableExpando ? null : (
         <button
+          type="button"
           className={`${prefix}--table-expand__button`}
           onClick={onExpand}
           title={expandIconDescription}

--- a/packages/react/src/components/DataTable/TableExpandRow.js
+++ b/packages/react/src/components/DataTable/TableExpandRow.js
@@ -42,6 +42,7 @@ const TableExpandRow = ({
         data-previous-value={previousValue}
         headers={expandHeader}>
         <button
+          type="button"
           className={`${prefix}--table-expand__button`}
           onClick={onExpand}
           title={expandIconDescription}

--- a/packages/react/src/components/DataTable/TableHeader.js
+++ b/packages/react/src/components/DataTable/TableHeader.js
@@ -91,7 +91,7 @@ const TableHeader = React.forwardRef(function TableHeader(
       colSpan={colSpan}
       ref={ref}
       scope={scope}>
-      <button className={className} onClick={onClick} {...rest}>
+      <button type="button" className={className} onClick={onClick} {...rest}>
         <span className={`${prefix}--table-sort__flex`}>
           <div className={`${prefix}--table-header-label`}>{children}</div>
           <Arrow

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2442,6 +2442,7 @@ exports[`DataTable should render 1`] = `
                         open={false}
                         tabIndex={0}
                         title="Settings"
+                        type="button"
                       >
                         <ForwardRef(Settings16)
                           aria-label="Settings"
@@ -3436,6 +3437,7 @@ exports[`DataTable sticky header should render 1`] = `
                         open={false}
                         tabIndex={0}
                         title="Settings"
+                        type="button"
                       >
                         <ForwardRef(Settings16)
                           aria-label="Settings"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -40,6 +40,7 @@ exports[`DataTable.TableExpandRow should render 1`] = `
                     aria-label="Aria label"
                     className="bx--table-expand__button"
                     onClick={[MockFunction]}
+                    type="button"
                   >
                     <ForwardRef(ChevronRight16)
                       className="bx--table-expand__svg"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
@@ -63,6 +63,7 @@ exports[`DataTable.TableToolbarMenu should render 1`] = `
           open={false}
           tabIndex={0}
           title="Add"
+          type="button"
         >
           <ForwardRef(Download16)
             aria-label="Add"

--- a/packages/react/src/components/DatePicker/DatePicker-story.js
+++ b/packages/react/src/components/DatePicker/DatePicker-story.js
@@ -206,7 +206,9 @@ storiesOf('DatePicker', module)
                 id="date-picker-input-id"
               />
             </DatePicker>
-            <button onClick={() => setState({ date: '01/01/2011' })}>
+            <button
+              type="button"
+              onClick={() => setState({ date: '01/01/2011' })}>
               Click me to set to 01/01/2011
             </button>
           </>

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -138,6 +138,7 @@ const Dropdown = React.forwardRef(function Dropdown(
           <WarningFilled16 className={`${prefix}--list-box__invalid-icon`} />
         )}
         <button
+          type="button"
           ref={ref}
           className={`${prefix}--list-box__field`}
           disabled={disabled}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -72,6 +72,7 @@ exports[`Dropdown should render 1`] = `
           id="downshift-0-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
           <span
             className="bx--list-box__label"
@@ -221,6 +222,7 @@ exports[`Dropdown should render custom item components 1`] = `
           id="downshift-6-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
           <span
             className="bx--list-box__label"
@@ -528,6 +530,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           id="downshift-4-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
           <span
             className="bx--list-box__label"

--- a/packages/react/src/components/ErrorBoundary/__tests__/ErrorBoundary-test.js
+++ b/packages/react/src/components/ErrorBoundary/__tests__/ErrorBoundary-test.js
@@ -93,7 +93,10 @@ describe('ErrorBoundary', () => {
 
       return (
         <ErrorBoundaryContext.Provider value={{ log: jest.fn() }}>
-          <button ref={(element) => (button = element)} onClick={onClick}>
+          <button
+            type="button"
+            ref={(element) => (button = element)}
+            onClick={onClick}>
             Toggle
           </button>
           <ErrorBoundary fallback={<MockFallback />}>

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -195,6 +195,7 @@ const MultiSelect = React.forwardRef(function MultiSelect(
           <WarningFilled16 className={`${prefix}--list-box__invalid-icon`} />
         )}
         <button
+          type="button"
           ref={ref}
           className={`${prefix}--list-box__field`}
           disabled={disabled}

--- a/packages/react/src/components/Notification/Notification-test.js
+++ b/packages/react/src/components/Notification/Notification-test.js
@@ -143,7 +143,10 @@ describe('ToastNotification', () => {
     });
 
     it('can render any node for the subtitle and caption', () => {
-      toast.setProps({ subtitle: <button />, caption: <button /> });
+      toast.setProps({
+        subtitle: <button type="button" />,
+        caption: <button type="button" />,
+      });
       expect(toast.length).toEqual(1);
     });
   });
@@ -254,7 +257,7 @@ describe('InlineNotification', () => {
     });
 
     it('can render any node for the subtitle', () => {
-      inline.setProps({ subtitle: <button /> });
+      inline.setProps({ subtitle: <button type="button" /> });
       expect(inline.length).toEqual(1);
     });
   });

--- a/packages/react/src/components/Notification/Notification.js
+++ b/packages/react/src/components/Notification/Notification.js
@@ -81,6 +81,7 @@ export function NotificationButton({
   });
 
   return (
+    // eslint-disable-next-line react/button-has-type
     <button
       {...rest}
       type={type}

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -319,7 +319,6 @@ class NumberInput extends Component {
 
     const buttonProps = {
       disabled,
-      type: 'button',
     };
 
     const inputWrapperProps = {};
@@ -386,6 +385,7 @@ class NumberInput extends Component {
                   {helper}
                   <div className={`${prefix}--number__input-wrapper`}>
                     <button
+                      type="button"
                       className={`${prefix}--number__control-btn down-icon`}
                       {...buttonProps}
                       onClick={(evt) => this.handleArrowClick(evt, 'down')}
@@ -403,6 +403,7 @@ class NumberInput extends Component {
                       ref={mergeRefs(ref, this._handleInputRef)}
                     />
                     <button
+                      type="button"
                       className={`${prefix}--number__control-btn up-icon`}
                       {...buttonProps}
                       onClick={(evt) => this.handleArrowClick(evt, 'up')}
@@ -435,6 +436,7 @@ class NumberInput extends Component {
                   )}
                   <div className={`${prefix}--number__controls`}>
                     <button
+                      type="button"
                       className={`${prefix}--number__control-btn up-icon`}
                       {...buttonProps}
                       onClick={(evt) => this.handleArrowClick(evt, 'up')}
@@ -445,6 +447,7 @@ class NumberInput extends Component {
                       <CaretUpGlyph className="up-icon" />
                     </button>
                     <button
+                      type="button"
                       className={`${prefix}--number__control-btn down-icon`}
                       {...buttonProps}
                       onClick={(evt) => this.handleArrowClick(evt, 'down')}

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -531,6 +531,7 @@ class OverflowMenu extends Component {
       <ClickListener onClickOutside={this.handleClickOutside}>
         <button
           {...other}
+          type="button"
           aria-haspopup
           aria-expanded={this.state.open}
           className={overflowMenuClasses}

--- a/packages/react/src/components/PaginationNav/PaginationNav.js
+++ b/packages/react/src/components/PaginationNav/PaginationNav.js
@@ -100,6 +100,7 @@ function PaginationItem({
   return (
     <li className={`${prefix}--pagination-nav__list-item`}>
       <button
+        type="button"
         className={classnames(`${prefix}--pagination-nav__page`, {
           [`${prefix}--pagination-nav__page--active`]: isActive,
         })}

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -104,6 +104,7 @@ export function ProgressStep({
   return (
     <li className={classes}>
       <button
+        type="button"
         className={classnames(`${prefix}--progress-step-button`, {
           [`${prefix}--progress-step-button--unclickable`]: !onClick || current,
         })}

--- a/packages/react/src/components/Slider/Slider-story.js
+++ b/packages/react/src/components/Slider/Slider-story.js
@@ -58,7 +58,9 @@ storiesOf('Slider', module)
     const [val, setVal] = useState(87);
     return (
       <>
-        <button onClick={() => setVal(Math.round(Math.random() * 100))}>
+        <button
+          type="button"
+          onClick={() => setVal(Math.round(Math.random() * 100))}>
           randomize value
         </button>
         <Slider

--- a/packages/react/src/components/Switch/Switch.js
+++ b/packages/react/src/components/Switch/Switch.js
@@ -49,6 +49,7 @@ const Switch = React.forwardRef(function Switch(props, tabRef) {
 
   return (
     <button
+      type="button"
       ref={tabRef}
       role="tab"
       tabIndex={selected ? '0' : '-1'}

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -67,6 +67,7 @@ const Tag = ({
         {children !== null && children !== undefined ? children : TYPES[type]}
       </span>
       <button
+        type="button"
         className={`${prefix}--tag__close-icon`}
         onClick={handleClose}
         disabled={disabled}

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -40,8 +40,12 @@ const ControlledPasswordInputApp = React.forwardRef(
           ref={ref}
           {...props}
         />
-        <button onClick={() => setType('text')}>Show password</button>
-        <button onClick={() => setType('password')}>Hide password</button>
+        <button type="button" onClick={() => setType('text')}>
+          Show password
+        </button>
+        <button type="button" onClick={() => setType('password')}>
+          Hide password
+        </button>
       </>
     );
   }

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -576,6 +576,7 @@ export class ExpandableTile extends Component {
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
       <button
+        type="button"
         ref={(tile) => {
           this.tile = tile;
         }}

--- a/packages/react/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/packages/react/src/components/ToolbarSearch/ToolbarSearch.js
@@ -138,6 +138,7 @@ export default class ToolbarSearch extends Component {
             }}
           />
           <button
+            type="button"
             className={`${prefix}--toolbar-search__btn`}
             title={labelText}
             onClick={this.expandSearch}>

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -74,6 +74,7 @@ const TooltipDefinition = ({
       onMouseEnter={composeEventHandlers([onMouseEnter, handleMouseEnter])}
       onMouseLeave={composeEventHandlers([onMouseLeave, handleMouseLeave])}>
       <button
+        type="button"
         className={tooltipTriggerClasses}
         aria-describedby={tooltipId}
         onFocus={composeEventHandlers([onFocus, handleFocus])}>

--- a/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
+++ b/packages/react/src/components/TooltipDefinition/__snapshots__/TooltipDefinition-test.js.snap
@@ -16,6 +16,7 @@ exports[`TooltipDefinition should allow the user to specify the direction 1`] = 
       aria-describedby="definition-tooltip-3"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
       onFocus={[Function]}
+      type="button"
     >
       tooltip trigger
     </button>
@@ -46,6 +47,7 @@ exports[`TooltipDefinition should render 1`] = `
       aria-describedby="definition-tooltip-1"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
       onFocus={[Function]}
+      type="button"
     >
       tooltip trigger
     </button>
@@ -77,6 +79,7 @@ exports[`TooltipDefinition should support a custom trigger element class 1`] = `
       aria-describedby="definition-tooltip-2"
       className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition custom-trigger-class bx--tooltip--bottom bx--tooltip--align-start"
       onFocus={[Function]}
+      type="button"
     >
       tooltip trigger
     </button>

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -53,6 +53,7 @@ const TooltipIcon = ({
   return (
     <button
       {...rest}
+      type="button"
       className={tooltipTriggerClasses}
       aria-describedby={tooltipId}
       onMouseEnter={composeEventHandlers([onMouseEnter, handleMouseEnter])}

--- a/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
+++ b/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
@@ -12,6 +12,7 @@ exports[`TooltipIcon should allow the user to specify the direction 1`] = `
     className="bx--tooltip__trigger bx--tooltip--a11y custom-class bx--tooltip--top bx--tooltip--align-center"
     onFocus={[Function]}
     onMouseEnter={[Function]}
+    type="button"
   >
     <span
       className="bx--assistive-text"
@@ -36,6 +37,7 @@ exports[`TooltipIcon should render 1`] = `
     className="bx--tooltip__trigger bx--tooltip--a11y custom-class bx--tooltip--bottom bx--tooltip--align-center"
     onFocus={[Function]}
     onMouseEnter={[Function]}
+    type="button"
   >
     <span
       className="bx--assistive-text"

--- a/packages/react/src/internal/__tests__/Selection-test.js
+++ b/packages/react/src/internal/__tests__/Selection-test.js
@@ -29,7 +29,7 @@ describe('Selection', () => {
       <Selection
         {...mockProps}
         render={({ onItemChange }) => (
-          <button onClick={() => onItemChange(1)} />
+          <button type="button" onClick={() => onItemChange(1)} />
         )}
       />
     );
@@ -46,7 +46,7 @@ describe('Selection', () => {
         {...mockProps}
         render={({ selectedItems, onItemChange }) => (
           <div>
-            <button onClick={() => onItemChange(1)} />
+            <button type="button" onClick={() => onItemChange(1)} />
             <ul>
               {selectedItems.map((item, index) => (
                 <li key={index}>{item}</li>
@@ -67,8 +67,16 @@ describe('Selection', () => {
         {...mockProps}
         render={({ onItemChange, clearSelection }) => (
           <div>
-            <button id="add-item" onClick={() => onItemChange(1)} />
-            <button id="clear-selection" onClick={clearSelection} />
+            <button
+              type="button"
+              id="add-item"
+              onClick={() => onItemChange(1)}
+            />
+            <button
+              type="button"
+              id="clear-selection"
+              onClick={clearSelection}
+            />
           </div>
         )}
       />
@@ -85,7 +93,7 @@ describe('Selection', () => {
       <Selection
         {...mockProps}
         render={({ onItemChange }) => (
-          <button onClick={() => onItemChange(1)} />
+          <button type="button" onClick={() => onItemChange(1)} />
         )}
         disabled
       />


### PR DESCRIPTION
Add rule for `button-has-type` to make sure we explicitly annotate buttons with a type. This catches a frequent bug we have for buttons where they don't have `type="button"`

#### Changelog

**New**

- Enable `react/button-has-type` rule

**Changed**

- Update files to pass eslint rule by adding explicit `type="button"` to buttons

**Removed**
