### PR TITLE
feat(Pagination): enable seperate disable controls for page size, page

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4371,7 +4371,9 @@ Map {
       "page": Object {
         "type": "number",
       },
-      "pageInputDisabled": [Function],
+      "pageInputDisabled": Object {
+        "type": "bool",
+      },
       "pageNumberText": Object {
         "type": "string",
       },
@@ -4380,6 +4382,9 @@ Map {
       },
       "pageSize": Object {
         "type": "number",
+      },
+      "pageSizeInputDisabled": Object {
+        "type": "bool",
       },
       "pageSizes": Object {
         "args": Array [

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -24,7 +24,11 @@ const props = () => ({
   totalItems: number('Total number of items (totalItems)', 103),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
   pageInputDisabled: boolean(
-    '[Deprecated]: Disable page input (pageInputDisabled)',
+    'Disable page input (pageInputDisabled)',
+    undefined
+  ),
+  pageSizeInputDisabled: boolean(
+    'Disable page size input (pageSizeInputDisabled)',
     undefined
   ),
   backwardText: text(

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -14,7 +14,6 @@ import Select from '../Select';
 import SelectItem from '../SelectItem';
 import { equals } from '../../tools/array';
 import Button from '../Button';
-import deprecate from '../../prop-types/deprecate';
 
 const { prefix } = settings;
 
@@ -105,12 +104,9 @@ export default class Pagination extends Component {
     page: PropTypes.number,
 
     /**
-     * Deprecated; `true` if the select box to change the page should be disabled.
+     * `true` if the select box to change the page should be disabled.
      */
-    pageInputDisabled: deprecate(
-      PropTypes.bool,
-      `The prop \`pageInputDisabled\` for Pagination has been deprecated, as the feature of \`pageInputDisabled\` has been combined with the general \`disabled\` prop.`
-    ),
+    pageInputDisabled: PropTypes.bool,
 
     pageNumberText: PropTypes.string,
 
@@ -123,6 +119,11 @@ export default class Pagination extends Component {
      * The number dictating how many items a page contains.
      */
     pageSize: PropTypes.number,
+
+    /**
+     * `true` if the select box to change the items per page should be disabled.
+     */
+    pageSizeInputDisabled: PropTypes.bool,
 
     /**
      * The choices for `pageSize`.
@@ -272,6 +273,7 @@ export default class Pagination extends Component {
       isLastPage,
       disabled,
       pageInputDisabled,
+      pageSizeInputDisabled,
       totalItems,
       onChange, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
@@ -318,7 +320,7 @@ export default class Pagination extends Component {
             noLabel
             inline
             onChange={this.handleSizeChange}
-            disabled={pageInputDisabled || disabled}
+            disabled={pageSizeInputDisabled || disabled}
             value={statePageSize}>
             {pageSizes.map((sizeObj) => (
               <SelectItem


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8311
Refs https://github.com/carbon-design-system/carbon/pull/6070
Refs https://github.com/carbon-design-system/carbon/issues/6055

This un-deprecates the `pageInputDisabled` prop, and adds in the `pageSizeInputDisabled` prop. Now, `pageInputDisabled` will _only_ disable the right-sided `page` `Select` input. `pageSizeInputDisabled` will disable the left `pageSize` `Select` element.

`disable` will still disable all select elements

#### Changelog

**New**

- `pageSizeInputDisabled` added to control the left page size `Select` element

**Changed**

- `pageInputDisabled` will only target the right page `Select` element

**Removed**

- Removed deprecation warning for `pageInputDisabled` so users have more control over which parts of the `Pagination` component they want disabled.

#### Testing / Reviewing

Use the knobs in the storybook to disable each select individually, and ensure the `disable` prop still works as expected and disabled all elements

Possibly breaking: Anyone that was using `pageInputDisabled` instead of `disable` to disable all elements will now only have the right page `Select` disabled. 
