### PR TITLE
fix(loading) small loader not spinning on fixed position

### DIFF
--- a/packages/components/src/components/loading/_loading.scss
+++ b/packages/components/src/components/loading/_loading.scss
@@ -49,8 +49,8 @@
   }
 
   .#{$prefix}--loading--small {
-    width: rem(16px);
-    height: rem(16px);
+    width: 2rem;
+    height: 2rem;
 
     circle {
       stroke-width: 16;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/2106 

change the height and width on small loader class to fix the issue
