### PR TITLE
fix(ComboBox): add missing dependencies to useEffect

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -150,7 +150,7 @@ const ComboBox = (props) => {
     if (onInputChange) {
       onInputChange(inputValue);
     }
-  });
+  }, [onInputChange, inputValue]);
 
   const handleSelectionClear = () => {
     if (textInput?.current) {

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -113,6 +113,7 @@ const ComboBox = (props) => {
   );
   const [prevSelectedItem, setPrevSelectedItem] = useState(null);
   const [doneInitialSelectedItem, setDoneInitialSelectedItem] = useState(null);
+  const savedOnInputChange = useRef(onInputChange);
 
   if (!doneInitialSelectedItem || prevSelectedItem !== selectedItem) {
     setDoneInitialSelectedItem(true);
@@ -147,10 +148,14 @@ const ComboBox = (props) => {
   };
 
   useEffect(() => {
-    if (onInputChange) {
-      onInputChange(inputValue);
+    savedOnInputChange.current = onInputChange;
+  }, [onInputChange]);
+
+  useEffect(() => {
+    if (savedOnInputChange.current) {
+      savedOnInputChange.current(inputValue);
     }
-  }, [onInputChange, inputValue]);
+  }, [inputValue]);
 
   const handleSelectionClear = () => {
     if (textInput?.current) {


### PR DESCRIPTION
Closes #8306

This PR adds missing dependencies to the Combobox `useEffect` to avoid a render loop when the component is controlled and rerendered on input changes

#### Testing / Reviewing

Substitute the Combobox component in the example code sandbox with a built version of the component from this PR, and observe that removing the setTimeout in the example app no longer causes the component to render infinitely