### PR TITLE
feat(tokens): new token update pt. 1

### DIFF
--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -42,20 +42,20 @@
     margin: 0;
     padding: $carbon--spacing-03 $carbon--spacing-05;
     overflow: hidden;
-    color: $text-02;
+    color: $text-secondary;
     white-space: nowrap;
     text-align: left;
     text-decoration: none;
     background-color: transparent;
     border: none;
-    border-top: rem(1px) solid $ui-05;
-    border-bottom: rem(1px) solid $ui-05;
+    border-top: rem(1px) solid $border-inverse;
+    border-bottom: rem(1px) solid $border-inverse;
     transition: all $duration--fast-01 motion(standard, productive);
 
     &:focus {
       z-index: 3;
       border-color: $focus;
-      box-shadow: inset 0 0 0 2px $focus, inset 0 0 0 3px $ui-01;
+      box-shadow: inset 0 0 0 2px $focus, inset 0 0 0 3px $focus-inset;
 
       // Firefox HCM Fix
       @media screen and (prefers-contrast) {
@@ -64,21 +64,21 @@
     }
 
     &:hover {
-      color: $text-01;
+      color: $text-primary;
       cursor: pointer;
     }
 
     &:hover,
     &:active {
       z-index: 3;
-      color: $text-01;
-      background-color: $hover-ui;
+      color: $text-primary;
+      background-color: $layer-hover;
     }
 
     &:disabled {
-      color: $disabled-02;
+      color: $text-disabled;
       background-color: transparent;
-      border-color: $disabled-02;
+      border-color: $border-disabled;
 
       &:hover {
         cursor: not-allowed;
@@ -87,18 +87,18 @@
 
     &:disabled:first-child,
     &:disabled:last-child {
-      border-color: $disabled-02;
+      border-color: $border-disabled;
     }
   }
 
   .#{$prefix}--content-switcher-btn:first-child {
-    border-left: rem(1px) solid $ui-05;
+    border-left: rem(1px) solid $border-inverse;
     border-top-left-radius: rem(4px);
     border-bottom-left-radius: rem(4px);
   }
 
   .#{$prefix}--content-switcher-btn:last-child {
-    border-right: rem(1px) solid $ui-05;
+    border-right: rem(1px) solid $border-inverse;
     border-top-right-radius: rem(4px);
     border-bottom-right-radius: rem(4px);
   }
@@ -116,7 +116,7 @@
     display: block;
     width: rem(1px);
     height: rem(16px);
-    background-color: $content-switcher-divider;
+    background-color: $border-subtle;
     content: '';
   }
 
@@ -139,7 +139,7 @@
   .#{$prefix}--content-switcher-btn:disabled::before,
   .#{$prefix}--content-switcher-btn:disabled:hover
     + .#{$prefix}--content-switcher-btn:disabled::before {
-    background-color: $disabled-02;
+    background-color: $border-disabled;
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected:disabled
@@ -151,7 +151,7 @@
 
   .#{$prefix}--content-switcher__icon {
     transition: fill $duration--fast-01 motion(standard, productive);
-    fill: $text-02;
+    fill: $icon-secondary;
   }
 
   .#{$prefix}--content-switcher__icon + span {
@@ -167,23 +167,23 @@
 
   .#{$prefix}--content-switcher-btn:hover .#{$prefix}--content-switcher__icon,
   .#{$prefix}--content-switcher-btn:focus .#{$prefix}--content-switcher__icon {
-    fill: $text-01;
+    fill: $icon-primary;
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected {
     z-index: 3;
-    color: $inverse-01;
-    background-color: $ui-05;
+    color: $text-inverse;
+    background-color: $layer-selected-inverse;
 
     &:disabled {
-      color: $disabled-02;
-      background-color: $disabled-03;
+      color: $text-disabled;
+      background-color: $layer-selected-disabled;
     }
   }
 
   .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected
     .#{$prefix}--content-switcher__icon {
-    fill: $inverse-01;
+    fill: $icon-inverse;
   }
 }
 

--- a/packages/components/src/components/context-menu/_context-menu.scss
+++ b/packages/components/src/components/context-menu/_context-menu.scss
@@ -40,8 +40,8 @@
   .#{$prefix}--context-menu-option {
     position: relative;
     height: $spacing-07;
-    color: $text-01;
-    background-color: $ui-01;
+    color: $text-primary;
+    background-color: $layer;
     cursor: pointer;
     transition: background-color $duration--fast-01 motion(standard, productive);
 
@@ -57,8 +57,8 @@
 
   .#{$prefix}--context-menu-option--danger:hover,
   .#{$prefix}--context-menu-option--danger:focus {
-    color: $text-04;
-    background-color: $danger-01;
+    color: $text-on-color;
+    background-color: $button-danger-primary;
   }
 
   .#{$prefix}--context-menu-option > .#{$prefix}--context-menu {
@@ -74,8 +74,8 @@
   }
 
   .#{$prefix}--context-menu-option__content--disabled {
-    color: $disabled-02;
-    background-color: $ui-01;
+    color: $text-disabled;
+    background-color: $layer;
     cursor: not-allowed;
   }
 

--- a/packages/components/src/components/context-menu/_context-menu.scss
+++ b/packages/components/src/components/context-menu/_context-menu.scss
@@ -21,7 +21,7 @@
     min-width: 13rem;
     max-width: 18rem;
     padding: $spacing-02 0;
-    background-color: $ui-01;
+    background-color: $layer;
     visibility: hidden;
   }
 
@@ -52,7 +52,7 @@
 
   .#{$prefix}--context-menu-option--active,
   .#{$prefix}--context-menu-option:hover {
-    background-color: $hover-ui;
+    background-color: $layer-hover;
   }
 
   .#{$prefix}--context-menu-option--danger:hover,
@@ -113,7 +113,7 @@
     width: 100%;
     height: 1px;
     margin: $spacing-02 0;
-    background-color: $ui-03;
+    background-color: $border-subtle;
   }
 }
 

--- a/packages/components/src/components/copy-button/_copy-button.scss
+++ b/packages/components/src/components/copy-button/_copy-button.scss
@@ -30,10 +30,6 @@
     left: 50%;
     display: none;
 
-    &:focus {
-      border: 2px solid $support-01;
-    }
-
     &::before {
       @include box-shadow;
       @include type-style('body-short-01');
@@ -41,7 +37,7 @@
       top: 1.1rem;
       z-index: 2;
       padding: $spacing-02;
-      color: $inverse-01;
+      color: $text-inverse;
       font-weight: 400;
       white-space: nowrap;
       border-radius: 4px;
@@ -56,8 +52,8 @@
       z-index: 1;
       width: 0.6rem;
       height: 0.6rem;
-      border-right: 1px solid $inverse-02;
-      border-bottom: 1px solid $inverse-02;
+      border-right: 1px solid $background-inverse;
+      border-bottom: 1px solid $background-inverse;
       transform: rotate(-135deg);
       content: '';
     }
