### PR TITLE
Update deploy-react-storybook.yml

### DIFF
--- a/.github/workflows/deploy-react-storybook.yml
+++ b/.github/workflows/deploy-react-storybook.yml
@@ -31,15 +31,16 @@ jobs:
           CLOUD_API_KEY: ${{ secrets.CLOUD_API_KEY}}
         run: |
           ibmcloud login \
-          -a 'https://cloud.ibm.com' \
-          -u 'apikey' \
-          -p "$CLOUD_API_KEY" \
-          -o 'carbon-design-system' \
-          -s 'production' \
-          -r 'us-south'
+            -a 'https://cloud.ibm.com' \
+            --apikey "$CLOUD_API_KEY" \
+            -r 'us-south'
+           
+          ibmcloud target -o 'carbon-design-system' -s 'production'
       - name: Install IBM Cloud plugins
         run: |
-          ibmcloud cf install
+          # We use v6.50.0 as v6.51.0 and v6.52.0 have a bug where we are unable to set
+          # the CF API
+          ibmcloud cf install -v 6.50.0
           ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
           ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
       - name: Deploy React storybook

--- a/.github/workflows/deploy-react-storybook.yml
+++ b/.github/workflows/deploy-react-storybook.yml
@@ -34,7 +34,6 @@ jobs:
             -a 'https://cloud.ibm.com' \
             --apikey "$CLOUD_API_KEY" \
             -r 'us-south'
-           
           ibmcloud target -o 'carbon-design-system' -s 'production'
       - name: Install IBM Cloud plugins
         run: |

--- a/.github/workflows/deploy-vanilla-devenv.yml
+++ b/.github/workflows/deploy-vanilla-devenv.yml
@@ -31,15 +31,15 @@ jobs:
           CLOUD_API_KEY: ${{ secrets.CLOUD_API_KEY}}
         run: |
           ibmcloud login \
-          -a 'https://cloud.ibm.com' \
-          -u 'apikey' \
-          -p "$CLOUD_API_KEY" \
-          -o 'carbon-design-system' \
-          -s 'production' \
-          -r 'us-south'
+            -a 'https://cloud.ibm.com' \
+            --apikey "$CLOUD_API_KEY" \
+            -r 'us-south'
+          ibmcloud target -o 'carbon-design-system' -s 'production'
       - name: Install IBM Cloud plugins
         run: |
-          ibmcloud cf install
+          # We use v6.50.0 as v6.51.0 and v6.52.0 have a bug where we are unable to set
+          # the CF API
+          ibmcloud cf install -v 6.50.0
           ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
           ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
       - name: Deploy vanilla devenv


### PR DESCRIPTION
There currently is a bug with CF version 6.52.0 that makes it inoperable with `ibmcloud` CLI. This version pins it to 6.50.0 and updates our existing login strategy to the new version.

#### Changelog

**New**

**Changed**

- Update our ibmcloud deployment strategy for our React storybook

**Removed**
