### PR TITLE
chore(storybook): reduce addon-docs to v5 package

### DIFF
--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -58,7 +58,7 @@
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@storybook/addon-actions": "^6.2.9",
-    "@storybook/addon-docs": "^6.2.9",
+    "@storybook/addon-docs": "^5.3.21",
     "@storybook/addon-essentials": "^6.2.9",
     "@storybook/react": "^6.2.9",
     "@storybook/theming": "^6.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,7 +1980,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^18.0.0
     "@rollup/plugin-node-resolve": ^11.2.1
     "@storybook/addon-actions": ^6.2.9
-    "@storybook/addon-docs": ^6.2.9
+    "@storybook/addon-docs": ^5.3.21
     "@storybook/addon-essentials": ^6.2.9
     "@storybook/react": ^6.2.9
     "@storybook/theming": ^6.2.9
@@ -4701,7 +4701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:6.2.9, @storybook/addon-docs@npm:^6.2.9":
+"@storybook/addon-docs@npm:6.2.9":
   version: 6.2.9
   resolution: "@storybook/addon-docs@npm:6.2.9"
   dependencies:


### PR DESCRIPTION
Fixes an issue with the storybook in `packages/react` that was causing an error during compilation. This should resolve this issue.

#### Changelog

**Changed**

- Reduces `@storybook/addon-docs` to `5.3.21` to match the other version

#### Testing / Reviewing

Ensure the storybooks in `packages/carbon-react` and `packages/react` both compile and render correctly
