### PR TITLE
docs(icons): update link to Angular icons

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -24,7 +24,7 @@ Icons in Carbon are provided through a variety of packages, often specific for
 the framework that will use them. Currently, we support the following packages
 for various frameworks:
 
-- [Angular](../icons-angular)
+- [Angular](https://github.com/carbon-design-system/carbon-icons-angular)
 - [React](../icons-react)
 - [Vue](../icons-vue)
 


### PR DESCRIPTION
The link to the Angular icons returns a 404, as it lives in a separate repo.

#### Changelog


**Changed**

- update hyperlink to Angular icons repo


#### Testing / Reviewing

Verify that the hyperlink is correct.
