### PR TITLE
feat(React): updates to size prop

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -73,7 +73,9 @@
   }
 
   // Size styles
-  .#{$prefix}--accordion--xl .#{$prefix}--accordion__heading {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--accordion--xl .#{$prefix}--accordion__heading,
+  .#{$prefix}--accordion--lg .#{$prefix}--accordion__heading {
     min-height: rem(48px);
   }
 

--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -26,7 +26,9 @@
     height: rem(32px);
   }
 
-  .#{$prefix}--content-switcher--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--content-switcher--xl,
+  .#{$prefix}--content-switcher--lg {
     height: rem(48px);
   }
 

--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -117,7 +117,9 @@
   }
 
   // Size variant styles
-  .#{$prefix}--date-picker__input--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--date-picker__input--xl,
+  .#{$prefix}--date-picker__input--lg {
     height: rem(48px);
   }
 

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -75,12 +75,16 @@
     }
   }
 
-  .#{$prefix}--dropdown--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--dropdown--xl,
+  .#{$prefix}--dropdown--lg {
     height: rem(48px);
     max-height: rem(48px);
   }
 
-  .#{$prefix}--dropdown--xl .#{$prefix}--dropdown__arrow {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--dropdown--xl .#{$prefix}--dropdown__arrow,
+  .#{$prefix}--dropdown--lg .#{$prefix}--dropdown__arrow {
     top: rem(16px);
   }
 

--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -87,7 +87,9 @@ $list-box-menu-width: rem(300px);
     }
   }
 
-  .#{$prefix}--list-box--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--list-box--xl,
+  .#{$prefix}--list-box--lg {
     height: rem(48px);
     max-height: rem(48px);
   }
@@ -567,7 +569,10 @@ $list-box-menu-width: rem(300px);
     max-height: rem(220px);
   }
 
+  // TODO V11: Remove xl selector
   .#{$prefix}--list-box--expanded.#{$prefix}--list-box--xl
+    .#{$prefix}--list-box__menu,
+  .#{$prefix}--list-box--expanded.#{$prefix}--list-box--lg
     .#{$prefix}--list-box__menu {
     // 48px item height * 5.5 items shown
     max-height: rem(264px);
@@ -607,7 +612,9 @@ $list-box-menu-width: rem(300px);
     height: rem(32px);
   }
 
-  .#{$prefix}--list-box--xl .#{$prefix}--list-box__menu-item {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--list-box--xl .#{$prefix}--list-box__menu-item,
+  .#{$prefix}--list-box--lg .#{$prefix}--list-box__menu-item {
     height: rem(48px);
   }
 
@@ -695,7 +702,9 @@ $list-box-menu-width: rem(300px);
     padding-bottom: rem(7px);
   }
 
-  .#{$prefix}--list-box--xl .#{$prefix}--list-box__menu-item__option {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--list-box--xl .#{$prefix}--list-box__menu-item__option,
+  .#{$prefix}--list-box--lg .#{$prefix}--list-box__menu-item__option {
     height: rem(48px);
     padding-top: rem(15px);
     padding-bottom: rem(15px);
@@ -815,9 +824,14 @@ $list-box-menu-width: rem(300px);
     bottom: 2rem;
   }
 
+  // TODO V11: Remove xl selector
   .#{$prefix}--list-box--up.#{$prefix}--dropdown--xl
     .#{$prefix}--list-box__menu,
   .#{$prefix}--list-box--up.#{$prefix}--list-box--xl
+    .#{$prefix}--list-box__menu,
+  .#{$prefix}--list-box--up.#{$prefix}--dropdown--lg
+    .#{$prefix}--list-box__menu,
+  .#{$prefix}--list-box--up.#{$prefix}--list-box--lg
     .#{$prefix}--list-box__menu {
     bottom: 3rem;
   }

--- a/packages/components/src/components/number-input/_number-input.scss
+++ b/packages/components/src/components/number-input/_number-input.scss
@@ -73,7 +73,9 @@
     }
   }
 
