### PR TITLE
docs: update Code Sandbox example to use latest Carbon version

### DIFF
--- a/packages/react/examples/react-router/package.json
+++ b/packages/react/examples/react-router/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "carbon-components": "^9.68.10",
-    "carbon-components-react": "^6.81.4",
+    "carbon-components": "latest",
+    "carbon-components-react": "latest",
+    "carbon-icons": "latest",
     "node-sass": "^4.11.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",


### PR DESCRIPTION
Closes #6990

This PR updates the react-router Code Sandbox example so that it uses the latest Carbon version and displays the scrollable tabs rather than the dropdown tabs at smaller screen sizes

#### Testing / Reviewing

View https://codesandbox.io/s/github/emyarod/carbon/tree/6990-update-react-router-example/packages/react/examples/react-router and confirm that the Tabs are up to spec