### PR TITLE
feat: add textDir property to FormLabel

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -304,6 +304,17 @@ Map {
       "defaultChecked": Object {
         "type": "bool",
       },
+      "dir": Object {
+        "args": Array [
+          Array [
+            "",
+            "ltr",
+            "rtl",
+            "auto",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "disabled": Object {
         "type": "bool",
       },
@@ -2836,6 +2847,17 @@ Map {
       },
       "className": Object {
         "type": "string",
+      },
+      "dir": Object {
+        "args": Array [
+          Array [
+            "",
+            "ltr",
+            "rtl",
+            "auto",
+          ],
+        ],
+        "type": "oneOf",
       },
       "id": Object {
         "type": "string",

--- a/packages/react/src/components/Checkbox/Checkbox-story.js
+++ b/packages/react/src/components/Checkbox/Checkbox-story.js
@@ -74,3 +74,12 @@ export const playground = () => (
     <Checkbox {...props()} id="checkbox-label-2" />
   </fieldset>
 );
+
+export const checkboxWithTextDir = () => {
+  return (
+    <fieldset className={`${prefix}--fieldset`}>
+      <legend className={`${prefix}--label`}>Checkbox with textDir</legend>
+      <Checkbox labelText={`שלום Hello !!`} dir="auto" id="checkbox-label-1" />
+    </fieldset>
+  );
+};

--- a/packages/react/src/components/Checkbox/Checkbox.js
+++ b/packages/react/src/components/Checkbox/Checkbox.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import resolveBaseTextDir from '../../tools/bidiUtils';
 
 const { prefix } = settings;
 
@@ -22,6 +23,7 @@ const Checkbox = React.forwardRef(function Checkbox(
     hideLabel,
     wrapperClassName,
     title = '',
+    dir,
     ...other
   },
   ref
@@ -58,7 +60,11 @@ const Checkbox = React.forwardRef(function Checkbox(
         }}
       />
       <label htmlFor={id} className={labelClasses} title={title || null}>
-        <span className={innerLabelClasses}>{labelText}</span>
+        <span
+          className={innerLabelClasses}
+          dir={resolveBaseTextDir(labelText, dir, false)}>
+          {labelText}
+        </span>
       </label>
     </div>
   );
@@ -79,6 +85,11 @@ Checkbox.propTypes = {
    * Specify whether the underlying input should be checked by default
    */
   defaultChecked: PropTypes.bool,
+
+  /**
+   * Provide the text direction for the given <FormLabel>
+   */
+  dir: PropTypes.oneOf(['', 'ltr', 'rtl', 'auto']),
 
   /**
    * Specify whether the Checkbox should be disabled

--- a/packages/react/src/components/FormLabel/FormLabel-story.js
+++ b/packages/react/src/components/FormLabel/FormLabel-story.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,6 +12,10 @@ import Tooltip from '../Tooltip';
 
 const additionalProps = {
   className: 'some-class',
+};
+
+const textDirProp = {
+  dir: 'auto',
 };
 
 export default {
@@ -41,5 +45,17 @@ WithTooltip.storyName = 'With tooltip';
 WithTooltip.parameters = {
   info: {
     text: 'Form label with tooltip.',
+  },
+};
+
+export const WithTextDir = () => (
+  <FormLabel {...textDirProp}>שלום Hello !!</FormLabel>
+);
+
+WithTextDir.storyName = 'With textDir';
+
+WithTextDir.parameters = {
+  info: {
+    text: 'Form label with textDir.',
   },
 };

--- a/packages/react/src/components/FormLabel/FormLabel.js
+++ b/packages/react/src/components/FormLabel/FormLabel.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,14 +9,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
+import resolveBaseTextDir from '../../tools/bidiUtils';
 
 const { prefix } = settings;
 
-const FormLabel = ({ className, children, id, ...other }) => {
+const FormLabel = ({ className, children, id, dir, ...other }) => {
   const classNames = classnames(`${prefix}--label`, className);
 
   return (
-    <label htmlFor={id} className={classNames} {...other}>
+    <label
+      htmlFor={id}
+      className={classNames}
+      dir={resolveBaseTextDir(children, dir, false)}
+      {...other}>
       {children}
     </label>
   );
@@ -32,6 +37,11 @@ FormLabel.propTypes = {
    * Provide a custom className to be applied to the containing <label> node
    */
   className: PropTypes.string,
+
+  /**
+   * Provide the text direction for the given <FormLabel>
+   */
+  dir: PropTypes.oneOf(['', 'ltr', 'rtl', 'auto']),
 
   /**
    * Provide a unique id for the given <FormLabel>

--- a/packages/react/src/components/FormLabel/__snapshots__/FormLabel-test.js.snap
+++ b/packages/react/src/components/FormLabel/__snapshots__/FormLabel-test.js.snap
@@ -3,5 +3,6 @@
 exports[`FormLabel should render 1`] = `
 <label
   className="bx--label"
+  dir={null}
 />
 `;

--- a/packages/react/src/tools/bidiUtils.js
+++ b/packages/react/src/tools/bidiUtils.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright IBM Corp. 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Checks if the character passed in is an Arabic character.
+ * @param {string} charCode - Character code
+ * @returns {boolean} True, if character is an Arabic character, false otherwise
+ */
+function isArabicChar(charCode) {
+  if (
+    (charCode >= 0x0600 && charCode <= 0x0669) ||
+    (charCode >= 0x06fa && charCode <= 0x07ff) ||
+    (charCode >= 0xfb50 && charCode <= 0xfdff) ||
+    (charCode >= 0xfe70 && charCode <= 0xfefc)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Checks if the character passed in is a Hebrew character.
+ * @param {string} charCode - Character code
+ * @returns {boolean} True, if character is a Hebrew character, false otherwise
+ */
+function isHebrewChar(charCode) {
+  if (charCode >= 0x05d0 && charCode <= 0x05ff) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Checks if the character passed in is a BiDi character.
+ * @param {number} charCode - Character code
+ * @returns {boolean} True, if the character is a BiDi (Arabic or Hebrew) character, false otherwise
+ */
+function isBidiChar(charCode) {
+  return isArabicChar(charCode) || isHebrewChar(charCode);
+}
+
+/**
+ * Checks if the character passed in is a Latin character (Only treats
+ * capital and lower case alphabets as latin characters)
+ * @param {number} charCode - Character code
+ * @returns {boolean} True if the character is a Latin character, false otherwise
+ */
+function isLatinChar(charCode) {
+  if ((charCode > 64 && charCode < 91) || (charCode > 96 && charCode < 123)) {
+    return true;
+  }
+  return false;
+}
+
+const AUTO = 'auto';
+
+/**
+ * Traverses the string passed in as a parameter from the beginning and
+ * determines the direction of the text based on the first strong character
+ * @param {string} text - A bi-directional text
+ * @param {textDir} textDir - the text direction
+ * @param {bool} isTextArea - Does the text belong to a textarea
+ * @returns {string} Direction of the text
+ */
+export default function resolveBaseTextDir(text, textDir, isTextArea) {
+  if (!textDir || typeof text !== 'string') {
+    return null;
+  }
+
+  if (textDir === AUTO && !isTextArea) {
+    for (let i = 0; text && i < text.length; i++) {
+      const character = text.charCodeAt(i);
+      if (isBidiChar(character)) {
+        textDir = 'rtl';
+        break;
+      } else if (isLatinChar(character)) {
+        textDir = 'ltr';
+        break;
+      }
+    }
+  }
+
+  return textDir;
+}


### PR DESCRIPTION
Ref #7264

Add the textDir property for FormLabel. This is just a sample. This property should be applied to all relevant react components

#### Changelog

**New**
bidiUtils


**Changed**

FormLabel



#### Testing / Reviewing

Add the new story WithTextDir in the FormLabel stroy
