### PR TITLE
chore: rename `master` branch references to `main` branch

### DIFF
--- a/packages/react/.storybook/theme.js
+++ b/packages/react/.storybook/theme.js
@@ -47,5 +47,5 @@ export default create({
 
   brandTitle: `Carbon Components React v${PackageInfo.version}`,
   brandUrl:
-    'https://github.com/carbon-design-system/carbon/tree/master/packages/react',
+    'https://github.com/carbon-design-system/carbon/tree/main/packages/react',
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,7 +1,7 @@
 # carbon-components-react
 
 > A collection of
-> [Carbon Components](https://github.com/carbon-design-system/carbon/tree/master/packages/components)
+> [Carbon Components](https://github.com/carbon-design-system/carbon/tree/main/packages/components)
 > built with [React](https://reactjs.org/).
 
 If you're new to React.js or Carbon, check out our
@@ -25,9 +25,9 @@ yarn add carbon-components carbon-components-react carbon-icons
 ```
 
 If you want to try out `carbon-components-react`, you can also use
-[CodeSandbox](https://codesandbox.io/s/github/carbon-design-system/carbon/tree/master/packages/react/examples/codesandbox).
+[CodeSandbox](https://codesandbox.io/s/github/carbon-design-system/carbon/tree/main/packages/react/examples/codesandbox).
 
-[![Edit carbon-components-react](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon/tree/master/packages/react/examples/codesandbox)
+[![Edit carbon-components-react](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon/tree/main/packages/react/examples/codesandbox)
 
 ## Usage
 

--- a/packages/react/__tests__/PublicAPI-test.js
+++ b/packages/react/__tests__/PublicAPI-test.js
@@ -35,7 +35,7 @@ const { isValidElementType } = require('react-is');
  *    below.
  *
  * For full details on our versioning policy, check out our versioning guide:
- * https://github.com/carbon-design-system/carbon/blob/master/docs/guides/versioning.md
+ * https://github.com/carbon-design-system/carbon/blob/main/docs/guides/versioning.md
  */
 
 beforeEach(() => {

--- a/packages/react/docs/g11n.md
+++ b/packages/react/docs/g11n.md
@@ -21,4 +21,4 @@
   you are using date/time in other components, make sure they are correctly
   formatted considering different formats in different locales.
 - Also refer to
-  [G11N considerations in our vanilla library](https://github.com/IBM/carbon-components/tree/master/docs/g11n.md).
+  [G11N considerations in our vanilla library](https://github.com/IBM/carbon-components/tree/main/docs/g11n.md).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -168,6 +168,6 @@
   ],
   "bundleSizeThreshold": 120000,
   "release": {
-    "branch": "master"
+    "branch": "main"
   }
 }

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -3,7 +3,7 @@ import { Accordion, AccordionItem, AccordionSkeleton } from '../Accordion';
 
 # Accordion
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Accordion)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Accordion)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/accordion/usage)
 &nbsp;|&nbsp;
@@ -172,4 +172,4 @@ or screen reader.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Accordion/Accordion.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Accordion/Accordion.mdx).

--- a/packages/react/src/components/AspectRatio/AspectRatio.mdx
+++ b/packages/react/src/components/AspectRatio/AspectRatio.mdx
@@ -4,7 +4,7 @@ import { AspectRatio } from '../AspectRatio';
 
 # AspectRatio
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/AspectRatio)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/AspectRatio)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview#aspect-ratio)
 
@@ -73,4 +73,4 @@ outermost node in the component.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/AspectRatio/AspectRatio.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/AspectRatio/AspectRatio.mdx).

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.mdx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.mdx
@@ -3,7 +3,7 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbSkeleton } from '../Breadcrumb';
 
 # Breadcrumb
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Breadcrumb)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Breadcrumb)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/breadcrumb/usage)
 &nbsp;|&nbsp;
@@ -74,4 +74,4 @@ current page.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Breadcrumb/Breadcrumb.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Breadcrumb/Breadcrumb.mdx).

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -7,7 +7,7 @@ import { Add16, Delete16 } from '@carbon/icons-react';
 
 # Button
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Button)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Button)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/button/usage)
 &nbsp;|&nbsp;
@@ -346,4 +346,4 @@ By passing in `stacked` to the `ButtonSet` component, you can arrange your two
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Button/Button.mdx)
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Button/Button.mdx)

--- a/packages/react/src/components/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/Checkbox/Checkbox.mdx
@@ -3,7 +3,7 @@ import { Checkbox, CheckboxSkeleton } from '../Checkbox';
 
 # Checkbox
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Checkbox)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Checkbox)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/checkbox/usage)
 &nbsp;|&nbsp;
@@ -95,4 +95,4 @@ event.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Checkbox/Checkbox.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Checkbox/Checkbox.mdx).

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.mdx
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.mdx
@@ -5,7 +5,7 @@ import CodeSnippet from '../CodeSnippet';
 
 # CodeSnippet
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/CodeSnippet)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/CodeSnippet)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/code-snippet/usage)
 &nbsp;|&nbsp;
@@ -80,4 +80,4 @@ invocations, expressions etc.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/CodeSnippet/CodeSnippet.stories.mdx)
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/CodeSnippet/CodeSnippet.stories.mdx)

--- a/packages/react/src/components/ComboBox/ComboBox.mdx
+++ b/packages/react/src/components/ComboBox/ComboBox.mdx
@@ -5,7 +5,7 @@ import ComboBox from '../ComboBox';
 
 # ComboBox
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ComboBox)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ComboBox)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/dropdown/usage#combo-box)
 &nbsp;|&nbsp;
@@ -129,4 +129,4 @@ If the `items` array is not an array of strings, you'll need to use
 ## Feedback
 
 Help us improve these docs by
-[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ComboBox/ComboBox.stories.mdx)
+[editing this file on GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/ComboBox/ComboBox.stories.mdx)

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -4,7 +4,7 @@ import { InlineNotification } from '../Notification';
 
 # ComposedModal
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ComposedModal)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ComposedModal)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
 &nbsp;|&nbsp;
@@ -321,4 +321,4 @@ on the Carbon Design System website.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ComposedModal/ComposedModal.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/ComposedModal/ComposedModal.mdx).

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
@@ -4,7 +4,7 @@ import Switch from '../Switch';
 
 # Content Switcher
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ContentSwitcher)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ContentSwitcher)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/content-switcher/usage)
 &nbsp;|&nbsp;
@@ -207,4 +207,4 @@ keyboard interactions.
 
 Help us improve this component by providing feedback, asking questions, and
 leaving any other comments on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx).

--- a/packages/react/src/components/CopyButton/CopyButton.mdx
+++ b/packages/react/src/components/CopyButton/CopyButton.mdx
@@ -2,7 +2,7 @@ import { Props, Story, Preview } from '@storybook/addon-docs/blocks';
 
 # CopyButton
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/CopyButton)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/CopyButton)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/patterns/common-actions/#copy)
 
@@ -35,4 +35,4 @@ By default we display the text “Copied!”.
 
 Help us improve this component by providing feedback through, asking questions
 on Slack, or updating this file on GitHub
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/DataTable/DataTable.mdx
+++ b/packages/react/src/components/DataTable/DataTable.mdx
@@ -2,7 +2,7 @@ import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
 
 # DataTable
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/DataTable)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/DataTable)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/data-table/usage)
 &nbsp;|&nbsp;
@@ -354,4 +354,4 @@ These are values that represent the current state of the `DataTable` component.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/DataTable/DataTable.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/DataTable/DataTable.mdx).

--- a/packages/react/src/components/DatePicker/DatePicker.mdx
+++ b/packages/react/src/components/DatePicker/DatePicker.mdx
@@ -4,7 +4,7 @@ import DatePickerInput from '../DatePickerInput';
 
 # Date Picker
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/DatePicker)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/DatePicker)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/date-picker/usage)
 &nbsp;|&nbsp;
@@ -272,4 +272,4 @@ start this at a different date, you can pass in a date string or date object.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/DatePicker/DatePicker.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/DatePicker/DatePicker.mdx).

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -4,7 +4,7 @@ import DropdownSkeleton from './Dropdown.Skeleton';
 
 # Dropdown
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Dropdown)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Dropdown)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/dropdown/usage)
 &nbsp;|&nbsp;
@@ -299,4 +299,4 @@ that, pass in `type="inline"` to the `Dropdown`
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Dropdown/Dropdown.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Dropdown/Dropdown.mdx).

--- a/packages/react/src/components/FileUploader/FileUploader.mdx
+++ b/packages/react/src/components/FileUploader/FileUploader.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # FileUploader
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/FileUploader)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/FileUploader)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/file-uploader/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/FileUploader/FileUploader.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/FileUploader/FileUploader.mdx).

--- a/packages/react/src/components/Form/Form.mdx
+++ b/packages/react/src/components/Form/Form.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Form
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Form)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Form)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/form/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Form/Form.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Form/Form.mdx).

--- a/packages/react/src/components/FormLabel/FormLabel.mdx
+++ b/packages/react/src/components/FormLabel/FormLabel.mdx
@@ -3,7 +3,7 @@ import Tooltip from '../Tooltip';
 
 # FormLabel
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/FormLabel)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/FormLabel)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/form/usage)
 [Accessibility](https://www.carbondesignsystem.com/components/form/accessibility)
@@ -33,4 +33,4 @@ import Tooltip from '../Tooltip';
 
 Help us improve this component by providing feedback through, asking questions
 on Slack, or updating this file on GitHub
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/Grid/Grid.mdx
+++ b/packages/react/src/components/Grid/Grid.mdx
@@ -2,7 +2,7 @@ import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 # Grid
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Grid)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Grid)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview)
 
@@ -82,7 +82,7 @@ function MyComponent() {
 _Note: by default, `carbon-components` ships with a 12 column grid. You can
 enable a 16 column grid, which will be the default grid in the next major
 version, by using our
-[feature flags in Sass](https://github.com/carbon-design-system/carbon/blob/master/docs/guides/sass.md#feature-flags)._
+[feature flags in Sass](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/sass.md#feature-flags)._
 
 You can pair up multiple breakpoint props to specify how many columns the
 `Column` component should span at different break points. In the example below,
@@ -259,4 +259,4 @@ would love for you to get in touch!
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Grid/Grid.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Grid/Grid.mdx).

--- a/packages/react/src/components/InlineLoading/InlineLoading.mdx
+++ b/packages/react/src/components/InlineLoading/InlineLoading.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # InlineLoading
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/InlineLoading)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/InlineLoading)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/inline-loading/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/InlineLoading/InlineLoading.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/InlineLoading/InlineLoading.mdx).

--- a/packages/react/src/components/Link/Link.mdx
+++ b/packages/react/src/components/Link/Link.mdx
@@ -2,7 +2,7 @@ import { Props, Preview, Story } from '@storybook/addon-docs/blocks';
 
 # Link
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Link)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Link)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/link/usage)
 &nbsp;|&nbsp;
@@ -34,4 +34,4 @@ links, which should be used sparingly.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Link/Link.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Link/Link.mdx).

--- a/packages/react/src/components/Loading/Loading.mdx
+++ b/packages/react/src/components/Loading/Loading.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Loading
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Loading)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Loading)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/loading/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Loading/Loading.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Loading/Loading.mdx).

--- a/packages/react/src/components/Modal/Modal.mdx
+++ b/packages/react/src/components/Modal/Modal.mdx
@@ -4,7 +4,7 @@ import { InlineNotification } from '../Notification';
 
 # Modal
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Modal)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Modal)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
 &nbsp;|&nbsp;
@@ -321,4 +321,4 @@ on the Carbon Design System website.
 
 Help us improve this component by providing feedback through, asking questions
 on Slack,or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Modal/Modal.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Modal/Modal.mdx).

--- a/packages/react/src/components/MultiSelect/MultiSelect.mdx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # MultiSelect
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/MultiSelect)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/MultiSelect)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/dropdown/usage#multiselect)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/MultiSelect/MultiSelect.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/MultiSelect/MultiSelect.mdx).

--- a/packages/react/src/components/Notification/Notification.mdx
+++ b/packages/react/src/components/Notification/Notification.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Notification
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Notification)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Notification)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/notification/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Notification/Notification.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Notification/Notification.mdx).

--- a/packages/react/src/components/NumberInput/NumberInput.mdx
+++ b/packages/react/src/components/NumberInput/NumberInput.mdx
@@ -2,7 +2,7 @@ import { Props, Preview, Story } from '@storybook/addon-docs/blocks';
 
 # NumberInput
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/NumberInput)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/NumberInput)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/number-input/usage)
 &nbsp;|&nbsp;
@@ -35,4 +35,4 @@ import { Props, Preview, Story } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/NumberInput/NumberInput.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/NumberInput/NumberInput.mdx).

--- a/packages/react/src/components/OrderedList/OrderedList.mdx
+++ b/packages/react/src/components/OrderedList/OrderedList.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # OrderedList
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/OrderedList)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/OrderedList)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/list/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/OrderedList/OrderedList.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/OrderedList/OrderedList.mdx).

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # OverflowMenu
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/OverflowMenu)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/OverflowMenu)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/overflow-menu/usage)
 &nbsp;|&nbsp;
@@ -30,4 +30,4 @@ this attribute is found, the menu will be placed on `document.body`.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/OverflowMenu/OverflowMenu.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/OverflowMenu/OverflowMenu.mdx).

--- a/packages/react/src/components/Pagination/Pagination.mdx
+++ b/packages/react/src/components/Pagination/Pagination.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Pagination
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Pagination)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Pagination)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/pagination/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Pagination/Pagination.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Pagination/Pagination.mdx).

--- a/packages/react/src/components/Popover/Popover.mdx
+++ b/packages/react/src/components/Popover/Popover.mdx
@@ -2,7 +2,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # [Unstable] Popover
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Popover)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Popover)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -30,4 +30,4 @@ surface.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Popover/Popover.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Popover/Popover.mdx).

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # ProgressIndicator
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ProgressIndicator)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ProgressIndicator)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/progress-indicator/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx).

--- a/packages/react/src/components/RadioButton/RadioButton.mdx
+++ b/packages/react/src/components/RadioButton/RadioButton.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # RadioButton
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/RadioButton)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/RadioButton)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/radio-button/usage)
 &nbsp;|&nbsp;
@@ -33,4 +33,4 @@ component instead of the checkbox.
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/RadioButton/RadioButton.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/RadioButton/RadioButton.mdx).

--- a/packages/react/src/components/Search/Search.mdx
+++ b/packages/react/src/components/Search/Search.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Search
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Search)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Search)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/search/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Search/Search.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Search/Search.mdx).

--- a/packages/react/src/components/Select/Select.mdx
+++ b/packages/react/src/components/Select/Select.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Select
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Select)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Select)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/select/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Select/Select.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Select/Select.mdx).

--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # SkeletonPlaceholder
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/SkeletonPlaceholder)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/SkeletonPlaceholder)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/patterns/loading-pattern/#skeleton-states)
 
@@ -18,4 +18,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.mdx).

--- a/packages/react/src/components/SkeletonText/SkeletonText.mdx
+++ b/packages/react/src/components/SkeletonText/SkeletonText.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # SkeletonText
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/SkeletonText)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/SkeletonText)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/patterns/loading-pattern/#skeleton-states)
 
@@ -18,4 +18,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/SkeletonText/SkeletonText.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/SkeletonText/SkeletonText.mdx).

--- a/packages/react/src/components/Slider/Slider.mdx
+++ b/packages/react/src/components/Slider/Slider.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Slider
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Slider)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Slider)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/slider/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Slider/Slider.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Slider/Slider.mdx).

--- a/packages/react/src/components/StructuredList/StructuredList.mdx
+++ b/packages/react/src/components/StructuredList/StructuredList.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # StructuredList
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/StructuredList)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/StructuredList)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/structured-list/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/StructuredList/StructuredList.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/StructuredList/StructuredList.mdx).

--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -4,7 +4,7 @@ import Tab from '../Tab';
 
 # Tabs
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tabs)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Tabs)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/tabs/usage)
 &nbsp;|&nbsp;
@@ -74,4 +74,4 @@ const TabContentRenderedOnlyWhenSelected = ({
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tabs/Tabs.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Tabs/Tabs.mdx).

--- a/packages/react/src/components/Tag/Tag.mdx
+++ b/packages/react/src/components/Tag/Tag.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Tag
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tag)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Tag)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/tag/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tag/Tag.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Tag/Tag.mdx).

--- a/packages/react/src/components/TextArea/TextArea.mdx
+++ b/packages/react/src/components/TextArea/TextArea.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # TextArea
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TextArea)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/TextArea)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/text-input/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TextArea/TextArea.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/TextArea/TextArea.mdx).

--- a/packages/react/src/components/TextInput/TextInput.mdx
+++ b/packages/react/src/components/TextInput/TextInput.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # TextInput
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TextInput)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/TextInput)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/text-input/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TextInput/TextInput.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/TextInput/TextInput.mdx).

--- a/packages/react/src/components/Tile/Tile.mdx
+++ b/packages/react/src/components/Tile/Tile.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Tile
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tile)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Tile)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/tile/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tile/Tile.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Tile/Tile.mdx).

--- a/packages/react/src/components/TimePicker/TimePicker.mdx
+++ b/packages/react/src/components/TimePicker/TimePicker.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # TimePicker
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TimePicker)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/TimePicker)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/date-picker/usage#time-picker)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TimePicker/TimePicker.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/TimePicker/TimePicker.mdx).

--- a/packages/react/src/components/Toggle/Toggle.mdx
+++ b/packages/react/src/components/Toggle/Toggle.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Toggle
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Toggle)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Toggle)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/toggle/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Toggle/Toggle.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Toggle/Toggle.mdx).

--- a/packages/react/src/components/ToggleSmall/ToggleSmall.mdx
+++ b/packages/react/src/components/ToggleSmall/ToggleSmall.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # ToggleSmall
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/ToggleSmall)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ToggleSmall)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/toggle/usage#small-toggles)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/ToggleSmall/ToggleSmall.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/ToggleSmall/ToggleSmall.mdx).

--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # Tooltip
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Tooltip)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Tooltip)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/tooltip/usage)
 &nbsp;|&nbsp;
@@ -25,4 +25,4 @@ is _not_ provided, the `iconDescription` prop is required to populate the
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/Tooltip/Tooltip.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/Tooltip/Tooltip.mdx).

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # TooltipDefinition
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TooltipDefinition)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/TooltipDefinition)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/tooltip/usage#definition-tooltip)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/TooltipDefinition/TooltipDefinition.mdx).

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.mdx
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # TooltipIcon
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/TooltipIcon)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/TooltipIcon)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/tooltip/usage#icon-tooltip)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/TooltipIcon/TooltipIcon.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/TooltipIcon/TooltipIcon.mdx).

--- a/packages/react/src/components/UIShell/UIShell.mdx
+++ b/packages/react/src/components/UIShell/UIShell.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # UIShell
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/UIShell)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/UIShell)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/UI-shell-header/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/UIShell/UIShell.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/UIShell/UIShell.mdx).

--- a/packages/react/src/components/UnorderedList/UnorderedList.mdx
+++ b/packages/react/src/components/UnorderedList/UnorderedList.mdx
@@ -2,7 +2,7 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 # UnorderedList
 
-[Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/UnorderedList)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/UnorderedList)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/list/usage)
 &nbsp;|&nbsp;
@@ -20,4 +20,4 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 Help us improve this component by providing feedback, asking questions on Slack,
 or updating this file on
-[GitHub](https://github.com/carbon-design-system/carbon/edit/master/packages/react/src/components/UnorderedList/UnorderedList.mdx).
+[GitHub](https://github.com/carbon-design-system/carbon/edit/main/packages/react/src/components/UnorderedList/UnorderedList.mdx).


### PR DESCRIPTION
Since we have some references and links to files on Carbon's `master` branch, this PR updates those references to point to `main` branch now

#### Testing / Reviewing

Confirm the updated references point to the correct resources