### PR TITLE
fix(a11y): Fixing Overflow menu accessibility on Window High Contrast Mode

### DIFF
--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -39,6 +39,13 @@
 
     &:focus {
       @include focus-outline('outline');
+
+      // Windows, Firefox HCM Fix
+      @media screen and (-ms-high-contrast: active),
+        screen and (prefers-contrast) {
+        outline: 3px solid transparent;
+        outline-offset: -3px;
+      }
     }
 
     &:hover {
@@ -225,6 +232,13 @@
 
     &:focus {
       @include focus-outline('outline');
+
+      // Windows, Firefox HCM Fix
+      @media screen and (-ms-high-contrast: active),
+        screen and (prefers-contrast) {
+        outline: 3px solid transparent;
+        outline-offset: -3px;
+      }
     }
 
     &::-moz-focus-inner {


### PR DESCRIPTION
Closes #6889 

Fixing Overflow menu accessibility on Window High Contrast Mode

#### Changelog

**Changed**

Overflow Menu component

#### Testing / Reviewing

On a Windows 10 machine, go to `settings --> ease of access --> high contrast` and flick the switch. Compare the storybook in Edge (Should be in High Contrast) to Chrome (Should look normal). 
For **Firefox**, you'll need to open it up and type `about:config` into the address bar. Then, search for `layout.css.prefers-contrast` and set it to `true`.

- Visit [Overflow Menu](http://192.168.1.158:9000/?path=/story/overflowmenu--basic) component
- Verify that the icon shows properly
- Verify the focus state works on the icon
- Verify that focus state works on the menu options