-  .#{$prefix}--number--xl.#{$prefix}--number input[type='number'] {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--number--xl.#{$prefix}--number input[type='number'],
+  .#{$prefix}--number--lg.#{$prefix}--number input[type='number'] {
     padding-right: rem(144px);
   }
 
@@ -310,7 +312,9 @@
     fill: $support-01;
   }
 
-  .#{$prefix}--number--xl .#{$prefix}--number__invalid {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--number--xl .#{$prefix}--number__invalid,
+  .#{$prefix}--number--lg .#{$prefix}--number__invalid {
     right: rem(112px);
   }
 
@@ -323,7 +327,11 @@
     right: rem(80px);
   }
 
+  // TODO V11: Remove xl selector
   .#{$prefix}--number--xl
+    .#{$prefix}--number__invalid
+    + .#{$prefix}--number__rule-divider,
+  .#{$prefix}--number--lg
     .#{$prefix}--number__invalid
     + .#{$prefix}--number__rule-divider {
     right: rem(96px);
@@ -383,15 +391,21 @@
   }
 
   // Size Variant styles
-  .#{$prefix}--number--xl input[type='number'] {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--number--xl input[type='number'],
+  .#{$prefix}--number--lg input[type='number'] {
     height: rem(48px);
   }
 
-  .#{$prefix}--number--xl .#{$prefix}--number__controls {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--number--xl .#{$prefix}--number__controls,
+  .#{$prefix}--number--lg .#{$prefix}--number__controls {
     width: rem(96px);
   }
 
-  .#{$prefix}--number--xl .#{$prefix}--number__control-btn {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--number--xl .#{$prefix}--number__control-btn,
+  .#{$prefix}--number--lg .#{$prefix}--number__control-btn {
     width: rem(48px);
 
     &::before,

--- a/packages/components/src/components/overflow-menu/_overflow-menu.scss
+++ b/packages/components/src/components/overflow-menu/_overflow-menu.scss
@@ -51,7 +51,9 @@
     height: rem(32px);
   }
 
-  .#{$prefix}--overflow-menu--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--overflow-menu--xl,
+  .#{$prefix}--overflow-menu--lg {
     width: rem(48px);
     height: rem(48px);
   }
@@ -172,7 +174,9 @@
     }
   }
 
-  .#{$prefix}--overflow-menu-options--xl.#{$prefix}--overflow-menu-options {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--overflow-menu-options--xl.#{$prefix}--overflow-menu-options,
+  .#{$prefix}--overflow-menu-options--lg.#{$prefix}--overflow-menu-options {
     &[data-floating-menu-direction='bottom']::after,
     &[data-floating-menu-direction='top']::after {
       width: rem(48px);
@@ -220,7 +224,10 @@
     height: rem(32px);
   }
 
+  // TODO V11: Remove xl selector
   .#{$prefix}--overflow-menu-options--xl
+    .#{$prefix}--overflow-menu-options__option,
+  .#{$prefix}--overflow-menu-options--lg
     .#{$prefix}--overflow-menu-options__option {
     height: rem(48px);
   }

--- a/packages/components/src/components/select/_select.scss
+++ b/packages/components/src/components/select/_select.scss
@@ -98,7 +98,9 @@
     max-height: rem(32px);
   }
 
-  .#{$prefix}--select-input--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--select-input--xl,
+  .#{$prefix}--select-input--lg {
     height: rem(48px);
     max-height: rem(48px);
   }

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -45,7 +45,9 @@
     }
   }
 
-  .#{$prefix}--text-input--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--text-input--xl,
+  .#{$prefix}--text-input--lg {
     height: rem(48px);
   }
 
@@ -315,7 +317,9 @@
     margin-top: rem(9px);
   }
 
-  .#{$prefix}--text-input-wrapper .#{$prefix}--label--inline--xl {
+  // TODO V11: Remove xl selector
+  .#{$prefix}--text-input-wrapper .#{$prefix}--label--inline--xl,
+  .#{$prefix}--text-input-wrapper .#{$prefix}--label--inline--lg {
     margin-top: rem(17px);
   }
 

