### PR TITLE
Fix modal overflow on  IE11

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -773,6 +773,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "carlosparreno",
+      "name": "Carlos Parreño",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25571131?v=4",
+      "profile": "https://github.com/carlosparreno",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/szymonbrandys"><img src="https://avatars.githubusercontent.com/u/79149899?v=4?s=100" width="100px;" alt=""/><br /><sub><b>szymonbrandys</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=szymonbrandys" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/carlosparreno"><img src="https://avatars.githubusercontent.com/u/25571131?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Carlos Parreño</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=carlosparreno" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -70,8 +70,12 @@
     position: fixed;
     top: 0;
     display: grid;
+    // stylelint-disable-next-line declaration-block-no-duplicate-properties
+    display: -ms-grid;
     grid-template-rows: auto 1fr auto;
+    -ms-grid-rows: auto 1fr auto;
     grid-template-columns: auto;
+    -ms-grid-columns: auto;
     width: 100%;
     height: 100%;
     max-height: 100%;
@@ -225,7 +229,9 @@
   }
 
   .#{$prefix}--modal-header {
+    -ms-grid-row: 1;
     grid-row: 1/1;
+    -ms-grid-column: 1;
     grid-column: 1/-1;
     margin-bottom: $spacing-03;
     padding-top: $spacing-05;
@@ -249,7 +255,9 @@
     @include type-style('body-long-01');
 
     position: relative;
+    -ms-grid-row: 2;
     grid-row: 2/-2;
+    -ms-grid-column: 1;
     grid-column: 1/-1;
     margin-bottom: $spacing-09;
 
@@ -278,7 +286,9 @@
     position: absolute;
     bottom: $spacing-09;
     left: 0;
+    -ms-grid-row: 2;
     grid-row: 2/-2;
+    -ms-grid-column: 1;
     grid-column: 1/-1;
     width: 100%;
     height: rem(32px);
@@ -303,10 +313,12 @@
       display: none;
     }
   }
-
+  // prettier-ignore
   .#{$prefix}--modal-footer {
     display: flex;
+    -ms-grid-row: -1;
     grid-row: -1/-1;
+    -ms-grid-column: 1;
     grid-column: 1/-1;
     justify-content: flex-end;
     height: rem(64px);


### PR DESCRIPTION
Closes #6919

- Modal content scrolls is not displayed. Instead, content overflows the header and footer containers.
- `display: grid`, `grid-template-columns` and `grid-template-rows` are not supported in IE11. Instead we need to use their correspondent IE11 values: `-ms-grid`, `-ms-grid-row` and `-ms-grid-column`
- Solution based on this article https://elad.medium.com/supporting-css-grid-in-internet-explorer-b38669e75d66


#### Changelog

**Changed**

- _modal.scss file

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
