### PR TITLE
chore(docs): update dropdown docs

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2236,9 +2236,7 @@ Map {
         ],
         "type": "oneOfType",
       },
-      "inline": Object {
-        "type": "bool",
-      },
+      "inline": [Function],
       "invalid": Object {
         "type": "bool",
       },
@@ -6277,16 +6275,11 @@ Map {
     },
   },
   "DropdownSkeleton" => Object {
-    "defaultProps": Object {
-      "inline": false,
-    },
     "propTypes": Object {
       "className": Object {
         "type": "string",
       },
-      "inline": Object {
-        "type": "bool",
-      },
+      "inline": [Function],
     },
   },
   "FileUploaderSkeleton" => Object {

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -10,7 +10,6 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import Dropdown from '../Dropdown';
 import DropdownSkeleton from './Dropdown.Skeleton';
-import WithState from '../../tools/withState';
 import mdx from './Dropdown.mdx';
 
 const items = [
@@ -41,15 +40,6 @@ const items = [
   },
 ];
 
-const stringItems = [
-  'Option 1',
-  'Option 2',
-  'Option 3',
-  'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Vitae, aliquam. Blanditiis quia nemo enim voluptatibus quos ducimus porro molestiae nesciunt error cumque quaerat, tempore vero unde eum aperiam eligendi repellendus.',
-  'Option 5',
-  'Option 6',
-];
-
 const sizes = {
   'Extra large size (xl)': 'xl',
   'Default size': undefined,
@@ -69,7 +59,7 @@ const props = () => ({
   ariaLabel: text('Aria Label (ariaLabel)', 'Dropdown'),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
-  titleText: text('Title (titleText)', 'This is a dropdown title.'),
+  titleText: text('Title (titleText)', 'Dropdown label'),
   helperText: text('Helper text (helperText)', 'This is some helper text.'),
   invalid: boolean('Show form validation UI (invalid)', false),
   invalidText: text(
@@ -97,7 +87,10 @@ export default {
 export const Default = () => (
   <div style={{ width: 300 }}>
     <Dropdown
-      {...props()}
+      id="default"
+      titleText="Dropdown label"
+      helperText="This is some helper text"
+      label="Dropdown menu options"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
       onChange={action('onChange')}
@@ -105,12 +98,12 @@ export const Default = () => (
   </div>
 );
 
-Default.storyName = 'default';
-
 export const Inline = () => (
   <div style={{ width: 600 }}>
     <Dropdown
-      {...props()}
+      id="inline"
+      titleText="Inline dropdown label"
+      label="Dropdown menu options"
       type="inline"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
@@ -119,70 +112,20 @@ export const Inline = () => (
   </div>
 );
 
-Inline.storyName = 'inline';
-
-Inline.parameters = {
-  info: {
-    text: 'Dropdown',
-  },
-};
-
-export const ItemsAsStrings = () => (
-  <div style={props.inline ? { width: 500 } : { width: 300 }}>
-    <Dropdown {...props()} items={stringItems} onChange={action('onChange')} />
-  </div>
-);
-
-ItemsAsStrings.storyName = 'items as strings';
-
-ItemsAsStrings.parameters = {
-  info: {
-    text: 'Rendering an array of strings as `items`',
-  },
-};
-
-export const FullyControlled = () => (
-  <WithState initialState={{ selectedItem: items[0] }}>
-    {({ state, setState }) => (
-      <div style={{ width: 300 }}>
-        <Dropdown
-          {...props()}
-          items={items}
-          itemToString={(item) => (item ? item.text : '')}
-          onChange={({ selectedItem }) =>
-            setTimeout(() => setState({ selectedItem }), 1000)
-          }
-          selectedItem={state.selectedItem}
-        />
-      </div>
-    )}
-  </WithState>
-);
-
-FullyControlled.storyName = 'fully controlled';
-
-FullyControlled.parameters = {
-  info: {
-    text: `
-        Sometimes you want to control everything.
-      `,
-  },
+export const Playground = () => {
+  return (
+    <div style={{ width: 300 }}>
+      <Dropdown
+        {...props()}
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+      />
+    </div>
+  );
 };
 
 export const Skeleton = () => (
   <div style={{ width: 300 }}>
     <DropdownSkeleton />
-    &nbsp;
-    <DropdownSkeleton inline />
   </div>
 );
-
-Skeleton.storyName = 'skeleton';
-
-Skeleton.parameters = {
-  info: {
-    text: `
-        Placeholder skeleton state to use when content is loading.
-      `,
-  },
-};

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -11,6 +11,7 @@ import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import Dropdown from '../Dropdown';
 import DropdownSkeleton from './Dropdown.Skeleton';
 import WithState from '../../tools/withState';
+import mdx from './Dropdown.mdx';
 
 const items = [
   {
@@ -87,6 +88,9 @@ export default {
     subcomponents: {
       DropdownSkeleton,
     },
+    docs: {
+      page: mdx,
+    },
   },
 };
 
@@ -102,12 +106,6 @@ export const Default = () => (
 );
 
 Default.storyName = 'default';
-
-Default.parameters = {
-  info: {
-    text: 'Dropdown',
-  },
-};
 
 export const Inline = () => (
   <div style={{ width: 600 }}>

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
@@ -12,13 +12,12 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const DropdownSkeleton = ({ inline, className, ...rest }) => {
+const DropdownSkeleton = ({ className, ...rest }) => {
   const wrapperClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--dropdown-v2`]: true,
     [`${prefix}--list-box`]: true,
     [`${prefix}--form-item`]: true,
-    [`${prefix}--list-box--inline`]: inline,
   });
 
   return (
@@ -35,15 +34,6 @@ DropdownSkeleton.propTypes = {
    * Specify an optional className to add.
    */
   className: PropTypes.string,
-
-  /**
-   * Specify whether you want the inline version of this control
-   */
-  inline: PropTypes.bool,
-};
-
-DropdownSkeleton.defaultProps = {
-  inline: false,
 };
 
 export default DropdownSkeleton;

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
@@ -9,15 +9,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import { settings } from 'carbon-components';
+import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
-const DropdownSkeleton = ({ className, ...rest }) => {
+const DropdownSkeleton = ({ inline, className, ...rest }) => {
   const wrapperClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--dropdown-v2`]: true,
     [`${prefix}--list-box`]: true,
     [`${prefix}--form-item`]: true,
+    [`${prefix}--list-box--inline`]: inline,
   });
 
   return (
@@ -34,6 +36,15 @@ DropdownSkeleton.propTypes = {
    * Specify an optional className to add.
    */
   className: PropTypes.string,
+
+  /**
+   * Specify whether you want the inline version of this control
+   */
+  inline: deprecate(
+    PropTypes.bool,
+    `The \`inline\` prop has been deprecated and will
+    be removed in the next major release. To specify the inline variant of Dropdown, please use the \`type\` prop.`
+  ),
 };
 
 export default DropdownSkeleton;

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { Checkmark16, WarningFilled16 } from '@carbon/icons-react';
 import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
 import { mapDownshiftProps } from '../../tools/createPropAdapter';
+import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
@@ -228,6 +229,15 @@ Dropdown.propTypes = {
     PropTypes.object,
     PropTypes.string,
   ]),
+
+  /**
+   * Specify whether you want the inline version of this control
+   */
+  inline: deprecate(
+    PropTypes.bool,
+    `The \`inline\` prop has been deprecated and will
+    be removed in the next major release. To specify the inline variant of Dropdown, please use the \`type\` prop.`
+  ),
 
   /**
    * Specify if the currently selected value is invalid.

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -230,11 +230,6 @@ Dropdown.propTypes = {
   ]),
 
   /**
-   * Specify whether you want the inline version of this control
-   */
-  inline: PropTypes.bool,
-
-  /**
    * Specify if the currently selected value is invalid.
    */
   invalid: PropTypes.bool,

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -1,0 +1,58 @@
+import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import Dropdown from '../Dropdown';
+import DropdownSkeleton from './Dropdown.Skeleton';
+
+# Dropdown
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Overview](#overview)
+  - [Simple DatePicker](#simple-datepicker)
+  - [Range Datepicker](#range-datepicker)
+  - [Skeleton state](#skeleton-state)
+- [Component API](#component-api)
+  - [DatePicker `appendTo`](#datepicker-appendto)
+  - [DatePicker `className`](#datepicker-classname)
+  - [DatePicker `dateFormat`](#datepicker-dateformat)
+  - [DatePicker `datePickerType`](#datepicker-datepickertype)
+  - [DatePicker `light`](#datepicker-light)
+  - [DatePicker `locale`](#datepicker-locale)
+  - [DatePicker `maxDate`](#datepicker-maxdate)
+  - [DatePicker `minDate`](#datepicker-mindate)
+- [References](#references)
+- [Feedback](#feedback)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+<Preview>
+  <Story id="dropdown--default" />
+</Preview>
+
+### Inline dropdown
+
+<Preview>
+  <Story id="dropdown--inline" />
+</Preview>
+
+### Skeleton state
+
+<Preview>
+  <Story id="dropdown--skeleton" />
+</Preview>
+
+## Component API
+
+<Props />
+
+### DatePicker `appendTo`
+
+## References
+
+## Feedback
+
+Help us improve this component by providing feedback, asking questions, and
+leaving any other comments on
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Dropdown/Dropdown.mdx).

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -8,18 +8,16 @@ import DropdownSkeleton from './Dropdown.Skeleton';
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Overview](#overview)
-  - [Simple DatePicker](#simple-datepicker)
-  - [Range Datepicker](#range-datepicker)
+  - [Inline dropdown](#inline-dropdown)
   - [Skeleton state](#skeleton-state)
 - [Component API](#component-api)
-  - [DatePicker `appendTo`](#datepicker-appendto)
-  - [DatePicker `className`](#datepicker-classname)
-  - [DatePicker `dateFormat`](#datepicker-dateformat)
-  - [DatePicker `datePickerType`](#datepicker-datepickertype)
-  - [DatePicker `light`](#datepicker-light)
-  - [DatePicker `locale`](#datepicker-locale)
-  - [DatePicker `maxDate`](#datepicker-maxdate)
-  - [DatePicker `minDate`](#datepicker-mindate)
+  - [Dropdown `direction`](#dropdown-direction)
+  - [Dropdown `downshiftProps`](#dropdown-downshiftprops)
+  - [Dropdown `initialSelectedItem`](#dropdown-initialselecteditem)
+  - [Dropdown `itemToElement`](#dropdown-itemtoelement)
+  - [Dropdown `itemToString`](#dropdown-itemtostring)
+  - [Dropdown `items`](#dropdown-items)
+  - [Dropdown `light`](#dropdown-light)
 - [References](#references)
 - [Feedback](#feedback)
 
@@ -27,17 +25,28 @@ import DropdownSkeleton from './Dropdown.Skeleton';
 
 ## Overview
 
+Dropdowns present a list of options from which a user can select one option, or
+several. A selected option can represent a value in a form, or can be used as an
+action to filter or sort existing content.
+
 <Preview>
   <Story id="dropdown--default" />
 </Preview>
 
 ### Inline dropdown
 
+You can place a `Dropdown` inline with other content by using the `inline`
+variant
+
 <Preview>
   <Story id="dropdown--inline" />
 </Preview>
 
 ### Skeleton state
+
+You can use the `DropdownSkeleton` component to render a skeleton variant of a
+`Dropdown`. This is useful to display on initial page load or when data needs to
+be fetched from an external API.
 
 <Preview>
   <Story id="dropdown--skeleton" />
@@ -47,7 +56,139 @@ import DropdownSkeleton from './Dropdown.Skeleton';
 
 <Props />
 
-### DatePicker `appendTo`
+### Dropdown `direction`
+
+When a `Dropdown` is near the bottom of a page, you may want to render the menu
+to the top of the screen. To do this, specify `direction="top"`
+
+<Dropdown
+  items={[
+    { id: 'option-0', text: 'Option 0' },
+    {
+      id: 'option-1',
+      text: 'Option 1',
+    },
+    { id: 'option-2', text: 'Option 2' },
+  ]}
+  itemToString={(item) => (item ? item.text : '')}
+  label="Select an option..."
+  direction="top"
+/>
+
+```jsx
+<Dropdown direction="top" />
+```
+
+### Dropdown `downshiftProps`
+
+Our `Dropdown` component utilizes [Downshift](https://www.downshift-js.com/)
+under the hood to help provide complex yet accessible custom dropdown
+components. We provide access to the built in Downshift features with this prop.
+For more information, checkout the Downshift prop
+[documentation](https://www.downshift-js.com/downshift#props-used-in-examples)
+
+### Dropdown `initialSelectedItem`
+
+If you want the `Dropdown` to render with a value already selected, but do not
+want to fully control the component, you can use `initialSelectedItem`.
+
+```jsx
+const items = ['Option 1', 'Option 2', 'Option 3']
+
+<Dropdown initialSelectedItem={items[2]} />;
+```
+
+### Dropdown `itemToElement`
+
+The `Dropdown` takes in an `items` array and can then be formatted by
+`itemToElement` and `itemToString`. `itemToElement` allows you to wrap each
+dropdown item in a custom element.
+
+<Dropdown
+  items={[
+    { id: 'option-0', text: 'Option 0' },
+    { id: 'option-1', text: 'Option 1' },
+    { id: 'option-2', text: 'Option 2' },
+  ]}
+  itemToElement={(item) =>
+    item ? (
+      <span className="test" style={{ color: 'red' }}>
+        {item.text} 🔥
+      </span>
+    ) : (
+      ''
+    )
+  }
+  label="Select an option..."
+/>
+
+```jsx
+<Dropdown
+  items={[
+    { id: 'option-0', text: 'Option 0' },
+    { id: 'option-1', text: 'Option 1' },
+    { id: 'option-2', text: 'Option 2' },
+  ]}
+  itemToElement={(item) =>
+    item ? (
+      <span className="test" style={{ color: 'red' }}>
+        {item.text} 🔥
+      </span>
+    ) : (
+      ''
+    )
+  }
+  label="Select an option..."
+/>
+```
+
+### Dropdown `itemToString`
+
+If the `items` array is not an array of strings, you'll need to use
+`itemToString` to grab the text to be used as the `Dropdown` item text.
+
+```jsx
+<Dropdown
+  items={[
+    { id: 'option-0', text: 'Option 0' },
+    { id: 'option-1', text: 'Option 1' },
+    { id: 'option-2', text: 'Option 2' },
+  ]}
+  itemToString={(item) => (item ? item.text : '')}
+/>
+```
+
+### Dropdown `items`
+
+This is the data that will be rendered as options for the `Dropdown`. If `items`
+is simply an array of strings, no further formatting is required. If `items` is
+an array of objects, you'll need to pass in an `itemToString` function as well.
+
+```jsx
+<Dropdown
+  items={['Option 0', 'Option 1', 'Option 2']}
+/>
+
+
+<Dropdown
+  items={[
+    { id: 'option-0', text: 'Option 0' },
+    { id: 'option-1', text: 'Option 1' },
+    { id: 'option-2', text: 'Option 2' },
+  ]}
+  itemToString={(item) => (item ? item.text : '')}
+/>
+```
+
+### Dropdown `light`
+
+In certain circumstances, a `Dropdown` will exist on a container element with
+the same background color. To improve contrast, you can use the `light` property
+to toggle the light variant of the `Dropdown`.
+
+```jsx
+<Dropdown light>...</Dropdown>
+```
 
 ## References
 

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -18,6 +18,10 @@ import DropdownSkeleton from './Dropdown.Skeleton';
   - [Dropdown `itemToString`](#dropdown-itemtostring)
   - [Dropdown `items`](#dropdown-items)
   - [Dropdown `light`](#dropdown-light)
+  - [Dropdown `selectedItem`](#dropdown-selecteditem)
+  - [Dropdown `size`](#dropdown-size)
+  - [Dropdown `titleText`](#dropdown-titletext)
+  - [Dropdown `type`](#dropdown-type)
 - [References](#references)
 - [Feedback](#feedback)
 
@@ -73,6 +77,7 @@ to the top of the screen. To do this, specify `direction="top"`
   itemToString={(item) => (item ? item.text : '')}
   label="Select an option..."
   direction="top"
+  id="direction"
 />
 
 ```jsx
@@ -120,6 +125,7 @@ dropdown item in a custom element.
     )
   }
   label="Select an option..."
+  id="item-to-element"
 />
 
 ```jsx
@@ -190,7 +196,96 @@ to toggle the light variant of the `Dropdown`.
 <Dropdown light>...</Dropdown>
 ```
 
+### Dropdown `selectedItem`
+
+You can pass a `selectedItem` to the `Dropdown` to set a value on initial load.
+Keep in mind, if you set a value the `Dropdown` will become a controlled
+component and you will need to handle state management.
+
+```jsx
+const [currentItem, setCurrentItem] = useState(items[4]);
+...
+<Dropdown
+  items={items}
+  itemToString={(item) => (item ? item.text : '')}
+  onChange={({ selectedItem }) => setCurrentItem(selectedItem)}
+  selectedItem={currentItem}
+/>
+```
+
+### Dropdown `size`
+
+There are three sizes of `Dropdown` available: `sm`, `lg` (the default), and
+`xl`.
+
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  size="sm"
+  label="Small [sm]"
+  id="sm"
+/>
+<br />
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  label="Large [lg]"
+  id="lg"
+/>
+<br />
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  size="xl"
+  label="Extra Large [xl]"
+  id="xl"
+/>
+
+```jsx
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  size="sm"
+  label="Small [sm]"
+/>
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  label="Large [lg]"
+/>
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  size="xl"
+  label="Extra Large [xl]"
+/>
+```
+
+### Dropdown `titleText`
+
+This is the text that will be used as a label for the `Dropdown`
+
+```jsx
+<Dropdown titleText="This is the Dropdown label" />
+```
+
+### Dropdown `type`
+
+Sometimes you will need to place a `Dropdown` inline with other content. To do
+that, pass in `type="inline"` to the `Dropdown`
+
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  label="Inline"
+  type="inline"
+  id="inline"
+/>
+
+```jsx
+<Dropdown
+  items={['Option 1', 'Option 2', 'Option 3']}
+  label="Inline"
+  type="inline"
+/>
+```
+
 ## References
+
+- [Carbon Usage Guidelines](https://www.carbondesignsystem.com/components/dropdown/usage/)
 
 ## Feedback
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6709

Updates `Dropdown` to new CSF format and adds in prop documentation 

**Done**
- [x] Update to CSF
- [x] Create `Dropdown.mdx` and fill out with template
- [x] Document any discrepancies for v11

### Changelog

**New**

**Removed**
- `inline` was listed in `PropTypes` but didn't seem to do anything. We use `type="inline` to render the `inline` variant

### Questions for v11
- `titleText` should probably be changed to something closer to `labelText`
- `label` refers to the placeholder text before you make a selection, might be better to use `placeholder` 
- I've gone ahead and deprecated the `inline` prop, as it was not doing anything.

#### Testing / Reviewing

Check updated docs for grammar usage and that the examples look correct
