### PR TITLE
fix(DataTable): return correct sort direction in sort action callback

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.js
+++ b/packages/react/src/components/DataTable/DataTable.js
@@ -217,17 +217,18 @@ export default class DataTable extends React.Component {
       sortDirection,
       isSortable,
       isSortHeader: sortHeaderKey === header.key,
-      // Compose the event handlers so we don't overwrite a consumer's `onClick`
-      // handler
-      onClick: composeEventHandlers([
-        this.handleSortBy(header.key),
-        onClick
-          ? this.handleOnHeaderClick(onClick, {
+      onClick: (event) => {
+        const nextSortState = getNextSortState(this.props, this.state, {
+          key: header.key,
+        });
+        this.setState(nextSortState, () => {
+          onClick &&
+            this.handleOnHeaderClick(onClick, {
               sortHeaderKey: header.key,
-              sortDirection,
-            })
-          : null,
-      ]),
+              sortDirection: nextSortState.sortDirection,
+            })(event);
+        });
+      },
     };
   };
 


### PR DESCRIPTION
Closes #4704

This PR returns the correct sort direction to the `handleSortBy` callback function in the DataTable's built in state manager

#### Testing / Reviewing

Confirm that the table sort parameters passed down to a user-provided `handleSortBy` callback accurately reflects the sort state now