### PR TITLE
fix(Tooltip): remove pointer from TooltipDefinition, add disabled TooltipIcon

### DIFF
--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -151,8 +151,6 @@
       color: $text-primary;
 
       &:hover {
-        cursor: pointer;
-
         + .#{$prefix}--tooltip--definition__top,
         + .#{$prefix}--tooltip--definition__bottom {
           display: block;
@@ -182,7 +180,6 @@
     margin-top: $carbon--spacing-04;
     background: $background-inverse;
     border-radius: rem(2px);
-    cursor: pointer;
     pointer-events: none;
 
     p {
@@ -343,7 +340,6 @@
 
     display: inline-flex;
     align-items: center;
-    cursor: pointer;
     font-size: 1rem;
 
     &:focus {

--- a/packages/components/src/components/tooltip/_tooltip.scss
+++ b/packages/components/src/components/tooltip/_tooltip.scss
@@ -349,6 +349,11 @@
     }
   }
 
+  // Disabled styles
+  .#{$prefix}--tooltip__trigger:not(.#{$prefix}--btn--icon-only)[disabled] svg {
+    fill: $icon-disabled;
+  }
+
   .#{$prefix}--tooltip__label .#{$prefix}--tooltip__trigger {
     // Override `margin: 0` from button-reset mixin
     margin-left: $carbon--spacing-03;

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -79,15 +79,16 @@
   overflow: visible;
   align-items: center;
 
-  @if $tooltip-type == 'icon' {
-    cursor: pointer;
-  }
-
   &:focus {
     @include focus-outline('border');
   }
 
