### PR TITLE
feat(react): add deferComponentRender HOC

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7011,6 +7011,7 @@ Map {
     },
     "render": [Function],
   },
+  "deferComponentRender" => Object {},
   "unstable_PageSelector" => Object {
     "defaultProps": Object {
       "className": null,

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -192,6 +192,7 @@ describe('Carbon Components React', () => {
         "TooltipDefinition",
         "TooltipIcon",
         "UnorderedList",
+        "deferComponentRender",
         "unstable_PageSelector",
         "unstable_Pagination",
         "unstable_TreeNode",

--- a/packages/react/src/components/Accordion/Accordion-story.js
+++ b/packages/react/src/components/Accordion/Accordion-story.js
@@ -22,6 +22,7 @@ import {
   AccordionSkeleton,
 } from '../Accordion';
 import Button from '../Button';
+import { deferComponentRender } from '../../tools/deferComponentRender';
 import mdx from './Accordion.mdx';
 
 export default {
@@ -81,6 +82,27 @@ export const skeleton = () => <AccordionSkeleton open count={4} />;
 skeleton.decorators = [
   (story) => <div style={{ width: '500px' }}>{story()}</div>,
 ];
+
+export const deferContent = () => {
+  const DeferredAccordionItem = deferComponentRender(AccordionItem);
+
+  function Story() {
+    return (
+      <Accordion>
+        <DeferredAccordionItem title="Section 1">
+          Deferred render
+        </DeferredAccordionItem>
+        <DeferredAccordionItem title="Section 2">
+          Deferred render
+        </DeferredAccordionItem>
+        <AccordionItem title="Section 3">Default render</AccordionItem>
+        <AccordionItem title="Section 4">Default render</AccordionItem>
+      </Accordion>
+    );
+  }
+
+  return <Story />;
+};
 
 const props = {
   onClick: action('onClick'),

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -47,6 +47,40 @@ fetched from an external resource like an API.
   <Story id="accordion--skeleton" />
 </Preview>
 
+## Performance
+
+When rendering pages with a lot of content, you may run into a situation where
+mounting and unmounting component trees in your application needs to be
+optimized.
+
+In general, you will rarely run into this situation with components like
+`Accordion`. However, in cases where you may run into this you can use the
+`deferComponentRender` utility that is provided on the `AccordionItem` component
+to defer rendering. This technique was inspired by a solution outlined by the
+team that built
+[Twitter Lite](https://medium.com/@paularmstrong/twitter-lite-and-high-performance-react-progressive-web-apps-at-scale-d28a00e780a3)
+when they ran into a similar problem.
+
+The `deferComponentRender` utility is a
+[Higher-Order Component](https://reactjs.org/docs/higher-order-components.html),
+meaning that it is a function that takes in a component and returns a new one.
+
+In our case, `deferComponentRender` will take in `AccordionItem` and return a
+`DeferredAccordionItem` which will defer rendering of its content.
+
+```js
+import { AccordionItem, deferComponentRender } from 'carbon-components-react';
+
+const DeferredAccordionItem = deferComponentRender(AccordionItem);
+```
+
+You can then use `DeferredAccordionItem` in place of `AccordionItem` where
+appropriate.
+
+<Preview>
+  <Story id="accordion--defer-content" />
+</Preview>
+
 ## Component API
 
 <Props />

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -197,6 +197,9 @@ export {
   SideNavSwitcher,
 } from './components/UIShell';
 
+// Tools or utilities
+export { deferComponentRender } from './tools/deferComponentRender';
+
 // Experimental
 export {
   PageSelector as unstable_PageSelector,

--- a/packages/react/src/tools/__tests__/deferComponentRender-test.js
+++ b/packages/react/src/tools/__tests__/deferComponentRender-test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { deferComponentRender } from '../deferComponentRender';
+
+jest.useFakeTimers();
+
+function TestComponent() {
+  return <div data-testid="test">test</div>;
+}
+
+describe('deferComponentRender', () => {
+  let mountNode;
+
+  beforeEach(() => {
+    mountNode = document.createElement('div');
+  });
+
+  it('should defer rendering the deferred component on the client', () => {
+    const Deferred = deferComponentRender(TestComponent);
+    ReactDOM.render(<Deferred />, mountNode);
+    expect(mountNode.querySelector('[data-testid="test"]')).toBe(null);
+
+    act(() => {
+      jest.runAllTimers();
+      jest.runAllTimers();
+    });
+
+    const testNode = mountNode.querySelector('[data-testid="test"]');
+    expect(testNode).toBeTruthy();
+    expect(testNode.textContent).toBe('test');
+  });
+});

--- a/packages/react/src/tools/__tests__/deferComponentRender.server-test.js
+++ b/packages/react/src/tools/__tests__/deferComponentRender.server-test.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { deferComponentRender } from '../deferComponentRender';
+
+function TestComponent() {
+  return 'test';
+}
+
+describe('deferComponentRender.server', () => {
+  it('should render the deferred component on the server', () => {
+    const Deferred = deferComponentRender(TestComponent);
+    const html = renderToString(<Deferred />);
+    expect(html).toEqual('test');
+  });
+});

--- a/packages/react/src/tools/deferComponentRender.js
+++ b/packages/react/src/tools/deferComponentRender.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+// Minimal implementation of `deferComponentRender` from:
+// https://medium.com/@paularmstrong/twitter-lite-and-high-performance-react-progressive-web-apps-at-scale-d28a00e780a3
+
+const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);
+
+export function deferComponentRender(WrappedComponent) {
+  function DeferredRender(props) {
+    // We defer rendering on the client but not the server
+    const [shouldRender, setShouldRender] = useState(!canUseDOM);
+
+    useEffect(() => {
+      let frameId = window.requestAnimationFrame(() => {
+        frameId = window.requestAnimationFrame(() => {
+          setShouldRender(true);
+        });
+      });
+
+      return () => {
+        window.cancelAnimationFrame(frameId);
+      };
+    }, []);
+
+    if (shouldRender) {
+      return <WrappedComponent {...props} />;
+    }
+
+    return null;
+  }
+
+  return DeferredRender;
+}

--- a/tasks/jest/setup.js
+++ b/tasks/jest/setup.js
@@ -13,9 +13,6 @@ jest.setTimeout(20000);
 
 global.requestAnimationFrame = function requestAnimationFrame(callback) {
   setTimeout(callback, 0);
-  // TODO: replace with async version
-  // setTimeout(callback);
-  // callback();
 };
 
 const enzyme = jest.requireActual('enzyme');

--- a/tasks/jest/setup.js
+++ b/tasks/jest/setup.js
@@ -12,9 +12,10 @@ global.__DEV__ = true;
 jest.setTimeout(20000);
 
 global.requestAnimationFrame = function requestAnimationFrame(callback) {
+  setTimeout(callback, 0);
   // TODO: replace with async version
   // setTimeout(callback);
-  callback();
+  // callback();
 };
 
 const enzyme = jest.requireActual('enzyme');


### PR DESCRIPTION
Closes #5901

This is a follow-up to #5901 that brings in a `deferComponentRender` HOC that can be used alongside components which teams may need to defer rendering for (Tabs, Accordion, Content Switcher) in pages with a large trees that are mounted/un-mounted (reference post for this issue is seen over in the [Twitter Lite](https://medium.com/@paularmstrong/twitter-lite-and-high-performance-react-progressive-web-apps-at-scale-d28a00e780a3) blog post)

#### Changelog

**New**

- Add `deferComponentRender` HOC that is derived from the implementation in the Twitter Lite blog post

**Changed**

- Updated Accordion docs to include performance section

**Removed**
