### PR TITLE
feat(modal): add preventCloseOnClickOutside prop to Modal

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3100,6 +3100,7 @@ Map {
       "onRequestClose": [Function],
       "onRequestSubmit": [Function],
       "passiveModal": false,
+      "preventCloseOnClickOutside": false,
       "primaryButtonDisabled": false,
       "selectorPrimaryFocus": "[data-modal-primary-focus]",
     },
@@ -3155,6 +3156,9 @@ Map {
         "type": "bool",
       },
       "passiveModal": Object {
+        "type": "bool",
+      },
+      "preventCloseOnClickOutside": Object {
         "type": "bool",
       },
       "primaryButtonDisabled": Object {

--- a/packages/react/src/components/Modal/Modal-story.js
+++ b/packages/react/src/components/Modal/Modal-story.js
@@ -63,6 +63,10 @@ const props = () => ({
   onRequestClose: action('onRequestClose'),
   onRequestSubmit: action('onRequestSubmit'),
   onSecondarySubmit: action('onSecondarySubmit'),
+  preventCloseOnClickOutside: boolean(
+    'Prevent closing on click outside of modal (preventCloseOnClickOutside)',
+    false
+  ),
 });
 
 const titleOnlyProps = () => {

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -133,6 +133,11 @@ export default class Modal extends Component {
     passiveModal: PropTypes.bool,
 
     /**
+     * Prevent closing on click outside of modal
+     */
+    preventCloseOnClickOutside: PropTypes.bool,
+
+    /**
      * Specify whether the Button should be disabled, or not
      */
     primaryButtonDisabled: PropTypes.bool,
@@ -179,6 +184,7 @@ export default class Modal extends Component {
     iconDescription: 'Close',
     modalHeading: '',
     modalLabel: '',
+    preventCloseOnClickOutside: false,
     selectorPrimaryFocus: '[data-modal-primary-focus]',
     hasScrollingContent: false,
   };
@@ -211,7 +217,8 @@ export default class Modal extends Component {
       !elementOrParentIsFloatingMenu(
         evt.target,
         this.props.selectorsFloatingMenus
-      )
+      ) &&
+      !this.props.preventCloseOnClickOutside
     ) {
       this.props.onRequestClose(evt);
     }
@@ -321,6 +328,7 @@ export default class Modal extends Component {
       shouldSubmitOnEnter, // eslint-disable-line
       size,
       hasScrollingContent,
+      preventCloseOnClickOutside, // eslint-disable-line
       ...other
     } = this.props;
 

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -57,6 +57,7 @@ exports[`ModalWrapper should render 1`] = `
       onRequestSubmit={[Function]}
       open={false}
       passiveModal={false}
+      preventCloseOnClickOutside={false}
       primaryButtonDisabled={false}
       primaryButtonText="Save"
       secondaryButtonText="Cancel"


### PR DESCRIPTION
This is based on #6793 .


#### Changelog

**New**

- `preventCloseOnClickOutside` to `Modal`.

**Changed**

- Added logic to the `handleMousedown` (Modal) to prevent closing when this prop is passed in and the click originates outside the modal itself.

#### Testing / Reviewing

Enable the `preventCloseOnClickOutside` prop and try clicking outside of the modal. It should not close the modal. Ensure all variants of `Modal` render properly and still close properly when the prop is not specified.

(Yes, I copied a lot of text from the original PR 😄 .)