### PR TITLE
fix(ContentSwitcher): set onChange event data correctly

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -98,7 +98,11 @@ export default class ContentSwitcher extends React.Component {
           () => {
             const switchRef = this._switchRefs[nextIndex];
             switchRef && switchRef.focus();
-              this.props.onChange({ index: nextIndex, name: this.props.children[nextIndex].props.name, text: this.props.children[nextIndex].props.text });
+            this.props.onChange({
+              index: nextIndex,
+              name: this.props.children[nextIndex].props.name,
+              text: this.props.children[nextIndex].props.text,
+            });
           }
         );
       }

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -97,7 +97,7 @@ export default class ContentSwitcher extends React.Component {
           () => {
             const switchRef = this._switchRefs[nextIndex];
             switchRef && switchRef.focus();
-            this.props.onChange(data);
+              this.props.onChange({ index: nextIndex, name: this.props.children[nextIndex].props.name, text: this.props.children[nextIndex].props.text });
           }
         );
       }


### PR DESCRIPTION
Closes #6162 

The `onChange` event data by pressing arrow keys should be the same as clicking on the previous/next switch.

#### Changelog

**Changed**

- set the `onChange` event data correctly by pressing arrow keys 


#### Testing / Reviewing

In the https://codesandbox.io/s/sad-moon-ji8u0 the event data should be the same with pressing arrow keys or clicking.