### PR TITLE
chore: use wildcard for dco bot allowlist

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -19,7 +19,7 @@ jobs:
           path-to-signatures: "dco-signatures.json"
           path-to-document: "https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md"
           branch: "main"
-          allowlist: dependabot,kodiakhq
+          allowlist: bot*
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-dco
           create-file-commit-message: "chore: create file to store dco signatures"


### PR DESCRIPTION
The current DCO Assistant config has `allowlist: dependabot,kodiakhq`.

PR #8171 is failing.
![image](https://user-images.githubusercontent.com/1691245/113020272-0e636580-9148-11eb-91aa-a3e1d3f77dcb.png)

According to the docs, we need to specify as `kodiakhq[bot]` or the wildcard `bot*`. This change uses the latter.

https://github.com/cla-assistant/github-action#5-users-and-bots-in-allowlist