### PR TITLE
docs(storybook): add links to source-code, usage guidelines to docs

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -155,6 +155,6 @@ or screen reader.
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and
-leaving any other comments on
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Accordion/Accordion.mdx).

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -3,6 +3,12 @@ import { Accordion, AccordionItem, AccordionSkeleton } from '../Accordion';
 
 # Accordion
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Accordion)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/accordion/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/accordion/accessibility)
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.mdx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.mdx
@@ -72,6 +72,6 @@ current page.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Breadcrumb/Breadcrumb.mdx).

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.mdx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.mdx
@@ -3,6 +3,12 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbSkeleton } from '../Breadcrumb';
 
 # Breadcrumb
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Breadcrumb)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/breadcrumb/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/breadcrumb/accessibility)
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -13,7 +19,10 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbSkeleton } from '../Breadcrumb';
 
 ## Overview
 
-You can build a breadcrumb using a combination of the `Breadcrumb` and `BreadcrumbItem` components. The `Breadcrumb` component accepts a list of `BreadcrumbItem` components as `children` and each `BreadcrumbItem` is responsible for displaying the page links in the hierarchy.
+You can build a breadcrumb using a combination of the `Breadcrumb` and
+`BreadcrumbItem` components. The `Breadcrumb` component accepts a list of
+`BreadcrumbItem` components as `children` and each `BreadcrumbItem` is
+responsible for displaying the page links in the hierarchy.
 
 <Preview>
   <Story id="breadcrumb--breadcrumb" />
@@ -21,7 +30,9 @@ You can build a breadcrumb using a combination of the `Breadcrumb` and `Breadcru
 
 ## Skeleton state
 
-You can use the `BreadcrumbSkeleton` component to render a skeleton variant of a breadcrumb. This is useful to display while content in your breadcrumb is being fetched from an external resource like an API.
+You can use the `BreadcrumbSkeleton` component to render a skeleton variant of a
+breadcrumb. This is useful to display while content in your breadcrumb is being
+fetched from an external resource like an API.
 
 <Preview>
   <Story id="breadcrumb--skeleton" />
@@ -33,7 +44,8 @@ You can use the `BreadcrumbSkeleton` component to render a skeleton variant of a
 
 ### Breadcrumb noTrailingSlash
 
-You can use the `noTrailingSlash` prop to omit the slash from the end of the current page.
+You can use the `noTrailingSlash` prop to omit the slash from the end of the
+current page.
 
 ```jsx
 <Breadcrumb noTrailingSlash>
@@ -45,7 +57,8 @@ You can use the `noTrailingSlash` prop to omit the slash from the end of the cur
 
 ### BreadcrumbItem isCurrentPage
 
-You can use the `isCurrentPage` prop on a `BreadcrumbItem` to represent the current page.
+You can use the `isCurrentPage` prop on a `BreadcrumbItem` to represent the
+current page.
 
 ```jsx
 <Breadcrumb>
@@ -59,5 +72,6 @@ You can use the `isCurrentPage` prop on a `BreadcrumbItem` to represent the curr
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Breadcrumb/Breadcrumb.mdx).

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -322,5 +322,6 @@ By passing in `stacked` to the `ButtonSet` component, you can arrange your two
 
 ## Feedback
 
-Help us improve these docs by
-[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Button/Button.mdx)
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Button/Button.mdx)

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -7,9 +7,16 @@ import { Add16, Delete16 } from '@carbon/icons-react';
 
 # Button
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Button)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/button/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/button/accessibility)
+
+## Table of Contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Overview](#overview)
 - [Icon-only Buttons](#icon-only-buttons)
@@ -316,4 +323,4 @@ By passing in `stacked` to the `ButtonSet` component, you can arrange your two
 ## Feedback
 
 Help us improve these docs by
-[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Accordion/Accordion.stories.mdx)
+[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Button/Button.mdx)

--- a/packages/react/src/components/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/Checkbox/Checkbox.mdx
@@ -93,6 +93,6 @@ event.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Checkbox/Checkbox.mdx).

--- a/packages/react/src/components/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/Checkbox/Checkbox.mdx
@@ -3,6 +3,12 @@ import { Checkbox, CheckboxSkeleton } from '../Checkbox';
 
 # Checkbox
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Checkbox)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/checkbox/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/checkbox/accessibility)
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -12,7 +18,8 @@ import { Checkbox, CheckboxSkeleton } from '../Checkbox';
 
 ## Overview
 
-You can build a checkbox using the `Checkbox` in combination with a `<fieldset>` element to group controls and `<legend>` element for the label.
+You can build a checkbox using the `Checkbox` in combination with a `<fieldset>`
+element to group controls and `<legend>` element for the label.
 
 <Preview>
   <Story id="checkbox--checkbox" />
@@ -25,13 +32,15 @@ You can also use a controlled checkbox component driven by state:
 ```jsx
 function ExampleComponent() {
   const [isChecked, setIsChecked] = useState(false);
-  return <Checkbox checked={isChecked} onChange={setIsChecked} />
+  return <Checkbox checked={isChecked} onChange={setIsChecked} />;
 }
 ```
 
 ## Skeleton state
 
-You can use the `CheckboxSkeleton` component to render a skeleton variant of a checkbox. This is useful to display while content in your checkbox is being fetched from an external resource like an API.
+You can use the `CheckboxSkeleton` component to render a skeleton variant of a
+checkbox. This is useful to display while content in your checkbox is being
+fetched from an external resource like an API.
 
 <Preview>
   <Story id="checkbox--skeleton" />
@@ -43,7 +52,8 @@ You can use the `CheckboxSkeleton` component to render a skeleton variant of a c
 
 ### Checkbox defaultChecked
 
-You can use the `defaultChecked` prop to specify weather a checkbox is checked by default or not on page load.  
+You can use the `defaultChecked` prop to specify weather a checkbox is checked
+by default or not on page load.
 
 ```jsx
 <Checkbox defaultChecked labelText={`Checkbox label`} id="checkbox-label-1" />
@@ -52,7 +62,8 @@ You can use the `defaultChecked` prop to specify weather a checkbox is checked b
 
 ### Checkbox id
 
