### PR TITLE
fix(FileUploader): resolve component audit issues

### DIFF
--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -185,7 +185,6 @@
     max-width: rem(320px);
     margin-bottom: $carbon--spacing-03;
     background-color: $field-01;
-
     outline-width: 1px;
   }
 
@@ -286,7 +285,6 @@
   .#{$prefix}--file__state-container .#{$prefix}--file-invalid {
     width: $carbon--spacing-05;
     height: $carbon--spacing-05;
-    margin-right: $carbon--spacing-03;
     fill: $support-01;
   }
 

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -119,8 +119,8 @@
   .#{$prefix}--file__selected-file {
     display: grid;
     grid-auto-rows: auto;
-    grid-gap: $carbon--spacing-05;
     grid-template-columns: 1fr auto;
+    gap: rem(14px) $carbon--spacing-05;
     align-items: center;
     max-width: rem(320px);
     min-height: $carbon--spacing-09;
@@ -161,10 +161,12 @@
   }
 
   .#{$prefix}--file__selected-file--field {
+    gap: rem(11px) $carbon--spacing-05;
     min-height: rem(40px);
   }
 
   .#{$prefix}--file__selected-file--sm {
+    gap: rem(7px) $carbon--spacing-05;
     min-height: rem(32px);
   }
 
@@ -185,9 +187,27 @@
     padding: $carbon--spacing-05 0;
   }
 
+  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--sm {
+    padding: rem(7px) 0;
+  }
+
+  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--field {
+    padding: rem(11px) 0;
+  }
+
   .#{$prefix}--file__selected-file--invalid .#{$prefix}--form-requirement {
     padding-top: $carbon--spacing-05;
     border-top: 1px solid $ui-03;
+  }
+
+  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--sm
+    .#{$prefix}--form-requirement {
+    padding-top: rem(7px);
+  }
+
+  .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--field
+    .#{$prefix}--form-requirement {
+    padding-top: rem(11px);
   }
 
   .#{$prefix}--file__selected-file--invalid
@@ -230,6 +250,7 @@
 
   .#{$prefix}--file__state-container {
     display: flex;
+    align-items: center;
     justify-content: center;
     min-width: 1.5rem;
     padding-right: $carbon--spacing-05;

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -122,7 +122,7 @@
     grid-template-columns: 1fr auto;
     gap: rem(14px) $carbon--spacing-05;
     align-items: center;
-    max-width: rem(320px);
+    max-width: rem(288px);
     min-height: $carbon--spacing-09;
     margin-bottom: $carbon--spacing-03;
     word-break: break-word;

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -36,6 +36,10 @@
     color: $text-01;
   }
 
+  .#{$prefix}--file--label--disabled {
+    color: $disabled-02;
+  }
+
   .#{$prefix}--file-input {
     @include hidden;
   }
@@ -100,6 +104,10 @@
 
     margin-bottom: $carbon--spacing-05;
     color: $text-02;
+  }
+
+  .#{$prefix}--label-description--disabled {
+    color: $disabled-02;
   }
 
   // For backwards compatibility

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -95,7 +95,7 @@
   }
 
   .#{$prefix}--file-browse-btn--disabled .#{$prefix}--file__drop-container {
-    border: 1px dashed $disabled-01;
+    border: 1px dashed $disabled-02;
   }
 
   .#{$prefix}--label-description {

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -263,8 +263,10 @@
 
   .#{$prefix}--file__state-container .#{$prefix}--file-close {
     display: flex;
-    width: $carbon--spacing-05;
-    height: $carbon--spacing-05;
+    align-items: center;
+    justify-content: center;
+    width: $carbon--spacing-06;
+    height: $carbon--spacing-06;
     padding: 0;
     background-color: transparent;
     border: none;
@@ -272,7 +274,7 @@
     fill: $icon-01;
 
     &:focus {
-      @include focus-outline('border');
+      @include focus-outline('outline');
     }
   }
 

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -130,7 +130,7 @@
     grid-template-columns: 1fr auto;
     gap: rem(14px) $carbon--spacing-05;
     align-items: center;