--- a/packages/components/src/components/time-picker/_time-picker.scss
+++ b/packages/components/src/components/time-picker/_time-picker.scss
@@ -83,8 +83,11 @@
     max-height: rem(32px);
   }
 
+  // TODO V11: Remove xl selector
   .#{$prefix}--time-picker--xl .#{$prefix}--select-input,
-  .#{$prefix}--time-picker--xl .#{$prefix}--time-picker__input-field {
+  .#{$prefix}--time-picker--xl .#{$prefix}--time-picker__input-field,
+  .#{$prefix}--time-picker--lg .#{$prefix}--select-input,
+  .#{$prefix}--time-picker--lg .#{$prefix}--time-picker__input-field {
     height: rem(48px);
     max-height: rem(48px);
   }

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -29,6 +29,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -652,6 +654,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -2447,6 +2451,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -3681,6 +3687,8 @@ Map {
           "args": Array [
             Array [
               "sm",
+              "md",
+              "lg",
               "xl",
             ],
           ],
@@ -3920,6 +3928,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -6665,6 +6675,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -731,6 +731,7 @@ Map {
           Array [
             "xs",
             "sm",
+            "md",
             "lg",
           ],
         ],
@@ -892,6 +893,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -2323,6 +2326,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -3223,6 +3228,7 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
             "lg",
           ],
         ],
@@ -3371,6 +3377,7 @@ Map {
           Array [
             "xs",
             "sm",
+            "md",
             "lg",
           ],
         ],
@@ -4852,6 +4859,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -5362,6 +5371,7 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
           ],
         ],
         "type": "oneOf",
@@ -5767,6 +5777,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -6144,6 +6156,8 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
+            "lg",
             "xl",
           ],
         ],
