### PR TITLE
fix(file-uploader): ensure form requirements are visible

### DIFF
--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -133,6 +133,7 @@
     }
 
     .#{$prefix}--form-requirement {
+      display: block;
       grid-column: 1 / -1;
       max-height: none;
       margin: 0;
@@ -196,6 +197,11 @@
     @include type-style('label-01');
 
     padding: 0 $carbon--spacing-05;
+  }
+
+  .#{$prefix}--file__selected-file--invalid
+    .#{$prefix}--form-requirement__title {
+    color: $text-error;
   }
 
   .#{$prefix}--file__selected-file--invalid


### PR DESCRIPTION
Closes #6866

This PR adds a style rule which ensures that form requirements for invalid file uploader contents are visible

#### Testing / Reviewing

Add an invalid file in a file uploader demo and confirm that the error details are visible