### PR TITLE
feat(Tabs): add unstable_Tabs component

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -18,415 +18,418 @@
 /// @access private
 /// @group tabs
 @mixin tabs {
-  .#{$prefix}--tabs {
-    @include reset;
-    @include type-style('body-short-01');
+  .#{$prefix}--tabs--stable {
+    .#{$prefix}--tabs {
+      @include reset;
+      @include type-style('body-short-01');
 
-    position: relative;
-    width: 100%;
-    height: auto;
-    color: $text-01;
-    @include carbon--breakpoint(md) {
-      min-height: rem(40px);
-      background: none;
-    }
-  }
-
-  .#{$prefix}--tabs--container {
-    @include carbon--breakpoint(md) {
-      min-height: rem(48px);
-    }
-  }
-
-  .#{$prefix}--tabs-trigger {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: rem(40px);
-    padding: 0 $spacing-09 0 $spacing-05;
-    color: $text-01;
-    background-color: $field-01;
-    border-bottom: 1px solid $ui-04;
-    outline: 2px solid transparent;
-    cursor: pointer;
-    @include carbon--breakpoint(md) {
-      display: none;
-    }
-  }
-
-  .#{$prefix}--tabs-trigger:focus,
-  .#{$prefix}--tabs-trigger:active {
-    @include focus-outline('outline');
-  }
-
-  .#{$prefix}--tabs-trigger svg {
-    position: absolute;
-    right: $spacing-05;
-    transition: transform $duration--fast-01 motion(standard, productive);
-    fill: $ui-05;
-  }
-
-  .#{$prefix}--tabs-trigger--open:focus,
-  .#{$prefix}--tabs-trigger--open:active {
-    @include focus-outline('reset');
-
-    transition: outline $duration--fast-01 motion(standard, productive);
-  }
-
-  .#{$prefix}--tabs-trigger--open {
-    background: $ui-03;
-  }
-
-  .#{$prefix}--tabs-trigger--open svg {
-    @include rotate(-180deg, $duration--fast-01, 50% 45%);
-  }
-
-  // There is only a difference in tab color when in mobile/dropdown view
-  .#{$prefix}--tabs--light.#{$prefix}--tabs-trigger {
-    background-color: $field-02;
-  }
-
-  .#{$prefix}--tabs-trigger-text {
-    padding-top: 2px;
-    overflow: hidden;
-    color: $text-01;
-    font-weight: 400;
-    white-space: nowrap;
-    text-decoration: none;
-    text-overflow: ellipsis;
-  }
-
-  .#{$prefix}--tabs-trigger-text:hover {
-    color: $text-01;
-  }
-
-  .#{$prefix}--tabs-trigger-text:focus {
-    outline: none;
-  }
-
-  .#{$prefix}--tabs__nav {
-    @include box-shadow;
-
-    position: absolute;
-    z-index: z('dropdown');
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    max-height: 600px;
-
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    background: $ui-01;
-    transition: max-height $duration--fast-01 motion(standard, productive);
-
-    @include carbon--breakpoint(md) {
-      z-index: auto;
-      flex-direction: row;
-      width: auto;
-      background: none;
-      box-shadow: none;
-      transition: inherit;
-    }
-  }
-
-  .#{$prefix}--tabs__nav--hidden {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height $duration--fast-01 motion(standard, productive);
-
-    @include carbon--breakpoint(md) {
-      display: flex;
-      max-width: 100%;
-      max-height: none;
-      overflow-x: auto;
-      transition: inherit;
-    }
-  }
-
-  //-----------------------------
-  // Item
-  //-----------------------------
-  .#{$prefix}--tabs__nav-item {
-    @include reset;
-
-    display: flex;
-    width: 100%;
-    height: rem(40px);
-    padding: 0;
-    background-color: $ui-01;
-    cursor: pointer;
-    transition: background-color $duration--fast-01 motion(standard, productive);
-
-    @include carbon--breakpoint(md) {
-      height: auto;
-      background: transparent;
-
-      + .#{$prefix}--tabs__nav-item {
-        margin-left: rem(1px);
-      }
-    }
-  }
-
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item {
-    @include carbon--breakpoint(md) {
-      background-color: $ui-03;
-
-      + .#{$prefix}--tabs__nav-item {
-        margin-left: 0;
-        // Draws the border without affecting the inner-content
-        box-shadow: -1px 0 0 0 $ui-04;
-      }
-
-      + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
-      &.#{$prefix}--tabs__nav-item--selected + .#{$prefix}--tabs__nav-item {
-        box-shadow: none;
-      }
-    }
-  }
-
-  .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
-    transition: color $duration--fast-01 motion(standard, productive),
-      border-bottom-color $duration--fast-01 motion(standard, productive),
-      outline $duration--fast-01 motion(standard, productive);
-  }
-
-  //-----------------------------
-  // Item Hover
-  //-----------------------------
-  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected) {
-    @include carbon--breakpoint(md) {
-      background: transparent;
-    }
-  }
-
-  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
-    background-color: $hover-ui;
-    box-shadow: 0 -1px 0 $hover-ui;
-
-    @include carbon--breakpoint(md) {
-      background-color: transparent;
-
-      + .#{$prefix}--tabs__nav-item {
-        box-shadow: none;
-      }
-    }
-  }
-
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
-    @include carbon--breakpoint(md) {
-      background-color: $hover-selected-ui;
-    }
-  }
-
-  //---------------------------------------------
-  // Item Disabled
-  //---------------------------------------------
-  .#{$prefix}--tabs__nav-item--disabled,
-  .#{$prefix}--tabs__nav-item--disabled:hover {
-    outline: none;
-    cursor: not-allowed;
-  }
-
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled,
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
-    @include carbon--breakpoint(md) {
-      background-color: $disabled-02;
-    }
-  }
-
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--disabled
-    .#{$prefix}--tabs__nav-link {
-    @include carbon--breakpoint(md) {
-      color: $disabled-03;
-      border-bottom: none;
-    }
-  }
-
-  //-----------------------------
-  // Item Selected
-  //-----------------------------
-  .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
-    display: none;
-    border: none;
-    transition: color $duration--fast-01 motion(standard, productive);
-
-    @include carbon--breakpoint(md) {
-      display: flex;
-      .#{$prefix}--tabs__nav-link,
-      .#{$prefix}--tabs__nav-link:focus,
-      .#{$prefix}--tabs__nav-link:active {
-        @include type-style('productive-heading-01');
-
-        color: $text-01;
-        border-bottom: 2px solid $interactive-04;
-      }
-    }
-  }
-
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled),
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--selected:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
-    @include carbon--breakpoint(md) {
-      background-color: $ui-01;
-
-      .#{$prefix}--tabs__nav-link {
-        padding: $spacing-03 $spacing-05;
-        // height - vertical padding
-        // Draws the border without affecting the inner-content
-        line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-        border-bottom: none;
-        box-shadow: inset 0 2px 0 0 $interactive-04;
-      }
-
-      .#{$prefix}--tabs__nav-link:focus,
-      .#{$prefix}--tabs__nav-link:active {
-        box-shadow: none;
-      }
-    }
-  }
-
-  //-----------------------------
-  // Link
-  //-----------------------------
-  a.#{$prefix}--tabs__nav-link {
-    @include focus-outline('reset');
-
-    display: inline-block;
-    width: calc(100% - 32px);
-    height: rem(40px);
-    margin: 0 $spacing-05;
-    padding: $spacing-04 0;
-    overflow: hidden;
-    color: $text-02;
-    font-weight: 400;
-    line-height: 1rem;
-    white-space: nowrap;
-    text-decoration: none;
-    text-overflow: ellipsis;
-    border-bottom: 1px solid $ui-03;
-    transition: border $duration--fast-01 motion(standard, productive),
-      outline $duration--fast-01 motion(standard, productive);
-
-    &:focus,
-    &:active {
-      @include focus-outline('outline');
-
+      position: relative;
       width: 100%;
-      margin: 0;
-      padding-left: 16px;
+      height: auto;
+      color: $text-01;
+      @include carbon--breakpoint(md) {
+        min-height: rem(40px);
+        background: none;
+      }
     }
 
-    @include carbon--breakpoint(md) {
-      width: rem(160px);
+    .#{$prefix}--tabs--container {
+      @include carbon--breakpoint(md) {
+        min-height: rem(48px);
+      }
+    }
+
+    .#{$prefix}--tabs-trigger {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: rem(40px);
+      padding: 0 $spacing-09 0 $spacing-05;
+      color: $text-01;
+      background-color: $field-01;
+      border-bottom: 1px solid $ui-04;
+      outline: 2px solid transparent;
+      cursor: pointer;
+      @include carbon--breakpoint(md) {
+        display: none;
+      }
+    }
+
+    .#{$prefix}--tabs-trigger:focus,
+    .#{$prefix}--tabs-trigger:active {
+      @include focus-outline('outline');
+    }
+
+    .#{$prefix}--tabs-trigger svg {
+      position: absolute;
+      right: $spacing-05;
+      transition: transform $duration--fast-01 motion(standard, productive);
+      fill: $ui-05;
+    }
+
+    .#{$prefix}--tabs-trigger--open:focus,
+    .#{$prefix}--tabs-trigger--open:active {
+      @include focus-outline('reset');
+
+      transition: outline $duration--fast-01 motion(standard, productive);
+    }
+
+    .#{$prefix}--tabs-trigger--open {
+      background: $ui-03;
+    }
+
+    .#{$prefix}--tabs-trigger--open svg {
+      @include rotate(-180deg, $duration--fast-01, 50% 45%);
+    }
+
+    // There is only a difference in tab color when in mobile/dropdown view
+    .#{$prefix}--tabs--light.#{$prefix}--tabs-trigger {
+      background-color: $field-02;
+    }
+
+    .#{$prefix}--tabs-trigger-text {
+      padding-top: 2px;
+      overflow: hidden;
+      color: $text-01;
+      font-weight: 400;
+      white-space: nowrap;
+      text-decoration: none;
+      text-overflow: ellipsis;
+    }
+
+    .#{$prefix}--tabs-trigger-text:hover {
+      color: $text-01;
+    }
+
+    .#{$prefix}--tabs-trigger-text:focus {
+      outline: none;
+    }
+
+    .#{$prefix}--tabs__nav {
+      @include box-shadow;
+
+      position: absolute;
+      z-index: z('dropdown');
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      max-height: 600px;
+
       margin: 0;
