### PR TITLE
docs: update default size knob description for Tag and Toggle

### DIFF
--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -26,7 +26,7 @@ const iconMap = {
 };
 
 const sizes = {
-  'Default size': undefined,
+  'Big/default size': undefined,
   'Small size (sm)': 'sm',
 };
 

--- a/packages/react/src/components/Toggle/Toggle-story.js
+++ b/packages/react/src/components/Toggle/Toggle-story.js
@@ -11,7 +11,7 @@ import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import Toggle from '../Toggle';
 
 const sizes = {
-  'Default size': undefined,
+  'Big/default size': undefined,
   'Small size (sm)': 'sm',
 };
 


### PR DESCRIPTION
Closes #8045

This PR is a docs update to match the big/small naming convention for the tag and toggle `size` prop values