### PR TITLE
feat(UI icons): add 'football' alias for 'soccer'

### DIFF
--- a/packages/icons/icons.yml
+++ b/packages/icons/icons.yml
@@ -13010,6 +13010,7 @@
   aliases:
     - soccer
     - sports
+    - football
   sizes:
     - 32
 - name: soil-moisture


### PR DESCRIPTION
Make the soccer icon more accessible to the rest of the world... 😉

#### Changelog

**New**

 - `football` alias on the `soccer` icon

**Changed**

_none_

**Removed**

_none_