-      padding: $spacing-04 $spacing-05 $spacing-03;
-      line-height: inherit;
-      border-bottom: $tab-underline-color;
+      padding: 0;
+      list-style: none;
+      background: $ui-01;
+      transition: max-height $duration--fast-01 motion(standard, productive);
+
+      @include carbon--breakpoint(md) {
+        z-index: auto;
+        flex-direction: row;
+        width: auto;
+        background: none;
+        box-shadow: none;
+        transition: inherit;
+      }
+    }
+
+    .#{$prefix}--tabs__nav--hidden {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height $duration--fast-01 motion(standard, productive);
+
+      @include carbon--breakpoint(md) {
+        display: flex;
+        max-width: 100%;
+        max-height: none;
+        overflow-x: auto;
+        transition: inherit;
+      }
+    }
+
+    //-----------------------------
+    // Item
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item {
+      @include reset;
+
+      display: flex;
+      width: 100%;
+      height: rem(40px);
+      padding: 0;
+      background-color: $ui-01;
+      cursor: pointer;
+      transition: background-color $duration--fast-01
+        motion(standard, productive);
+
+      @include carbon--breakpoint(md) {
+        height: auto;
+        background: transparent;
+
+        + .#{$prefix}--tabs__nav-item {
+          margin-left: rem(1px);
+        }
+      }
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item {
+      @include carbon--breakpoint(md) {
+        background-color: $ui-03;
+
+        + .#{$prefix}--tabs__nav-item {
+          margin-left: 0;
+          // Draws the border without affecting the inner-content
+          box-shadow: -1px 0 0 0 $ui-04;
+        }
+
+        + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
+        &.#{$prefix}--tabs__nav-item--selected + .#{$prefix}--tabs__nav-item {
+          box-shadow: none;
+        }
+      }
+    }
+
+    .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
+      transition: color $duration--fast-01 motion(standard, productive),
+        border-bottom-color $duration--fast-01 motion(standard, productive),
+        outline $duration--fast-01 motion(standard, productive);
+    }
+
+    //-----------------------------
+    // Item Hover
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected) {
+      @include carbon--breakpoint(md) {
+        background: transparent;
+      }
+    }
+
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+      background-color: $hover-ui;
+      box-shadow: 0 -1px 0 $hover-ui;
+
+      @include carbon--breakpoint(md) {
+        background-color: transparent;
+
+        + .#{$prefix}--tabs__nav-item {
+          box-shadow: none;
+        }
+      }
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+      @include carbon--breakpoint(md) {
+        background-color: $hover-selected-ui;
+      }
+    }
+
+    //---------------------------------------------
+    // Item Disabled
+    //---------------------------------------------
+    .#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs__nav-item--disabled:hover {
+      outline: none;
+      cursor: not-allowed;
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
+      @include carbon--breakpoint(md) {
+        background-color: $disabled-02;
+      }
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--disabled
+      .#{$prefix}--tabs__nav-link {
+      @include carbon--breakpoint(md) {
+        color: $disabled-03;
+        border-bottom: none;
+      }
+    }
+
+    //-----------------------------
+    // Item Selected
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+      display: none;
+      border: none;
+      transition: color $duration--fast-01 motion(standard, productive);
+
+      @include carbon--breakpoint(md) {
+        display: flex;
+        .#{$prefix}--tabs__nav-link,
+        .#{$prefix}--tabs__nav-link:focus,
+        .#{$prefix}--tabs__nav-link:active {
+          @include type-style('productive-heading-01');
+
+          color: $text-01;
+          border-bottom: 2px solid $interactive-04;
+        }
+      }
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled),
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+      @include carbon--breakpoint(md) {
+        background-color: $ui-01;
+
+        .#{$prefix}--tabs__nav-link {
+          padding: $spacing-03 $spacing-05;
+          // height - vertical padding
+          // Draws the border without affecting the inner-content
+          line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+          border-bottom: none;
+          box-shadow: inset 0 2px 0 0 $interactive-04;
+        }
+
+        .#{$prefix}--tabs__nav-link:focus,
+        .#{$prefix}--tabs__nav-link:active {
+          box-shadow: none;
+        }
+      }
+    }
+
+    //-----------------------------
+    // Link
+    //-----------------------------
+    a.#{$prefix}--tabs__nav-link {
+      @include focus-outline('reset');
+
+      display: inline-block;
+      width: calc(100% - 32px);
+      height: rem(40px);
+      margin: 0 $spacing-05;
+      padding: $spacing-04 0;
+      overflow: hidden;
+      color: $text-02;
+      font-weight: 400;
+      line-height: 1rem;
+      white-space: nowrap;
+      text-decoration: none;
+      text-overflow: ellipsis;
+      border-bottom: 1px solid $ui-03;
+      transition: border $duration--fast-01 motion(standard, productive),
+        outline $duration--fast-01 motion(standard, productive);
 
       &:focus,
       &:active {
+        @include focus-outline('outline');
+
+        width: 100%;
+        margin: 0;
+        padding-left: 16px;
+      }
+
+      @include carbon--breakpoint(md) {
         width: rem(160px);
-        border-bottom: 2px;
+        margin: 0;
+        padding: $spacing-04 $spacing-05 $spacing-03;
+        line-height: inherit;
+        border-bottom: $tab-underline-color;
+
+        &:focus,
+        &:active {
+          width: rem(160px);
+          border-bottom: 2px;
+        }
       }
     }
-  }
 
-  .#{$prefix}--tabs--container a.#{$prefix}--tabs__nav-link {
-    @include carbon--breakpoint(md) {
-      height: rem(48px);
-      padding: $spacing-03 $spacing-05;
-      // Height - vertical padding
-      line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-      border-bottom: none;
+    .#{$prefix}--tabs--container a.#{$prefix}--tabs__nav-link {
+      @include carbon--breakpoint(md) {
+        height: rem(48px);
+        padding: $spacing-03 $spacing-05;
+        // Height - vertical padding
+        line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+        border-bottom: none;
+      }
     }
-  }
 
-  //-----------------------------
-  //  Link Hover
-  //-----------------------------
-  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
-    .#{$prefix}--tabs__nav-link {
-    color: $text-01;
-    @include carbon--breakpoint(md) {
-      color: $text-01;
-      border-bottom: $tab-underline-color-hover;
-    }
-  }
-
-  .#{$prefix}--tabs--container
+    //-----------------------------
+    //  Link Hover
+    //-----------------------------
     .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
-    .#{$prefix}--tabs__nav-link {
-    @include carbon--breakpoint(md) {
-      border-bottom: none;
+      .#{$prefix}--tabs__nav-link {
+      color: $text-01;
+      @include carbon--breakpoint(md) {
+        color: $text-01;
+        border-bottom: $tab-underline-color-hover;
+      }
     }
-  }
 
-  //-----------------------------
-  //  Link Disabled
-  //-----------------------------
-  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
-    color: $tab-text-disabled;
-    border-bottom: $tab-underline-disabled;
-    pointer-events: none;
-  }
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+      .#{$prefix}--tabs__nav-link {
+      @include carbon--breakpoint(md) {
+        border-bottom: none;
+      }
+    }
 
-  .#{$prefix}--tabs__nav-item--disabled:hover .#{$prefix}--tabs__nav-link {
-    border-bottom: $tab-underline-disabled;
-    cursor: no-drop;
-  }
+    //-----------------------------
+    //  Link Disabled
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
+      color: $tab-text-disabled;
+      border-bottom: $tab-underline-disabled;
+      pointer-events: none;
+    }
 
-  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs__nav-item--disabled a.#{$prefix}--tabs__nav-link:active {
-    border-bottom: $tab-underline-disabled;
-    outline: none;
-  }
+    .#{$prefix}--tabs__nav-item--disabled:hover .#{$prefix}--tabs__nav-link {
+      border-bottom: $tab-underline-disabled;
+      cursor: no-drop;
+    }
 
-  //-----------------------------
-  //  Link Focus
-  //-----------------------------
-  .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
-    .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
-    a.#{$prefix}--tabs__nav-link:active {
-    color: $text-02;
-  }
+    .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs__nav-item--disabled a.#{$prefix}--tabs__nav-link:active {
+      border-bottom: $tab-underline-disabled;
+      outline: none;
+    }
 
-  //-----------------------------
-  //  Tab Content Container
-  //-----------------------------
-  .#{$prefix}--tab-content {
-    padding: $carbon--spacing-05;
-  }
+    //-----------------------------
+    //  Link Focus
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
+      .#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
+      a.#{$prefix}--tabs__nav-link:active {
+      color: $text-02;
+    }
 
-  //-----------------------------
-  // Skeleton state
-  //-----------------------------
-  .#{$prefix}--tabs.#{$prefix}--skeleton {
-    cursor: default;
-    pointer-events: none;
-  }
+    //-----------------------------
+    //  Tab Content Container
+    //-----------------------------
+    .#{$prefix}--tab-content {
+      padding: $carbon--spacing-05;
+    }
 
-  .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs__nav-link {
-    @include skeleton;
+    //-----------------------------
+    // Skeleton state
+    //-----------------------------
+    .#{$prefix}--tabs.#{$prefix}--skeleton {
+      cursor: default;
+      pointer-events: none;
+    }
 
-    width: rem(75px);
-    height: rem(12px);
-  }
+    .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs__nav-link {
+      @include skeleton;
 
-  .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger {
-    @include skeleton;
+      width: rem(75px);
+      height: rem(12px);
+    }
 
-    width: rem(100px);
-  }
+    .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger {
+      @include skeleton;
 
-  .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger svg {
-    @include hidden;
+      width: rem(100px);
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger svg {
+      @include hidden;
+    }
   }
 }
 

--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -22,131 +22,126 @@
     @include reset;
     @include type-style('body-short-01');
 
-    display: flex;
+    position: relative;
     width: 100%;
     height: auto;
-    min-height: rem(40px);
     color: $text-01;
+    @include carbon--breakpoint(md) {
+      min-height: rem(40px);
+      background: none;
+    }
   }
 
   .#{$prefix}--tabs--container {
-    min-height: rem(48px);
+    @include carbon--breakpoint(md) {
+      min-height: rem(48px);
+    }
   }
 
-  .#{$prefix}--tabs__nav {
+  .#{$prefix}--tabs-trigger {
     display: flex;
-    flex-direction: row;
-    width: auto;
-    max-width: 100%;
-    margin: 0;
-    padding: 0;
-    overflow: auto hidden;
-    list-style: none;
-    transition: max-height $duration--fast-01 motion(standard, productive);
-
-    // hide scrollbars
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
+    align-items: center;
+    justify-content: space-between;
+    height: rem(40px);
+    padding: 0 $spacing-09 0 $spacing-05;
+    color: $text-01;
+    background-color: $field-01;
+    border-bottom: 1px solid $ui-04;
+    outline: 2px solid transparent;
+    cursor: pointer;
+    @include carbon--breakpoint(md) {
       display: none;
     }
   }
 
-  //-----------------------------
-  // Overflow Nav Buttons
-  //-----------------------------
-  .#{$prefix}--tabs__overflow-indicator--left,
-  .#{$prefix}--tabs__overflow-indicator--right {
-    z-index: 1;
-    flex: 1 0 auto;
-    width: $carbon--spacing-03;
+  .#{$prefix}--tabs-trigger:focus,
+  .#{$prefix}--tabs-trigger:active {
+    @include focus-outline('outline');
   }
 
-  .#{$prefix}--tabs__overflow-indicator--left {
-    margin-right: -$carbon--spacing-03;
-    background-image: linear-gradient(to left, transparent, $ui-background);
+  .#{$prefix}--tabs-trigger svg {
+    position: absolute;
+    right: $spacing-05;
+    transition: transform $duration--fast-01 motion(standard, productive);
+    fill: $ui-05;
   }
 
-  .#{$prefix}--tabs__overflow-indicator--right {
-    margin-left: -$carbon--spacing-03;
-    background-image: linear-gradient(to right, transparent, $ui-background);
+  .#{$prefix}--tabs-trigger--open:focus,
+  .#{$prefix}--tabs-trigger--open:active {
+    @include focus-outline('reset');
+
+    transition: outline $duration--fast-01 motion(standard, productive);
   }
 
-  .#{$prefix}--tabs--light .#{$prefix}--tabs__overflow-indicator--left {
-    background-image: linear-gradient(to left, transparent, $ui-01);
+  .#{$prefix}--tabs-trigger--open {
+    background: $ui-03;
   }
 
-  .#{$prefix}--tabs--light .#{$prefix}--tabs__overflow-indicator--right {
-    background-image: linear-gradient(to right, transparent, $ui-01);
+  .#{$prefix}--tabs-trigger--open svg {
+    @include rotate(-180deg, $duration--fast-01, 50% 45%);
   }
 
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__overflow-indicator--left {
-    background-image: linear-gradient(to left, transparent, $ui-03);
+  // There is only a difference in tab color when in mobile/dropdown view
+  .#{$prefix}--tabs--light.#{$prefix}--tabs-trigger {
+    background-color: $field-02;
   }
 
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__overflow-indicator--right {
-    background-image: linear-gradient(to right, transparent, $ui-03);
+  .#{$prefix}--tabs-trigger-text {
+    padding-top: 2px;
+    overflow: hidden;
+    color: $text-01;
+    font-weight: 400;
+    white-space: nowrap;
+    text-decoration: none;
+    text-overflow: ellipsis;
   }
 
-  // Safari-only media query
-  // won't appear correctly with CSS custom properties
-  // see: code snippet and modal overflow indicators
-  @media not all and (min-resolution: 0.001dpcm) {
-    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-      .#{$prefix}--tabs__overflow-indicator--left {
-        margin-right: -$carbon--spacing-05;
-        background-image: linear-gradient(
-          to left,
-          rgba($ui-background, 0),
-          $ui-background
-        );
-      }
-
-      .#{$prefix}--tabs__overflow-indicator--right {
-        margin-left: -$carbon--spacing-05;
-        background-image: linear-gradient(
-          to right,
-          rgba($ui-background, 0),
-          $ui-background
-        );
-      }
-
-      .#{$prefix}--tabs--container .#{$prefix}--tabs__overflow-indicator--left {
-        background-image: linear-gradient(to left, rgba($ui-03, 0), $ui-03);
-      }
-      .#{$prefix}--tabs--container
-        .#{$prefix}--tabs__overflow-indicator--right {
-        background-image: linear-gradient(to right, rgba($ui-03, 0), $ui-03);
-      }
-    }
+  .#{$prefix}--tabs-trigger-text:hover {
+    color: $text-01;
   }
 
-  .#{$prefix}--tab--overflow-nav-button {
-    @include button-reset;
+  .#{$prefix}--tabs-trigger-text:focus {
+    outline: none;
+  }
 
