### PR TITLE
feat(FileUploaderDropContainer): validate filetypes from OS file picker

### DIFF
--- a/packages/react/examples/drag-and-drop-file-uploader/src/index.js
+++ b/packages/react/examples/drag-and-drop-file-uploader/src/index.js
@@ -56,6 +56,23 @@ function ExampleDropContainerApp(props) {
       );
       return;
     }
+    // file type validation
+    if (fileToUpload.invalidFileType) {
+      const updatedFile = {
+        ...fileToUpload,
+        status: 'edit',
+        iconDescription: 'Delete file',
+        invalid: true,
+        errorSubject: 'Invalid file type',
+        errorBody: `"${fileToUpload.name}" does not have a valid file type.`,
+      };
+      setFiles((files) =>
+        files.map((file) =>
+          file.uuid === fileToUpload.uuid ? updatedFile : file
+        )
+      );
+      return;
+    }
     try {
       const response = await fetch(
         'https://www.mocky.io/v2/5185415ba171ea3a00704eed?mocky-delay=1000ms',

--- a/packages/react/examples/drag-and-drop-file-uploader/src/index.js
+++ b/packages/react/examples/drag-and-drop-file-uploader/src/index.js
@@ -24,10 +24,10 @@ const { prefix } = settings;
 
 function ExampleDropContainerApp(props) {
   const [files, setFiles] = useState([]);
-  const handleDrop = e => {
+  const handleDrop = (e) => {
     e.preventDefault();
   };
-  const handleDragover = e => {
+  const handleDragover = (e) => {
     e.preventDefault();
   };
   useEffect(() => {
@@ -38,7 +38,7 @@ function ExampleDropContainerApp(props) {
       document.removeEventListener('dragover', handleDragover);
     };
   }, []);
-  const uploadFile = async fileToUpload => {
+  const uploadFile = async (fileToUpload) => {
     // file size validation
     if (fileToUpload.filesize > 512000) {
       const updatedFile = {
@@ -49,8 +49,8 @@ function ExampleDropContainerApp(props) {
         errorSubject: 'File size exceeds limit',
         errorBody: '500kb max file size. Select a new file and try again.',
       };
-      setFiles(files =>
-        files.map(file =>
+      setFiles((files) =>
+        files.map((file) =>
           file.uuid === fileToUpload.uuid ? updatedFile : file
         )
       );
@@ -73,8 +73,8 @@ function ExampleDropContainerApp(props) {
         status: 'complete',
         iconDescription: 'Upload complete',
       };
-      setFiles(files =>
-        files.map(file =>
+      setFiles((files) =>
+        files.map((file) =>
           file.uuid === fileToUpload.uuid ? updatedFile : file
         )
       );
@@ -86,8 +86,8 @@ function ExampleDropContainerApp(props) {
           status: 'edit',
           iconDescription: 'Remove file',
         };
-        setFiles(files =>
-          files.map(file =>
+        setFiles((files) =>
+          files.map((file) =>
             file.uuid === fileToUpload.uuid ? updatedFile : file
           )
         );
@@ -99,8 +99,8 @@ function ExampleDropContainerApp(props) {
         iconDescription: 'Upload failed',
         invalid: true,
       };
-      setFiles(files =>
-        files.map(file =>
+      setFiles((files) =>
+        files.map((file) =>
           file.uuid === fileToUpload.uuid ? updatedFile : file
         )
       );
@@ -110,7 +110,7 @@ function ExampleDropContainerApp(props) {
   const onAddFiles = useCallback(
     (evt, { addedFiles }) => {
       evt.stopPropagation();
-      const newFiles = addedFiles.map(file => ({
+      const newFiles = addedFiles.map((file) => ({
         uuid: uid(),
         name: file.name,
         filesize: file.size,

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
@@ -43,23 +43,28 @@ function FileUploaderDropContainer({
    * @param {Event} event - Event object, used to get the list of files added
    */
   function validateFiles(event) {
-    if (event.type === 'drop') {
-      const transferredFiles = [...event.dataTransfer.files];
-      if (!accept.length) {
-        return transferredFiles;
-      }
-      const acceptedTypes = new Set(accept);
-      return transferredFiles.filter(({ name, type: mimeType = '' }) => {
-        const fileExtensionRegExp = new RegExp(/\.[0-9a-z]+$/, 'i');
-        const hasFileExtension = fileExtensionRegExp.test(name);
-        if (!hasFileExtension) {
-          return false;
-        }
-        const [fileExtension] = name.match(fileExtensionRegExp);
-        return acceptedTypes.has(mimeType) || acceptedTypes.has(fileExtension);
-      });
+    const transferredFiles =
+      event.type === 'drop'
+        ? [...event.dataTransfer.files]
+        : [...event.target.files];
+    if (!accept.length) {
+      return transferredFiles;
     }
-    return [...event.target.files];
+    const acceptedTypes = new Set(accept);
+    return transferredFiles.reduce((acc, curr) => {
+      const { name, type: mimeType = '' } = curr;
+      const fileExtensionRegExp = new RegExp(/\.[0-9a-z]+$/, 'i');
+      const hasFileExtension = fileExtensionRegExp.test(name);
+      if (!hasFileExtension) {
+        return acc;
+      }
+      const [fileExtension] = name.match(fileExtensionRegExp);
+      if (acceptedTypes.has(mimeType) || acceptedTypes.has(fileExtension)) {
+        return acc.concat([curr]);
+      }
+      curr.invalidFileType = true;
+      return acc.concat([curr]);
+    }, []);
   }
 
   function handleChange(event) {

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -49,6 +49,24 @@ const ExampleDropContainerApp = (props) => {
       return;
     }
 
+    // file type validation
+    if (fileToUpload.invalidFileType) {
+      const updatedFile = {
+        ...fileToUpload,
+        status: 'edit',
+        iconDescription: 'Delete file',
+        invalid: true,
+        errorSubject: 'Invalid file type',
+        errorBody: `"${fileToUpload.name}" does not have a valid file type.`,
+      };
+      setFiles((files) =>
+        files.map((file) =>
+          file.uuid === fileToUpload.uuid ? updatedFile : file
+        )
+      );
+      return;
+    }
+
     // simulate network request time
     const rand = Math.random() * 1000;
     setTimeout(() => {
@@ -87,6 +105,7 @@ const ExampleDropContainerApp = (props) => {
         filesize: file.size,
         status: 'uploading',
         iconDescription: 'Uploading',
+        invalidFileType: file.invalidFileType,
       }));
       // eslint-disable-next-line react/prop-types
       if (props.multiple) {


### PR DESCRIPTION
Closes #6864

This PR validates file types when using the native OS file picker for the scenario where the user deliberate selects the option to choose all file types rather than remaining on the default OS file picker behavior of only allowing supported file types (see [screenshot in ticket thread](https://github.com/carbon-design-system/carbon/issues/6864#issuecomment-696223509) for more context). This PR also updates the demos to show examples of file type validation

#### Changelog

**New**

- validate file types for native OS file picker

**Changed**

- update component demos

#### Testing / Reviewing

Using the native OS file picker, select the option to pick all file types (rather than keeping the default option of only allowing supported file types) and select an invalid file. The demo should mark the file as invalid
