### PR TITLE
Re-enabled All-Contributors to help recognize public maintainers of Carbon

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,17 @@
+{
+  "files": ["README.md"],
+  "imageSize": 100,
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "types": {
+    "custom": {
+      "symbol": "🔭",
+      "description": "A custom contribution type.",
+      "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
+    }
+  },
+  "skipCi": "true",
+  "contributors": []
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,7 @@
 {
-  "files": ["README.md"],
+  "files": [
+    "README.md"
+  ],
   "imageSize": 100,
   "contributorsPerLine": 7,
   "contributorsSortAlphabetically": false,

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ or help us improve the project documentation. If you're interested, definitely
 check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
 [Developer Guide](./docs/developer-handbook.md)! 👀
 
+## Contributors 
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the
+[all-contributors](https://github.com/kentcdodds/all-contributors)
+specification. Contributions of any kind welcome!
+
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -76,11 +76,10 @@ or help us improve the project documentation. If you're interested, definitely
 check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
 [Developer Guide](./docs/developer-handbook.md)! 👀
 
-## Contributors 
+## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the


### PR DESCRIPTION
Closes #6963 

Hi, I have added all the necessary files for the ``all-contributors bot``  to function, please have it installed to this repo to complete the installation process.

#### Changelog

**New**

- ``all-contributors bot`` added

#### Testing / Reviewing

Once merged, install the ``all-contributors`` bot via Github and run the following command to check if it works: ``@all-contributors please add NishithP2004 for plugin``

[all-contributors bot](https://github.com/apps/allcontributors/installations/new) -- Installation link on Github