### PR TITLE
feat: add FloatingMenu to dropdown

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import Dropdown from '../Dropdown';
 import DropdownSkeleton from './Dropdown.Skeleton';
 import mdx from './Dropdown.mdx';
+import Modal from '../Modal';
+import Button from '../Button';
 
 const items = [
   {
@@ -141,3 +143,34 @@ export const Skeleton = () => (
     <DropdownSkeleton />
   </div>
 );
+
+export const Overflow = () => {
+  const propsObj = props();
+  return (
+    <div style={{ width: 300, overflow: 'auto', resize: 'both' }}>
+      <Dropdown
+        {...propsObj}
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+      />
+    </div>
+  );
+};
+export const OverflowInModal = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const propsObj = props();
+  return (
+    <div>
+      <Button onClick={() => setIsOpen(!isOpen)}>Open</Button>
+      <Modal open={isOpen} onRequestClose={() => setIsOpen(false)}>
+        <div style={{ width: 300, overflow: 'auto' }}>
+          <Dropdown
+            {...propsObj}
+            items={items}
+            itemToString={(item) => (item ? item.text : '')}
+          />
+        </div>
+      </Modal>
+    </div>
+  );
+};

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -148,9 +148,13 @@ export const Skeleton = () => (
 export const Overflow = () => (
   <div style={{ width: 300, height: 100, overflow: 'auto', resize: 'both' }}>
     <Dropdown
-      {...{ detachMenu: boolean('Detach menu (detachMenu)', true) }}
+      id="default"
+      titleText="Dropdown label"
+      helperText="This is some helper text"
+      label="Dropdown menu options"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
+      {...{ detachMenu: boolean('Detach menu (detachMenu)', true) }}
     />
   </div>
 );
@@ -162,9 +166,13 @@ export const OverflowInModal = () => {
       <Modal open={isOpen} onRequestClose={() => setIsOpen(false)}>
         <div style={{ width: 300, height: 100, overflow: 'auto' }}>
           <Dropdown
-            {...{ detachMenu: boolean('Detach menu (detachMenu)', true) }}
+            id="default"
+            titleText="Dropdown label"
+            helperText="This is some helper text"
+            label="Dropdown menu options"
             items={items}
             itemToString={(item) => (item ? item.text : '')}
+            {...{ detachMenu: boolean('Detach menu (detachMenu)', true) }}
           />
         </div>
       </Modal>

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -61,6 +61,7 @@ const types = {
 const props = () => ({
   id: text('Dropdown ID (id)', 'carbon-dropdown-example'),
   size: select('Field size (size)', sizes, undefined) || undefined,
+  detachMenu: boolean('Detach menu (detachMenu)', false),
   direction: select('Dropdown direction (direction)', directions, 'bottom'),
   label: text('Label (label)', 'Dropdown menu options'),
   ariaLabel: text('Aria Label (ariaLabel)', 'Dropdown'),
@@ -144,28 +145,24 @@ export const Skeleton = () => (
   </div>
 );
 
-export const Overflow = () => {
-  const propsObj = props();
-  return (
-    <div style={{ width: 300, overflow: 'auto', resize: 'both' }}>
-      <Dropdown
-        {...propsObj}
-        items={items}
-        itemToString={(item) => (item ? item.text : '')}
-      />
-    </div>
-  );
-};
+export const Overflow = () => (
+  <div style={{ width: 300, height: 100, overflow: 'auto', resize: 'both' }}>
+    <Dropdown
+      {...{ detachMenu: boolean('Detach menu (detachMenu)', true) }}
+      items={items}
+      itemToString={(item) => (item ? item.text : '')}
+    />
+  </div>
+);
 export const OverflowInModal = () => {
   const [isOpen, setIsOpen] = useState(true);
-  const propsObj = props();
   return (
     <div>
       <Button onClick={() => setIsOpen(!isOpen)}>Open</Button>
       <Modal open={isOpen} onRequestClose={() => setIsOpen(false)}>
-        <div style={{ width: 300, overflow: 'auto' }}>
+        <div style={{ width: 300, height: 100, overflow: 'auto' }}>
           <Dropdown
-            {...propsObj}
+            {...{ detachMenu: boolean('Detach menu (detachMenu)', true) }}
             items={items}
             itemToString={(item) => (item ? item.text : '')}
           />

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -144,7 +144,22 @@ const Dropdown = React.forwardRef(function Dropdown(
       setMenuBounds(buttonRef.current.getBoundingClientRect());
     }
   }, [isOpen]);
-  const menuProps = getMenuProps();
+  const detachMenuWrapper = (menuEl) =>
+    !detachMenu ? (
+      menuEl
+    ) : (
+      <FloatingMenu
+        target={() => document.body}
+        triggerRef={buttonRef}
+        menuDirection={direction == 'top' ? DIRECTION_TOP : DIRECTION_BOTTOM}
+        menuRef={() => {}}
+        menuOffset={() => {}}
+        styles={{ width: menuBounds.width }}>
+        <div role="presentation" {...getMenuProps()} onKeyDown={() => {}}>
+          {menuEl}
+        </div>
+      </FloatingMenu>
+    );
 
   return (
     <div className={wrapperClasses} {...other}>
@@ -178,65 +193,43 @@ const Dropdown = React.forwardRef(function Dropdown(
           disabled={disabled}
           aria-disabled={disabled}
           {...toggleButtonProps}
-          onKeyDown={menuProps.onKeyDown}
           ref={mergeRefs(toggleButtonProps.ref, ref, buttonRef)}>
           <span className={`${prefix}--list-box__label`}>
             {selectedItem ? itemToString(selectedItem) : label}
           </span>
           <ListBox.MenuIcon isOpen={isOpen} translateWithId={translateWithId} />
         </button>
-        {(() => {
-          const menuEl = (
-            <ListBox.Menu
-              onMouseDown={(e) => e.stopPropagation()}
-              {...menuProps}>
-              {isOpen &&
-                items.map((item, index) => {
-                  const itemProps = getItemProps({ item, index });
-                  return (
-                    <ListBox.MenuItem
-                      key={itemProps.id}
-                      isActive={selectedItem === item}
-                      isHighlighted={
-                        highlightedIndex === index || selectedItem === item
-                      }
-                      title={itemToElement ? item.text : itemToString(item)}
-                      {...itemProps}>
-                      {itemToElement ? (
-                        <ItemToElement key={itemProps.id} {...item} />
-                      ) : (
-                        itemToString(item)
-                      )}
-                      {selectedItem === item && (
-                        <Checkmark16
-                          className={`${prefix}--list-box__menu-item__selected-icon`}
-                        />
-                      )}
-                    </ListBox.MenuItem>
-                  );
-                })}
-            </ListBox.Menu>
-          );
-
-          if (!detachMenu) {
-            return menuEl;
-          } else {
-            return (
-              <FloatingMenu
-                target={() => document.body}
-                triggerRef={buttonRef}
-                menuDirection={
-                  direction == 'top' ? DIRECTION_TOP : DIRECTION_BOTTOM
-                }
-                menuRef={() => {}}
-                menuOffset={() => {}}
-                styles={{ width: menuBounds.width }}
-                {...menuProps}>
-                {menuEl}
-              </FloatingMenu>
-            );
-          }
-        })()}
+        {detachMenuWrapper(
+          <ListBox.Menu
+            onMouseDown={(e) => e.stopPropagation()}
+            {...getMenuProps()}>
+            {isOpen &&
+              items.map((item, index) => {
+                const itemProps = getItemProps({ item, index });
+                return (
+                  <ListBox.MenuItem
+                    key={itemProps.id}
+                    isActive={selectedItem === item}
+                    isHighlighted={
+                      highlightedIndex === index || selectedItem === item
+                    }
+                    title={itemToElement ? item.text : itemToString(item)}
+                    {...itemProps}>
+                    {itemToElement ? (
+                      <ItemToElement key={itemProps.id} {...item} />
+                    ) : (
+                      itemToString(item)
+                    )}
+                    {selectedItem === item && (
+                      <Checkmark16
+                        className={`${prefix}--list-box__menu-item__selected-icon`}
+                      />
+                    )}
+                  </ListBox.MenuItem>
+                );
+              })}
+          </ListBox.Menu>
+        )}
       </ListBox>
       {!inline && !invalid && !warn && helper}
     </div>

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -139,7 +139,7 @@ const Dropdown = React.forwardRef(function Dropdown(
   const buttonRef = useRef();
   const [menuBounds, setMenuBounds] = useState({});
   useEffect(() => {
-    if (buttonRef && buttonRef.current) {
+    if (buttonRef && buttonRef.current) {
       setMenuBounds(buttonRef.current.getBoundingClientRect());
     }
   }, [isOpen]);
@@ -182,17 +182,20 @@ const Dropdown = React.forwardRef(function Dropdown(
           </span>
           <ListBox.MenuIcon isOpen={isOpen} translateWithId={translateWithId} />
         </button>
-        {isOpen && <FloatingMenu
-          target={() => document.body}
-          triggerRef={buttonRef}
-          menuDirection={direction == 'top' ? DIRECTION_TOP : DIRECTION_BOTTOM}
-          menuRef={() => {}}
-          menuOffset={() => {}}
-          styles={{width: menuBounds.width}}>
-          <ListBox.Menu
-            onMouseDown={e => e.stopPropagation()}
-            {...getMenuProps()}>
-            { items.map((item, index) => {
+        {isOpen && (
+          <FloatingMenu
+            target={() => document.body}
+            triggerRef={buttonRef}
+            menuDirection={
+              direction == 'top' ? DIRECTION_TOP : DIRECTION_BOTTOM
+            }
+            menuRef={() => {}}
+            menuOffset={() => {}}
+            styles={{ width: menuBounds.width }}>
+            <ListBox.Menu
+              onMouseDown={(e) => e.stopPropagation()}
+              {...getMenuProps()}>
+              {items.map((item, index) => {
                 const itemProps = getItemProps({ item, index });
                 return (
                   <ListBox.MenuItem
@@ -216,8 +219,9 @@ const Dropdown = React.forwardRef(function Dropdown(
                   </ListBox.MenuItem>
                 );
               })}
-          </ListBox.Menu>
-        </FloatingMenu> }
+            </ListBox.Menu>
+          </FloatingMenu>
+        )}
       </ListBox>
       {!inline && !invalid && !warn && helper}
     </div>

--- a/packages/react/src/components/MultiSelect/MultiSelect-story.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect-story.js
@@ -67,7 +67,7 @@ const directions = {
   'Top ': 'top',
 };
 
-const props = () => ({
+const props = (defaults = {}) => ({
   id: text('MultiSelect ID (id)', 'carbon-multiselect-example'),
   titleText: text('Title (titleText)', 'Multiselect title'),
   helperText: text('Helper text (helperText)', 'This is helper text'),
@@ -76,6 +76,7 @@ const props = () => ({
   useTitleInItem: boolean('Show tooltip on hover', false),
   type: select('UI type (Only for `<MultiSelect>`) (type)', types, 'default'),
   size: select('Field size (size)', sizes, undefined) || undefined,
+  detachMenu: boolean('Detach menu (detachMenu)', defaults.detachMenu),
   direction: select('Dropdown direction (direction)', directions, 'bottom'),
   label: text('Label (label)', defaultLabel),
   invalid: boolean('Show form validation UI (invalid)', false),
@@ -149,6 +150,25 @@ Default.parameters = {
       `,
   },
 };
+
+export const Overflow = withReadme(readme, () => {
+  const {
+    listBoxMenuIconTranslationIds,
+    selectionFeedback,
+    ...multiSelectProps
+  } = props({ detachMenu: true });
+  return (
+    <div style={{ width: 300, height: 100, overflow: 'auto', resize: 'both' }}>
+      <MultiSelect
+        {...multiSelectProps}
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+        translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
+        selectionFeedback={selectionFeedback}
+      />
+    </div>
+  );
+});
 
 export const WithInitialSelectedItems = withReadme(readme, () => {
   const {

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -209,7 +209,26 @@ const MultiSelect = React.forwardRef(function MultiSelect(
       setMenuBounds(buttonRef.current.getBoundingClientRect());
     }
   }, [isOpen]);
-  const menuProps = getMenuProps();
+  const detachMenuWrapper = (menuEl) =>
+    !detachMenu ? (
+      menuEl
+    ) : (
+      <FloatingMenu
+        target={() => document.body}
+        triggerRef={buttonRef}
+        menuDirection={direction == 'top' ? DIRECTION_TOP : DIRECTION_BOTTOM}
+        menuRef={() => {}}
+        menuOffset={() => {}}
+        styles={{ width: menuBounds.width }}>
+        <div
+          className={className}
+          role="presentation"
+          {...getMenuProps()}
+          onKeyDown={() => {}}>
+          {menuEl}
+        </div>
+      </FloatingMenu>
+    );
 
   return (
     <div className={wrapperClasses}>
@@ -244,7 +263,6 @@ const MultiSelect = React.forwardRef(function MultiSelect(
           disabled={disabled}
           aria-disabled={disabled}
           {...toggleButtonProps}
-          onKeyDown={menuProps.onKeyDown}
           ref={mergeRefs(toggleButtonProps.ref, ref, buttonRef)}>
           {selectedItems.length > 0 && (
             <ListBox.Selection
@@ -259,63 +277,42 @@ const MultiSelect = React.forwardRef(function MultiSelect(
           </span>
           <ListBox.MenuIcon isOpen={isOpen} translateWithId={translateWithId} />
         </button>
-        {(() => {
-          const menuEl = (
-            <ListBox.Menu aria-multiselectable="true" {...getMenuProps()}>
-              {isOpen &&
-                sortItems(items, sortOptions).map((item, index) => {
-                  const itemProps = getItemProps({
-                    item,
-                    // we don't want Downshift to set aria-selected for us
-                    // we also don't want to set 'false' for reader verbosity's sake
-                    ['aria-selected']: isChecked ? true : null,
-                  });
-                  const itemText = itemToString(item);
-                  const isChecked =
-                    selectedItems.filter((selected) => isEqual(selected, item))
-                      .length > 0;
-                  return (
-                    <ListBox.MenuItem
-                      key={itemProps.id}
-                      isActive={isChecked}
-                      aria-label={itemText}
-                      isHighlighted={highlightedIndex === index}
-                      title={itemText}
-                      {...itemProps}>
-                      <div className={`${prefix}--checkbox-wrapper`}>
-                        <span
-                          title={useTitleInItem ? itemText : null}
-                          className={`${prefix}--checkbox-label`}
-                          data-contained-checkbox-state={isChecked}
-                          id={`${itemProps.id}__checkbox`}>
-                          {itemText}
-                        </span>
-                      </div>
-                    </ListBox.MenuItem>
-                  );
-                })}
-            </ListBox.Menu>
-          );
-
-          if (!detachMenu) {
-            return menuEl;
-          } else {
-            return (
-              <FloatingMenu
-                target={() => document.body}
-                triggerRef={buttonRef}
-                menuDirection={
-                  direction == 'top' ? DIRECTION_TOP : DIRECTION_BOTTOM
-                }
-                menuRef={() => {}}
-                menuOffset={() => {}}
-                styles={{ width: menuBounds.width }}
-                {...menuProps}>
-                {menuEl}
-              </FloatingMenu>
-            );
-          }
-        })()}
+        {detachMenuWrapper(
+          <ListBox.Menu aria-multiselectable="true" {...getMenuProps()}>
+            {isOpen &&
+              sortItems(items, sortOptions).map((item, index) => {
+                const itemProps = getItemProps({
+                  item,
+                  // we don't want Downshift to set aria-selected for us
+                  // we also don't want to set 'false' for reader verbosity's sake
+                  ['aria-selected']: isChecked ? true : null,
+                });
+                const itemText = itemToString(item);
+                const isChecked =
+                  selectedItems.filter((selected) => isEqual(selected, item))
+                    .length > 0;
+                return (
+                  <ListBox.MenuItem
+                    key={itemProps.id}
+                    isActive={isChecked}
+                    aria-label={itemText}
+                    isHighlighted={highlightedIndex === index}
+                    title={itemText}
+                    {...itemProps}>
+                    <div className={`${prefix}--checkbox-wrapper`}>
+                      <span
+                        title={useTitleInItem ? itemText : null}
+                        className={`${prefix}--checkbox-label`}
+                        data-contained-checkbox-state={isChecked}
+                        id={`${itemProps.id}__checkbox`}>
+                        {itemText}
+                      </span>
+                    </div>
+                  </ListBox.MenuItem>
+                );
+              })}
+          </ListBox.Menu>
+        )}
       </ListBox>
       {!inline && !invalid && !warn && helperText && (
         <div id={helperId} className={helperClasses}>

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -155,6 +155,11 @@ class FloatingMenu extends React.Component {
     focusTrap: PropTypes.bool,
 
     /**
+     * Forward elemet reference
+     */
+    innerRef: PropTypes.object,
+
+    /**
      * Where to put the tooltip, relative to the trigger button.
      */
     menuDirection: PropTypes.oneOf([
@@ -433,7 +438,9 @@ class FloatingMenu extends React.Component {
     if (typeof document !== 'undefined') {
       const { focusTrap, target } = this.props;
       return ReactDOM.createPortal(
-        <div onBlur={focusTrap ? this.handleBlur : null}>
+        <div
+          onBlur={focusTrap ? this.handleBlur : null}
+          ref={this.props.innerRef}>
           {/* Non-translatable: Focus management code makes this `<span>` not actually read by screen readers */}
           <span
             ref={this.startSentinel}
@@ -459,4 +466,6 @@ class FloatingMenu extends React.Component {
   }
 }
 
-export default FloatingMenu;
+export default React.forwardRef((props, ref) => (
+  <FloatingMenu innerRef={ref} {...props} />
+));

--- a/packages/react/src/internal/FloatingMenu.js
+++ b/packages/react/src/internal/FloatingMenu.js
@@ -155,11 +155,6 @@ class FloatingMenu extends React.Component {
     focusTrap: PropTypes.bool,
 
     /**
-     * Forward elemet reference
-     */
-    innerRef: PropTypes.object,
-
-    /**
      * Where to put the tooltip, relative to the trigger button.
      */
     menuDirection: PropTypes.oneOf([
@@ -438,9 +433,7 @@ class FloatingMenu extends React.Component {
     if (typeof document !== 'undefined') {
       const { focusTrap, target } = this.props;
       return ReactDOM.createPortal(
-        <div
-          onBlur={focusTrap ? this.handleBlur : null}
-          ref={this.props.innerRef}>
+        <div onBlur={focusTrap ? this.handleBlur : null}>
           {/* Non-translatable: Focus management code makes this `<span>` not actually read by screen readers */}
           <span
             ref={this.startSentinel}
@@ -466,6 +459,4 @@ class FloatingMenu extends React.Component {
   }
 }
 
-export default React.forwardRef((props, ref) => (
-  <FloatingMenu innerRef={ref} {...props} />
-));
+export default FloatingMenu;


### PR DESCRIPTION
Closes #7565

Adds a FloatingMenu to the dropdown component, to use it within scrollable areas

#### Changelog

**New**

**Changed**

- Dropdown with FloatingMenu

**Removed**

#### Testing / Reviewing

- open dropdown story "Overflow" and "Overflow in Modal" to check if the dropdown menu is shown properly (not cut off by the overflow area)

#### Open points
1. Should this be a default or triggered by a property?
2. Should this be added to multi select?

3. This is required by the FloatingMenu, should these properties optional? ([Code](https://github.com/carbon-design-system/carbon/pull/7928/files#diff-b645c78914204385341704484c6145f99bbfa3765701ebc9e2c7bf1154212133R189))
```js
          menuRef={() => {}}
          menuOffset={() => {}}
```
4. This is needed for the modal to work (otherwise it closes on select) - any other ideas to fix this? ([Code](https://github.com/carbon-design-system/carbon/pull/7928/files#diff-b645c78914204385341704484c6145f99bbfa3765701ebc9e2c7bf1154212133R193))
```js
          <ListBox.Menu
            onMouseDown={e => e.stopPropagation()}
```

5. The FloatingMenu works fine except that it is not taking scrolling into account and should be addressed in another issue
![carbon-dropdown-scroll-issue](https://user-images.githubusercontent.com/3808948/109527629-29dd4100-7ab4-11eb-8563-1436286a837c.gif)
A simple solution for the dropdown would be to close it on scroll, to avoid updating the menu via JS (because this is laggy). For other components like the Tooltip this could work as well, but I guess this needs to be discussed in the separate issue.