### PR TITLE
fix(Tabs): diff tablist properties on component update

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -161,6 +161,32 @@ export default class Tabs extends React.Component {
     window.removeEventListener('resize', this._debouncedHandleWindowResize);
   }
 
+  componentDidUpdate() {
+    // compare current tablist properties to current state
+    const {
+      clientWidth: tablistClientWidth,
+      scrollLeft: tablistScrollLeft,
+      scrollWidth: tablistScrollWidth,
+    } = this.tablist.current;
+    const {
+      tablistClientWidth: currentStateClientWidth,
+      tablistScrollLeft: currentStateScrollLeft,
+      tablistScrollWidth: currentStateScrollWidth,
+    } = this.state;
+    if (
+      tablistClientWidth !== currentStateClientWidth ||
+      tablistScrollLeft !== currentStateScrollLeft ||
+      tablistScrollWidth !== currentStateScrollWidth
+    ) {
+      this.setState({
+        horizontalOverflow: tablistScrollWidth > tablistClientWidth,
+        tablistClientWidth,
+        tablistScrollLeft,
+        tablistScrollWidth,
+      });
+    }
+  }
+
   getEnabledTabs = () =>
     React.Children.toArray(this.props.children).reduce(
       (enabledTabs, tab, index) =>


### PR DESCRIPTION
Closes #6838

This PR adds a comparison check for the tablist `clientWidth`, `scrollLeft`, and `scrollWidth` values on component update so that dynamic tab list updates will not require interaction to update the overflow button visibility

#### Changelog

**New**

- diff tablist properties on component update

#### Testing / Reviewing

Refer to the example in the ticket for an example to test with. When the tablist is dynamically modified, the overflow button visibility should reflect the current tablist width