@@ -66,7 +62,7 @@
     &::after {
       position: absolute;
       display: block;
-      background: $inverse-02;
+      background: $background-inverse;
     }
 
     &--displayed {
@@ -86,16 +82,16 @@
     width: $carbon--spacing-08;
     height: $carbon--spacing-08;
     padding: 0;
-    background-color: $ui-01;
+    background-color: $layer;
     border: none;
     cursor: pointer;
 
     &:hover {
-      background-color: $hover-ui;
+      background-color: $layer-hover;
     }
 
     &:active {
-      background-color: $active-ui;
+      background-color: $layer-active;
     }
 
     &::before {

--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -23,7 +23,7 @@
     width: 100%;
     height: $spacing-09;
     overflow: hidden;
-    background-color: $ui-01;
+    background-color: $layer;
   }
 
   .#{$prefix}--toolbar-content {
@@ -68,7 +68,7 @@
       background-color $duration--fast-02 motion(entrance, productive);
 
     &:hover {
-      background-color: $hover-field;
+      background-color: $field;
     }
   }
 
@@ -89,12 +89,12 @@
 
   .#{$prefix}--toolbar-search-container-expandable.#{$prefix}--search--disabled
     .#{$prefix}--search-magnifier-icon {
-    background-color: $disabled-01;
+    background-color: $layer-disabled;
     cursor: not-allowed;
     transition: background-color none;
   }
 
-  .#{$prefix}--toolbar-search-container-disabled {
+  .#{$prefix}--toolbar-search-container-disabled .#{$prefix}--search-input {
     cursor: not-allowed;
   }
 
@@ -111,7 +111,7 @@
     &::before {
       top: rem(2px);
       height: calc(100% - #{rem(4px)});
-      background-color: $hover-ui;
+      background-color: $field-hover;
     }
   }
 
@@ -148,7 +148,7 @@
 
   .#{$prefix}--toolbar-search-container-active
     .#{$prefix}--search-input:not(:placeholder-shown) {
-    background-color: $hover-field;
+    background-color: $field-hover;
     border: none;
   }
 
@@ -206,11 +206,11 @@
   }
 
   .#{$prefix}--toolbar-action:hover:not([disabled]) {
-    background-color: $hover-field;
+    background-color: $field-hover;
   }
 
   .#{$prefix}--toolbar-action:hover[aria-expanded='true'] {
-    background-color: $ui-01;
+    background-color: $layer;
   }
 
   .#{$prefix}--toolbar-action[disabled] {
@@ -219,7 +219,7 @@
 
   .#{$prefix}--toolbar-action[disabled] .#{$prefix}--toolbar-action__icon {
     cursor: not-allowed;
-    fill: $disabled;
+    fill: $icon-disabled;
   }
 
   .#{$prefix}--toolbar-action:focus:not([disabled]),
@@ -249,7 +249,7 @@
     width: auto;
     max-width: $spacing-05;
     height: $spacing-05;
-    fill: $icon-01;
+    fill: $icon-primary;
   }
 
   //-------------------------------------------------
@@ -290,14 +290,14 @@
 
   .#{$prefix}--toolbar-search-container-persistent
     .#{$prefix}--search-input:hover:not([disabled]) {
-    background-color: $hover-field;
+    background-color: $field-hover;
   }
 
   .#{$prefix}--toolbar-search-container-persistent
     .#{$prefix}--search-input:active:not([disabled]),
   .#{$prefix}--toolbar-search-container-persistent
     .#{$prefix}--search-input:not(:placeholder-shown) {
-    background-color: $hover-field;
+    background-color: $field-hover;
   }
 
   .#{$prefix}--toolbar-search-container-persistent .#{$prefix}--search-close {
@@ -327,7 +327,7 @@
     padding-right: $spacing-06;
     padding-left: $spacing-06;
     overflow-x: auto;
-    background-color: $interactive-01;
+    background-color: $background-brand;
     transform: translate3d(0, 48px, 0);
     transition: transform $duration--fast-02 motion(standard, productive),
       clip-path $duration--fast-02 motion(standard, productive),
@@ -357,17 +357,17 @@
   .#{$prefix}--action-list .#{$prefix}--btn {
     min-width: 0;
     padding: $button-padding-ghost;
-    color: $text-04;
+    color: $text-on-color;
   }
 
   .#{$prefix}--action-list .#{$prefix}--btn:disabled {
-    color: $disabled-03;
+    color: $text-on-color-disabled;
   }
 
   .#{$prefix}--action-list .#{$prefix}--btn .#{$prefix}--btn__icon {
     position: static;
     margin-left: $spacing-03;
-    fill: $icon-03;
+    fill: $icon-on-color;
   }
 
   .#{$prefix}--action-list .#{$prefix}--btn .#{$prefix}--btn__icon .st0 {
@@ -388,7 +388,7 @@
   }
 
   .#{$prefix}--action-list .#{$prefix}--btn--primary:focus {
-    outline: 2px solid $ui-01;
+    outline: 2px solid $layer;
     outline-offset: rem(-2px);
   }
 
@@ -410,7 +410,7 @@
     display: block;
     width: rem(1px);
     height: $spacing-05;
-    background-color: $text-04;
+    background-color: $text-on-color;
     border: none;
     opacity: 1;
     transition: opacity $duration--fast-02 motion(standard, productive);
@@ -435,7 +435,7 @@
     display: flex;
     align-items: center;
     margin-left: $spacing-05;
-    color: $text-04;
+    color: $text-on-color;
   }
 
   .#{$prefix}--batch-summary__para {
@@ -502,14 +502,14 @@
       .#{$prefix}--search-input:focus {
       @include focus-outline('outline');
 
-      background-color: $hover-field;
+      background-color: $field-hover;
     }
 
     .#{$prefix}--toolbar-search-container-active
       .#{$prefix}--search-input:active,
     .#{$prefix}--toolbar-search-container-active
       .#{$prefix}--search-input:not(:placeholder-shown) {
-      background-color: $hover-field;
+      background-color: $field-hover;
     }
 
     .#{$prefix}--toolbar-search-container-active

--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -68,7 +68,7 @@
       background-color $duration--fast-02 motion(entrance, productive);
 
     &:hover {
-      background-color: $field;
+      background-color: $field-hover;
     }
   }
 

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -58,7 +58,7 @@
   .#{$prefix}--data-table thead {
     @include type-style('productive-heading-01');
 
-    background-color: $layer-alt;
+    background-color: $layer-accent;
   }
 
   .#{$prefix}--data-table tbody {
