### PR TITLE
feat(Link): add noopener when target="_blank" is applied

### DIFF
--- a/packages/react/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
+++ b/packages/react/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
@@ -24,6 +24,7 @@ exports[`Breadcrumb should render 1`] = `
             <a
               className="bx--link"
               href="www.carbondesignsystem.com"
+              rel={null}
             >
               Breadcrumb 1
             </a>
@@ -55,6 +56,7 @@ exports[`Breadcrumb should support rendering the current page 1`] = `
             <a
               className="bx--link"
               href="#a"
+              rel={null}
             >
               A
             </a>
@@ -73,6 +75,7 @@ exports[`Breadcrumb should support rendering the current page 1`] = `
             <a
               className="bx--link"
               href="#b"
+              rel={null}
             >
               B
             </a>
@@ -92,6 +95,7 @@ exports[`Breadcrumb should support rendering the current page 1`] = `
             <a
               className="bx--link"
               href="#c"
+              rel={null}
             >
               C
             </a>
@@ -123,6 +127,7 @@ exports[`Breadcrumb should support rendering the current page 2`] = `
             <a
               className="bx--link"
               href="#a"
+              rel={null}
             >
               A
             </a>
@@ -141,6 +146,7 @@ exports[`Breadcrumb should support rendering the current page 2`] = `
             <a
               className="bx--link"
               href="#b"
+              rel={null}
             >
               B
             </a>
@@ -162,6 +168,7 @@ exports[`Breadcrumb should support rendering the current page 2`] = `
               aria-current="page"
               className="bx--link"
               href="#c"
+              rel={null}
             >
               C
             </a>
@@ -195,6 +202,7 @@ exports[`Breadcrumb should support rendering without a trailing slash 1`] = `
             <a
               className="bx--link"
               href="www.carbondesignsystem.com"
+              rel={null}
             >
               Breadcrumb 1
             </a>

--- a/packages/react/src/components/Link/Link-test.js
+++ b/packages/react/src/components/Link/Link-test.js
@@ -19,27 +19,38 @@ describe('Link', () => {
         A simple link
       </Link>
     );
+
     it('should use the appropriate link class', () => {
       expect(link.name()).toEqual('a');
       expect(link.hasClass(`${prefix}--link`)).toEqual(true);
     });
+
     it('should inherit the href property', () => {
       expect(link.props().href).toEqual('www.google.com');
     });
+
     it('should include child content', () => {
       expect(link.text()).toEqual('A simple link');
     });
+
     it('should all for custom classes to be applied', () => {
       expect(link.hasClass('some-class')).toEqual(true);
     });
+
     it('should support disabled link', () => {
       link.setProps({ disabled: true });
       expect(link.name()).toEqual('p');
       expect(link.hasClass(`${prefix}--link--disabled`)).toEqual(true);
     });
+
     it('should support inline link', () => {
       link.setProps({ inline: true });
       expect(link.hasClass(`${prefix}--link--inline`)).toEqual(true);
+    });
+
+    it('should add rel="noopener" automatically if target="_blank"', () => {
+      link.setProps({ target: '_blank' });
+      expect(link.props().rel).toEqual('noopener');
     });
   });
 });

--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -27,8 +27,13 @@ const Link = ({
     [`${prefix}--link--visited`]: visited,
   });
   const Tag = disabled ? 'p' : 'a';
+  const rel = other.target === '_blank' ? 'noopener' : null;
   return (
-    <Tag href={disabled ? null : href} className={classNames} {...other}>
+    <Tag
+      href={disabled ? null : href}
+      className={classNames}
+      rel={rel}
+      {...other}>
       {children}
     </Tag>
   );


### PR DESCRIPTION
Closes #6910

This PR automatically adds `rel="noopener"` to Carbon `<Link />`s when `target="_blank"` is applied. Not sure if we want to break this out into an `ExternalLink` component but this PR serves as a starting point to implement this feature

#### Testing / Reviewing

Confirm that `rel="noopener"` is automatically added to links that also have `target="_blank"`