### PR TITLE
fix(a11y): fixing Pagination accessibility in Windows High Contrast Mode

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -212,6 +212,13 @@
 
   .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger:focus {
     border-color: $focus;
+
+    // Windows, Firefox HCM Fix
+    @media screen and (-ms-high-contrast: active),
+      screen and (prefers-contrast) {
+      outline: 3px solid transparent;
+      outline-offset: -3px;
+    }
   }
 
   .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger:focus

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -81,6 +81,13 @@
       @include focus-outline('outline');
 
       color: $text-01;
+
+      // Windows, Firefox HCM Fix
+      @media screen and (-ms-high-contrast: active),
+        screen and (prefers-contrast) {
+        outline: 3px solid transparent;
+        outline-offset: -3px;
+      }
     }
 
     &:disabled,


### PR DESCRIPTION
Closes #6890 

Fixing Pagination accessibility on Window High Contrast Mode

#### Changelog

**Changed**

Button and Select component

#### Testing / Reviewing

On a Windows 10 machine, go to `settings --> ease of access --> high contrast` and flick the switch. Compare the storybook in Edge (Should be in High Contrast) to Chrome (Should look normal). 
For **Firefox**, you'll need to open it up and type `about:config` into the address bar. Then, search for `layout.css.prefers-contrast` and set it to `true`.

- Visit [Pagination](http://192.168.1.158:9000/?path=/story/pagination--multiple-pagination-components) component
- Verify that the forward arrow is visible
- Verify that the down arrows is visible
- Verify that there's a focus state on the arrow containers