### PR TITLE
feat(translations): pass reference to default translate function (#7492)

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.js
+++ b/packages/react/src/components/DataTable/DataTable.js
@@ -41,7 +41,7 @@ const defaultTranslations = {
   [translationKeys.unselectRow]: 'Unselect row',
 };
 
-const translateWithId = (id) => defaultTranslations[id];
+const defaultTranslateWithId = (id) => defaultTranslations[id];
 
 /**
  * Data Tables are used to represent a collection of resources, displaying a
@@ -154,7 +154,7 @@ export default class DataTable extends React.Component {
     locale: 'en',
     size: 'normal',
     overflowMenuOnHover: true,
-    translateWithId,
+    translateWithId: defaultTranslateWithId,
   };
 
   static translationKeys = Object.values(translationKeys);
@@ -248,7 +248,7 @@ export default class DataTable extends React.Component {
       : translationKeys.expandAll;
     return {
       ...rest,
-      ariaLabel: t(translationKey),
+      ariaLabel: t(translationKey, undefined, defaultTranslateWithId),
       isExpanded,
       // Compose the event handlers so we don't overwrite a consumer's `onClick`
       // handler
@@ -305,7 +305,7 @@ export default class DataTable extends React.Component {
       // handler
       onExpand: composeEventHandlers([this.handleOnExpandRow(row.id), onClick]),
       isExpanded: row.isExpanded,
-      ariaLabel: t(translationKey),
+      ariaLabel: t(translationKey, undefined, defaultTranslateWithId),
       isSelected: row.isSelected,
       disabled: row.disabled,
     };
@@ -336,7 +336,7 @@ export default class DataTable extends React.Component {
         ]),
         id: `${this.getTablePrefix()}__select-row-${row.id}`,
         name: `select-row-${row.id}`,
-        ariaLabel: t(translationKey),
+        ariaLabel: t(translationKey, undefined, defaultTranslateWithId),
         disabled: row.disabled,
         radio: this.props.radio || null,
       };
@@ -356,7 +356,7 @@ export default class DataTable extends React.Component {
 
     return {
       ...rest,
-      ariaLabel: t(translationKey),
+      ariaLabel: t(translationKey, undefined, defaultTranslateWithId),
       checked,
       id: `${this.getTablePrefix()}__select-all`,
       indeterminate,

--- a/packages/react/src/components/DataTable/TableBatchActions.js
+++ b/packages/react/src/components/DataTable/TableBatchActions.js
@@ -20,7 +20,7 @@ const translationKeys = {
   'carbon.table.batch.item.selected': 'item selected',
 };
 
-const translateWithId = (id, state) => {
+const defaultTranslateWithId = (id, state) => {
   if (id === 'carbon.table.batch.cancel') {
     return translationKeys[id];
   }
@@ -50,8 +50,16 @@ const TableBatchActions = ({
         <p className={`${prefix}--batch-summary__para`}>
           <span>
             {totalSelected > 1
-              ? t('carbon.table.batch.items.selected', { totalSelected })
-              : t('carbon.table.batch.item.selected', { totalSelected })}
+              ? t(
+                  'carbon.table.batch.items.selected',
+                  { totalSelected },
+                  defaultTranslateWithId
+                )
+              : t(
+                  'carbon.table.batch.item.selected',
+                  { totalSelected },
+                  defaultTranslateWithId
+                )}
           </span>
         </p>
       </div>
@@ -101,7 +109,7 @@ TableBatchActions.propTypes = {
 };
 
 TableBatchActions.defaultProps = {
-  translateWithId,
+  translateWithId: defaultTranslateWithId,
 };
 
 export default TableBatchActions;

--- a/packages/react/src/components/DataTable/TableHeader.js
+++ b/packages/react/src/components/DataTable/TableHeader.js
@@ -21,7 +21,7 @@ const translationKeys = {
   buttonDescription: 'carbon.table.header.icon.description',
 };
 
-const translateWithId = (
+const defaultTranslateWithId = (
   key,
   { header, sortDirection, isSortHeader, sortStates }
 ) => {
@@ -89,12 +89,16 @@ const TableHeader = React.forwardRef(function TableHeader(
   });
   const ariaSort = !isSortHeader ? 'none' : sortDirections[sortDirection];
   const uniqueId = Math.random();
-  const sortDescription = t('carbon.table.header.icon.description', {
-    header: children,
-    sortDirection,
-    isSortHeader,
-    sortStates,
-  });
+  const sortDescription = t(
+    'carbon.table.header.icon.description',
+    {
+      header: children,
+      sortDirection,
+      isSortHeader,
+      sortStates,
+    },
+    defaultTranslateWithId
+  );
 
   return (
     <th
@@ -179,7 +183,7 @@ TableHeader.propTypes = {
 TableHeader.defaultProps = {
   isSortable: false,
   scope: 'col',
-  translateWithId,
+  translateWithId: defaultTranslateWithId,
 };
 
 TableHeader.translationKeys = Object.values(translationKeys);

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -19,7 +19,7 @@ const translationKeys = {
   'carbon.table.toolbar.search.label': 'Filter table',
   'carbon.table.toolbar.search.placeholder': 'Filter table',
 };
-const translateWithId = (id) => {
+const defaultTranslateWithId = (id) => {
   return translationKeys[id];
 };
 const TableToolbarSearch = ({
@@ -118,9 +118,21 @@ const TableToolbarSearch = ({
         className={className}
         value={value}
         id={typeof id !== 'undefined' ? id : uniqueId.toString()}
-        labelText={labelText || t('carbon.table.toolbar.search.label')}
+        labelText={
+          labelText ||
+          t(
+            'carbon.table.toolbar.search.label',
+            undefined,
+            defaultTranslateWithId
+          )
+        }
         placeHolderText={
-          placeHolderText || t('carbon.table.toolbar.search.placeholder')
+          placeHolderText ||
+          t(
+            'carbon.table.toolbar.search.placeholder',
+            undefined,
+            defaultTranslateWithId
+          )
         }
         onChange={onChange}
         {...rest}
@@ -204,7 +216,7 @@ TableToolbarSearch.propTypes = {
 
 TableToolbarSearch.defaultProps = {
   tabIndex: '0',
-  translateWithId,
+  translateWithId: defaultTranslateWithId,
   persistent: false,
 };
 

--- a/packages/react/src/components/ListBox/ListBoxMenuIcon.js
+++ b/packages/react/src/components/ListBox/ListBoxMenuIcon.js
@@ -23,6 +23,8 @@ const defaultTranslations = {
   [translationIds['open.menu']]: 'Open menu',
 };
 
+const defaultTranslateById = (id) => defaultTranslations[id];
+
 /**
  * `ListBoxMenuIcon` is used to orient the icon up or down depending on the
  * state of the menu for a given `ListBox`
@@ -31,7 +33,9 @@ const ListBoxMenuIcon = ({ isOpen, translateWithId: t }) => {
   const className = cx(`${prefix}--list-box__menu-icon`, {
     [`${prefix}--list-box__menu-icon--open`]: isOpen,
   });
-  const description = isOpen ? t('close.menu') : t('open.menu');
+  const description = isOpen
+    ? t('close.menu', undefined, defaultTranslateById)
+    : t('open.menu', undefined, defaultTranslateById);
   return (
     <div className={className}>
       <ChevronDown16 name="chevron--down" aria-label={description}>
@@ -57,7 +61,7 @@ ListBoxMenuIcon.propTypes = {
 };
 
 ListBoxMenuIcon.defaultProps = {
-  translateWithId: (id) => defaultTranslations[id],
+  translateWithId: defaultTranslateById,
 };
 
 export default ListBoxMenuIcon;

--- a/packages/react/src/components/ListBox/ListBoxSelection.js
+++ b/packages/react/src/components/ListBox/ListBoxSelection.js
@@ -54,7 +54,9 @@ const ListBoxSelection = ({
       }
     }
   };
-  const description = selectionCount ? t('clear.all') : t('clear.selection');
+  const description = selectionCount
+    ? t('clear.all', undefined, defaultTranslateById)
+    : t('clear.selection', undefined, defaultTranslateById);
   return (
     <div
       role="button"
@@ -79,6 +81,8 @@ const defaultTranslations = {
   [translationIds['clear.all']]: 'Clear all selected items',
   [translationIds['clear.selection']]: 'Clear selected item',
 };
+
+const defaultTranslateById = (id) => defaultTranslations[id];
 
 ListBoxSelection.propTypes = {
   /**
@@ -125,7 +129,7 @@ ListBoxSelection.propTypes = {
 };
 
 ListBoxSelection.defaultProps = {
-  translateWithId: (id) => defaultTranslations[id],
+  translateWithId: defaultTranslateById,
 };
 
 export default ListBoxSelection;

--- a/packages/react/src/components/ListBox/__tests__/ListBoxMenuIcon-test.js
+++ b/packages/react/src/components/ListBox/__tests__/ListBoxMenuIcon-test.js
@@ -20,13 +20,21 @@ describe('ListBoxMenuIcon', () => {
   it('should call `translateWithId` to determine the description', () => {
     const translateWithId = jest.fn(() => 'message');
     mount(<ListBox.MenuIcon isOpen={true} translateWithId={translateWithId} />);
-    expect(translateWithId).toHaveBeenCalledWith('close.menu');
+    expect(translateWithId).toHaveBeenCalledWith(
+      'close.menu',
+      undefined,
+      ListBox.MenuIcon.defaultProps.translateWithId
+    );
 
     translateWithId.mockClear();
 
     mount(
       <ListBox.MenuIcon isOpen={false} translateWithId={translateWithId} />
     );
-    expect(translateWithId).toHaveBeenCalledWith('open.menu');
+    expect(translateWithId).toHaveBeenCalledWith(
+      'open.menu',
+      undefined,
+      ListBox.MenuIcon.defaultProps.translateWithId
+    );
   });
 });

--- a/packages/react/src/components/ListBox/__tests__/ListBoxSelection-test.js
+++ b/packages/react/src/components/ListBox/__tests__/ListBoxSelection-test.js
@@ -30,12 +30,20 @@ describe('ListBoxSelection', () => {
 
   it('should call `translateWithId` with the id strings needed to translate', () => {
     mount(<ListBox.Selection {...mockProps} />);
-    expect(mockProps.translateWithId).toHaveBeenCalledWith('clear.selection');
+    expect(mockProps.translateWithId).toHaveBeenCalledWith(
+      'clear.selection',
+      undefined,
+      ListBox.Selection.defaultProps.translateWithId
+    );
 
     mockProps.translateWithId.mockClear();
 
     mount(<ListBox.Selection {...mockProps} selectionCount={3} />);
-    expect(mockProps.translateWithId).toHaveBeenCalledWith('clear.all');
+    expect(mockProps.translateWithId).toHaveBeenCalledWith(
+      'clear.all',
+      undefined,
+      ListBox.Selection.defaultProps.translateWithId
+    );
   });
 
   it('should call clearSelection when clicked', () => {

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -31,6 +31,8 @@ const defaultTranslations = {
   [translationIds['decrement.number']]: 'Decrement number',
 };
 
+const defaultTranslateById = (id) => defaultTranslations[id];
+
 const capMin = (min, value) =>
   isNaN(min) || (!min && min !== 0) || isNaN(value) || (!value && value !== 0)
     ? value
@@ -167,7 +169,7 @@ class NumberInput extends Component {
     helperText: '',
     light: false,
     allowEmpty: false,
-    translateWithId: (id) => defaultTranslations[id],
+    translateWithId: defaultTranslateById,
   };
 
   static getDerivedStateFromProps({ min, max, value }, state) {
@@ -399,8 +401,8 @@ class NumberInput extends Component {
     ) : null;
 
     const [incrementNumLabel, decrementNumLabel] = [
-      t('increment.number'),
-      t('decrement.number'),
+      t('increment.number', undefined, defaultTranslateById),
+      t('decrement.number', undefined, defaultTranslateById),
     ];
 
     const wrapperClasses = classNames(`${prefix}--number__input-wrapper`, {

--- a/packages/react/src/components/PaginationNav/PaginationNav.js
+++ b/packages/react/src/components/PaginationNav/PaginationNav.js
@@ -95,7 +95,7 @@ function PaginationItem({
   onClick,
   translateWithId: t = translateWithId,
 }) {
-  const itemLabel = t('carbon.pagination-nav.item');
+  const itemLabel = t('carbon.pagination-nav.item', undefined, translateWithId);
 
   return (
     <li className={`${prefix}--pagination-nav__list-item`}>

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -87,18 +87,22 @@ export function ProgressStep({
     );
   };
 
-  let message = t('carbon.progress-step.incomplete');
+  let message = t(
+    'carbon.progress-step.incomplete',
+    undefined,
+    translateWithId
+  );
 
   if (current) {
-    message = t('carbon.progress-step.current');
+    message = t('carbon.progress-step.current', undefined, translateWithId);
   }
 
   if (complete) {
-    message = t('carbon.progress-step.complete');
+    message = t('carbon.progress-step.complete', undefined, translateWithId);
   }
 
   if (invalid) {
-    message = t('carbon.progress-step.invalid');
+    message = t('carbon.progress-step.invalid', undefined, translateWithId);
   }
 
   return (

--- a/packages/react/src/components/UIShell/SideNav.js
+++ b/packages/react/src/components/UIShell/SideNav.js
@@ -15,6 +15,14 @@ import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 
 const { prefix } = settings;
 
+const defaultTranslateById = (id) => {
+  const translations = {
+    'carbon.sidenav.state.open': 'Close',
+    'carbon.sidenav.state.closed': 'Open',
+  };
+  return translations[id];
+};
+
 const SideNav = React.forwardRef(function SideNav(props, ref) {
   const {
     expanded: expandedProp,
@@ -59,8 +67,8 @@ const SideNav = React.forwardRef(function SideNav(props, ref) {
 
   // TO-DO: comment back in when footer is added for rails
   // const assistiveText = expanded
-  //   ? t('carbon.sidenav.state.open')
-  //   : t('carbon.sidenav.state.closed');
+  //   ? t('carbon.sidenav.state.open', undefined, defaultTranslateById);
+  //   : t('carbon.sidenav.state.closed', undefined, defaultTranslateById);
 
   const className = cx({
     [`${prefix}--side-nav`]: true,
@@ -127,13 +135,7 @@ const SideNav = React.forwardRef(function SideNav(props, ref) {
 });
 
 SideNav.defaultProps = {
-  translateById: (id) => {
-    const translations = {
-      'carbon.sidenav.state.open': 'Close',
-      'carbon.sidenav.state.closed': 'Open',
-    };
-    return translations[id];
-  },
+  translateById: defaultTranslateById,
   defaultExpanded: false,
   isChildOfHeader: true,
   isFixedNav: false,


### PR DESCRIPTION
Closes #7492

## Changelog

Passes the default function to the translate prop callback as the 3rd parameter to use optionally as a fallback in a custom `translateWithId`. The 2nd parameter due to the usage in DataTable is for args to the translation so for the calls with no existing args, `undefined` is passed as the 2nd parameter. This should introduce no breaking changes.
