### PR TITLE
fix(navigation): ignore disabled focusable elements

### DIFF
--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -336,10 +336,8 @@ class FloatingMenu extends React.Component {
     const primaryFocusNode = menuBody.querySelector(
       this.props.selectorPrimaryFocus || null
     );
-    const tabbableNodes = menuBody.querySelectorAll(selectorTabbable);
-    const focusableNodes = menuBody.querySelectorAll(selectorFocusable);
-    const tabbableNode = [...tabbableNodes].find((node) => !node.disabled);
-    const focusableNode = [...focusableNodes].find((node) => !node.disabled);
+    const tabbableNode = menuBody.querySelector(selectorTabbable);
+    const focusableNode = menuBody.querySelector(selectorFocusable);
     const focusTarget =
       primaryFocusNode || // User defined focusable node
       tabbableNode || // First sequentially focusable node

--- a/packages/react/src/internal/keyboard/navigation.js
+++ b/packages/react/src/internal/keyboard/navigation.js
@@ -68,5 +68,5 @@ export const selectorFocusable = `
   a[href], area[href], input:not([disabled]),
   button:not([disabled]),select:not([disabled]),
   textarea:not([disabled]),
-  iframe, object, embed, *[tabindex], *[contenteditable=true]
+  iframe, object, embed, *[tabindex]:not([disabled]), *[contenteditable=true]
 `;


### PR DESCRIPTION
Related #6677 #6679

This PR fixes an issue with our `selectorFocusable` selectors to ignore disabled nodes with a tabindex attribute, which allows us to revert to the original autofocus logic in FloatingMenu

#### Testing / Reviewing

Confirm the autofocus behavior is consistent with the result of #6679