### PR TITLE
fix(tooltip): add :active:visited styles on links

### DIFF
--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -418,7 +418,9 @@
         outline-offset: 2px;
       }
 
-      &:active {
+      &:active,
+      &:active:visited,
+      &:active:visited:hover {
         color: $inverse-01;
       }
 


### PR DESCRIPTION
Closes #7247

This PR adds style rules for active visited links within tooltips

#### Testing / Reviewing

Confirm that active visited links within tooltips are readable and use `$inverse-01`