### PR TITLE
fix(sketch): fetch default icon layer styles from IDL Sketch library

### DIFF
--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -60,6 +60,7 @@ function removeDeprecatedSymbolArtboards({ icons, sizes, symbolsPage }) {
  * Sync Carbon icon symbols into current Sketch Document
  * @param {object} params - syncIconSymbols parameters
  * @param {Document} params.document - current document
+ * @param {object} params.IDL_SKETCH_LIBRARY_METADATA - IDL Sketch file metadata
  * @param {Array<SymbolMaster>} params.symbols
  * @param {Page} params.symbolsPage - the symbols page as identified by Sketch
  * @param {Array<number>} params.sizes - array of icon sizes

--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -7,6 +7,7 @@
 
 /* global MSSVGImporter, NSString, NSUTF8StringEncoding */
 
+import sketch from 'sketch';
 import { Artboard, Library, Rectangle, Shape } from 'sketch/dom';
 import { groupByKey } from '../../tools/grouping';
 import { syncSymbol } from '../../tools/symbols';
@@ -57,6 +58,35 @@ function removeDeprecatedSymbolArtboards({ icons, sizes, symbolsPage }) {
 }
 
 /**
+ * Fetch the IDL Sketch Library if it is installed
+ * @param {object} params - fetchIDLSketchLibrary parameters
+ * @param {Array<object>} params.icons - array of all icon object metadata
+ * @param {Array<number>} params.sizes - array of icon sizes
+ * @param {Page} params.symbolsPage - the symbols page as identified by Sketch
+ */
+function fetchIDLSketchLibrary({ IDL_SKETCH_LIBRARY_METADATA }) {
+  const {
+    id: idlSketchLibraryId,
+    name: idlSketchLibraryName,
+  } = IDL_SKETCH_LIBRARY_METADATA;
+
+  const installedLibraries = Library.getLibraries().filter(
+    ({ id, name }) => id === idlSketchLibraryId && name === idlSketchLibraryName
+  );
+
+  if (!installedLibraries.length) {
+    sketch.UI.message(
+      'Please install the IDL V2 Sketch library before trying again'
+    );
+    throw new Error(
+      'Please install the IDL V2 Sketch library before trying again'
+    );
+  }
+
+  return installedLibraries[0];
+}
+
+/**
  * Sync Carbon icon symbols into current Sketch Document
  * @param {object} params - syncIconSymbols parameters
  * @param {Document} params.document - current document
@@ -72,14 +102,9 @@ export function syncIconSymbols({
   symbolsPage,
   sizes = [32, 24, 20, 16],
 }) {
-  const {
-    id: idlSketchLibraryId,
-    name: idlSketchLibraryName,
-  } = IDL_SKETCH_LIBRARY_METADATA;
-
-  const [idlSketchLibrary] = Library.getLibraries().filter(
-    ({ id, name }) => id === idlSketchLibraryId && name === idlSketchLibraryName
-  );
+  const idlSketchLibrary = fetchIDLSketchLibrary({
+    IDL_SKETCH_LIBRARY_METADATA,
+  });
 
   idlSketchLibrary
     .getImportableLayerStyleReferencesForDocument(document)

--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -106,6 +106,7 @@ export function syncIconSymbols({
     IDL_SKETCH_LIBRARY_METADATA,
   });
 
+  // import shared color styles from IDL Sketch library
   idlSketchLibrary
     .getImportableLayerStyleReferencesForDocument(document)
     .forEach((layerStyle) => {
@@ -114,6 +115,7 @@ export function syncIconSymbols({
       }
     });
 
+  // set default icon color shared style
   const sharedStyle = [...document.sharedLayerStyles].find((sharedLayerStyle) =>
     sharedLayerStyle?.name.endsWith('black')
   );

--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -60,9 +60,8 @@ function removeDeprecatedSymbolArtboards({ icons, sizes, symbolsPage }) {
 /**
  * Fetch the IDL Sketch Library if it is installed
  * @param {object} params - fetchIDLSketchLibrary parameters
- * @param {Array<object>} params.icons - array of all icon object metadata
- * @param {Array<number>} params.sizes - array of icon sizes
- * @param {Page} params.symbolsPage - the symbols page as identified by Sketch
+ * @param {object} params.IDL_SKETCH_LIBRARY_METADATA - IDL Sketch file metadata
+ * @returns {Library}
  */
 function fetchIDLSketchLibrary({ IDL_SKETCH_LIBRARY_METADATA }) {
   const {

--- a/packages/sketch/src/commands/icons/sync.js
+++ b/packages/sketch/src/commands/icons/sync.js
@@ -10,6 +10,11 @@ import { command } from '../command';
 import { syncIconSymbols } from './shared';
 import { findOrCreateSymbolPage } from '../../tools/page';
 
+const IDL_SKETCH_LIBRARY_METADATA = {
+  id: '9E0A7EC6-C3F3-4DE6-BA36-3F90C4853BA5',
+  name: 'IBM Design Language v2',
+};
+
 export function syncSmallIcons() {
   command('commands/icons/syncSmallIcons', () => {
     const document = Document.getSelectedDocument();
@@ -17,6 +22,7 @@ export function syncSmallIcons() {
     const symbols = document.getSymbols();
     syncIconSymbols({
       document,
+      IDL_SKETCH_LIBRARY_METADATA,
       symbols: Array.from(symbols),
       symbolsPage,
       sizes: [16, 20],
@@ -31,6 +37,7 @@ export function syncLargeIcons() {
     const symbols = document.getSymbols();
     syncIconSymbols({
       document,
+      IDL_SKETCH_LIBRARY_METADATA,
       symbols: Array.from(symbols),
       symbolsPage,
       sizes: [24, 32],


### PR DESCRIPTION
Closes #8127

This PR connects the default icon shared layer styles to the IDL V2 Sketch library instead of regenerating them in the document. The icons sync command is now no longer dependent on the colors sync command or `@carbon/colors` 

#### Changelog

**New**

- link icon shared layer styles to IDL V2 Sketch library

**Changed**

- decouple icons sync command from colors sync command
- use param objects for icon sync functions and helpers

#### Testing / Reviewing

Confirm that icon layer shared styles are linked to the IDL V2 Sketch library when syncing icons

[carbon-elements.sketchplugin.zip](https://github.com/carbon-design-system/carbon/files/6207179/carbon-elements.sketchplugin.zip)

[carbon-elements.sketchplugin.zip](https://github.com/carbon-design-system/carbon/files/6238013/carbon-elements.sketchplugin.zip)

[carbon-elements.sketchplugin.zip](https://github.com/carbon-design-system/carbon/files/6267500/carbon-elements.sketchplugin.zip)
