### PR TITLE
fix(button): fix ghost button padding

### DIFF
--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -114,19 +114,19 @@ $button-padding-lg: $carbon--spacing-04 !default;
 /// @access public
 /// @group button
 /// Uses the same padding-y as normal buttons, but removes extra padding-right
-$button-padding-ghost: calc(0.875rem - 3px) 12px !default;
+$button-padding-ghost: calc(0.875rem - 3px) 16px !default;
 
 /// @type Number
 /// @access public
 /// @group button
 /// Uses the same padding-y as field buttons, but removes extra padding-right
-$button-padding-ghost-field: calc(0.675rem - 3px) 12px !default;
+$button-padding-ghost-field: calc(0.675rem - 3px) 16px !default;
 
 /// @type Number
 /// @access public
 /// @group button
 /// Uses the same padding-y as small buttons, but removes extra padding-right
-$button-padding-ghost-sm: calc(0.375rem - 3px) 12px !default;
+$button-padding-ghost-sm: calc(0.375rem - 3px) 16px !default;
 
 /// @type Number
 /// @access public


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7091

Adjusts padding on Ghost Button variant

#### Changelog

**Changed**

- Bumps horizontal padding from `12px` to `16px`

#### Testing / Reviewing

Ensure padding looks correct
