### PR TITLE
docs(proptypes): escape elements referenced in proptypes docs

### DIFF
--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -38,7 +38,7 @@ ButtonSkeleton.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Optionally specify an href for your Button to become an <a> element
+   * Optionally specify an href for your Button to become an `<a>` element
    */
   href: PropTypes.string,
 

--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -129,7 +129,7 @@ Button.propTypes = {
   hasIconOnly: PropTypes.bool,
 
   /**
-   * Optionally specify an href for your Button to become an <a> element
+   * Optionally specify an href for your Button to become an `<a>` element
    */
   href: PropTypes.string,
 

--- a/packages/react/src/components/Copy/Copy.js
+++ b/packages/react/src/components/Copy/Copy.js
@@ -80,12 +80,12 @@ export default function Copy({
 
 Copy.propTypes = {
   /**
-   * Pass in content to be rendred in the underlying <button>
+   * Pass in content to be rendred in the underlying `<button>`
    */
   children: PropTypes.node,
 
   /**
-   * Specify an optional className to be applied to the underlying <button>
+   * Specify an optional className to be applied to the underlying `<button>`
    */
   className: PropTypes.string,
 
@@ -108,7 +108,7 @@ Copy.propTypes = {
 
   /**
    * Specify an optional `onClick` handler that is called when the underlying
-   * <button> is clicked
+   * `<button>` is clicked
    */
   onClick: PropTypes.func,
 };

--- a/packages/react/src/components/CopyButton/CopyButton.js
+++ b/packages/react/src/components/CopyButton/CopyButton.js
@@ -28,7 +28,7 @@ export default function CopyButton({ iconDescription, className, ...other }) {
 
 CopyButton.propTypes = {
   /**
-   * Specify an optional className to be applied to the underlying <button>
+   * Specify an optional className to be applied to the underlying `<button>`
    */
   className: PropTypes.string,
 
@@ -51,7 +51,7 @@ CopyButton.propTypes = {
 
   /**
    * Specify an optional `onClick` handler that is called when the underlying
-   * <button> is clicked
+   * `<button>` is clicked
    */
   onClick: PropTypes.func,
 };

--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -66,7 +66,7 @@ export default class FileUploader extends React.Component {
     multiple: PropTypes.bool,
 
     /**
-     * Provide a name for the underlying <input> node
+     * Provide a name for the underlying `<input>` node
      */
     name: PropTypes.string,
 

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
@@ -148,7 +148,7 @@ FileUploaderDropContainer.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Provide a unique id for the underlying <input> node
+   * Provide a unique id for the underlying `<input>` node
    */
   id: PropTypes.string,
 
@@ -164,7 +164,7 @@ FileUploaderDropContainer.propTypes = {
   multiple: PropTypes.bool,
 
   /**
-   * Provide a name for the underlying <input> node
+   * Provide a name for the underlying `<input>` node
    */
   name: PropTypes.string,
 

--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -41,7 +41,7 @@ Link.propTypes = {
   children: PropTypes.node,
 
   /**
-   * Provide a custom className to be applied to the containing <a> node
+   * Provide a custom className to be applied to the containing `<a>` node
    */
   className: PropTypes.string,
 
@@ -51,7 +51,7 @@ Link.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Provide the `href` attribute for the <a> node
+   * Provide the `href` attribute for the `<a>` node
    */
   href: PropTypes.string,
 

--- a/packages/react/src/components/ListItem/ListItem.js
+++ b/packages/react/src/components/ListItem/ListItem.js
@@ -28,7 +28,7 @@ ListItem.propTypes = {
   children: PropTypes.node,
 
   /**
-   * Specify an optional className to apply to the underlying <li> node
+   * Specify an optional className to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 };

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -137,7 +137,7 @@ export function ProgressStep({
 
 ProgressStep.propTypes = {
   /**
-   * Provide an optional className to be applied to the containing <li> node
+   * Provide an optional className to be applied to the containing `<li>` node
    */
   className: PropTypes.string,
 

--- a/packages/react/src/components/RadioButton/RadioButton.js
+++ b/packages/react/src/components/RadioButton/RadioButton.js
@@ -42,7 +42,7 @@ class RadioButton extends React.Component {
     hideLabel: PropTypes.bool,
 
     /**
-     * Provide a unique id for the underlying <input> node
+     * Provide a unique id for the underlying `<input>` node
      */
     id: PropTypes.string,
 
@@ -59,13 +59,13 @@ class RadioButton extends React.Component {
     labelText: PropTypes.node.isRequired,
 
     /**
-     * Provide a name for the underlying <input> node
+     * Provide a name for the underlying `<input>` node
      */
     name: PropTypes.string,
 
     /**
      * Provide an optional `onChange` hook that is called each time the value of
-     * the underlying <input> changes
+     * the underlying `<input>` changes
      */
     onChange: PropTypes.func,
 

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -44,7 +44,7 @@ export default class RadioButtonGroup extends React.Component {
     labelPosition: PropTypes.oneOf(['left', 'right']),
 
     /**
-     * Specify the name of the underlying <input> nodes
+     * Specify the name of the underlying `<input>` nodes
      */
     name: PropTypes.string.isRequired,
 

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -27,7 +27,7 @@ export default class Search extends Component {
     closeButtonLabelText: PropTypes.string,
 
     /**
-     * Optionally provide the default value of the <input>
+     * Optionally provide the default value of the `<input>`
      */
     defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -81,7 +81,7 @@ export default class Search extends Component {
     type: PropTypes.string,
 
     /**
-     * Specify the value of the <input>
+     * Specify the value of the `<input>`
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -200,7 +200,7 @@ Select.propTypes = {
 
   /**
    * Provide an optional `onChange` hook that is called each time the value of
-   * the underlying <input> changes
+   * the underlying `<input>` changes
    */
   onChange: PropTypes.func,
 

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -91,7 +91,7 @@ export default class Tab extends React.Component {
     selected: PropTypes.bool.isRequired,
 
     /**
-     * Specify the tab index of the <a> node
+     * Specify the tab index of the `<a>` node
      */
     tabIndex: PropTypes.number.isRequired,
   };

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -107,17 +107,17 @@ TextArea.displayName = 'TextArea';
 TextArea.propTypes = {
   /**
    * Provide a custom className that is applied directly to the underlying
-   * <textarea> node
+   * `<textarea>` node
    */
   className: PropTypes.string,
 
   /**
-   * Specify the `cols` attribute for the underlying <textarea> node
+   * Specify the `cols` attribute for the underlying `<textarea>` node
    */
   cols: PropTypes.number,
 
   /**
-   * Optionally provide the default value of the <textarea>
+   * Optionally provide the default value of the `<textarea>`
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -163,29 +163,29 @@ TextArea.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * Optionally provide an `onChange` handler that is called whenever <textarea>
+   * Optionally provide an `onChange` handler that is called whenever `<textarea>`
    * is updated
    */
   onChange: PropTypes.func,
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the
-   * <textarea> is clicked
+   * `<textarea>` is clicked
    */
   onClick: PropTypes.func,
 
   /**
-   * Specify the placeholder attribute for the <textarea>
+   * Specify the placeholder attribute for the `<textarea>`
    */
   placeholder: PropTypes.string,
 
   /**
-   * Specify the rows attribute for the <textarea>
+   * Specify the rows attribute for the `<textarea>`
    */
   rows: PropTypes.number,
 
   /**
-   * Provide the current value of the <textarea>
+   * Provide the current value of the `<textarea>`
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/react/src/components/TextInput/ControlledPasswordInput.js
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.js
@@ -138,12 +138,12 @@ const ControlledPasswordInput = React.forwardRef(
 ControlledPasswordInput.propTypes = {
   /**
    * Provide a custom className that is applied directly to the underlying
-   * <input> node
+   * `<input>` node
    */
   className: PropTypes.string,
 
   /**
-   * Optionally provide the default value of the <input>
+   * Optionally provide the default value of the `<input>`
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -189,19 +189,19 @@ ControlledPasswordInput.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * Optionally provide an `onChange` handler that is called whenever <input>
+   * Optionally provide an `onChange` handler that is called whenever `<input>`
    * is updated
    */
   onChange: PropTypes.func,
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the
-   * <input> is clicked
+   * `<input>` is clicked
    */
   onClick: PropTypes.func,
 
   /**
-   * Specify the placeholder attribute for the <input>
+   * Specify the placeholder attribute for the `<input>`
    */
   placeholder: PropTypes.string,
 
@@ -223,7 +223,7 @@ ControlledPasswordInput.propTypes = {
   tooltipPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
-   * Provide the current value of the <input>
+   * Provide the current value of the `<input>`
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/react/src/components/TextInput/PasswordInput.js
+++ b/packages/react/src/components/TextInput/PasswordInput.js
@@ -135,12 +135,12 @@ const PasswordInput = React.forwardRef(function PasswordInput(
 PasswordInput.propTypes = {
   /**
    * Provide a custom className that is applied directly to the underlying
-   * <input> node
+   * `<input>` node
    */
   className: PropTypes.string,
 
   /**
-   * Optionally provide the default value of the <input>
+   * Optionally provide the default value of the `<input>`
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -191,19 +191,19 @@ PasswordInput.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * Optionally provide an `onChange` handler that is called whenever <input>
+   * Optionally provide an `onChange` handler that is called whenever `<input>`
    * is updated
    */
   onChange: PropTypes.func,
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the
-   * <input> is clicked
+   * `<input>` is clicked
    */
   onClick: PropTypes.func,
 
   /**
-   * Specify the placeholder attribute for the <input>
+   * Specify the placeholder attribute for the `<input>`
    */
   placeholder: PropTypes.string,
 
@@ -230,7 +230,7 @@ PasswordInput.propTypes = {
   tooltipPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
-   * Provide the current value of the <input>
+   * Provide the current value of the `<input>`
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -166,17 +166,17 @@ TextInput.PasswordInput = PasswordInput;
 TextInput.ControlledPasswordInput = ControlledPasswordInput;
 TextInput.propTypes = {
   /**
-   * Specify an optional className to be applied to the <input> node
+   * Specify an optional className to be applied to the `<input>` node
    */
   className: PropTypes.string,
 
   /**
-   * Optionally provide the default value of the <input>
+   * Optionally provide the default value of the `<input>`
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
-   * Specify whether the <input> should be disabled
+   * Specify whether the `<input>` should be disabled
    */
   disabled: PropTypes.bool,
 
@@ -191,7 +191,7 @@ TextInput.propTypes = {
   hideLabel: PropTypes.bool,
 
   /**
-   * Specify a custom `id` for the <input>
+   * Specify a custom `id` for the `<input>`
    */
   id: PropTypes.string.isRequired,
 
@@ -222,19 +222,19 @@ TextInput.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * Optionally provide an `onChange` handler that is called whenever <input>
+   * Optionally provide an `onChange` handler that is called whenever `<input>`
    * is updated
    */
   onChange: PropTypes.func,
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the
-   * <input> is clicked
+   * `<input>` is clicked
    */
   onClick: PropTypes.func,
 
   /**
-   * Specify the placeholder attribute for the <input>
+   * Specify the placeholder attribute for the `<input>`
    */
   placeholder: PropTypes.string,
 
@@ -244,12 +244,12 @@ TextInput.propTypes = {
   size: PropTypes.oneOf(['sm', 'xl']),
 
   /**
-   * Specify the type of the <input>
+   * Specify the type of the `<input>`
    */
   type: PropTypes.string,
 
   /**
-   * Specify the value of the <input>
+   * Specify the value of the `<input>`
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 

--- a/packages/react/src/components/TileGroup/TileGroup.js
+++ b/packages/react/src/components/TileGroup/TileGroup.js
@@ -46,7 +46,7 @@ export default class TileGroup extends React.Component {
     legend: PropTypes.string,
 
     /**
-     * Specify the name of the underlying <input> nodes
+     * Specify the name of the underlying `<input>` nodes
      */
     name: PropTypes.string.isRequired,
 

--- a/packages/react/src/components/TimePicker/TimePicker.js
+++ b/packages/react/src/components/TimePicker/TimePicker.js
@@ -27,7 +27,7 @@ export default class TimePicker extends Component {
     className: PropTypes.string,
 
     /**
-     * Specify whether the <input> should be disabled
+     * Specify whether the `<input>` should be disabled
      */
     disabled: PropTypes.bool,
 
@@ -37,7 +37,7 @@ export default class TimePicker extends Component {
     hideLabel: PropTypes.bool,
 
     /**
-     * Specify a custom `id` for the <input>
+     * Specify a custom `id` for the `<input>`
      */
     id: PropTypes.string.isRequired,
 
@@ -63,45 +63,45 @@ export default class TimePicker extends Component {
     light: PropTypes.bool,
 
     /**
-     * Specify the maximum length of the time string in <input>
+     * Specify the maximum length of the time string in `<input>`
      */
     maxLength: PropTypes.number,
 
     /**
      * Optionally provide an `onBlur` handler that is called whenever the
-     * <input> loses focus
+     * `<input>` loses focus
      */
     onBlur: PropTypes.func,
 
     /**
-     * Optionally provide an `onChange` handler that is called whenever <input>
+     * Optionally provide an `onChange` handler that is called whenever `<input>`
      * is updated
      */
     onChange: PropTypes.func,
 
     /**
      * Optionally provide an `onClick` handler that is called whenever the
-     * <input> is clicked
+     * `<input>` is clicked
      */
     onClick: PropTypes.func,
 
     /**
-     * Specify the regular expression working as the pattern of the time string in <input>
+     * Specify the regular expression working as the pattern of the time string in `<input>`
      */
     pattern: PropTypes.string,
 
     /**
-     * Specify the placeholder attribute for the <input>
+     * Specify the placeholder attribute for the `<input>`
      */
     placeholder: PropTypes.string,
 
     /**
-     * Specify the type of the <input>
+     * Specify the type of the `<input>`
      */
     type: PropTypes.string,
 
     /**
-     * Specify the value of the <input>
+     * Specify the value of the `<input>`
      */
     value: PropTypes.string,
   };

--- a/packages/react/src/components/Toggle/Toggle.Skeleton.js
+++ b/packages/react/src/components/Toggle/Toggle.Skeleton.js
@@ -21,7 +21,7 @@ export default class ToggleSkeleton extends React.Component {
      */
     className: PropTypes.string,
     /**
-     * Provide an id that unique represents the underlying <input>
+     * Provide an id that unique represents the underlying `<input>`
      */
     id: PropTypes.string,
 

--- a/packages/react/src/components/Toggle/Toggle.js
+++ b/packages/react/src/components/Toggle/Toggle.js
@@ -30,7 +30,7 @@ class Toggle extends React.Component {
     defaultToggled: PropTypes.bool,
 
     /**
-     * Provide an id that unique represents the underlying <input>
+     * Provide an id that unique represents the underlying `<input>`
      */
     id: PropTypes.string.isRequired,
 

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.Skeleton.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.Skeleton.js
@@ -21,7 +21,7 @@ export default class ToggleSmallSkeleton extends React.Component {
      */
     className: PropTypes.string,
     /**
-     * Provide an id that unique represents the underlying <input>
+     * Provide an id that unique represents the underlying `<input>`
      */
     id: PropTypes.string,
 

--- a/packages/react/src/components/UIShell/HeaderMenuItem.js
+++ b/packages/react/src/components/UIShell/HeaderMenuItem.js
@@ -60,7 +60,7 @@ HeaderMenuItem.propTypes = {
   children: PropTypes.node.isRequired,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 
@@ -70,8 +70,8 @@ HeaderMenuItem.propTypes = {
   isCurrentPage: PropTypes.bool,
 
   /**
-   * Optionally supply a role for the underlying <li> node. Useful for resetting
-   * <ul> semantics for menus.
+   * Optionally supply a role for the underlying `<li>` node. Useful for resetting
+   * `<ul>` semantics for menus.
    */
   role: PropTypes.string,
 };

--- a/packages/react/src/components/UIShell/HeaderName.js
+++ b/packages/react/src/components/UIShell/HeaderName.js
@@ -50,7 +50,7 @@ HeaderName.propTypes = {
   children: PropTypes.node.isRequired,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 

--- a/packages/react/src/components/UIShell/HeaderPanel.js
+++ b/packages/react/src/components/UIShell/HeaderPanel.js
@@ -48,7 +48,7 @@ HeaderPanel.propTypes = {
   ...AriaLabelPropType,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 

--- a/packages/react/src/components/UIShell/SideNav.js
+++ b/packages/react/src/components/UIShell/SideNav.js
@@ -159,7 +159,7 @@ SideNav.propTypes = {
   addMouseListeners: PropTypes.bool,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 
@@ -175,7 +175,7 @@ SideNav.propTypes = {
   expanded: PropTypes.bool,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   isChildOfHeader: PropTypes.bool,
 

--- a/packages/react/src/components/UIShell/SideNavDetails.js
+++ b/packages/react/src/components/UIShell/SideNavDetails.js
@@ -32,7 +32,7 @@ SideNavDetails.propTypes = {
   children: PropTypes.node,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 

--- a/packages/react/src/components/UIShell/Switcher.js
+++ b/packages/react/src/components/UIShell/Switcher.js
@@ -49,7 +49,7 @@ Switcher.propTypes = {
   children: PropTypes.node.isRequired,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <ul> node
+   * Optionally provide a custom class to apply to the underlying `<ul>` node
    */
   className: PropTypes.string,
 };

--- a/packages/react/src/components/UIShell/SwitcherDivider.js
+++ b/packages/react/src/components/UIShell/SwitcherDivider.js
@@ -22,7 +22,7 @@ const SwitcherDivider = ({ className: customClassName, ...other }) => {
 
 SwitcherDivider.propTypes = {
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 };

--- a/packages/react/src/components/UIShell/SwitcherItem.js
+++ b/packages/react/src/components/UIShell/SwitcherItem.js
@@ -63,7 +63,7 @@ SwitcherItem.propTypes = {
   children: PropTypes.node.isRequired,
 
   /**
-   * Optionally provide a custom class to apply to the underlying <li> node
+   * Optionally provide a custom class to apply to the underlying `<li>` node
    */
   className: PropTypes.string,
 };

--- a/packages/react/src/components/UnorderedList/UnorderedList.js
+++ b/packages/react/src/components/UnorderedList/UnorderedList.js
@@ -30,7 +30,7 @@ UnorderedList.propTypes = {
   children: PropTypes.node,
 
   /**
-   * Specify an optional className to be applied to the underlying <ul> node
+   * Specify an optional className to be applied to the underlying `<ul>` node
    */
   className: PropTypes.string,
 


### PR DESCRIPTION
Closes #6764 

Escapes elements that are mentioned in PropTypes docs so that Storybook doesn't end up rendering them.

#### Changelog

**Changed**

- escape referenced elements in PropType docs

#### Testing / Reviewing

You should be able to see the element name in the storybook demo, not a rendered "button", "input", etc. Please let me know if I missed any! Thanks!
