### PR TITLE
Add danger button assistive text

### DIFF
--- a/packages/components/src/components/structured-list/_structured-list.scss
+++ b/packages/components/src/components/structured-list/_structured-list.scss
@@ -18,8 +18,8 @@
     @include padding--data-structured-list;
   }
 
-  .#{$prefix}--structured-list-input {
-    display: none;
+  .#{$prefix}--structured-list-row--focused-within {
+    @include focus-outline('outline');
   }
 
   .#{$prefix}--structured-list {
@@ -60,10 +60,6 @@
   .#{$prefix}--structured-list-row.#{$prefix}--structured-list-row--header-row {
     border-bottom: 1px solid $selected-ui;
     cursor: inherit;
-  }
-
-  .#{$prefix}--structured-list-row:focus:not(.#{$prefix}--structured-list-row--header-row) {
-    @include focus-outline('outline');
   }
 
   .#{$prefix}--structured-list--selection

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4990,43 +4990,24 @@ Map {
   },
   "StructuredListInput" => Object {
     "defaultProps": Object {
-      "onChange": [Function],
       "title": "title",
-      "value": "value",
     },
     "propTypes": Object {
       "className": Object {
         "type": "string",
       },
-      "defaultChecked": Object {
-        "type": "bool",
-      },
+      "defaultChecked": [Function],
       "id": Object {
         "type": "string",
       },
       "name": Object {
         "type": "string",
       },
-      "onChange": Object {
-        "type": "func",
-      },
+      "onChange": [Function],
       "title": Object {
         "type": "string",
       },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOfType",
-      },
+      "value": [Function],
     },
   },
   "StructuredListCell" => Object {

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4970,9 +4970,7 @@ Map {
   "StructuredListRow" => Object {
     "defaultProps": Object {
       "head": false,
-      "label": false,
       "onKeyDown": [Function],
-      "tabIndex": 0,
     },
     "propTypes": Object {
       "children": Object {
@@ -4984,14 +4982,8 @@ Map {
       "head": Object {
         "type": "bool",
       },
-      "label": Object {
-        "type": "bool",
-      },
       "onKeyDown": Object {
         "type": "func",
-      },
-      "tabIndex": Object {
-        "type": "number",
       },
     },
   },

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4982,6 +4982,7 @@ Map {
       "head": Object {
         "type": "bool",
       },
+      "label": [Function],
       "onKeyDown": Object {
         "type": "func",
       },

--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -70,14 +70,28 @@ const Button = React.forwardRef(function Button(
   let otherProps = {
     disabled,
     type,
+    'aria-describedby': kind === 'danger' ? 'danger-description' : null,
     'aria-pressed': hasIconOnly && kind === 'ghost' ? isSelected : null,
   };
   const anchorProps = {
     href,
   };
-  const assistiveText = hasIconOnly ? (
-    <span className={`${prefix}--assistive-text`}>{iconDescription}</span>
-  ) : null;
+
+  let assistiveText;
+  if (hasIconOnly) {
+    assistiveText = (
+      <span className={`${prefix}--assistive-text`}>{iconDescription}</span>
+    );
+  } else if (kind === 'danger') {
+    assistiveText = (
+      <span id="danger-description" className={`${prefix}--visually-hidden`}>
+        danger
+      </span>
+    );
+  } else {
+    assistiveText = null;
+  }
+
   if (as) {
     component = as;
     otherProps = {

--- a/packages/react/src/components/StructuredList/StructuredList-test.js
+++ b/packages/react/src/components/StructuredList/StructuredList-test.js
@@ -26,11 +26,13 @@ describe('StructuredListWrapper', () => {
     );
 
     it('should have the expected classes', () => {
-      expect(wrapper.hasClass(`${prefix}--structured-list`)).toEqual(true);
+      expect(
+        wrapper.find('div').hasClass(`${prefix}--structured-list`)
+      ).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
-      expect(wrapper.hasClass('extra-class')).toEqual(true);
+      expect(wrapper.find('div').hasClass('extra-class')).toEqual(true);
     });
 
     it('By default, selection prop is false', () => {
@@ -41,9 +43,9 @@ describe('StructuredListWrapper', () => {
 
     it('Should add the modifier class for selection when selection prop is true', () => {
       wrapper.setProps({ selection: true });
-      expect(wrapper.hasClass(`${prefix}--structured-list--selection`)).toEqual(
-        true
-      );
+      expect(
+        wrapper.find('div').hasClass(`${prefix}--structured-list--selection`)
+      ).toEqual(true);
     });
   });
 });

--- a/packages/react/src/components/StructuredList/StructuredList-test.js
+++ b/packages/react/src/components/StructuredList/StructuredList-test.js
@@ -120,16 +120,6 @@ describe('StructuredListRow', () => {
       ).toEqual(true);
     });
 
-    it('should use <div> HTML by default (or when label prop is false)', () => {
-      const wrapperLabel = shallow(<StructuredListRow />);
-      expect(wrapperLabel.getElement().type).toEqual('div');
-    });
-
-    it('should use <label> HTML when label prop is true', () => {
-      const wrapperLabel = shallow(<StructuredListRow label />);
-      expect(wrapperLabel.getElement().type).toEqual('label');
-    });
-
     it('Should accept other props from ...other', () => {
       const wrapperProps = shallow(
         <StructuredListRow title="title">hi</StructuredListRow>

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
+import { useFocusWithin } from '../../internal/useFocusWithin';
 import { useId } from '../../internal/useId';
 import deprecate from '../../prop-types/deprecate';
 
@@ -126,11 +127,6 @@ StructuredListBody.defaultProps = {
   onKeyDown: () => {},
 };
 
-function useFocusWithin() {
-  const [hasFocusWithin, setHasFocusWithin] = useState(false);
-  return [hasFocusWithin, setHasFocusWithin];
-}
-
 export function StructuredListRow(props) {
   const { onKeyDown, children, className, head, ...other } = props;
   const [hasFocusWithin, setHasFocusWithin] = useFocusWithin();
@@ -140,15 +136,14 @@ export function StructuredListRow(props) {
   });
 
   return head ? (
-    <div tabIndex={-1} role="row" {...other} className={classes}>
+    <div role="row" {...other} className={classes}>
       {children}
     </div>
   ) : (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    // eslint-disable-next-line jsx-a11y/interactive-supports-focus
     <div
       {...other}
       role="row"
-      tabIndex={-1}
       className={classes}
       onFocus={() => {
         setHasFocusWithin(true);
@@ -179,6 +174,14 @@ StructuredListRow.propTypes = {
   head: PropTypes.bool,
 
   /**
+   * Specify whether a `<label>` should be used
+   */
+  label: deprecate(
+    PropTypes.bool,
+    `\nThe prop \`label\` will be removed in the next major version of Carbon.`
+  ),
+
+  /**
    * Provide a handler that is invoked on the key down event for the control,
    */
   onKeyDown: PropTypes.func,
@@ -194,7 +197,7 @@ export function StructuredListInput(props) {
   const {
     className,
     value,
-    name = `structuredListInput-${defaultId}`,
+    name = `structured-list-input-${defaultId}`,
     title,
     id,
     ...other
@@ -270,8 +273,12 @@ export function StructuredListCell(props) {
     [`${prefix}--structured-list-content--nowrap`]: noWrap,
   });
 
-  return (
-    <div className={classes} role={head ? 'columnheader' : 'cell'} {...other}>
+  return head ? (
+    <span className={classes} role="columnheader" {...other}>
+      {children}
+    </span>
+  ) : (
+    <div className={classes} role="cell" {...other}>
       {children}
     </div>
   );

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
@@ -126,6 +126,11 @@ StructuredListBody.defaultProps = {
   onKeyDown: () => {},
 };
 
+function useFocusWithin() {
+  const [hasFocusWithin, setHasFocusWithin] = useState(false);
+  return [hasFocusWithin, setHasFocusWithin];
+}
+
 export function StructuredListRow(props) {
   const {
     onKeyDown,
@@ -136,8 +141,10 @@ export function StructuredListRow(props) {
     label,
     ...other
   } = props;
+  const [hasFocusWithin, setHasFocusWithin] = useFocusWithin();
   const classes = classNames(`${prefix}--structured-list-row`, className, {
     [`${prefix}--structured-list-row--header-row`]: head,
+    [`${prefix}--structured-list-row--focused-within`]: hasFocusWithin,
   });
 
   return label ? (
@@ -146,6 +153,14 @@ export function StructuredListRow(props) {
       {...other}
       tabIndex={tabIndex}
       className={classes}
+      onFocus={() => {
+        setHasFocusWithin(true);
+      }}
+      onBlur={() => {
+        // potential special case where when focus is moved this row is not blurred
+        // multiple interactable per row?
+        setHasFocusWithin(false);
+      }}
       onKeyDown={onKeyDown}>
       {children}
     </label>
@@ -192,9 +207,13 @@ StructuredListRow.propTypes = {
 StructuredListRow.defaultProps = {
   head: false,
   label: false,
+  // tabIndex: 0,
   onKeyDown: () => {},
 };
 
+// when the input gets focus it should add the data- attribute to the parent row
+// on blur it should be removed
+// that can be targeted
 export function StructuredListInput(props) {
   const classes = classNames(`${prefix}--structured-list-input`, className);
   const defaultId = useId('structureListInput');

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -9,11 +9,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
-const getInstanceId = setupGetInstanceId();
 
 export function StructuredListWrapper(props) {
   const {
@@ -193,21 +192,27 @@ StructuredListRow.propTypes = {
 StructuredListRow.defaultProps = {
   head: false,
   label: false,
-  tabIndex: 0,
   onKeyDown: () => {},
 };
 
 export function StructuredListInput(props) {
-  const { className, value, name, title, id, ...other } = props;
   const classes = classNames(`${prefix}--structured-list-input`, className);
-  const instanceId = id || getInstanceId();
+  const defaultId = useId('structureListInput');
+  const {
+    className,
+    value,
+    name = `structuredListInput-${defaultId}`,
+    title,
+    id,
+    ...other
+  } = props;
 
   return (
     <input
       {...other}
       type="radio"
-      tabIndex={-1}
-      id={instanceId}
+      tabIndex={0}
+      id={id || defaultId}
       className={classes}
       value={value}
       name={name}

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -253,7 +253,7 @@ StructuredListInput.propTypes = {
    */
   defaultChecked: deprecate(
     PropTypes.bool,
-    `\nThe prop \`defaultChecked\` will be removed in the next major version of Carbon.`
+    `\nThe prop \`defaultChecked\` is no longer needed and will be removed in the next major version of Carbon.`
   ),
 
   /**

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -28,7 +28,7 @@ export function StructuredListWrapper(props) {
   });
 
   return (
-    <div role="table" className={classes} {...other} aria-label={ariaLabel}>
+    <div role="grid" className={classes} {...other} aria-label={ariaLabel}>
       {children}
     </div>
   );
@@ -132,40 +132,31 @@ function useFocusWithin() {
 }
 
 export function StructuredListRow(props) {
-  const {
-    onKeyDown,
-    tabIndex,
-    children,
-    className,
-    head,
-    label,
-    ...other
-  } = props;
+  const { onKeyDown, children, className, head, ...other } = props;
   const [hasFocusWithin, setHasFocusWithin] = useFocusWithin();
   const classes = classNames(`${prefix}--structured-list-row`, className, {
     [`${prefix}--structured-list-row--header-row`]: head,
     [`${prefix}--structured-list-row--focused-within`]: hasFocusWithin,
   });
 
-  return label ? (
+  return head ? (
+    <div tabIndex={-1} role="row" {...other} className={classes}>
+      {children}
+    </div>
+  ) : (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-    <label
+    <div
       {...other}
-      tabIndex={tabIndex}
+      role="row"
+      tabIndex={-1}
       className={classes}
       onFocus={() => {
         setHasFocusWithin(true);
       }}
       onBlur={() => {
-        // potential special case where when focus is moved this row is not blurred
-        // multiple interactable per row?
         setHasFocusWithin(false);
       }}
       onKeyDown={onKeyDown}>
-      {children}
-    </label>
-  ) : (
-    <div {...other} className={classes}>
       {children}
     </div>
   );
@@ -188,25 +179,13 @@ StructuredListRow.propTypes = {
   head: PropTypes.bool,
 
   /**
-   * Specify whether a `<label>` should be used
-   */
-  label: PropTypes.bool,
-
-  /**
    * Provide a handler that is invoked on the key down event for the control,
-   * if `<label>` is in use
    */
   onKeyDown: PropTypes.func,
-
-  /**
-   * Specify the tab index of the container node, if `<label>` is in use
-   */
-  tabIndex: PropTypes.number,
 };
 
 StructuredListRow.defaultProps = {
   head: false,
-  label: false,
   onKeyDown: () => {},
 };
 

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -5,11 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
-import { useFocusWithin } from '../../internal/useFocusWithin';
 import { useId } from '../../internal/useId';
 import deprecate from '../../prop-types/deprecate';
 
@@ -138,7 +137,7 @@ const GridRowContext = React.createContext(null);
 
 export function StructuredListRow(props) {
   const { onKeyDown, children, className, head, ...other } = props;
-  const [hasFocusWithin, setHasFocusWithin] = useFocusWithin();
+  const [hasFocusWithin, setHasFocusWithin] = useState(false);
   const id = useId('grid-input');
   const setSelectedRow = React.useContext(GridSelectedRowDispatchContext);
   const value = { id };
@@ -230,12 +229,12 @@ export function StructuredListInput(props) {
       {...other}
       type="radio"
       tabIndex={0}
-      checked={row.id === selectedRow}
-      value={row.id}
+      checked={row && row.id === selectedRow}
+      value={row ? row.id : ''}
       onChange={(event) => {
         setSelectedRow(event.target.value);
       }}
-      id={id}
+      id={!id && defaultId}
       className={classes}
       name={name}
       title={title}

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -207,15 +207,15 @@ StructuredListRow.propTypes = {
 StructuredListRow.defaultProps = {
   head: false,
   label: false,
-  // tabIndex: 0,
   onKeyDown: () => {},
 };
 
-// when the input gets focus it should add the data- attribute to the parent row
-// on blur it should be removed
-// that can be targeted
 export function StructuredListInput(props) {
-  const classes = classNames(`${prefix}--structured-list-input`, className);
+  const classes = classNames(
+    `${prefix}--structured-list-input`,
+    `${prefix}--visually-hidden`,
+    className
+  );
   const defaultId = useId('structureListInput');
   const {
     className,

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -190,11 +190,6 @@ StructuredListRow.defaultProps = {
 };
 
 export function StructuredListInput(props) {
-  const classes = classNames(
-    `${prefix}--structured-list-input`,
-    `${prefix}--visually-hidden`,
-    className
-  );
   const defaultId = useId('structureListInput');
   const {
     className,
@@ -204,6 +199,11 @@ export function StructuredListInput(props) {
     id,
     ...other
   } = props;
+  const classes = classNames(
+    `${prefix}--structured-list-input`,
+    `${prefix}--visually-hidden`,
+    className
+  );
 
   return (
     <input

--- a/packages/react/src/internal/useFocusWithin.js
+++ b/packages/react/src/internal/useFocusWithin.js
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+
+function useFocusWithin() {
+  const [hasFocusWithin, setHasFocusWithin] = useState(false);
+  return [hasFocusWithin, setHasFocusWithin];
+}
+
+export default useFocusWithin;

--- a/packages/react/src/internal/useFocusWithin.js
+++ b/packages/react/src/internal/useFocusWithin.js
@@ -1,6 +1,0 @@
-import { useState } from 'react';
-
-export function useFocusWithin() {
-  const [hasFocusWithin, setHasFocusWithin] = useState(false);
-  return [hasFocusWithin, setHasFocusWithin];
-}

--- a/packages/react/src/internal/useFocusWithin.js
+++ b/packages/react/src/internal/useFocusWithin.js
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 
-function useFocusWithin() {
+export function useFocusWithin() {
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
   return [hasFocusWithin, setHasFocusWithin];
 }
-
-export default useFocusWithin;


### PR DESCRIPTION
Closes #8220 

Adds assistiveText for 'danger' button variant 

#### Testing / Reviewing

- Make sure that `danger` button doesn't throw any Accessibility Checker errors
- With NVDA, JAWS, and VoiceOver ensure that "Danger" is read along with the button's label
