### PR TITLE
fix(icons): add more aliases for external link icon

### DIFF
--- a/packages/icons/icons.yml
+++ b/packages/icons/icons.yml
@@ -1435,7 +1435,7 @@
     - 32
 - name: calendar--heat-map
   friendly_name: Calendar heat map
-  aliases: 
+  aliases:
     - heat map
     - date
     - schedule
@@ -6510,6 +6510,9 @@
     - new window
     - window
     - expand
+    - link
+    - external link
+    - outbound
   sizes:
     - 16
     - 32


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7071

Adds a few more aliases so the external link icon is easier to find on the website

