### PR TITLE
Fix/a11y improvement header menu

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -46,6 +46,11 @@ class HeaderMenu extends React.Component {
      * Optional component to render instead of string
      */
     renderMenuContent: PropTypes.func,
+    /**
+     * Optionally supply a role for the underlying `<li>` node. Useful for resetting
+     * `<ul>` semantics for menus.
+     */
+    role: PropTypes.string,
 
     /**
      * Optionally provide a tabIndex for the underlying menu button
@@ -173,6 +178,7 @@ class HeaderMenu extends React.Component {
       children,
       renderMenuContent: MenuContent,
       menuLinkName,
+      role,
     } = this.props;
     const accessibilityLabel = {
       'aria-label': ariaLabel,
@@ -188,6 +194,7 @@ class HeaderMenu extends React.Component {
     // - href can be set to javascript:void(0), ideally this will be a button
     return (
       <li // eslint-disable-line jsx-a11y/mouse-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+        role={role}
         className={className}
         onKeyDown={this.handleMenuClose}
         onClick={this.handleOnClick}

--- a/packages/react/src/components/UIShell/__tests__/HeaderMenu-test.js
+++ b/packages/react/src/components/UIShell/__tests__/HeaderMenu-test.js
@@ -22,6 +22,7 @@ describe('HeaderMenu', () => {
       'aria-label': 'Accessibility label',
       className: 'custom-class',
       menuLinkName: 'test',
+      role: 'menuitem',
       // We use `ref` instead of `focusRef` becase `HeaderMenu` forwards the ref
       // to the underlying menu button
       ref: jest.fn(),
@@ -66,6 +67,17 @@ describe('HeaderMenu', () => {
       .prop('aria-label');
 
     expect(headerMenuText).toMatch('Accessibility label');
+  });
+
+  it('should render role', () => {
+    const wrapper = mount(<HeaderMenu {...mockProps}></HeaderMenu>, {
+      attachTo: mountNode,
+    });
+    const headerMenu = wrapper.childAt(0);
+    const headerMenuText = headerMenu.find(`li`).prop('role');
+    console.log(headerMenuText);
+
+    expect(headerMenuText).toMatch('menuitem');
   });
 
   it('should render content prop', () => {

--- a/packages/react/src/components/UIShell/__tests__/HeaderMenu-test.js
+++ b/packages/react/src/components/UIShell/__tests__/HeaderMenu-test.js
@@ -75,7 +75,6 @@ describe('HeaderMenu', () => {
     });
     const headerMenu = wrapper.childAt(0);
     const headerMenuText = headerMenu.find(`li`).prop('role');
-    console.log(headerMenuText);
 
     expect(headerMenuText).toMatch('menuitem');
   });

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap
@@ -5,6 +5,7 @@ exports[`HeaderMenu should render 1`] = `
   aria-label="Accessibility label"
   className="custom-class"
   menuLinkName="test"
+  role="menuitem"
   tabIndex={-1}
 >
   <HeaderMenu
@@ -51,6 +52,7 @@ exports[`HeaderMenu should render 1`] = `
     }
     menuLinkName="test"
     renderMenuContent={[Function]}
+    role="menuitem"
     tabIndex={-1}
   >
     <li
@@ -58,6 +60,7 @@ exports[`HeaderMenu should render 1`] = `
       onBlur={[Function]}
       onClick={[Function]}
       onKeyDown={[Function]}
+      role="menuitem"
     >
       <a
         aria-expanded={false}


### PR DESCRIPTION
Closes #7377

This implements the `role` attribute for the react `HeaderMenu` component

#### Changelog

**New**

- implented `role` attribute for `HeaderMenu` component

**Changed**

- `src/components/UIShell/HeaderMenu.js`
- `src/components/UIShell/__tests__/HeaderMenu-test.js`
- `src/components/UIShell/__tests__/__snapshots__/HeaderMenu-test.js.snap`

#### Testing / Reviewing
Create a HeaderMenu and add a `role="menuitem"` to the component to see it in action