### PR TITLE
fix(ClickableTile): ensure links are correct color when link has been visited

### DIFF
--- a/packages/components/src/components/tile/_tile.scss
+++ b/packages/components/src/components/tile/_tile.scss
@@ -76,7 +76,9 @@
   }
 
   .#{$prefix}--tile--clickable:hover,
-  .#{$prefix}--tile--clickable:active {
+  .#{$prefix}--tile--clickable:active,
+  .#{$prefix}--tile--clickable:visited,
+  .#{$prefix}--tile--clickable:visited:hover {
     color: $text-01;
     text-decoration: none;
   }

--- a/packages/react/src/components/Tile/Tile-story.js
+++ b/packages/react/src/components/Tile/Tile-story.js
@@ -25,6 +25,7 @@ import {
 } from '../Tile';
 import TileGroup from '../TileGroup';
 import RadioTile from '../RadioTile';
+import Link from '../Link';
 import mdx from './Tile.mdx';
 
 const radioValues = {
@@ -109,7 +110,14 @@ export default {
 
 export const Default = () => {
   const regularProps = props.regular();
-  return <Tile {...regularProps}>Default tile</Tile>;
+  return (
+    <Tile {...regularProps}>
+      Default tile
+      <br />
+      <br />
+      <Link href="https://www.carbondesignsystem.com">Link</Link>
+    </Tile>
+  );
 };
 
 Default.parameters = {

--- a/packages/react/src/components/Tile/Tile-story.js
+++ b/packages/react/src/components/Tile/Tile-story.js
@@ -40,7 +40,10 @@ const props = {
   }),
   clickable: () => ({
     disabled: boolean('disabled (disabled)', false),
-    href: text('Href for clickable UI (href)', 'javascript:void(0)'),
+    href: text(
+      'Href for clickable UI (href)',
+      'https://www.carbondesignsystem.com/'
+    ),
     light: boolean('Light variant (light)', false),
   }),
   selectable: () => ({

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import Link from '../Link';
 import {
   CheckmarkFilled16 as CheckmarkFilled,
   ChevronDown16,
@@ -168,14 +169,14 @@ export class ClickableTile extends Component {
     );
 
     return (
-      <a
+      <Link
         href={href}
         className={classes}
         {...other}
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}>
         {children}
-      </a>
+      </Link>
     );
   }
 }

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import Link from '../Link';
 import {
   CheckmarkFilled16 as CheckmarkFilled,
   ChevronDown16,
@@ -169,14 +168,14 @@ export class ClickableTile extends Component {
     );
 
     return (
-      <Link
+      <a
         href={href}
         className={classes}
         {...other}
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}>
         {children}
-      </Link>
+      </a>
     );
   }
 }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8158

Overrides `:visited` styles on `ClickableTile` so that text always renders `text-01`

#### Changelog

**New**

- `Link` added to the normal Tile story to ensure `Link` styles are correctly rendered in that variant

**Changed**

- `:visited` style overrides in the `ClickableTile` component

#### Testing / Reviewing

Ensure that text renders correctly (not blue) when an `href` is provided to `ClickableTile` (added one by default to the story).
