### PR TITLE
chore: update pictograms metadata

### DIFF
--- a/packages/pictograms/pictograms.yml
+++ b/packages/pictograms/pictograms.yml
@@ -2000,7 +2000,7 @@
     - headphones
     - electronics
 - name: heart
-  friendly_name: heart
+  friendly_name: Heart
   aliases:
     - heart
     - like

--- a/packages/pictograms/pictograms.yml
+++ b/packages/pictograms/pictograms.yml
@@ -4291,11 +4291,12 @@
     - cities
     - city
 - name: watson--logo
-  friendly_name: Watson logo
+  friendly_name: IBM Watson
   aliases:
     - Watson logo
     - logo
     - watson
+    - ibm watson
     - avatar
 - name: weather
   friendly_name: Weather

--- a/packages/pictograms/pictograms.yml
+++ b/packages/pictograms/pictograms.yml
@@ -3742,7 +3742,7 @@
   aliases:
     - systems devops deploy
 - name: systems-devops--monitor
-  friendly_name: Systems DevOps nonitor
+  friendly_name: Systems DevOps monitor
   aliases:
     - systems devops monitor
 - name: systems-devops--plan


### PR DESCRIPTION
Closes #7355

This PR updates some metadata for specific pictograms according to Slack comments

#### Changelog

**Changed**

- update friendly name for `watson--logo`
- update friendly name for `heart`
- fix friendly name for `Systems DevOps monitor`

#### Testing / Reviewing

Confirm that the pictograms metadata is correct