### PR TITLE
fix(overflow): fix styling color for danger overflow to use danger to…

### DIFF
--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -306,7 +306,7 @@
   .#{$prefix}--overflow-menu-options__option--danger
     .#{$prefix}--overflow-menu-options__btn:focus {
     color: $text-04;
-    background-color: $danger;
+    background-color: $danger-01;
 
     svg {
       fill: currentColor;

--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -306,10 +306,10 @@
   .#{$prefix}--overflow-menu-options__option--danger
     .#{$prefix}--overflow-menu-options__btn:focus {
     color: $text-04;
-    background-color: $support-01;
+    background-color: $danger;
 
     svg {
-      fill: $text-04;
+      fill: currentColor;
     }
   }
 


### PR DESCRIPTION
…ken. Harness the power of currentColor

fixes: https://github.com/carbon-design-system/carbon/issues/7467

- fix overflow danger class to use danger token. (this effects theming, its referenced as danger so lets use the correct token)
- Also harness the all powerful currentColor to get fill color - this is a more dynamic and cross browser supported way that simplifies logic