### PR TITLE
fix(progress-indicator): don't overwrite explicit "complete" on step

### DIFF
--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -285,7 +285,7 @@ export class ProgressIndicator extends Component {
       }
       if (index > this.state.currentIndex) {
         return React.cloneElement(child, {
-          complete: false,
+          complete: child.props.complete || false,
           index,
           onClick,
         });


### PR DESCRIPTION
This PR respects an explicit `complete` status of a `ProgressStep` even when it is a future step.

#### Changelog

**Changed**

- By default, future steps are set to incomplete. If a ProgressStep's `props.complete` is set to true though, it is respected.

#### Testing / Reviewing

- Pull PR
- Add `complete` to the prop list of the third step in the ProgressIndicator story
- Current step should still be 2, 3rd step should be marked as complete
![image](https://user-images.githubusercontent.com/28265588/100226929-aba35880-2f20-11eb-8427-f1c1ec9cf3a2.png)

