### PR TITLE
fix(link): update visited link color

### DIFF
--- a/packages/components/src/components/link/_link.scss
+++ b/packages/components/src/components/link/_link.scss
@@ -47,7 +47,7 @@
     }
 
     &:visited {
-      color: $link-01;
+      color: $visited-link;
     }
 
     &:visited:hover {

--- a/packages/components/src/components/link/link.hbs
+++ b/packages/components/src/components/link/link.hbs
@@ -5,10 +5,7 @@
   LICENSE file in the root directory of this source tree.
 -->
 
-<a href="#"
-  class="{{@root.prefix}}--link{{#if inline}} {{@root.prefix}}--link--inline{{/if}}{{#if visited}} {{@root.prefix}}--link--inline{{/if}}">Link</a>
-<a href="http://www.google.com"
-  class="{{@root.prefix}}--link {{@root.prefix}}--link--visited {{#if inline}} {{@root.prefix}}--link--inline{{/if}}">Link</a>
+<a href="#" class="{{@root.prefix}}--link{{#if inline}} {{@root.prefix}}--link--inline{{/if}}">Link</a>
 <a class="{{@root.prefix}}--link{{#if inline}} {{@root.prefix}}--link--inline{{/if}}" aria-disabled="true">Placeholder
   link</a>
 <p class="{{@root.prefix}}--link--disabled{{#if inline}} {{@root.prefix}}--link--inline{{/if}}">Disabled Link</p>

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3207,9 +3207,7 @@ Map {
         ],
         "type": "oneOf",
       },
-      "visited": Object {
-        "type": "bool",
-      },
+      "visited": [Function],
     },
   },
   "ListItem" => Object {

--- a/packages/react/src/components/Link/Link-story.js
+++ b/packages/react/src/components/Link/Link-story.js
@@ -17,7 +17,7 @@ const props = () => ({
   className: 'some-class',
   href: text('The link href (href)', '#'),
   inline: boolean('Use the in-line variant (inline)', false),
-  visited: boolean('Allow visited styles', false),
+  visited: boolean('[Deprecated]: Allow visited styles', false),
   onClick: ((handler) => (evt) => {
     evt.preventDefault(); // Prevent link from being followed for demo purpose
     handler(evt);

--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
+import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
@@ -76,7 +77,11 @@ Link.propTypes = {
   /**
    * Specify whether you want the link to receive visited styles after the link has been clicked
    */
-  visited: PropTypes.bool,
+  visited: deprecate(
+    PropTypes.bool,
+    `\nThe prop \`visited\` for Link has been deprecated and will
+  be removed in the next major release.`
+  ),
 };
 
 export default Link;


### PR DESCRIPTION
Related #3581
Related #5239
Related #7115
Related #8158

based on the latest spec from design

![image](https://user-images.githubusercontent.com/8265238/112340672-c5ff0000-8c8e-11eb-83b4-f213a1fbe1fd.png)

This PR restores visited link styles to the Link component. The removal of visited link styles was meant to be scoped to product and possibly dotcom, but it should remain in the core component library. The Gatsby theme should also be unaffected by this https://github.com/carbon-design-system/gatsby-theme-carbon/pull/697

#### Testing / Reviewing

Confirm that visited Carbon links receive the correct styles by setting the Link story's `href` knob to an address in your browser history