### PR TITLE
fix(data-table): high contrast mode fixes

### DIFF
--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -205,6 +205,12 @@
     transform: rotate(90deg);
     transition: transform $duration--moderate-01 motion(standard, productive);
     fill: $ui-05;
+
+    // Windows HCM fix
+    @media screen and (-ms-high-contrast: active) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+    }
   }
 
   // fix expanded parent separating border length

--- a/packages/components/src/components/data-table/_data-table-sort.scss
+++ b/packages/components/src/components/data-table/_data-table-sort.scss
@@ -150,6 +150,15 @@
     fill: $ui-05;
   }
 
+  // Windows HCM fix
+  .#{$prefix}--table-sort__icon,
+  .#{$prefix}--table-sort__icon-unsorted {
+    @media screen and (-ms-high-contrast: active) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+    }
+  }
+
   //----------------------------------------------------------------------------
   // Compact, Short, Tall Sortable
   //----------------------------------------------------------------------------

--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -74,6 +74,12 @@
     width: rem(16px);
     height: rem(16px);
     fill: $icon-01;
+
+    // Windows HCM fix
+    @media screen and (-ms-high-contrast: active) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+    }
   }
 
   .#{$prefix}--overflow-menu-options {

--- a/packages/components/src/components/search/_search.scss
+++ b/packages/components/src/components/search/_search.scss
@@ -119,6 +119,12 @@
     transform: translateY(-50%);
     pointer-events: none;
     fill: $icon-02;
+
+    // Windows HCM fix
+    @media screen and (-ms-high-contrast: active) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+    }
   }
 
   .#{$prefix}--search-close {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6607
Closes https://github.com/carbon-design-system/carbon/issues/6871

Adds in a specific selector for Windows HCM mode to enable proper SVG fill colors.

CSS Tricks article about [accessible SVGs in HCM](https://css-tricks.com/accessible-svgs-high-contrast-mode/)


#### Changelog

**New**

- Specific Windows HCM media queries to use the [CSS2 system color](https://www.w3.org/TR/css-color-3/#css2-system) `ButtonText` as the fill property for our SVG icons

#### Testing / Reviewing

On Windows, go to Settings --> Ease of Access --> High Contrast, and enable High Contrast mode. Ensure all icons are visible in all Data Table variants. Experience in HCM should be the same as a user not in HCM. 
