### PR TITLE
fix(Tabs): select tab do not vertical scroll into view

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -229,7 +229,7 @@ export default class Tabs extends React.Component {
       event.type === 'click'
     ) {
       const currentScrollLeft = this.state.tablistScrollLeft;
-      tab?.tabAnchor?.scrollIntoView({ inline: 'nearest' });
+      tab?.tabAnchor?.scrollIntoView(false, { inline: 'nearest' });
       const newScrollLeft = this.tablist.current.scrollLeft;
       if (newScrollLeft > currentScrollLeft) {
         this.tablist.current.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -229,7 +229,7 @@ export default class Tabs extends React.Component {
       event.type === 'click'
     ) {
       const currentScrollLeft = this.state.tablistScrollLeft;
-      tab?.tabAnchor?.scrollIntoView(false, { inline: 'nearest' });
+      tab?.tabAnchor?.scrollIntoView(false);
       const newScrollLeft = this.tablist.current.scrollLeft;
       if (newScrollLeft > currentScrollLeft) {
         this.tablist.current.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;


### PR DESCRIPTION
Closes #6973

Prevent vertical scrolling when selecting tabs

#### Changelog

No longer vertically scrolls on new tab selection.

Use regular (bool) argument for the scrollIntoView api instead of the experimental (object) type argument, ref: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

#### Testing / Reviewing

1. Go to the storybook and open the storybook addons panel (Keyboard press 'A', or via the storybook menu)
2. Drag the addons section such that it covers half the container portion (so the canvas is scrollable)
3. Scroll the panel such that it's at the very top (i.e. showing a gap between the tabs and the top of the storybook container)
![image](https://user-images.githubusercontent.com/20601623/95111225-3203a100-070d-11eb-8543-64118c751f79.png)
4. Click on the 2nd tab, it should no longer scroll vertically