### PR TITLE
fix(ComposedModal): remove invalid DOM attribute

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal-story.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-story.js
@@ -50,6 +50,10 @@ const props = {
       '[data-modal-primary-focus]'
     ),
     size: select('Size (size)', sizes, titleOnly ? 'sm' : ''),
+    preventCloseOnClickOutside: boolean(
+      'Prevent closing on click outside of modal (preventCloseOnClickOutside)',
+      false
+    ),
   }),
   modalHeader: ({ titleOnly } = {}) => ({
     label: text('Optional Label (label in <ModalHeader>)', 'Optional Label'),

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -220,6 +220,7 @@ export default class ComposedModal extends Component {
       containerClassName,
       children,
       danger,
+      preventCloseOnClickOutside, // eslint-disable-line
       selectorPrimaryFocus, // eslint-disable-line
       size,
       ...other
@@ -371,6 +372,7 @@ export class ModalHeader extends Component {
       iconDescription,
       closeModal, // eslint-disable-line
       buttonOnClick, // eslint-disable-line
+      preventCloseOnClickOutside, // eslint-disable-line
       ...other
     } = this.props;
 
@@ -421,7 +423,14 @@ export class ModalHeader extends Component {
 }
 
 export function ModalBody(props) {
-  const { className, children, hasForm, hasScrollingContent, ...other } = props;
+  const {
+    className,
+    children,
+    hasForm,
+    hasScrollingContent,
+    preventCloseOnClickOutside, // eslint-disable-line
+    ...other
+  } = props;
   const contentClass = classNames({
     [`${prefix}--modal-content`]: true,
     [`${prefix}--modal-content--with-form`]: hasForm,


### PR DESCRIPTION
Closes #7100
related #6000
related #6793

This PR prevents `preventCloseOnClickOutside` from being applied to ComposedModal DOM elements and removes the unknown prop warnings emitted by React as a result

#### Changelog

**Removed**

- `preventCloseOnClickOutside` from appearing in the DOM

#### Testing / Reviewing

Confirm that no React warnings are emitted in the ComposedModal due to the `preventCloseOnClickOutside` prop
