### PR TITLE
ci: move lint and format to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '14.x'
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
-      - name: Check formatting of JavaScript files
+      - name: Check formatting of project files
         run: yarn format:diff
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v2.1.4
         with:
           node-version: '14.x'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
       - name: Check formatting of JavaScript files
         run: yarn format:diff
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,29 @@ jobs:
           node-version: '14.x'
       - name: Run yarn dedupe
         run: yarn dedupe --check
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: '14.x'
+      - name: Check formatting of JavaScript files
+        run: yarn format:diff
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Lint JavaScript files
+        run: yarn lint
+      - name: Lint Sass files
+        run: yarn lint:styles

--- a/packages/cli/src/commands/ci-check.js
+++ b/packages/cli/src/commands/ci-check.js
@@ -21,9 +21,6 @@ async function check(args, env) {
     stdio: 'inherit',
   };
   const tasks = [
-    'yarn format:diff',
-    'yarn lint --quiet',
-    'yarn lint:styles',
     `yarn bundler check --ignore '**/@(node_modules|examples|components|react|fixtures)/**' 'packages/**/*.scss'`,
     `cross-env BABEL_ENV=test yarn test --ci --maxWorkers 2 --reporters=default --reporters=jest-junit`,
     `cross-env BABEL_ENV=test yarn test:e2e --ci --maxWorkers 2 --reporters=default --reporters=jest-junit`,

--- a/packages/components/tests/spec/.eslintrc.js
+++ b/packages/components/tests/spec/.eslintrc.js
@@ -44,4 +44,12 @@ module.exports = {
     'no-unused-expressions': 0,
     'prefer-arrow-callback': 0,
   },
+  overrides: [
+    {
+      files: ['*_spec.js'],
+      rules: {
+        'import/no-unresolved': 0,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Move lint and format tasks from CircleCI to GitHub Actions. This should help speed up CI builds by using parallelism across workers.

#### Changelog

**New**

**Changed**

- Update CLI to only run tests
- Update CI workflow to include format and lint

**Removed**
