### PR TITLE
fix(pagination): high contrast mode fixes

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -250,6 +250,16 @@
   .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost:hover
     .#{$prefix}--btn__icon {
     fill: $icon-01;
+
+    // Windows HCM Fix
+    @media screen and (-ms-high-contrast: active) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+
+      path {
+        fill: ButtonText;
+      }
+    }
   }
 
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only
@@ -267,6 +277,16 @@
   .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost[disabled]:hover
     .#{$prefix}--btn__icon {
     fill: $disabled-02;
+
+    // Windows HCM Fix
+    @media screen and (-ms-high-contrast: active) {
+      // `GrayText` is a CSS2 system color to help improve colors in HCM
+      fill: GrayText;
+
+      path {
+        fill: GrayText;
+      }
+    }
   }
 
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only[disabled] {

--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -156,6 +156,11 @@ $css--helpers: true;
     transition: outline $duration--fast-02 motion(standard, productive),
       background-color $duration--fast-02 motion(standard, productive);
     fill: $ui-05;
+
+    @media screen and (-ms-high-contrast: active) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      border: 1px solid transparent;
+    }
   }
 
   .#{$prefix}--pagination__button:focus,

--- a/packages/components/src/components/pagination/_pagination.scss
+++ b/packages/components/src/components/pagination/_pagination.scss
@@ -158,7 +158,6 @@ $css--helpers: true;
     fill: $ui-05;
 
     @media screen and (-ms-high-contrast: active) {
-      // `ButtonText` is a CSS2 system color to help improve colors in HCM
       border: 1px solid transparent;
     }
   }

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -137,6 +137,16 @@
     height: 100%;
     pointer-events: none;
     fill: $ui-05;
+
+    // Windows HCM Fix
+    @media screen and (-ms-high-contrast: active) {
+      // `GrayText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+
+      path {
+        fill: ButtonText;
+      }
+    }
   }
 
   .#{$prefix}--select-input__wrapper[data-invalid]

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -50,14 +50,20 @@
 
   // IE media query
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    width: rem(208px);
+    width: auto;
   }
   // Edge 12-15 and Edge 16 feature queries
   @supports (-ms-accelerator: true) {
-    width: rem(208px);
+    width: auto;
   }
   @supports (-ms-ime-align: auto) {
-    width: rem(208px);
+    width: auto;
+  }
+
+  // Windows HCM Fix
+  @media screen and (-ms-high-contrast: active) {
+    // `GrayText` is a CSS2 system color to help improve colors in HCM
+    border: 1px solid transparent;
   }
 }
 

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -62,7 +62,6 @@
 
   // Windows HCM Fix
   @media screen and (-ms-high-contrast: active) {
-    // `GrayText` is a CSS2 system color to help improve colors in HCM
     border: 1px solid transparent;
   }
 }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6767

Adds in a specific selector for Windows HCM mode to enable proper SVG fill colors in the Pagination component. Also adds in borders to the tooltips and buttons that appear 

CSS Tricks article about [accessible SVGs in HCM](https://css-tricks.com/accessible-svgs-high-contrast-mode/)


#### Changelog

**New**

- Specific Windows HCM media queries to use the [CSS2 system color](https://www.w3.org/TR/css-color-3/#css2-system) `ButtonText` as the fill property for our SVG icons

- Specific Windows HCM media queries to use the [CSS2 system color](https://www.w3.org/TR/css-color-3/#css2-system) `GrayText` as the `disabled` fill property for our SVG icons


#### Testing / Reviewing

On Windows, go to Settings --> Ease of Access --> High Contrast, and enable High Contrast mode. Ensure all icons are visible in all Data Table variants. Experience in HCM should be the same as a user not in HCM. 
