### PR TITLE
fix(NumberInput): correct disabled input and text styles

### DIFF
--- a/packages/components/src/components/number-input/_number-input.scss
+++ b/packages/components/src/components/number-input/_number-input.scss
@@ -157,6 +157,13 @@
     background-color: $field-02;
   }
 
+  .#{$prefix}--number--light input[type='number']:disabled,
+  .#{$prefix}--number--light
+    .#{$prefix}--number--readonly
+    input[type='number'] {
+    background-color: $field-02;
+  }
+
   .#{$prefix}--number--mobile {
     width: auto;
     min-width: rem(144px);

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -355,11 +355,16 @@ class NumberInput extends Component {
       );
     }
 
+    const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
+      [`${prefix}--form__helper-text--disabled`]: disabled,
+    });
+
     const helper = helperText ? (
-      <div className={`${prefix}--form__helper-text`}>{helperText}</div>
+      <div className={helperTextClasses}>{helperText}</div>
     ) : null;
 
     const labelClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--label--disabled`]: disabled,
       [`${prefix}--visually-hidden`]: hideLabel,
     });
 


### PR DESCRIPTION
Closes #6741

This PR fixes the disabled styles for the number input label, helper text, and the light variant input background 

#### Changelog

**Changed**

- disabled light input field background color
- disabled label color
- disabled helper text color

#### Testing / Reviewing

Confirm the disabled number input styles match the component spec