### PR TITLE
fix(OverflowMenu): resolve child.props NPE

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -494,7 +494,7 @@ class OverflowMenu extends Component {
     const childrenWithProps = React.Children.toArray(children).map(
       (child, index) =>
         React.cloneElement(child, {
-          closeMenu: child.props.closeMenu || this.closeMenu,
+          closeMenu: child?.props?.closeMenu || this.closeMenu,
           handleOverflowMenuItemFocus: this.handleOverflowMenuItemFocus,
           ref: (e) => {
             this[`overflowMenuItem${index}`] = e;


### PR DESCRIPTION
Closes #7837

This PR adds a check for overflow menu children props before calling `child.props.closeMenu` to avoid type errors when the props object is not found

#### Testing / Reviewing

Confirm that the component will still render even when its children do not contain props