-    max-width: rem(288px);
+    max-width: rem(320px);
     min-height: $carbon--spacing-09;
     margin-bottom: $carbon--spacing-03;
     word-break: break-word;

--- a/packages/components/src/components/file-uploader/_file-uploader.scss
+++ b/packages/components/src/components/file-uploader/_file-uploader.scss
@@ -128,7 +128,7 @@
     display: grid;
     grid-auto-rows: auto;
     grid-template-columns: 1fr auto;
-    gap: rem(14px) $carbon--spacing-05;
+    gap: rem(12px) $carbon--spacing-05;
     align-items: center;
     max-width: rem(320px);
     min-height: $carbon--spacing-09;
@@ -169,12 +169,12 @@
   }
 
   .#{$prefix}--file__selected-file--field {
-    gap: rem(11px) $carbon--spacing-05;
+    gap: $carbon--spacing-03 $carbon--spacing-05;
     min-height: rem(40px);
   }
 
   .#{$prefix}--file__selected-file--sm {
-    gap: rem(7px) $carbon--spacing-05;
+    gap: $carbon--spacing-02 $carbon--spacing-05;
     min-height: rem(32px);
   }
 
@@ -191,15 +191,15 @@
   .#{$prefix}--file__selected-file--invalid {
     @include focus-outline('invalid');
 
-    padding: $carbon--spacing-05 0;
+    padding: rem(12px) 0;
   }
 
   .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--sm {
-    padding: rem(7px) 0;
+    padding: $carbon--spacing-02 0;
   }
 
   .#{$prefix}--file__selected-file--invalid.#{$prefix}--file__selected-file--field {
-    padding: rem(11px) 0;
+    padding: $carbon--spacing-03 0;
   }
 
   .#{$prefix}--file__selected-file--invalid .#{$prefix}--form-requirement {

