### PR TITLE
fix(Slider): add validation when entering number via input

### DIFF
--- a/packages/components/src/components/slider/_slider.scss
+++ b/packages/components/src/components/slider/_slider.scss
@@ -143,7 +143,7 @@
 
   .#{$prefix}--slider-text-input,
   .#{$prefix}-slider-text-input {
-    width: rem(64px);
+    width: auto;
     height: rem(40px);
     text-align: center;
     -moz-appearance: textfield;

--- a/packages/react/src/components/Modal/Modal.mdx
+++ b/packages/react/src/components/Modal/Modal.mdx
@@ -13,9 +13,6 @@ import { InlineNotification } from '../Notification';
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-**Table of Contents** _generated with
-[DocToc](https://github.com/thlorenz/doctoc)_
-
 - [Modal](#modal)
   - [Overview](#overview)
   - [Component API](#component-api)

--- a/packages/react/src/components/Slider/Slider-story.js
+++ b/packages/react/src/components/Slider/Slider-story.js
@@ -54,17 +54,23 @@ export default {
   },
 };
 
-export const Default = () => <Slider required id="slider" {...props()} />;
+export const Default = () => (
+  <Slider
+    labelText="Slider Label"
+    value={50}
+    min={0}
+    max={100}
+    step={1}
+    stepMultiplier={10}
+    novalidate
+  />
+);
 
-Default.storyName = 'default';
-
-Default.parameters = {
-  info: {
-    text: `
-            Sliders provide a visual indication of adjustable content, where the user can move the handle along a horizontal track to increase or decrease the value.
-          `,
-  },
+Default.story = {
+  name: 'Slider',
 };
+
+export const Playground = () => <Slider id="slider" {...props()} />;
 
 export const ControlledSlider = () => {
   const [val, setVal] = useState(87);
@@ -86,26 +92,4 @@ export const ControlledSlider = () => {
   );
 };
 
-ControlledSlider.storyName = 'controlled slider';
-
-export const Skeleton = () => (
-  <div
-    style={{ marginTop: '2rem' }}
-    aria-label="loading slider"
-    aria-live="assertive"
-    role="status"
-    tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-  >
-    <SliderSkeleton />
-  </div>
-);
-
-Skeleton.storyName = 'skeleton';
-
-Skeleton.parameters = {
-  info: {
-    text: `
-        Placeholder skeleton state to use when content is loading.
-      `,
-  },
-};
+export const Skeleton = () => <SliderSkeleton />;

--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -224,15 +224,30 @@ describe('Slider', () => {
       });
     });
 
-    it('sets correct state when typing in input field', () => {
+    it('does not set incorrect state when typing a invalid value in input field', () => {
       const evt = {
         target: {
           value: '999',
+          checkValidity: () => false,
         },
       };
+
       wrapper.instance().onChange(evt);
-      expect(wrapper.state().value).toEqual(999);
-      expect(handleChange).lastCalledWith({ value: 999 });
+      expect(wrapper.state().value).toEqual(100);
+      expect(handleChange).lastCalledWith({ value: 100 });
+    });
+
+    it('sets correct state when typing a valid value in input field', () => {
+      const evt = {
+        target: {
+          value: '12',
+          checkValidity: () => true,
+        },
+      };
+
+      wrapper.instance().onChange(evt);
+      expect(wrapper.state().value).toEqual(12);
+      expect(handleChange).lastCalledWith({ value: 12 });
     });
   });
 

--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -399,11 +399,16 @@ export default class Slider extends PureComponent {
 
     let targetValue = Number.parseFloat(evt.target.value);
 
-    // Avoid calling calcValue for invaid numbers, but still update the state
+    // Avoid calling calcValue for invalid numbers, but still update the state
     if (isNaN(targetValue)) {
       this.setState({ value: evt.target.value });
     } else {
       // Recalculate the state's value and update the Slider
+      // if it is a valid number
+      if (evt.target.checkValidity() === false) {
+        return;
+      }
+
       const { value, left } = this.calcValue({
         value: targetValue,
         useRawValue: true,

--- a/packages/react/src/components/Slider/Slider.mdx
+++ b/packages/react/src/components/Slider/Slider.mdx
@@ -1,4 +1,4 @@
-import { Props } from '@storybook/addon-docs/blocks';
+import { Props, Story, Preview } from '@storybook/addon-docs/blocks';
 
 # Slider
 
@@ -10,7 +10,19 @@ import { Props } from '@storybook/addon-docs/blocks';
 
 ## Table of Contents
 
+- [Slider](#slider)
+  - [Overview](#overview)
+  - [Component API](#component-api)
+  - [Feedback](#feedback)
+
 ## Overview
+
+Sliders provide a visual indication of adjustable content, where the user can
+increase or decrease the value by moving the handle along a horizontal track.
+
+<Preview>
+  <Story id="components-slider--default" />
+</Preview>
 
 ## Component API
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7106

This prevents `onChange` from being fired if an invalid number is entered into the input element. The number entered is invalid if:
- it is larger than `max`
- it is lower than `min`
- not a valid increment of `step`

#### Changelog

**New**

- Aligned `mdx` files to match other components
- Before updating state, [checks if the number is valid](https://github.com/carbon-design-system/carbon/compare/main...tw15egan:slider-update?expand=1#diff-40db71ab0c0e12a32571d489b8e73a09dba8b90e1f00bf3198caf5d1841973b0R408-R410)

**Changed**

- `input` width set to `auto` so that it expands based on larger `max` values, like `NumberInput`
- Updated tests to check if that state is only updated for valid numbers

**Removed**

- Old storybook remnants
- DocToc comment in `Modal.mdx`

#### Testing / Reviewing

In the Slider story, try entering a value outside of the `min` and `max`. Default is `0` and `100`. It should not update to invalid values. Also, try entering `1.5` to validate the `step` of `1`
