### PR TITLE
Update Node.js range in package.json to include v12 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:carbon-design-system/carbon.git",
   "license": "Apache-2.0",
   "engines": {
-    "node": "12.x"
+    "node": ">=12.x"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
Based on https://github.com/carbon-design-system/carbon/pull/7064#issuecomment-710769936, this PR updates our `engines.node`  config to >= v12

#### Changelog

**New**

**Changed**

- Update `engines.node` from `12.x` to `>=12.x`

**Removed**