@@ -107,7 +107,7 @@
     padding-right: $spacing-05;
     padding-left: $spacing-05;
     color: $text-primary;
-    background-color: $layer-alt;
+    background-color: $layer-accent;
   }
 
   .#{$prefix}--data-table th:last-of-type {
@@ -292,7 +292,7 @@
     width: rem(44px);
     padding-right: $spacing-05;
     padding-left: $spacing-05;
-    background: $layer-alt;
+    background: $layer-accent;
     transition: background-color $duration--fast-01 motion(entrance, productive);
   }
 
@@ -539,7 +539,7 @@
   // Sticky header
   // -------------
   .#{$prefix}--data-table_inner-container {
-    background-color: $layer-alt;
+    background-color: $layer-accent;
     transform: translateZ(0);
   }
 

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -31,19 +31,19 @@
   //----------------------------------------------------------------------------
   .#{$prefix}--data-table-header {
     padding: $spacing-05 0 $spacing-06 $spacing-05;
-    background: $ui-01;
+    background: $layer;
   }
 
   .#{$prefix}--data-table-header__title {
     @include type-style('productive-heading-03');
 
-    color: $text-01;
+    color: $text-primary;
   }
 
   .#{$prefix}--data-table-header__description {
     @include type-style('body-short-01');
 
-    color: $text-02;
+    color: $text-secondary;
   }
 
   //----------------------------------------------------------------------------
@@ -58,14 +58,14 @@
   .#{$prefix}--data-table thead {
     @include type-style('productive-heading-01');
 
-    background-color: $ui-03;
+    background-color: $layer-alt;
   }
 
   .#{$prefix}--data-table tbody {
     @include type-style('body-short-01');
 
     width: 100%;
-    background-color: $ui-01;
+    background-color: $layer;
   }
 
   .#{$prefix}--data-table tr {
@@ -81,20 +81,20 @@
   }
 
   .#{$prefix}--data-table tbody tr:hover {
-    background: $hover-ui;
+    background: $layer-hover;
   }
 
   .#{$prefix}--data-table tbody tr:hover td,
   .#{$prefix}--data-table tbody tr:hover th {
-    color: $text-01;
-    background: $hover-ui;
-    border-top: 1px solid $hover-ui;
-    border-bottom: 1px solid $hover-ui;
+    color: $text-primary;
+    background: $layer-hover;
+    border-top: 1px solid $layer-hover;
+    border-bottom: 1px solid $layer-hover;
   }
 
   .#{$prefix}--data-table tbody tr:hover td .#{$prefix}--link,
   .#{$prefix}--data-table tbody tr:hover th .#{$prefix}--link {
-    color: $link-02;
+    color: $link-secondary;
   }
 
   .#{$prefix}--data-table th,
@@ -106,8 +106,8 @@
   .#{$prefix}--data-table th {
     padding-right: $spacing-05;
     padding-left: $spacing-05;
-    color: $text-01;
-    background-color: $ui-03;
+    color: $text-primary;
+    background-color: $layer-alt;
   }
 
   .#{$prefix}--data-table th:last-of-type {
@@ -124,10 +124,10 @@
   .#{$prefix}--data-table tbody th {
     padding-right: $spacing-05;
     padding-left: $spacing-05;
-    color: $text-02;
-    background: $ui-01;
-    border-top: 1px solid $ui-01;
-    border-bottom: 1px solid $ui-03;
+    color: $text-secondary;
+    background: $layer;
+    border-top: 1px solid $layer;
+    border-bottom: 1px solid $layer-alt;
 
     + td:first-of-type {
       padding-left: $spacing-04;
@@ -219,19 +219,19 @@
   .#{$prefix}--data-table .#{$prefix}--overflow-menu,
   .#{$prefix}--data-table .#{$prefix}--overflow-menu__trigger {
     &:hover {
-      background-color: $hover-selected-ui;
+      background-color: $layer-selected-hover;
     }
   }
 
   .#{$prefix}--data-table--selected .#{$prefix}--overflow-menu,
   .#{$prefix}--data-table--selected .#{$prefix}--overflow-menu__trigger {
     &:hover {
-      background-color: $hover-ui;
+      background-color: $layer-hover;
     }
   }
 
   .#{$prefix}--data-table--selected .#{$prefix}--link {
-    color: $link-02;
+    color: $link-secondary;
   }
 
   .#{$prefix}--data-table--compact td.#{$prefix}--table-column-menu,
@@ -257,7 +257,7 @@
     tbody
     tr:not(.#{$prefix}--parent-row):nth-child(odd)
     td {
-    border-bottom: 1px solid $ui-01;
+    border-bottom: 1px solid $layer;
   }
 
   .#{$prefix}--data-table--zebra
@@ -273,9 +273,9 @@
     tbody
     tr:not(.#{$prefix}--parent-row):hover
     td {
-    background-color: $hover-ui;
-    border-top: 1px solid $hover-ui;
-    border-bottom: 1px solid $hover-ui;
+    background-color: $layer-hover;
+    border-top: 1px solid $layer-hover;
+    border-bottom: 1px solid $layer-hover;
   }
 
   //----------------------------------------------------------------------------
@@ -292,7 +292,7 @@
     width: rem(44px);
     padding-right: $spacing-05;
     padding-left: $spacing-05;
-    background: $ui-03;
+    background: $layer-alt;
     transition: background-color $duration--fast-01 motion(entrance, productive);
   }
 
@@ -365,11 +365,11 @@
     tr:nth-child(odd).#{$prefix}--data-table--selected
     td,
   tr.#{$prefix}--data-table--selected td {
-    color: $text-01;
-    background-color: $selected-ui;
-    border-top: 1px solid $selected-ui;
+    color: $text-primary;
+    background-color: $layer-selected;
+    border-top: 1px solid $layer-selected;
     // Bottom border acts as separator from other rows
-    border-bottom: 1px solid $active-ui;
+    border-bottom: 1px solid $layer-active;
   }
 
   // First row
@@ -379,7 +379,7 @@
     td,
   tr.#{$prefix}--data-table--selected:first-of-type td {
     // Top border acts as separator from thead
-    border-top: 1px solid $active-ui;
+    border-top: 1px solid $layer-active;
   }
 
   // last row + zebra select last
@@ -393,8 +393,8 @@
     td,
   tr.#{$prefix}--data-table--selected:last-of-type td {
     // Doesn't need separators
-    border-top: 1px solid $selected-ui;
-    border-bottom: 1px solid $selected-ui;
+    border-top: 1px solid $layer-selected;
+    border-bottom: 1px solid $layer-selected;
   }
 
   // zebra select - odd child
