### PR TITLE
fix(Tabs): keep selected tab in view

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -145,6 +145,29 @@ export default class Tabs extends React.Component {
 
     this._handleWindowResize();
     window.addEventListener('resize', this._debouncedHandleWindowResize);
+
+    // scroll selected tab into view on mount
+    const {
+      clientWidth: tablistClientWidth,
+      scrollLeft: tablistScrollLeft,
+      scrollWidth: tablistScrollWidth,
+    } = this.tablist.current;
+    const tab = this.getTabAt(this.state.selected);
+    const horizontalOverflow = tablistScrollWidth > tablistClientWidth;
+
+    if (horizontalOverflow) {
+      const leftOverflowNavButtonHidden =
+        tab?.tabAnchor?.getBoundingClientRect().right <
+        tab?.tabAnchor?.offsetParent.getBoundingClientRect().right;
+      const rightOverflowNavButtonHidden =
+        tablistScrollLeft + tablistClientWidth === tablistScrollWidth;
+      tab?.tabAnchor?.scrollIntoView(false);
+
+      // account for overflow buttons in scroll position on mount
+      if (!leftOverflowNavButtonHidden && !rightOverflowNavButtonHidden) {
+        this.tablist.current.scrollLeft += this.OVERFLOW_BUTTON_OFFSET * 2;
+      }
+    }
   }
 
   componentWillUnmount() {
@@ -154,7 +177,7 @@ export default class Tabs extends React.Component {
     window.removeEventListener('resize', this._debouncedHandleWindowResize);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(_, prevState) {
     // compare current tablist properties to current state
     const {
       clientWidth: tablistClientWidth,
@@ -165,7 +188,9 @@ export default class Tabs extends React.Component {
       tablistClientWidth: currentStateClientWidth,
       tablistScrollLeft: currentStateScrollLeft,
       tablistScrollWidth: currentStateScrollWidth,
+      selected,
     } = this.state;
+
     if (
       tablistClientWidth !== currentStateClientWidth ||
       tablistScrollLeft !== currentStateScrollLeft ||
@@ -177,6 +202,10 @@ export default class Tabs extends React.Component {
         tablistScrollLeft,
         tablistScrollWidth,
       });
+    }
+
+    if (prevState.selected !== selected) {
+      this.getTabAt(selected)?.tabAnchor?.scrollIntoView(false);
     }
   }
 

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -151,7 +151,7 @@ export default class Tabs extends React.Component {
       clientWidth: tablistClientWidth,
       scrollLeft: tablistScrollLeft,
       scrollWidth: tablistScrollWidth,
-    } = this.tablist.current;
+    } = this.tablist?.current || {};
     const tab = this.getTabAt(this.state.selected);
     const horizontalOverflow = tablistScrollWidth > tablistClientWidth;
 

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -161,7 +161,7 @@ export default class Tabs extends React.Component {
         tab?.tabAnchor?.offsetParent.getBoundingClientRect().right;
       const rightOverflowNavButtonHidden =
         tablistScrollLeft + tablistClientWidth === tablistScrollWidth;
-      tab?.tabAnchor?.scrollIntoView(false);
+      tab?.tabAnchor?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 
       // account for overflow buttons in scroll position on mount
       if (!leftOverflowNavButtonHidden && !rightOverflowNavButtonHidden) {


### PR DESCRIPTION
Closes #6917

This PR makes sure the selected tab in the component state is visible (component scrolls to the selected tab) when the component updates

#### Changelog

**Changed**

- scroll selected tab into view on component update

#### Testing / Reviewing

Change the selected tab and confirm that the tab is in view on initial render in addition to subsequent renders
