### PR TITLE
fix(modal): override base paragraph styles in modal content

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -265,6 +265,10 @@
     }
   }
 
+  .#{$prefix}--modal-content > p {
+    @include type-style('body-long-01');
+  }
+
   // Required so overflow-indicator disappears at end of content
   .#{$prefix}--modal-scroll-content > *:last-child {
     padding-bottom: $spacing-07;


### PR DESCRIPTION
Closes #8043

This PR overrides the system wide text style rules on paragraphs only within modals (similar to existing overrides on other components e.g. accordion)

#### Testing / Reviewing

Confirm the text styles are correct in our modal storybook examples