### PR TITLE
fix(HeaderContainer): use previous state

### DIFF
--- a/packages/react/src/components/UIShell/HeaderContainer.js
+++ b/packages/react/src/components/UIShell/HeaderContainer.js
@@ -16,8 +16,10 @@ const HeaderContainer = ({ isSideNavExpanded, render: Children }) => {
   );
 
   const handleHeaderMenuButtonClick = useCallback(() => {
-    setIsSideNavExpandedState(!isSideNavExpandedState);
-  }, [isSideNavExpandedState, setIsSideNavExpandedState]);
+    setIsSideNavExpandedState(
+      (prevIsSideNavExpanded) => !prevIsSideNavExpanded
+    );
+  }, [setIsSideNavExpandedState]);
 
   return (
     <Children


### PR DESCRIPTION
I noticed specifically on Safari on iPhone that sometimes tapping the side nav button has no effect in our app, at least on the first try.
Not sure what's causing it but taking a look at the code I believe the recommended way to update state if it depends on previous status value is to use the callback variant. My theory is that somehow our code is getting a stale reference for `onClickSideNavExpand` in some cases. In any case this should prevent any such issue from occurring.

On a related note I needed to do the following to handle external link clicks and closing the side nav:

```typescript
import { useUpdate } from "react-use";
...
const rerender = useUpdate();
...
<SideNavLink<React.AnchorHTMLAttributes<HTMLAnchorElement>>
  href={href}
  onClick={(e) => {
    e.preventDefault();
    onClickSideNavExpand();
    rerender(); // this is required otherwise the side nav won't close
    window.open(href, "_blank", "noopener,noreferrer");
  }}
>
  Some external link
</SideNavLink>
```

I'm thinking it might be related to this button click issue somehow.

#### Changelog

**Changed**

- Update HeaderContainer to use previous state when changing the expanded state.
