### PR TITLE
refactor(sharedStyles): use param object instead of list of params

### DIFF
--- a/packages/sketch/src/commands/icons/shared.js
+++ b/packages/sketch/src/commands/icons/shared.js
@@ -57,6 +57,14 @@ function removeDeprecatedSymbolArtboards({ icons, sizes, symbolsPage }) {
   });
 }
 
+/**
+ * Sync Carbon icon symbols into current Sketch Document
+ * @param {object} params - syncIconSymbols parameters
+ * @param {Document} params.document - current document
+ * @param {Array<SymbolMaster>} params.symbols
+ * @param {Page} params.symbolsPage - the symbols page as identified by Sketch
+ * @param {Array<number>} params.sizes - array of icon sizes
+ */
 export function syncIconSymbols({
   document,
   symbols,

--- a/packages/sketch/src/commands/test/sync-shared-styles.js
+++ b/packages/sketch/src/commands/test/sync-shared-styles.js
@@ -133,10 +133,10 @@ export function testSyncSharedStyles() {
      */
     clear();
 
-    const textSharedStyle = syncSharedStyle(
+    const textSharedStyle = syncSharedStyle({
       document,
-      'test-shared-text-style',
-      {
+      name: 'test-shared-text-style',
+      style: {
         textColor: '#000000ff',
         fontSize: 16,
         textTransform: 'none',
@@ -149,19 +149,19 @@ export function testSyncSharedStyles() {
         alignment: 'left',
         styleType: SharedStyle.StyleType.Text,
       },
-      SharedStyle.StyleType.Text
-    );
+      styleType: SharedStyle.StyleType.Text,
+    });
 
     if (document.sharedTextStyles.length !== 1) {
       throw new Error('Expected sync command to generate a shared text style');
     }
 
-    syncSharedStyle(
+    syncSharedStyle({
       document,
-      'test-shared-text-style',
-      {},
-      SharedStyle.StyleType.Text
-    );
+      name: 'test-shared-text-style',
+      style: {},
+      styleType: SharedStyle.StyleType.Text,
+    });
 
     if (document.sharedTextStyles.length !== 1) {
       throw new Error(
@@ -189,14 +189,14 @@ export function testSyncSharedStyles() {
       throw new Error('Inserted layer is out of sync with shared text style');
     }
 
-    syncSharedStyle(
+    syncSharedStyle({
       document,
-      'test-shared-text-style',
-      {
+      name: 'test-shared-text-style',
+      style: {
         textColor: '#343434ff',
       },
-      SharedStyle.StyleType.Text
-    );
+      styleType: SharedStyle.StyleType.Text,
+    });
 
     if (getTextFillColor() !== '#343434ff') {
       throw new Error('Shared text style textColor was not updated');

--- a/packages/sketch/src/sharedStyles/type.js
+++ b/packages/sketch/src/sharedStyles/type.js
@@ -42,12 +42,12 @@ export function syncTextStyles(document) {
     .map((token) => {
       const name = formatSharedStyleName(token);
       const style = convertTypeStyle(token, styles[token]);
-      const sharedTextStyle = syncSharedStyle(
+      const sharedTextStyle = syncSharedStyle({
         document,
         name,
         style,
-        SharedStyle.StyleType.Text
-      );
+        styleType: SharedStyle.StyleType.Text,
+      });
 
       sharedTextStyle.style.textColor = '#000000ff';
       sharedTextStyle.style.borders = [];

--- a/packages/sketch/src/tools/sharedStyles.js
+++ b/packages/sketch/src/tools/sharedStyles.js
@@ -9,18 +9,19 @@ import { SharedStyle, Style } from 'sketch/dom';
 
 /**
  * Sync a shared style within a document.
- * @param {Document} document
- * @param {string} name
- * @param {object} style
- * @param {StyleType?} styleType
+ * @param {object} params - syncSharedStyle parameters
+ * @param {Document} params.document
+ * @param {string} params.name
+ * @param {object} params.style
+ * @param {StyleType?} params.styleType
  * @returns {SharedStyle}
  */
-export function syncSharedStyle(
+export function syncSharedStyle({
   document,
   name,
   style,
-  styleType = SharedStyle.StyleType.Layer
-) {
+  styleType = SharedStyle.StyleType.Layer,
+}) {
   // Figure out the type of shared style and try and find if we have already
   // created a shared style with the given name
   const documentSharedStyles =
@@ -84,12 +85,16 @@ export function syncSharedStyle(
  * @returns {SharedStyle}
  */
 export function syncColorStyle({ document, name, value }) {
-  return syncSharedStyle(document, name, {
-    fills: [
-      {
-        color: value,
-        fillType: Style.FillType.Color,
-      },
-    ],
+  return syncSharedStyle({
+    document,
+    name,
+    style: {
+      fills: [
+        {
+          color: value,
+          fillType: Style.FillType.Color,
+        },
+      ],
+    },
   });
 }


### PR DESCRIPTION
This PR adds in the refactoring from #8188 while it remains blocked. The `syncColorStyle`  function now uses a param object instead of a list of params. This helped with linting by triggering warnings with unused params while refactoring. It will also help in case new params need to be added in the future, since the order of the function params will be unimportant within the config object.

#### Testing / Reviewing

Confirm there are no regressions with the current plugin behavior since this change is 100% organizational

[carbon-elements.sketchplugin.zip](https://github.com/carbon-design-system/carbon/files/6495000/carbon-elements.sketchplugin.zip)