### PR TITLE
fix(DataTable): allow content to overflow table container

### DIFF
--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -24,6 +24,10 @@
 
   .#{$prefix}--data-table-content {
     overflow-x: auto;
+
+    @include carbon--breakpoint(md) {
+      overflow: visible;
+    }
   }
 
   //----------------------------------------------------------------------------

--- a/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion-story.js
+++ b/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion-story.js
@@ -20,6 +20,7 @@ import DataTable, {
   TableHeader,
   TableRow,
 } from '../../../DataTable';
+import Dropdown from '../../../Dropdown';
 import { rows, headers } from '../shared';
 import mdx from '../../DataTable.mdx';
 
@@ -82,7 +83,12 @@ export const Usage = () => (
                   colSpan={headers.length + 1}
                   className="demo-expanded-td">
                   <h6>Expandable row content</h6>
-                  <div>Description here</div>
+                  <Dropdown
+                    ariaLabel="Dropdown"
+                    label="Choose an option"
+                    items={['Option 1', 'Option 2', ' Option 3']}
+                    titleText="Dropdown Options"
+                  />
                 </TableExpandedRow>
               </React.Fragment>
             ))}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6706

Allows extraneous DataTable content to overflow the main container. 

#### Changelog

**Changed**

- Changed to allow all overflow on `.bx--data-table-content`
- Added a `Dropdown` to the expandable DataTable example to test

#### Testing / Reviewing

Ensure a `Dropdown` in the expandable DataTable example section works properly, and that no other examples are affected. 