@@ -402,7 +402,7 @@
     tbody
     tr:nth-child(even).#{$prefix}--data-table--selected
     td {
-    border-bottom: 1px solid $active-ui;
+    border-bottom: 1px solid $layer-active;
   }
 
   .#{$prefix}--data-table--zebra
@@ -418,7 +418,7 @@
     tr:nth-child(odd).#{$prefix}--data-table--selected:hover
     td,
   .#{$prefix}--data-table tbody .#{$prefix}--data-table--selected:hover td {
-    color: $text-01;
+    color: $text-primary;
     background: $data-table-column-hover;
     border-top: 1px solid $data-table-column-hover;
     border-bottom: 1px solid $data-table-column-hover;
@@ -539,7 +539,7 @@
   // Sticky header
   // -------------
   .#{$prefix}--data-table_inner-container {
-    background-color: $ui-03;
+    background-color: $layer-alt;
     transform: translateZ(0);
   }
 
@@ -567,7 +567,7 @@
     }
 
     thead tr th {
-      border-bottom: 1px solid $active-ui;
+      border-bottom: 1px solid $layer-active;
     }
 
     tbody {
@@ -609,7 +609,7 @@
     tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover
       + tr[data-child-row]
       td {
-      border-top: 1px solid $hover-ui;
+      border-top: 1px solid $layer-hover;
     }
 
     tr.#{$prefix}--expandable-row:last-of-type {

--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -127,7 +127,7 @@
     color: $text-secondary;
     background: $layer;
     border-top: 1px solid $layer;
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
 
     + td:first-of-type {
       padding-left: $spacing-04;

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -242,7 +242,7 @@
     left: 0;
     width: rem(8px);
     height: rem(1px);
-    background: $layer-alt;
+    background: $layer-accent;
     content: '';
   }
 

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -18,7 +18,7 @@
   //----------------------------------------------------------------------------
   //first row top border
   .#{$prefix}--data-table tr.#{$prefix}--parent-row:first-of-type td {
-    border-top: 1px solid $layer-alt;
+    border-top: 1px solid $border-subtle;
   }
 
   //----------------------------------------------------------------------------
@@ -64,7 +64,7 @@
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] td {
     padding-left: 4rem;
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
     transition: padding-bottom $duration--fast-02 motion(standard, productive),
       transform $duration--fast-02 motion(standard, productive),
       background-color $duration--fast-02 motion(standard, productive);
@@ -80,8 +80,8 @@
   // bottom border overrides
   .#{$prefix}--parent-row.#{$prefix}--expandable-row > td,
   .#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] > td {
-    border-bottom: 1px solid $layer-alt;
-    box-shadow: 0 1px $layer-alt;
+    border-bottom: 1px solid $border-subtle;
+    box-shadow: 0 1px $border-subtle;
   }
 
   .#{$prefix}--parent-row:not(.#{$prefix}--expandable-row)
@@ -108,16 +108,16 @@
   // hovering on collapsed parent
   tr.#{$prefix}--parent-row:not(.#{$prefix}--expandable-row):first-of-type:hover
     td {
-    border-top: 1px solid $layer-alt;
-    border-bottom: 1px solid $layer-alt;
+    border-top: 1px solid $border-subtle;
+    border-bottom: 1px solid $border-subtle;
   }
 
   // hovering on expanded parent
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover td {
     color: $text-primary;
     background-color: $layer-hover;
-    border-top: 1px solid $layer-alt;
-    border-bottom: 1px solid $layer-alt;
+    border-top: 1px solid $border-subtle;
+    border-bottom: 1px solid $border-subtle;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover td:first-of-type {
@@ -131,12 +131,12 @@
     td {
     color: $text-primary;
     background-color: $layer-hover;
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
   }
 
   //hovering on expanded child row
   tr.#{$prefix}--expandable-row--hover + tr[data-child-row] td {
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
   }
 
   //hovering on expanded child row (class added to parent)
@@ -147,8 +147,8 @@
   tr.#{$prefix}--expandable-row--hover td {
     color: $text-primary;
     background-color: $layer-hover;
-    border-top: 1px solid $layer-alt;
-    border-bottom: 1px solid $layer-alt;
+    border-top: 1px solid $border-subtle;
+    border-bottom: 1px solid $border-subtle;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row.#{$prefix}--expandable-row--hover
@@ -161,7 +161,7 @@
   // Expand icon column
   //----------------------------------------------------------------------------
   .#{$prefix}--data-table td.#{$prefix}--table-expand {
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
   }
 
   .#{$prefix}--data-table
@@ -313,7 +313,7 @@
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:first-of-type td {
     background: $layer-selected;
     border-top: 1px solid $layer-active;
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
     box-shadow: 0 1px $layer-active;
   }
 
@@ -327,7 +327,7 @@
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:last-of-type td {
     background: $layer-selected;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $layer-alt;
+    box-shadow: 0 1px $border-subtle;
   }
 
   // Parent collapsed hover
@@ -335,7 +335,7 @@
     td {
     background: $layer-selected-hover;
     border-top: 1px solid $layer-selected-hover;
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
     box-shadow: 0 1px $layer-selected-hover;
   }
 
@@ -371,7 +371,7 @@
     color: $text-primary;
     background-color: $layer-hover;
     border-top: 1px solid $layer-active;
-    border-bottom: 1px solid $layer-alt;
+    border-bottom: 1px solid $border-subtle;
     box-shadow: 0 1px $layer-active;
   }
 

--- a/packages/components/src/components/data-table/_data-table-expandable.scss
+++ b/packages/components/src/components/data-table/_data-table-expandable.scss
@@ -18,7 +18,7 @@
   //----------------------------------------------------------------------------
   //first row top border
   .#{$prefix}--data-table tr.#{$prefix}--parent-row:first-of-type td {
-    border-top: 1px solid $ui-03;
+    border-top: 1px solid $layer-alt;
   }
 
   //----------------------------------------------------------------------------
@@ -43,7 +43,7 @@
     td {
     padding-top: 0;
     padding-bottom: 0;
-    background-color: $hover-ui;
+    background-color: $layer-hover;
     border: 0;
     transition: padding $duration--moderate-01 motion(standard, productive),
       background-color $duration--moderate-01 motion(standard, productive);
@@ -64,34 +64,10 @@
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] td {
     padding-left: 4rem;
-    border-bottom: 1px solid $ui-03;
+    border-bottom: 1px solid $layer-alt;
     transition: padding-bottom $duration--fast-02 motion(standard, productive),
       transform $duration--fast-02 motion(standard, productive),
       background-color $duration--fast-02 motion(standard, productive);
-  }
-
-  //compact child row padding
-  .#{$prefix}--data-table--compact
-    tr.#{$prefix}--parent-row.#{$prefix}--expandable-row
-    + tr[data-child-row]
-    td {
-    padding-left: 2.5rem;
-  }
-
-  //short child row padding
-  .#{$prefix}--data-table--short
-    tr.#{$prefix}--parent-row.#{$prefix}--expandable-row
-    + tr[data-child-row]
-    td {
-    padding-left: 3rem;
-  }
-
-  //tall child row padding
-  .#{$prefix}--data-table--tall
-    tr.#{$prefix}--parent-row.#{$prefix}--expandable-row
-    + tr[data-child-row]
-    td {
-    padding-left: 5rem;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row
@@ -104,8 +80,8 @@
   // bottom border overrides
   .#{$prefix}--parent-row.#{$prefix}--expandable-row > td,
   .#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] > td {
-    border-bottom: 1px solid $ui-03;
-    box-shadow: 0 1px $ui-03;
+    border-bottom: 1px solid $layer-alt;
+    box-shadow: 0 1px $layer-alt;
   }
 
   .#{$prefix}--parent-row:not(.#{$prefix}--expandable-row)
