### PR TITLE
fix(dropdown): state disabled background color

### DIFF
--- a/packages/components/docs/sass.md
+++ b/packages/components/docs/sass.md
@@ -10622,6 +10622,7 @@ $disabled-01: if(
   - [accordion [mixin]](#accordion-mixin)
   - [content-switcher [mixin]](#content-switcher-mixin)
   - [date-picker [mixin]](#date-picker-mixin)
+  - [dropdown [mixin]](#dropdown-mixin)
   - [file-uploader [mixin]](#file-uploader-mixin)
   - [listbox [mixin]](#listbox-mixin)
   - [number-input [mixin]](#number-input-mixin)
@@ -20553,6 +20554,7 @@ Dropdown styles
   }
 
   .#{$prefix}--dropdown--disabled {
+    background-color: $disabled-01;
     border-bottom-color: transparent;
 
     &:hover {
@@ -20703,6 +20705,7 @@ Dropdown styles
   - [selected-ui [variable]](#selected-ui-variable)
   - [text-02 [variable]](#text-02-variable)
   - [decorative-01 [variable]](#decorative-01-variable)
+  - [disabled-01 [variable]](#disabled-01-variable)
   - [disabled-02 [variable]](#disabled-02-variable)
   - [carbon--spacing-07 [variable]](#carbon--spacing-07-variable)
   - [carbon--spacing-04 [variable]](#carbon--spacing-04-variable)

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -348,6 +348,7 @@
   }
 
   .#{$prefix}--dropdown--disabled {
+    background-color: $disabled-01;
     border-bottom-color: transparent;
 
     &:hover {


### PR DESCRIPTION
This PR makes compliance with [the guide](https://www.carbondesignsystem.com/components/dropdown/style#interactive-states)

#### Changelog
**Changed**
- Indicated a specific color for the disabled state. The error was not visible because the colors in the theme correspond to `field-01` and` disabled-01`.

#### Testing / Reviewing

- Pull PR
- Look fix at netlify storybook for dropdown :disabled