+  .#{$prefix}--tabs__nav {
+    @include box-shadow;
+
+    position: absolute;
+    z-index: z('dropdown');
     display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-    width: $carbon--spacing-08;
+    flex-direction: column;
+    width: 100%;
+    max-height: 600px;
 
-    &:focus {
-      @include focus-outline('outline');
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    background: $ui-01;
+    transition: max-height $duration--fast-01 motion(standard, productive);
+
+    @include carbon--breakpoint(md) {
+      z-index: auto;
+      flex-direction: row;
+      width: auto;
+      background: none;
+      box-shadow: none;
+      transition: inherit;
     }
   }
 
-  .#{$prefix}--tab--overflow-nav-button--hidden {
-    display: none;
-  }
+  .#{$prefix}--tabs__nav--hidden {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height $duration--fast-01 motion(standard, productive);
 
-  .#{$prefix}--tabs--container .#{$prefix}--tab--overflow-nav-button {
-    width: $carbon--spacing-09;
-    margin: 0;
-    background-color: $ui-03;
-  }
-
-  .#{$prefix}--tab--overflow-nav-button svg {
-    fill: $icon-01;
+    @include carbon--breakpoint(md) {
+      display: flex;
+      max-width: 100%;
+      max-height: none;
+      overflow-x: auto;
+      transition: inherit;
+    }
   }
 
   //-----------------------------
@@ -156,34 +151,38 @@
     @include reset;
 
     display: flex;
+    width: 100%;
+    height: rem(40px);
     padding: 0;
+    background-color: $ui-01;
     cursor: pointer;
     transition: background-color $duration--fast-01 motion(standard, productive);
-  }
 
-  .#{$prefix}--tabs__nav-item + .#{$prefix}--tabs__nav-item {
-    margin-left: rem(1px);
+    @include carbon--breakpoint(md) {
+      height: auto;
+      background: transparent;
+
+      + .#{$prefix}--tabs__nav-item {
+        margin-left: rem(1px);
+      }
+    }
   }
 
   .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item {
-    background-color: $ui-03;
-  }
+    @include carbon--breakpoint(md) {
+      background-color: $ui-03;
 
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item
-    + .#{$prefix}--tabs__nav-item {
-    margin-left: 0;
-    // Draws the border without affecting the inner-content
-    box-shadow: rem(-1px) 0 0 0 $ui-04;
-  }
+      + .#{$prefix}--tabs__nav-item {
+        margin-left: 0;
+        // Draws the border without affecting the inner-content
+        box-shadow: -1px 0 0 0 $ui-04;
+      }
 
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item
-    + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected
-    + .#{$prefix}--tabs__nav-item {
-    box-shadow: none;
+      + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
+      &.#{$prefix}--tabs__nav-item--selected + .#{$prefix}--tabs__nav-item {
+        box-shadow: none;
+      }
+    }
   }
 
   .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
@@ -195,8 +194,30 @@
   //-----------------------------
   // Item Hover
   //-----------------------------
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item:hover {
-    background-color: $hover-selected-ui;
+  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected) {
+    @include carbon--breakpoint(md) {
+      background: transparent;
+    }
+  }
+
+  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+    background-color: $hover-ui;
+    box-shadow: 0 -1px 0 $hover-ui;
+
+    @include carbon--breakpoint(md) {
+      background-color: transparent;
+
+      + .#{$prefix}--tabs__nav-item {
+        box-shadow: none;
+      }
+    }
+  }
+
+  .#{$prefix}--tabs--container
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+    @include carbon--breakpoint(md) {
+      background-color: $hover-selected-ui;
+    }
   }
 
   //---------------------------------------------
@@ -204,7 +225,6 @@
   //---------------------------------------------
   .#{$prefix}--tabs__nav-item--disabled,
   .#{$prefix}--tabs__nav-item--disabled:hover {
-    background-color: transparent;
     outline: none;
     cursor: not-allowed;
   }
@@ -213,94 +233,138 @@
     .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled,
   .#{$prefix}--tabs--container
     .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
-    background-color: $disabled-02;
+    @include carbon--breakpoint(md) {
+      background-color: $disabled-02;
+    }
+  }
+
+  .#{$prefix}--tabs--container
+    .#{$prefix}--tabs__nav-item--disabled
+    .#{$prefix}--tabs__nav-link {
+    @include carbon--breakpoint(md) {
+      color: $disabled-03;
+      border-bottom: none;
+    }
   }
 
   //-----------------------------
   // Item Selected
   //-----------------------------
-  .#{$prefix}--tabs__nav-item--selected {
+  .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled) {
+    display: none;
+    border: none;
     transition: color $duration--fast-01 motion(standard, productive);
-  }
 
-  .#{$prefix}--tabs__nav-item--selected .#{$prefix}--tabs__nav-link,
-  .#{$prefix}--tabs__nav-item--selected .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs__nav-item--selected .#{$prefix}--tabs__nav-link:active {
-    @include type-style('productive-heading-01');
+    @include carbon--breakpoint(md) {
+      display: flex;
+      .#{$prefix}--tabs__nav-link,
+      .#{$prefix}--tabs__nav-link:focus,
+      .#{$prefix}--tabs__nav-link:active {
+        @include type-style('productive-heading-01');
 
-    color: $text-01;
-    border-bottom: 2px solid $interactive-04;
-  }
-
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item--selected,
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item--selected:hover {
-    background-color: $ui-01;
-
-    .#{$prefix}--tabs__nav-link:focus,
-    .#{$prefix}--tabs__nav-link:active {
-      box-shadow: none;
+        color: $text-01;
+        border-bottom: 2px solid $interactive-04;
+      }
     }
   }
 
   .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--selected
-    .#{$prefix}--tabs__nav-link {
-    // height - vertical padding
-    line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-    // Draws the border without affecting the inner-content
-    box-shadow: inset 0 2px 0 0 $interactive-04;
-  }
+    .#{$prefix}--tabs__nav-item--selected:not(.#{$prefix}--tabs__nav-item--disabled),
+  .#{$prefix}--tabs--container
+    .#{$prefix}--tabs__nav-item--selected:hover:not(.#{$prefix}--tabs__nav-item--disabled) {
+    @include carbon--breakpoint(md) {
+      background-color: $ui-01;
 
-  .#{$prefix}--tabs--light.#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--selected,
-  .#{$prefix}--tabs--light.#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--selected:hover {
-    background-color: $ui-background;
+      .#{$prefix}--tabs__nav-link {
+        padding: $spacing-03 $spacing-05;
+        // height - vertical padding
+        // Draws the border without affecting the inner-content
+        line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+        border-bottom: none;
+        box-shadow: inset 0 2px 0 0 $interactive-04;
+      }
+
+      .#{$prefix}--tabs__nav-link:focus,
+      .#{$prefix}--tabs__nav-link:active {
+        box-shadow: none;
+      }
+    }
   }
 
   //-----------------------------
   // Link
   //-----------------------------
-  .#{$prefix}--tabs__nav-link {
+  a.#{$prefix}--tabs__nav-link {
     @include focus-outline('reset');
 
-    width: rem(160px);
-    padding: $spacing-04 $spacing-05 $spacing-03;
+    display: inline-block;
+    width: calc(100% - 32px);
+    height: rem(40px);
+    margin: 0 $spacing-05;
+    padding: $spacing-04 0;
     overflow: hidden;
     color: $text-02;
+    font-weight: 400;
+    line-height: 1rem;
     white-space: nowrap;
     text-decoration: none;
     text-overflow: ellipsis;
-    border-bottom: $tab-underline-color;
+    border-bottom: 1px solid $ui-03;
     transition: border $duration--fast-01 motion(standard, productive),
       outline $duration--fast-01 motion(standard, productive);
 
     &:focus,
     &:active {
       @include focus-outline('outline');
+
+      width: 100%;
+      margin: 0;
+      padding-left: 16px;
+    }
+
+    @include carbon--breakpoint(md) {
+      width: rem(160px);
+      margin: 0;
+      padding: $spacing-04 $spacing-05 $spacing-03;
+      line-height: inherit;
+      border-bottom: $tab-underline-color;
+
+      &:focus,
+      &:active {
+        width: rem(160px);
+        border-bottom: 2px;
+      }
     }
   }
 
-  .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-link {
-    height: rem(48px);
-    padding: $spacing-03 $spacing-05;
-    // height - vertical padding
-    line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-    border-bottom: 0;
+  .#{$prefix}--tabs--container a.#{$prefix}--tabs__nav-link {
+    @include carbon--breakpoint(md) {
+      height: rem(48px);
+      padding: $spacing-03 $spacing-05;
+      // Height - vertical padding
+      line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+      border-bottom: none;
+    }
   }
 
   //-----------------------------
   //  Link Hover
   //-----------------------------
-  .#{$prefix}--tabs__nav-item:hover .#{$prefix}--tabs__nav-link {
+  .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
+    .#{$prefix}--tabs__nav-link {
     color: $text-01;
-    border-bottom: $tab-underline-color-hover;
+    @include carbon--breakpoint(md) {
+      color: $text-01;
+      border-bottom: $tab-underline-color-hover;
+    }
   }
 
   .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item
+    .#{$prefix}--tabs__nav-item:hover:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled)
     .#{$prefix}--tabs__nav-link {
-    border-bottom: none;
+    @include carbon--breakpoint(md) {
+      border-bottom: none;
+    }
   }
 
   //-----------------------------
@@ -309,47 +373,28 @@
   .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
     color: $tab-text-disabled;
     border-bottom: $tab-underline-disabled;
-  }
-
-  .#{$prefix}--tabs__nav-item--disabled:hover .#{$prefix}--tabs__nav-link {
-    color: $tab-text-disabled;
-    border-bottom: $tab-underline-disabled;
-    cursor: not-allowed;
     pointer-events: none;
   }
 
+  .#{$prefix}--tabs__nav-item--disabled:hover .#{$prefix}--tabs__nav-link {
+    border-bottom: $tab-underline-disabled;
+    cursor: no-drop;
+  }
+
   .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:active {
+  .#{$prefix}--tabs__nav-item--disabled a.#{$prefix}--tabs__nav-link:active {
     border-bottom: $tab-underline-disabled;
     outline: none;
   }
 
-  .#{$prefix}--tabs--light
-    .#{$prefix}--tabs__nav-item--disabled
-    .#{$prefix}--tabs__nav-link {
-    border-bottom-color: $ui-03;
-  }
-
-  .#{$prefix}--tabs--light
-    .#{$prefix}--tabs__nav-item--disabled:hover
-    .#{$prefix}--tabs__nav-link {
-    border-bottom-color: $ui-03;
-  }
-
-  .#{$prefix}--tabs--light
-    .#{$prefix}--tabs__nav-item--disabled
+  //-----------------------------
+  //  Link Focus
+  //-----------------------------
+  .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
     .#{$prefix}--tabs__nav-link:focus,
-  .#{$prefix}--tabs--light
-    .#{$prefix}--tabs__nav-item--disabled
-    .#{$prefix}--tabs__nav-link:active {
-    border-bottom-color: $ui-03;
-  }
-
-  .#{$prefix}--tabs--container
-    .#{$prefix}--tabs__nav-item--disabled
-    .#{$prefix}--tabs__nav-link {
-    color: $disabled-03;
-    border-bottom: none;
+  .#{$prefix}--tabs__nav-item:not(.#{$prefix}--tabs__nav-item--selected):not(.#{$prefix}--tabs__nav-item--disabled):not(.#{$prefix}--tabs__nav-item--selected)
+    a.#{$prefix}--tabs__nav-link:active {
+    color: $text-02;
   }
 
   //-----------------------------
@@ -371,13 +416,13 @@
     @include skeleton;
 
     width: rem(75px);