-The `id` should be used to provide each checkbox input with a unique id and is a required prop.
+The `id` should be used to provide each checkbox input with a unique id and is a
+required prop.
 
 ```jsx
 <Checkbox labelText={`Checkbox label`} id="checkbox-label-1" />
@@ -61,7 +72,8 @@ The `id` should be used to provide each checkbox input with a unique id and is a
 
 ### Checkbox labelText
 
-The `labelText` should be used to provide a label that describes the checkbox input that is being exposed to the user and is a required prop.
+The `labelText` should be used to provide a label that describes the checkbox
+input that is being exposed to the user and is a required prop.
 
 ```jsx
 <Checkbox labelText={`Checkbox label`} id="checkbox-label-1" />
@@ -70,7 +82,9 @@ The `labelText` should be used to provide a label that describes the checkbox in
 
 ### Checkbox onChange
 
-You can use the `onChange` prop to pass in a custom function for event handling. This prop recieves three arguements: a boolean, the checkbox id, and the dom event.
+You can use the `onChange` prop to pass in a custom function for event handling.
+This prop recieves three arguements: a boolean, the checkbox id, and the dom
+event.
 
 ```jsx
 <Checkbox onChange={()=>{}} labelText={`Checkbox label`} id="checkbox-label-1" />
@@ -79,5 +93,6 @@ You can use the `onChange` prop to pass in a custom function for event handling.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Checkbox/Checkbox.mdx).

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.mdx
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.mdx
@@ -77,5 +77,6 @@ invocations, expressions etc.
 
 ## Feedback
 
-Help us improve these docs by
-[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/CodeSnippet/CodeSnippet.stories.mdx)
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/CodeSnippet/CodeSnippet.stories.mdx)

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.mdx
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.mdx
@@ -3,10 +3,13 @@ import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import * as stories from './CodeSnippet-story.js';
 import CodeSnippet from '../CodeSnippet';
 
-<!-- How do I get <Props> to work?
- -->
-
 # CodeSnippet
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/CodeSnippet)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/code-snippet/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/code-snippet/accessibility)
 
 ## Table of Contents
 
@@ -70,7 +73,7 @@ invocations, expressions etc.
 
 ## Component API
 
-<Props sort="asc" />
+<Props />
 
 ## Feedback
 

--- a/packages/react/src/components/ComboBox/ComboBox-story.js
+++ b/packages/react/src/components/ComboBox/ComboBox-story.js
@@ -9,6 +9,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import ComboBox from '../ComboBox';
+import mdx from './ComboBox.mdx';
 
 const items = [
   {
@@ -71,6 +72,9 @@ export default {
 
   parameters: {
     component: ComboBox,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/ComboBox/ComboBox.mdx
+++ b/packages/react/src/components/ComboBox/ComboBox.mdx
@@ -1,0 +1,37 @@
+import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import * as stories from './ComboBox-story.js';
+import ComboBox from '../ComboBox';
+
+# ComboBox
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ComboBox)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/dropdown/usage#combo-box)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/dropdown/accessibility)
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
+- [Overview](#overview)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+<Preview>
+  <Story id="combobox--default" />
+</Preview>
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve these docs by
+[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ComboBox/ComboBox.mdx)

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -1,7 +1,35 @@
 import { Story, Props } from '@storybook/addon-docs/blocks';
 import ComposedModal from '../ComposedModal';
+import { InlineNotification } from '../Notification';
 
 # ComposedModal
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ComposedModal)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/modal/accessibility)
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Overview](#overview)
+- [Component API](#component-api)
+- [Opening/closing modal](#openingclosing-modal)
+- [Modal sizes](#modal-sizes)
+  - [Alignment](#alignment)
+  - [Overflow content](#overflow-content)
+- [Modal button variants](#modal-button-variants)
+- [Using modal title as message](#using-modal-title-as-message)
+- [Focus management](#focus-management)
+  - [Setting `data-modal-primary-focus` attribute to the target element](#setting-data-modal-primary-focus-attribute-to-the-target-element)
+  - [Specifying a query selector to the target element](#specifying-a-query-selector-to-the-target-element)
+- [References](#references)
+- [Feedback](#feedback)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Overview
 
@@ -23,7 +51,7 @@ For both modal variants, you can open/close the modal by changing the `open`
 prop. For example, you can implement a launcher button with a React state and a
 `<Button>` that changes the state:
 
-```javascript
+```jsx
 function ModalStateManager() {
   const [open, setOpen] = useState(false);
   return (
@@ -46,7 +74,7 @@ function ModalStateManager() {
 
 You can create an abstract version of such state manager, as shown below.
 
-```javascript
+```jsx
 const ModalStateManager = ({
   renderLauncher: LauncherContent,
   children: ModalContent,
@@ -69,11 +97,13 @@ const ModalStateManager = ({
 `<ModalWrapper>` is a modal state manager implementation which ships out of the
 box with Carbon.
 
-<InlineNotification kind="warning">
-  <code>{`<Modal>`}</code>/<code>{`<ComposedModal>`}</code> has to be put at the
+<InlineNotification
+  kind="warning"
+  title="Warning"
+  subtitle="`Modal` and `ComposedModal` have to be put at the
   top level in a React tree. The easiest way to ensure that is using React
-  portal as shown in above example.
-</InlineNotification>
+  portal as shown in above example."
+/>
 
 ## Modal sizes
 
@@ -81,7 +111,7 @@ There are four responsive
 [modal sizes](https://www.carbondesignsystem.com/components/modal/usage/#modal-sizes):
 `xs`, `small`, default, and `large`. You can set it via the `size` prop.
 
-```javascript
+```jsx
 <ComposedModal size="lg">
   <ModalHeader />
   <ModalBody>
@@ -96,7 +126,7 @@ There are four responsive
 </ComposedModal>
 ```
 
-#### Alignment
+### Alignment
 
 Depending on the modal size of your choice and the viewport size,
 `<Modal>`/`<ComposedModal>` adds 20% padding at the right of the modal body
@@ -105,7 +135,7 @@ form elements. You can set `hasForm` prop to `<Modal>`/`<ModalBody>` to remove
 the padding, and use `bx--modal-content__regular-content` class to apply the 20%
 padding to non-form contents, as shown below.
 
-```javascript
+```jsx
 <ComposedModal>
   <ModalHeader />
   <ModalBody hasForm>
