### PR TITLE
docs(Welcome): update welcome page docs tab

### DIFF
--- a/packages/react/.storybook/Welcome/Welcome.mdx
+++ b/packages/react/.storybook/Welcome/Welcome.mdx
@@ -1,0 +1,15 @@
+# Welcome
+
+- [Carbon Website](https://www.carbondesignsystem.com/)
+- [IBM Design Language](https://www.ibm.com/design/language/)
+
+### Other Frameworks
+
+- [Carbon Angular](https://angular.carbondesignsystem.com)
+- [Carbon Vue](http://vue.carbondesignsystem.com)
+
+## Feedback
+
+Help us improve the documentation by providing feedback, asking questions on
+Slack, or updating the mdx files file on
+[GitHub](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components).

--- a/packages/react/.storybook/Welcome/Welcome.mdx
+++ b/packages/react/.storybook/Welcome/Welcome.mdx
@@ -3,7 +3,7 @@
 - [Carbon Website](https://www.carbondesignsystem.com/)
 - [IBM Design Language](https://www.ibm.com/design/language/)
 
-### Other Frameworks
+## Other Frameworks
 
 - [Carbon Angular](https://angular.carbondesignsystem.com)
 - [Carbon Vue](http://vue.carbondesignsystem.com)

--- a/packages/react/.storybook/Welcome/Welcome.stories.js
+++ b/packages/react/.storybook/Welcome/Welcome.stories.js
@@ -9,10 +9,16 @@
 
 import React from 'react';
 import { Welcome as Intro } from './Welcome';
+import mdx from './Welcome.mdx';
 
 export default {
   title: ' Getting Started/ Welcome',
   component: Intro,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
 };
 
 export const Welcome = () => <Intro />;


### PR DESCRIPTION
Updated the `Docs` tab for the Welcome page, so that it does not display a scrollable container.

Added in some helpful links, let me know if we want to add anything else