### PR TITLE
fix(code-snippet): set multi-line snippet overflow-x to auto

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -183,7 +183,7 @@
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre {
     padding-right: $carbon--spacing-08;
     padding-bottom: rem(24px);
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--no-copy


### PR DESCRIPTION
multiline code snippets always show a horizontal scroll bar. this was fixed once before [here](https://github.com/carbon-design-system/carbon/pull/4360), so i'm not sure how/why it has been reverted. apologies if there's a valid reason.

#### Changelog

**Changed**

- `code-snippet` - change `overflow-x: scroll` to `overflow-x: auto`