### PR TITLE
Add onChange event handler to TableSelectRow

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1250,6 +1250,9 @@ Map {
           "isRequired": true,
           "type": "string",
         },
+        "onChange": Object {
+          "type": "func",
+        },
         "onSelect": Object {
           "isRequired": true,
           "type": "func",
@@ -1869,6 +1872,9 @@ Map {
       "name": Object {
         "isRequired": true,
         "type": "string",
+      },
+      "onChange": Object {
+        "type": "func",
       },
       "onSelect": Object {
         "isRequired": true,

--- a/packages/react/src/components/DataTable/TableSelectRow.js
+++ b/packages/react/src/components/DataTable/TableSelectRow.js
@@ -19,6 +19,7 @@ const TableSelectRow = ({
   id,
   name,
   onSelect,
+  onChange,
   disabled,
   radio,
   className,
@@ -27,6 +28,7 @@ const TableSelectRow = ({
     id,
     name,
     onClick: onSelect,
+    onChange: onChange,
     checked,
     disabled,
   };

--- a/packages/react/src/components/DataTable/TableSelectRow.js
+++ b/packages/react/src/components/DataTable/TableSelectRow.js
@@ -28,7 +28,7 @@ const TableSelectRow = ({
     id,
     name,
     onClick: onSelect,
-    onChange: onChange,
+    onChange,
     checked,
     disabled,
   };

--- a/packages/react/src/components/DataTable/TableSelectRow.js
+++ b/packages/react/src/components/DataTable/TableSelectRow.js
@@ -82,6 +82,11 @@ TableSelectRow.propTypes = {
   name: PropTypes.string.isRequired,
 
   /**
+   * Provide an optional hook that is called each time the input is updated
+   */
+  onChange: PropTypes.func,
+
+  /**
    * Provide a handler to listen to when a user initiates a selection request
    */
   onSelect: PropTypes.func.isRequired,


### PR DESCRIPTION
It allows to pass an `onChange` function to the TableSelectRow component when the row was selected. Only tested it with the radio button version.

#### Changelog

**New**

- Added `onChange` property to TableSelectRow

#### Testing / Reviewing

https://react.carbondesignsystem.com/?path=/story/datatable-selection--with-radio-selection
`<TableSelectRow {...getSelectionProps({ row })} onChange={action('row changed/selected', row)}/>`
