### PR TITLE
fix(multi-select): remove left padding on filterable input after selection

### DIFF
--- a/packages/components/src/components/multi-select/_multi-select.scss
+++ b/packages/components/src/components/multi-select/_multi-select.scss
@@ -80,6 +80,11 @@
     @include focus-outline('outline');
   }
 
+  .#{$prefix}--multi-select--filterable.#{$prefix}--multi-select--selected
+    .#{$prefix}--text-input {
+    padding-left: 0;
+  }
+
   .#{$prefix}--multi-select--filterable.#{$prefix}--list-box--disabled:hover
     .#{$prefix}--text-input {
     background-color: $field-01;


### PR DESCRIPTION
Closes #7735

Related #7722

This PR removes the left padding on the filterable multiselect input field after making a selection, resolving an existing issue with filterable multiselect spacing

#### Testing / Reviewing

Confirm the filterable multiselect input has the correct spacing from the tag