### PR TITLE
fix(elements): use explicit exports from motion to prevent duplicates

### DIFF
--- a/packages/elements/src/index.js
+++ b/packages/elements/src/index.js
@@ -162,4 +162,13 @@ export {
   spacing,
 } from '@carbon/layout';
 export * from '@carbon/themes';
-export * from '@carbon/motion';
+export {
+  fast01,
+  fast02,
+  moderate01,
+  moderate02,
+  slow01,
+  slow02,
+  easings,
+  motion,
+} from '@carbon/motion';


### PR DESCRIPTION
This came up during our 10.29 release. The motion package and type package both share `unstable_tokens` exports. Re-exporting all members from the `motion` package caused duplicates to appear in the ESM build. This PR addresses that by using explicit exports from the motion package

#### Changelog

**New**

**Changed**

- Update elements package to re-export explicit bindings from the motion package

**Removed**
