### PR TITLE
fix(components): update sideEffects flag for CSS compilations

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -176,10 +176,12 @@
     "whatwg-fetch": "^3.0.0"
   },
   "sideEffects": [
+    "css/**/*.css",
     "es/bundle.js",
     "es/globals/js/boot.js",
     "es/globals/js/watch.js",
     "scripts/*",
+    "scss/**/*.scss",
     "umd/bundle.js",
     "umd/globals/js/boot.js",
     "umd/globals/js/watch.js"


### PR DESCRIPTION
Closes #6824 

Update `sideEffects` flag to include CSS and Sass files

#### Changelog

**New**

**Changed**

- Update `sideEffects` flag to include CSS and Sass files

**Removed**
