### PR TITLE
docs(button): update icon only button story to show props

### DIFF
--- a/packages/react/src/components/Button/Button-story.js
+++ b/packages/react/src/components/Button/Button-story.js
@@ -192,7 +192,9 @@ export const Playground = () => {
   );
 };
 
-export const IconButton = () => <Button {...props.iconOnly()} hasIconOnly />;
+export const IconButton = () => (
+  <Button renderIcon={Add16} iconDescription="Icon Description" hasIconOnly />
+);
 
 IconButton.story = {
   name: 'Icon Button',


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7002

Explicitly sets props for the icon only variant so they props are displayed when `show more` is clicked in the Button docs. 

#### Changelog

**Changed**

- Used props explicitly instead of spreading playground props

#### Testing / Reviewing

Ensure you can see the correct props in the documentation 
