### PR TITLE
fix(NumberInput): restore `defaultValue` prop functionality in uncontrolled number input

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput-test.js
+++ b/packages/react/src/components/NumberInput/NumberInput-test.js
@@ -155,6 +155,24 @@ describe('NumberInput', () => {
           );
         const getNumberInput = (wrapper) => wrapper.find('input');
 
+        it('should correctly set defaultValue on uncontrolled input', () => {
+          const wrapper = mount(
+            <NumberInput
+              min={-1}
+              max={100}
+              defaultValue={10}
+              id="test"
+              label="Number Input"
+              className="extra-class"
+            />
+          );
+          const numberInput = getNumberInput(wrapper);
+          expect(wrapper.find('NumberInput').instance().state.value).toEqual(
+            10
+          );
+          expect(numberInput.prop('value')).toEqual(10);
+        });
+
         it('should set value as expected when value > min', () => {
           const wrapper = getWrapper(-1, 100, 0);
           const numberInput = getNumberInput(wrapper);

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -170,7 +170,7 @@ class NumberInput extends Component {
     translateWithId: (id) => defaultTranslations[id],
   };
 
-  static getDerivedStateFromProps({ min, max, value = 0 }, state) {
+  static getDerivedStateFromProps({ min, max, value }, state) {
     const { prevValue } = state;
 
     if (useControlledStateWithValue && value === '' && prevValue !== '') {

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -300,6 +300,7 @@ class NumberInput extends Component {
       translateWithId: t,
       isMobile,
       size,
+      defaultValue, // eslint-disable-line
       ...other
     } = this.props;
 

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -204,7 +204,10 @@ class NumberInput extends Component {
       this.state = {};
       return;
     }
-    let value = useControlledStateWithValue ? props.defaultValue : props.value;
+    let value =
+      useControlledStateWithValue || typeof props.defaultValue !== 'undefined'
+        ? props.defaultValue
+        : props.value;
     value = value === undefined ? 0 : value;
     if (props.min || props.min === 0) {
       value = Math.max(props.min, value);


### PR DESCRIPTION
Closes #7299

This PR restores functionality to the `defaultValue` prop in uncontrolled number inputs and removes the React warning about setting both `defaultValue` and `value` on the input

#### Changelog

**New**

- uncontrolled number input `defaultValue` test

**Changed**

- avoid spreading `defaultValue` into input
- add `defaultValue` typecheck
- remove default internal state value in `gDSFP`

#### Testing / Reviewing

Confirm that setting a `defaultValue` on an uncontrolled number input works as expected and the correct value is displayed on render
