### PR TITLE
feat(components,react): add telemetry package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -57,6 +57,7 @@
     "dev": "gulp serve",
     "docs": "carbon-cli sassdoc \"scss{/components,/globals/grid,/globals/scss/vendor/@carbon/elements}/**/*.scss\" -i \"scss/globals/scss/vendor/@carbon/elements/**/{_inlined,vendor}/**\"",
     "format:check": "prettier --check \"**/*.{css,js,md,scss}\"",
+    "postinstall": "carbon-telemetry collect --install",
     "prebuild": "gulp clean",
     "prepublishOnly": "yarn build",
     "start": "node server.js",
@@ -70,6 +71,7 @@
     "freshy": ">= 1.0.3"
   },
   "dependencies": {
+    "@carbon/telemetry": "0.0.0-alpha.6",
     "flatpickr": "4.6.1",
     "lodash.debounce": "^4.0.8",
     "warning": "^3.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,7 @@
     "build": "yarn clean && node scripts/build.js && rollup -c",
     "build-storybook": "cross-env NODE_ENV=production build-storybook",
     "clean": "rimraf es lib umd storybook-static build react-docgen.json",
+    "postinstall": "carbon-telemetry collect --install",
     "prepublish": "yarn build",
     "start": "yarn storybook",
     "storybook": "rimraf node_modules/.cache/storybook && start-storybook -p 9000",
@@ -44,6 +45,7 @@
   },
   "dependencies": {
     "@carbon/icons-react": "^10.24.0-rc.0",
+    "@carbon/telemetry": "0.0.0-alpha.6",
     "classnames": "2.2.6",
     "downshift": "5.2.1",
     "flatpickr": "4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8955,6 +8955,7 @@ __metadata:
     "@babel/preset-env": ^7.10.0
     "@babel/preset-react": ^7.10.0
     "@carbon/icons-react": ^10.24.0-rc.0
+    "@carbon/telemetry": 0.0.0-alpha.6
     "@carbon/test-utils": ^10.14.0-rc.0
     "@percy/storybook": ^3.3.1
     "@storybook/addon-storysource": ^5.3.19
@@ -9043,6 +9044,7 @@ __metadata:
     "@carbon/elements": ^10.26.0-rc.0
     "@carbon/icons-handlebars": ^10.24.0-rc.0
     "@carbon/icons-react": ^10.24.0-rc.0
+    "@carbon/telemetry": 0.0.0-alpha.6
     "@carbon/test-utils": ^10.14.0-rc.0
     "@frctl/fractal": ^1.1.0
     adaro: 1.0.4


### PR DESCRIPTION
Adds in the telemetry package to `carbon-components` and `carbon-components-react`

#### Changelog

**New**

**Changed**

- Update `packages/components` and `packages/react` to include `@carbon/telemetry` in their postinstall step

**Removed**

#### Testing / Reviewing

- Verify that the build succeeds on CI
