### PR TITLE
feat(Select): support warning state

### DIFF
--- a/packages/components/src/components/form/_form.scss
+++ b/packages/components/src/components/form/_form.scss
@@ -88,6 +88,7 @@
   .#{$prefix}--text-input__field-wrapper--warning > .#{$prefix}--text-input,
   .#{$prefix}--text-area__wrapper[data-invalid],
   .#{$prefix}--select-input__wrapper[data-invalid],
+  .#{$prefix}--select--warning .#{$prefix}--select-input__wrapper,
   .#{$prefix}--time-picker[data-invalid],
   .#{$prefix}--list-box[data-invalid],
   .#{$prefix}--list-box--warning {

--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -127,8 +127,7 @@ $list-box-menu-width: rem(300px);
     fill: $support-03;
   }
 
-  .#{$prefix}--list-box__invalid-icon--warning
-    path[data-icon-path='inner-path'] {
+  .#{$prefix}--list-box__invalid-icon--warning path[fill] {
     opacity: 1;
     fill: $carbon__black-100;
   }

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -165,6 +165,11 @@
     fill: $support-03;
   }
 
+  .#{$prefix}--select__invalid-icon--warning path[fill] {
+    opacity: 1;
+    fill: $carbon__black-100;
+  }
+
   .#{$prefix}--select-optgroup,
   .#{$prefix}--select-option {
     // For the options to show in IE11

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -158,7 +158,6 @@
   .#{$prefix}--select-input__wrapper[data-invalid]
     .#{$prefix}--select-input
     ~ .#{$prefix}--select__invalid-icon {
-    right: $spacing-09;
     fill: $support-01;
   }
 

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -108,8 +108,9 @@
     color: $disabled-02;
   }
 
-  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input {
-    padding-right: carbon--mini-units(10);
+  .#{$prefix}--select-input__wrapper[data-invalid] .#{$prefix}--select-input,
+  .#{$prefix}--select--warning .#{$prefix}--select-input {
+    padding-right: carbon--mini-units(9);
   }
 
   .#{$prefix}--select-input:disabled ~ .#{$prefix}--select__arrow {
@@ -149,12 +150,20 @@
     }
   }
 
+  .#{$prefix}--select__invalid-icon {
+    position: absolute;
+    right: $spacing-08;
+  }
+
   .#{$prefix}--select-input__wrapper[data-invalid]
     .#{$prefix}--select-input
     ~ .#{$prefix}--select__invalid-icon {
-    position: absolute;
     right: $spacing-09;
     fill: $support-01;
+  }
+
+  .#{$prefix}--select__invalid-icon--warning {
+    fill: $support-03;
   }
 
   .#{$prefix}--select-optgroup,

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4727,6 +4727,12 @@ Map {
         ],
         "type": "oneOf",
       },
+      "warn": Object {
+        "type": "bool",
+      },
+      "warnText": Object {
+        "type": "node",
+      },
     },
     "render": [Function],
   },

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -40,6 +40,11 @@ const props = {
     labelText: text('Label text (labelText)', 'Select'),
     helperText: text('Helper text (helperText)', 'Optional helper text.'),
     onChange: action('onChange'),
+    warn: boolean('Show warning state (warn)', false),
+    warnText: text(
+      'Warning state text (warnText)',
+      'This will overwrite your current settings'
+    ),
   }),
   group: () => ({
     disabled: boolean('Disabled (disabled in <SelectItemGroup>)', false),

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -9,7 +9,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import { ChevronDown16, WarningFilled16 } from '@carbon/icons-react';
+import {
+  ChevronDown16,
+  WarningFilled16,
+  WarningAltFilled16,
+} from '@carbon/icons-react';
 import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
@@ -32,6 +36,8 @@ const Select = React.forwardRef(function Select(
     helperText,
     light,
     size,
+    warn,
+    warnText,
     ...other
   },
   ref
@@ -42,6 +48,7 @@ const Select = React.forwardRef(function Select(
     [`${prefix}--select--light`]: light,
     [`${prefix}--select--invalid`]: invalid,
     [`${prefix}--select--disabled`]: disabled,
+    [`${prefix}--select--warning`]: warn,
     [className]: className,
   });
   const labelClasses = classNames(`${prefix}--label`, {
@@ -53,11 +60,20 @@ const Select = React.forwardRef(function Select(
     [`${prefix}--select-input--${size}`]: size,
   });
   const errorId = `${id}-error-msg`;
-  const error = invalid ? (
-    <div className={`${prefix}--form-requirement`} id={errorId}>
-      {invalidText}
-    </div>
-  ) : null;
+  const errorText = (() => {
+    if (invalid) {
+      return invalidText;
+    }
+    if (warn) {
+      return warnText;
+    }
+  })();
+  const error =
+    invalid || warn ? (
+      <div className={`${prefix}--form-requirement`} id={errorId}>
+        {errorText}
+      </div>
+    ) : null;
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: disabled,
   });
@@ -84,6 +100,11 @@ const Select = React.forwardRef(function Select(
         <ChevronDown16 className={`${prefix}--select__arrow`} />
         {invalid && (
           <WarningFilled16 className={`${prefix}--select__invalid-icon`} />
+        )}
+        {!invalid && warn && (
+          <WarningAltFilled16
+            className={`${prefix}--select__invalid-icon ${prefix}--select__invalid-icon--warning`}
+          />
         )}
       </>
     );
@@ -208,6 +229,16 @@ Select.propTypes = {
    * Specify the size of the Select Input. Currently supports either `sm` or `xl` as an option.
    */
   size: PropTypes.oneOf(['sm', 'xl']),
+
+  /**
+   * Specify whether the control is currently in warning state
+   */
+  warn: PropTypes.bool,
+
+  /**
+   * Provide the text that is displayed when the control is in warning state
+   */
+  warnText: PropTypes.node,
 };
 
 Select.defaultProps = {


### PR DESCRIPTION
Closes #8082

This PR adds support for warning states in the Select component and fixes an existing issue with the warning icon spacing

#### Testing / Reviewing

Confirm that the `warn` and `warnText` props function as expected and appear as described in the component spec