### PR TITLE
refactor(select): remove unused disabled option styles

### DIFF
--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -51,6 +51,8 @@
     border-bottom: 1px solid $ui-04;
     border-radius: 0;
     cursor: pointer;
+    // reset disabled <select> opacity
+    opacity: 1;
 
     // Do not transition on background-color (see: https://github.com/carbon-design-system/carbon/issues/4464)
     transition: outline $duration--fast-01 motion(standard, productive);

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -161,11 +161,6 @@
     color: $text-01;
   }
 
-  .#{$prefix}--select-option[disabled] {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-
   // Override some Firefox user-agent styles
   @-moz-document url-prefix() {
     .#{$prefix}--select-option {


### PR DESCRIPTION
Closes #7475

This PR removes unused styles on the Select component for disabled options. The disabled component already matches the component spec, and opacity rules on disabled `<select>` options are not rendered in the browsers we support

#### Testing / Reviewing

Confirm there are no visual component regressions