### PR TITLE
feat(Tooltip): allow focusTrap prop passthrough

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -110,7 +110,17 @@ function UncontrolledTooltipExample() {
           triggerText={<div>My text wrapped with tooltip</div>}
           open={value}
           showIcon={false}>
-          Some text
+          <p id="tooltip-body">
+            This is some tooltip text. This box shows the maximum amount of text
+            that should appear inside. If more room is needed please use a modal
+            instead.
+          </p>
+          <div className={`${prefix}--tooltip__footer`}>
+            <a href="/" className={`${prefix}--link`}>
+              Learn More
+            </a>
+            <Button size="small">Create</Button>
+          </div>
         </Tooltip>
       </div>
     </>

--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -29,7 +29,6 @@ const directions = {
 const props = {
   withIcon: () => ({
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
-    focusTrap: boolean('Focus trap (focusTrap)', true),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -40,7 +39,6 @@ const props = {
   withoutIcon: () => ({
     showIcon: false,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
-    focusTrap: boolean('Focus trap (focusTrap)', true),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -51,7 +49,6 @@ const props = {
   customIcon: () => ({
     showIcon: true,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
-    focusTrap: boolean('Focus trap (focusTrap)', true),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -70,7 +67,6 @@ const props = {
   customIconOnly: () => ({
     showIcon: true,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
-    focusTrap: boolean('Focus trap (focusTrap)', true),
     iconDescription: 'Helpful Information',
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -106,10 +102,12 @@ function UncontrolledTooltipExample() {
       </Button>
       <div style={{ padding: '15px', margin: '4px 20px' }}>
         <Tooltip
-          focusTrap={false}
+          {...{
+            ...props.withoutIcon(),
+            focusTrap: boolean('Focus trap (focusTrap)', true),
+          }}
           triggerText={<div>My text wrapped with tooltip</div>}
-          open={value}
-          showIcon={false}>
+          open={value}>
           <p id="tooltip-body">
             This is some tooltip text. This box shows the maximum amount of text
             that should appear inside. If more room is needed please use a modal

--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -7,7 +7,13 @@
 
 import React, { useState } from 'react';
 import { settings } from 'carbon-components';
-import { withKnobs, select, text, number } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  select,
+  text,
+  number,
+  boolean,
+} from '@storybook/addon-knobs';
 import Tooltip from '../Tooltip';
 import Button from '../Button';
 import { OverflowMenuVertical16 } from '@carbon/icons-react';
@@ -23,6 +29,7 @@ const directions = {
 const props = {
   withIcon: () => ({
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
+    focusTrap: boolean('Focus trap (focusTrap)', true),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -33,6 +40,7 @@ const props = {
   withoutIcon: () => ({
     showIcon: false,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
+    focusTrap: boolean('Focus trap (focusTrap)', true),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -43,6 +51,7 @@ const props = {
   customIcon: () => ({
     showIcon: true,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
+    focusTrap: boolean('Focus trap (focusTrap)', true),
     triggerText: text('Trigger text (triggerText)', 'Tooltip label'),
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -61,6 +70,7 @@ const props = {
   customIconOnly: () => ({
     showIcon: true,
     direction: select('Tooltip direction (direction)', directions, 'bottom'),
+    focusTrap: boolean('Focus trap (focusTrap)', true),
     iconDescription: 'Helpful Information',
     tabIndex: number('Tab index (tabIndex in <Tooltip>)', 0),
     selectorPrimaryFocus: text(
@@ -96,6 +106,7 @@ function UncontrolledTooltipExample() {
       </Button>
       <div style={{ padding: '15px', margin: '4px 20px' }}>
         <Tooltip
+          focusTrap={false}
           triggerText={<div>My text wrapped with tooltip</div>}
           open={value}
           showIcon={false}>

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -108,6 +108,11 @@ class Tooltip extends Component {
     direction: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
 
     /**
+     * Enable or disable focus trap behavior
+     */
+    focusTrap: PropTypes.bool,
+
+    /**
      * The name of the default tooltip icon.
      */
     iconName: PropTypes.string,
@@ -203,6 +208,7 @@ class Tooltip extends Component {
 
   static defaultProps = {
     direction: DIRECTION_BOTTOM,
+    focusTrap: true,
     renderIcon: Information,
     showIcon: true,
     triggerText: null,
@@ -271,6 +277,9 @@ class Tooltip extends Component {
   }
 
   _handleUserInputOpenClose = (event, { open }) => {
+    if (this.isControlled) {
+      return;
+    }
     // capture tooltip body element before it is removed from the DOM
     const tooltipBody = this._tooltipEl;
     this.setState({ open }, () => {
@@ -396,6 +405,7 @@ class Tooltip extends Component {
       className,
       triggerClassName,
       direction,
+      focusTrap,
       triggerText,
       showIcon,
       iconName,
@@ -474,7 +484,7 @@ class Tooltip extends Component {
         </ClickListener>
         {open && (
           <FloatingMenu
-            focusTrap
+            focusTrap={focusTrap}
             selectorPrimaryFocus={this.props.selectorPrimaryFocus}
             target={this._getTarget}
             triggerRef={this._triggerRef}

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -343,7 +343,9 @@ class FloatingMenu extends React.Component {
       tabbableNode || // First sequentially focusable node
       focusableNode || // First programmatic focusable node
       menuBody;
-    focusTarget.focus();
+    if (this.props.focusTrap) {
+      focusTarget.focus();
+    }
     if (focusTarget === menuBody && __DEV__) {
       warning(
         focusableNode === null,


### PR DESCRIPTION
Closes #6719 

Related #6458

This PR allows users to set the `focusTrap` prop on Tooltikps to passthrough to the underlying `FloatingMenu`. A check for the `focusTrap` prop is also added to the `FloatingMenu` to prevent moving focus away from tooltip trigger elements

#### Changelog

**New**

- `focusTrap` prop on `Tooltip` to control the underlying `FloatingMenu`

**Changed**

- check `focusTrap` prop before calling focus method in `FloatingMenu`

#### Testing / Reviewing

Confirm that tooltips do not steal focus away from focusable trigger elements when `focusTrap` is false