@@ -121,7 +151,7 @@ padding to non-form contents, as shown below.
 </ComposedModal>
 ```
 
-#### Overflow content
+### Overflow content
 
 In cases where the largest modal size cannot fit your modal body content in,
 Carbon design specifies to have a "visual fade" look at the end of the modal
@@ -129,7 +159,7 @@ body area to indicate there is additional content out of view. You can set
 `hasScrollingContent` prop to `<Modal>`/`<ModalBody>` to do that, as shown
 below.
 
-```javascript
+```jsx
 <ComposedModal size="large">
   <ModalHeader />
   <ModalBody hasScrollingContent>
@@ -150,7 +180,7 @@ table shows the supported patterns.
 | Two buttons                                                                                          | Use `<Modal>` without `passiveModal` prop |
 | Two buttons with danger button                                                                       | Use `danger` prop in `<Modal>`            |
 
-```javascript
+```jsx
 <Modal danger>
   <ModalHeader />
   <p className="bx--modal-content__text">The modal body content</p>
@@ -167,21 +197,22 @@ With `<ComposedModal>`, you can control the buttons with the following code.
 | Three buttons                                                                                        | Put three buttons as children of `<ModalFooter>`, instead of using `primaryButtonText` or `secondaryButtonText`. Using this option requires style adjustment defined in application-level CSS for `<ModalFooter>`, e.g. `.bx--modal-footer { padding: 25%; }`. |
 | Two buttons with danger button                                                                       | Set `danger` prop in `<ModalFooter>` (like below)                                                                                                                                                                                                              |
 
-```javascript
+```jsx
 <ComposedModal>
   ...
   <ModalFooter danger primaryButtonText="OK" secondaryButtonText="Cancel" />
 </ComposedModal>
 ```
 
-<InlineNotification kind="warning">
-  As the instruction for the three buttons implies, <code>{`<ModalFooter>`}</code>
-  is flexible on the buttons as you render <code>{`<Button>`}</code> s by yourself,
+<InlineNotification
+  kind="warning"
+  title="Warning"
+  subtitle="As the instruction for the three buttons implies, <ModalFooter>
+  is flexible on the buttons as you render <Button>'s by yourself,
   as shown below. In this case, the application code needs to take care of running
-  actions upon clicking those buttons, e.g. closing the modal:
-</InlineNotification>
+  actions upon clicking those buttons, e.g. closing the modal"></InlineNotification>
 
-```javascript
+```jsx
 <ComposedModal>
   ...
   <ModalFooter>
@@ -211,7 +242,7 @@ clarity to an otherwise repetitive title and body message.
 
 To use this pattern with `<Modal>`, you can omit the `children` prop.
 
-```javascript
+```jsx
 const modalHeadding =
   'Are you sure you want to add the "Speech to Text" service ' +
   'to the node-test app?';
@@ -225,7 +256,7 @@ const modalHeadding =
 
 To use this pattern with `<ComposedModal>`, you can omit `<ModalBody>`.
 
-```javascript
+```jsx
 <ComposedModal>
   <ModalHeader label="Modla label">
     <h1>
@@ -256,11 +287,11 @@ to `<Modal>`/`<ComposedModal>`.
 Also for both modal variants, you can set the DOM element that gets focus when
 the modal gets open, by either of the following ways:
 
-#### Setting `data-modal-primary-focus` attribute to the target element
+### Setting `data-modal-primary-focus` attribute to the target element
 
 <br />
 
-```javascript
+```jsx
 <ComposedModal>
   <ModalBody hasForm>
     <TextInput data-modal-primary-focus labelText="Enter something" />