@@ -132,47 +108,47 @@
   // hovering on collapsed parent
   tr.#{$prefix}--parent-row:not(.#{$prefix}--expandable-row):first-of-type:hover
     td {
-    border-top: 1px solid $ui-03;
-    border-bottom: 1px solid $ui-03;
+    border-top: 1px solid $layer-alt;
+    border-bottom: 1px solid $layer-alt;
   }
 
   // hovering on expanded parent
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover td {
-    color: $text-01;
-    background-color: $hover-ui;
-    border-top: 1px solid $ui-03;
-    border-bottom: 1px solid $ui-03;
+    color: $text-primary;
+    background-color: $layer-hover;
+    border-top: 1px solid $layer-alt;
+    border-bottom: 1px solid $layer-alt;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover td:first-of-type {
     // First td doesn't have a visible border
-    border-bottom: 1px solid $hover-ui;
+    border-bottom: 1px solid $layer-hover;
   }
 
   // Child row when hovering on expanded parent
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row:hover
     + tr[data-child-row]
     td {
-    color: $text-01;
-    background-color: $hover-ui;
-    border-bottom: 1px solid $ui-03;
+    color: $text-primary;
+    background-color: $layer-hover;
+    border-bottom: 1px solid $layer-alt;
   }
 
   //hovering on expanded child row
   tr.#{$prefix}--expandable-row--hover + tr[data-child-row] td {
-    border-bottom: 1px solid $ui-03;
+    border-bottom: 1px solid $layer-alt;
   }
 
   //hovering on expanded child row (class added to parent)
   tr.#{$prefix}--expandable-row--hover {
-    background-color: $hover-ui;
+    background-color: $layer-hover;
   }
 
   tr.#{$prefix}--expandable-row--hover td {
-    color: $text-01;
-    background-color: $hover-ui;
-    border-top: 1px solid $ui-03;
-    border-bottom: 1px solid $ui-03;
+    color: $text-primary;
+    background-color: $layer-hover;
+    border-top: 1px solid $layer-alt;
+    border-bottom: 1px solid $layer-alt;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row.#{$prefix}--expandable-row--hover
@@ -185,7 +161,7 @@
   // Expand icon column
   //----------------------------------------------------------------------------
   .#{$prefix}--data-table td.#{$prefix}--table-expand {
-    border-bottom: 1px solid $ui-03;
+    border-bottom: 1px solid $layer-alt;
   }
 
   .#{$prefix}--data-table
@@ -266,7 +242,7 @@
     left: 0;
     width: rem(8px);
     height: rem(1px);
-    background: $ui-03;
+    background: $layer-alt;
     content: '';
   }
 
@@ -276,7 +252,7 @@
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row.#{$prefix}--expandable-row--hover
     td.#{$prefix}--table-expand
     + td::after {
-    background: $hover-ui;
+    background: $layer-hover;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected
@@ -290,7 +266,7 @@
   //----------------------------------------------------------------------------
   .#{$prefix}--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td,
   .#{$prefix}--data-table--zebra tbody tr[data-child-row]:nth-child(4n + 4) td {
-    border-bottom: 1px solid $ui-01;
+    border-bottom: 1px solid $layer;
   }
 
   .#{$prefix}--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 1) td,
@@ -317,17 +293,17 @@
     + tr[data-child-row]
     td,
   .#{$prefix}--data-table--zebra tbody tr[data-child-row]:hover td {
-    background-color: $hover-field;
-    border-top: 1px solid $hover-field;
-    border-bottom: 1px solid $hover-field;
+    background-color: $layer-hover;
+    border-top: 1px solid $layer-hover;
+    border-bottom: 1px solid $layer-hover;
   }
 
   .#{$prefix}--data-table--zebra
     tr.#{$prefix}--parent-row.#{$prefix}--expandable-row.#{$prefix}--expandable-row--hover
     td {
-    background: $hover-ui;
-    border-top: 1px solid $hover-field;
-    border-bottom: 1px solid $hover-field;
+    background: $layer-hover;
+    border-top: 1px solid $layer-hover;
+    border-bottom: 1px solid $layer-hover;
   }
 
   //----------------------------------------------------------------------------
