### PR TITLE
fix(modal): only call toggleClass when needed

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -150,11 +150,14 @@ export default class ComposedModal extends Component {
     } else if (prevState.open && !this.state.open) {
       this.beingOpen = false;
     }
-    toggleClass(
-      document.body,
-      `${prefix}--body--with-modal-open`,
-      this.state.open
-    );
+
+    if (prevState.open !== this.state.open) {
+      toggleClass(
+        document.body,
+        `${prefix}--body--with-modal-open`,
+        this.state.open
+      );
+    }
   }
 
   focusButton = (focusContainerElement) => {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7011

Adds in check to ensure we only call `toggleClass` when the open state is changed 

#### Changelog

**New**

- Check to only call `toggleClass` when the state has changed 

#### Testing / Reviewing

Go to `ComposedModal` and try toggling the modal via knobs and `x` icon and ensure everything still works 
