### PR TITLE
fix(OverflowMenu): set focusTrap prop on FloatingMenu

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -513,6 +513,7 @@ class OverflowMenu extends Component {
 
     const wrappedMenuBody = (
       <FloatingMenu
+        focusTrap
         triggerRef={this._triggerRef}
         menuDirection={direction}
         menuOffset={flipped ? menuOffsetFlip : menuOffset}


### PR DESCRIPTION
Closes #6977
Related https://github.com/carbon-design-system/carbon/pull/5489/ https://github.com/carbon-design-system/carbon/pull/6458 https://github.com/carbon-design-system/carbon/pull/6722

This PR sets the `focusTrap` prop on the overflow menu's internal FloatingMenu so that browser focus automatically moves into the overflow menu when the menu is opened, fixing a regression

#### Testing / Reviewing

Confirm that the autofocus behavior of the overflow menu is restored