### PR TITLE
fix(storybook): label text prop name for the react select component

### DIFF
--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -37,7 +37,7 @@ const props = {
       'Form validation UI content (invalidText in <Select>)',
       'A valid value is required'
     ),
-    labelText: text('Label text (helperText)', 'Select'),
+    labelText: text('Label text (labelText)', 'Select'),
     helperText: text('Helper text (helperText)', 'Optional helper text.'),
     onChange: action('onChange'),
   }),


### PR DESCRIPTION
In the storybook the prop for Label Text says helperText

<img width="842" alt="Screenshot 2020-09-28 at 1 45 34 PM" src="https://user-images.githubusercontent.com/272230/94407367-feff6180-0190-11eb-8fa6-fb59d317ca54.png">

Changes:
The pr will fix the prop name and change it to labelText instead of helperText which is incorrect.