@@ -268,11 +299,11 @@ the modal gets open, by either of the following ways:
 </ComposedModal>
 ```
 
-#### Specifying a query selector to the target element
+### Specifying a query selector to the target element
 
 <br />
 
-```javascript
+```jsx
 {
   /* `.bx--text-input` selects the `<input>` in `<TextInput>` */
 }
@@ -291,6 +322,6 @@ on the Carbon Design System website.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
@@ -4,9 +4,16 @@ import Switch from '../Switch';
 
 # Content Switcher
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ContentSwitcher)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/content-switcher/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/content-switcher/accessibility)
+
+## Table of Contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Overview](#overview)
 - [Component API](#component-api)

--- a/packages/react/src/components/CopyButton/CopyButton-story.js
+++ b/packages/react/src/components/CopyButton/CopyButton-story.js
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 
 import { withKnobs, number, text } from '@storybook/addon-knobs';
 import CopyButton from '../CopyButton';
+import mdx from './CopyButton.mdx';
 
 const props = () => ({
   feedback: text('The text shown upon clicking (feedback)', 'Copied!'),
@@ -30,6 +31,9 @@ export default {
 
   parameters: {
     component: CopyButton,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/CopyButton/CopyButton.mdx
+++ b/packages/react/src/components/CopyButton/CopyButton.mdx
@@ -27,5 +27,5 @@ import { Props } from '@storybook/addon-docs/blocks';
 ## Feedback
 
 Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+on Slack, or updating this file on GitHub
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/CopyButton/CopyButton.mdx
+++ b/packages/react/src/components/CopyButton/CopyButton.mdx
@@ -1,0 +1,31 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# CopyButton
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/CopyButton)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/patterns/common-actions/#copy)
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Overview](#overview)
+- [Component API](#component-api)
+- [References](#references)
+- [Feedback](#feedback)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/DataTable/DataTable.mdx
+++ b/packages/react/src/components/DataTable/DataTable.mdx
@@ -2,6 +2,12 @@ import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
 
 # DataTable
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/DataTable)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/data-table/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/data-table/accessibility)
+
 <Preview>
   <Story id="datatable--usage" />
 </Preview>

--- a/packages/react/src/components/DataTable/DataTable.mdx
+++ b/packages/react/src/components/DataTable/DataTable.mdx
@@ -352,6 +352,6 @@ These are values that represent the current state of the `DataTable` component.
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and
-leaving any other comments on
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/DataTable/DataTable.mdx).

--- a/packages/react/src/components/DatePicker/DatePicker.mdx
+++ b/packages/react/src/components/DatePicker/DatePicker.mdx
@@ -4,6 +4,14 @@ import DatePickerInput from '../DatePickerInput';
 
 # Date Picker
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/DatePicker)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/date-picker/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/date-picker/accessibility)
+
+## Table of Contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/packages/react/src/components/DatePicker/DatePicker.mdx
+++ b/packages/react/src/components/DatePicker/DatePicker.mdx
@@ -270,6 +270,6 @@ start this at a different date, you can pass in a date string or date object.
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and
-leaving any other comments on
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/DatePicker/DatePicker.mdx).

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -4,6 +4,14 @@ import DropdownSkeleton from './Dropdown.Skeleton';
 
 # Dropdown
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Dropdown)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/dropdown/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/dropdown/accessibility)
+
+## Table of Contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -297,6 +297,6 @@ that, pass in `type="inline"` to the `Dropdown`
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and
-leaving any other comments on
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Dropdown/Dropdown.mdx).

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -22,6 +22,7 @@ import FileUploader, { FileUploaderButton } from '../FileUploader';
 import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
 import FileUploaderItem from './FileUploaderItem';
 import FileUploaderDropContainer from './FileUploaderDropContainer';
+import mdx from './FileUploader.mdx';
 
 const { prefix } = settings;
 const buttonKinds = {
@@ -143,6 +144,9 @@ export default {
 
   parameters: {
     component: FileUploader,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       FileUploaderButton,

--- a/packages/react/src/components/FileUploader/FileUploader.mdx
+++ b/packages/react/src/components/FileUploader/FileUploader.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# FileUploader
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/FileUploader)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/file-uploader/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/file-uploader/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/FileUploader/FileUploader.mdx).

--- a/packages/react/src/components/FileUploader/FileUploader.mdx
+++ b/packages/react/src/components/FileUploader/FileUploader.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/FileUploader/FileUploader.mdx).

--- a/packages/react/src/components/Form/Form-story.js
+++ b/packages/react/src/components/Form/Form-story.js
@@ -23,6 +23,7 @@ import SelectItem from '../SelectItem';
 import TextArea from '../TextArea';
 import TextInput from '../TextInput';
 import Toggle from '../Toggle';
+import mdx from './Form.mdx';
 
 const additionalProps = {
   className: 'some-class',
@@ -139,6 +140,9 @@ export default {
 
   parameters: {
     component: Form,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       FormGroup,

--- a/packages/react/src/components/Form/Form.mdx
+++ b/packages/react/src/components/Form/Form.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Form/Form.mdx).

--- a/packages/react/src/components/Form/Form.mdx
+++ b/packages/react/src/components/Form/Form.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Form
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Form)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/form/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/form/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Form/Form.mdx).

--- a/packages/react/src/components/Grid/Grid.mdx
+++ b/packages/react/src/components/Grid/Grid.mdx
@@ -257,6 +257,6 @@ would love for you to get in touch!
 
 ## Feedback
 
-Help us improve these components by providing feedback, reaching out tot he
-team, or updating this file on
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Grid/Grid.mdx).

--- a/packages/react/src/components/Grid/Grid.mdx
+++ b/packages/react/src/components/Grid/Grid.mdx
@@ -2,6 +2,10 @@ import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 # Grid
 
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Grid)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview)
+
 <!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -42,8 +46,8 @@ import { Grid, Row, Column } from 'carbon-components-react';
 ## Overview
 
 Every layout starts with the `Grid` component. You can specify a `Grid` at the
-top-level of your project, or at different depths provided that it can span
-100% width of its container.
+top-level of your project, or at different depths provided that it can span 100%
+width of its container.
 
 Next, you will use a combination of `Row` and `Column`. You can have multiple
 `Row` components in a `Grid`, and multiple `Column` components in a `Row`. Each

--- a/packages/react/src/components/InlineLoading/InlineLoading-story.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading-story.js
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, number, select, text } from '@storybook/addon-knobs';
 import Button from '../Button';
 import InlineLoading from '../InlineLoading';
+import mdx from './InlineLoading.mdx';
 
 const props = () => ({
   status: select(
@@ -38,6 +39,9 @@ export default {
 
   parameters: {
     component: InlineLoading,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/InlineLoading/InlineLoading.mdx
+++ b/packages/react/src/components/InlineLoading/InlineLoading.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/InlineLoading/InlineLoading.mdx).

--- a/packages/react/src/components/InlineLoading/InlineLoading.mdx
+++ b/packages/react/src/components/InlineLoading/InlineLoading.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# InlineLoading
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/InlineLoading)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/inline-loading/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/inline-loading/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/InlineLoading/InlineLoading.mdx).

--- a/packages/react/src/components/Link/Link-story.js
+++ b/packages/react/src/components/Link/Link-story.js
@@ -11,6 +11,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import Link from '../Link';
+import mdx from './Link.mdx';
 
 const props = () => ({
   className: 'some-class',
@@ -30,6 +31,9 @@ export default {
 
   parameters: {
     component: Link,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/Link/Link.mdx
+++ b/packages/react/src/components/Link/Link.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Link/Link.mdx).

--- a/packages/react/src/components/Link/Link.mdx
+++ b/packages/react/src/components/Link/Link.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Link
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Link)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/link/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/link/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Link/Link.mdx).

--- a/packages/react/src/components/Loading/Loading-story.js
+++ b/packages/react/src/components/Loading/Loading-story.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import Loading from '../Loading';
+import mdx from './Loading.mdx';
 
 const props = () => ({
   active: boolean('Active (active)', true),
@@ -22,6 +23,9 @@ export default {
 
   parameters: {
     component: Loading,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/Loading/Loading.mdx
+++ b/packages/react/src/components/Loading/Loading.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Loading/Loading.mdx).

--- a/packages/react/src/components/Loading/Loading.mdx
+++ b/packages/react/src/components/Loading/Loading.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Loading
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Loading)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/loading/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/loading/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Loading/Loading.mdx).

--- a/packages/react/src/components/MultiSelect/MultiSelect-story.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect-story.js
@@ -17,6 +17,7 @@ import {
 import { withReadme } from 'storybook-readme';
 import readme from './README.md';
 import MultiSelect from '../MultiSelect';
+import mdx from './MultiSelect.mdx';
 
 const items = [
   {
@@ -104,7 +105,9 @@ export default {
 
   parameters: {
     component: MultiSelect,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       'MultiSelect.Filterable': MultiSelect.Filterable,
     },

--- a/packages/react/src/components/MultiSelect/MultiSelect.mdx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/MultiSelect/MultiSelect.mdx).

--- a/packages/react/src/components/MultiSelect/MultiSelect.mdx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# MultiSelect
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/MultiSelect)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/dropdown/usage#multiselect)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/dropdown/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/MultiSelect/MultiSelect.mdx).

--- a/packages/react/src/components/Notification/Notification-story.js
+++ b/packages/react/src/components/Notification/Notification-story.js
@@ -13,6 +13,7 @@ import {
   InlineNotification,
   NotificationActionButton,
 } from '../Notification';
+import mdx from './Notification.mdx';
 
 const kinds = {
   'Error (error)': 'error',
@@ -45,6 +46,9 @@ export default {
   decorators: [withKnobs],
 
   parameters: {
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       ToastNotification,
       InlineNotification,

--- a/packages/react/src/components/Notification/Notification.mdx
+++ b/packages/react/src/components/Notification/Notification.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Notification
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Notification)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/notification/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/notification/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Notification/Notification.mdx).

--- a/packages/react/src/components/Notification/Notification.mdx
+++ b/packages/react/src/components/Notification/Notification.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Notification/Notification.mdx).

--- a/packages/react/src/components/NumberInput/NumberInput-story.js
+++ b/packages/react/src/components/NumberInput/NumberInput-story.js
@@ -18,6 +18,7 @@ import {
 } from '@storybook/addon-knobs';
 import NumberInput from '../NumberInput';
 import NumberInputSkeleton from '../NumberInput/NumberInput.Skeleton';
+import mdx from './NumberInput.mdx';
 
 const sizes = {
   'Extra large size (xl)': 'xl',
@@ -63,6 +64,9 @@ export default {
 
   parameters: {
     component: NumberInput,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       NumberInputSkeleton,
@@ -78,15 +82,6 @@ export const Default = () => {
       {...rest}
     />
   );
-};
-
-Default.parameters = {
-  info: {
-    text: `
-        Number inputs are similar to text fields, but contain controls used to increase or decrease an incremental value.
-        The Number Input component can be passed a starting value, a min, a max, and the step.
-      `,
-  },
 };
 
 export const Skeleton = () => (

--- a/packages/react/src/components/NumberInput/NumberInput.mdx
+++ b/packages/react/src/components/NumberInput/NumberInput.mdx
@@ -23,6 +23,6 @@ directly to view the `PropType` definitions.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/NumberInput/NumberInput.mdx).

--- a/packages/react/src/components/NumberInput/NumberInput.mdx
+++ b/packages/react/src/components/NumberInput/NumberInput.mdx
@@ -1,0 +1,28 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# NumberInput
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/NumberInput)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/number-input/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/number-input/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+We are currently investigating why the props are not displaying properly for
+this component. In the meantime, please
+[view the source code](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/NumberInput/NumberInput.js#L43-L146)
+directly to view the `PropType` definitions.
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/NumberInput/NumberInput.mdx).

--- a/packages/react/src/components/OrderedList/OrderedList-story.js
+++ b/packages/react/src/components/OrderedList/OrderedList-story.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import OrderedList from '../OrderedList';
 import ListItem from '../ListItem';
+import mdx from './OrderedList.mdx';
 
 export default {
   title: 'OrderedList',
 
   parameters: {
     component: OrderedList,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       ListItem,

--- a/packages/react/src/components/OrderedList/OrderedList.mdx
+++ b/packages/react/src/components/OrderedList/OrderedList.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# OrderedList
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/OrderedList)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/list/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/list/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/OrderedList/OrderedList.mdx).

--- a/packages/react/src/components/OrderedList/OrderedList.mdx
+++ b/packages/react/src/components/OrderedList/OrderedList.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/OrderedList/OrderedList.mdx).

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -12,6 +12,7 @@ import { withReadme } from 'storybook-readme';
 import OverflowMenu from '../OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
 import OverflowREADME from './README.md';
+import mdx from './OverflowMenu.mdx';
 
 const directions = {
   'Bottom of the trigger button (bottom)': 'bottom',
@@ -54,6 +55,9 @@ export default {
 
   parameters: {
     component: OverflowMenu,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       OverflowMenuItem,

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
@@ -1,0 +1,28 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# OverflowMenu
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/OverflowMenu)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/overflow-menu/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/overflow-menu/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+We are currently investigating why the props are not displaying properly for
+this component. In the meantime, please
+[view the source code](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/OverflowMenu/OverflowMenu.js#L98-L217)
+directly to view the `PropType` definitions.
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/OverflowMenu/OverflowMenu.mdx).

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
@@ -23,6 +23,6 @@ directly to view the `PropType` definitions.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/OverflowMenu/OverflowMenu.mdx).

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -16,6 +16,7 @@ import {
   text,
 } from '@storybook/addon-knobs';
 import Pagination from '../Pagination';
+import mdx from './Pagination.mdx';
 
 const props = () => ({
   disabled: boolean('Disable page inputs (disabled)', false),
@@ -52,6 +53,9 @@ export default {
 
   parameters: {
     component: Pagination,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/Pagination/Pagination.mdx
+++ b/packages/react/src/components/Pagination/Pagination.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Pagination/Pagination.mdx).

--- a/packages/react/src/components/Pagination/Pagination.mdx
+++ b/packages/react/src/components/Pagination/Pagination.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Pagination
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Pagination)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/pagination/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/pagination/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Pagination/Pagination.mdx).

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator-story.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator-story.js
@@ -12,6 +12,7 @@ import { ProgressIndicator, ProgressStep } from '../ProgressIndicator';
 import ProgressIndicatorSkeleton from '../ProgressIndicator/ProgressIndicator.Skeleton';
 import Tooltip from '../Tooltip';
 import { settings } from 'carbon-components';
+import mdx from './ProgressIndicator.mdx';
 
 const { prefix } = settings;
 
@@ -21,6 +22,9 @@ export default {
 
   parameters: {
     component: ProgressIndicator,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       ProgressStep,

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx).

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# ProgressIndicator
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ProgressIndicator)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/progress-indicator/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/progress-indicator/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx).

--- a/packages/react/src/components/RadioButton/RadioButton-story.js
+++ b/packages/react/src/components/RadioButton/RadioButton-story.js
@@ -11,6 +11,7 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import RadioButton from '../RadioButton';
 import RadioButtonSkeleton from '../RadioButton/RadioButton.Skeleton';
+import mdx from './RadioButton.mdx';
 
 const labelPositions = {
   'Left (left)': 'left',
@@ -37,6 +38,9 @@ export default {
 
   parameters: {
     component: RadioButton,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       RadioButtonSkeleton,

--- a/packages/react/src/components/RadioButton/RadioButton.mdx
+++ b/packages/react/src/components/RadioButton/RadioButton.mdx
@@ -23,6 +23,6 @@ directly to view the `PropType` definitions.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/RadioButton/RadioButton.mdx).

--- a/packages/react/src/components/RadioButton/RadioButton.mdx
+++ b/packages/react/src/components/RadioButton/RadioButton.mdx
@@ -1,0 +1,28 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# RadioButton
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/RadioButton)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/radio-button/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/radio-button/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+We are currently investigating why the props are not displaying properly for
+this component. In the meantime, please
+[view the source code](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/RadioButton/RadioButton.js#L18-L81)
+directly to view the `PropType` definitions.
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/RadioButton/RadioButton.mdx).

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup-story.js
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup-story.js
@@ -12,6 +12,7 @@ import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import RadioButtonGroup from '../RadioButtonGroup';
 import RadioButton from '../RadioButton';
 import FormGroup from '../FormGroup';
+import mdx from './RadioButtonGroup.mdx';
 
 const values = {
   standard: 'standard',
@@ -68,6 +69,9 @@ export default {
 
   parameters: {
     component: RadioButtonGroup,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       RadioButton,

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.mdx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.mdx).

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.mdx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# RadioButtonGroup
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/RadioButtonGroup)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/radio-button/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/radio-button/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.mdx).

--- a/packages/react/src/components/Search/Search-story.js
+++ b/packages/react/src/components/Search/Search-story.js
@@ -15,6 +15,7 @@ import Search from '../Search';
 import SearchSkeleton from '../Search/Search.Skeleton';
 import SearchFilterButton from '../SearchFilterButton';
 import SearchLayoutButton from '../SearchLayoutButton';
+import mdx from './Search.mdx';
 
 const sizes = {
   'Regular size (xl)': 'xl',
@@ -43,6 +44,9 @@ export default {
 
   parameters: {
     component: Search,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       SearchSkeleton,

--- a/packages/react/src/components/Search/Search.mdx
+++ b/packages/react/src/components/Search/Search.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Search
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Search)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/search/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/search/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Search/Search.mdx).

--- a/packages/react/src/components/Search/Search.mdx
+++ b/packages/react/src/components/Search/Search.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Search/Search.mdx).

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -13,6 +13,7 @@ import Select from '../Select';
 import SelectItem from '../SelectItem';
 import SelectItemGroup from '../SelectItemGroup';
 import SelectSkeleton from '../Select/Select.Skeleton';
+import mdx from './Select.mdx';
 
 const sizes = {
   'Extra large size (xl)': 'xl',
@@ -51,6 +52,9 @@ export default {
 
   parameters: {
     component: Select,
+    docs: {
+      page: mdx,
+    },
 
     subcomponents: {
       SelectItem,

--- a/packages/react/src/components/Select/Select.mdx
+++ b/packages/react/src/components/Select/Select.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Select/Select.mdx).

--- a/packages/react/src/components/Select/Select.mdx
+++ b/packages/react/src/components/Select/Select.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Select
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Select)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/select/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/select/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Select/Select.mdx).

--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder-story.js
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder-story.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import { withKnobs, select } from '@storybook/addon-knobs';
 import SkeletonPlaceholder from '../SkeletonPlaceholder';
+import mdx from './SkeletonPlaceholder.mdx';
 
 const classNames = {
   'my--skeleton__placeholder--small': 'my--skeleton__placeholder--small',
@@ -28,6 +29,9 @@ export default {
 
   parameters: {
     component: SkeletonPlaceholder,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx
@@ -1,0 +1,21 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# SkeletonPlaceholder
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/SkeletonPlaceholder)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/patterns/loading-pattern/#skeleton-states)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx).

--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx
@@ -16,6 +16,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx).

--- a/packages/react/src/components/SkeletonText/SkeletonText-story.js
+++ b/packages/react/src/components/SkeletonText/SkeletonText-story.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import { withKnobs, boolean, number, select } from '@storybook/addon-knobs';
 import SkeletonText from '../SkeletonText';
+import mdx from './SkeletonText.mdx';
 
 const widths = {
   '100%': '100%',
@@ -34,6 +35,9 @@ export default {
 
   parameters: {
     component: SkeletonText,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/SkeletonText/SkeletonText.mdx
+++ b/packages/react/src/components/SkeletonText/SkeletonText.mdx
@@ -1,0 +1,21 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# SkeletonText
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/SkeletonText)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/patterns/loading-pattern/#skeleton-states)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/SkeletonText/SkeletonText.mdx).

--- a/packages/react/src/components/SkeletonText/SkeletonText.mdx
+++ b/packages/react/src/components/SkeletonText/SkeletonText.mdx
@@ -16,6 +16,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/SkeletonText/SkeletonText.mdx).

--- a/packages/react/src/components/Slider/Slider-story.js
+++ b/packages/react/src/components/Slider/Slider-story.js
@@ -12,6 +12,7 @@ import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import Slider from '../Slider';
 import SliderSkeleton from '../Slider/Slider.Skeleton';
 import { sliderValuePropSync } from '../../internal/FeatureFlags';
+import mdx from './Slider.mdx';
 
 const props = () => ({
   name: text('Form item name (name)', ''),
@@ -44,7 +45,9 @@ export default {
 
   parameters: {
     component: Slider,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       SliderSkeleton,
     },

--- a/packages/react/src/components/Slider/Slider.mdx
+++ b/packages/react/src/components/Slider/Slider.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Slider
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Slider)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/slider/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/slider/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Slider/Slider.mdx).

--- a/packages/react/src/components/Slider/Slider.mdx
+++ b/packages/react/src/components/Slider/Slider.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Slider/Slider.mdx).

--- a/packages/react/src/components/StructuredList/StructuredList-story.js
+++ b/packages/react/src/components/StructuredList/StructuredList-story.js
@@ -17,6 +17,7 @@ import {
 } from '../StructuredList';
 import StructuredListSkeleton from '../StructuredList/StructuredList.Skeleton';
 import { settings } from 'carbon-components';
+import mdx from './StructuredList.mdx';
 
 const { prefix } = settings;
 
@@ -25,7 +26,9 @@ export default {
 
   parameters: {
     component: StructuredListWrapper,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       StructuredListHead,
       StructuredListBody,

--- a/packages/react/src/components/StructuredList/StructuredList.mdx
+++ b/packages/react/src/components/StructuredList/StructuredList.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/StructuredList/StructuredList.mdx).

--- a/packages/react/src/components/StructuredList/StructuredList.mdx
+++ b/packages/react/src/components/StructuredList/StructuredList.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# StructuredList
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/StructuredList)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/structured-list/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/structured-list/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/StructuredList/StructuredList.mdx).

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -22,6 +22,7 @@ import Tabs from '../Tabs';
 import Tab from '../Tab';
 import TextInput from '../TextInput';
 import TabsSkeleton from '../Tabs/Tabs.Skeleton';
+import mdx from './Tabs.mdx';
 
 const selectionModes = {
   'Change selection automatically upon focus (automatic)': 'automatic',
@@ -107,6 +108,9 @@ export default {
   decorators: [withKnobs],
   parameters: {
     component: Tabs,
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       Tab,
       TabsSkeleton,

--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Tabs
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tabs)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tabs/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tabs/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tabs/Tabs.mdx).

--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tabs/Tabs.mdx).

--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -10,6 +10,7 @@ import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
 import Tag, { types as typesList } from '../Tag';
 import TagSkeleton from '../Tag/Tag.Skeleton';
 import { action } from '@storybook/addon-actions/dist/preview';
+import mdx from './Tag.mdx';
 
 const props = {
   regular: () => ({
@@ -43,7 +44,9 @@ export default {
 
   parameters: {
     component: Tag,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       TagSkeleton,
     },

--- a/packages/react/src/components/Tag/Tag.mdx
+++ b/packages/react/src/components/Tag/Tag.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tag/Tag.mdx).

--- a/packages/react/src/components/Tag/Tag.mdx
+++ b/packages/react/src/components/Tag/Tag.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Tag
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tag)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tag/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tag/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tag/Tag.mdx).

--- a/packages/react/src/components/TextArea/TextArea-story.js
+++ b/packages/react/src/components/TextArea/TextArea-story.js
@@ -11,6 +11,7 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import TextArea from '../TextArea';
 import TextAreaSkeleton from '../TextArea/TextArea.Skeleton';
+import mdx from './TextArea.mdx';
 
 const TextAreaProps = () => ({
   className: 'some-class',
@@ -38,7 +39,9 @@ export default {
 
   parameters: {
     component: TextArea,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       TextAreaSkeleton,
     },

--- a/packages/react/src/components/TextArea/TextArea.mdx
+++ b/packages/react/src/components/TextArea/TextArea.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TextArea/TextArea.mdx).

--- a/packages/react/src/components/TextArea/TextArea.mdx
+++ b/packages/react/src/components/TextArea/TextArea.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# TextArea
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TextArea)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/text-input/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/text-input/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TextArea/TextArea.mdx).

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -11,6 +11,7 @@ import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import TextInput from '../TextInput';
 import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
 import FluidForm from '../FluidForm/FluidForm';
+import mdx from './TextInput.mdx';
 
 const types = {
   None: '',
@@ -109,7 +110,9 @@ export default {
 
   parameters: {
     component: TextInput,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       TextInputSkeleton,
       'TextInput.ControlledPasswordInput': TextInput.ControlledPasswordInput,

--- a/packages/react/src/components/TextInput/TextInput.mdx
+++ b/packages/react/src/components/TextInput/TextInput.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TextInput/TextInput.mdx).

--- a/packages/react/src/components/TextInput/TextInput.mdx
+++ b/packages/react/src/components/TextInput/TextInput.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# TextInput
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TextInput)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/text-input/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/text-input/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TextInput/TextInput.mdx).

--- a/packages/react/src/components/Tile/Tile-story.js
+++ b/packages/react/src/components/Tile/Tile-story.js
@@ -25,6 +25,7 @@ import {
 } from '../Tile';
 import TileGroup from '../TileGroup';
 import RadioTile from '../RadioTile';
+import mdx from './Tile.mdx';
 
 const radioValues = {
   None: '',
@@ -83,7 +84,9 @@ export default {
 
   parameters: {
     component: Tile,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       ClickableTile,
       SelectableTile,

--- a/packages/react/src/components/Tile/Tile.mdx
+++ b/packages/react/src/components/Tile/Tile.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Tile
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tile)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tile/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tile/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tile/Tile.mdx).

--- a/packages/react/src/components/Tile/Tile.mdx
+++ b/packages/react/src/components/Tile/Tile.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tile/Tile.mdx).

--- a/packages/react/src/components/TimePicker/TimePicker-story.js
+++ b/packages/react/src/components/TimePicker/TimePicker-story.js
@@ -12,6 +12,7 @@ import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import TimePicker from '../TimePicker';
 import TimePickerSelect from '../TimePickerSelect';
 import SelectItem from '../SelectItem';
+import mdx from './TimePicker.mdx';
 
 const props = {
   timepicker: () => ({
@@ -58,7 +59,9 @@ export default {
 
   parameters: {
     component: TimePicker,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       TimePickerSelect,
       SelectItem,

--- a/packages/react/src/components/TimePicker/TimePicker.mdx
+++ b/packages/react/src/components/TimePicker/TimePicker.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TimePicker/TimePicker.mdx).

--- a/packages/react/src/components/TimePicker/TimePicker.mdx
+++ b/packages/react/src/components/TimePicker/TimePicker.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# TimePicker
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TimePicker)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/date-picker/usage#time-picker)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/date-picker/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TimePicker/TimePicker.mdx).

--- a/packages/react/src/components/Toggle/Toggle-story.js
+++ b/packages/react/src/components/Toggle/Toggle-story.js
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import Toggle from '../Toggle';
 import ToggleSkeleton from '../Toggle/Toggle.Skeleton';
+import mdx from './Toggle.mdx';
 
 const a11yProps = () => ({
   labelText: text('Label toggle input control (labelText)', ''),
@@ -32,7 +33,9 @@ export default {
 
   parameters: {
     component: Toggle,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       ToggleSkeleton,
     },

--- a/packages/react/src/components/Toggle/Toggle.mdx
+++ b/packages/react/src/components/Toggle/Toggle.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Toggle
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Toggle)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/toggle/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/toggle/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Toggle/Toggle.mdx).

--- a/packages/react/src/components/Toggle/Toggle.mdx
+++ b/packages/react/src/components/Toggle/Toggle.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Toggle/Toggle.mdx).

--- a/packages/react/src/components/ToggleSmall/ToggleSmall-story.js
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall-story.js
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import ToggleSmall from '../ToggleSmall';
 import ToggleSmallSkeleton from '../ToggleSmall/ToggleSmall.Skeleton';
+import mdx from './ToggleSmall.mdx';
 
 const a11yprops = () => ({
   labelText: text('Label toggle input control (labelText)', ''),
@@ -32,7 +33,9 @@ export default {
 
   parameters: {
     component: ToggleSmall,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       ToggleSmallSkeleton,
     },

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.mdx
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ToggleSmall/ToggleSmall.mdx).

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.mdx
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# ToggleSmall
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ToggleSmall)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/toggle/usage#small-toggles)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/toggle/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ToggleSmall/ToggleSmall.mdx).

--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -11,6 +11,7 @@ import { withKnobs, select, text, number } from '@storybook/addon-knobs';
 import Tooltip from '../Tooltip';
 import Button from '../Button';
 import { OverflowMenuVertical16 } from '@carbon/icons-react';
+import mdx from './Tooltip.mdx';
 
 const { prefix } = settings;
 const directions = {
@@ -111,6 +112,9 @@ export default {
 
   parameters: {
     component: Tooltip,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -23,6 +23,6 @@ directly to view the `PropType` definitions.
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tooltip/Tooltip.mdx).

--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -1,0 +1,28 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# Tooltip
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tooltip)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tooltip/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tooltip/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+We are currently investigating why the props are not displaying properly for
+this component. In the meantime, please
+[view the source code](https://github.com/carbon-design-system/carbon/blob/master/packages/react/src/components/Tooltip/Tooltip.js#L89-L202)
+directly to view the `PropType` definitions.
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tooltip/Tooltip.mdx).

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition-story.js
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import TooltipDefinition from '../TooltipDefinition';
+import mdx from './TooltipDefinition.mdx';
 
 const directions = {
   'Bottom (bottom)': 'bottom',
@@ -44,6 +45,9 @@ export default {
 
   parameters: {
     component: TooltipDefinition,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# TooltipDefinition
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TooltipDefinition)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tooltip/usage#definition-tooltip)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tooltip/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx).

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx).

--- a/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
@@ -9,6 +9,7 @@ import React from 'react';
 import { Filter16 } from '@carbon/icons-react';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import TooltipIcon from '../TooltipIcon';
+import mdx from './TooltipIcon.mdx';
 
 const directions = {
   'Top (top)': 'top',
@@ -35,6 +36,9 @@ export default {
 
   parameters: {
     component: TooltipIcon,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.mdx
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# TooltipIcon
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TooltipIcon)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/tooltip/usage#icon-tooltip)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/tooltip/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TooltipIcon/TooltipIcon.mdx).

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.mdx
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TooltipIcon/TooltipIcon.mdx).

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -41,6 +41,7 @@ import {
   SwitcherItem,
   SwitcherDivider,
 } from '../UIShell';
+import mdx from './UIShell.mdx';
 
 SideNav.displayName = 'SideNav';
 SideNavMenu.displayName = 'SideNavMenu';
@@ -132,6 +133,9 @@ export default {
   title: 'UI Shell',
 
   parameters: {
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       Content,
       Header,

--- a/packages/react/src/components/UIShell/UIShell.mdx
+++ b/packages/react/src/components/UIShell/UIShell.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/UIShell/UIShell.mdx).

--- a/packages/react/src/components/UIShell/UIShell.mdx
+++ b/packages/react/src/components/UIShell/UIShell.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# UIShell
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/UIShell)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/UI-shell-header/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/UI-shell-header/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/UIShell/UIShell.mdx).

--- a/packages/react/src/components/UnorderedList/UnorderedList-story.js
+++ b/packages/react/src/components/UnorderedList/UnorderedList-story.js
@@ -9,13 +9,16 @@ import React from 'react';
 
 import ListItem from '../ListItem';
 import UnorderedList from '../UnorderedList';
+import mdx from './UnorderedList.mdx';
 
 export default {
   title: 'UnorderedList',
 
   parameters: {
     component: UnorderedList,
-
+    docs: {
+      page: mdx,
+    },
     subcomponents: {
       ListItem,
     },

--- a/packages/react/src/components/UnorderedList/UnorderedList.mdx
+++ b/packages/react/src/components/UnorderedList/UnorderedList.mdx
@@ -18,6 +18,6 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Feedback
 
-Help us improve this component by providing feedback through, asking questions
-on Slack,or updating this file on GitHub
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
 [GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/UnorderedList/UnorderedList.mdx).

--- a/packages/react/src/components/UnorderedList/UnorderedList.mdx
+++ b/packages/react/src/components/UnorderedList/UnorderedList.mdx
@@ -1,0 +1,23 @@
+import { Props } from '@storybook/addon-docs/blocks';
+
+# UnorderedList
+
+[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/UnorderedList)
+&nbsp;|&nbsp;
+[Usage guidelines](https://www.carbondesignsystem.com/components/list/usage)
+&nbsp;|&nbsp;
+[Accessibility](https://www.carbondesignsystem.com/components/list/accessibility)
+
+## Table of Contents
+
+## Overview
+
+## Component API
+
+<Props />
+
+## Feedback
+
+Help us improve this component by providing feedback through, asking questions
+on Slack,or updating this file on GitHub
+[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/UnorderedList/UnorderedList.mdx).


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/6848
Closes https://github.com/carbon-design-system/carbon/issues/6832

---

Adds in an `MDX` file for all components that have a story, and adds in an initial scaffold for future docs work.

This also adds in a few quick links to the top of the `docs` page to link users to more information on the component they are viewing. 

![Screen Shot 2020-09-16 at 11 55 15 AM](https://user-images.githubusercontent.com/11928039/93380079-9967b880-f813-11ea-8383-bb4a73a8a874.png)

--- 

Also adds in a note to components that are not properly rendering their `props` correctly, with a link to the source code so the `props` can still be viewed. 

![Screen Shot 2020-09-16 at 11 57 28 AM](https://user-images.githubusercontent.com/11928039/93380243-d3d15580-f813-11ea-8120-3e136d39f790.png)


#### Changelog

**New**

- `mdx` files for components that did not have them. @emyarod I didn't touch any Modal files to prevent conflicts as you work on docs, so you'll need to add in the links. 
- Added in a note to components that are not showing their `props` correctly with a link to the `PropTypes` source code 

#### Testing / Reviewing

Ensure docs render properly, no broken links
