### PR TITLE
fix(Modal): set default focus to secondary button

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -429,14 +429,16 @@ export default class Modal extends Component {
         )}
         {!passiveModal && (
           <ButtonSet className={`${prefix}--modal-footer`}>
-            <Button kind="secondary" onClick={onSecondaryButtonClick}>
+            <Button
+              kind="secondary"
+              onClick={onSecondaryButtonClick}
+              ref={this.button}>
               {secondaryButtonText}
             </Button>
             <Button
               kind={danger ? 'danger' : 'primary'}
               disabled={primaryButtonDisabled}
-              onClick={onRequestSubmit}
-              ref={this.button}>
+              onClick={onRequestSubmit}>
               {primaryButtonText}
             </Button>
           </ButtonSet>


### PR DESCRIPTION
Closes #6939

Change default focus to secondary button


#### Testing / Reviewing

- Check storybook for the modal component
![image](https://user-images.githubusercontent.com/7947934/94860312-e480ee80-0403-11eb-93f4-20f90b3c77de.png)

