### PR TITLE
fix(CodeSnippet): horizontal scrollbars missing

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -203,7 +203,7 @@
     order: 1;
     min-height: rem(56px);
     max-height: rem(238px);
-    overflow: hidden;
+    overflow: auto;
     transition: max-height $duration--moderate-01 motion(standard, productive);
   }
 
@@ -224,20 +224,12 @@
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre {
     padding-right: $carbon--spacing-08;
     padding-bottom: rem(24px);
-    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--no-copy
     .#{$prefix}--snippet-container
     pre {
     padding-right: 0;
-  }
-
-  // expanded pre
-  .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
-    .#{$prefix}--snippet-container
-    pre {
-    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {
@@ -249,10 +241,6 @@
     // Safari interprets `transparent` differently, so make color token value transparent instead:
     background-image: linear-gradient(to right, rgba($field-01, 0), $field-01);
     content: '';
-  }
-
-  .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre code {
-    overflow: hidden;
   }
 
   //Copy Button


### PR DESCRIPTION
This PR is in draft mode.
- #7574 requires UX input

This PR is not the solution for #7574.
This PR is to discuss the issues.
And in the case of fixing the horizontal scroll bars, to demonstrate the problems that need UX input.

```
Please note that scrollbars have a different look and feel on different platforms.
This issue looks different on Mac and windows.
```

This is the current layout of CodeSnippet...

```
<div class="bx--snippet-container" style={{overflow-y: auto}}>
   <code>
      <pre style={{overflow-x: auto}}>
      </pre>
   </code>
</div>
```

The vertical scrollbar(overflow-y) is available in both closed and expanded mode when the data exceeds the height.
UX is needed for this because the scroll bar collides with the copy and show button.
See attachment (vertical scrollbar issues.mov).

The horizontal scrollbar(overflow-x) are available when wrapText = F and the data exceeds the width.
The current problem with the horizontal scrollbar is that it is on the `<pre>` tag.
Meaning: the scroll bar is part of the vertically scrolled content and is not visible until you scroll to the bottom of the data.
ie: You can horizontally scroll without ever seeing the scrollbar.
See attachment (horizontal scrollbar issues.mov).

The horizontal scrollbar needs to be on the `<div class="bx--snippet-container">` tag, the same as the vertical scrollbar.
This PR demos moving it to that location.
The problem with doing that is that the horizontal scrollbar then collides with the show button (same issue the vertical scrollbar has).
This is the UX that is needed to address this.
See attachment (horizontal issue when on div.mov).
