### PR TITLE
fix(Tabs): remove required role prop

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4932,7 +4932,6 @@ Map {
   },
   "Tabs" => Object {
     "defaultProps": Object {
-      "role": "navigation",
       "selected": 0,
       "selectionMode": "automatic",
       "type": "default",
@@ -4958,10 +4957,6 @@ Map {
       },
       "onSelectionChange": Object {
         "type": "func",
-      },
-      "role": Object {
-        "isRequired": true,
-        "type": "string",
       },
       "selected": Object {
         "type": "number",

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -26,16 +26,6 @@ describe('Tabs', () => {
         </Tabs>
       );
 
-      it('renders [role="navigation"] props on wrapping <div> by default', () => {
-        expect(
-          wrapper
-            // TODO: uncomment and replace in next major version
-            // .find(`.${prefix}--tabs`).props().role
-            .find(`.${prefix}--tabs--scrollable .${prefix}--tabs--scrollable`)
-            .props().role
-        ).toEqual('navigation');
-      });
-
       it('renders [role="tablist"] props on <ul> by default', () => {
         expect(wrapper.find('ul').props().role).toEqual('tablist');
       });

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -24,7 +24,7 @@ export default class Tabs extends React.Component {
     children: PropTypes.node,
 
     /**
-     * Provide a className that is applied to the root <nav> component for the
+     * Provide a className that is applied to the root <div> component for the
      * <Tabs>
      */
     className: PropTypes.string,

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -59,12 +59,6 @@ export default class Tabs extends React.Component {
     onSelectionChange: PropTypes.func,
 
     /**
-     * By default, this value is "navigation". You can also provide an alternate
-     * role if it makes sense from the accessibility-side
-     */
-    role: PropTypes.string.isRequired,
-
-    /**
      * Optionally provide an index for the currently selected <Tab>
      */
     selected: PropTypes.number,
@@ -86,7 +80,6 @@ export default class Tabs extends React.Component {
   };
 
   static defaultProps = {
-    role: 'navigation',
     type: 'default',
     selected: 0,
     selectionMode: 'automatic',
@@ -332,7 +325,6 @@ export default class Tabs extends React.Component {
   render() {
     const {
       className,
-      role,
       type,
       light,
       onSelectionChange,
@@ -427,11 +419,7 @@ export default class Tabs extends React.Component {
     return (
       // TODO: remove classname and revert div to React Fragment after next major release
       <div className={`${prefix}--tabs--scrollable`}>
-        <div
-          {...other}
-          className={classes.tabs}
-          role={role}
-          onScroll={this.handleScroll}>
+        <div {...other} className={classes.tabs} onScroll={this.handleScroll}>
           <button
             type="button"
             className={classes.leftOverflowButtonClasses}


### PR DESCRIPTION
Closes #6931

This PR removes the `role` prop requirement on the Tabs component to avoid a11y testing issues with navigation landmarks

#### Testing / Reviewing

Confirm that `role="navigation"` prop is no longer added by default to the Tabs component