+  @if $tooltip-type == 'definition' {
+    cursor: default;
+  }
+
   @if $tooltip-type == 'icon' {
+    cursor: pointer;
     &:focus {
       outline: 1px solid transparent;
 

--- a/packages/components/src/globals/scss/_tooltip.scss
+++ b/packages/components/src/globals/scss/_tooltip.scss
@@ -78,7 +78,10 @@
   display: inline-flex;
   overflow: visible;
   align-items: center;
-  cursor: pointer;
+
+  @if $tooltip-type == 'icon' {
+    cursor: pointer;
+  }
 
   &:focus {
     @include focus-outline('border');

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6487,6 +6487,9 @@ Map {
         ],
         "type": "oneOf",
       },
+      "disabled": Object {
+        "type": "bool",
+      },
       "id": Object {
         "type": "string",
       },

--- a/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
@@ -6,13 +6,15 @@
  */
 
 import React from 'react';
-<<<<<<< HEAD
-import { Add16, AddFilled16, Filter16, Search16 } from '@carbon/icons-react';
-=======
-import { Filter16, Information16 } from '@carbon/icons-react';
->>>>>>> 71c231cd4... feat(TooltipIcon): add disabled support
+import {
+  Add16,
+  AddFilled16,
+  Filter16,
+  Search16,
+  Information16,
+} from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, select, boolean } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
 import TooltipIcon from '../TooltipIcon';
 import mdx from './TooltipIcon.mdx';
 
@@ -47,9 +49,9 @@ const props = () => {
   const iconToUse = iconMap[select('Icon (icon)', icons, 'Filter16')];
 
   return {
-  disabled: boolean('Disabled (disabled)', false),
-  direction: select('Tooltip direction (direction)', directions, 'bottom'),
-  align: select('Tooltip alignment (align)', alignments, 'center'),
+    disabled: boolean('Disabled (disabled)', false),
+    direction: select('Tooltip direction (direction)', directions, 'bottom'),
+    align: select('Tooltip alignment (align)', alignments, 'center'),
     renderIcon: !iconToUse || iconToUse.svgData ? undefined : iconToUse,
     tooltipText: text('Tooltip content (tooltipText)', 'Filter'),
     onClick: action('onClick'),
@@ -68,7 +70,6 @@ export default {
   },
 };
 
-
 export const Default = () => (
   <div
     style={{
@@ -78,13 +79,25 @@ export const Default = () => (
       width: '200px',
     }}>
     <TooltipIcon
-      {...props()}
       tooltipText="Interactive tooltip"
-      onClick={action('onClick')}>
-      <Filter16 />
-    </TooltipIcon>
-    <TooltipIcon {...props()} tooltipText="Non-interactive tooltip">
-      <Information16 />
-    </TooltipIcon>
+      onClick={action('onClick')}
+      renderIcon={Filter16}
+    />
+    <TooltipIcon
+      tooltipText="Non-interactive tooltip"
+      renderIcon={Information16}
+    />
+  </div>
+);
+
+export const Playground = () => (
+  <div
+    style={{
+      padding: '2rem',
+      display: 'flex',
+      justifyContent: 'space-between',
+      width: '200px',
+    }}>
+    <TooltipIcon {...props()} />
   </div>
 );

--- a/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
@@ -10,6 +10,7 @@ import { Add16, AddFilled16, Filter16, Search16 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import TooltipIcon from '../TooltipIcon';
+import { Information16 } from '@carbon/icons-react';
 import mdx from './TooltipIcon.mdx';
 
 const directions = {
@@ -63,7 +64,26 @@ export default {
   },
 };
 
+<<<<<<< HEAD
 export const Default = () => <TooltipIcon {...props()} />;
+=======
+export const Default = () => (
+  <div
+    style={{
+      padding: '2rem',
+      display: 'flex',
+      justifyContent: 'space-between',
+      width: '200px',
+    }}>
+    <TooltipIcon {...props()}>
+      <Filter16 />
+    </TooltipIcon>
+    <TooltipIcon tooltipText="Non-interactive tooltip">
+      <Information16 />
+    </TooltipIcon>
+  </div>
+);
+>>>>>>> 942b60f2e... fix(TooltipIcon): prevent pointer cursor on nointeractive variant
 
 Default.storyName = 'default';
 

--- a/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon-story.js
@@ -6,11 +6,14 @@
  */
 
 import React from 'react';
+<<<<<<< HEAD
 import { Add16, AddFilled16, Filter16, Search16 } from '@carbon/icons-react';
+=======
+import { Filter16, Information16 } from '@carbon/icons-react';
+>>>>>>> 71c231cd4... feat(TooltipIcon): add disabled support
 import { action } from '@storybook/addon-actions';
-import { withKnobs, select, text } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean } from '@storybook/addon-knobs';
 import TooltipIcon from '../TooltipIcon';
-import { Information16 } from '@carbon/icons-react';
 import mdx from './TooltipIcon.mdx';
 
 const directions = {
@@ -44,8 +47,9 @@ const props = () => {
   const iconToUse = iconMap[select('Icon (icon)', icons, 'Filter16')];
 
   return {
-    direction: select('Tooltip direction (direction)', directions, 'bottom'),
-    align: select('Tooltip alignment (align)', alignments, 'center'),
+  disabled: boolean('Disabled (disabled)', false),
+  direction: select('Tooltip direction (direction)', directions, 'bottom'),
+  align: select('Tooltip alignment (align)', alignments, 'center'),
     renderIcon: !iconToUse || iconToUse.svgData ? undefined : iconToUse,
     tooltipText: text('Tooltip content (tooltipText)', 'Filter'),
     onClick: action('onClick'),
@@ -64,9 +68,7 @@ export default {
   },
 };
 
-<<<<<<< HEAD
-export const Default = () => <TooltipIcon {...props()} />;
-=======
+
 export const Default = () => (
   <div
     style={{
@@ -75,24 +77,14 @@ export const Default = () => (
       justifyContent: 'space-between',
       width: '200px',
     }}>
-    <TooltipIcon {...props()}>
+    <TooltipIcon
+      {...props()}
+      tooltipText="Interactive tooltip"
+      onClick={action('onClick')}>
       <Filter16 />
     </TooltipIcon>
-    <TooltipIcon tooltipText="Non-interactive tooltip">
+    <TooltipIcon {...props()} tooltipText="Non-interactive tooltip">
       <Information16 />
     </TooltipIcon>
   </div>
 );
->>>>>>> 942b60f2e... fix(TooltipIcon): prevent pointer cursor on nointeractive variant
-
-Default.storyName = 'default';
-
-Default.parameters = {
-  info: {
-    text: `
-      Icon tooltip is for short single line of text describing an icon.
-      Icon tooltip does not use any JavaScript. No label should be added to this variation.
-      If there are actions a user can take in the tooltip (e.g. a link or a button), use interactive tooltip.
-    `,
-  },
-};

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -117,6 +117,7 @@ const TooltipIcon = ({
 
   return (
     <button
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
       {...rest}
       type="button"
       className={tooltipTriggerClasses}

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -21,6 +21,7 @@ const TooltipIcon = ({
   className,
   children,
   direction,
+  disabled,
   align,
   onClick,
   onBlur,
@@ -44,7 +45,7 @@ const TooltipIcon = ({
     {
       [`${prefix}--tooltip--${direction}`]: direction,
       [`${prefix}--tooltip--align-${align}`]: align,
-      [`${prefix}--tooltip--hidden`]: !allowTooltipVisibility,
+      [`${prefix}--tooltip--hidden`]: !allowTooltipVisibility || disabled,
       [`${prefix}--tooltip--visible`]: isHovered,
     }
   );
@@ -74,17 +75,19 @@ const TooltipIcon = ({
   };
 
   const handleMouseEnter = (evt) => {
-    setIsHovered(true);
-    tooltipTimeout.current && clearTimeout(tooltipTimeout.current);
+    if (!disabled) {
+      setIsHovered(true);
+      tooltipTimeout.current && clearTimeout(tooltipTimeout.current);
 
-    if (evt.target === tooltipRef.current) {
+      if (evt.target === tooltipRef.current) {
+        setAllowTooltipVisibility(true);
+        return;
+      }
+
+      closeTooltips(evt);
+
       setAllowTooltipVisibility(true);
-      return;
     }
-
-    closeTooltips(evt);
-
-    setAllowTooltipVisibility(true);
   };
 
   const handleMouseLeave = () => {
@@ -115,9 +118,17 @@ const TooltipIcon = ({
     return () => document.removeEventListener('keydown', handleEscKeyDown);
   }, []);
 
+  let cursorStyle;
+  if (disabled) {
+    cursorStyle = 'not-allowed';
+  } else {
+    cursorStyle = onClick ? 'pointer' : 'default';
+  }
+
   return (
     <button
-      style={{ cursor: onClick ? 'pointer' : 'default' }}
+      disabled={disabled}
+      style={{ cursor: cursorStyle }}
       {...rest}
       type="button"
       className={tooltipTriggerClasses}
@@ -162,6 +173,11 @@ TooltipIcon.propTypes = {
    * Specify the direction of the tooltip. Can be either top or bottom.
    */
   direction: PropTypes.oneOf(['top', 'right', 'left', 'bottom']),
+
+  /**
+   * Specify whether the `<TooltipIcon>` should be disabled
+   */
+  disabled: PropTypes.bool,
 
   /**
    * Optionally specify a custom id for the tooltip. If one is not provided, we

--- a/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
+++ b/packages/react/src/components/TooltipIcon/__snapshots__/TooltipIcon-test.js.snap
@@ -15,6 +15,11 @@ exports[`TooltipIcon should allow the user to specify the direction 1`] = `
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    style={
+      Object {
+        "cursor": "default",
+      }
+    }
     type="button"
   >
     <span
@@ -44,6 +49,11 @@ exports[`TooltipIcon should render 1`] = `
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    style={
+      Object {
+        "cursor": "default",
+      }
+    }
     type="button"
   >
     <span


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8542

Removes the pointer cursor for `TooltipDefinition`, as the content shows on hover and is not interactive. Retains the pointer cursor for `TooltipIcon` if there is an `onClick`.

This also adds in proper `disabled` support for `TooltipIcon`. 

#### Changelog

**New**
- `TooltipIcon` now ships with a `disabled` prop that will change the cursor and icon fill
- Disabled tooltips now use `not-allowed` cursor

**Changed**

- Only add `cursor: pointer` if it is an `icon` tooltip with an `onClick`, otherwise use default cursor

#### Testing / Reviewing

Ensure no pointer cursor is added for `TooltipDefinition`, but it is still added for `TooltipIcon` (if `onClick` is present) and `Icon-only Button`. Ensure disabled styles render correctly for `TooltipIcon` and now tooltip is shown when it is disabled. 