@@ -6238,6 +6252,7 @@ Map {
         "args": Array [
           Array [
             "sm",
+            "md",
           ],
         ],
         "type": "oneOf",

--- a/packages/react/src/components/Accordion/Accordion-story.js
+++ b/packages/react/src/components/Accordion/Accordion-story.js
@@ -88,9 +88,9 @@ const props = {
 };
 
 const sizes = {
-  'Small (sm)': 'sm',
-  'Medium - default (md)': 'md',
-  'Large (lg)': 'lg',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 export const playground = () => (

--- a/packages/react/src/components/Accordion/Accordion-story.js
+++ b/packages/react/src/components/Accordion/Accordion-story.js
@@ -88,9 +88,9 @@ const props = {
 };
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small (sm)': 'sm',
+  'Medium - default (md)': 'md',
+  'Large (lg)': 'lg',
 };
 
 export const playground = () => (

--- a/packages/react/src/components/Accordion/Accordion.js
+++ b/packages/react/src/components/Accordion/Accordion.js
@@ -61,9 +61,10 @@ Accordion.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Specify the size of the Accordion. Currently supports either `sm` or `xl` as an option.
+   * Specify the size of the Accordion. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+   * TODO V11: remove `xl` (replaced with lg)
    */
-  size: PropTypes.oneOf(['sm', 'xl']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 };
 
 export default Accordion;

--- a/packages/react/src/components/ComboBox/ComboBox-story.js
+++ b/packages/react/src/components/ComboBox/ComboBox-story.js
@@ -28,7 +28,6 @@ const items = [
   {
     id: 'option-3',
     text: 'Option 3',
-    selected: true,
   },
   {
     id: 'option-4',
@@ -41,9 +40,9 @@ const items = [
 ];
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const directions = {
@@ -64,6 +63,8 @@ export default {
 export const combobox = () => (
   <div style={{ width: 300 }}>
     <ComboBox
+      onChange={() => {}}
+      id="carbon-combobox"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
       placeholder="Filter..."
@@ -118,6 +119,8 @@ export const Playground = () => {
 export const disabled = () => (
   <div style={{ width: 300 }}>
     <ComboBox
+      onChange={() => {}}
+      id="carbon-combobox-disabled"
       disabled
       items={items}
       itemToString={(item) => (item ? item.text : '')}
@@ -131,6 +134,8 @@ export const disabled = () => (
 export const light = () => (
   <div style={{ width: 300 }}>
     <ComboBox
+      onChange={() => {}}
+      id="carbon-combobox-light"
       light
       items={items}
       itemToString={(item) => (item ? item.text : '')}

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -503,7 +503,7 @@ ComboBox.propTypes = {
   shouldFilterItem: PropTypes.func,
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `lg` or `xl` as an option.
+   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
    */
   size: ListBoxPropTypes.ListBoxSize,
 

--- a/packages/react/src/components/ComposedModal/ComposedModal-story.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-story.js
@@ -28,9 +28,9 @@ import Button from '../Button';
 import mdx from './ComposedModal.mdx';
 
 const sizes = {
-  Default: '',
   'Extra small (xs)': 'xs',
   'Small (sm)': 'sm',
+  'Medium (md)': 'md',
   'Large (lg)': 'lg',
 };
 
@@ -42,7 +42,7 @@ const buttons = {
 };
 
 const props = {
-  composedModal: ({ titleOnly } = {}) => ({
+  composedModal: () => ({
     numberOfButtons: options('Number of Buttons', buttons, '2', {
       display: 'inline-radio',
     }),
@@ -52,7 +52,7 @@ const props = {
       'Primary focus element selector (selectorPrimaryFocus)',
       '[data-modal-primary-focus]'
     ),
-    size: select('Size (size)', sizes, titleOnly ? 'sm' : ''),
+    size: select('Size (size)', sizes, 'md'),
     preventCloseOnClickOutside: boolean(
       'Prevent closing on click outside of modal (preventCloseOnClickOutside)',
       true

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -97,7 +97,7 @@ export default class ComposedModal extends Component {
     /**
      * Specify the size variant.
      */
-    size: PropTypes.oneOf(['xs', 'sm', 'lg']),
+    size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
   };
 
   static getDerivedStateFromProps({ open }, state) {

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher-story.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher-story.js
@@ -18,9 +18,9 @@ const selectionModes = {
 };
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const props = {

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -62,9 +62,10 @@ export default class ContentSwitcher extends React.Component {
     selectionMode: PropTypes.oneOf(['automatic', 'manual']),
 
     /**
-     * Specify the size of the Content Switcher. Currently supports either `sm` or `xl` as an option.
+     * Specify the size of the Content Switcher. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+     * TODO V11: remove `xl` (replaced with lg)
      */
-    size: PropTypes.oneOf(['sm', 'xl']),
+    size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
   };
 
   static defaultProps = {

--- a/packages/react/src/components/DatePicker/DatePicker-story.js
+++ b/packages/react/src/components/DatePicker/DatePicker-story.js
@@ -18,9 +18,9 @@ const patterns = {
 };
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const types = {

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.js
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.js
@@ -99,9 +99,10 @@ export default class DatePickerInput extends Component {
     placeholder: PropTypes.string,
 
     /**
-     * Specify the size of the Date Picker Input. Currently supports either `sm` or `xl` as an option.
+     * Specify the size of the Date Picker Input. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+     * TODO V11: remove `xl` (replaced with lg)
      */
-    size: PropTypes.oneOf(['sm', 'xl']),
+    size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 
     /**
      * Specify the type of the `<input>`

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -46,9 +46,9 @@ const items = [
 ];
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const directions = {
@@ -57,7 +57,7 @@ const directions = {
 };
 
 const types = {
-  Default: '',
+  Default: 'default',
   Inline: 'inline',
 };
 
@@ -77,7 +77,7 @@ const props = () => ({
     'Form validation UI content (invalidText)',
     'A valid value is required'
   ),
-  type: select('Type (type)', types, ''),
+  type: select('Type (type)', types, 'default'),
   warn: boolean('Show warning state (warn)', false),
   warnText: text(
     'Warning state text (warnText)',

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
@@ -55,7 +55,7 @@ DropdownSkeleton.propTypes = {
   ),
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `lg` or `xl` as an option.
+   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
    */
   size: ListBoxPropTypes.ListBoxSize,
 };

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -322,7 +322,7 @@ Dropdown.propTypes = {
   selectedItem: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `lg` or `xl` as an option.
+   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
    */
   size: ListBoxPropTypes.ListBoxSize,
 

--- a/packages/react/src/components/Link/Link-story.js
+++ b/packages/react/src/components/Link/Link-story.js
@@ -13,6 +13,12 @@ import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import Link from '../Link';
 import mdx from './Link.mdx';
 
+const sizes = {
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
+};
+
 const props = () => ({
   className: 'some-class',
   href: text('The link href (href)', '#'),
@@ -23,11 +29,7 @@ const props = () => ({
     handler(evt);
   })(action('onClick')),
   disabled: boolean('Disabled', false),
-  size: select('Link size', {
-    Default: undefined,
-    'Small (sm)': 'sm',
-    'Large (lg)': 'lg',
-  }),
+  size: select('Field size (size)', sizes, undefined) || undefined,
 });
 
 export default {

--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -69,9 +69,9 @@ Link.propTypes = {
   inline: PropTypes.bool,
 
   /**
-   * Specify the size of the Link. Currently supports either `sm` or `lg` as an option.
+   * Specify the size of the Link. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
    */
-  size: PropTypes.oneOf(['sm', 'lg']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
 
   /**
    * Specify whether you want the link to receive visited styles after the link has been clicked

--- a/packages/react/src/components/ListBox/ListBox.js
+++ b/packages/react/src/components/ListBox/ListBox.js
@@ -117,7 +117,7 @@ ListBox.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm` or `xl` as an option.
+   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
    */
   size: ListBoxSize,
 

--- a/packages/react/src/components/ListBox/ListBoxPropTypes.js
+++ b/packages/react/src/components/ListBox/ListBoxPropTypes.js
@@ -8,4 +8,5 @@
 import PropTypes from 'prop-types';
 
 export const ListBoxType = PropTypes.oneOf(['default', 'inline']);
-export const ListBoxSize = PropTypes.oneOf(['sm', 'xl']);
+// TODO V11: remove xl
+export const ListBoxSize = PropTypes.oneOf(['sm', 'md', 'lg', 'xl']);

--- a/packages/react/src/components/Modal/Modal-story.js
+++ b/packages/react/src/components/Modal/Modal-story.js
@@ -24,9 +24,9 @@ import TextInput from '../TextInput';
 import mdx from './Modal.mdx';
 
 const sizes = {
-  Default: '',
   'Extra small (xs)': 'xs',
   'Small (sm)': 'sm',
+  'Medium (md)': 'md',
   'Large (lg)': 'lg',
 };
 
@@ -65,7 +65,7 @@ const props = {
       'Primary focus element selector (selectorPrimaryFocus)',
       '[data-modal-primary-focus]'
     ),
-    size: select('Size (size)', sizes),
+    size: select('Size (size)', sizes, 'md'),
     iconDescription: text('Close icon description (iconDescription)', 'Close'),
     onBlur: action('onBlur'),
     onClick: action('onClick'),

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -208,7 +208,7 @@ export default class Modal extends Component {
     /**
      * Specify the size variant.
      */
-    size: PropTypes.oneOf(['xs', 'sm', 'lg']),
+    size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
   };
 
   static defaultProps = {

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -122,7 +122,7 @@ export default class FilterableMultiSelect extends React.Component {
     selectionFeedback: PropTypes.oneOf(['top', 'fixed', 'top-after-reopen']),
 
     /**
-     * Specify the size of the ListBox. Currently supports either `sm`, `lg` or `xl` as an option.
+     * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
      */
     size: ListBoxPropTypes.ListBoxSize,
 

--- a/packages/react/src/components/MultiSelect/MultiSelect-story.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect-story.js
@@ -57,9 +57,9 @@ const types = {
 };
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const directions = {

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -407,7 +407,7 @@ MultiSelect.propTypes = {
   selectionFeedback: PropTypes.oneOf(['top', 'fixed', 'top-after-reopen']),
 
   /**
-   * Specify the size of the ListBox. Currently supports either `sm`, `lg` or `xl` as an option.
+   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
    */
   size: ListBoxPropTypes.ListBoxSize,
 

--- a/packages/react/src/components/NumberInput/NumberInput-story.js
+++ b/packages/react/src/components/NumberInput/NumberInput-story.js
@@ -22,9 +22,9 @@ import NumberInputSkeleton from '../NumberInput/NumberInput.Skeleton';
 import mdx from './NumberInput.mdx';
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const props = () => ({
@@ -82,6 +82,7 @@ export default {
 export const Default = () => {
   return (
     <NumberInput
+      id="carbon-number"
       min={0}
       max={100}
       value={50}

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -152,9 +152,10 @@ class NumberInput extends Component {
     readOnly: PropTypes.bool,
 
     /**
-     * Specify the size of the Number Input. Currently supports either `sm` or `xl` as an option.
+     * Specify the size of the Number Input. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+     * TODO V11: remove `xl` (replaced with lg)
      */
-    size: PropTypes.oneOf(['sm', 'xl']),
+    size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 
     /**
      * Specify how much the valus should increase/decrease upon clicking on up/down button

--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -18,11 +18,13 @@ const directions = {
   'Bottom of the trigger button (bottom)': 'bottom',
   'Top of the trigger button (top)': 'top',
 };
+
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
+
 const props = {
   menu: () => ({
     direction: select('Menu direction (direction)', directions, 'bottom'),

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -211,10 +211,10 @@ class OverflowMenu extends Component {
     selectorPrimaryFocus: PropTypes.string,
 
     /**
-     * Specify the size of the OverflowMenu. Currently supports either `sm` or
-     * `xl` as an option.
+     * Specify the size of the OverflowMenu. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+     * TODO V11: remove `xl` (replaced with lg)
      */
-    size: PropTypes.oneOf(['sm', 'xl']),
+    size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
   };
 
   static defaultProps = {

--- a/packages/react/src/components/Select/Select-story.js
+++ b/packages/react/src/components/Select/Select-story.js
@@ -16,9 +16,9 @@ import SelectSkeleton from '../Select/Select.Skeleton';
 import mdx from './Select.mdx';
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const props = {

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -226,9 +226,10 @@ Select.propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * Specify the size of the Select Input. Currently supports either `sm` or `xl` as an option.
+   * Specify the size of the Select Input. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+   * TODO V11: remove `xl` (replaced with lg)
    */
-  size: PropTypes.oneOf(['sm', 'xl']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 
   /**
    * Specify whether the control is currently in warning state

--- a/packages/react/src/components/Tag/Tag-story.js
+++ b/packages/react/src/components/Tag/Tag-story.js
@@ -26,8 +26,8 @@ const iconMap = {
 };
 
 const sizes = {
-  'Big/default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
 };
 
 const props = {

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -146,9 +146,9 @@ Tag.propTypes = {
 
   /**
    * Specify the size of the Tag. Currently supports either `sm` or
-   * default sizes.
+   * 'md' (default) sizes.
    */
-  size: PropTypes.oneOf(['sm']),
+  size: PropTypes.oneOf(['sm', 'md']),
 
   /**
    * Text to show on clear filters

--- a/packages/react/src/components/TextInput/TextInput-story.js
+++ b/packages/react/src/components/TextInput/TextInput-story.js
@@ -21,9 +21,9 @@ const types = {
 };
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const ControlledPasswordInputApp = React.forwardRef(

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -241,9 +241,10 @@ TextInput.propTypes = {
   placeholder: PropTypes.string,
 
   /**
-   * Specify the size of the Text Input. Currently supports either `sm` or `xl` as an option.
+   * Specify the size of the Text Input. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+   * TODO V11: remove `xl` (replaced with lg)
    */
-  size: PropTypes.oneOf(['sm', 'xl']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 
   /**
    * Specify the type of the `<input>`

--- a/packages/react/src/components/TimePicker/TimePicker-story.js
+++ b/packages/react/src/components/TimePicker/TimePicker-story.js
@@ -21,9 +21,9 @@ import SelectItem from '../SelectItem';
 import mdx from './TimePicker.mdx';
 
 const sizes = {
-  'Extra large size (xl)': 'xl',
-  'Default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
+  'Large  (lg)': 'lg',
 };
 
 const props = {

--- a/packages/react/src/components/TimePicker/TimePicker.js
+++ b/packages/react/src/components/TimePicker/TimePicker.js
@@ -96,10 +96,10 @@ export default class TimePicker extends Component {
     placeholder: PropTypes.string,
 
     /**
-     * Specify the size of the Time Picker. Currently supports either `sm` or
-     * `xl` as an option.
+     * Specify the size of the Time Picker. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+     * TODO V11: remove `xl` (replaced with lg)
      */
-    size: PropTypes.oneOf(['sm', 'xl']),
+    size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 
     /**
      * Specify the type of the `<input>`

--- a/packages/react/src/components/Toggle/Toggle-story.js
+++ b/packages/react/src/components/Toggle/Toggle-story.js
@@ -11,8 +11,8 @@ import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import Toggle from '../Toggle';
 
 const sizes = {
-  'Big/default size': undefined,
-  'Small size (sm)': 'sm',
+  'Small  (sm)': 'sm',
+  'Medium (md) - default': undefined,
 };
 
 const toggleProps = () => ({

--- a/packages/react/src/components/Toggle/Toggle.js
+++ b/packages/react/src/components/Toggle/Toggle.js
@@ -60,9 +60,9 @@ class Toggle extends React.Component {
     onToggle: PropTypes.func,
 
     /**
-     * Specify the size of the Toggle. Currently only supports 'sm'
+     * Specify the size of the Toggle. Currently only supports 'sm' or 'md' (default)
      */
-    size: PropTypes.oneOf(['sm']),
+    size: PropTypes.oneOf(['sm', 'md']),
 
     /**
      * Specify whether the control is toggled


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/8151

This PR will update the `size` prop across components to use `sm`, `md`, and `lg`. 

For now, I am adding in comments anywhere `xl` is used to mark for deletion when we create our alpha branch. Until then, `lg` and `xl` should function interchangeably. I've also added `md` to the allowed values for `size` for consistency throughout.  

#### Changelog

**New**

- `lg` is now the preferred `size` value to get the "bigger" version of a component. 
- `md` is added to the `size` propType definition. Will be set as a default where needed.

**Changed**

- Changed the `size` prop knob to reflect new values

List of components that use the size prop and that will be updated:

- [x] Accordion
- [ ] Button 
- [x] Listbox
   - [x] Combobox
   - [x] Dropdown
   - [x] Multiselect
   - [x] Filterable Multiselect
- [x] Content Switcher
- [x] DatePicker
- [ ] FileUploader
   - [ ] FileUploaderButton
   - [ ] FileUploaderDropContainer
   - [ ] FileUploaderItem
- [x] Link
- [x] Modal
   - [x] ComposedModal
- [x] Number Input
- [x] Overflow Menu
- [ ] Search
- [x] Select
- [x] Tag
- [x] Text Input
- [x] Time Picker
- [x] Toggle

Questions:
- Do we want to keep the `field` button size? This also cascades into `FileUploader`, which has `small` field` and `default` size buttons
- `Data Table` has a few sizes (`compact`, `short`, `normal`, `tall`). Do we want to change any of these? 
- Treeview has a size prop with `default` and `compact`. Do we want to change these? 


Blockers:
- Search cannot be updated yet as it has `sm` `lg` and `xl` styles


#### Testing / Reviewing

Ensure the components listed above that are checked correctly render at the correct sizes
Ensure no prop warnings are emitted when toggling sizes