### PR TITLE
style(data-table): update styles based on audit

### DIFF
--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -63,9 +63,11 @@
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] td {
+    padding-left: $carbon--spacing-09;
     border-bottom: 1px solid $ui-03;
     transition: padding-bottom $duration--fast-02 motion(standard, productive),
-      transform $duration--fast-02 motion(standard, productive);
+      transform $duration--fast-02 motion(standard, productive),
+      background-color $duration--fast-02 motion(standard, productive);
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row
@@ -194,11 +196,11 @@
   }
 
   .#{$prefix}--table-expand__button:focus {
-    outline: 1px solid transparent;
+    outline: none;
   }
 
   .#{$prefix}--table-expand__button:focus .#{$prefix}--table-expand__svg {
-    box-shadow: inset 0 0 0 1px $focus;
+    box-shadow: inset 0 0 0 2px $focus;
   }
 
   .#{$prefix}--table-expand__svg {

--- a/packages/react/src/components/DataTable/DataTable-story.js
+++ b/packages/react/src/components/DataTable/DataTable-story.js
@@ -207,7 +207,7 @@ export const WithToolbar = () => (
         <TableToolbar {...getToolbarProps()} aria-label="data table toolbar">
           <TableToolbarContent>
             <TableToolbarSearch onChange={onInputChange} />
-            <TableToolbarMenu>
+            <TableToolbarMenu light>
               <TableToolbarAction
                 onClick={action('Action 1 Click')}
                 primaryFocus>

--- a/packages/react/src/components/DataTable/stories/datatable-story.scss
+++ b/packages/react/src/components/DataTable/stories/datatable-story.scss
@@ -8,13 +8,6 @@
 @import '~@carbon/type/scss/type';
 @import '~@carbon/themes/scss/themes';
 
-.demo-expanded-td td {
-  /* stylelint-disable-next-line declaration-no-important */
-  padding-left: 3.25rem !important;
-  padding-bottom: 1.5rem;
-  padding-top: 1rem;
-}
-
 .demo-inner-container-header {
   @include carbon--type-style('productive-heading-01');
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7283

Fixes issues uncovered in style audit

#### Changelog

**Changed**

- `TableToolbarMenu` now uses the `light` prop
- Updated expandable `td` left padding
- Updated expandable chevron focus styles
- Updated expandable `td` background color transition to match parent row transition speed

**Removed**

- unnecessary storybook styles 

#### Testing / Reviewing

Ensure the style updates are correct
