### PR TITLE
fix(component-tokens): only emit static values in emit-component-tokens

### DIFF
--- a/packages/components/src/globals/scss/_component-tokens.scss
+++ b/packages/components/src/globals/scss/_component-tokens.scss
@@ -20,7 +20,10 @@ $enable-css-custom-properties: feature-flag-enabled(
 /// @example get-token-value($component-tokens, 'tag-background-red');
 /// @returns {String} Token value
 /// @group component-tokens
-@function get-token-value($tokens, $name) {
+@function get-token-value($tokens, $name, $force-static-values: false) {
+  $emit-as-css-custom-property: $force-static-values == false and
+    feature-flag-enabled('enable-css-custom-properties');
+
   @if map-has-key($tokens, $name) {
     $config: map-get($tokens, $name);
     $fallback: map-get($config, 'fallback');
@@ -33,7 +36,7 @@ $enable-css-custom-properties: feature-flag-enabled(
         $value: map-get($option, 'value');
 
         @return if(
-          feature-flag-enabled('enable-css-custom-properties'),
+          $emit-as-css-custom-property,
           var(--#{$custom-property-prefix}-#{$name}, #{$value}),
           $value
         );
@@ -41,7 +44,7 @@ $enable-css-custom-properties: feature-flag-enabled(
     }
 
     @return if(
-      feature-flag-enabled('enable-css-custom-properties'),
+      $emit-as-css-custom-property,
       var(--#{$custom-property-prefix}-#{$name}, #{$fallback}),
       $fallback
     );
@@ -73,6 +76,6 @@ $enable-css-custom-properties: feature-flag-enabled(
 /// @example @include emit-component-tokens($component-tokens);
 @mixin emit-component-tokens($tokens) {
   @each $key, $options in $tokens {
-    @include custom-property($key, get-token-value($tokens, $key));
+    @include custom-property($key, get-token-value($tokens, $key, true));
   }
 }


### PR DESCRIPTION
Closes #7800

The `emit-component-tokens` mixin currently emits all tokens as css custom properties if the feature flag is enabled, resulting in the actual css variable never declared and the colors always falling back to the default, white theme.

The workaround so far was to include the component's styles again, like so:
```scss
:root {
  @include carbon--theme($carbon--theme--g100, true) {
    @include emit-component-tokens($tag-colors);
    @include tags;
  }
}
```

This results in a lot of unnecessary css being generated and can create specificity issues.

#### Changelog

**New**

- Added an optional parameter `$force-static-values` to `get-token-value` mixin.

**Changed**

- Pass `true` to `$force-static-values` from `emit-component-tokens` mixin.

#### Testing / Reviewing

Before, this code should **not** result in the correct tag colors:
```scss
:root {
    @include carbon--theme($carbon--theme--g100, true) {
      @include emit-component-tokens($tag-colors);
    }
  }
```

With the changes in this PR, it should result in the correct tag colors.

In the inspector, all tag colors should be shown as static values: 
![image](https://user-images.githubusercontent.com/28265588/107959816-25893200-6fa4-11eb-9586-3999bbfe6bf8.png)

compared to before
![image](https://user-images.githubusercontent.com/28265588/107959884-3df94c80-6fa4-11eb-8835-461af1aff82c.png)
