### PR TITLE
refactor(project): update enable-2021-release to enable-v11-release

### DIFF
--- a/packages/components/src/components/structured-list/_structured-list.scss
+++ b/packages/components/src/components/structured-list/_structured-list.scss
@@ -17,7 +17,7 @@
   .#{$prefix}--structured-list--selection .#{$prefix}--structured-list-th {
     @include padding--data-structured-list;
   }
-  @if feature-flag-enabled('enable-2021-release') {
+  @if feature-flag-enabled('enable-v11-release') {
     .#{$prefix}--structured-list-row--focused-within {
       @include focus-outline('outline');
     }
@@ -67,7 +67,7 @@
     cursor: inherit;
   }
 
-  @if not feature-flag-enabled('enable-2021-release') {
+  @if not feature-flag-enabled('enable-v11-release') {
     .#{$prefix}--structured-list-row:focus:not(.#{$prefix}--structured-list-row--header-row) {
       @include focus-outline('outline');
     }
@@ -123,7 +123,7 @@
     display: table-cell;
     max-width: 36rem;
     color: $text-secondary;
-    @if feature-flag-enabled('enable-2021-release') {
+    @if feature-flag-enabled('enable-v11-release') {
       border-top: 1px solid $border-subtle;
     }
 

--- a/packages/components/src/globals/scss/_feature-flags.scss
+++ b/packages/components/src/globals/scss/_feature-flags.scss
@@ -33,12 +33,12 @@ $default-feature-flags: (
   grid-columns-16: false,
   grid--fallback: false,
   enable-css-custom-properties: false,
-  enable-2021-release: false,
+  enable-v11-release: false,
 );
 
 $feature-flags: map-merge($default-feature-flags, $feature-flags);
 
-@if feature-flag-enabled('enable-2021-release') == true {
+@if feature-flag-enabled('enable-v11-release') == true {
   @if variable-exists(css--disable-css-custom-properties) ==
     false or
     $css--disable-css-custom-properties ==

--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -15,7 +15,7 @@
 // to make sure that they're in sync if one has diverged from the other.
 @include carbon--theme();
 
-@if not feature-flag-enabled('enable-2021-release') {
+@if not feature-flag-enabled('enable-v11-release') {
   $background: $ui-background;
   $layer: $ui-01;
   $layer-accent: $ui-03;

--- a/packages/components/src/globals/scss/styles.scss
+++ b/packages/components/src/globals/scss/styles.scss
@@ -61,7 +61,7 @@ $css--use-experimental-grid: false !default;
 /// @deprecated (For v10) v10 always uses `@carbon/grid`
 $css--use-experimental-grid-fallback: false !default;
 
-/// If `enable-2021-release` is set to `true`, it automatically enables the custom properties flag.
+/// If `enable-v11-release` is set to `true`, it automatically enables the custom properties flag.
 /// If so, we need a way to disable custom properties, but use the new tokens.
 /// @access public
 /// @type Bool

--- a/packages/feature-flags/feature-flags.yml
+++ b/packages/feature-flags/feature-flags.yml
@@ -18,7 +18,7 @@ feature-flags:
     description: >
       Enable CSS Grid Layout in the Grid and Column React components
     enabled: false
-  - name: enable-2021-release
+  - name: enable-v11-release
     description: >
-      Enable the features and functionality for the 2021 Release
+      Enable the features and functionality for the v11 Release
     enabled: false

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4666,7 +4666,7 @@ Map {
           "enable-css-custom-properties" => false,
           "enable-use-controlled-state-with-value" => false,
           "enable-css-grid" => false,
-          "enable-2021-release" => false,
+          "enable-v11-release" => false,
         },
       },
       "_currentValue2": FeatureFlagScope {
@@ -4674,7 +4674,7 @@ Map {
           "enable-css-custom-properties" => false,
           "enable-use-controlled-state-with-value" => false,
           "enable-css-grid" => false,
-          "enable-2021-release" => false,
+          "enable-v11-release" => false,
         },
       },
       "_threadCount": 0,

--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -118,7 +118,7 @@ const Button = React.forwardRef(function Button(
     return () => document.removeEventListener('keydown', handleEscKeyDown);
   }, []);
 
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
 
   const buttonClasses = classNames(className, {
     [`${prefix}--btn`]: true,

--- a/packages/react/src/components/Checkbox/Checkbox-story.js
+++ b/packages/react/src/components/Checkbox/Checkbox-story.js
@@ -43,7 +43,7 @@ export const checkbox = () => {
 
 export const unstable_Checkbox = () => {
   return (
-    <FeatureFlags flags={{ 'enable-2021-release': true }}>
+    <FeatureFlags flags={{ 'enable-v11-release': true }}>
       <fieldset className={`${prefix}--fieldset`}>
         <legend className={`${prefix}--label`}>Checkbox heading</legend>
         <Checkbox

--- a/packages/react/src/components/Checkbox/Checkbox.js
+++ b/packages/react/src/components/Checkbox/Checkbox.js
@@ -37,7 +37,7 @@ const Checkbox = React.forwardRef(function Checkbox(
     wrapperClassName
   );
 
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
 
   return (
     <div className={wrapperClasses}>

--- a/packages/react/src/components/Search/Search-story.js
+++ b/packages/react/src/components/Search/Search-story.js
@@ -84,7 +84,7 @@ export const SizeStory = () => (
     </div>
     <br />
     <br />
-    <FeatureFlags flags={{ 'enable-2021-release': true }}>
+    <FeatureFlags flags={{ 'enable-v11-release': true }}>
       <h3>Feature Flags: ENABLED</h3>
       <br />
       <br />

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -192,7 +192,7 @@ export default class Search extends Component {
     let enabled;
 
     if (scope.enabled) {
-      enabled = scope.enabled('enable-2021-release');
+      enabled = scope.enabled('enable-v11-release');
     }
 
     const searchClasses = classNames({

--- a/packages/react/src/components/StructuredList/index.js
+++ b/packages/react/src/components/StructuredList/index.js
@@ -24,7 +24,7 @@ import {
 import { useFeatureFlag } from '../FeatureFlags';
 
 export function StructuredListWrapper(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <StructuredListWrapperNext {...props} />;
   }
@@ -32,14 +32,14 @@ export function StructuredListWrapper(props) {
 }
 
 export function StructuredListHead(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <StructuredListHeadNext {...props} />;
   }
   return <StructuredListHeadClassic {...props} />;
 }
 export function StructuredListInput(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <StructuredListInputNext {...props} />;
   }
@@ -47,7 +47,7 @@ export function StructuredListInput(props) {
 }
 
 export function StructuredListBody(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <StructuredListBodyNext {...props} />;
   }
@@ -55,7 +55,7 @@ export function StructuredListBody(props) {
 }
 
 export function StructuredListRow(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <StructuredListRowNext {...props} />;
   }
@@ -63,7 +63,7 @@ export function StructuredListRow(props) {
 }
 
 export function StructuredListCell(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <StructuredListCellNext {...props} />;
   }

--- a/packages/react/src/components/Toggle/index.js
+++ b/packages/react/src/components/Toggle/index.js
@@ -13,7 +13,7 @@ import ToggleClassic from './Toggle';
 import { useFeatureFlag } from '../FeatureFlags';
 
 function Toggle(props) {
-  const enabled = useFeatureFlag('enable-2021-release');
+  const enabled = useFeatureFlag('enable-v11-release');
   if (enabled) {
     return <ToggleNext {...props} />;
   }


### PR DESCRIPTION
This PR updates our `enable-2021-release` flag to `enable-v11-release` and all code that currently uses that flag 👀 

#### Changelog

**New**

**Changed**

- Update v11 feature flag from `enable-2021-release` to `enable-v11-release`

**Removed**

#### Testing / Reviewing

- Verify all places where `enable-2021-release` was used is replaced by `enable-v11-release`