### PR TITLE
docs: update icon documentation link

### DIFF
--- a/docs/guides/building-an-icon-library.md
+++ b/docs/guides/building-an-icon-library.md
@@ -43,7 +43,7 @@ assets, in addition to exporting the following assets:
   library!
 
 If you're curious about `@carbon/icons` and want to learn more, definitely check
-out our [Icon documentation](/docs/icons.md)!
+out our [Icon documentation](/docs/guides/icons.md)!
 
 ### Philosophy
 


### PR DESCRIPTION
This is a small PR that updates a link in our Icon guides on GitHub so that it doesn't 404