### PR TITLE
fix(FilterableMultiSelect): extend input outline to trigger button area

### DIFF
--- a/packages/components/src/components/multi-select/_multi-select.scss
+++ b/packages/components/src/components/multi-select/_multi-select.scss
@@ -65,6 +65,21 @@
     color: $text-01;
   }
 
+  .#{$prefix}--multi-select--filterable {
+    transition: outline-color $duration--fast-01 motion(standard, productive);
+  }
+
+  .#{$prefix}--multi-select--filterable.#{$prefix}--combo-box
+    .#{$prefix}--text-input {
+    background-clip: padding-box;
+    border: rem(2px) solid transparent;
+    outline: none;
+  }
+
+  .#{$prefix}--multi-select--filterable--input-focused {
+    @include focus-outline('outline');
+  }
+
   .#{$prefix}--multi-select--filterable.#{$prefix}--list-box--disabled:hover
     .#{$prefix}--text-input {
     background-color: $field-01;

--- a/packages/components/src/components/multi-select/_multi-select.scss
+++ b/packages/components/src/components/multi-select/_multi-select.scss
@@ -70,10 +70,9 @@
     background-color: $field-01;
   }
 
-  .#{$prefix}--multi-select--filterable {
+  .#{$prefix}--multi-select--filterable
     .#{$prefix}--list-box__selection--multi {
-      margin: 0 0 0 $spacing-05;
-    }
+    margin: 0 0 0 $spacing-05;
   }
 
   .#{$prefix}--multi-select--filterable.#{$prefix}--multi-select--inline,

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -181,6 +181,7 @@ export default class FilterableMultiSelect extends React.Component {
       isOpen: props.open,
       inputValue: '',
       topItems: [],
+      inputFocused: false,
     };
   }
 
@@ -271,6 +272,14 @@ export default class FilterableMultiSelect extends React.Component {
     event.stopPropagation();
     this.setState({ inputValue: '' });
     this.inputNode && this.inputNode.focus && this.inputNode.focus();
+  };
+
+  handleInputFocus = (_) => {
+    this.setState({ inputFocused: true });
+  };
+
+  handleInputBlur = (_) => {
+    this.setState({ inputFocused: false });
   };
 
   render() {
@@ -385,6 +394,8 @@ export default class FilterableMultiSelect extends React.Component {
                   [`${prefix}--multi-select--inline`]: inline,
                   [`${prefix}--multi-select--selected`]:
                     selectedItem.length > 0,
+                  [`${prefix}--multi-select--filterable--input-focused`]: this
+                    .state.inputFocused,
                 }
               );
               const buttonProps = {
@@ -426,6 +437,8 @@ export default class FilterableMultiSelect extends React.Component {
                       {...getInputProps({
                         disabled,
                         placeholder,
+                        onFocus: this.handleInputFocus,
+                        onBlur: this.handleInputBlur,
                         onKeyDown: this.handleOnInputKeyDown,
                       })}
                     />

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -137,6 +137,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
                   id="test-filterable-multiselect-input"
                   onBlur={[Function]}
                   onChange={[Function]}
+                  onFocus={[Function]}
                   onKeyDown={[Function]}
                   placeholder="Placeholder..."
                   value=""


### PR DESCRIPTION
Closes #7535

related #7615

This PR resolves a visual issue in the filterable multiselect which expands the input focus outline to the multiselect menu trigger button area

#### Changelog

**New**

- input focus and blur handlers for FilterableMultiSelect

**Changed**

- FilterableMultiSelect focus styles

#### Testing / Reviewing

Confirm the filterable multiselect styles are now correct