### PR TITLE
docs(layout): add migration guide for layout tokens

### DIFF
--- a/docs/migration/11.x-layout.md
+++ b/docs/migration/11.x-layout.md
@@ -22,3 +22,17 @@
 | `carbon--breakpoint-between`      | `breakpoint-between`      |
 | `carbon--largest-breakpoint`      | `largest-breakpoint`      |
 | `carbon--breakpoint`              | `breakpoint`              |
+| `$carbon--layout-01`              | `$spacing-05`             |
+| `$carbon--layout-02`              | `$spacing-06`             |
+| `$carbon--layout-03`              | `$spacing-07`             |
+| `$carbon--layout-04`              | `$spacing-09`             |
+| `$carbon--layout-05`              | `$spacing-10`             |
+| `$carbon--layout-06`              | `$spacing-12`             |
+| `$carbon--layout-07`              | `$spacing-13`             |
+| `$layout-01`                      | `$spacing-05`             |
+| `$layout-02`                      | `$spacing-06`             |
+| `$layout-03`                      | `$spacing-07`             |
+| `$layout-04`                      | `$spacing-09`             |
+| `$layout-05`                      | `$spacing-10`             |
+| `$layout-06`                      | `$spacing-12`             |
+| `$layout-07`                      | `$spacing-13`             |


### PR DESCRIPTION
#8397 

Given that our layout scale has been deprecated and the docs for it on the site have been removed, here is a migration guide that documents what the layout tokens map to in the spacing scale.

Credit to @metonym for answering this question over in Slack 🙏 

#### Changelog

**New**

**Changed**

- Add entries for mapping layout to spacing scale in the layout package

**Removed**
