### PR TITLE
fix(ListBox): change ListBox z-index higher than modal

### DIFF
--- a/packages/components/src/globals/scss/_layout.scss
+++ b/packages/components/src/globals/scss/_layout.scss
@@ -17,12 +17,12 @@ $z-indexes: (
   // having a higher z-index *should* not cause issues.
   dropdown: 9100,
   modal: 9000,
-  overlay: 6000,
   header: 8000,
+  overlay: 6000,
+  floating: 6000,
   footer: 5000,
   hidden: - 1,
-  overflowHidden: - 1,
-  floating: 6000
+  overflowHidden: - 1
 );
 
 /// @access public

--- a/packages/components/src/globals/scss/_layout.scss
+++ b/packages/components/src/globals/scss/_layout.scss
@@ -12,9 +12,9 @@
 /// @type Map
 /// @group global-layout
 $z-indexes: (
+  dropdown: 9100,
   modal: 9000,
   overlay: 6000,
-  dropdown: 6000,
   header: 8000,
   footer: 5000,
   hidden: - 1,

--- a/packages/components/src/globals/scss/_layout.scss
+++ b/packages/components/src/globals/scss/_layout.scss
@@ -12,6 +12,9 @@
 /// @type Map
 /// @group global-layout
 $z-indexes: (
+  // Dropdowns that render outside of a Modal should render above a Modal.
+  // Dropdowns below the modal will close when the Modal is opened, so
+  // having a higher z-index *should* not cause issues.
   dropdown: 9100,
   modal: 9000,
   overlay: 6000,
@@ -19,7 +22,7 @@ $z-indexes: (
   footer: 5000,
   hidden: - 1,
   overflowHidden: - 1,
-  floating: 6000,
+  floating: 6000
 );
 
 /// @access public


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/2660
Refs https://github.com/carbon-design-system/carbon/pull/6365

<img width="847" alt="Screen Shot 2021-03-16 at 1 12 03 PM" src="https://user-images.githubusercontent.com/11928039/111373517-34bdd700-8659-11eb-922d-468e9a719680.png">

This stems from a conversation on Slack from @carbon-design-system/angular-maintainers and you can see the issue occurring [here](https://angular.carbondesignsystem.com/?path=/story/components-combobox--in-modal). This was previously fixed by the Angular team in #2660 but reverted in #6365 

Updates `ListBox` elements z-index values to above `Modal`, so that a Dropdown rendered _outside_ of the Modal content (to prevent Dropdown causing scrolling inside Modal) will appear above the Modal itself. This should not cause any issues when triggering a Modal when a `ListBox` element is open, since the menu's all close when the focus is removed. Let me know if I am missing a particular use-case.



#### Changelog

**Changed**

- Bumps `dropdown` value from `6000` to `9100`
- Rearranged values in descending order

#### Testing / Reviewing

`z('dropdown')` is only used in `Dropdown` and `Listbox` components
