### PR TITLE
fix(a11y): fixing accessibility on Window High Contrast Mode

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -297,10 +297,22 @@ $list-box-menu-width: rem(300px);
     vertical-align: top;
     outline: none;
     cursor: pointer;
+
+    @media screen and (-ms-high-contrast: active),
+      screen and (prefers-contrast) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      border: 1px solid ButtonText;
+    }
   }
 
   .#{$prefix}--list-box__field:focus {
     @include focus-outline('outline');
+
+    @media screen and (-ms-high-contrast: active),
+      screen and (prefers-contrast) {
+      // `ButtonText` is a CSS2 system color to help improve colors in HCM
+      border: 2px solid ButtonText;
+    }
   }
 
   .#{$prefix}--list-box__field[disabled] {
@@ -458,6 +470,12 @@ $list-box-menu-width: rem(300px);
     background-color: $inverse-02;
     border-radius: rem(12px);
     transform: none;
+
+    // Windows, Firefox HCM Fix
+    @media screen and (-ms-high-contrast: active),
+      screen and (prefers-contrast) {
+      border: 1px solid transparent;
+    }
   }
 
   .#{$prefix}--list-box__selection--multi > svg {
@@ -635,6 +653,13 @@ $list-box-menu-width: rem(300px);
       margin: 0;
       padding: rem(11px) rem(16px);
       border-color: transparent;
+
+      // Windows, Firefox HCM Fix
+      @media screen and (-ms-high-contrast: active),
+        screen and (prefers-contrast) {
+        outline: 3px solid transparent;
+        outline-offset: -3px;
+      }
     }
 
     &:hover {
@@ -677,6 +702,13 @@ $list-box-menu-width: rem(300px);
     color: $text-01;
     background-color: $hover-ui;
     border-color: transparent;
+
+    // Windows, Firefox HCM Fix
+    @media screen and (-ms-high-contrast: active),
+      screen and (prefers-contrast) {
+      outline: 3px solid transparent;
+      outline-offset: -3px;
+    }
   }
 
   .#{$prefix}--list-box__menu-item--highlighted


### PR DESCRIPTION
Closes #6888 

Fixing Overflow menu accessibility on Window High Contrast Mode

#### Changelog

**Changed**

Overflow Menu component

#### Testing / Reviewing

On a Windows 10 machine, go to `settings --> ease of access --> high contrast` and flick the switch. Compare the storybook in Edge (Should be in High Contrast) to Chrome (Should look normal). 
For **Firefox**, you'll need to open it up and type `about:config` into the address bar. Then, search for `layout.css.prefers-contrast` and set it to `true`.

- Visit [Multiselect](http://192.168.1.158:9000/?path=/story/multiselect--default) component
- Verify that there is a focus state on the multiselect
- Verify that the options have a highlight state
- Verify that the options have a focus state