### PR TITLE
fix(ClickListener): support Shadow DOM

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -409,7 +409,7 @@ class OverflowMenu extends Component {
         menuBody.ownerDocument,
         focusinEventName,
         (event) => {
-          const { target } = event;
+          const target = ClickListener.getEventTarget(event);
           const { current: triggerEl } = this._triggerRef;
           if (typeof target.matches === 'function') {
             if (

--- a/packages/react/src/internal/ClickListener.js
+++ b/packages/react/src/internal/ClickListener.js
@@ -18,6 +18,14 @@ export default class ClickListener extends React.Component {
     onClickOutside: PropTypes.func.isRequired,
   };
 
+  static getEventTarget(evt) {
+    // support Shadow DOM
+    if (evt.composed && typeof evt.composedPath === 'function') {
+      return evt.composedPath()[0];
+    }
+    return evt.target;
+  }
+
   constructor(props) {
     super(props);
     // We manually bind handlers in this Component, versus using class
@@ -37,7 +45,10 @@ export default class ClickListener extends React.Component {
 
   handleDocumentClick(evt) {
     if (this.element) {
-      if (this.element.contains && !this.element.contains(evt.target)) {
+      if (
+        this.element.contains &&
+        !this.element.contains(ClickListener.getEventTarget(evt))
+      ) {
         this.props.onClickOutside(evt);
       }
     }


### PR DESCRIPTION
Closes

When using the OverflowMenu in a Shadow DOM, the it closes immediately.
The ClickListener wrongly determines that the clicked element (which is the OverflowMenu itself) is outside.
This is because in this scenario evt.target is the root element, which indeed lies outside.

#### Changelog

**Changed**

- Check if the event is [composed](https://developer.mozilla.org/en-US/docs/Web/API/Event/composed) and in that case use the first one in the [composedPath](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath)

#### Testing / Reviewing

* verify that the behavior in normal circumstances (non Shadow DOM, e.g. in the Storybook) still works for components that use ClickListener:
  - OverflowMenu
  - ToolbarSearch
  - Tooltip