### PR TITLE
fix(combobox): match "clear selection" icon fill when disabled

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -187,7 +187,8 @@ $list-box-menu-width: rem(300px);
     color: $disabled-02;
   }
 
-  .#{$prefix}--list-box--disabled .#{$prefix}--list-box__menu-icon > svg {
+  .#{$prefix}--list-box--disabled .#{$prefix}--list-box__menu-icon > svg,
+  .#{$prefix}--list-box--disabled .#{$prefix}--list-box__selection > svg {
     fill: $disabled-02;
 
     // Windows, Firefox HCM Fix


### PR DESCRIPTION
Currently the "X" button to clear a combobox's selection is still shown in `icon-01` when the control is disabled. This PR updates the icon fill to use `disabled-02`.

**Before**
![image](https://user-images.githubusercontent.com/28265588/112829856-03e69480-9092-11eb-8ea2-0972301897f5.png)

**After**
![image](https://user-images.githubusercontent.com/28265588/112829870-0ba63900-9092-11eb-862d-ee5dd6b5659e.png)


#### Changelog

**Changed**

- Use `disabled-02` as icon fill for "clear selection" button in combobox when control is disabled

#### Testing / Reviewing

- Ensure the "X" icon fill matches the chevron icon fill when a value is selected and the control is disabled
- The icon should still use `icon-01` when the control is not disabled
