### PR TITLE
fix(overflow-menu): check if function exists before calling

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -405,14 +405,16 @@ class OverflowMenu extends Component {
         (event) => {
           const { target } = event;
           const { current: triggerEl } = this._triggerRef;
-          if (
-            !menuBody.contains(target) &&
-            triggerEl &&
-            !target.matches(
-              `.${prefix}--overflow-menu,.${prefix}--overflow-menu-options`
-            )
-          ) {
-            this.closeMenu();
+          if (typeof target.matches === 'function') {
+            if (
+              !menuBody.contains(target) &&
+              triggerEl &&
+              !target.matches(
+                `.${prefix}--overflow-menu,.${prefix}--overflow-menu-options`
+              )
+            ) {
+              this.closeMenu();
+            }
           }
         },
         !hasFocusin


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6705

Check if `target.matches` exists before invoking it

#### Changelog

**Changed**

- Check if `target.matches` exists before invoking it



#### Testing / Reviewing

Using Firefox, open OverflowMenu, and open the menu. Then click anywhere outside the browser, return to the browser, and click anywhere inside to close the menu. There should not be an error.