+    height: rem(12px);
   }
 
   .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger {
     @include skeleton;
 
-    width: rem(75px);
-    margin-right: rem(1px);
+    width: rem(100px);
   }
 
   .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger svg {

--- a/packages/components/src/components/tabs/_unstable_tabs.scss
+++ b/packages/components/src/components/tabs/_unstable_tabs.scss
@@ -1,0 +1,394 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+//-----------------------------
+// Tabs
+//-----------------------------
+
+@import '../../globals/scss/vars';
+@import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/layout';
+@import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+
+/// Tabs styles
+/// @access private
+/// @group tabs
+@mixin unstable_tabs {
+  .#{$prefix}--unstable_tabs {
+    .#{$prefix}--tabs {
+      @include reset;
+      @include type-style('body-short-01');
+
+      display: flex;
+      width: 100%;
+      height: auto;
+      min-height: rem(40px);
+      color: $text-01;
+    }
+
+    .#{$prefix}--tabs--container {
+      min-height: rem(48px);
+    }
+
+    .#{$prefix}--tabs__nav {
+      display: flex;
+      flex-direction: row;
+      width: auto;
+      max-width: 100%;
+      margin: 0;
+      padding: 0;
+      overflow: auto hidden;
+      list-style: none;
+      transition: max-height $duration--fast-01 motion(standard, productive);
+
+      // hide scrollbars
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    //-----------------------------
+    // Overflow Nav Buttons
+    //-----------------------------
+    .#{$prefix}--tabs__overflow-indicator--left,
+    .#{$prefix}--tabs__overflow-indicator--right {
+      z-index: 1;
+      flex: 1 0 auto;
+      width: $carbon--spacing-03;
+    }
+
+    .#{$prefix}--tabs__overflow-indicator--left {
+      margin-right: -$carbon--spacing-03;
+      background-image: linear-gradient(to left, transparent, $ui-background);
+    }
+
+    .#{$prefix}--tabs__overflow-indicator--right {
+      margin-left: -$carbon--spacing-03;
+      background-image: linear-gradient(to right, transparent, $ui-background);
+    }
+
+    .#{$prefix}--tabs--light .#{$prefix}--tabs__overflow-indicator--left {
+      background-image: linear-gradient(to left, transparent, $ui-01);
+    }
+
+    .#{$prefix}--tabs--light .#{$prefix}--tabs__overflow-indicator--right {
+      background-image: linear-gradient(to right, transparent, $ui-01);
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__overflow-indicator--left {
+      background-image: linear-gradient(to left, transparent, $ui-03);
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__overflow-indicator--right {
+      background-image: linear-gradient(to right, transparent, $ui-03);
+    }
+
+    // Safari-only media query
+    // won't appear correctly with CSS custom properties
+    // see: code snippet and modal overflow indicators
+    @media not all and (min-resolution: 0.001dpcm) {
+      @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+        .#{$prefix}--tabs__overflow-indicator--left {
+          margin-right: -$carbon--spacing-05;
+          background-image: linear-gradient(
+            to left,
+            rgba($ui-background, 0),
+            $ui-background
+          );
+        }
+
+        .#{$prefix}--tabs__overflow-indicator--right {
+          margin-left: -$carbon--spacing-05;
+          background-image: linear-gradient(
+            to right,
+            rgba($ui-background, 0),
+            $ui-background
+          );
+        }
+
+        .#{$prefix}--tabs--container
+          .#{$prefix}--tabs__overflow-indicator--left {
+          background-image: linear-gradient(to left, rgba($ui-03, 0), $ui-03);
+        }
+        .#{$prefix}--tabs--container
+          .#{$prefix}--tabs__overflow-indicator--right {
+          background-image: linear-gradient(to right, rgba($ui-03, 0), $ui-03);
+        }
+      }
+    }
+
+    .#{$prefix}--tab--overflow-nav-button {
+      @include button-reset;
+
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+      width: $carbon--spacing-08;
+
+      &:focus {
+        @include focus-outline('outline');
+      }
+    }
+
+    .#{$prefix}--tab--overflow-nav-button--hidden {
+      display: none;
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tab--overflow-nav-button {
+      width: $carbon--spacing-09;
+      margin: 0;
+      background-color: $ui-03;
+    }
+
+    .#{$prefix}--tab--overflow-nav-button svg {
+      fill: $icon-01;
+    }
+
+    //-----------------------------
+    // Item
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item {
+      @include reset;
+
+      display: flex;
+      padding: 0;
+      cursor: pointer;
+      transition: background-color $duration--fast-01
+        motion(standard, productive);
+    }
+
+    .#{$prefix}--tabs__nav-item + .#{$prefix}--tabs__nav-item {
+      margin-left: rem(1px);
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item {
+      background-color: $ui-03;
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item
+      + .#{$prefix}--tabs__nav-item {
+      margin-left: 0;
+      // Draws the border without affecting the inner-content
+      box-shadow: rem(-1px) 0 0 0 $ui-04;
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item
+      + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected
+      + .#{$prefix}--tabs__nav-item {
+      box-shadow: none;
+    }
+
+    .#{$prefix}--tabs__nav-item .#{$prefix}--tabs__nav-link {
+      transition: color $duration--fast-01 motion(standard, productive),
+        border-bottom-color $duration--fast-01 motion(standard, productive),
+        outline $duration--fast-01 motion(standard, productive);
+    }
+
+    //-----------------------------
+    // Item Hover
+    //-----------------------------
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item:hover {
+      background-color: $hover-selected-ui;
+    }
+
+    //---------------------------------------------
+    // Item Disabled
+    //---------------------------------------------
+    .#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs__nav-item--disabled:hover {
+      background-color: transparent;
+      outline: none;
+      cursor: not-allowed;
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled,
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
+      background-color: $disabled-02;
+    }
+
+    //-----------------------------
+    // Item Selected
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item--selected {
+      transition: color $duration--fast-01 motion(standard, productive);
+    }
+
+    .#{$prefix}--tabs__nav-item--selected .#{$prefix}--tabs__nav-link,
+    .#{$prefix}--tabs__nav-item--selected .#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs__nav-item--selected .#{$prefix}--tabs__nav-link:active {
+      @include type-style('productive-heading-01');
+
+      color: $text-01;
+      border-bottom: 2px solid $interactive-04;
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item--selected,
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-item--selected:hover {
+      background-color: $ui-01;
+
+      .#{$prefix}--tabs__nav-link:focus,
+      .#{$prefix}--tabs__nav-link:active {
+        box-shadow: none;
+      }
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected
+      .#{$prefix}--tabs__nav-link {
+      // height - vertical padding
+      line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+      // Draws the border without affecting the inner-content
+      box-shadow: inset 0 2px 0 0 $interactive-04;
+    }
+
+    .#{$prefix}--tabs--light.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected,
+    .#{$prefix}--tabs--light.#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--selected:hover {
+      background-color: $ui-background;
+    }
+
+    //-----------------------------
+    // Link
+    //-----------------------------
+    .#{$prefix}--tabs__nav-link {
+      @include focus-outline('reset');
+
+      width: rem(160px);
+      padding: $spacing-04 $spacing-05 $spacing-03;
+      overflow: hidden;
+      color: $text-02;
+      white-space: nowrap;
+      text-decoration: none;
+      text-overflow: ellipsis;
+      border-bottom: $tab-underline-color;
+      transition: border $duration--fast-01 motion(standard, productive),
+        outline $duration--fast-01 motion(standard, productive);
+
+      &:focus,
+      &:active {
+        @include focus-outline('outline');
+      }
+    }
+
+    .#{$prefix}--tabs--container .#{$prefix}--tabs__nav-link {
+      height: rem(48px);
+      padding: $spacing-03 $spacing-05;
+      // height - vertical padding
+      line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
+      border-bottom: 0;
+    }
+
+    //-----------------------------
+    //  Link Hover
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item:hover .#{$prefix}--tabs__nav-link {
+      color: $text-01;
+      border-bottom: $tab-underline-color-hover;
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item
+      .#{$prefix}--tabs__nav-link {
+      border-bottom: none;
+    }
+
+    //-----------------------------
+    //  Link Disabled
+    //-----------------------------
+    .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link {
+      color: $tab-text-disabled;
+      border-bottom: $tab-underline-disabled;
+    }
+
+    .#{$prefix}--tabs__nav-item--disabled:hover .#{$prefix}--tabs__nav-link {
+      color: $tab-text-disabled;
+      border-bottom: $tab-underline-disabled;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+
+    .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs__nav-item--disabled .#{$prefix}--tabs__nav-link:active {
+      border-bottom: $tab-underline-disabled;
+      outline: none;
+    }
+
+    .#{$prefix}--tabs--light
+      .#{$prefix}--tabs__nav-item--disabled
+      .#{$prefix}--tabs__nav-link {
+      border-bottom-color: $ui-03;
+    }
+
+    .#{$prefix}--tabs--light
+      .#{$prefix}--tabs__nav-item--disabled:hover
+      .#{$prefix}--tabs__nav-link {
+      border-bottom-color: $ui-03;
+    }
+
+    .#{$prefix}--tabs--light
+      .#{$prefix}--tabs__nav-item--disabled
+      .#{$prefix}--tabs__nav-link:focus,
+    .#{$prefix}--tabs--light
+      .#{$prefix}--tabs__nav-item--disabled
+      .#{$prefix}--tabs__nav-link:active {
+      border-bottom-color: $ui-03;
+    }
+
+    .#{$prefix}--tabs--container
+      .#{$prefix}--tabs__nav-item--disabled
+      .#{$prefix}--tabs__nav-link {
+      color: $disabled-03;
+      border-bottom: none;
+    }
+
+    //-----------------------------
+    //  Tab Content Container
+    //-----------------------------
+    .#{$prefix}--tab-content {
+      padding: $carbon--spacing-05;
+    }
+
+    //-----------------------------
+    // Skeleton state
+    //-----------------------------
+    .#{$prefix}--tabs.#{$prefix}--skeleton {
+      cursor: default;
+      pointer-events: none;
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs__nav-link {
+      @include skeleton;
+
+      width: rem(75px);
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger {
+      @include skeleton;
+
+      width: rem(75px);
+      margin-right: rem(1px);
+    }
+
+    .#{$prefix}--tabs.#{$prefix}--skeleton .#{$prefix}--tabs-trigger svg {
+      @include hidden;
+    }
+  }
+}
+
+@include exports('unstable_tabs') {
+  @include unstable_tabs;
+}

--- a/packages/components/src/globals/scss/styles.scss
+++ b/packages/components/src/globals/scss/styles.scss
@@ -156,6 +156,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 // 🔬 Experimental
 //-------------------------------------
 @import '../../components/pagination/unstable_pagination';
+@import '../../components/tabs/unstable_tabs';
 @import '../../components/ui-shell/ui-shell';
 
 //-------------------------------------

--- a/packages/react/.storybook/styles.scss
+++ b/packages/react/.storybook/styles.scss
@@ -59,6 +59,7 @@ $prefix: 'bx';
 @import '~carbon-components/src/components/notification/toast-notification';
 @import '~carbon-components/src/components/tooltip/tooltip';
 @import '~carbon-components/src/components/tabs/tabs';
