### PR TITLE
docs(tooltip): add additional note for missing tooltip props

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -14,6 +14,11 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Component API
 
+Please note that in addition to the props below, `Tooltip` also has two
+additional props: `triggerText` and `iconDescription`. If the `triggerText` prop
+is _not_ provided, the `iconDescription` prop is required to populate the
+`aria-label` property for a11y reasons.
+
 <Props />
 
 ## Feedback


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7470

Adds in a note for the two missing props autogenerated by Storybook

#### Changelog

**New**

- Note explaining when to use `iconDescription` property

#### Testing / Reviewing

Ensure the note makes sense 