@@ -335,32 +311,32 @@
   //----------------------------------------------------------------------------
   // Parent collapsed
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:first-of-type td {
-    background: $selected-ui;
-    border-top: 1px solid $active-ui;
-    border-bottom: 1px solid $ui-03;
-    box-shadow: 0 1px $active-ui;
+    background: $layer-selected;
+    border-top: 1px solid $layer-active;
+    border-bottom: 1px solid $layer-alt;
+    box-shadow: 0 1px $layer-active;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected td {
-    color: $text-01;
-    background: $selected-ui;
+    color: $text-primary;
+    background: $layer-selected;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $active-ui;
+    box-shadow: 0 1px $layer-active;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:last-of-type td {
-    background: $selected-ui;
+    background: $layer-selected;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $ui-03;
+    box-shadow: 0 1px $layer-alt;
   }
 
   // Parent collapsed hover
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected:not(.#{$prefix}--expandable-row):hover
     td {
-    background: $hover-selected-ui;
-    border-top: 1px solid $hover-selected-ui;
-    border-bottom: 1px solid $ui-03;
-    box-shadow: 0 1px $hover-selected-ui;
+    background: $layer-selected-hover;
+    border-top: 1px solid $layer-selected-hover;
+    border-bottom: 1px solid $layer-alt;
+    box-shadow: 0 1px $layer-selected-hover;
   }
 
   // Parent expanded
@@ -370,7 +346,7 @@
     td:first-of-type {
     border-bottom: 1px solid transparent;
     // No visible border when expanded
-    box-shadow: 0 1px $selected-ui;
+    box-shadow: 0 1px $layer-selected;
   }
 
   // Parent expanded hover
@@ -382,28 +358,28 @@
     td,
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row--hover
     td:first-of-type {
-    background: $hover-selected-ui;
-    border-top: 1px solid $hover-selected-ui;
+    background: $layer-selected-hover;
+    border-top: 1px solid $layer-selected-hover;
     border-bottom: 1px solid transparent;
-    box-shadow: 0 1px $hover-selected-ui;
+    box-shadow: 0 1px $layer-selected-hover;
   }
 
   // Child row expanded
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row
     + tr[data-child-row]
     td {
-    color: $text-01;
-    background-color: $hover-ui;
-    border-top: 1px solid $active-ui;
-    border-bottom: 1px solid $ui-03;
-    box-shadow: 0 1px $active-ui;
+    color: $text-primary;
+    background-color: $layer-hover;
+    border-top: 1px solid $layer-active;
+    border-bottom: 1px solid $layer-alt;
+    box-shadow: 0 1px $layer-active;
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row
     + tr[data-child-row]:last-of-type
     td {
     padding-bottom: rem(24px);
-    box-shadow: inset 0 -1px $active-ui;
+    box-shadow: inset 0 -1px $layer-active;
   }
 
   // Child row expanded hover
@@ -413,7 +389,7 @@
   tr.#{$prefix}--parent-row.#{$prefix}--data-table--selected.#{$prefix}--expandable-row--hover
     + tr[data-child-row]
     td {
-    background: $selected-ui;
+    background: $layer-selected;
   }
 }
 

--- a/packages/components/src/components/data-table/_data-table-inline-edit-cell.scss
+++ b/packages/components/src/components/data-table/_data-table-inline-edit-cell.scss
@@ -299,7 +299,7 @@
     padding: 1rem;
     color: $text-error;
     font-size: rem(12px);
-    background-color: $background-inverse;
+    background-color: $icon-inverse;
     border: 1px solid $border-subtle;
     box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.1);
     transform: translateY(-100%);
@@ -315,7 +315,7 @@
     z-index: 10;
     width: rem(10px);
     height: rem(10px);
-    background-color: $background-inverse;
+    background-color: $icon-inverse;
     border: 1px solid $border-subtle;
     border-top: 1px solid transparent;
     border-left: 1px solid transparent;

--- a/packages/components/src/components/data-table/_data-table-inline-edit-cell.scss
+++ b/packages/components/src/components/data-table/_data-table-inline-edit-cell.scss
@@ -54,16 +54,16 @@
   // Reset hover styles while editing
   .#{$prefix}--data-table--editing tr:hover td {
     background-color: inherit;
-    border-top: 1px solid $ui-04;
-    border-bottom: 1px solid $ui-04;
+    border-top: 1px solid $border-strong;
+    border-bottom: 1px solid $border-strong;
   }
 
   .#{$prefix}--data-table--editing tr:hover td:first-of-type {
-    border-left: 1px solid $ui-04;
+    border-left: 1px solid $border-strong;
   }
 
   .#{$prefix}--data-table--editing tr:hover td:last-of-type {
-    border-right: 1px solid $ui-04;
+    border-right: 1px solid $border-strong;
   }
 
   //----------------------------------------------------------------------------
@@ -135,16 +135,16 @@
   }
 
   .#{$prefix}--data-table-cell__icon--edit {
-    fill: $ui-05;
+    fill: $icon-primary;
   }
 
   .#{$prefix}--data-table-cell__edit:active
     > .#{$prefix}--data-table-cell__icon--edit {
-    fill: $brand-01;
+    fill: $interactive;
   }
 
   .#{$prefix}--data-table-cell__edit:focus {
-    outline: 1px solid $brand-01;
+    outline: 1px solid $focus;
     outline-offset: 2px;
   }
 
@@ -218,7 +218,7 @@
     justify-content: flex-end;
     height: $size--edit-actions--height;
     padding: $spacing--cell-actions;
-    background-color: $inverse-01;
+    background-color: $background-inverse;
   }
 
   // Undo default margin-left from btn classes
@@ -268,7 +268,7 @@
 
   // Status - Success ----------------------------------------------------------
   .#{$prefix}--data-table__icon--success {
-    fill: $support-02;
+    fill: $support-success;
   }
 
   // Status - Error ------------------------------------------------------------
@@ -282,11 +282,11 @@
     height: 100%;
     // Specify outline on child SVG node instead
     outline: none;
-    fill: $support-01;
+    fill: $support-error;
   }
 
   .#{$prefix}--data-table__edit-field--error {
-    border-bottom: 2px solid $support-01;
+    border-bottom: 2px solid $support-error;
   }
 
   .#{$prefix}--data-table__error-text {
@@ -299,8 +299,8 @@
     padding: 1rem;
     color: $text-error;
     font-size: rem(12px);
-    background-color: $inverse-01;
-    border: 1px solid $ui-03;
+    background-color: $background-inverse;
+    border: 1px solid $border-subtle;
     box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.1);
     transform: translateY(-100%);
     opacity: 0;
@@ -315,8 +315,8 @@
     z-index: 10;
     width: rem(10px);
     height: rem(10px);
-    background-color: $inverse-01;
-    border: 1px solid $ui-03;
+    background-color: $background-inverse;
+    border: 1px solid $border-subtle;
     border-top: 1px solid transparent;
     border-left: 1px solid transparent;
     transform: rotate(45deg);
@@ -330,13 +330,13 @@
 
   .#{$prefix}--data-table__status--error:focus
     .#{$prefix}--data-table__error-text {
-    box-shadow: 0 0 0 1px $brand-01;
+    box-shadow: 0 0 0 1px $focus;
   }
 
   .#{$prefix}--data-table__status--error:focus
     .#{$prefix}--data-table__error-text::after {
-    border-right-color: $brand-01;
-    border-bottom-color: $brand-01;
+    border-right-color: $focus;
+    border-bottom-color: $focus;
   }
 
   // Visually show the error message

--- a/packages/components/src/components/data-table/_data-table-inline-edit.scss
+++ b/packages/components/src/components/data-table/_data-table-inline-edit.scss
@@ -47,7 +47,7 @@
 
   .#{$prefix}--inline-edit-label__icon {
     opacity: 0;
-    fill: $ui-05;
+    fill: $icon-primary;
   }
 
   .#{$prefix}--inline-edit-input {

