### PR TITLE
style(List): change from body-short-01 to body-long-01

### DIFF
--- a/packages/components/src/components/list/_list.scss
+++ b/packages/components/src/components/list/_list.scss
@@ -23,7 +23,7 @@
   .#{$prefix}--list--ordered,
   .#{$prefix}--list--ordered--native {
     @include reset;
-    @include type-style('body-short-01');
+    @include type-style('body-long-01');
 
     list-style: none;
   }


### PR DESCRIPTION
Based on request from @jeanservaas and @janchild 

#### Changelog

**Changed**

- Both list variants now use `body-long-01`, was `body-short-01`

#### Testing / Reviewing

Ensure the line-heights are correct in all variants 
