### PR TITLE
fix(tile-group): correct legend style

### DIFF
--- a/packages/react/src/components/TileGroup/TileGroup.js
+++ b/packages/react/src/components/TileGroup/TileGroup.js
@@ -113,7 +113,7 @@ export default class TileGroup extends React.Component {
 
   renderLegend = (legend) => {
     if (legend) {
-      return <legend>{legend}</legend>;
+      return <legend className={`${prefix}--label`}>{legend}</legend>;
     }
   };
 


### PR DESCRIPTION
Applies the correct styling to the legend of a TileGroup (radio tiles)

#### Changelog

**New**

- added `bx--label` class to `<legend>` in `TileGroup` component

#### Testing / Reviewing

Before (current storybook):
![image](https://user-images.githubusercontent.com/28265588/96703186-d7b44280-1392-11eb-9d41-71da9111a472.png)

After (PR storybook):
![image](https://user-images.githubusercontent.com/28265588/96703158-d2ef8e80-1392-11eb-9365-ba27d4c0ff7c.png)