--- a/packages/react/examples/drag-and-drop-file-uploader/src/index.js
+++ b/packages/react/examples/drag-and-drop-file-uploader/src/index.js
@@ -151,9 +151,9 @@ function ExampleDropContainerApp(props) {
   );
   return (
     <FormItem>
-      <strong className={`${prefix}--file--label`}>Account photo</strong>
+      <strong className={`${prefix}--file--label`}>Upload files</strong>
       <p className={`${prefix}--label-description`}>
-        Only .jpg and .png files. 500kb max file size
+        Max file size is 500kb. Supported file types are .jpg and .png.
       </p>
       <FileUploaderDropContainer {...props} onAddFiles={onAddFiles} />
       <div className="uploaded-files" style={{ width: '100%' }}>

--- a/packages/react/examples/drag-and-drop-file-uploader/src/index.js
+++ b/packages/react/examples/drag-and-drop-file-uploader/src/index.js
@@ -145,7 +145,7 @@ function ExampleDropContainerApp(props) {
     [files, props.multiple]
   );
   const handleFileUploaderItemClick = useCallback(
-    (evt, { uuid: clickedUuid }) =>
+    (_, { uuid: clickedUuid }) =>
       setFiles(files.filter(({ uuid }) => clickedUuid !== uuid)),
     [files]
   );

--- a/packages/react/examples/drag-and-drop-file-uploader/src/index.js
+++ b/packages/react/examples/drag-and-drop-file-uploader/src/index.js
@@ -27,9 +27,11 @@ function ExampleDropContainerApp(props) {
   const handleDrop = (e) => {
     e.preventDefault();
   };
+
   const handleDragover = (e) => {
     e.preventDefault();
   };
+
   useEffect(() => {
     document.addEventListener('drop', handleDrop);
     document.addEventListener('dragover', handleDragover);
@@ -38,6 +40,7 @@ function ExampleDropContainerApp(props) {
       document.removeEventListener('dragover', handleDragover);
     };
   }, []);
+
   const uploadFile = async (fileToUpload) => {
     // file size validation
     if (fileToUpload.filesize > 512000) {
@@ -124,6 +127,7 @@ function ExampleDropContainerApp(props) {
       console.log(error);
     }
   };
+
   const onAddFiles = useCallback(
     (evt, { addedFiles }) => {
       evt.stopPropagation();
@@ -144,11 +148,13 @@ function ExampleDropContainerApp(props) {
     },
     [files, props.multiple]
   );
+
   const handleFileUploaderItemClick = useCallback(
     (_, { uuid: clickedUuid }) =>
       setFiles(files.filter(({ uuid }) => clickedUuid !== uuid)),
     [files]
   );
+
   return (
     <FormItem>
       <strong className={`${prefix}--file--label`}>Upload files</strong>

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -157,20 +157,6 @@ export default {
   },
 };
 
-export const _FileUploaderButton = () => (
-  <FileUploaderButton {...props.fileUploaderButton()} />
-);
-
-_FileUploaderButton.storyName = 'FileUploaderButton';
-
-_FileUploaderButton.parameters = {
-  info: {
-    text: `
-        The FileUploaderButton can be used as a standalone component if you do not need the extra UI that comes with FileUploader. The FileUploaderButton is used in FileUploader.
-      `,
-  },
-};
-
 export const _FileUploader = () => {
   return (
     <div className={`${prefix}--file__container`}>

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -75,12 +75,12 @@ const props = {
       ''
     );
     return {
-      labelTitle: text('The label title (labelTitle)', 'Upload file'),
+      labelTitle: text('The label title (labelTitle)', 'Upload files'),
       labelDescription: text(
         'The label description (labelDescription)',
         'Max file size is 500mb. Only .jpg files are supported.'
       ),
-      buttonLabel: text('The button label (buttonLabel)', 'Add files'),
+      buttonLabel: text('The button label (buttonLabel)', 'Add file'),
       buttonKind: buttonKind || 'primary',
       size: select('Button size (size)', sizes, 'default'),
       filenameStatus: select(

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -74,10 +74,10 @@ const props = {
       ''
     );
     return {
-      labelTitle: text('The label title (labelTitle)', 'Upload'),
+      labelTitle: text('The label title (labelTitle)', 'Upload file'),
       labelDescription: text(
         'The label description (labelDescription)',
-        'only .jpg files at 500mb or less'
+        'Max file size is 500mb. Only .jpg files are supported.'
       ),
       buttonLabel: text('The button label (buttonLabel)', 'Add files'),
       buttonKind: buttonKind || 'primary',

--- a/packages/react/src/components/FileUploader/FileUploader-story.js
+++ b/packages/react/src/components/FileUploader/FileUploader-story.js
@@ -23,6 +23,7 @@ import FileUploaderSkeleton from '../FileUploader/FileUploader.Skeleton';
 import FileUploaderItem from './FileUploaderItem';
 import FileUploaderDropContainer from './FileUploaderDropContainer';
 import mdx from './FileUploader.mdx';
+import './FileUploader-story.scss';
 
 const { prefix } = settings;
 const buttonKinds = {

--- a/packages/react/src/components/FileUploader/FileUploader-story.scss
+++ b/packages/react/src/components/FileUploader/FileUploader-story.scss
@@ -1,0 +1,3 @@
+.bx--file__selected-file {
+  width: 288px;
+}

--- a/packages/react/src/components/FileUploader/FileUploaderItem.js
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.js
@@ -35,7 +35,9 @@ function FileUploaderItem({
   });
   return (
     <span className={classes} {...other}>
-      <p className={`${prefix}--file-filename`}>{name}</p>
+      <p className={`${prefix}--file-filename`} title={name}>
+        {name}
+      </p>
       <span className={`${prefix}--file__state-container`}>
         <Filename
           iconDescription={iconDescription}

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -120,7 +120,7 @@ const ExampleDropContainerApp = (props) => {
     [files, props.multiple]
   );
   const handleFileUploaderItemClick = useCallback(
-    (evt, { uuid: clickedUuid }) =>
+    (_, { uuid: clickedUuid }) =>
       setFiles(files.filter(({ uuid }) => clickedUuid !== uuid)),
     [files]
   );

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -12,6 +12,7 @@ import FileUploaderItem from '../FileUploaderItem';
 import FileUploaderDropContainer from '../FileUploaderDropContainer';
 import FormItem from '../../FormItem';
 import uid from '../../../tools/uniqueId';
+import '../FileUploader-story.scss';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -126,9 +126,9 @@ const ExampleDropContainerApp = (props) => {
   );
   return (
     <FormItem>
-      <strong className={`${prefix}--file--label`}>Account photo</strong>
+      <strong className={`${prefix}--file--label`}>Upload files</strong>
       <p className={`${prefix}--label-description`}>
-        Only .jpg and .png files. 500kb max file size
+        Max file size is 500kb. Supported file types are .jpg and .png.
       </p>
       <FileUploaderDropContainer {...props} onAddFiles={onAddFiles} />
       <div className={`${prefix}--file-container`} style={{ width: '100%' }}>

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useCallback, useEffect } from 'react';
+import classnames from 'classnames';
 import { settings } from 'carbon-components';
 import FileUploaderItem from '../FileUploaderItem';
 import FileUploaderDropContainer from '../FileUploaderDropContainer';
@@ -19,9 +20,11 @@ const ExampleDropContainerApp = (props) => {
   const handleDrop = (e) => {
     e.preventDefault();
   };
+
   const handleDragover = (e) => {
     e.preventDefault();
   };
+
   useEffect(() => {
     document.addEventListener('drop', handleDrop);
     document.addEventListener('dragover', handleDragover);
@@ -30,6 +33,7 @@ const ExampleDropContainerApp = (props) => {
       document.removeEventListener('dragover', handleDragover);
     };
   }, []);
+
   const uploadFile = async (fileToUpload) => {
     // file size validation
     if (fileToUpload.filesize > 512000) {
@@ -96,6 +100,7 @@ const ExampleDropContainerApp = (props) => {
       );
     }, rand + 1000);
   };
+
   const onAddFiles = useCallback(
     (evt, { addedFiles }) => {
       evt.stopPropagation();
@@ -119,15 +124,27 @@ const ExampleDropContainerApp = (props) => {
     // eslint-disable-next-line react/prop-types
     [files, props.multiple]
   );
+
   const handleFileUploaderItemClick = useCallback(
     (_, { uuid: clickedUuid }) =>
       setFiles(files.filter(({ uuid }) => clickedUuid !== uuid)),
     [files]
   );
+
+  const labelClasses = classnames(`${prefix}--file--label`, {
+    // eslint-disable-next-line react/prop-types
+    [`${prefix}--file--label--disabled`]: props.disabled,
+  });
+
+  const helperTextClasses = classnames(`${prefix}--label-description`, {
+    // eslint-disable-next-line react/prop-types
+    [`${prefix}--label-description--disabled`]: props.disabled,
+  });
+
   return (
     <FormItem>
-      <strong className={`${prefix}--file--label`}>Upload files</strong>
-      <p className={`${prefix}--label-description`}>
+      <strong className={labelClasses}>Upload files</strong>
+      <p className={helperTextClasses}>
         Max file size is 500kb. Supported file types are .jpg and .png.
       </p>
       <FileUploaderDropContainer {...props} onAddFiles={onAddFiles} />


### PR DESCRIPTION
Closes #7448

This PR updates the file uploader examples to resolve component audit bugs. A few questions about the audit points:

>  Alert icon needs a `black` inner fill for dark themes.

for the black fill within alert icons on dark themes, we run into the same issue with notifications from before (https://github.com/carbon-design-system/carbon/issues/3216) except we're not able to force file uploaders to be on dark backgrounds. alternatively we can just apply the black fill across the board on all themes if that's fine

>  The container needs to be `disabled-02`.

which container is this referring to?

#### Testing / Reviewing

Confirm the file uploaders match the updated spec