### PR TITLE
chore: format

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the


### PR DESCRIPTION
allcontributors bot removed a line from the README which is causing prettier checks to fail in CI. This PR restores that empty line