### PR TITLE
chore(docs): update AccordionItem docs

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -106,6 +106,19 @@ for layout.
 </Accordion>
 ```
 
+### AccordionItem onHeadingClick
+
+You can use the `onHeadingClick` prop to determine the state of the
+`AccordionItem` when it is clicked. it will return
+
+```jsx
+<Accordion>
+  <AccordionItem onHeadingClick={(evt) => console.log(evt.isOpen)}>
+    Panel A
+  </AccordionItem>
+</Accordion>
+```
+
 ### AccordionItem title
 
 You can use the `title` prop to specify the accordion item's heading. The

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -94,7 +94,9 @@ through to the underlying accordion header.
 
 The `className` prop passed into `AccordionItem` will be forwarded along to the
 underlying accordion header. This is useful for specifying a custom class name
-for layout.
+for layout. As a reminder, the callback signature will look like
+`{ isOpen: boolean, event: Event }` rather than the usual
+`event: Event, state: { isOpen: boolean }` until the next major version.
 
 ```jsx
 <Accordion>

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -115,7 +115,7 @@ You can use the `onHeadingClick` prop to determine the state of the
 
 ```jsx
 <Accordion>
-  <AccordionItem onHeadingClick={(evt) => console.log(evt.isOpen)}>
+  <AccordionItem onHeadingClick={({ isOpen }) => console.log(isOpen)}>
     Panel A
   </AccordionItem>
 </Accordion>

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -95,8 +95,8 @@ through to the underlying accordion header.
 The `className` prop passed into `AccordionItem` will be forwarded along to the
 underlying accordion header. This is useful for specifying a custom class name
 for layout. As a reminder, the callback signature will look like
-`{ isOpen: boolean, event: Event }` rather than the usual
-`event: Event, state: { isOpen: boolean }` until the next major version.
+`({ isOpen: boolean, event: Event })` rather than the usual
+`(event: Event, state: { isOpen: boolean })` until the next major version.
 
 ```jsx
 <Accordion>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6951

Adds in a short blurb about obscure `AccordionItem` prop

#### Changelog

**New**

- docs about `onHeadingClick`

#### Testing / Reviewing

Ensure the docs help inform about the `onHeadingClick` prop 
