### PR TITLE
fix(textarea): fix disabled state background on g10 theme

### DIFF
--- a/packages/components/src/components/text-area/_text-area.scss
+++ b/packages/components/src/components/text-area/_text-area.scss
@@ -75,7 +75,7 @@
   //-----------------------------
   .#{$prefix}--text-area:disabled {
     color: $disabled-02;
-    background-color: $disabled-background-color;
+    background-color: $disabled-01;
     border-bottom: 1px solid transparent;
     outline: none;
     cursor: not-allowed;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7058

Fixes disabled state background color on g10 theme

#### Changelog

**Changed**

- Uses correct token for disabled background color

#### Testing / Reviewing

Enable the `g10` theme and then disable the `TextArea`. Ensure the input does not blend into the background 