--- a/packages/components/src/components/data-table/_data-table-skeleton.scss
+++ b/packages/components/src/components/data-table/_data-table-skeleton.scss
@@ -29,7 +29,7 @@
     tr:hover {
       td {
         background: transparent;
-        border-color: $layer-alt;
+        border-color: $border-subtle;
 
         &:first-of-type,
         &:last-of-type {

--- a/packages/components/src/components/data-table/_data-table-skeleton.scss
+++ b/packages/components/src/components/data-table/_data-table-skeleton.scss
@@ -29,11 +29,11 @@
     tr:hover {
       td {
         background: transparent;
-        border-color: $ui-03;
+        border-color: $layer-alt;
 
         &:first-of-type,
         &:last-of-type {
-          border-color: $ui-03;
+          border-color: $border-subtle;
         }
       }
     }
@@ -44,11 +44,11 @@
   }
 
   .#{$prefix}--data-table.#{$prefix}--skeleton th span {
-    background: $skeleton-02;
+    background: $skeleton-element;
   }
 
   .#{$prefix}--data-table.#{$prefix}--skeleton th span::before {
-    background: $skeleton-01;
+    background: $skeleton-background;
   }
 
   .#{$prefix}--data-table-container.#{$prefix}--skeleton

--- a/packages/components/src/components/data-table/_data-table-sort.scss
+++ b/packages/components/src/components/data-table/_data-table-sort.scss
@@ -39,7 +39,7 @@
     color: $text-primary;
     font: inherit;
     line-height: 1;
-    background-color: $layer-alt;
+    background-color: $layer-accent;
     transition: background-color $duration--fast-01 motion(entrance, productive),
       outline $duration--fast-01 motion(entrance, productive);
   }

--- a/packages/components/src/components/data-table/_data-table-sort.scss
+++ b/packages/components/src/components/data-table/_data-table-sort.scss
@@ -36,10 +36,10 @@
     width: 100%;
     min-height: 100%;
     padding-left: $spacing-05;
-    color: $text-01;
+    color: $text-primary;
     font: inherit;
     line-height: 1;
-    background-color: $ui-03;
+    background-color: $layer-alt;
     transition: background-color $duration--fast-01 motion(entrance, productive),
       outline $duration--fast-01 motion(entrance, productive);
   }
@@ -126,7 +126,7 @@
     margin-right: $spacing-03;
     margin-left: $spacing-03;
     opacity: 0;
-    fill: $ui-05;
+    fill: $icon-primary;
   }
 
   .#{$prefix}--table-sort.#{$prefix}--table-sort--active {
@@ -157,7 +157,7 @@
     transform: rotate(0);
     opacity: 1;
     transition: transform $transition--base $carbon--standard-easing;
-    fill: $ui-05;
+    fill: $icon-primary;
   }
 
   // Windows, Firefox HCM Fix

--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -153,7 +153,7 @@
     fill: $support-warning;
   }
 
-  // Do we have an always black token?
+  // V11: Do we have an always black token?
   .#{$prefix}--date-picker__icon--warn path:first-of-type {
     opacity: 1;
     fill: $carbon__black-100;

--- a/packages/components/src/components/date-picker/_date-picker.scss
+++ b/packages/components/src/components/date-picker/_date-picker.scss
@@ -23,6 +23,7 @@
     display: flex;
   }
 
+  // V11: Possibly deprecate
   .#{$prefix}--date-picker--light .#{$prefix}--date-picker__input {
     background: $field-02;
   }
@@ -74,7 +75,7 @@
   .#{$prefix}--date-picker
     .#{$prefix}--date-picker-input__wrapper--warn
     ~ .#{$prefix}--form-requirement {
-    color: $text-01;
+    color: $text-primary;
   }
   .#{$prefix}--date-picker__input {
     @include reset;
@@ -85,10 +86,10 @@
     display: block;
     height: rem(40px);
     padding: 0 $carbon--spacing-05;
-    color: $text-01;
-    background-color: $field-01;
+    color: $text-primary;
+    background-color: $field;
     border: none;
-    border-bottom: 1px solid $ui-04;
+    border-bottom: 1px solid $border-strong;
     transition: $duration--fast-01 motion(standard, productive) all;
 
     &:focus,
@@ -97,14 +98,14 @@
     }
 
     &:disabled {
-      color: $disabled-02;
-      background-color: $disabled-01;
+      color: $text-disabled;
+      background-color: $field-disabled;
       border-bottom: 1px solid transparent;
       cursor: not-allowed;
     }
 
     &:disabled::placeholder {
-      color: $disabled-02;
+      color: $text-disabled;
     }
 
     &:disabled:hover {
@@ -133,7 +134,7 @@
     z-index: 1;
     transform: translateY(-50%);
     cursor: pointer;
-    fill: $icon-01;
+    fill: $icon-primary;
 
     // Windows, Firefox HCM Fix
     @media screen and (-ms-high-contrast: active),
@@ -149,16 +150,17 @@
   }
 
   .#{$prefix}--date-picker__icon--warn {
-    fill: $support-03;
+    fill: $support-warning;
   }
 
+  // Do we have an always black token?
   .#{$prefix}--date-picker__icon--warn path:first-of-type {
     opacity: 1;
     fill: $carbon__black-100;
   }
 
   .#{$prefix}--date-picker__icon--invalid {
-    fill: $support-01;
+    fill: $support-error;
   }
 
   .#{$prefix}--date-picker__icon ~ .#{$prefix}--date-picker__input {
@@ -167,7 +169,7 @@
 
   .#{$prefix}--date-picker__input:disabled ~ .#{$prefix}--date-picker__icon {
     cursor: not-allowed;
-    fill: $disabled-02;
+    fill: $icon-disabled;
   }
 
   .#{$prefix}--date-picker--range

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -50,17 +50,17 @@
     display: block;
     width: 100%;
     height: rem(40px);
-    color: $text-01;
+    color: $text-primary;
     list-style: none;
-    background-color: $field-01;
+    background-color: $field;
     border: none;
-    border-bottom: 1px solid $ui-04;
+    border-bottom: 1px solid $border-strong;
     outline: 2px solid transparent;
     cursor: pointer;
     transition: background-color $duration--fast-01 motion(standard, productive);
 
     &:hover {
-      background-color: $hover-ui;
+      background-color: $field-hover;
     }
   }
 
@@ -94,7 +94,7 @@
   }
 
   .#{$prefix}--dropdown--open {
-    border-bottom-color: $ui-03;
+    border-bottom-color: $border-subtle;
   }
 
   .#{$prefix}--dropdown--invalid {
@@ -116,11 +116,11 @@
     top: 50%;
     right: $spacing-08;
     transform: translateY(-50%);
-    fill: $support-01;
+    fill: $support-error;
   }
 
   .#{$prefix}--dropdown--open:hover {
-    background-color: $field-01;
+    background-color: $field;
   }
 
   .#{$prefix}--dropdown--open:focus {
@@ -135,6 +135,7 @@
     transition: max-height $duration--fast-02 motion(entrance, productive);
   }
 
+  // V11: Possibly deprecate
   .#{$prefix}--dropdown--light {
     background-color: $field-02;
 
