### PR TITLE
docs(ComposedModal): add storybook MDX example

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal-story.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-story.js
@@ -5,16 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { settings } from 'carbon-components';
 import ComposedModal, {
   ModalHeader,
   ModalBody,
   ModalFooter,
 } from '../ComposedModal';
 import Button from '../Button';
-import { settings } from 'carbon-components';
+import mdx from './ComposedModal.mdx';
 
 const { prefix } = settings;
 
@@ -39,6 +41,15 @@ const props = {
       'Prevent closing on click outside of modal (preventCloseOnClickOutside)',
       false
     ),
+  }),
+  composedModalWithLauncher: ({ titleOnly } = {}) => ({
+    onKeyDown: action('onKeyDown'),
+    danger: boolean('Danger mode (danger)', false),
+    selectorPrimaryFocus: text(
+      'Primary focus element selector (selectorPrimaryFocus)',
+      '[data-modal-primary-focus]'
+    ),
+    size: select('Size (size)', sizes, titleOnly ? 'sm' : ''),
   }),
   modalHeader: ({ titleOnly } = {}) => ({
     label: text('Optional Label (label in <ModalHeader>)', 'Optional Label'),
@@ -140,23 +151,45 @@ const scrollingContent = (
   </>
 );
 
+/**
+ * Simple state manager for modals.
+ */
+const ModalStateManager = ({
+  renderLauncher: LauncherContent,
+  children: ModalContent,
+}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      {!ModalContent || typeof document === 'undefined'
+        ? null
+        : ReactDOM.createPortal(
+            <ModalContent open={open} setOpen={setOpen} />,
+            document.body
+          )}
+      {LauncherContent && <LauncherContent open={open} setOpen={setOpen} />}
+    </>
+  );
+};
+
 export default {
   title: 'ComposedModal',
   decorators: [withKnobs],
-
   parameters: {
     component: ComposedModal,
-
     subcomponents: {
       ModalHeader,
       ModalBody,
       ModalFooter,
     },
+    docs: {
+      page: mdx,
+    },
   },
 };
 
 export const UsingHeaderFooterProps = () => {
-  const { size, ...rest } = props.composedModal();
+  const { size, ...rest } = props.composedModalWithLauncher();
   const { hasScrollingContent, ...bodyProps } = props.modalBody();
   return (
     <ComposedModal {...rest} danger={true} size={size || undefined}>
@@ -248,46 +281,40 @@ TitleOnly.parameters = {
   },
 };
 
-export const ExampleUsageWithTriggerButton = () => {
-  class ComposedModalExample extends React.Component {
-    state = { open: false };
-    toggleModal = (open) => this.setState({ open });
-    render() {
-      const { open } = this.state;
-      const { size, ...rest } = props.composedModal();
-      const { hasScrollingContent, ...bodyProps } = props.modalBody();
-      return (
-        <>
-          <Button onClick={() => this.toggleModal(true)}>
-            Launch composed modal
-          </Button>
-          <ComposedModal
-            {...rest}
-            open={open}
-            size={size || undefined}
-            onClose={() => this.toggleModal(false)}>
-            <ModalHeader {...props.modalHeader()} />
-            <ModalBody
-              {...bodyProps}
-              aria-label={hasScrollingContent ? 'Modal content' : undefined}>
-              <p className={`${prefix}--modal-content__text`}>
-                Please see ModalWrapper for more examples and demo of the
-                functionality.
-              </p>
-              {hasScrollingContent && scrollingContent}
-            </ModalBody>
-            <ModalFooter {...props.modalFooter()} />
-          </ComposedModal>
-        </>
-      );
-    }
-  }
-  return <ComposedModalExample />;
+export const WithTriggerButton = () => {
+  const { size, ...rest } = props.composedModalWithLauncher();
+  const { hasScrollingContent, ...bodyProps } = props.modalBody();
+  return (
+    <ModalStateManager
+      renderLauncher={({ setOpen }) => (
+        <Button onClick={() => setOpen(true)}>Launch composed modal</Button>
+      )}>
+      {({ open, setOpen }) => (
+        <ComposedModal
+          {...rest}
+          open={open}
+          size={size || undefined}
+          onClose={() => setOpen(false)}>
+          <ModalHeader {...props.modalHeader()} />
+          <ModalBody
+            {...bodyProps}
+            aria-label={hasScrollingContent ? 'Modal content' : undefined}>
+            <p className={`${prefix}--modal-content__text`}>
+              Please see ModalWrapper for more examples and demo of the
+              functionality.
+            </p>
+            {hasScrollingContent && scrollingContent}
+          </ModalBody>
+          <ModalFooter {...props.modalFooter()} />
+        </ComposedModal>
+      )}
+    </ModalStateManager>
+  );
 };
 
-ExampleUsageWithTriggerButton.storyName = 'Example usage with trigger button';
+WithTriggerButton.storyName = 'Example usage with trigger button';
 
-ExampleUsageWithTriggerButton.parameters = {
+WithTriggerButton.parameters = {
   info: {
     text: `
         An example ComposedModal with a trigger button

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -292,5 +292,5 @@ on the Carbon Design System website.
 ## Feedback
 
 Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+on Slack,or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -1,0 +1,296 @@
+import { Story, Props } from '@storybook/addon-docs/blocks';
+import ComposedModal from '../ComposedModal';
+
+# ComposedModal
+
+## Overview
+
+`<ComposedModal>` provides more flexibility when it comes to custom content.
+Modal content can be customized via the `<ModalHeader>`, `<ModalBody>` and
+`<ModalFooter>` components.
+
+<Preview>
+  <Story id="composedmodal--with-trigger-button" />
+</Preview>
+
+## Component API
+
+<Props />
+
+## Opening/closing modal
+
+For both modal variants, you can open/close the modal by changing the `open`
+prop. For example, you can implement a launcher button with a React state and a
+`<Button>` that changes the state:
+
+```javascript
+function ModalStateManager() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      {typeof document === 'undefined'
+        ? null
+        : ReactDOM.createPortal(
+            <ComposedModal open={open} onClose={() => setOpen(false)}>
+              ...
+            </ComposedModal>,
+            document.body
+          )}
+      <Button kind="primary" onClick={() => setOpen(true)}>
+        Open modal
+      </Button>
+    </>
+  );
+}
+```
+
+You can create an abstract version of such state manager, as shown below.
+
+```javascript
+const ModalStateManager = ({
+  renderLauncher: LauncherContent,
+  children: ModalContent,
+}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      {!ModalContent || typeof document === 'undefined'
+        ? null
+        : ReactDOM.createPortal(
+            <ModalContent open={open} setOpen={setOpen} />,
+            document.body
+          )}
+      {LauncherContent && <LauncherContent open={open} setOpen={setOpen} />}
+    </>
+  );
+};
+```
+
+`<ModalWrapper>` is a modal state manager implementation which ships out of the
+box with Carbon.
+
+<InlineNotification kind="warning">
+  <code>{`<Modal>`}</code>/<code>{`<ComposedModal>`}</code> has to be put at the
+  top level in a React tree. The easiest way to ensure that is using React
+  portal as shown in above example.
+</InlineNotification>
+
+## Modal sizes
+
+There are four responsive
+[modal sizes](https://www.carbondesignsystem.com/components/modal/usage/#modal-sizes):
+`xs`, `small`, default, and `large`. You can set it via the `size` prop.
+
+```javascript
+<ComposedModal size="lg">
+  <ModalHeader />
+  <ModalBody>
+    <p className="bx--modal-content__text">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+      cursus fermentum risus, sit amet fringilla nunc pellentesque quis. Duis
+      quis odio ultrices, cursus lacus ac, posuere felis. Donec dignissim libero
+      in augue mattis, a molestie metus vestibulum. Aliquam placerat felis
+      ultrices lorem condimentum, nec ullamcorper felis porttitor.
+    </p>
+  </ModalBody>
+</ComposedModal>
+```
+
+#### Alignment
+
+Depending on the modal size of your choice and the viewport size,
+`<Modal>`/`<ComposedModal>` adds 20% padding at the right of the modal body
+content. Carbon design specifies that such 20% padding shouldn't be applied to
+form elements. You can set `hasForm` prop to `<Modal>`/`<ModalBody>` to remove
+the padding, and use `bx--modal-content__regular-content` class to apply the 20%
+padding to non-form contents, as shown below.
+
+```javascript
+<ComposedModal>
+  <ModalHeader />
+  <ModalBody hasForm>
+    <TextInput data-modal-primary-focus labelText="Enter something" />
+    <p className="bx--modal-content__text bx--modal-content__regular-content">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+      cursus fermentum risus, sit amet fringilla nunc pellentesque quis. Duis
+      quis odio ultrices, cursus lacus ac, posuere felis. Donec dignissim libero
+      in augue mattis, a molestie metus vestibulum. Aliquam placerat felis
+      ultrices lorem condimentum, nec ullamcorper felis porttitor.
+    </p>
+  </ModalBody>
+</ComposedModal>
+```
+
+#### Overflow content
+
+In cases where the largest modal size cannot fit your modal body content in,
+Carbon design specifies to have a "visual fade" look at the end of the modal
+body area to indicate there is additional content out of view. You can set
+`hasScrollingContent` prop to `<Modal>`/`<ModalBody>` to do that, as shown
+below.
+
+```javascript
+<ComposedModal size="large">
+  <ModalHeader />
+  <ModalBody hasScrollingContent>
+    <p className=".bx--modal-content__text">Some very large contents...</p>
+  </ModalBody>
+</ComposedModal>
+```
+
+## Modal button variants
+
+With `<Modal>`, you have limited control over the set of buttons. The following
+table shows the supported patterns.
+
+| Button group variant                                                                                 | Usage                                     |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| No button ([passive modal](https://www.carbondesignsystem.com/components/modal/usage#passive-modal)) | Use `passiveModal` prop in `<Modal>`      |
+| One button                                                                                           | Use `<ComposedModal>`                     |
+| Two buttons                                                                                          | Use `<Modal>` without `passiveModal` prop |
+| Two buttons with danger button                                                                       | Use `danger` prop in `<Modal>`            |
+
+```javascript
+<Modal danger>
+  <ModalHeader />
+  <p className="bx--modal-content__text">The modal body content</p>
+</Modal>
+```
+
+With `<ComposedModal>`, you can control the buttons with the following code.
+
+| Button group variant                                                                                 | Usage                                                                                                                                                                                                                                                          |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No button ([passive modal](https://www.carbondesignsystem.com/components/modal/usage#passive-modal)) | Use `<ComposedModal>` without `<ModalFooter>`                                                                                                                                                                                                                  |
+| One button                                                                                           | Use `primaryButtonText` in `<ModalFooter>`                                                                                                                                                                                                                     |
+| Two buttons                                                                                          | Use `primaryButtonText` and `secondaryButtonText` in `<ModalFooter>`                                                                                                                                                                                           |
+| Three buttons                                                                                        | Put three buttons as children of `<ModalFooter>`, instead of using `primaryButtonText` or `secondaryButtonText`. Using this option requires style adjustment defined in application-level CSS for `<ModalFooter>`, e.g. `.bx--modal-footer { padding: 25%; }`. |
+| Two buttons with danger button                                                                       | Set `danger` prop in `<ModalFooter>` (like below)                                                                                                                                                                                                              |
+
+```javascript
+<ComposedModal>
+  ...
+  <ModalFooter danger primaryButtonText="OK" secondaryButtonText="Cancel" />
+</ComposedModal>
+```
+
+<InlineNotification kind="warning">
+  As the instruction for the three buttons implies, <code>{`<ModalFooter>`}</code>
+  is flexible on the buttons as you render <code>{`<Button>`}</code> s by yourself,
+  as shown below. In this case, the application code needs to take care of running
+  actions upon clicking those buttons, e.g. closing the modal:
+</InlineNotification>
+
+```javascript
+<ComposedModal>
+  ...
+  <ModalFooter>
+    <Button
+      kind="secondary"
+      onClick={() => { (Run some action...) setOpen(false); }}>
+      Another button
+    </Buttton>
+    <Button
+      kind="secondary"
+      onClick={() => { (Run some action...) setOpen(false); }}>
+      Secondary button
+    </Buttton>
+    <Button
+      kind="primary"
+      onClick={() => { (Run some action...) setOpen(false); }}>
+      Priamry button
+    </Buttton>
+  </ModalFooter>
+</ComposedModal>
+```
+
+## Using modal title as message
+
+For short, direct messages the title can include the whole message to add visual
+clarity to an otherwise repetitive title and body message.
+
+To use this pattern with `<Modal>`, you can omit the `children` prop.
+
+```javascript
+const modalHeadding =
+  'Are you sure you want to add the "Speech to Text" service ' +
+  'to the node-test app?';
+...
+<Modal
+  modalHeading={modalHeading}
+  secondaryButtonText="Cancel"
+  primaryButtonText="Add"
+/>
+```
+
+To use this pattern with `<ComposedModal>`, you can omit `<ModalBody>`.
+
+```javascript
+<ComposedModal>
+  <ModalHeader label="Modla label">
+    <h1>
+      Are you sure you want to add the "Speech to Text" service to the node-test
+      app?
+    </h1>
+  </ModalHeader>
+  <ModalFooter primaryButtonText="OK" secondaryButtonText="Cancel" />
+</ComposedModal>
+```
+
+## Focus management
+
+For both modal variants, once the modal is open, keyboard focus will be
+restricted inside modal. This means:
+
+- If you press `Tab` at the last keyboard-focusable element in modal, the first
+  keyboard-focusable element in modal will get focus.
+- If you press `Shift-Tab` at the first keyboard-focusable element in the modal,
+  the last keyboard-focusable element in the modal will get focus.
+
+We take extra step here to ensure such behavior works with floating menus, given
+floating menu is placed outside of modal in DOM. If you use any non-Carbon
+floating menus in your application, set
+`selectorsFloatingMenus={['.bx--overflow-menu-options', '.bx--tooltip', '.flatpickr-calendar', '.your-floating-menu-foo', '.your-floating-menu-bar']}`
+to `<Modal>`/`<ComposedModal>`.
+
+Also for both modal variants, you can set the DOM element that gets focus when
+the modal gets open, by either of the following ways:
+
+#### Setting `data-modal-primary-focus` attribute to the target element
+
+<br />
+
+```javascript
+<ComposedModal>
+  <ModalBody hasForm>
+    <TextInput data-modal-primary-focus labelText="Enter something" />
+  </ModalBody>
+</ComposedModal>
+```
+
+#### Specifying a query selector to the target element
+
+<br />
+
+```javascript
+{
+  /* `.bx--text-input` selects the `<input>` in `<TextInput>` */
+}
+<ComposedModal selectorPrimaryFocus=".bx--text-input">
+  <ModalBody hasForm>
+    <TextInput labelText="Enter something" />
+  </ModalBody>
+</ComposedModal>;
+```
+
+## References
+
+Check out the
+[usage guidelines](https://www.carbondesignsystem.com/components/modal/usage/)
+on the Carbon Design System website.
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).


### PR DESCRIPTION
Ref #6591

This PR adds a custom modal state manager example and MDX docs to the existing ComposedModal docs

#### Testing / Reviewing

Review the composed modal state manager example and the storybook Docs tabs updates
