### PR TITLE
feat(carbon): update Downshift to v6

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@carbon/icons-react": "^10.19.0",
     "classnames": "2.2.6",
-    "downshift": "5.2.1",
+    "downshift": "6.0.6",
     "flatpickr": "4.6.1",
     "invariant": "^2.2.3",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Updates Downshift to latest. prerequisite pull request I figured we should get in before we refactor MultiSelect to use Downshift's fancy new `useMultipleSelection` hook.

Did a quick run through of the effected components and everything seemed a-okay, but check my work for sure. 