### PR TITLE
fix(modal): improve modal transition performance

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -31,21 +31,17 @@
     justify-content: center;
     width: 100vw;
     height: 100vh;
-    background-color: transparent;
+    background-color: $overlay;
     visibility: hidden;
     opacity: 0;
-    transition: background-color $duration--slow-02 motion(exit, expressive),
-      opacity $duration--moderate-02 motion(exit, expressive),
+    transition: opacity $duration--moderate-02 motion(exit, expressive),
       visibility 0ms linear $duration--moderate-02;
     content: '';
 
     &.is-visible {
-      background-color: $overlay;
       visibility: inherit;
       opacity: 1;
-      transition: background-color $duration--slow-02
-          motion(entrance, expressive),
-        opacity $duration--moderate-02 motion(entrance, expressive),
+      transition: opacity $duration--moderate-02 motion(entrance, expressive),
         visibility 0ms linear;
     }
 


### PR DESCRIPTION
Closes #8391

This PR removes modal overlay background transitions to improve performance when modals animate on open and close

#### Testing / Reviewing

Observe the differences in modal open/close performance in the profiler and confirm if the visual changes are acceptable