@@ -154,12 +155,12 @@
     transform-origin: 50% 45%;
     transition: transform $duration--fast-02 motion(standard, productive);
     pointer-events: none;
-    fill: $ui-05;
+    fill: $icon-primary;
   }
 
   button.#{$prefix}--dropdown-text {
     width: 100%;
-    color: $text-01;
+    color: $text-primary;
     text-align: left;
     // button-reset mixin contradicts with bx--dropdown-text styles
     background: none;
@@ -201,10 +202,11 @@
     overflow-y: auto;
     list-style: none;
 
-    background-color: $ui-01;
+    background-color: $layer;
     transition: max-height $duration--fast-02 motion(standard, productive);
   }
 
+  // V11: Possibly deprecate
   .#{$prefix}--dropdown--light .#{$prefix}--dropdown-list {
     background-color: $field-02;
   }
@@ -223,7 +225,7 @@
       background-color $duration--fast-01 motion(standard, productive);
 
     &:hover {
-      background-color: $hover-ui;
+      background-color: $field-hover;
 
       + .#{$prefix}--dropdown-item .#{$prefix}--dropdown-link {
         border-color: transparent;
@@ -231,7 +233,7 @@
     }
 
     &:active {
-      background-color: $selected-ui;
+      background-color: $layer-selected;
     }
 
     &:first-of-type .#{$prefix}--dropdown-link {
@@ -251,14 +253,14 @@
     margin: 0 $carbon--spacing-05;
     padding: rem(11px) 0;
     overflow: hidden;
-    color: $text-02;
+    color: $text-secondary;
     font-weight: normal;
     line-height: 1rem;
     white-space: nowrap;
     text-decoration: none;
     text-overflow: ellipsis;
     border: 1px solid transparent;
-    border-top-color: $ui-03;
+    border-top-color: $border-subtle;
 
     &:hover {
       color: $text-01;
@@ -266,6 +268,7 @@
     }
   }
 
+  // V11: Possibly deprecate
   .#{$prefix}--dropdown--light .#{$prefix}--dropdown-link {
     border-top-color: $decorative-01;
   }
@@ -321,7 +324,7 @@
   }
 
   .#{$prefix}--dropdown-item:hover .#{$prefix}--dropdown-link {
-    border-bottom-color: $hover-ui;
+    border-bottom-color: $field-hover;
   }
 
   .#{$prefix}--dropdown--selected {
@@ -352,7 +355,7 @@
     border-bottom-color: transparent;
 
     &:hover {
-      background-color: $field-01;
+      background-color: $field;
     }
 
     &:focus {
@@ -362,15 +365,16 @@
     // TODO: remove in v11
     .#{$prefix}--dropdown-text,
     .#{$prefix}--list-box__label {
-      color: $disabled-02;
+      color: $text-disabled;
     }
 
     // TODO: remove in v11
     .#{$prefix}--dropdown__arrow,
     .#{$prefix}--list-box__menu-icon svg {
-      fill: $disabled-02;
+      fill: $icon-disabled;
     }
 
+    // V11: Possibly deprecate
     &.#{$prefix}--dropdown--light:hover {
       background-color: $field-02;
     }
@@ -395,7 +399,7 @@
     transition: background $duration--fast-01 motion(entrance, productive);
 
     &:hover {
-      background-color: $hover-ui;
+      background-color: $field-hover;
     }
 
     &.#{$prefix}--dropdown--disabled {
@@ -417,12 +421,12 @@
     height: rem(32px);
     padding: rem(7px) $carbon--spacing-07 rem(7px) $carbon--spacing-04;
     overflow: visible;
-    color: $text-01;
+    color: $text-primary;
   }
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled
     .#{$prefix}--dropdown-text {
-    color: $disabled-02;
+    color: $text-disabled;
   }
 
   .#{$prefix}--dropdown--inline.#{$prefix}--dropdown--disabled:focus
@@ -451,11 +455,11 @@
 
   .#{$prefix}--dropdown--show-selected .#{$prefix}--dropdown--selected {
     display: block;
-    color: $text-01;
-    background-color: $hover-ui;
+    color: $text-primary;
+    background-color: $field-hover;
 
     &:hover {
-      background-color: $selected-ui;
+      background-color: $layer-selected;
     }
 
     .#{$prefix}--dropdown-link {

--- a/packages/components/src/components/dropdown/_dropdown.scss
+++ b/packages/components/src/components/dropdown/_dropdown.scss
@@ -225,7 +225,7 @@
       background-color $duration--fast-01 motion(standard, productive);
 
     &:hover {
-      background-color: $field-hover;
+      background-color: $layer-hover;
 
       + .#{$prefix}--dropdown-item .#{$prefix}--dropdown-link {
         border-color: transparent;
@@ -324,7 +324,7 @@
   }
 
   .#{$prefix}--dropdown-item:hover .#{$prefix}--dropdown-link {
-    border-bottom-color: $field-hover;
+    border-bottom-color: $layer-hover;
   }
 
   .#{$prefix}--dropdown--selected {
@@ -456,7 +456,7 @@
   .#{$prefix}--dropdown--show-selected .#{$prefix}--dropdown--selected {
     display: block;
     color: $text-primary;
-    background-color: $field-hover;
+    background-color: $layer-hover;
 
     &:hover {
       background-color: $layer-selected;

--- a/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion-story.scss
+++ b/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion-story.scss
@@ -1,10 +1,6 @@
 @import '~@carbon/type/scss/type';
 @import '~@carbon/themes/scss/themes';
 
-.demo-expanded-td td {
-  padding-left: 4rem;
-}
-
 .demo-inner-container-header {
   @include carbon--type-style('productive-heading-01');
   color: $text-01;

--- a/packages/themes/src/tokens.js
+++ b/packages/themes/src/tokens.js
@@ -106,6 +106,7 @@ const colors = [
   'skeleton02',
 
   // New color tokens
+  // TO-DO: remove fallback color when v11 is released and assign carbon colors to new tokens
   'background',
   'layer',
   'layerAccent',


### PR DESCRIPTION
Refs #8149 

Updates the following components to use the new tokens:
- [x] ContentSwitcher
- [x] ContextMenu
- [x] CopyButton
- [x] DataTable
- [x] DatePicker
- [x] Dropdown

#### Changelog

**Changed**

- New tokens replace old tokens in a few components

**Removed**

- Some extra styles that were causing padding differences in `DataTable`, see [here](https://github.com/carbon-design-system/carbon/pull/8269#discussion_r605711813)

#### Testing / Reviewing

Ensure the correct tokens are being used in the following components, and there are no visual changes in the storybook:

- [ ] ContentSwitcher
- [ ] ContextMenu
- [ ] CopyButton
- [ ] DataTable
- [ ] DatePicker
- [ ] Dropdown
