### PR TITLE
fix(Tabs): remove nested tabs selector

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -431,16 +431,14 @@
 
   // TODO: remove namespace and suffix in next major release
   .#{$prefix}--tabs--scrollable {
-    .#{$prefix}--tabs--scrollable {
-      @include reset;
-      @include type-style('body-short-01');
+    @include reset;
+    @include type-style('body-short-01');
 
-      display: flex;
-      width: 100%;
-      height: auto;
-      min-height: rem(40px);
-      color: $text-01;
-    }
+    display: flex;
+    width: 100%;
+    height: auto;
+    min-height: rem(40px);
+    color: $text-01;
 
     .#{$prefix}--tabs--scrollable--container {
       min-height: rem(48px);

--- a/packages/react/src/components/Tabs/Tabs-test.js
+++ b/packages/react/src/components/Tabs/Tabs-test.js
@@ -35,7 +35,7 @@ describe('Tabs', () => {
           wrapper
             // TODO: uncomment and replace in next major version
             // .find(`.${prefix}--tabs`).hasClass('extra-class')
-            .find(`.${prefix}--tabs--scrollable .${prefix}--tabs--scrollable`)
+            .find(`.${prefix}--tabs--scrollable`)
             .hasClass('extra-class')
         ).toBe(true);
       });
@@ -55,9 +55,7 @@ describe('Tabs', () => {
             </Tabs>
           )
             .find('div')
-            // TODO: uncomment and replace .at() in next major version
-            // .first()
-            .at(1)
+            .first()
             .hasClass(`${prefix}--tabs--scrollable--container`)
         ).toBe(true);
       });
@@ -68,7 +66,7 @@ describe('Tabs', () => {
             wrapper
               // TODO: uncomment in next major version
               // .find(`.${prefix}--tabs`)
-              .find(`.${prefix}--tabs--scrollable .${prefix}--tabs--scrollable`)
+              .find(`.${prefix}--tabs--scrollable`)
               .props()
         ).toBe(false);
       });

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -417,8 +417,7 @@ export default class Tabs extends React.Component {
     };
 
     return (
-      // TODO: remove classname and revert div to React Fragment after next major release
-      <div className={`${prefix}--tabs--scrollable`}>
+      <>
         <div {...other} className={classes.tabs} onScroll={this.handleScroll}>
           <button
             type="button"
@@ -453,7 +452,7 @@ export default class Tabs extends React.Component {
           </button>
         </div>
         {tabContentWithProps}
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
related #6928

This PR removes an extra level of nesting in our scrollable tabs component, reverting the wrapper div back to a React Fragment just as it was prior to #6928

#### Changelog

**Changed**

- update test selectors

**Removed**

- remove nested selector in Tabs
- unnest styles

#### Testing / Reviewing

Ensure the tabs component styles are still namespaced and there are no regressions in scrollable tab styles
