### PR TITLE
fix(button): restrict transitions to relevant properties

### DIFF
--- a/packages/components/src/components/button/_mixins.scss
+++ b/packages/components/src/components/button/_mixins.scss
@@ -30,7 +30,10 @@
   border-radius: $button-border-radius;
   outline: none;
   cursor: pointer;
-  transition: all $duration--fast-01 motion(entrance, productive);
+  transition: background $duration--fast-01 motion(entrance, productive),
+    box-shadow $duration--fast-01 motion(entrance, productive),
+    border-color $duration--fast-01 motion(entrance, productive),
+    outline $duration--fast-01 motion(entrance, productive);
 
   &:disabled,
   &:hover:disabled,


### PR DESCRIPTION
Closes #6823

This PR specifies the properties for Carbon button transitions so that they do not interfere with focus logic inside the interactive tooltips

#### Changelog

**Changed**

- target only specific properties for button `transition`

#### Testing / Reviewing

Set the button in the tooltip menu as the primary focus element and confirm that it is automatically focused when the tooltip is opened