### PR TITLE
feat(Tag): implement short tag size

### DIFF
--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -36,7 +36,6 @@
     min-height: rem(24px);
     margin: $carbon--spacing-02;
     padding: $carbon--spacing-02 $carbon--spacing-03;
-    line-height: 1;
     word-break: break-word;
     border-radius: rem(15px);
     cursor: default;

--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -33,9 +33,10 @@
     min-width: rem(32px);
     // restricts size of contained elements
     max-width: 100%;
-    min-height: 1.5rem;
+    min-height: rem(24px);
     margin: $carbon--spacing-02;
     padding: $carbon--spacing-02 $carbon--spacing-03;
+    line-height: 1;
     word-break: break-word;
     border-radius: rem(15px);
     cursor: default;
@@ -216,6 +217,26 @@
 
   .#{$prefix}--tag--filter.#{$prefix}--tag--disabled svg {
     fill: $disabled-02;
+  }
+
+  // short tags
+  .#{$prefix}--tag--short {
+    min-height: rem(18px);
+    padding: 0 $carbon--spacing-03;
+  }
+
+  .#{$prefix}--tag--short > svg {
+    width: rem(14px);
+    height: rem(14px);
+    padding: 0;
+  }
+
+  .#{$prefix}--tag--short:focus > svg {
+    box-shadow: inset 0 0 0 1px $inverse-focus-ui;
+  }
+
+  .#{$prefix}--tag--short.#{$prefix}--tag--filter {
+    padding-right: rem(2px);
   }
 
   // Skeleton state

--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -224,16 +224,6 @@
     padding: 0 $carbon--spacing-03;
   }
 
-  .#{$prefix}--tag--short > svg {
-    width: rem(14px);
-    height: rem(14px);
-    padding: 0;
-  }
-
-  .#{$prefix}--tag--short:focus > svg {
-    box-shadow: inset 0 0 0 1px $inverse-focus-ui;
-  }
-
   .#{$prefix}--tag--short.#{$prefix}--tag--filter {
     padding-right: rem(2px);
   }

--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -218,13 +218,13 @@
     fill: $disabled-02;
   }
 
-  // short tags
-  .#{$prefix}--tag--short {
+  // small tags
+  .#{$prefix}--tag--sm {
     min-height: rem(18px);
     padding: 0 $carbon--spacing-03;
   }
 
-  .#{$prefix}--tag--short.#{$prefix}--tag--filter {
+  .#{$prefix}--tag--sm.#{$prefix}--tag--filter {
     padding-right: rem(2px);
   }
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5181,6 +5181,14 @@ Map {
         ],
         "type": "oneOfType",
       },
+      "size": Object {
+        "args": Array [
+          Array [
+            "short",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "title": Object {
         "type": "string",
       },
@@ -6586,6 +6594,14 @@ Map {
     "propTypes": Object {
       "className": Object {
         "type": "string",
+      },
+      "size": Object {
+        "args": Array [
+          Array [
+            "short",
+          ],
+        ],
+        "type": "oneOf",
       },
     },
   },

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5184,7 +5184,7 @@ Map {
       "size": Object {
         "args": Array [
           Array [
-            "short",
+            "sm",
           ],
         ],
         "type": "oneOf",
@@ -6598,7 +6598,7 @@ Map {
       "size": Object {
         "args": Array [
           Array [
-            "short",
+            "sm",
           ],
         ],
         "type": "oneOf",

--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -129,6 +129,7 @@ CustomIcon.parameters = {
 export const Skeleton = () => (
   <div>
     <TagSkeleton />
+    <TagSkeleton size="short" />
   </div>
 );
 

--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -25,6 +25,11 @@ const iconMap = {
   Tag16,
 };
 
+const sizes = {
+  'Default size': undefined,
+  'Short size (short)': 'short',
+};
+
 const props = {
   regular: () => ({
     type: select(
@@ -40,6 +45,7 @@ const props = {
       )
     ),
     disabled: boolean('Disabled (disabled)', false),
+    size: select('Field size (size)', sizes, undefined) || undefined,
     title: text('Title (title)', 'Clear Filter'),
   }),
   filter() {

--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -27,7 +27,7 @@ const iconMap = {
 
 const sizes = {
   'Default size': undefined,
-  'Short size (short)': 'short',
+  'Small size (sm)': 'sm',
 };
 
 const props = {
@@ -129,7 +129,7 @@ CustomIcon.parameters = {
 export const Skeleton = () => (
   <div>
     <TagSkeleton />
-    <TagSkeleton size="short" />
+    <TagSkeleton size="sm" />
   </div>
 );
 

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -30,10 +30,10 @@ TagSkeleton.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Specify the size of the Tag. Currently supports either `short` or
+   * Specify the size of the Tag. Currently supports either `sm` or
    * default sizes.
    */
-  size: PropTypes.oneOf(['short']),
+  size: PropTypes.oneOf(['sm']),
 };
 
 export default TagSkeleton;

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -12,10 +12,12 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-function TagSkeleton({ className, ...rest }) {
+function TagSkeleton({ className, size, ...rest }) {
   return (
     <span
-      className={cx(`${prefix}--tag`, `${prefix}--skeleton`, className)}
+      className={cx(`${prefix}--tag`, `${prefix}--skeleton`, className, {
+        [`${prefix}--tag--${size}`]: size,
+      })}
       {...rest}
     />
   );
@@ -26,6 +28,12 @@ TagSkeleton.propTypes = {
    * Specify an optional className to add.
    */
   className: PropTypes.string,
+
+  /**
+   * Specify the size of the Tag. Currently supports either `short` or
+   * default sizes.
+   */
+  size: PropTypes.oneOf(['short']),
 };
 
 export default TagSkeleton;

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -134,10 +134,10 @@ Tag.propTypes = {
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
-   * Specify the size of the Tag. Currently supports either `short` or
+   * Specify the size of the Tag. Currently supports either `sm` or
    * default sizes.
    */
-  size: PropTypes.oneOf(['short']),
+  size: PropTypes.oneOf(['sm']),
 
   /**
    * Text to show on clear filters

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -38,12 +38,14 @@ const Tag = ({
   title,
   disabled,
   onClose,
+  size,
   ...other
 }) => {
   const tagId = id || `tag-${getInstanceId()}`;
   const tagClasses = classNames(`${prefix}--tag`, className, {
     [`${prefix}--tag--disabled`]: disabled,
     [`${prefix}--tag--filter`]: filter,
+    [`${prefix}--tag--${size}`]: size,
     [`${prefix}--tag--${type}`]: type,
   });
   const handleClose = (event) => {
@@ -130,6 +132,12 @@ Tag.propTypes = {
    * Can be a React component class
    */
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+
+  /**
+   * Specify the size of the Tag. Currently supports either `short` or
+   * default sizes.
+   */
+  size: PropTypes.oneOf(['short']),
 
   /**
    * Text to show on clear filters


### PR DESCRIPTION
Closes #7512

related #4953

This PR implements support for short Tag and Filter Tag sizes

#### Changelog

**New**

- `size` support for short tags

#### Testing / Reviewing

Confirm the short tag, short filter tag, and short skeleton tags appear correct