+@import '~carbon-components/src/components/tabs/unstable_tabs';
 @import '~carbon-components/src/components/tag/tag';
 @import '~carbon-components/src/components/treeview/treeview';
 @import '~carbon-components/src/components/pagination/pagination';

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4932,12 +4932,18 @@ Map {
   },
   "Tabs" => Object {
     "defaultProps": Object {
+      "ariaLabel": "listbox",
+      "iconDescription": "show menu options",
       "role": "navigation",
       "selected": 0,
       "selectionMode": "automatic",
+      "triggerHref": "#",
       "type": "default",
     },
     "propTypes": Object {
+      "ariaLabel": Object {
+        "type": "string",
+      },
       "children": Object {
         "type": "node",
       },
@@ -4947,8 +4953,9 @@ Map {
       "hidden": Object {
         "type": "bool",
       },
-      "light": Object {
-        "type": "bool",
+      "iconDescription": Object {
+        "isRequired": true,
+        "type": "string",
       },
       "onClick": Object {
         "type": "func",
@@ -4976,6 +4983,10 @@ Map {
         "type": "oneOf",
       },
       "tabContentClassName": Object {
+        "type": "string",
+      },
+      "triggerHref": Object {
+        "isRequired": true,
         "type": "string",
       },
       "type": Object {

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7105,6 +7105,65 @@ Map {
       },
     },
   },
+  "unstable_Tabs" => Object {
+    "defaultProps": Object {
+      "role": "navigation",
+      "selected": 0,
+      "selectionMode": "automatic",
+      "type": "default",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "hidden": Object {
+        "type": "bool",
+      },
+      "light": Object {
+        "type": "bool",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "onKeyDown": Object {
+        "type": "func",
+      },
+      "onSelectionChange": Object {
+        "type": "func",
+      },
+      "role": Object {
+        "isRequired": true,
+        "type": "string",
+      },
+      "selected": Object {
+        "type": "number",
+      },
+      "selectionMode": Object {
+        "args": Array [
+          Array [
+            "automatic",
+            "manual",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "tabContentClassName": Object {
+        "type": "string",
+      },
+      "type": Object {
+        "args": Array [
+          Array [
+            "default",
+            "container",
+          ],
+        ],
+        "type": "oneOf",
+      },
+    },
+  },
   "unstable_TreeView" => Object {
     "TreeNode": Object {
       "propTypes": Object {

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -194,6 +194,7 @@ describe('Carbon Components React', () => {
         "UnorderedList",
         "unstable_PageSelector",
         "unstable_Pagination",
+        "unstable_Tabs",
         "unstable_TreeNode",
         "unstable_TreeView",
       ]

--- a/packages/react/src/components/TabContent/TabContent.js
+++ b/packages/react/src/components/TabContent/TabContent.js
@@ -23,8 +23,7 @@ const TabContent = (props) => {
       {...other}
       className={tabContentClasses}
       selected={selected}
-      hidden={!selected}
-      aria-live="polite">
+      hidden={!selected}>
       {children}
     </div>
   );

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -33,12 +33,19 @@ const { prefix } = settings;
 const props = {
   tabs: () => ({
     className: 'some-class',
-    light: boolean('Light variant (light)', false),
     selected: number('The index of the selected tab (selected in <Tabs>)', 1),
+    triggerHref: text(
+      'The href of trigger button for narrow mode (triggerHref in <Tabs>)',
+      '#'
+    ),
     role: text('ARIA role (role in <Tabs>)', 'navigation'),
-    // Disabling action logger for `<Tabs onClick onKeyDown>` for now given it seems to be significantly slowing down Storybook
+    iconDescription: text(
+      'The description of the trigger icon for narrow mode (iconDescription in <Tabs>)',
+      'show menu options'
+    ),
+    // Disabling action logger for `<Tabs onClick>` for now given it seems to be significantly slowing down Storybook
     // onClick: action('onClick'),
-    // onKeyDown: action('onKeyDown'),
+    onKeyDown: action('onKeyDown'),
     onSelectionChange: action('onSelectionChange'),
     tabContentClassName: text(
       'The className for the child `<TabContent>` components',
@@ -106,6 +113,7 @@ const TabContentRenderedOnlyWhenSelected = ({
 export default {
   title: 'Tabs',
   decorators: [withKnobs],
+
   parameters: {
     component: Tabs,
     docs: {
@@ -119,49 +127,47 @@ export default {
 };
 
 export const Default = () => (
-  <div className={props.tabs().light ? 'tabs-story-wrapper--light' : null}>
-    <Tabs {...props.tabs()}>
-      <Tab id="tab-1" {...props.tab()} label="Tab label 1">
-        <div className="some-content">
-          <p>Content for first tab goes here.</p>
-        </div>
-      </Tab>
-      <Tab id="tab-2" {...props.tab()} label="Tab label 2">
-        <div className="some-content">
-          <p>Content for second tab goes here.</p>
-        </div>
-      </Tab>
-      <Tab id="tab-3" {...props.tab()} label="Tab label 3" disabled>
-        <div className="some-content">
-          <p>Content for third tab goes here.</p>
-        </div>
-      </Tab>
-      <Tab
-        id="tab-4"
-        {...props.tab()}
-        label="Tab label 4 shows truncation"
-        title="Tab label 4 shows truncation"
-        renderContent={TabContentRenderedOnlyWhenSelected}>
-        <div className="some-content">
-          <p>Content for fourth tab goes here.</p>
-          <p>
-            This example uses the&nbsp;
-            <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
-            re-render content when the tab is selected.
-          </p>
-          <CodeSnippetExample />
-        </div>
-      </Tab>
-      <Tab
-        id="tab-5"
-        {...props.tab()}
-        label={<CustomLabel text="Custom Label" />}>
-        <div className="some-content">
-          <p>Content for fifth tab goes here.</p>
-        </div>
-      </Tab>
-    </Tabs>
-  </div>
+  <Tabs {...props.tabs()}>
+    <Tab id="tab-1" {...props.tab()} label="Tab label 1">
+      <div className="some-content">
+        <p>Content for first tab goes here.</p>
+      </div>
+    </Tab>
+    <Tab id="tab-2" {...props.tab()} label="Tab label 2">
+      <div className="some-content">
+        <p>Content for second tab goes here.</p>
+      </div>
+    </Tab>
+    <Tab id="tab-3" {...props.tab()} label="Tab label 3" disabled>
+      <div className="some-content">
+        <p>Content for third tab goes here.</p>
+      </div>
+    </Tab>
+    <Tab
+      id="tab-4"
+      {...props.tab()}
+      label="Tab label 4 shows truncation"
+      title="Tab label 4 shows truncation"
+      renderContent={TabContentRenderedOnlyWhenSelected}>
+      <div className="some-content">
+        <p>Content for fourth tab goes here.</p>
+        <p>
+          This example uses the&nbsp;
+          <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
+          re-render content when the tab is selected.
+        </p>
+        <CodeSnippetExample />
+      </div>
+    </Tab>
+    <Tab
+      id="tab-5"
+      {...props.tab()}
+      label={<CustomLabel text="Custom Label" />}>
+      <div className="some-content">
+        <p>Content for fifth tab goes here.</p>
+      </div>
+    </Tab>
+  </Tabs>
 );
 
 Default.parameters = {
@@ -174,48 +180,43 @@ Default.parameters = {
 };
 
 export const Container = () => (
-  <div
-    className={
-      props.tabs().light ? 'container-tabs-story-wrapper--light' : null
-    }>
-    <Tabs type="container" {...props.tabs()}>
-      <Tab id="tab-1" {...props.tab()} label="Tab label 1">
-        <div className="some-content">
-          <p>Content for first tab goes here.</p>
-        </div>
-      </Tab>
-      <Tab id="tab-2" {...props.tab()} label="Tab label 2">
-        <div className="some-content">
-          <p>Content for second tab goes here.</p>
-        </div>
-      </Tab>
-      <Tab
-        id="tab-3"
-        {...props.tab()}
-        label="Tab label 3 renders content only when selected"
-        title="Tab label 3 renders content only when selected"
-        renderContent={TabContentRenderedOnlyWhenSelected}>
-        <div className="some-content">
-          <p>Content for third tab goes here.</p>
-          <p>
-            This example uses the&nbsp;
-            <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
-            re-render content when the tab is selected.
-          </p>
-          <CodeSnippetExample />
-        </div>
-      </Tab>
-      <Tab
-        id="tab-4"
-        {...props.tab()}
-        label={<CustomLabel text="Custom Label" />}>
-        <div className="some-content">
-          <p>Content for fourth tab goes here.</p>
-          <TextInput light id="sample-input" labelText="Text Input Label" />
-        </div>
-      </Tab>
-    </Tabs>
-  </div>
+  <Tabs type="container" {...props.tabs()}>
+    <Tab id="tab-1" {...props.tab()} label="Tab label 1">
+      <div className="some-content">
+        <p>Content for first tab goes here.</p>
+      </div>
+    </Tab>
+    <Tab id="tab-2" {...props.tab()} label="Tab label 2">
+      <div className="some-content">
+        <p>Content for second tab goes here.</p>
+      </div>
+    </Tab>
+    <Tab
+      id="tab-3"
+      {...props.tab()}
+      label="Tab label 3 renders content only when selected"
+      title="Tab label 3 renders content only when selected"
+      renderContent={TabContentRenderedOnlyWhenSelected}>
+      <div className="some-content">
+        <p>Content for third tab goes here.</p>
+        <p>
+          This example uses the&nbsp;
+          <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
+          re-render content when the tab is selected.
+        </p>
+        <CodeSnippetExample />
+      </div>
+    </Tab>
+    <Tab
+      id="tab-4"
+      {...props.tab()}
+      label={<CustomLabel text="Custom Label" />}>
+      <div className="some-content">
+        <p>Content for fourth tab goes here.</p>
+        <TextInput light id="sample-input" labelText="Text Input Label" />
+      </div>
+    </Tab>
+  </Tabs>
 );
 
 Container.parameters = {
@@ -228,7 +229,9 @@ Container.parameters = {
 };
 
 export const Skeleton = () => <TabsSkeleton />;
+
 Skeleton.storyName = 'skeleton';
+
 Skeleton.parameters = {
   info: {
     text: `

--- a/packages/react/src/components/Tabs/Tabs-story.scss
+++ b/packages/react/src/components/Tabs/Tabs-story.scss
@@ -13,16 +13,3 @@ $css--reset: false;
   min-height: 320px;
   background-color: $ui-01;
 }
-
-.bx--tabs--container.bx--tabs--light ~ div {
-  background-color: $ui-background;
-}
-
-.tabs-story-wrapper--light {
-  background-color: $ui-01;
-}
-
-.container-tabs-story-wrapper--light {
-  padding: 2rem 1rem;
-  background-color: $ui-01;
-}

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { ChevronDown16 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
 import { shallow, mount } from 'enzyme';
 import Tabs from '../Tabs';
@@ -14,7 +15,16 @@ import TabsSkeleton from '../Tabs/Tabs.Skeleton';
 
 const { prefix } = settings;
 
-Element.prototype.scrollIntoView = jest.fn();
+window.matchMedia = jest.fn().mockImplementation((query) => ({
+  matches: true,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(), // deprecated
+  removeListener: jest.fn(), // deprecated
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+}));
 
 describe('Tabs', () => {
   describe('renders as expected', () => {
@@ -66,6 +76,36 @@ describe('Tabs', () => {
         expect(
           'selectionMode' in wrapper.find(`.${prefix}--tabs`).props()
         ).toBe(false);
+      });
+    });
+
+    describe('Trigger (<div>)', () => {
+      const wrapper = shallow(
+        <Tabs className="extra-class">
+          <Tab label="firstTab">content1</Tab>
+          <Tab label="lastTab">content2</Tab>
+        </Tabs>
+      );
+
+      const trigger = wrapper.find(`div.${prefix}--tabs-trigger`);
+      const tablist = wrapper.find('ul');
+
+      it('renders default className for trigger', () => {
+        expect(trigger.hasClass(`${prefix}--tabs-trigger`)).toBe(true);
+      });
+
+      it('renders hidden className by default', () => {
+        expect(tablist.hasClass(`${prefix}--tabs__nav--hidden`)).toBe(true);
+      });
+
+      it('renders default className for triggerText', () => {
+        expect(trigger.find('a').hasClass(`${prefix}--tabs-trigger-text`)).toBe(
+          true
+        );
+      });
+
+      it('renders <Icon>', () => {
+        expect(trigger.find(ChevronDown16).length).toBe(1);
       });
     });
 
@@ -132,6 +172,39 @@ describe('Tabs', () => {
   });
 
   describe('events', () => {
+    describe('click', () => {
+      const wrapper = mount(
+        <Tabs>
+          <Tab label="firstTab" className="firstTab">
+            content1
+          </Tab>
+          <Tab label="lastTab" className="lastTab">
+            content2
+          </Tab>
+        </Tabs>
+      );
+
+      describe('state: dropdownHidden', () => {
+        it('toggles dropdownHidden state after trigger is clicked', () => {
+          const trigger = wrapper.find(`.${prefix}--tabs-trigger`);
+
+          trigger.simulate('click');
+          expect(wrapper.state().dropdownHidden).toEqual(false);
+          trigger.simulate('click');
+          expect(wrapper.state().dropdownHidden).toEqual(true);
+        });
+
+        it('toggles hidden state after trigger-text is clicked', () => {
+          const triggerText = wrapper.find(`.${prefix}--tabs-trigger-text`);
+
+          triggerText.simulate('click');
+          expect(wrapper.state().dropdownHidden).toEqual(false);
+          triggerText.simulate('click');
+          expect(wrapper.state().dropdownHidden).toEqual(true);
+        });
+      });
+    });
+
     describe('keydown', () => {
       const leftKey = 37;
       const rightKey = 39;
@@ -267,6 +340,12 @@ describe('Tabs', () => {
         </Tab>
       </Tabs>
     );
+
+    describe('dropdownHidden', () => {
+      it('should be true', () => {
+        expect(wrapper.state().dropdownHidden).toEqual(true);
+      });
+    });
 
     describe('selected', () => {
       it('should be 0', () => {

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -53,7 +53,7 @@ describe('Tabs', () => {
       });
 
       it('renders expected classes on wrapping <div> by default', () => {
-        expect(wrapper.find('div').first().hasClass(`${prefix}--tabs`)).toBe(
+        expect(wrapper.find('div').at(1).hasClass(`${prefix}--tabs`)).toBe(
           true
         );
       });
@@ -67,7 +67,7 @@ describe('Tabs', () => {
             </Tabs>
           )
             .find('div')
-            .first()
+            .at(1)
             .hasClass(`${prefix}--tabs--container`)
         ).toBe(true);
       });

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -295,7 +295,7 @@ export default class Tabs extends React.Component {
     const selectedLabel = selectedTab ? selectedTab.props.label : '';
 
     return (
-      <>
+      <div className={`${prefix}--tabs--stable`}>
         <div {...other} className={classes.tabs} role={role}>
           <div
             role="listbox"
@@ -320,7 +320,7 @@ export default class Tabs extends React.Component {
           </ul>
         </div>
         {tabContentWithProps}
-      </>
+      </div>
     );
   }
 }

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -161,32 +161,6 @@ export default class Tabs extends React.Component {
     window.removeEventListener('resize', this._debouncedHandleWindowResize);
   }
 
-  componentDidUpdate() {
-    // compare current tablist properties to current state
-    const {
-      clientWidth: tablistClientWidth,
-      scrollLeft: tablistScrollLeft,
-      scrollWidth: tablistScrollWidth,
-    } = this.tablist.current;
-    const {
-      tablistClientWidth: currentStateClientWidth,
-      tablistScrollLeft: currentStateScrollLeft,
-      tablistScrollWidth: currentStateScrollWidth,
-    } = this.state;
-    if (
-      tablistClientWidth !== currentStateClientWidth ||
-      tablistScrollLeft !== currentStateScrollLeft ||
-      tablistScrollWidth !== currentStateScrollWidth
-    ) {
-      this.setState({
-        horizontalOverflow: tablistScrollWidth > tablistClientWidth,
-        tablistClientWidth,
-        tablistScrollLeft,
-        tablistScrollWidth,
-      });
-    }
-  }
-
   getEnabledTabs = () =>
     React.Children.toArray(this.props.children).reduce(
       (enabledTabs, tab, index) =>

--- a/packages/react/src/components/Tabs/experimental/Tabs-story.js
+++ b/packages/react/src/components/Tabs/experimental/Tabs-story.js
@@ -1,0 +1,238 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import {
+  withKnobs,
+  boolean,
+  number,
+  select,
+  text,
+} from '@storybook/addon-knobs';
+import { settings } from 'carbon-components';
+import classNames from 'classnames';
+import './Tabs-story.scss';
+import CodeSnippet from '../../CodeSnippet';
+import Tabs from './Tabs';
+import Tab from '../../Tab';
+import TextInput from '../../TextInput';
+import TabsSkeleton from '../Tabs.Skeleton';
+import mdx from './Tabs.mdx';
+
+const selectionModes = {
+  'Change selection automatically upon focus (automatic)': 'automatic',
+  'Change selection on explicit gesture (manual)': 'manual',
+};
+
+const { prefix } = settings;
+const props = {
+  tabs: () => ({
+    className: 'some-class',
+    light: boolean('Light variant (light)', false),
+    selected: number('The index of the selected tab (selected in <Tabs>)', 1),
+    role: text('ARIA role (role in <Tabs>)', 'navigation'),
+    // Disabling action logger for `<Tabs onClick onKeyDown>` for now given it seems to be significantly slowing down Storybook
+    // onClick: action('onClick'),
+    // onKeyDown: action('onKeyDown'),
+    onSelectionChange: action('onSelectionChange'),
+    tabContentClassName: text(
+      'The className for the child `<TabContent>` components',
+      'tab-content'
+    ),
+    selectionMode: select(
+      'Selection mode (selectionMode)',
+      selectionModes,
+      'automatic'
+    ),
+  }),
+  tab: () => ({
+    disabled: boolean('Disabled (disabled in <Tab>)', false),
+    href: text('The href for tab (href in <Tab>)', '#'),
+    role: text('ARIA role (role in <Tab>)', 'presentation'),
+    tabIndex: number('Tab index (tabIndex in <Tab>)', 0),
+    onClick: action('onClick'),
+    onKeyDown: action('onKeyDown'),
+  }),
+};
+
+const CustomLabel = ({ text }) => text;
+
+const CodeSnippetExample = () => (
+  <CodeSnippet type="multi">
+    {`@mixin grid-container {
+  width: 100%;
+  padding-right: padding(mobile);
+  padding-left: padding(mobile);
+  @include breakpoint(bp--xs--major) {
+    padding-right: padding(xs);
+    padding-left: padding(xs);
+  }
+}
+$z-indexes: (
+  modal : 9000,
+  overlay : 8000,
+  dropdown : 7000,
+  header : 6000,
+  footer : 5000,
+  hidden : - 1,
+  overflowHidden: - 1,
+  floating: 10000
+);`}
+  </CodeSnippet>
+);
+
+const TabContentRenderedOnlyWhenSelected = ({
+  selected,
+  children,
+  className,
+  ...other
+}) =>
+  !selected ? (
+    <div {...other} className={`${prefix}--visually-hidden`} />
+  ) : (
+    <div
+      {...other}
+      className={classNames(className, `${prefix}--tab-content`)}
+      selected={selected}>
+      {children}
+    </div>
+  );
+
+export default {
+  title: 'unstable_Tabs',
+  decorators: [withKnobs],
+  parameters: {
+    component: Tabs,
+    docs: {
+      page: mdx,
+    },
+    subcomponents: {
+      Tab,
+      TabsSkeleton,
+    },
+  },
+};
+
+export const Default = () => (
+  <div className={props.tabs().light ? 'tabs-story-wrapper--light' : null}>
+    <Tabs {...props.tabs()}>
+      <Tab id="tab-1" {...props.tab()} label="Tab label 1">
+        <div className="some-content">
+          <p>Content for first tab goes here.</p>
+        </div>
+      </Tab>
+      <Tab id="tab-2" {...props.tab()} label="Tab label 2">
+        <div className="some-content">
+          <p>Content for second tab goes here.</p>
+        </div>
+      </Tab>
+      <Tab id="tab-3" {...props.tab()} label="Tab label 3" disabled>
+        <div className="some-content">
+          <p>Content for third tab goes here.</p>
+        </div>
+      </Tab>
+      <Tab
+        id="tab-4"
+        {...props.tab()}
+        label="Tab label 4 shows truncation"
+        title="Tab label 4 shows truncation"
+        renderContent={TabContentRenderedOnlyWhenSelected}>
+        <div className="some-content">
+          <p>Content for fourth tab goes here.</p>
+          <p>
+            This example uses the&nbsp;
+            <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
+            re-render content when the tab is selected.
+          </p>
+          <CodeSnippetExample />
+        </div>
+      </Tab>
+      <Tab
+        id="tab-5"
+        {...props.tab()}
+        label={<CustomLabel text="Custom Label" />}>
+        <div className="some-content">
+          <p>Content for fifth tab goes here.</p>
+        </div>
+      </Tab>
+    </Tabs>
+  </div>
+);
+
+Default.parameters = {
+  info: {
+    text: `
+        Tabs are used to quickly navigate between views within the same context. Create individual
+        Tab components for each item in the Tabs list.
+      `,
+  },
+};
+
+export const Container = () => (
+  <div
+    className={
+      props.tabs().light ? 'container-tabs-story-wrapper--light' : null
+    }>
+    <Tabs type="container" {...props.tabs()}>
+      <Tab id="tab-1" {...props.tab()} label="Tab label 1">
+        <div className="some-content">
+          <p>Content for first tab goes here.</p>
+        </div>
+      </Tab>
+      <Tab id="tab-2" {...props.tab()} label="Tab label 2">
+        <div className="some-content">
+          <p>Content for second tab goes here.</p>
+        </div>
+      </Tab>
+      <Tab
+        id="tab-3"
+        {...props.tab()}
+        label="Tab label 3 renders content only when selected"
+        title="Tab label 3 renders content only when selected"
+        renderContent={TabContentRenderedOnlyWhenSelected}>
+        <div className="some-content">
+          <p>Content for third tab goes here.</p>
+          <p>
+            This example uses the&nbsp;
+            <CodeSnippet type="inline">renderContent</CodeSnippet> prop to
+            re-render content when the tab is selected.
+          </p>
+          <CodeSnippetExample />
+        </div>
+      </Tab>
+      <Tab
+        id="tab-4"
+        {...props.tab()}
+        label={<CustomLabel text="Custom Label" />}>
+        <div className="some-content">
+          <p>Content for fourth tab goes here.</p>
+          <TextInput light id="sample-input" labelText="Text Input Label" />
+        </div>
+      </Tab>
+    </Tabs>
+  </div>
+);
+
+Container.parameters = {
+  info: {
+    text: `
+        Tabs are used to quickly navigate between views within the same context. Create individual
+        Tab components for each item in the Tabs list.
+      `,
+  },
+};
+
+export const Skeleton = () => <TabsSkeleton />;
+Skeleton.storyName = 'skeleton';
+Skeleton.parameters = {
+  info: {
+    text: `
+            Placeholder skeleton state to use when content is loading.
+          `,
+  },
+};

--- a/packages/react/src/components/Tabs/experimental/Tabs-story.scss
+++ b/packages/react/src/components/Tabs/experimental/Tabs-story.scss
@@ -1,0 +1,28 @@
+// IMPORTANT: This import path should _not_ be used outside our source tree
+// as `src` directory is _not_ meant to be shipped in our NPM package.
+// Use e.g. `@import '~carbon-components/scss/globals/scss/styles.scss'` instead.
+
+$css--font-face: false;
+$css--body: false;
+$css--reset: false;
+
+// SEE THE NOTE ABOVE
+@import '~carbon-components/src/globals/scss/css--helpers';
+
+.bx--tabs--unstable.bx--tabs--container ~ div {
+  min-height: 320px;
+  background-color: $ui-01;
+}
+
+.bx--tabs--unstable.bx--tabs--container.bx--tabs--light ~ div {
+  background-color: $ui-background;
+}
+
+.tabs-story-wrapper--light {
+  background-color: $ui-01;
+}
+
+.container-tabs-story-wrapper--light {
+  padding: 2rem 1rem;
+  background-color: $ui-01;
+}

--- a/packages/react/src/components/Tabs/experimental/Tabs-test.js
+++ b/packages/react/src/components/Tabs/experimental/Tabs-test.js
@@ -1,0 +1,351 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { settings } from 'carbon-components';
+import { shallow, mount } from 'enzyme';
+import Tabs from './Tabs';
+import Tab from '../../Tab';
+import TabsSkeleton from '../Tabs.Skeleton';
+
+const { prefix } = settings;
+
+Element.prototype.scrollIntoView = jest.fn();
+
+describe('Tabs', () => {
+  describe('renders as expected', () => {
+    describe('navigation (<div>)', () => {
+      const wrapper = shallow(
+        <Tabs className="extra-class">
+          <Tab label="firstTab">content1</Tab>
+          <Tab label="lastTab">content2</Tab>
+        </Tabs>
+      );
+
+      it('renders [role="navigation"] props on wrapping <div> by default', () => {
+        expect(wrapper.find(`.${prefix}--tabs`).props().role).toEqual(
+          'navigation'
+        );
+      });
+
+      it('renders [role="tablist"] props on <ul> by default', () => {
+        expect(wrapper.find('ul').props().role).toEqual('tablist');
+      });
+
+      it('renders extra classes on wrapping <div> via className prop', () => {
+        expect(wrapper.find(`.${prefix}--tabs`).hasClass('extra-class')).toBe(
+          true
+        );
+      });
+
+      it('renders expected classes on wrapping <div> by default', () => {
+        expect(wrapper.find('div').at(1).hasClass(`${prefix}--tabs`)).toBe(
+          true
+        );
+      });
+
+      it('supports container variant', () => {
+        expect(
+          shallow(
+            <Tabs className="extra-class" type="container">
+              <Tab label="firstTab">content1</Tab>
+              <Tab label="lastTab">content2</Tab>
+            </Tabs>
+          )
+            .find('div')
+            .at(1)
+            .hasClass(`${prefix}--tabs--container`)
+        ).toBe(true);
+      });
+
+      it('has no selectionMode prop', () => {
+        expect(
+          'selectionMode' in wrapper.find(`.${prefix}--tabs`).props()
+        ).toBe(false);
+      });
+    });
+
+    describe('Children (<Tab>)', () => {
+      const wrapper = shallow(
+        <Tabs>
+          <Tab label="firstTab">content1</Tab>
+          <Tab label="lastTab">content2</Tab>
+        </Tabs>
+      );
+
+      const firstTab = wrapper.find('[label="firstTab"]');
+      const lastTab = wrapper.find('[label="lastTab"]');
+
+      it('renders children as expected', () => {
+        expect(wrapper.props().children.length).toEqual(2);
+      });
+
+      it('renders index prop', () => {
+        expect(firstTab.props().index).toEqual(0);
+        expect(lastTab.props().index).toEqual(1);
+      });
+
+      it('renders selected prop (where firstTab is selected by default)', () => {
+        expect(firstTab.props().selected).toEqual(true);
+        expect(lastTab.props().selected).toEqual(false);
+      });
+    });
+  });
+
+  describe('Children (<TabContent>)', () => {
+    const wrapper = shallow(
+      <Tabs>
+        <Tab label="firstTab">content1</Tab>
+        <Tab label="lastTab">content2</Tab>
+      </Tabs>
+    );
+
+    it('renders content children as expected', () => {
+      expect(wrapper.find('TabContent').length).toEqual(2);
+    });
+
+    it('allows for custom classNames on <TabContent>', () => {
+      const customTabContentClassWrapper = shallow(
+        <Tabs tabContentClassName="tab-content">
+          <Tab label="firstTab">content1</Tab>
+          <Tab label="lastTab">content2</Tab>
+        </Tabs>
+      );
+      expect(customTabContentClassWrapper.find('.tab-content').length).toEqual(
+        2
+      );
+    });
+
+    it('renders hidden props with boolean value', () => {
+      const hiddenProp = wrapper.find('TabContent').first().props().hidden;
+      expect(typeof hiddenProp).toBe('boolean');
+    });
+
+    it('renders selected props with boolean value', () => {
+      const selectedProp = wrapper.find('TabContent').first().props().hidden;
+      expect(typeof selectedProp).toBe('boolean');
+    });
+  });
+
+  describe('events', () => {
+    describe('keydown', () => {
+      const leftKey = 37;
+      const rightKey = 39;
+      const spaceKey = 32;
+      const enterKey = 13;
+
+      let wrapper;
+      let firstTab;
+      let lastTab;
+      let anchorInFirstTab;
+      let anchorInLastTab;
+      let spyFocusAnchorInFirstTab;
+      let spyFocusAnchorInLastTab;
+
+      describe('state: selected', () => {
+        beforeEach(() => {
+          wrapper = mount(
+            <Tabs selected={0}>
+              <Tab label="firstTab" className="firstTab">
+                content
+              </Tab>
+              <Tab label="lastTab" className="lastTab">
+                content
+              </Tab>
+            </Tabs>
+          );
+          firstTab = wrapper.find('.firstTab').last();
+          lastTab = wrapper.find('.lastTab').last();
+          anchorInFirstTab = firstTab.find('a').getDOMNode();
+          anchorInLastTab = lastTab.find('a').getDOMNode();
+        });
+
+        it('updates selected state when pressing arrow keys', () => {
+          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
+          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          firstTab.simulate('keydown', { which: rightKey });
+          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+          lastTab.simulate('keydown', { which: leftKey });
+          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+        });
+
+        it('loops focus and selected state from lastTab to firstTab', () => {
+          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
+          lastTab.simulate('keydown', { which: rightKey });
+          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+        });
+
+        it('loops focus and selected state from firstTab to lastTab', () => {
+          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          firstTab.simulate('keydown', { which: leftKey });
+          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+        });
+
+        it('updates selected state when pressing space or enter key', () => {
+          firstTab.simulate('keydown', { which: spaceKey });
+          expect(wrapper.state().selected).toEqual(0);
+          lastTab.simulate('keydown', { which: enterKey });
+          expect(wrapper.state().selected).toEqual(1);
+        });
+      });
+
+      describe('ignore disabled child tab', () => {
+        beforeEach(() => {
+          wrapper = mount(
+            <Tabs>
+              <Tab label="firstTab" className="firstTab">
+                content1
+              </Tab>
+              <Tab label="middleTab" className="middleTab" disabled>
+                content2
+              </Tab>
+              <Tab label="lastTab" className="lastTab">
+                content3
+              </Tab>
+            </Tabs>
+          );
+          firstTab = wrapper.find('.firstTab').last();
+          lastTab = wrapper.find('.lastTab').last();
+          anchorInFirstTab = firstTab.find('a').getDOMNode();
+          anchorInLastTab = lastTab.find('a').getDOMNode();
+        });
+        it('updates selected state when pressing arrow keys', () => {
+          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
+          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          firstTab.simulate('keydown', { which: rightKey });
+          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+          lastTab.simulate('keydown', { which: leftKey });
+          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+        });
+
+        it('loops focus and selected state from lastTab to firstTab', () => {
+          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
+          wrapper.setState({ selected: 2 });
+          lastTab.simulate('keydown', { which: rightKey });
+          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+        });
+
+        it('loops focus and selected state from firstTab to lastTab', () => {
+          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          firstTab.simulate('keydown', { which: leftKey });
+          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+        });
+
+        it('updates selected state when pressing space or enter key', () => {
+          firstTab.simulate('keydown', { which: spaceKey });
+          expect(wrapper.state().selected).toEqual(0);
+          lastTab.simulate('keydown', { which: enterKey });
+          expect(wrapper.state().selected).toEqual(2);
+        });
+      });
+
+      afterEach(() => {
+        if (spyFocusAnchorInLastTab) {
+          spyFocusAnchorInLastTab.mockRestore();
+          spyFocusAnchorInLastTab = null;
+        }
+        if (spyFocusAnchorInFirstTab) {
+          spyFocusAnchorInFirstTab.mockRestore();
+          spyFocusAnchorInFirstTab = null;
+        }
+      });
+    });
+  });
+
+  describe('default state', () => {
+    const wrapper = mount(
+      <Tabs>
+        <Tab label="firstTab" className="firstTab">
+          content
+        </Tab>
+        <Tab label="lastTab" className="lastTab">
+          content
+        </Tab>
+      </Tabs>
+    );
+
+    describe('selected', () => {
+      it('should be 0', () => {
+        expect(wrapper.state().selected).toEqual(0);
+      });
+    });
+  });
+
+  describe('Allow initial state to draw from props', () => {
+    const wrapper = mount(
+      <Tabs selected={1}>
+        <Tab label="firstTab" className="firstTab">
+          content
+        </Tab>
+        <Tab label="lastTab" className="lastTab">
+          content
+        </Tab>
+      </Tabs>
+    );
+
+    const children = wrapper.find(Tab);
+
+    it('Should apply the selected property on the selected tab', () => {
+      expect(children.first().props().selected).toEqual(false);
+      expect(children.last().props().selected).toEqual(true);
+    });
+  });
+});
+
+describe('props update', () => {
+  const wrapper = mount(
+    <Tabs selected={0}>
+      <Tab label="firstTab" className="firstTab">
+        content
+      </Tab>
+      <Tab label="lastTab" className="lastTab">
+        content
+      </Tab>
+    </Tabs>
+  );
+
+  it('updates selected state when selected prop changes', () => {
+    wrapper.setProps({ selected: 1 });
+    expect(wrapper.state().selected).toEqual(1);
+    wrapper.setProps({ selected: 0 });
+    expect(wrapper.state().selected).toEqual(0);
+  });
+
+  it('avoids updating state upon setting props, unless there the value actually changes', () => {
+    wrapper.setProps({ selected: 1 });
+    wrapper.setState({ selected: 2 });
+    wrapper.setProps({ selected: 1 });
+    expect(wrapper.state().selected).toEqual(2);
+  });
+});
+
+describe('selection change', () => {
+  const wrapper = mount(
+    <Tabs selected={0} onSelectionChange={jest.fn()}>
+      <Tab label="firstTab">content</Tab>
+      <Tab label="lastTab" className="secondTab">
+        content
+      </Tab>
+    </Tabs>
+  );
+
+  it('updates selected state when selected prop changes', () => {
+    wrapper.find('.secondTab').last().simulate('click');
+    expect(wrapper.props().onSelectionChange).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('TabsSkeleton', () => {
+  describe('Renders as expected', () => {
+    const wrapper = shallow(<TabsSkeleton />);
+
+    it('Has the expected classes', () => {
+      expect(wrapper.hasClass(`${prefix}--skeleton`)).toEqual(true);
+      expect(wrapper.hasClass(`${prefix}--tabs`)).toEqual(true);
+    });
+  });
+});

--- a/packages/react/src/components/Tabs/experimental/Tabs.Skeleton.js
+++ b/packages/react/src/components/Tabs/experimental/Tabs.Skeleton.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import cx from 'classnames';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
+
+const tab = (
+  <li className={`${prefix}--tabs__nav-item`}>
+    <div className={`${prefix}--tabs__nav-link`}>&nbsp;</div>
+  </li>
+);
+
+function TabsSkeleton({ className, ...rest }) {
+  return (
+    <div
+      className={cx(`${prefix}--tabs`, `${prefix}--skeleton`, className)}
+      {...rest}>
+      <div className={`${prefix}--tabs-trigger`}>
+        <div className={`${prefix}--tabs-trigger-text`}>&nbsp;</div>
+        <svg width="10" height="5" viewBox="0 0 10 5" fillRule="evenodd">
+          <path d="M10 0L5 5 0 0z" />
+        </svg>
+      </div>
+      <ul className={`${prefix}--tabs__nav ${prefix}--tabs__nav--hidden`}>
+        {tab}
+        {tab}
+        {tab}
+        {tab}
+      </ul>
+    </div>
+  );
+}
+
+TabsSkeleton.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+};
+
+export default TabsSkeleton;

--- a/packages/react/src/components/Tabs/experimental/Tabs.js
+++ b/packages/react/src/components/Tabs/experimental/Tabs.js
@@ -1,0 +1,463 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+import { settings } from 'carbon-components';
+import { ChevronLeft16, ChevronRight16 } from '@carbon/icons-react';
+import debounce from 'lodash.debounce';
+import { keys, match, matches } from '../../../internal/keyboard';
+
+const { prefix } = settings;
+
+export default class Tabs extends React.Component {
+  static propTypes = {
+    /**
+     * Pass in a collection of <Tab> children to be rendered depending on the
+     * currently selected tab
+     */
+    children: PropTypes.node,
+
+    /**
+     * Provide a className that is applied to the root <nav> component for the
+     * <Tabs>
+     */
+    className: PropTypes.string,
+
+    /**
+     * Specify whether the Tab content is hidden
+     */
+    hidden: PropTypes.bool,
+
+    /**
+     * Specify whether or not to use the light component variant
+     */
+    light: PropTypes.bool,
+
+    /**
+     * Optionally provide an `onClick` handler that is invoked when a <Tab> is
+     * clicked
+     */
+    onClick: PropTypes.func,
+
+    /**
+     * Optionally provide an `onKeyDown` handler that is invoked when keyed
+     * navigation is triggered
+     */
+    onKeyDown: PropTypes.func,
+
+    /**
+     * Provide an optional handler that is called whenever the selection
+     * changes. This method is called with the index of the tab that was
+     * selected
+     */
+    onSelectionChange: PropTypes.func,
+
+    /**
+     * By default, this value is "navigation". You can also provide an alternate
+     * role if it makes sense from the accessibility-side
+     */
+    role: PropTypes.string.isRequired,
+
+    /**
+     * Optionally provide an index for the currently selected <Tab>
+     */
+    selected: PropTypes.number,
+
+    /**
+     * Choose whether or not to automatically change selection on focus
+     */
+    selectionMode: PropTypes.oneOf(['automatic', 'manual']),
+
+    /**
+     * Provide a className that is applied to the <TabContent> components
+     */
+    tabContentClassName: PropTypes.string,
+
+    /**
+     * Provide the type of Tab
+     */
+    type: PropTypes.oneOf(['default', 'container']),
+  };
+
+  static defaultProps = {
+    role: 'navigation',
+    type: 'default',
+    selected: 0,
+    selectionMode: 'automatic',
+  };
+
+  state = {
+    horizontalOverflow: false,
+  };
+
+  tablist = React.createRef();
+  leftOverflowNavButton = React.createRef();
+  rightOverflowNavButton = React.createRef();
+  // width of the overflow buttons
+  OVERFLOW_BUTTON_OFFSET = 40;
+
+  static getDerivedStateFromProps({ selected }, state) {
+    const { prevSelected } = state;
+    return prevSelected === selected
+      ? null
+      : {
+          selected,
+          prevSelected: selected,
+        };
+  }
+
+  /**
+   * `scroll` event handler to save tablist clientWidth, scrollWidth, and
+   * scrollLeft
+   */
+  handleScroll = () => {
+    if (!this.tablist?.current) {
+      return;
+    }
+    const {
+      clientWidth: tablistClientWidth,
+      scrollLeft: tablistScrollLeft,
+      scrollWidth: tablistScrollWidth,
+    } = this.tablist.current;
+    this.setState({
+      tablistClientWidth,
+      horizontalOverflow: tablistScrollWidth > tablistClientWidth,
+      tablistScrollWidth,
+      tablistScrollLeft,
+    });
+  };
+
+  /**
+   * The debounced version of the `resize` event handler.
+   * @type {Function}
+   * @private
+   */
+  _debouncedHandleWindowResize = null;
+
+  _handleWindowResize = this.handleScroll;
+
+  componentDidMount() {
+    if (!this._debouncedHandleWindowResize) {
+      this._debouncedHandleWindowResize = debounce(
+        this._handleWindowResize,
+        200
+      );
+    }
+
+    this._handleWindowResize();
+    window.addEventListener('resize', this._debouncedHandleWindowResize);
+  }
+
+  componentWillUnmount() {
+    if (this._debouncedHandleWindowResize) {
+      this._debouncedHandleWindowResize.cancel();
+    }
+    window.removeEventListener('resize', this._debouncedHandleWindowResize);
+  }
+
+  componentDidUpdate() {
+    // compare current tablist properties to current state
+    const {
+      clientWidth: tablistClientWidth,
+      scrollLeft: tablistScrollLeft,
+      scrollWidth: tablistScrollWidth,
+    } = this.tablist.current;
+    const {
+      tablistClientWidth: currentStateClientWidth,
+      tablistScrollLeft: currentStateScrollLeft,
+      tablistScrollWidth: currentStateScrollWidth,
+    } = this.state;
+    if (
+      tablistClientWidth !== currentStateClientWidth ||
+      tablistScrollLeft !== currentStateScrollLeft ||
+      tablistScrollWidth !== currentStateScrollWidth
+    ) {
+      this.setState({
+        horizontalOverflow: tablistScrollWidth > tablistClientWidth,
+        tablistClientWidth,
+        tablistScrollLeft,
+        tablistScrollWidth,
+      });
+    }
+  }
+
+  getEnabledTabs = () =>
+    React.Children.toArray(this.props.children).reduce(
+      (enabledTabs, tab, index) =>
+        !tab.props.disabled ? enabledTabs.concat(index) : enabledTabs,
+      []
+    );
+
+  getNextIndex = (index, direction) => {
+    const enabledTabs = this.getEnabledTabs();
+    const nextIndex = Math.max(
+      enabledTabs.indexOf(index) + direction,
+      // For `tab` not found in `enabledTabs`
+      -1
+    );
+    const nextIndexLooped =
+      nextIndex >= 0 && nextIndex < enabledTabs.length
+        ? nextIndex
+        : nextIndex - Math.sign(nextIndex) * enabledTabs.length;
+    return enabledTabs[nextIndexLooped];
+  };
+
+  getDirection = (evt) => {
+    if (match(evt, keys.ArrowLeft)) {
+      return -1;
+    }
+    if (match(evt, keys.ArrowRight)) {
+      return 1;
+    }
+    return 0;
+  };
+
+  getTabAt = (index, useFresh) =>
+    (!useFresh && this[`tab${index}`]) ||
+    React.Children.toArray(this.props.children)[index];
+
+  scrollTabIntoView = (event, { index }) => {
+    const tab = this.getTabAt(index);
+    if (
+      matches(event, [keys.ArrowLeft, keys.ArrowRight]) ||
+      event.type === 'click'
+    ) {
+      const currentScrollLeft = this.state.tablistScrollLeft;
+      tab?.tabAnchor?.scrollIntoView({ inline: 'nearest' });
+      const newScrollLeft = this.tablist.current.scrollLeft;
+      if (newScrollLeft > currentScrollLeft) {
+        this.tablist.current.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;
+      }
+    }
+  };
+
+  selectTabAt = (event, { index, onSelectionChange }) => {
+    this.scrollTabIntoView(event, { index });
+    if (this.state.selected !== index) {
+      this.setState({
+        selected: index,
+      });
+      if (typeof onSelectionChange === 'function') {
+        onSelectionChange(index);
+      }
+    }
+  };
+
+  handleTabKeyDown = (onSelectionChange) => {
+    return (index, evt) => {
+      if (matches(evt, [keys.Enter, keys.Space])) {
+        this.selectTabAt(evt, { index, onSelectionChange });
+      }
+      const nextIndex = this.getNextIndex(index, this.getDirection(evt));
+      const tab = this.getTabAt(nextIndex);
+      if (matches(evt, [keys.ArrowLeft, keys.ArrowRight])) {
+        evt.preventDefault();
+        if (this.props.selectionMode !== 'manual') {
+          this.selectTabAt(evt, { index: nextIndex, onSelectionChange });
+        } else {
+          this.scrollTabIntoView(evt, { index: nextIndex });
+        }
+        tab?.tabAnchor?.focus();
+      }
+    };
+  };
+
+  getTabs = () => React.Children.map(this.props.children, (tab) => tab);
+
+  // following functions (handle*) are Props on Tab.js, see Tab.js for parameters
+  handleTabClick = (onSelectionChange) => (index, evt) => {
+    evt.preventDefault();
+    this.selectTabAt(evt, { index, onSelectionChange });
+  };
+
+  setTabAt = (index, tabRef) => {
+    this[`tab${index}`] = tabRef;
+  };
+
+  overflowNavInterval = null;
+
+  handleOverflowNavClick = (_, { direction, multiplier = 15 }) => {
+    // account for overflow button appearing and causing tablist width change
+    const { clientWidth, scrollLeft, scrollWidth } = this.tablist?.current;
+    if (direction === 1 && !scrollLeft) {
+      this.tablist.current.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;
+    }
+
+    this.tablist.current.scrollLeft += direction * multiplier;
+
+    const leftEdgeReached =
+      direction === -1 && scrollLeft < this.OVERFLOW_BUTTON_OFFSET;
+    const rightEdgeReached =
+      direction === 1 &&
+      scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
+    if (leftEdgeReached || rightEdgeReached) {
+      if (leftEdgeReached) {
+        this.rightOverflowNavButton?.current?.focus();
+      }
+      if (rightEdgeReached) {
+        this.leftOverflowNavButton?.current?.focus();
+      }
+    }
+  };
+
+  handleOverflowNavMouseDown = (_, { direction }) => {
+    this.overflowNavInterval = setInterval(() => {
+      const { clientWidth, scrollLeft, scrollWidth } = this.tablist?.current;
+
+      // clear interval if scroll reaches left or right edge
+      const leftEdgeReached =
+        direction === -1 && scrollLeft < this.OVERFLOW_BUTTON_OFFSET;
+      const rightEdgeReached =
+        direction === 1 &&
+        scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
+      if (leftEdgeReached || rightEdgeReached) {
+        clearInterval(this.overflowNavInterval);
+      }
+
+      // account for overflow button appearing and causing tablist width change
+      this.handleOverflowNavClick(_, { direction });
+    });
+  };
+
+  handleOverflowNavMouseUp = () => {
+    clearInterval(this.overflowNavInterval);
+  };
+
+  render() {
+    const {
+      className,
+      role,
+      type,
+      light,
+      onSelectionChange,
+      selectionMode, // eslint-disable-line no-unused-vars
+      tabContentClassName,
+      ...other
+    } = this.props;
+
+    /**
+     * The tab panel acts like a tab panel when the screen is wider, but acts
+     * like a select list when the screen is narrow.  In the wide case we want
+     * to allow the user to use the tab key to set the focus in the tab panel
+     * and then use the left and right arrow keys to navigate the tabs.  In the
+     * narrow case we want to use the tab key to select different options in
+     * the list.
+     *
+     * We set the tab index based on the different states so the browser will treat
+     * the whole tab panel as a single focus component when it looks like a tab
+     * panel and separate components when it looks like a select list.
+     */
+    const tabsWithProps = this.getTabs().map((tab, index) => {
+      const tabIndex = index === this.state.selected ? 0 : -1;
+      const newTab = React.cloneElement(tab, {
+        index,
+        selected: index === this.state.selected,
+        handleTabClick: this.handleTabClick(onSelectionChange),
+        tabIndex,
+        ref: (e) => {
+          this.setTabAt(index, e);
+        },
+        handleTabKeyDown: this.handleTabKeyDown(onSelectionChange),
+      });
+
+      return newTab;
+    });
+
+    const tabContentWithProps = React.Children.map(tabsWithProps, (tab) => {
+      const {
+        id: tabId,
+        children,
+        selected,
+        renderContent: TabContent,
+      } = tab.props;
+
+      return (
+        <TabContent
+          id={tabId && `${tabId}__panel`}
+          className={tabContentClassName}
+          aria-hidden={!selected}
+          hidden={!selected}
+          selected={selected}
+          aria-labelledby={tabId}>
+          {children}
+        </TabContent>
+      );
+    });
+
+    const leftOverflowNavButtonHidden =
+      !this.state.horizontalOverflow || !this.state.tablistScrollLeft;
+    const rightOverflowNavButtonHidden =
+      !this.state.horizontalOverflow ||
+      this.state.tablistScrollLeft + this.state.tablistClientWidth ===
+        this.state.tablistScrollWidth;
+    const classes = {
+      tabs: classNames(
+        `${prefix}--tabs`,
+        `${prefix}--tabs--unstable`,
+        className,
+        {
+          [`${prefix}--tabs--container`]: type === 'container',
+          [`${prefix}--tabs--light`]: light,
+        }
+      ),
+      tablist: classNames(`${prefix}--tabs__nav`),
+      leftOverflowButtonClasses: classNames({
+        [`${prefix}--tab--overflow-nav-button`]: this.state.horizontalOverflow,
+        [`${prefix}--tab--overflow-nav-button--hidden`]: leftOverflowNavButtonHidden,
+      }),
+      rightOverflowButtonClasses: classNames({
+        [`${prefix}--tab--overflow-nav-button`]: this.state.horizontalOverflow,
+        [`${prefix}--tab--overflow-nav-button--hidden`]: rightOverflowNavButtonHidden,
+      }),
+    };
+
+    return (
+      <div className={`${prefix}--unstable_tabs`}>
+        <div
+          {...other}
+          className={classes.tabs}
+          role={role}
+          onScroll={this.handleScroll}>
+          <button
+            type="button"
+            className={classes.leftOverflowButtonClasses}
+            onClick={(_) => this.handleOverflowNavClick(_, { direction: -1 })}
+            onMouseDown={(_) =>
+              this.handleOverflowNavMouseDown(_, { direction: -1 })
+            }
+            onMouseUp={this.handleOverflowNavMouseUp}
+            ref={this.leftOverflowNavButton}>
+            <ChevronLeft16 />
+          </button>
+          {!leftOverflowNavButtonHidden && (
+            <div className={`${prefix}--tabs__overflow-indicator--left`} />
+          )}
+          <ul role="tablist" className={classes.tablist} ref={this.tablist}>
+            {tabsWithProps}
+          </ul>
+          {!rightOverflowNavButtonHidden && (
+            <div className={`${prefix}--tabs__overflow-indicator--right`} />
+          )}
+          <button
+            type="button"
+            className={classes.rightOverflowButtonClasses}
+            onClick={(_) => this.handleOverflowNavClick(_, { direction: 1 })}
+            onMouseDown={(_) =>
+              this.handleOverflowNavMouseDown(_, { direction: 1 })
+            }
+            onMouseUp={this.handleOverflowNavMouseUp}
+            ref={this.rightOverflowNavButton}>
+            <ChevronRight16 />
+          </button>
+        </div>
+        {tabContentWithProps}
+      </div>
+    );
+  }
+}

--- a/packages/react/src/components/Tabs/experimental/Tabs.mdx
+++ b/packages/react/src/components/Tabs/experimental/Tabs.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Tabs
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tabs)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tabs/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tabs/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tabs/Tabs.mdx).

--- a/packages/react/src/components/Tabs/experimental/index.js
+++ b/packages/react/src/components/Tabs/experimental/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export * from './Tabs.Skeleton';
+export default from './Tabs';

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -202,6 +202,7 @@ export {
   PageSelector as unstable_PageSelector,
   Pagination as unstable_Pagination,
 } from './components/Pagination/experimental';
+export unstable_Tabs from './components/Tabs/experimental';
 export unstable_TreeView, {
   TreeNode as unstable_TreeNode,
 } from './components/TreeView';


### PR DESCRIPTION
Closes #6798
Ref #4758

This PR restores the dropdown tabs and moves the new mobile Tabs variation to the `unstable_Tabs` component

**Changed**

- converted fragment to namespaced `div` in `Tabs` and `unstable_Tabs`. This saves us the trouble of renaming classes individually and only requires us to remove the added parent class in our stylesheet, once the scrolling tabs variant replaces the default. The div can be reverted to a fragment at that time as well

#### Testing / Reviewing

Ensure the dropdown tabs and new mobile tabs appear and function correctly