### PR TITLE
fix(FloatingMenu): ignore extra scroll offset in sticky container

### DIFF
--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -98,8 +98,8 @@ const getFloatingPosition = ({
     right: refRight = 0,
     bottom: refBottom = 0,
   } = refPosition;
-  const scrollX = container.position === 'sticky' ? 0 : pageXOffset;
-  const scrollY = container.position === 'sticky' ? 0 : pageYOffset;
+  const scrollX = container.position !== 'static' ? 0 : pageXOffset;
+  const scrollY = container.position !== 'static' ? 0 : pageYOffset;
   const relativeDiff = {
     top: container.position !== 'static' ? container.rect.top : 0,
     left: container.position !== 'static' ? container.rect.left : 0,

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -61,10 +61,8 @@ export const DIRECTION_BOTTOM = 'bottom';
 const hasChangeInOffset = (oldMenuOffset = {}, menuOffset = {}) => {
   if (typeof oldMenuOffset !== typeof menuOffset) {
     return true;
-  } else if (
-    Object(menuOffset) === menuOffset &&
-    typeof menuOffset !== 'function'
-  ) {
+  }
+  if (Object(menuOffset) === menuOffset && typeof menuOffset !== 'function') {
     return (
       oldMenuOffset.top !== menuOffset.top ||
       oldMenuOffset.left !== menuOffset.left

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -88,8 +88,8 @@ const getFloatingPosition = ({
   refPosition = {},
   offset = {},
   direction = DIRECTION_BOTTOM,
-  scrollX = 0,
-  scrollY = 0,
+  scrollX: pageXOffset = 0,
+  scrollY: pageYOffset = 0,
   container,
 }) => {
   const {
@@ -98,17 +98,12 @@ const getFloatingPosition = ({
     right: refRight = 0,
     bottom: refBottom = 0,
   } = refPosition;
-  const relativeDiff =
-    container.position !== 'static'
-      ? {
-          top: container.rect.top,
-          left: container.rect.left,
-        }
-      : {
-          top: 0,
-          left: 0,
-        };
-
+  const scrollX = container.position === 'sticky' ? 0 : pageXOffset;
+  const scrollY = container.position === 'sticky' ? 0 : pageYOffset;
+  const relativeDiff = {
+    top: container.position !== 'static' ? container.rect.top : 0,
+    left: container.position !== 'static' ? container.rect.left : 0,
+  };
   const { width, height } = menuSize;
   const { top = 0, left = 0 } = offset;
   const refCenterHorizontal = (refLeft + refRight) / 2;


### PR DESCRIPTION
Closes #7308

This PR fixes lazy placement of floating menus within sticky containers

#### Changelog

**New**

- support floating menu placement in sticky container

#### Testing / Reviewing

Confirm that floating menus are correctly positioned when the trigger element is inside a sticky container and ensure that there are no regressions with floating menu component placement (interactive tooltip, overflow menu)