### PR TITLE
fix(carbon-cli): change MASTER reference to MAIN

### DIFF
--- a/packages/cli/src/git.js
+++ b/packages/cli/src/git.js
@@ -30,7 +30,7 @@ async function fetchLatestFromUpstream() {
       'git@github.com:carbon-design-system/carbon.git',
     ]);
   }
-  await execa('git', ['fetch', 'upstream', 'master', '--tags']);
+  await execa('git', ['fetch', 'upstream', 'main', '--tags']);
 }
 
 module.exports = {


### PR DESCRIPTION
Carbon-cli had a reference to `master` and was failing. This updates it so we're 👍🏽 