### PR TITLE
fix(Tabs): prevent unnecessary vertical scrolling

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -222,7 +222,7 @@ export default class Tabs extends React.Component {
       event.type === 'click'
     ) {
       const currentScrollLeft = this.state.tablistScrollLeft;
-      tab?.tabAnchor?.scrollIntoView(false);
+      tab?.tabAnchor?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       const newScrollLeft = this.tablist.current.scrollLeft;
       if (newScrollLeft > currentScrollLeft) {
         this.tablist.current.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;


### PR DESCRIPTION
Closes #7084

related #6973
related #6974

This PR updates the fix from #6974 to avoid unnecessary vertical scrolling when selecting tabs. It should now align to the nearest edge rather than always to the bottom or always to the top if the tabs component is off screen

#### Changelog

**Changed**

- scroll behavior when tab selection is modified

#### Testing / Reviewing

Confirm that the tabs component is not unnecessarily aligned to the top or bottom of the viewport when tab selections are modified. The original ticket as well as the related tickets contain different methods to test this behavior 