### PR TITLE
fix(overflow-menu): add styles for `visually-hidden`

### DIFF
--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -11,6 +11,7 @@
 
 @import '../../globals/scss/vars';
 @import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/css--helpers';
 @import '../../globals/scss/css--reset';
 @import '../../globals/scss/layout';
 @import '../../globals/scss/typography';


### PR DESCRIPTION
#### Changelog

**New**

- Add style dependency for `visually hidden` as required by `FloatingMenu` - https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/internal/FloatingMenu.js#L447