### PR TITLE
docs(DataTable): add custom state manager example

### DIFF
--- a/packages/react/examples/custom-data-table-state-manager/package.json
+++ b/packages/react/examples/custom-data-table-state-manager/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "carbon-components-react-example-fully-customized-data-table",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sample project for creating fully customized state management of carbon-components-react data table",
+  "dependencies": {
+    "carbon-components": "latest",
+    "carbon-components-react": "latest",
+    "carbon-icons": "latest",
+    "lodash-es": "^4.17.0",
+    "node-sass": "^4.14.1",
+    "prop-types": "^15.7.0",
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2",
+    "react-scripts": "^3.2.0",
+    "use-debounce": "^3.3.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    "last 1 version",
+    "Firefox ESR",
+    "ie >= 11"
+  ]
+}

--- a/packages/react/examples/custom-data-table-state-manager/public/index.html
+++ b/packages/react/examples/custom-data-table-state-manager/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <style type="text/css">
+      body {
+        font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+      }
+    </style>
+    <title>
+      Sample project for creating fully customized state management of
+      carbon-components-react data table
+    </title>
+  </head>
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/react/examples/custom-data-table-state-manager/src/components/CustomDataTable.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/components/CustomDataTable.js
@@ -1,0 +1,352 @@
+import PropTypes from 'prop-types';
+import React, { useCallback, useState } from 'react';
+import { Delete16 as Delete } from '@carbon/icons-react';
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableSelectRow,
+  TableSelectAll,
+  TableToolbar,
+  TableToolbarAction,
+  TableToolbarContent,
+  TableToolbarSearch,
+  TableToolbarMenu,
+  TableBatchActions,
+  TableBatchAction,
+} from 'carbon-components-react';
+import {
+  useFilteredRows,
+  usePageInfo,
+  useRowSelection,
+  useSortedRows,
+  useSortInfo,
+  useUniqueId,
+} from '../hooks';
+import Pagination from './Pagination';
+import {
+  TABLE_SIZE,
+  TABLE_SORT_DIRECTION,
+  doesRowMatchSearchString,
+} from '../misc';
+
+/**
+ * An example state manager that an application can start with to achieve
+ * a fully-customized data table.
+ *
+ * There are many different use cases for managing data table state,
+ * i.e. lazy-loading table row data that are not on the current page.
+ *
+ * Carbon has `<DataTable>` component manage table state,
+ * but one `<DataTable>` supporting every possible use case will make it very complex.
+ *
+ * In case Carbon `<DataTable>` doesn't meet the needs of BU/application,
+ * PALs/applications create a state manager by their own, i.e. starting with
+ * this example.
+ *
+ * Carbon design for table is implemented by `<Table>`, `<TableRow>`,
+ * `<TableCell>`, etc.,
+ * whereas `<DataTable>` is merely a state manager.
+ *
+ * Threfore, using a custom component in place of `<DataTable>` does _not_ mean
+ * going away from Carbon design.
+ *
+ * THIS COMPONENT IS FOR DEMONSTRATION PURPOSES ONLY.
+ */
+const CustomDataTable = ({
+  id,
+  collator,
+  columns,
+  hasSelection,
+  pageSize: propPageSize,
+  rows: propRows,
+  size,
+  sortInfo: propSortInfo,
+  start: propStart,
+  zebra,
+}) => {
+  const [rows, setRows] = useState(propRows);
+  const [sortInfo, setSortInfo] = useSortInfo(propSortInfo);
+  const [filteredRows, searchString, setSearchString] = useFilteredRows(rows);
+  const [setRowSelection] = useRowSelection(
+    filteredRows,
+    searchString,
+    setRows
+  );
+  const [sortedRows] = useSortedRows(filteredRows, sortInfo, collator);
+  const [start, pageSize, setStart, setPageSize] = usePageInfo(
+    propStart,
+    propPageSize,
+    filteredRows.length
+  );
+
+  const elementId = useUniqueId(id);
+  const selectedRowsCountInFiltered = filteredRows.filter(
+    ({ selected }) => selected
+  ).length;
+  const selectedAllInFiltered =
+    selectedRowsCountInFiltered > 0 &&
+    filteredRows.length === selectedRowsCountInFiltered;
+  const hasBatchActions = hasSelection && selectedRowsCountInFiltered > 0;
+  const { columnId: sortColumnId, direction: sortDirection } = sortInfo;
+  const selectionAllName = !hasSelection
+    ? undefined
+    : `__custom-data-table_select-all_${elementId}`;
+
+  const handleCancelSelection = useCallback(() => {
+    setRowSelection(undefined, false);
+  }, [setRowSelection]);
+
+  const handleChangeSearchString = useCallback(
+    ({ target }) => {
+      setSearchString(target.value);
+    },
+    [setSearchString]
+  );
+
+  const handleChangeSelection = useCallback(
+    (event) => {
+      const { currentTarget } = event;
+      const row = currentTarget.closest('tr');
+      if (row) {
+        setRowSelection(Number(row.dataset.rowId), currentTarget.checked);
+      }
+    },
+    [setRowSelection]
+  );
+
+  const handleChangeSelectionAll = useCallback(
+    (event) => {
+      setRowSelection(undefined, event.currentTarget.checked);
+    },
+    [setRowSelection]
+  );
+
+  const handleChangeSort = useCallback(
+    (event) => {
+      const { currentTarget } = event;
+      const {
+        columnId,
+        sortCycle,
+        sortDirection: oldDirection,
+      } = currentTarget.dataset;
+      setSortInfo({ columnId, sortCycle, oldDirection });
+    },
+    [setSortInfo]
+  );
+
+  const handleChangePageSize = useCallback(
+    ({ pageSize }) => {
+      setPageSize(pageSize);
+    },
+    [setPageSize]
+  );
+
+  const handleChangeStart = useCallback(
+    ({ start }) => {
+      setStart(start);
+    },
+    [setStart]
+  );
+
+  const handleDeleteRows = useCallback(() => {
+    setRows(
+      rows.filter(
+        (row) => !row.selected || !doesRowMatchSearchString(row, searchString)
+      )
+    );
+  }, [rows, searchString]);
+
+  /* eslint-disable no-script-url */
+  return (
+    <TableContainer title="DataTable" description="Fully customized">
+      <TableToolbar>
+        <TableBatchActions
+          shouldShowBatchActions={hasBatchActions}
+          totalSelected={selectedRowsCountInFiltered}
+          onCancel={handleCancelSelection}>
+          <TableBatchAction
+            tabIndex={hasBatchActions ? 0 : -1}
+            renderIcon={Delete}
+            onClick={handleDeleteRows}>
+            Delete
+          </TableBatchAction>
+        </TableBatchActions>
+        <TableToolbarContent>
+          <TableToolbarSearch
+            tabIndex={hasBatchActions ? -1 : 0}
+            onChange={handleChangeSearchString}
+          />
+          <TableToolbarMenu tabIndex={hasBatchActions ? -1 : 0}>
+            <TableToolbarAction primaryFocus onClick={() => alert('Alert 1')}>
+              Action 1
+            </TableToolbarAction>
+            <TableToolbarAction onClick={() => alert('Alert 2')}>
+              Action 2
+            </TableToolbarAction>
+            <TableToolbarAction onClick={() => alert('Alert 3')}>
+              Action 3
+            </TableToolbarAction>
+          </TableToolbarMenu>
+        </TableToolbarContent>
+      </TableToolbar>
+      <Table size={size} isSortable>
+        <TableHead>
+          <TableRow>
+            {hasSelection && (
+              <TableSelectAll
+                id={`${elementId}--select-all`}
+                checked={selectedAllInFiltered}
+                indeterminate={
+                  selectedRowsCountInFiltered > 0 && !selectedAllInFiltered
+                }
+                ariaLabel="Select all rows"
+                name={selectionAllName}
+                onSelect={handleChangeSelectionAll}
+              />
+            )}
+            {columns.map(({ id: columnId, sortCycle, title }) => {
+              const sortDirectionForThisCell =
+                sortCycle &&
+                (columnId === sortColumnId
+                  ? sortDirection
+                  : TABLE_SORT_DIRECTION.NONE);
+              return (
+                <TableHeader
+                  key={columnId}
+                  isSortable={Boolean(sortCycle)}
+                  isSortHeader={sortCycle && columnId === sortColumnId}
+                  sortDirection={sortDirectionForThisCell}
+                  data-column-id={columnId}
+                  data-sort-cycle={sortCycle}
+                  data-sort-direction={sortDirectionForThisCell}
+                  onClick={handleChangeSort}>
+                  {title}
+                </TableHeader>
+              );
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody zebra={zebra}>
+          {sortedRows.slice(start, start + pageSize).map((row) => {
+            const { id: rowId, selected } = row;
+            const selectionName = !hasSelection
+              ? undefined
+              : `__custom-data-table_${elementId}_${rowId}`;
+            return (
+              <TableRow
+                key={rowId}
+                isSelected={hasSelection && selected}
+                data-row-id={rowId}>
+                {hasSelection && (
+                  <TableSelectRow
+                    id={`${elementId}--select-${rowId}`}
+                    checked={Boolean(selected)}
+                    name={selectionName}
+                    ariaLabel="Select row"
+                    onSelect={handleChangeSelection}
+                  />
+                )}
+                {columns.map(({ id: columnId }) => (
+                  <TableCell key={columnId}>{row[columnId]}</TableCell>
+                ))}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      {typeof pageSize !== 'undefined' && (
+        <Pagination
+          start={start}
+          count={filteredRows.length}
+          pageSize={pageSize}
+          pageSizes={[5, 10, 15]}
+          totalItems={filteredRows.length}
+          onChangePageSize={handleChangePageSize}
+          onChangeStart={handleChangeStart}
+        />
+      )}
+    </TableContainer>
+  );
+  /* eslint-enable no-script-url */
+};
+
+CustomDataTable.propTypes = {
+  /**
+   * The g11n collator to use.
+   */
+  collator: PropTypes.shape({}),
+
+  /**
+   * Data table columns.
+   */
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      title: PropTypes.string,
+      sortCycle: PropTypes.string,
+    })
+  ),
+
+  /**
+   * `true` if the the table should support selection UI. Corresponds to the attribute with the same name.
+   */
+  hasSelection: PropTypes.bool,
+
+  /**
+   * Provide an `id` to uniquely identify the Checkbox input
+   */
+  id: PropTypes.string,
+
+  /**
+   * Number of items per page.
+   */
+  pageSize: PropTypes.number,
+
+  /**
+   * Data table rows.
+   */
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      selected: PropTypes.bool,
+    })
+  ),
+
+  /**
+   * `true` if the the table should use the compact version of the UI. Corresponds to the attribute with the same name.
+   */
+  size: PropTypes.string,
+
+  /**
+   * Table sorting info.
+   */
+  sortInfo: PropTypes.shape({
+    columnId: PropTypes.string,
+    direction: PropTypes.string,
+  }),
+
+  /**
+   * The row number where current page start with, index that starts with zero. Corresponds to the attribute with the same name.
+   */
+  start: PropTypes.number,
+
+  /**
+   * `true` if the zebra stripe should be shown.
+   */
+  zebra: PropTypes.bool,
+};
+
+CustomDataTable.defaultProps = {
+  collator: new Intl.Collator(),
+  hasSelection: false,
+  pageSize: 5,
+  size: TABLE_SIZE.REGULAR,
+  start: 0,
+};
+
+export default CustomDataTable;

--- a/packages/react/examples/custom-data-table-state-manager/src/components/Pagination.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/components/Pagination.js
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
+import { Pagination as CarbonPagination } from 'carbon-components-react';
+
+/**
+ * Wrapeed version of Carbon `<Pagination>`, that uses zero-based starting row
+ * index instead of page number.
+ */
+const Pagination = ({
+  start,
+  count,
+  pageSize,
+  pageSizes,
+  onChangeStart,
+  onChangePageSize,
+}) => {
+  const handleChangePage = useCallback(
+    ({ page: newPage, pageSize: newPageSize }) => {
+      if (onChangePageSize && pageSize !== newPageSize) {
+        onChangePageSize({ pageSize: newPageSize });
+      }
+      const page = Math.floor(start / pageSize) + 1;
+      if (page !== newPage) {
+        const newStart = Math.min(
+          Math.max(start + (newPage - page) * pageSize, 0),
+          count
+        );
+        if (onChangeStart && start !== newStart) {
+          onChangeStart({ start: newStart });
+        }
+      }
+    },
+    [start, count, pageSize, onChangeStart, onChangePageSize]
+  );
+
+  return (
+    <CarbonPagination
+      page={Math.floor(start / pageSize) + 1}
+      pageSize={pageSize}
+      pageSizes={pageSizes}
+      totalItems={count}
+      onChange={handleChangePage}
+    />
+  );
+};
+
+Pagination.propTypes = {
+  /**
+   * Total number of rows.
+   */
+  count: PropTypes.number.isRequired,
+
+  /**
+   * Callback function for page size change
+   */
+  onChangePageSize: PropTypes.func,
+
+  /**
+   * Callback function for page start change
+   */
+  onChangeStart: PropTypes.func,
+
+  /**
+   * Number of items per page.
+   */
+  pageSize: PropTypes.number.isRequired,
+
+  /**
+   * List of page sizes.
+   */
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+
+  /**
+   * The row number where current page start with, index that starts with zero. Corresponds to the attribute with the same name.
+   */
+  start: PropTypes.number.isRequired,
+};
+
+export default Pagination;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/index.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/index.js
@@ -1,0 +1,7 @@
+export { default as useCollator } from './useCollator';
+export { default as useFilteredRows } from './useFilteredRows';
+export { default as usePageInfo } from './usePageInfo';
+export { default as useRowSelection } from './useRowSelection';
+export { default as useSortedRows } from './useSortedRows';
+export { default as useSortInfo } from './useSortInfo';
+export { default as useUniqueId } from './useUniqueId';

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/useCollator.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/useCollator.js
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+
+/**
+ * @param {Intl.Collator} collator The ECMA402 collator.
+ * @returns {(a: any, b: any) => boolean} The comparator.
+ */
+const useCollator = (collator) =>
+  useCallback(
+    (lhs, rhs) => {
+      if (typeof lhs === 'number' && typeof rhs === 'number') {
+        return lhs - rhs;
+      }
+      return collator.compare(lhs, rhs);
+    },
+    [collator]
+  );
+
+export default useCollator;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/useFilteredRows.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/useFilteredRows.js
@@ -1,0 +1,24 @@
+import { useMemo, useState } from 'react';
+import { useDebounce } from 'use-debounce';
+import doesRowMatchSearchString from '../misc/doesRowMatchSearchString';
+
+/**
+ * @param {object[]} rows The table rows.
+ * @returns {Array} The memorized version of filtered rows, search string and the setter for the search string.
+ */
+const useFilteredRows = (rows) => {
+  const [searchString, setSearchString] = useState('');
+  const [debouncedSearchString] = useDebounce(searchString, 500);
+  const filteredRows = useMemo(
+    () =>
+      !debouncedSearchString
+        ? rows
+        : rows.filter((row) =>
+            doesRowMatchSearchString(row, debouncedSearchString)
+          ),
+    [debouncedSearchString, rows]
+  );
+  return [filteredRows, searchString, setSearchString];
+};
+
+export default useFilteredRows;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/usePageInfo.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/usePageInfo.js
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+/**
+ * @param {number} initialStart The initial start row index, zero-based.
+ * @param {number} initialPageSize The initial page size.
+ * @param {number} count The total row count.
+ * @returns {Array} The start row index, page size, the setter for the start
+ * row index, the setter for the page size.
+ */
+const usePageInfo = (initialStart, initialPageSize, count) => {
+  const [start, setStart] = useState(initialStart);
+  const [pageSize, setPageSize] = useState(initialPageSize);
+  // Copes with `start` going beyond the row count
+  const adjustedStart =
+    count === 0 || start < count
+      ? start
+      : Math.max(
+          start - (Math.floor((start - count) / pageSize) + 1) * pageSize,
+          0
+        );
+  return [adjustedStart, pageSize, setStart, setPageSize];
+};
+
+export default usePageInfo;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/useRowSelection.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/useRowSelection.js
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import doesRowMatchSearchString from '../misc/doesRowMatchSearchString';
+
+/**
+ * @param {object[]} rows The table rows.
+ * @param {string} searchString The search string.
+ * @param {Function} setRows The setter for the table rows.
+ * @returns {Array} The setter for the table row selection.
+ */
+const useRowSelection = (rows, searchString, setRows) => {
+  const setRowSelection = useCallback(
+    (rowId, selected) => {
+      setRows(
+        rows.map((row) => {
+          const doChange = rowId
+            ? rowId === row.id
+            : !searchString || doesRowMatchSearchString(row, searchString);
+          return !doChange ? row : { ...row, selected };
+        })
+      );
+    },
+    [rows, searchString, setRows]
+  );
+  return [setRowSelection];
+};
+
+export default useRowSelection;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/useSortInfo.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/useSortInfo.js
@@ -1,0 +1,66 @@
+import { useCallback, useState } from 'react';
+import {
+  TABLE_SORT_CYCLE,
+  TABLE_SORT_CYCLES,
+  TABLE_SORT_DIRECTION,
+} from '../misc';
+
+/**
+ * @param options The options.
+ * @param [options.sortCycle=tri-states-from-ascending] The sorting cycle.
+ * @param options.oldDirection The old sort direction.
+ * @returns The next sort direction.
+ */
+const getNextSort = ({
+  sortCycle = TABLE_SORT_CYCLE.TRI_STATES_FROM_ASCENDING,
+  oldDirection,
+}) => {
+  if (!oldDirection) {
+    throw new TypeError(
+      'Table sort direction is not defined. ' +
+        'Likely that `getNextSort()` is called with non-sorted table column, which should not happen in regular condition.'
+    );
+  }
+  const directions = TABLE_SORT_CYCLES[sortCycle];
+  const index = directions.indexOf(oldDirection);
+  if (index < 0) {
+    if (oldDirection === TABLE_SORT_DIRECTION.NONE) {
+      // If the current sort direction is `none` in bi-state sort cycle,
+      // returns the first one in the cycle
+      return directions[0];
+    }
+    throw new RangeError(
+      `The given sort state (${oldDirection}) is not found in the given table sort cycle: ${sortCycle}`
+    );
+  }
+  return directions[(index + 1) % directions.length];
+};
+
+/**
+ * @param {object} initialSortInfo The initial table sort info.
+ * @returns {Array} The current table sort info and the setter for the table
+ * sort info.
+ */
+const useSortInfo = (initialSortInfo) => {
+  const [sortInfo, setSortInfo] = useState(initialSortInfo);
+  const invokeSetSortInfo = useCallback(
+    ({ columnId, sortCycle, oldDirection }) => {
+      const direction = getNextSort({ sortCycle, oldDirection });
+      if (direction === TABLE_SORT_DIRECTION.NONE && columnId !== 'name') {
+        // Resets the sorting, given non-primary sorting column has got in
+        //  non-sorting state
+        setSortInfo(initialSortInfo);
+      } else {
+        // Sets the sorting as user desires
+        setSortInfo({
+          columnId,
+          direction,
+        });
+      }
+    },
+    [initialSortInfo, setSortInfo]
+  );
+  return [sortInfo, invokeSetSortInfo];
+};
+
+export default useSortInfo;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/useSortedRows.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/useSortedRows.js
@@ -1,0 +1,34 @@
+import { TABLE_SORT_DIRECTION } from '../misc';
+import useCollator from './useCollator';
+
+/**
+ * The map of how sorting direction affects sorting order.
+ */
+const collationFactors = {
+  [TABLE_SORT_DIRECTION.ASCENDING]: 1,
+  [TABLE_SORT_DIRECTION.DESCENDING]: -1,
+};
+
+/**
+ * @param {object[]} rows The table rows.
+ * @param {object} sortInfo The table sort info.
+ * @param {Intl.Collator} collator The g11n collator.
+ * @returns {Array} The sorted table rows.
+ */
+const useSortedRows = (rows, sortInfo, collator) => {
+  const compare = useCollator(collator);
+  const { columnId: sortColumnId, direction: sortDirection } = sortInfo;
+  const sortedRows =
+    sortDirection === TABLE_SORT_DIRECTION.NONE
+      ? rows
+      : rows
+          .slice()
+          .sort(
+            (lhs, rhs) =>
+              collationFactors[sortDirection] *
+              compare(lhs[sortColumnId], rhs[sortColumnId])
+          );
+  return [sortedRows];
+};
+
+export default useSortedRows;

--- a/packages/react/examples/custom-data-table-state-manager/src/hooks/useUniqueId.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/hooks/useUniqueId.js
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+
+/**
+ * @param {string} id A user-specified unique ID. If present, ID won't be
+ * auto-generated and the given one will be used.
+ * @returns {string} The auto-generated unique ID.
+ */
+const useUniqueId = (id) => {
+  const uniqueId = useMemo(() => Math.random().toString(36).slice(2), []);
+  return id || uniqueId;
+};
+
+export default useUniqueId;

--- a/packages/react/examples/custom-data-table-state-manager/src/index.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from 'react-dom';
+import CustomDataTable from './components/CustomDataTable';
+import {
+  rowsMany as demoRowsMany,
+  columns as demoColumns,
+  sortInfo as demoSortInfo,
+} from './table-data';
+import 'carbon-components/scss/globals/scss/styles.scss';
+
+const App = () => (
+  <CustomDataTable
+    columns={demoColumns}
+    rows={demoRowsMany}
+    sortInfo={demoSortInfo}
+    hasSelection={true}
+    pageSize={5}
+    start={0}
+  />
+);
+
+render(<App />, document.getElementById('root'));

--- a/packages/react/examples/custom-data-table-state-manager/src/misc/doesRowMatchSearchString.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/misc/doesRowMatchSearchString.js
@@ -1,0 +1,11 @@
+/**
+ * @param row A table row.
+ * @param searchString A search string.
+ * @returns `true` if the given table row matches the given search string.
+ */
+const doesRowMatchSearchString = (row, searchString) =>
+  Object.keys(row).some(
+    (key) => key !== 'id' && String(row[key] ?? '').indexOf(searchString) >= 0
+  );
+
+export default doesRowMatchSearchString;

--- a/packages/react/examples/custom-data-table-state-manager/src/misc/enums.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/misc/enums.js
@@ -1,0 +1,78 @@
+/**
+ * Table size.
+ */
+export const TABLE_SIZE = {
+  /**
+   * Compact size.
+   */
+  COMPACT: 'compact',
+
+  /**
+   * Short size.
+   */
+  SHORT: 'short',
+
+  /**
+   * Regular size.
+   */
+  REGULAR: 'normal',
+
+  /**
+   * Tall size.
+   */
+  TALL: 'tall',
+};
+
+/**
+ * Table sort state.
+ */
+export const TABLE_SORT_DIRECTION = {
+  /**
+   * Not sorted.
+   */
+  NONE: 'NONE',
+
+  /**
+   * Sorted ascendingly.
+   */
+  ASCENDING: 'ASC',
+
+  /**
+   * Sorted descendingly.
+   */
+  DESCENDING: 'DESC',
+};
+
+/**
+ * Table sort cycle.
+ */
+export const TABLE_SORT_CYCLE = {
+  BI_STATES_FROM_ASCENDING: 'bi-states-from-ascending',
+  BI_STATES_FROM_DESCENDING: 'bi-states-from-descending',
+  TRI_STATES_FROM_ASCENDING: 'tri-states-from-ascending',
+  TRI_STATES_FROM_DESCENDING: 'tri-states-from-descending',
+};
+
+/**
+ * Mapping of table sort cycles to table sort states.
+ */
+export const TABLE_SORT_CYCLES = {
+  [TABLE_SORT_CYCLE.BI_STATES_FROM_ASCENDING]: [
+    TABLE_SORT_DIRECTION.ASCENDING,
+    TABLE_SORT_DIRECTION.DESCENDING,
+  ],
+  [TABLE_SORT_CYCLE.BI_STATES_FROM_DESCENDING]: [
+    TABLE_SORT_DIRECTION.DESCENDING,
+    TABLE_SORT_DIRECTION.ASCENDING,
+  ],
+  [TABLE_SORT_CYCLE.TRI_STATES_FROM_ASCENDING]: [
+    TABLE_SORT_DIRECTION.NONE,
+    TABLE_SORT_DIRECTION.ASCENDING,
+    TABLE_SORT_DIRECTION.DESCENDING,
+  ],
+  [TABLE_SORT_CYCLE.TRI_STATES_FROM_DESCENDING]: [
+    TABLE_SORT_DIRECTION.NONE,
+    TABLE_SORT_DIRECTION.DESCENDING,
+    TABLE_SORT_DIRECTION.ASCENDING,
+  ],
+};

--- a/packages/react/examples/custom-data-table-state-manager/src/misc/index.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/misc/index.js
@@ -1,0 +1,2 @@
+export * from './enums';
+export { default as doesRowMatchSearchString } from './doesRowMatchSearchString';

--- a/packages/react/examples/custom-data-table-state-manager/src/table-data.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/table-data.js
@@ -1,0 +1,76 @@
+import { TABLE_SORT_DIRECTION } from './misc';
+
+export const columns = [
+  {
+    id: 'name',
+    title: 'Name',
+    sortCycle: 'bi-states-from-ascending',
+  },
+  {
+    id: 'protocol',
+    title: 'Protocol',
+  },
+  {
+    id: 'port',
+    title: 'Port',
+    sortCycle: 'tri-states-from-ascending',
+  },
+  {
+    id: 'rule',
+    title: 'Rule',
+  },
+  {
+    id: 'attachedGroups',
+    title: 'Attached Groups',
+  },
+  {
+    id: 'status',
+    title: 'Status',
+  },
+];
+
+export const rows = [
+  {
+    id: 1,
+    name: 'Load Balancer 1',
+    protocol: 'HTTP',
+    port: 80,
+    rule: 'Round Robin',
+    attachedGroups: "Maureen's VM Groups",
+    status: 'Active',
+  },
+  {
+    id: 2,
+    name: 'Load Balancer 2',
+    protocol: 'HTTPS',
+    port: 443,
+    rule: 'Round Robin',
+    attachedGroups: "Maureen's VM Groups",
+    status: 'Active',
+  },
+  {
+    id: 3,
+    selected: true,
+    name: 'Load Balancer 3',
+    protocol: 'HTTP',
+    port: 80,
+    rule: 'Round Robin',
+    attachedGroups: "Maureen's VM Groups",
+    status: 'Active',
+  },
+];
+
+export const rowsMany = Array.from(new Array(50))
+  .map((_item, i) =>
+    rows.map((row, j) => ({
+      ...row,
+      id: i * 3 + j,
+      name: `Load Balancer ${String(i * 3 + j + 1).padStart(3, '0')}`,
+    }))
+  )
+  .flat();
+
+export const sortInfo = {
+  columnId: 'name',
+  direction: TABLE_SORT_DIRECTION.ASCENDING,
+};


### PR DESCRIPTION
This PR adds a Code Sandbox example for implementing a data table with a custom state manager. This will help answer the extremely common questions about the limitations of the Carbon `<DataTable>`'s state manager. In case Carbon `<DataTable>` does not meet the needs of a BU/application, PALs/applications can create a custom state manager of their own with this example as a reference. This example covers selection, sorting, pagination, filtering and batch actions.

#### Changelog

**New**

- Code Sandbox example of a Carbon data table component with custom state manager