### PR TITLE
fix(context-menu): add aria-label to SelectableItem and ContextMenuRadioGroupOptions

### DIFF
--- a/packages/react/src/components/ContextMenu/ContextMenuRadioGroupOptions.js
+++ b/packages/react/src/components/ContextMenu/ContextMenuRadioGroupOptions.js
@@ -30,6 +30,7 @@ function ContextMenuRadioGroupOptions({
         key={i}
         role="menuitemradio"
         aria-checked={isSelected}
+        aria-label={option}
         renderIcon={isSelected ? Checkmark16 : null}
         label={option}
         indented

--- a/packages/react/src/components/ContextMenu/ContextMenuSelectableItem.js
+++ b/packages/react/src/components/ContextMenu/ContextMenuSelectableItem.js
@@ -26,6 +26,7 @@ function ContextMenuSelectableItem({
     <ContextMenuOption
       role="menuitemcheckbox"
       aria-checked={checked}
+      aria-label={label}
       renderIcon={checked ? Checkmark16 : null}
       label={label}
       indented


### PR DESCRIPTION
Closes #8553 

Adds an aria-label on the ContextMenuSelectableItem and ContextMenuRadioGroupOptions to pass a11y scans.

#### Changelog

**New**

- pass `aria-label` prop from ContextMenuSelectableItem to ContextMenuOption
- pass `aria-label` prop from ContextMenuRadioGroupOptions to ContextMenuOption

#### Testing / Reviewing

Repeating steps in #8553 should not have an aria violation for a missing label now.
