### PR TITLE
docs(NumberInput): update NumberInput story

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput-story.js
+++ b/packages/react/src/components/NumberInput/NumberInput-story.js
@@ -30,7 +30,7 @@ const sizes = {
 const props = () => ({
   className: 'some-class',
   id: 'tj-input',
-  label: text('Label (label)', 'Number Input label'),
+  label: text('Label (label)', 'NumberInput label'),
   hideLabel: boolean('No label (hideLabel)', false),
   min: number('Minimum value (min)', 0),
   max: number('Maximum value (max)', 100),
@@ -80,6 +80,23 @@ export default {
 };
 
 export const Default = () => {
+  return (
+    <NumberInput
+      min={0}
+      max={100}
+      value={50}
+      label="NumberInput label"
+      helperText="Optional helper text."
+      invalidText="Number is not valid"
+    />
+  );
+};
+
+Default.story = {
+  name: 'Number Input',
+};
+
+export const Playground = () => {
   const { numberInputArrowTranslationIds, ...rest } = props();
   return (
     <NumberInput
@@ -89,23 +106,4 @@ export const Default = () => {
   );
 };
 
-export const Skeleton = () => (
-  <div
-    aria-label="loading number input"
-    aria-live="assertive"
-    role="status"
-    tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-  >
-    <NumberInputSkeleton />
-  </div>
-);
-
-Skeleton.storyName = 'skeleton';
-
-Skeleton.parameters = {
-  info: {
-    text: `
-        Placeholder skeleton state to use when content is loading.
-      `,
-  },
-};
+export const Skeleton = () => <NumberInputSkeleton />;

--- a/packages/react/src/components/NumberInput/NumberInput.mdx
+++ b/packages/react/src/components/NumberInput/NumberInput.mdx
@@ -1,4 +1,4 @@
-import { Props } from '@storybook/addon-docs/blocks';
+import { Props, Preview, Story } from '@storybook/addon-docs/blocks';
 
 # NumberInput
 
@@ -10,7 +10,22 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Table of Contents
 
+- [Overview](#overview)
+- [Skeleton state](#skeleton-state)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
 ## Overview
+
+<Preview>
+  <Story id="components-numberinput--default" />
+</Preview>
+
+## Skeleton State
+
+<Preview>
+  <Story id="components-numberinput--skeleton" />
+</Preview>
 
 ## Component API
 


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/6848

Adds in a default story that does not spread props for easier copy/pasting

#### Changelog

**Changed**

- Small tweaks to the `NumberInput` story

#### Testing / Reviewing

Ensure `NumberInput` story renders as expected 
