### PR TITLE
fix(PasswordInput): resolve visibility toggle style issues

### DIFF
--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -59,6 +59,14 @@
     padding-right: $carbon--spacing-08;
   }
 
+  .#{$prefix}--text-input--sm.#{$prefix}--password-input {
+    padding-right: $carbon--spacing-07;
+  }
+
+  .#{$prefix}--text-input--lg.#{$prefix}--password-input {
+    padding-right: $carbon--spacing-09;
+  }
+
   .#{$prefix}--text-input::placeholder {
     @include placeholder-colors;
   }
@@ -110,7 +118,7 @@
     right: 0;
     display: flex;
     width: rem(40px);
-    height: rem(40px);
+    height: 100%;
     min-height: auto;
     align-items: center;
     justify-content: center;
@@ -119,6 +127,16 @@
     background: none;
     cursor: pointer;
     transition: outline $duration--fast-01 motion(standard, productive);
+  }
+
+  .#{$prefix}--text-input--sm
+    + .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger {
+    width: rem(32px);
+  }
+
+  .#{$prefix}--text-input--lg
+    + .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger {
+    width: rem(48px);
   }
 
   .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger

--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -134,7 +134,7 @@
     }
   }
 
-  .#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:focus {
+  .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:focus {
     @include focus-outline('outline');
   }
 


### PR DESCRIPTION
Closes #8672

This PR restores the focus outline to the password input visibility toggle button and properly positions it for all component size variants

#### Testing / Reviewing

Verify that the focus border appears as expected on the password input visibility toggle and that it is properly sized and aligned in all size variants of the component