### PR TITLE
fix(a11y): fixing StructuredList accessibility in Windows High Contrast Mode

### DIFF
--- a/packages/components/src/components/structured-list/_structured-list.scss
+++ b/packages/components/src/components/structured-list/_structured-list.scss
@@ -138,6 +138,13 @@
     + .#{$prefix}--structured-list-td
     .#{$prefix}--structured-list-svg {
     fill: $icon-01;
+
+    // Windows, Firefox HCM Fix
+    @media screen and (-ms-high-contrast: active),
+      screen and (prefers-contrast) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      fill: ButtonText;
+    }
   }
 
   // Skeleton State


### PR DESCRIPTION
Closes #6894 

Fixing StructuredList accessibility in Windows High Contrast Mode

#### Changelog

**Changed**

StructuredList component

#### Testing / Reviewing

On a Windows 10 machine, go to `settings --> ease of access --> high contrast` and flick the switch. Compare the storybook in Edge (Should be in High Contrast) to Chrome (Should look normal). 
For **Firefox**, you'll need to open it up and type `about:config` into the address bar. Then, search for `layout.css.prefers-contrast` and set it to `true`.

- Visit [StructuredList](http://192.168.1.158:9000/?path=/story/structuredlist--simple) component
- Verify that the icon checkmarks indicating a selection are visually accessible