### PR TITLE
fix(components): button tertiary active

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -14143,6 +14143,7 @@ Button styles
     }
 
     &:active {
+      color: $text-04;
       background-color: $active-tertiary;
       border-color: transparent;
     }

--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -14143,7 +14143,7 @@ Button styles
     }
 
     &:active {
-      color: $text-04;
+      color: $inverse-01;
       background-color: $active-tertiary;
       border-color: transparent;
     }

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -79,7 +79,7 @@
     }
 
     &:active {
-      color: $text-04;
+      color: $inverse-01;
       background-color: $active-tertiary;
       border-color: transparent;
     }

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -79,6 +79,7 @@
     }
 
     &:active {
+      color: $text-04;
       background-color: $active-tertiary;
       border-color: transparent;
     }


### PR DESCRIPTION
This PR makes compliance with the [guide](https://www.carbondesignsystem.com/components/button/style#tertiary-button)

#### Changelog

**Changed**

- fix text color for button tertiary for the active state with [guide ](https://www.carbondesignsystem.com/components/button/style#tertiary-button)

#### Testing / Reviewing

- Pull PR
- Look fix at [netlify storybook](https://deploy-preview-7349--carbon-components-react.netlify.app/?path=/story/button--tertiary) and add state :active for button
