### PR TITLE
feat(Github Actions): add auto-assign github action

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -12,4 +12,6 @@ jobs:
         uses: pozil/auto-assign-issue@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: dakahn
+          assignees:
+            dakahn, aledavila, andreancardona, emyarod, joshblack, tw15egan,
+            jnm2377

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,15 @@
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Auto-assign issue'
+        uses: pozil/auto-assign-issue@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: dakahn


### PR DESCRIPTION
This adds a Github action that will auto assigning a dev team maintainer to the issue to see through to close. 

#### Changelog

**New**

- adds ...workflows/auto-assign-issues.yml

#### Testing / Reviewing

I'm not super sure how we can test a Github action adding PR.