### PR TITLE
feat(CodeSnippet): add copy functionality by default

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -114,6 +114,15 @@ function CodeSnippet({
     handleScroll();
   }, [handleScroll]);
 
+  const handleCopyClick = (evt) => {
+    if (onClick) {
+      onClick(evt);
+      return;
+    }
+
+    navigator?.clipboard?.writeText(children);
+  };
+
   const codeSnippetClasses = classNames(className, `${prefix}--snippet`, {
     [`${prefix}--snippet--${type}`]: type,
     [`${prefix}--snippet--disabled`]: type !== 'inline' && disabled,
@@ -137,7 +146,7 @@ function CodeSnippet({
     return (
       <Copy
         {...rest}
-        onClick={onClick}
+        onClick={handleCopyClick}
         aria-label={copyLabel || ariaLabel}
         aria-describedby={uid}
         className={codeSnippetClasses}
@@ -177,7 +186,7 @@ function CodeSnippet({
       {!hideCopyButton && (
         <CopyButton
           disabled={disabled}
-          onClick={onClick}
+          onClick={handleCopyClick}
           feedback={feedback}
           iconDescription={copyButtonDescription}
         />


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6995
Closes https://github.com/carbon-design-system/carbon/issues/4448

[Comment](https://github.com/carbon-design-system/carbon/issues/4448#issuecomment-580514714) in #4448 suggest `doc.execCommand`, but it seems like this is [deprecated](https://caniuse.com/?search=execCommand) and is not suggested for use. This uses `navigator.clipboard.writeText` which is fully supported outside of IE11. 

I believe if we want to handle IE11 support, we'd need to introduce an external library (like `copy-to-clipboard`). It seems lightweight enough. https://www.npmjs.com/package/copy-to-clipboard

If we are dropping IE11 in the next major, we can always just hold off on adding the external library (and perhaps waiting to add this until the next major), but I wanted to see what everyone's thoughts were

#### Changelog

**New**

- `onClick` of copy button now calls internal `handleCopyClick` function
    - This function checks first to see if an `onClick` is provided, and if so, returns. This is to prevent duplicate copies.
    - If not, we run the copy command `navigator?.clipboard?.writeText(children);`

#### Testing / Reviewing

Ensure `inline` and `single` copy the content as expected. `playground` and `multi` should not since it provides an `onClick`
