### PR TITLE
fix(overflow-menu): update ARIA role list items in OverflowMenuItem

### DIFF
--- a/packages/react/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/packages/react/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -186,12 +186,13 @@ export default class OverflowMenuItem extends React.Component {
       );
     })();
     return (
-      <li className={overflowMenuItemClasses} role="menuitem">
+      <li className={overflowMenuItemClasses} role="none">
         <TagToUse
           {...other}
           {...{
             'data-floating-menu-primary-focus': primaryFocus || null,
           }}
+          role="menuitem"
           href={href}
           className={overflowMenuBtnClasses}
           disabled={disabled}


### PR DESCRIPTION
Follow the menuitem pattern used here: https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html

Closes #7445

The JAWS screen reader is confused by a `button` inside of a `menuitem`. The containing `ul` is correctly a `menu`, so the li no longer has real semantic meaning. Those are therefore `role=none`. The `button` or `a[href]` element then becomes the focusable element and should have the `role=menuitem`.

#### Changelog

**Changed**

- Changed OverflowMenuItem `li` role to `none` and added `role="menuitem"` to the `button/a[href]`

#### Testing / Reviewing

Need to open an overflow menu in Firefox with JAWS and arrow up/down. It should simply read the options with 1 of X, 2 of X, etc without stating that it's leaving the menu. Reach out to @thbrunet on Slack if an example is deployed somewhere and you just need me to confirm with JAWS.
