### PR TITLE
fix(DataTableSkeleton): fix support for visible headers

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6394,7 +6394,6 @@ Map {
     "defaultProps": Object {
       "columnCount": 5,
       "compact": false,
-      "headers": Array [],
       "rowCount": 5,
       "showHeader": true,
       "showToolbar": true,

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton-story.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton-story.js
@@ -16,11 +16,11 @@ const props = () => ({
   headers: array(
     'Optional table headers (headers)',
     [
-      { key: 'name' },
-      { key: 'protocol' },
-      { key: 'port' },
-      { key: 'rule' },
-      { key: 'attached-groups' },
+      { key: 'Name' },
+      { key: 'Protocol' },
+      { key: 'Port' },
+      { key: 'Rule' },
+      { key: 'Attached Groups' },
     ],
     ','
   ),

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton-story.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton-story.js
@@ -9,21 +9,19 @@
 
 import React from 'react';
 
-import { withKnobs, boolean, array } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import DataTableSkeleton from '../DataTableSkeleton';
 
+const headers = [
+  { key: 'Name' },
+  { key: 'Protocol' },
+  { key: 'Port' },
+  { key: 'Rule' },
+  { key: 'Attached Groups' },
+];
+
 const props = () => ({
-  headers: array(
-    'Optional table headers (headers)',
-    [
-      { key: 'Name' },
-      { key: 'Protocol' },
-      { key: 'Port' },
-      { key: 'Rule' },
-      { key: 'Attached Groups' },
-    ],
-    ','
-  ),
+  showHeaders: boolean('Show table headers', true),
   zebra: boolean('Use zebra stripe (zebra)', false),
   compact: boolean('Compact variant (compact)', false),
   showHeader: boolean('Show the Table Header (showHeader)', true),
@@ -39,12 +37,15 @@ export default {
   },
 };
 
-export const Skeleton = () => (
-  <div style={{ width: '800px' }}>
-    <DataTableSkeleton {...props()} />
-    <br />
-  </div>
-);
+export const Skeleton = () => {
+  const { showHeaders } = props();
+  return (
+    <div style={{ width: '800px' }}>
+      <DataTableSkeleton {...props()} headers={showHeaders ? headers : null} />
+      <br />
+    </div>
+  );
+};
 
 Skeleton.storyName = 'default';
 

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -13,6 +13,7 @@ import { settings } from 'carbon-components';
 const { prefix } = settings;
 
 const DataTableSkeleton = ({
+  headers,
   rowCount,
   columnCount,
   zebra,
@@ -67,7 +68,13 @@ const DataTableSkeleton = ({
           <tr>
             {columnsArray.map((i) => (
               <th key={i}>
-                <span></span>
+                {headers ? (
+                  <div className="bx--table-header-label">
+                    {headers[i]?.key}
+                  </div>
+                ) : (
+                  <span></span>
+                )}
               </th>
             ))}
           </tr>

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.js
@@ -138,7 +138,6 @@ DataTableSkeleton.defaultProps = {
   columnCount: 5,
   zebra: false,
   compact: false,
-  headers: [],
   showHeader: true,
   showToolbar: true,
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7302

Fixes support for visible headers in `DataTableSkeleton`. `headers` prop was not being properly passed down to `DataTableSkeleton`. Now, if the `headers` array exists, it is fed into the Table headers. If not, it renders the skeleton spans as before. 

#### Changelog

**Changed**

- `headers` prop now works as expected 

#### Testing / Reviewing

Ensure table headers now render on `DataTableSkeleton`
