### PR TITLE
fix(slider): add label to slider

### DIFF
--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -505,6 +505,7 @@ export default class Slider extends PureComponent {
 
     const { value, left } = this.state;
 
+    const labelId = `${id}-label`;
     const labelClasses = classNames(`${prefix}--label`, {
       [`${prefix}--label--disabled`]: disabled,
     });
@@ -536,7 +537,7 @@ export default class Slider extends PureComponent {
 
     return (
       <div className={`${prefix}--form-item`}>
-        <label htmlFor={id} className={labelClasses}>
+        <label htmlFor={id} className={labelClasses} id={labelId}>
           {labelText}
         </label>
         <div className={`${prefix}--slider-container`}>
@@ -560,6 +561,7 @@ export default class Slider extends PureComponent {
               role="slider"
               id={id}
               tabIndex={0}
+              aria-labelledby={labelId}
               aria-valuemax={max}
               aria-valuemin={min}
               aria-valuenow={value}


### PR DESCRIPTION
Closes #7059

Add accessibility label to slider through the existing label.

#### Changelog

**New**

**Changed**

- Add id to Slider label and use it to label the element with `role="slider"`

**Removed**

#### Testing / Reviewing

- Verify the AC error no longer is reported when testing the Slider component
