### PR TITLE
fix(FormGroup): use node prop type for legend text

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2680,7 +2680,7 @@ Map {
       },
       "legendText": Object {
         "isRequired": true,
-        "type": "string",
+        "type": "node",
       },
       "message": Object {
         "type": "bool",

--- a/packages/react/src/components/FormGroup/FormGroup.js
+++ b/packages/react/src/components/FormGroup/FormGroup.js
@@ -57,7 +57,7 @@ FormGroup.propTypes = {
   /**
    * Provide the text to be rendered inside of the fieldset <legend>
    */
-  legendText: PropTypes.string.isRequired,
+  legendText: PropTypes.node.isRequired,
 
   /**
    * Specify whether the message should be displayed in the <FormGroup>


### PR DESCRIPTION
Closes #6686

This PR updates the proptype definition for `legendText` in `FormGroup` to match labels in our other form components

#### Testing / Reviewing

Confirm no prop type warnings are thrown when a node is used within a form group label