### PR TITLE
fix(themes): correct color for highlight token in g10 theme

### DIFF
--- a/packages/themes/src/g10.js
+++ b/packages/themes/src/g10.js
@@ -8,7 +8,7 @@ import { adjustLightness } from './tools';
 
 import {
   // Blue
-  blue20,
+  blue10,
   blue40,
   blue60,
   blue70,
@@ -124,7 +124,7 @@ export const disabled01 = white;
 export const disabled02 = gray30;
 export const disabled03 = gray50;
 
-export const highlight = blue20;
+export const highlight = blue10;
 
 export const decorative01 = gray20;
 


### PR DESCRIPTION
According to the [color usage](https://www.carbondesignsystem.com/guidelines/color/usage) page, the token `highlight` should use `blue-10` in the Gray 10 theme as opposed to `blue-20` in the White theme. This is also reflected in the Sketch kit (layer styles).

![image](https://user-images.githubusercontent.com/28265588/95886068-62d37e00-0d7e-11eb-8b23-4bc63d86bd6a.png)

However, in code, the gray 10 theme currently uses `blue-20` instead of `blue-10`. This PR fixes that.


#### Changelog

**Changed**

- Corrected color used for token `highlight` in g10 theme

#### Testing / Reviewing

- Verify that the g10 theme emits `blue-10 (#edf5ff)` for `highlight` instead of `blue-20 (#d0e2ff)`
