### PR TITLE
fix(tabs): override browser focus styles in tab content container

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -402,6 +402,10 @@
   //-----------------------------
   .#{$prefix}--tab-content {
     padding: $carbon--spacing-05;
+
+    &:focus {
+      @include focus-outline('outline');
+    }
   }
 
   //-----------------------------


### PR DESCRIPTION
Closes #8342
Related #7894

This PR adds Carbon focus styles to focusable tab content containers

#### Testing / Reviewing

Focusable tab content panels should no longer receive the default browser styles shown in the screenshots below

![image](https://user-images.githubusercontent.com/8265238/114201968-5d658380-991c-11eb-8c1c-2f8077519df4.png)

![image](https://user-images.githubusercontent.com/8265238/114201943-563e7580-991c-11eb-984d-45cd7494c7c7.png)

