### PR TITLE
fix(react): update CodeSnippet html from code > pre to pre > code

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -224,13 +224,11 @@ function CodeSnippet({
         aria-label={ariaLabel || copyLabel || 'code-snippet'}
         onScroll={(type === 'single' && handleScroll) || null}
         {...containerStyle}>
-        <code>
-          <pre
-            ref={codeContentRef}
-            onScroll={(type === 'multi' && handleScroll) || null}>
-            {children}
-          </pre>
-        </code>
+        <pre
+          ref={codeContentRef}
+          onScroll={(type === 'multi' && handleScroll) || null}>
+          <code>{children}</code>
+        </pre>
       </div>
       {/**
        * left overflow indicator must come after the snippet due to z-index and


### PR DESCRIPTION
Closes #8436 

#### Changelog

**New**

**Changed**

- Update code snippet to use pre > code instead of code > pre

**Removed**

#### Testing / Reviewing

- Verify no visual style changes have occured