### PR TITLE
fix(tabs): remove Safari specific overflow indicator margins

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -509,7 +509,6 @@
     @media not all and (min-resolution: 0.001dpcm) {
       @supports (-webkit-appearance: none) and (stroke-color: transparent) {
         .#{$prefix}--tabs__overflow-indicator--left {
-          margin-right: -$carbon--spacing-05;
           background-image: linear-gradient(
             to left,
             rgba($ui-background, 0),
@@ -518,7 +517,6 @@
         }
 
         .#{$prefix}--tabs__overflow-indicator--right {
-          margin-left: -$carbon--spacing-05;
           background-image: linear-gradient(
             to right,
             rgba($ui-background, 0),


### PR DESCRIPTION
Closes #7906

This PR removes previously needed margins for the tab overflow indicators in Safari

#### Testing / Reviewing

Reduce the width of the viewport so that scrolling tabs are enabled and the indicators appear. This will not be testable in the storybook due to custom properties support, so this will need to be viewed with custom properties disabled locally