### PR TITLE
fix(text-input): correct padding when in warning state

### DIFF
--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -142,7 +142,8 @@
       fill: $icon-01;
     }
 
-    .#{$prefix}--text-input--invalid {
+    .#{$prefix}--text-input--invalid,
+    .#{$prefix}--text-input--warning {
       padding-right: $carbon--spacing-08;
     }
 

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -43,6 +43,7 @@ const TextInput = React.forwardRef(function TextInput(
   const textInputClasses = classNames(`${prefix}--text-input`, className, {
     [`${prefix}--text-input--light`]: light,
     [`${prefix}--text-input--invalid`]: invalid,
+    [`${prefix}--text-input--warning`]: !invalid && warn,
     [`${prefix}--text-input--${size}`]: size,
   });
   const sharedTextInputProps = {


### PR DESCRIPTION
Currently, the `TextInput` doesn't have any additional padding on the right when in warning state, resulting in the warning icon overlaying longer text. The error state accounts for that already. This PR adds the same additional padding to the warning state.

Before
![image](https://user-images.githubusercontent.com/28265588/114712512-7a40f300-9d30-11eb-895e-7c8ca8806cd9.png)
![image](https://user-images.githubusercontent.com/28265588/114712527-7dd47a00-9d30-11eb-8df3-dc61e2c67ba9.png)
![image](https://user-images.githubusercontent.com/28265588/114712556-8331c480-9d30-11eb-8193-05738a1c5d31.png)

After
![image](https://user-images.githubusercontent.com/28265588/114712633-96449480-9d30-11eb-94cb-7facd618d77b.png)



#### Changelog

**New**

- Add class `bx--text-input--warning` to text input when in warning state

#### Testing / Reviewing

- Ensure there is enough padding to the right so that the icon doesn't overlay the text but the text is cut off earler (as seen in the screenshots above)
