### PR TITLE
chore(carbon-react): set hoisting limit to workspace

### DIFF
--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -86,5 +86,8 @@
   "sideEffects": [
     "es/feature-flags.js",
     "lib/feature-flags.js"
-  ]
+  ],
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  }
 }


### PR DESCRIPTION
Updates the hoisiting limits for `@carbon/react` so that v6 storybook does not get hoisted to the top level `node_modules` (causing `carbon-components-react` to break)

#### Changelog

**New**

**Changed**

- Set hoisting limits to workspace for `packages/carbon-react`

**Removed**

#### Testing / Reviewing

- Pull down PR
- Run install
- Run `yarn storybook` in `packages/react` to verify that it runs

_Note: you may need to clear our node_modules but this shouldn't be necessary_