### PR TITLE
Component - React - DatePicker -Enable support for inline calendar 

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -269,6 +269,7 @@ export default class DatePicker extends Component {
       datePickerType,
       dateFormat,
       locale,
+      inline
       minDate,
       maxDate,
       value,
@@ -288,6 +289,7 @@ export default class DatePicker extends Component {
           allowInput: allowInput ?? true,
           dateFormat: dateFormat,
           locale: l10n[locale],
+          inline: inline === "true",
           minDate: minDate,
           maxDate: maxDate,
           plugins: [

--- a/packages/react/src/components/DatePicker/DatePicker.mdx
+++ b/packages/react/src/components/DatePicker/DatePicker.mdx
@@ -24,6 +24,7 @@ import DatePickerInput from '../DatePickerInput';
   - [DatePicker `className`](#datepicker-classname)
   - [DatePicker `dateFormat`](#datepicker-dateformat)
   - [DatePicker `datePickerType`](#datepicker-datepickertype)
+  - [DatePicker `inline`](#datepicker-inline)
   - [DatePicker `light`](#datepicker-light)
   - [DatePicker `locale`](#datepicker-locale)
   - [DatePicker `maxDate`](#datepicker-maxdate)
@@ -134,6 +135,17 @@ There are three supported variations of `DatePicker` in Carbon.
   <DatePickerInput placeholder="Start" />
   <DatePickerInput placeholder="End" />
 </DatePicker>
+```
+
+
+### DatePicker `inline`
+
+Thie `inline` prop will always display the calander picker. For correct
+rendering it is best to also supply the `appendTo` prop of the location where
+the calander picker should be rendered. 
+
+```jsx
+<DatePicker inline="true" appendTo={node}>...</DatePicker>
 ```
 
 ### DatePicker `light`


### PR DESCRIPTION
Closes #

Within the Carbon React Datepicker component, the flatpicker `inline` option should be exposed.

#### Changelog

**New**

- Added inline prop to the Datepicker and passed the value when initializing flat picker.

**Changed**

- Update associated documentation

**Removed**

- none

#### Testing / Reviewing

Enable inline prop within the playground. 