### PR TITLE
docs: fix Node.js version requirement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ contributing environment. Please take a look at our
 Before contributing to Carbon, you should make sure you have the following tools
 installed:
 
-- [Node.js](https://nodejs.org/en/download/) v10 or above here or follow their
+- [Node.js](https://nodejs.org/en/download/) v12 or above here or follow their
   installation through a package manager
   [here](https://nodejs.org/en/download/package-manager/))
   - If you're on macOS, we recommend using


### PR DESCRIPTION
Closes

```
> yarn install --offline

yarn install v1.22.5
[1/5] 🔍  Validating package.json...
error carbon@0.0.0: The engine "node" is incompatible with this module. Expected version "12.x". Got "10.20.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

#### Changelog

**Changed**

- Match Node.js version requirement in the Contributor guide with version in https://github.com/carbon-design-system/carbon/blob/master/package.json#L8

