### PR TITLE
docs: remove Storybook and CodeSandbox PropType warnings

### DIFF
--- a/packages/react/examples/custom-data-table-state-manager/src/components/CustomDataTable.js
+++ b/packages/react/examples/custom-data-table-state-manager/src/components/CustomDataTable.js
@@ -182,7 +182,7 @@ const CustomDataTable = ({
             onChange={handleChangeSearchString}
           />
           <TableToolbarMenu tabIndex={hasBatchActions ? -1 : 0}>
-            <TableToolbarAction primaryFocus onClick={() => alert('Alert 1')}>
+            <TableToolbarAction onClick={() => alert('Alert 1')}>
               Action 1
             </TableToolbarAction>
             <TableToolbarAction onClick={() => alert('Alert 2')}>

--- a/packages/react/src/components/DataTable/DataTable-story.js
+++ b/packages/react/src/components/DataTable/DataTable-story.js
@@ -208,9 +208,7 @@ export const WithToolbar = () => (
           <TableToolbarContent>
             <TableToolbarSearch onChange={onInputChange} />
             <TableToolbarMenu light>
-              <TableToolbarAction
-                onClick={action('Action 1 Click')}
-                primaryFocus>
+              <TableToolbarAction onClick={action('Action 1 Click')}>
                 Action 1
               </TableToolbarAction>
               <TableToolbarAction onClick={action('Action 2 Click')}>

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -103,7 +103,7 @@ describe('DataTable', () => {
                   id="custom-id"
                 />
                 <TableToolbarMenu>
-                  <TableToolbarAction primaryFocus onClick={jest.fn()}>
+                  <TableToolbarAction onClick={jest.fn()}>
                     Action 1
                   </TableToolbarAction>
                   <TableToolbarAction onClick={jest.fn()}>
@@ -390,7 +390,7 @@ describe('DataTable', () => {
                     id="custom-id"
                   />
                   <TableToolbarMenu>
-                    <TableToolbarAction primaryFocus onClick={jest.fn()}>
+                    <TableToolbarAction onClick={jest.fn()}>
                       Action 1
                     </TableToolbarAction>
                     <TableToolbarAction onClick={jest.fn()}>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1870,7 +1870,6 @@ exports[`DataTable should render 1`] = `
                 >
                   <TableToolbarAction
                     onClick={[MockFunction]}
-                    primaryFocus={true}
                   >
                     Action 1
                   </TableToolbarAction>
@@ -2873,7 +2872,6 @@ exports[`DataTable sticky header should render 1`] = `
                 >
                   <TableToolbarAction
                     onClick={[MockFunction]}
-                    primaryFocus={true}
                   >
                     Action 1
                   </TableToolbarAction>

--- a/packages/react/src/components/DataTable/stories/DataTable-batch-actions-story.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-batch-actions-story.js
@@ -110,7 +110,7 @@ export const Usage = () => (
             />
             <TableToolbarMenu
               tabIndex={getBatchActionProps().shouldShowBatchActions ? -1 : 0}>
-              <TableToolbarAction primaryFocus onClick={() => alert('Alert 1')}>
+              <TableToolbarAction onClick={() => alert('Alert 1')}>
                 Action 1
               </TableToolbarAction>
               <TableToolbarAction onClick={() => alert('Alert 2')}>

--- a/packages/react/src/components/DataTable/stories/DataTable-filtering-story.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-filtering-story.js
@@ -65,9 +65,7 @@ export const Usage = () => (
             {/* pass in `onInputChange` change here to make filtering work */}
             <TableToolbarSearch onChange={onInputChange} />
             <TableToolbarMenu>
-              <TableToolbarAction
-                onClick={action('Action 1 Click')}
-                primaryFocus>
+              <TableToolbarAction onClick={action('Action 1 Click')}>
                 Action 1
               </TableToolbarAction>
               <TableToolbarAction onClick={action('Action 2 Click')}>

--- a/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content-story.js
+++ b/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content-story.js
@@ -148,9 +148,7 @@ export const Example = (props) => {
                 <TableToolbarContent>
                   <TableToolbarSearch onChange={onInputChange} />
                   <TableToolbarMenu>
-                    <TableToolbarAction
-                      primaryFocus
-                      onClick={this.handleOnRowAdd}>
+                    <TableToolbarAction onClick={this.handleOnRowAdd}>
                       Add row
                     </TableToolbarAction>
                     <TableToolbarAction onClick={this.handleOnHeaderAdd}>


### PR DESCRIPTION
Related https://github.com/carbon-design-system/carbon/pull/5489

This PR removes deprecated `primaryFocus` prop references in Storybook and CodeSandbox examples