### PR TITLE
fix(skeleton): updates skeleton state performance

### DIFF
--- a/config/browserslist-config-carbon/index.js
+++ b/config/browserslist-config-carbon/index.js
@@ -7,4 +7,4 @@
 
 'use strict';
 
-module.exports = ['last 1 versions', 'ie >= 11', 'Firefox ESR'];
+module.exports = ['last 1 version', 'ie >= 11', 'Firefox ESR'];

--- a/packages/components/gulpfile.js
+++ b/packages/components/gulpfile.js
@@ -417,14 +417,7 @@ gulp.task('sass:dev', () => {
         })
       ).on('error', sass.logError)
     )
-    .pipe(
-      postcss([
-        customProperties(),
-        autoprefixer({
-          browsers: ['> 1%', 'last 2 versions'],
-        }),
-      ])
-    )
+    .pipe(postcss([customProperties(), autoprefixer()]))
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('demo'))
     .pipe(browserSync.stream({ match: '**/*.css' }));

--- a/packages/components/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
+++ b/packages/components/src/globals/grid/__tests__/__snapshots__/grid-test.js.snap
@@ -51,43 +51,34 @@ em {
 
 @keyframes skeleton {
   0% {
-    right: auto;
-    left: 0;
-    width: 0%;
+    transform: scaleX(0);
+    transform-origin: left;
     opacity: 0.3; }
   20% {
-    right: auto;
-    left: 0;
-    width: 100%;
+    transform: scaleX(1);
+    transform-origin: left;
     opacity: 1; }
   28% {
-    right: 0;
-    left: auto;
-    width: 100%; }
+    transform: scaleX(1);
+    transform-origin: right; }
   51% {
-    right: 0;
-    left: auto;
-    width: 0%; }
+    transform: scaleX(0);
+    transform-origin: right; }
   58% {
-    right: 0;
-    left: auto;
-    width: 0%; }
+    transform: scaleX(0);
+    transform-origin: right; }
   82% {
-    right: 0;
-    left: auto;
-    width: 100%; }
+    transform: scaleX(1);
+    transform-origin: right; }
   83% {
-    right: auto;
-    left: 0;
-    width: 100%; }
+    transform: scaleX(1);
+    transform-origin: left; }
   96% {
-    right: auto;
-    left: 0;
-    width: 0%; }
+    transform: scaleX(0);
+    transform-origin: left; }
   100% {
-    right: auto;
-    left: 0;
-    width: 0%;
+    transform: scaleX(0);
+    transform-origin: left;
     opacity: 0.3; } }
 
 .bx--grid {

--- a/packages/components/src/globals/scss/_helper-mixins.scss
+++ b/packages/components/src/globals/scss/_helper-mixins.scss
@@ -185,13 +185,12 @@
 
   &::before {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 0%;
+    width: 100%;
     height: 100%;
     background: $skeleton-02;
     animation: 3000ms ease-in-out skeleton infinite;
     content: '';
+    will-change: transform-origin, transform, opacity;
 
     @media (prefers-reduced-motion: reduce) {
       animation: none;
@@ -202,51 +201,42 @@
 @include exports('skeleton') {
   @keyframes skeleton {
     0% {
-      right: auto;
-      left: 0;
-      width: 0%;
+      transform: scaleX(0);
+      transform-origin: left;
       opacity: 0.3;
     }
     20% {
-      right: auto;
-      left: 0;
-      width: 100%;
+      transform: scaleX(1);
+      transform-origin: left;
       opacity: 1;
     }
     28% {
-      right: 0;
-      left: auto;
-      width: 100%;
+      transform: scaleX(1);
+      transform-origin: right;
     }
     51% {
-      right: 0;
-      left: auto;
-      width: 0%;
+      transform: scaleX(0);
+      transform-origin: right;
     }
     58% {
-      right: 0;
-      left: auto;
-      width: 0%;
+      transform: scaleX(0);
+      transform-origin: right;
     }
     82% {
-      right: 0;
-      left: auto;
-      width: 100%;
+      transform: scaleX(1);
+      transform-origin: right;
     }
     83% {
-      right: auto;
-      left: 0;
-      width: 100%;
+      transform: scaleX(1);
+      transform-origin: left;
     }
     96% {
-      right: auto;
-      left: 0;
-      width: 0%;
+      transform: scaleX(0);
+      transform-origin: left;
     }
     100% {
-      right: auto;
-      left: 0;
-      width: 0%;
+      transform: scaleX(0);
+      transform-origin: left;
       opacity: 0.3;
     }
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7850

Animations involving `width` are costly and have performance drawbacks. This PR updates the Skeleton state animation to use `transform` and `will-change` to improve performance by utilizing the GPU and eliminating canvas redraws 

#### Changelog

**New**

- Skeleton animation now uses `transform`

**Changed**

- Changed browser list export to correct syntax 

**Removed**

- Remove browserlist option in gulpfile to eliminate warning when running `yarn dev` in the components repo

#### Testing / Reviewing

Open up a skeleton component, open Chrome Dev tools, then <kbd>&#8984; CMD</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd>, then type `render`

Once there, check `Paint Flashing` and ensure there are no redraws

**Perf Before**:
<img width="1177" alt="Screen Shot 2021-03-03 at 12 21 06 PM" src="https://user-images.githubusercontent.com/11928039/109870439-f23ed800-7c1e-11eb-8cac-c82f40b6d1e5.png">



**Perf After**:
<img width="1181" alt="Screen Shot 2021-03-03 at 12 21 53 PM" src="https://user-images.githubusercontent.com/11928039/109870406-e81cd980-7c1e-11eb-8d6e-7dd696323efb.png">

