### PR TITLE
fix(Slider): transform invalid into proper attributes

### DIFF
--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -497,6 +497,7 @@ export default class Slider extends PureComponent {
       disabled,
       name,
       light,
+      invalid,
       ...other
     } = this.props;
 
@@ -552,6 +553,7 @@ export default class Slider extends PureComponent {
             onKeyDown={this.onKeyDown}
             role="presentation"
             tabIndex={-1}
+            data-invalid={invalid || null}
             {...other}>
             <div
               className={`${prefix}--slider__thumb`}
@@ -591,6 +593,8 @@ export default class Slider extends PureComponent {
             max={max}
             step={step}
             onChange={this.onChange}
+            data-invalid={invalid || null}
+            aria-invalid={invalid || null}
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #6808

This fixes `invalid` on Slider by transforming this prop into proper props (`aria-disabled`, `data-disabled`)

#### Changelog

**Changed**

-  Passing `invalid` on `Slider` won't no longer throws a console.log error

#### Testing / Reviewing

1. Pass invalid={true} to Slider
2. Check console log for the error