### PR TITLE
fix(Tooltip): make screenreader description less verbose

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -505,12 +505,13 @@ class Tooltip extends Component {
       <>
         <ClickListener onClickOutside={this.handleClickOutside}>
           {showIcon ? (
-            <div id={triggerId} className={triggerClasses}>
+            <div className={triggerClasses}>
               {triggerText}
               <div
                 className={`${prefix}--tooltip__trigger`}
                 {...properties}
-                ref={refProp}>
+                ref={refProp}
+                aria-describedby={tooltipBodyId}>
                 <IconCustomElement {...iconProperties} />
               </div>
             </div>
@@ -519,7 +520,8 @@ class Tooltip extends Component {
               id={triggerId}
               className={triggerClasses}
               ref={refProp}
-              {...properties}>
+              {...properties}
+              aria-describedby={tooltipBodyId}>
               {triggerText}
             </div>
           )}
@@ -544,14 +546,9 @@ class Tooltip extends Component {
               onMouseOut={this.handleMouse}
               onFocus={this.handleMouse}
               onBlur={this.handleMouse}
-              onContextMenu={this.handleMouse}
-              role="tooltip">
+              onContextMenu={this.handleMouse}>
               <span className={`${prefix}--tooltip__caret`} />
-              <div
-                className={`${prefix}--tooltip__content`}
-                role="dialog"
-                aria-describedby={tooltipBodyId}
-                aria-labelledby={triggerId}>
+              <div className={`${prefix}--tooltip__content`} role="dialog">
                 {children}
               </div>
             </div>

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -505,7 +505,7 @@ class Tooltip extends Component {
       <>
         <ClickListener onClickOutside={this.handleClickOutside}>
           {showIcon ? (
-            <div className={triggerClasses}>
+            <div id={triggerId} className={triggerClasses}>
               {triggerText}
               <div
                 className={`${prefix}--tooltip__trigger`}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/7226

Makes screenreader for `Tooltip` less verbose. Found various examples that show accessible tooltips should be built, and almost all of them had the aria-describedby on the trigger element, and the actual "tooltip" content just served as the description, so this is what I went with here.

The one downside I can think of is that there wouldn't be a description if people don't include a `tooltipBodyId`, which currently isn't required. 


**Changed**
- moved `aria-describedby` from the tooltip content to the tooltip trigger (as seen in most examples)

**Removed**
- removed `role="tooltip"` per Carolyn's recommendation since we're already using `role="dialog"`
- removed `aria-labelledby` since we're already using `aria-describedby` (most documentation I found said to use one or the other to make it accessible for screen readers, but I haven't found any examples using both)

#### Testing / Reviewing
- Go to `Tooltip` story
- turn on voice over for testing
- tab to the tooltip icon, which should automatically open the tooltip dialog
- note that the tooltip dialog should be less verbose
    - compare to old dialog:
    - > Tooltip label button collapsed
Tooltip label Tooltip label
Tooltip label Tooltip label dialog This is some tooltip text. This box shows the maximum amount of text that should appear inside. If more room is needed please use a modal instead.
Learn More visited link
Tooltip label Tooltip label
visited link Learn More
button Create
