### PR TITLE
fix(toggle): adjust disabled toggle styles in data table

### DIFF
--- a/packages/components/src/components/toggle/_toggle.scss
+++ b/packages/components/src/components/toggle/_toggle.scss
@@ -421,6 +421,21 @@
     box-shadow: none;
   }
 
+  // disabled toggle in data table #7351
+  .#{$prefix}--data-table
+    .#{$prefix}--toggle-input:disabled
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::before {
+    background-color: $disabled-02;
+  }
+
+  .#{$prefix}--data-table
+    .#{$prefix}--toggle-input:disabled
+    + .#{$prefix}--toggle-input__label
+    > .#{$prefix}--toggle__switch::after {
+    background-color: $disabled-03;
+  }
+
   //----------------------------------------------
   // Small toggle
   // ---------------------------------------------


### PR DESCRIPTION
Closes #7351

This PR adds one off disabled styles for toggles in data tables. The example story will be removed prior to merging

#### Testing / Reviewing

Check the Test data table story and confirm the disabled toggle appears correct