### PR TITLE
style(select): allow select to fill its parent container by default

### DIFF
--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -27,12 +27,15 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    width: 100%;
   }
 
   .#{$prefix}--select-input__wrapper {
     position: relative;
     display: flex;
     align-items: center;
+    width: 100%;
+    max-width: rem(448px);
   }
 
   .#{$prefix}--select-input {
@@ -40,7 +43,7 @@
     @include focus-outline('reset');
 
     display: block;
-    width: rem(224px);
+    width: 100%;
     min-width: rem(128px);
     max-width: rem(448px);
 

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -35,7 +35,6 @@
     display: flex;
     align-items: center;
     width: 100%;
-    max-width: rem(448px);
   }
 
   .#{$prefix}--select-input {
@@ -44,9 +43,6 @@
 
     display: block;
     width: 100%;
-    min-width: rem(128px);
-    max-width: rem(448px);
-
     height: rem(40px);
     padding: 0 $spacing-09 0 $spacing-05;
     color: $text-01;

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -207,6 +207,7 @@
   }
 
   .#{$prefix}--select--inline .#{$prefix}--select-input {
+    width: auto;
     padding-right: $spacing-07;
     padding-left: $carbon--spacing-03;
     color: $text-01;

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -90,7 +90,7 @@ export default {
 };
 
 export const Default = () => (
-  <div style={{ width: 300 }}>
+  <div style={{ width: 400 }}>
     <Dropdown
       id="default"
       titleText="Dropdown label"

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -67,22 +67,24 @@ export default {
 export const Default = () => {
   const groupProps = props.group();
   return (
-    <Select {...props.select()} id="select-1" defaultValue="placeholder-item">
-      <SelectItem
-        disabled
-        hidden
-        value="placeholder-item"
-        text="Choose an option"
-      />
-      <SelectItemGroup label="Category 1" {...groupProps}>
-        <SelectItem value="option-1" text="Option 1" />
-        <SelectItem value="option-2" text="Option 2" />
-      </SelectItemGroup>
-      <SelectItemGroup label="Category 2" {...groupProps}>
-        <SelectItem value="option-3" text="Option 3" />
-        <SelectItem value="option-4" text="Option 4" />
-      </SelectItemGroup>
-    </Select>
+    <div style={{ width: 300 }}>
+      <Select {...props.select()} id="select-1" defaultValue="placeholder-item" >
+        <SelectItem
+          disabled
+          hidden
+          value="placeholder-item"
+          text="Choose an option"
+        />
+        <SelectItemGroup label="Category 1" {...groupProps}>
+          <SelectItem value="option-1" text="Option 1" />
+          <SelectItem value="option-2" text="Option 2" />
+        </SelectItemGroup>
+        <SelectItemGroup label="Category 2" {...groupProps}>
+          <SelectItem value="option-3" text="Option 3" />
+          <SelectItem value="option-4" text="Option 4" />
+        </SelectItemGroup>
+      </Select>
+    </div>
   );
 };
 

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -68,7 +68,7 @@ export const Default = () => {
   const groupProps = props.group();
   return (
     <div style={{ width: 300 }}>
-      <Select {...props.select()} id="select-1" defaultValue="placeholder-item" >
+      <Select {...props.select()} id="select-1" defaultValue="placeholder-item">
         <SelectItem
           disabled
           hidden

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -67,7 +67,7 @@ export default {
 export const Default = () => {
   const groupProps = props.group();
   return (
-    <div style={{ width: 300 }}>
+    <div style={{ width: 400 }}>
       <Select {...props.select()} id="select-1" defaultValue="placeholder-item">
         <SelectItem
           disabled


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7259

Aligns `Select` to `Dropdown` behavior. 

Questions for design:
- Should a `Dropdown` or `Select` have a `min-width`? 
  - Currently `Select` has a `min-width` of `128px`, `Dropdown` has none specified. 
- Should a `Dropdown` or `Select` have a `max-width`? 
  - Currently `Select` has a `max-width` of `448px`, `Dropdown` has none specified and will expand to fill it's container.

#### Changelog

**New**
- Added a div with a fixed width, akin to `Dropdown`, in `Select-story.js` to show that the select expands to fill its container

**Changed**
- `.#{$prefix}--select`, `.#{$prefix}--select-input__wrapper`, and `.#{$prefix}--select-input` now have `width: 100%` set by default.
- `.#{$prefix}--select-input__wrapper` now also has a `max-width`, otherwise, the chevron renders out of place if the container is larger that the select inputs `max-width`

**Removed**

- Hardcoded default `width` on `select`

#### Testing / Reviewing

Ensure `Select` renders as expected. Inspect the styles and change the inline `width: 300px` to a different value and ensure the chevron and input change accordingly
