### PR TITLE
fix(Tooltip): prevent focus hijacking on tooltip dismissal

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -244,6 +244,7 @@ class Tooltip extends Component {
    * @private
    */
   _tooltipId =
+    this.props.id ||
     this.props.tooltipId ||
     `__carbon-tooltip_${Math.random().toString(36).substr(2)}`;
 
@@ -506,9 +507,9 @@ class Tooltip extends Component {
               this._tooltipEl = node;
             }}>
             <div
-              id={this._tooltipId}
               className={tooltipClasses}
               {...other}
+              id={this._tooltipId}
               data-floating-menu-direction={direction}
               onMouseOver={this.handleMouse}
               onMouseOut={this.handleMouse}

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -21,6 +21,10 @@ import FloatingMenu, {
 import ClickListener from '../../internal/ClickListener';
 import mergeRefs from '../../tools/mergeRefs';
 import { keys, matches as keyDownMatch } from '../../internal/keyboard';
+import {
+  selectorFocusable,
+  selectorTabbable,
+} from '../../internal/keyboard/navigation';
 import isRequiredOneOf from '../../prop-types/isRequiredOneOf';
 import requiredIfValueExists from '../../prop-types/requiredIfValueExists';
 import { useControlledStateWithValue } from '../../internal/FeatureFlags';
@@ -296,7 +300,19 @@ class Tooltip extends Component {
       }
       if (!open && tooltipBody && tooltipBody.id === this._tooltipId) {
         this._tooltipDismissed = true;
-        this._triggerRef?.current.focus();
+        const primaryFocusNode = tooltipBody.querySelector(
+          this.props.selectorPrimaryFocus || null
+        );
+        const tabbableNode = tooltipBody.querySelector(selectorTabbable);
+        const focusableNode = tooltipBody.querySelector(selectorFocusable);
+        const focusTarget =
+          primaryFocusNode || // User defined focusable node
+          tabbableNode || // First sequentially focusable node
+          focusableNode || // First programmatic focusable node
+          tooltipBody;
+        if (focusTarget !== tooltipBody) {
+          this._triggerRef?.current.focus();
+        }
       }
     });
   };
@@ -520,7 +536,6 @@ class Tooltip extends Component {
               <span className={`${prefix}--tooltip__caret`} />
               <div
                 className={`${prefix}--tooltip__content`}
-                tabIndex="-1"
                 role="dialog"
                 aria-describedby={tooltipBodyId}
                 aria-labelledby={triggerId}>

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -323,7 +323,10 @@ class Tooltip extends Component {
    * @param {Element} [evt] For handing `mouseout` event, indicates where the mouse pointer is gone.
    */
   _handleFocus = (state, evt) => {
-    const { relatedTarget } = evt;
+    const { currentTarget, relatedTarget } = evt;
+    if (currentTarget !== relatedTarget) {
+      this._tooltipDismissed = false;
+    }
     if (state === 'over') {
       if (!this._tooltipDismissed) {
         this._handleUserInputOpenClose(evt, { open: true });


### PR DESCRIPTION
Closes #7260
ref #7165

This PR prevents the tooltip from hijacking keyboard focus after dismissing the tooltip. We check whether or not the tooltip contains focusable content, and if it doesn't then we can preserve the existing tab order. otherwise if it does contain focusable content, we will place focus back on the trigger button (like we do currently)

#### Changelog

**Changed**

- consolidate internal tooltip ID and prevent ID prop from overwriting internal ID value
- tooltip focus behavior on tooltip dismissal

**Removed**

- negative tabindex on tooltip content container

#### Testing / Reviewing

Confirm the reported focus issues are no longer present, and that there are no regressions with tooltip focus management