### PR TITLE
fix(TableToolbarSearch): ensure search cannot be expanded when disabled

### DIFF
--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -89,7 +89,7 @@
     .#{$prefix}--search-magnifier {
     background: $disabled-01;
     cursor: not-allowed;
-    transition: none;
+    transition: background-color none;
   }
 
   .#{$prefix}--toolbar-search-container-expandable
@@ -113,7 +113,7 @@
     .#{$prefix}--search-magnifier:hover {
     background: $disabled-01;
     cursor: not-allowed;
-    transition: none;
+    transition: background-color none;
   }
 
   .#{$prefix}--toolbar-search-container-expandable

--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -85,6 +85,14 @@
   }
 
   .#{$prefix}--toolbar-search-container-expandable
+    .#{$prefix}--search--disabled
+    .#{$prefix}--search-magnifier {
+    background: $disabled-01;
+    cursor: not-allowed;
+    transition: none;
+  }
+
+  .#{$prefix}--toolbar-search-container-expandable
     .#{$prefix}--search
     .#{$prefix}--search-magnifier:focus {
     @include focus-outline('outline');
@@ -94,6 +102,18 @@
     .#{$prefix}--search
     .#{$prefix}--search-magnifier:hover {
     background: $hover-field;
+  }
+
+  .#{$prefix}--toolbar-action.#{$prefix}--toolbar-search-container-disabled {
+    cursor: not-allowed;
+  }
+
+  .#{$prefix}--toolbar-search-container-expandable
+    .#{$prefix}--search--disabled
+    .#{$prefix}--search-magnifier:hover {
+    background: $disabled-01;
+    cursor: not-allowed;
+    transition: none;
   }
 
   .#{$prefix}--toolbar-search-container-expandable
@@ -577,6 +597,10 @@
 
       background: transparent;
     }
+  }
+
+  .#{$prefix}--search--disabled .#{$prefix}--search-magnifier:hover {
+    background: transparent;
   }
 
   //-------------------------------------------------

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1374,6 +1374,9 @@ Map {
         "defaultValue": Object {
           "type": "string",
         },
+        "disabled": Object {
+          "type": "bool",
+        },
         "expanded": Object {
           "type": "bool",
         },
@@ -1961,6 +1964,9 @@ Map {
       },
       "defaultValue": Object {
         "type": "string",
+      },
+      "disabled": Object {
+        "type": "bool",
       },
       "expanded": Object {
         "type": "bool",

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -32,6 +32,7 @@ const TableToolbarSearch = ({
   expanded: expandedProp,
   defaultExpanded,
   defaultValue,
+  disabled,
   onExpand,
   persistent,
   persistant,
@@ -71,6 +72,7 @@ const TableToolbarSearch = ({
     [searchContainerClass]: searchContainerClass,
     [`${prefix}--toolbar-action`]: true,
     [`${prefix}--toolbar-search-container-active`]: expanded,
+    [`${prefix}--toolbar-search-container-disabled`]: disabled,
     [`${prefix}--toolbar-search-container-expandable`]:
       !persistent || (!persistent && !persistant),
     [`${prefix}--toolbar-search-container-persistent`]:
@@ -78,14 +80,16 @@ const TableToolbarSearch = ({
   });
 
   const handleExpand = (event, value = !expanded) => {
-    if (!controlled && (!persistent || (!persistent && !persistant))) {
-      setExpandedState(value);
-      if (value && !expanded) {
-        setFocusTarget(searchRef);
+    if (!disabled) {
+      if (!controlled && (!persistent || (!persistent && !persistant))) {
+        setExpandedState(value);
+        if (value && !expanded) {
+          setFocusTarget(searchRef);
+        }
       }
-    }
-    if (onExpand) {
-      onExpand(event, value);
+      if (onExpand) {
+        onExpand(event, value);
+      }
     }
   };
 
@@ -105,7 +109,7 @@ const TableToolbarSearch = ({
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
-      tabIndex={searchExpanded ? '-1' : tabIndex}
+      tabIndex={searchExpanded || disabled ? '-1' : tabIndex}
       ref={searchRef}
       onKeyDown={(event) => onClick(event)}
       onClick={(event) => onClick(event)}
@@ -113,6 +117,7 @@ const TableToolbarSearch = ({
       onBlur={(event) => !value && handleExpand(event, false)}
       className={searchContainerClasses}>
       <Search
+        disabled={disabled}
         size="sm"
         tabIndex={searchExpanded ? tabIndex : '-1'}
         className={className}
@@ -146,6 +151,11 @@ TableToolbarSearch.propTypes = {
    * Provide an optional default value for the Search component
    */
   defaultValue: PropTypes.string,
+
+  /**
+   * Specifies if the search should be disabled
+   */
+  disabled: PropTypes.bool,
 
   /**
    * Specifies if the search should expand

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -186,10 +186,7 @@ export default class Search extends Component {
 
     return (
       <div role="search" aria-labelledby={searchId} className={searchClasses}>
-        <Search16
-          disabled={disabled}
-          className={`${prefix}--search-magnifier`}
-        />
+        <Search16 className={`${prefix}--search-magnifier`} />
         <label id={searchId} htmlFor={id} className={`${prefix}--label`}>
           {labelText}
         </label>

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -186,7 +186,10 @@ export default class Search extends Component {
 
     return (
       <div role="search" aria-labelledby={searchId} className={searchClasses}>
-        <Search16 className={`${prefix}--search-magnifier`} />
+        <Search16
+          disabled={disabled}
+          className={`${prefix}--search-magnifier`}
+        />
         <label id={searchId} htmlFor={id} className={`${prefix}--label`}>
           {labelText}
         </label>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7522

Disabled styles will now prevent the search from expanding if `disabled` is passed to `TableToolbarSearch`

#### Changelog

**New**

- Disabled styles for non-expanded disabled Search button
- Logic to prevent expansion if `disabled` is passed to `TableToolbarSearch`
- Removes `TableToolbarSearch` from the tab order if it is disabled

#### Testing / Reviewing

Pass `disabled` to `TableToolbarSearch` in the `DataTable-filtering.js` file and make sure the search is not able to interact with
