### PR TITLE
fix(Toggle): support labels for small toggles

### DIFF
--- a/packages/react/src/components/Toggle/Toggle-test.js
+++ b/packages/react/src/components/Toggle/Toggle-test.js
@@ -122,12 +122,5 @@ describe('Toggle', () => {
       const svg = wrapper.find(`.${prefix}--toggle__check`);
       expect(svg.length).toBe(1);
     });
-
-    it('Does not render toggle text', () => {
-      const offLabel = wrapper.find(`.${prefix}--toggle__text--off`);
-      const onLabel = wrapper.find(`.${prefix}--toggle__text--on`);
-      expect(offLabel.length).toBe(0);
-      expect(onLabel.length).toBe(0);
-    });
   });
 });

--- a/packages/react/src/components/Toggle/Toggle.js
+++ b/packages/react/src/components/Toggle/Toggle.js
@@ -152,20 +152,12 @@ class Toggle extends React.Component {
                 <path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
               </svg>
             )}
-            {!size && (
-              <>
-                <span
-                  className={`${prefix}--toggle__text--off`}
-                  aria-hidden="true">
-                  {labelA}
-                </span>
-                <span
-                  className={`${prefix}--toggle__text--on`}
-                  aria-hidden="true">
-                  {labelB}
-                </span>
-              </>
-            )}
+            <span className={`${prefix}--toggle__text--off`} aria-hidden="true">
+              {labelA}
+            </span>
+            <span className={`${prefix}--toggle__text--on`} aria-hidden="true">
+              {labelB}
+            </span>
           </span>
         </label>
       </div>


### PR DESCRIPTION
Closes #7750

related #6653 #7380

This PR supports visible inline labels on the small toggle component

#### Testing / Reviewing

Confirm that labels are now visible on the small toggle component when a label value is provided