### PR TITLE
fix(FilterableMultiselect): extend focus around entire input

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -458,8 +458,10 @@ $list-box-menu-width: rem(300px);
   .#{$prefix}--list-box__selection--multi {
     @include type-style('label-01');
 
-    position: static;
+    position: absolute;
     top: auto;
+    right: auto;
+    left: 0;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -391,6 +391,15 @@ export default class FilterableMultiSelect extends React.Component {
                 ...getToggleButtonProps({ disabled }),
                 'aria-label': undefined,
               };
+
+              // Calculate input padding based on number of selected items
+              let inputPadding;
+              let itemCount = selectedItems.length;
+              if (itemCount > 0 && itemCount <= 9) {
+                inputPadding = '64px';
+              } else if (itemCount >= 10 && itemCount <= 99) {
+                inputPadding = '68px';
+              }
               return (
                 <ListBox
                   className={className}
@@ -423,6 +432,7 @@ export default class FilterableMultiSelect extends React.Component {
                       aria-autocomplete="list"
                       ref={(el) => (this.inputNode = el)}
                       id={`${id}-input`}
+                      style={{ paddingLeft: inputPadding }}
                       {...getInputProps({
                         disabled,
                         placeholder,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7535

<img width="371" alt="Screen Shot 2021-01-20 at 2 27 04 PM" src="https://user-images.githubusercontent.com/11928039/105248669-a8e17000-5b2b-11eb-83c5-6ad887065bdd.png">


#### Changelog

**New**

- Absolutely positions the `clear selection` button
- Adjusts the `padding-left` based on the number of items shown. Currently handles single-digit and double-digit values. If needed, we can add more logic to handle triple-digit numbers and beyond pretty easily ([Logic](https://github.com/carbon-design-system/carbon/compare/master...tw15egan:filterable-multiselect?expand=1#diff-74ff9651e7339bd8467d8ddff586e5970baac132f753acc00035ab140649fde7R399-R401))

#### Testing / Reviewing

Navigate to Filterable Multiselect and select a few items. You should see the padding adjust when an item is selected and the focus should extend around the entire Multiselect. Add more items to the story to test double-digit numbers
