### PR TITLE
fix(Tabs): improve screen reader support

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -689,13 +689,16 @@
     // Link
     //-----------------------------
     .#{$prefix}--tabs--scrollable__nav-link {
+      @include button-reset($width: false);
       @include focus-outline('reset');
+      @include type-style('body-short-01');
 
       width: rem(160px);
       padding: $spacing-04 $spacing-05 $spacing-03;
       overflow: hidden;
       color: $text-02;
       white-space: nowrap;
+      text-align: left;
       text-decoration: none;
       text-overflow: ellipsis;
       border-bottom: $tab-underline-color;

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4970,9 +4970,7 @@ Map {
         "isRequired": true,
         "type": "func",
       },
-      "renderAnchor": Object {
-        "type": "func",
-      },
+      "renderAnchor": [Function],
       "renderContent": Object {
         "type": "func",
       },

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4979,10 +4979,7 @@ Map {
         "isRequired": true,
         "type": "bool",
       },
-      "tabIndex": Object {
-        "isRequired": true,
-        "type": "number",
-      },
+      "tabIndex": [Function],
     },
   },
   "TabContent" => Object {

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4949,10 +4949,7 @@ Map {
       "handleTabKeyDown": Object {
         "type": "func",
       },
-      "href": Object {
-        "isRequired": true,
-        "type": "string",
-      },
+      "href": [Function],
       "id": Object {
         "type": "string",
       },

--- a/packages/react/src/components/Tab/Tab-test.js
+++ b/packages/react/src/components/Tab/Tab-test.js
@@ -33,16 +33,16 @@ describe('Tab', () => {
       expect(wrapper.props().role).toEqual('presentation');
     });
 
-    it('renders <a> with tabindex set to 0', () => {
+    it('renders <button> with tabindex set to 0', () => {
       expect(wrapper.find('button').props().tabIndex).toEqual(0);
     });
 
-    it('sets tabIndex on <a> if one is passed via props', () => {
+    it('sets tabIndex on <button> if one is passed via props', () => {
       wrapper.setProps({ tabIndex: 2 });
       expect(wrapper.find('button').props().tabIndex).toEqual(2);
     });
 
-    it('uses label to set children on <a> when passed via props', () => {
+    it('uses label to set children on <button> when passed via props', () => {
       expect(wrapper.find('button').props().children).toEqual('firstTab');
     });
 

--- a/packages/react/src/components/Tab/Tab-test.js
+++ b/packages/react/src/components/Tab/Tab-test.js
@@ -46,11 +46,6 @@ describe('Tab', () => {
       expect(wrapper.find('button').props().children).toEqual('firstTab');
     });
 
-    it('sets new href value when passed in via props', () => {
-      wrapper.setProps({ href: '#other-content' });
-      expect(wrapper.find('button').props().href).toEqual('#other-content');
-    });
-
     it(`should not have [className="${prefix}--tabs__nav-item--selected"] by default`, () => {
       expect(wrapper.hasClass(`${prefix}--tabs__nav-item--selected`)).toBe(
         false

--- a/packages/react/src/components/Tab/Tab-test.js
+++ b/packages/react/src/components/Tab/Tab-test.js
@@ -29,8 +29,8 @@ describe('Tab', () => {
       ).toBe(true);
     });
 
-    it('renders <li> with [role="tab"]', () => {
-      expect(wrapper.props().role).toEqual('tab');
+    it('renders <li> with [role="presentation"]', () => {
+      expect(wrapper.props().role).toEqual('presentation');
     });
 
     it('renders <a> with tabindex set to 0', () => {

--- a/packages/react/src/components/Tab/Tab-test.js
+++ b/packages/react/src/components/Tab/Tab-test.js
@@ -21,11 +21,11 @@ describe('Tab', () => {
       expect(wrapper.hasClass('extra-class')).toBe(true);
     });
 
-    it('renders <a> with expected className', () => {
+    it('renders <buttton> with expected className', () => {
       expect(
         // TODO: uncomment and replace assertion in next major version
-        // wrapper.find('a').hasClass(`${prefix}--tabs__nav-link`)
-        wrapper.find('a').hasClass(`${prefix}--tabs--scrollable__nav-link`)
+        // wrapper.find('button').hasClass(`${prefix}--tabs__nav-link`)
+        wrapper.find('button').hasClass(`${prefix}--tabs--scrollable__nav-link`)
       ).toBe(true);
     });
 
@@ -34,25 +34,21 @@ describe('Tab', () => {
     });
 
     it('renders <a> with tabindex set to 0', () => {
-      expect(wrapper.find('a').props().tabIndex).toEqual(0);
+      expect(wrapper.find('button').props().tabIndex).toEqual(0);
     });
 
     it('sets tabIndex on <a> if one is passed via props', () => {
       wrapper.setProps({ tabIndex: 2 });
-      expect(wrapper.find('a').props().tabIndex).toEqual(2);
+      expect(wrapper.find('button').props().tabIndex).toEqual(2);
     });
 
     it('uses label to set children on <a> when passed via props', () => {
-      expect(wrapper.find('a').props().children).toEqual('firstTab');
-    });
-
-    it('sets href as # by default', () => {
-      expect(wrapper.find('a').props().href).toEqual('#');
+      expect(wrapper.find('button').props().children).toEqual('firstTab');
     });
 
     it('sets new href value when passed in via props', () => {
       wrapper.setProps({ href: '#other-content' });
-      expect(wrapper.find('a').props().href).toEqual('#other-content');
+      expect(wrapper.find('button').props().href).toEqual('#other-content');
     });
 
     it(`should not have [className="${prefix}--tabs__nav-item--selected"] by default`, () => {

--- a/packages/react/src/components/Tab/Tab-test.js
+++ b/packages/react/src/components/Tab/Tab-test.js
@@ -21,7 +21,7 @@ describe('Tab', () => {
       expect(wrapper.hasClass('extra-class')).toBe(true);
     });
 
-    it('renders <buttton> with expected className', () => {
+    it('renders <button> with expected className', () => {
       expect(
         // TODO: uncomment and replace assertion in next major version
         // wrapper.find('button').hasClass(`${prefix}--tabs__nav-link`)

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -179,7 +179,7 @@ export default class Tab extends React.Component {
         {renderButton ? (
           renderButton(buttonProps)
         ) : (
-          <button type="button" {...buttonProps}>
+          <button type="button" role="tab" {...buttonProps}>
             {label}
           </button>
         )}

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -41,7 +41,7 @@ export default class Tab extends React.Component {
     /**
      * Provide a string that represents the `href` of the Tab
      */
-    href: PropTypes.string.isRequired,
+    href: deprecate(PropTypes.string),
 
     /**
      * The element ID for the top-level element.

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -10,6 +10,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import TabContent from '../TabContent';
+import deprecate from '../../prop-types/deprecate.js';
 
 const { prefix } = settings;
 
@@ -72,7 +73,7 @@ export default class Tab extends React.Component {
      * Useful for using Tab along with react-router or other client
      * side router libraries.
      **/
-    renderAnchor: PropTypes.func,
+    renderAnchor: deprecate(PropTypes.func),
 
     /*
      * An optional parameter to allow overriding the content rendering.
@@ -121,7 +122,8 @@ export default class Tab extends React.Component {
       tabIndex,
       onClick,
       onKeyDown,
-      renderAnchor,
+      // TODO: rename renderAnchor to renderButton in next major version
+      renderAnchor: renderButton,
       renderContent, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
@@ -140,7 +142,7 @@ export default class Tab extends React.Component {
       }
     );
 
-    const anchorProps = {
+    const buttonProps = {
       ['aria-selected']: selected,
       ['aria-disabled']: disabled,
       ['aria-controls']: `${id}__panel`,
@@ -175,10 +177,12 @@ export default class Tab extends React.Component {
           onKeyDown(evt);
         }}
         role="presentation">
-        {renderAnchor ? (
-          renderAnchor(anchorProps)
+        {renderButton ? (
+          renderButton(buttonProps)
         ) : (
-          <a {...anchorProps}>{label}</a>
+          <button type="button" {...buttonProps}>
+            {label}
+          </button>
         )}
       </li>
     );

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -141,6 +141,9 @@ export default class Tab extends React.Component {
     );
 
     const anchorProps = {
+      ['aria-selected']: selected,
+      ['aria-disabled']: disabled,
+      ['aria-controls']: `${id}__panel`,
       id,
       // TODO: remove scrollable in next major release
       // className:  `${prefix}--tabs__nav-link`,
@@ -171,10 +174,7 @@ export default class Tab extends React.Component {
           handleTabKeyDown(index, evt);
           onKeyDown(evt);
         }}
-        role="presentation"
-        aria-selected={selected}
-        aria-disabled={disabled}
-        aria-controls={`${id}__panel`}>
+        role="presentation">
         {renderAnchor ? (
           renderAnchor(anchorProps)
         ) : (

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -94,7 +94,7 @@ export default class Tab extends React.Component {
     /**
      * Specify the tab index of the `<button>` node
      */
-    tabIndex: PropTypes.number.isRequired,
+    tabIndex: deprecate(PropTypes.number),
   };
 
   static defaultProps = {

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -92,7 +92,7 @@ export default class Tab extends React.Component {
     selected: PropTypes.bool.isRequired,
 
     /**
-     * Specify the tab index of the `<a>` node
+     * Specify the tab index of the `<button>` node
      */
     tabIndex: PropTypes.number.isRequired,
   };
@@ -160,7 +160,6 @@ export default class Tab extends React.Component {
     return (
       <li
         {...other}
-        tabIndex={-1}
         className={classes}
         onClick={(evt) => {
           if (disabled) {

--- a/packages/react/src/components/Tab/Tab.js
+++ b/packages/react/src/components/Tab/Tab.js
@@ -171,7 +171,7 @@ export default class Tab extends React.Component {
           handleTabKeyDown(index, evt);
           onKeyDown(evt);
         }}
-        role="tab"
+        role="presentation"
         aria-selected={selected}
         aria-disabled={disabled}
         aria-controls={`${id}__panel`}>

--- a/packages/react/src/components/TabContent/TabContent.js
+++ b/packages/react/src/components/TabContent/TabContent.js
@@ -23,8 +23,7 @@ const TabContent = (props) => {
       {...other}
       className={tabContentClasses}
       selected={selected}
-      hidden={!selected}
-      aria-live="polite">
+      hidden={!selected}>
       {children}
     </div>
   );

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -51,7 +51,6 @@ const props = {
   }),
   tab: () => ({
     disabled: boolean('Disabled (disabled in <Tab>)', false),
-    href: text('The href for tab (href in <Tab>)', '#'),
     tabIndex: number('Tab index (tabIndex in <Tab>)', 0),
     onClick: action('onClick'),
     onKeyDown: action('onKeyDown'),

--- a/packages/react/src/components/Tabs/Tabs-story.js
+++ b/packages/react/src/components/Tabs/Tabs-story.js
@@ -95,6 +95,7 @@ const TabContentRenderedOnlyWhenSelected = ({
     <div
       {...other}
       className={classNames(className, `${prefix}--tab-content`)}
+      role="tabpanel"
       selected={selected}>
       {children}
     </div>

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -144,10 +144,10 @@ describe('Tabs', () => {
       let wrapper;
       let firstTab;
       let lastTab;
-      let anchorInFirstTab;
-      let anchorInLastTab;
-      let spyFocusAnchorInFirstTab;
-      let spyFocusAnchorInLastTab;
+      let buttonInFirstTab;
+      let buttonInLastTab;
+      let spyFocusButtonInFirstTab;
+      let spyFocusButtonInLastTab;
 
       describe('state: selected', () => {
         beforeEach(() => {
@@ -163,29 +163,29 @@ describe('Tabs', () => {
           );
           firstTab = wrapper.find('.firstTab').last();
           lastTab = wrapper.find('.lastTab').last();
-          anchorInFirstTab = firstTab.find('a').getDOMNode();
-          anchorInLastTab = lastTab.find('a').getDOMNode();
+          buttonInFirstTab = firstTab.find('button').getDOMNode();
+          buttonInLastTab = lastTab.find('button').getDOMNode();
         });
 
         it('updates selected state when pressing arrow keys', () => {
-          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
-          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          spyFocusButtonInFirstTab = jest.spyOn(buttonInFirstTab, 'focus');
+          spyFocusButtonInLastTab = jest.spyOn(buttonInLastTab, 'focus');
           firstTab.simulate('keydown', { which: rightKey });
-          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+          expect(spyFocusButtonInLastTab).toHaveBeenCalled();
           lastTab.simulate('keydown', { which: leftKey });
-          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+          expect(spyFocusButtonInFirstTab).toHaveBeenCalled();
         });
 
         it('loops focus and selected state from lastTab to firstTab', () => {
-          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
+          spyFocusButtonInFirstTab = jest.spyOn(buttonInFirstTab, 'focus');
           lastTab.simulate('keydown', { which: rightKey });
-          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+          expect(spyFocusButtonInFirstTab).toHaveBeenCalled();
         });
 
         it('loops focus and selected state from firstTab to lastTab', () => {
-          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          spyFocusButtonInLastTab = jest.spyOn(buttonInLastTab, 'focus');
           firstTab.simulate('keydown', { which: leftKey });
-          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+          expect(spyFocusButtonInLastTab).toHaveBeenCalled();
         });
 
         it('updates selected state when pressing space or enter key', () => {
@@ -213,29 +213,29 @@ describe('Tabs', () => {
           );
           firstTab = wrapper.find('.firstTab').last();
           lastTab = wrapper.find('.lastTab').last();
-          anchorInFirstTab = firstTab.find('a').getDOMNode();
-          anchorInLastTab = lastTab.find('a').getDOMNode();
+          buttonInFirstTab = firstTab.find('button').getDOMNode();
+          buttonInLastTab = lastTab.find('button').getDOMNode();
         });
         it('updates selected state when pressing arrow keys', () => {
-          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
-          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          spyFocusButtonInFirstTab = jest.spyOn(buttonInFirstTab, 'focus');
+          spyFocusButtonInLastTab = jest.spyOn(buttonInLastTab, 'focus');
           firstTab.simulate('keydown', { which: rightKey });
-          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+          expect(spyFocusButtonInLastTab).toHaveBeenCalled();
           lastTab.simulate('keydown', { which: leftKey });
-          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+          expect(spyFocusButtonInFirstTab).toHaveBeenCalled();
         });
 
         it('loops focus and selected state from lastTab to firstTab', () => {
-          spyFocusAnchorInFirstTab = jest.spyOn(anchorInFirstTab, 'focus');
+          spyFocusButtonInFirstTab = jest.spyOn(buttonInFirstTab, 'focus');
           wrapper.setState({ selected: 2 });
           lastTab.simulate('keydown', { which: rightKey });
-          expect(spyFocusAnchorInFirstTab).toHaveBeenCalled();
+          expect(spyFocusButtonInFirstTab).toHaveBeenCalled();
         });
 
         it('loops focus and selected state from firstTab to lastTab', () => {
-          spyFocusAnchorInLastTab = jest.spyOn(anchorInLastTab, 'focus');
+          spyFocusButtonInLastTab = jest.spyOn(buttonInLastTab, 'focus');
           firstTab.simulate('keydown', { which: leftKey });
-          expect(spyFocusAnchorInLastTab).toHaveBeenCalled();
+          expect(spyFocusButtonInLastTab).toHaveBeenCalled();
         });
 
         it('updates selected state when pressing space or enter key', () => {
@@ -247,13 +247,13 @@ describe('Tabs', () => {
       });
 
       afterEach(() => {
-        if (spyFocusAnchorInLastTab) {
-          spyFocusAnchorInLastTab.mockRestore();
-          spyFocusAnchorInLastTab = null;
+        if (spyFocusButtonInLastTab) {
+          spyFocusButtonInLastTab.mockRestore();
+          spyFocusButtonInLastTab = null;
         }
-        if (spyFocusAnchorInFirstTab) {
-          spyFocusAnchorInFirstTab.mockRestore();
-          spyFocusAnchorInFirstTab = null;
+        if (spyFocusButtonInFirstTab) {
+          spyFocusButtonInFirstTab.mockRestore();
+          spyFocusButtonInFirstTab = null;
         }
       });
     });

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -328,7 +328,11 @@ export default class Tabs extends React.Component {
     }
   };
 
-  handleOverflowNavMouseDown = (_, { direction }) => {
+  handleOverflowNavMouseDown = (event, { direction }) => {
+    // disregard mouse buttons aside from LMB
+    if (event.buttons !== 1) {
+      return;
+    }
     this.overflowNavInterval = setInterval(() => {
       const { clientWidth, scrollLeft, scrollWidth } = this.tablist?.current;
 
@@ -343,7 +347,7 @@ export default class Tabs extends React.Component {
       }
 
       // account for overflow button appearing and causing tablist width change
-      this.handleOverflowNavClick(_, { direction });
+      this.handleOverflowNavClick(event, { direction });
     });
   };
 
@@ -451,8 +455,8 @@ export default class Tabs extends React.Component {
             type="button"
             className={classes.leftOverflowButtonClasses}
             onClick={(_) => this.handleOverflowNavClick(_, { direction: -1 })}
-            onMouseDown={(_) =>
-              this.handleOverflowNavMouseDown(_, { direction: -1 })
+            onMouseDown={(event) =>
+              this.handleOverflowNavMouseDown(event, { direction: -1 })
             }
             onMouseUp={this.handleOverflowNavMouseUp}
             ref={this.leftOverflowNavButton}>
@@ -471,8 +475,8 @@ export default class Tabs extends React.Component {
             type="button"
             className={classes.rightOverflowButtonClasses}
             onClick={(_) => this.handleOverflowNavClick(_, { direction: 1 })}
-            onMouseDown={(_) =>
-              this.handleOverflowNavMouseDown(_, { direction: 1 })
+            onMouseDown={(event) =>
+              this.handleOverflowNavMouseDown(event, { direction: 1 })
             }
             onMouseUp={this.handleOverflowNavMouseUp}
             ref={this.rightOverflowNavButton}>

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -205,7 +205,10 @@ export default class Tabs extends React.Component {
     }
 
     if (prevState.selected !== selected) {
-      this.getTabAt(selected)?.tabAnchor?.scrollIntoView(false);
+      this.getTabAt(selected)?.tabAnchor?.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      });
     }
   }
 

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -452,14 +452,16 @@ export default class Tabs extends React.Component {
       <>
         <div {...other} className={classes.tabs} onScroll={this.handleScroll}>
           <button
-            type="button"
+            aria-hidden="true"
             className={classes.leftOverflowButtonClasses}
             onClick={(_) => this.handleOverflowNavClick(_, { direction: -1 })}
             onMouseDown={(event) =>
               this.handleOverflowNavMouseDown(event, { direction: -1 })
             }
             onMouseUp={this.handleOverflowNavMouseUp}
-            ref={this.leftOverflowNavButton}>
+            ref={this.leftOverflowNavButton}
+            tabIndex="-1"
+            type="button">
             <ChevronLeft16 />
           </button>
           {!leftOverflowNavButtonHidden && (
@@ -472,14 +474,16 @@ export default class Tabs extends React.Component {
             <div className={`${prefix}--tabs__overflow-indicator--right`} />
           )}
           <button
-            type="button"
+            aria-hidden="true"
             className={classes.rightOverflowButtonClasses}
             onClick={(_) => this.handleOverflowNavClick(_, { direction: 1 })}
             onMouseDown={(event) =>
               this.handleOverflowNavMouseDown(event, { direction: 1 })
             }
             onMouseUp={this.handleOverflowNavMouseUp}
-            ref={this.rightOverflowNavButton}>
+            ref={this.rightOverflowNavButton}
+            tabIndex="-1"
+            type="button">
             <ChevronRight16 />
           </button>
         </div>

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -402,7 +402,6 @@ export default class Tabs extends React.Component {
         <TabContent
           id={tabId && `${tabId}__panel`}
           className={tabContentClassName}
-          aria-hidden={!selected}
           hidden={!selected}
           selected={selected}
           aria-labelledby={tabId}>

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -467,7 +467,11 @@ export default class Tabs extends React.Component {
           {!leftOverflowNavButtonHidden && (
             <div className={`${prefix}--tabs__overflow-indicator--left`} />
           )}
-          <ul role="tablist" className={classes.tablist} ref={this.tablist}>
+          <ul
+            role="tablist"
+            tabIndex={-1}
+            className={classes.tablist}
+            ref={this.tablist}>
             {tabsWithProps}
           </ul>
           {!rightOverflowNavButtonHidden && (


### PR DESCRIPTION
Closes #6984

This PR updates the `role` attribute on the tab anchor and moves the aria attributes from the parent list item element to the anchor as well. The anchor is also updated to be a button now to prevent things like "Open link in new window" or "Copy link address" from appearing in the context menu

#### Changelog

**Changed**

- deprecate `renderAnchor` (to be replaced with `renderButton`, unless we have a better name in mind)
- move role and aria attributes from list item to inner anchor
- convert anchor to button element

**Removed**

- outdated tests

#### Testing / Reviewing

Ensure the updated tabs match the existing tabs in behavior and appearance and confirm the updated markup matches the expected markup from the referenced issue
