### PR TITLE
feat(Plex): add Plex package to carbon-react storybook

### DIFF
--- a/packages/carbon-react/.storybook/preview.js
+++ b/packages/carbon-react/.storybook/preview.js
@@ -24,6 +24,11 @@ export const globalTypes = {
           title: 'English',
           value: 'en',
         },
+        {
+          right: '🇵🇸',
+          title: 'Arabic',
+          value: 'ar',
+        },
       ],
     },
   },
@@ -83,11 +88,15 @@ configureActions({
 
 export const decorators = [
   (Story, context) => {
-    const { theme } = context.globals;
+    const { locale, theme } = context.globals;
 
     React.useEffect(() => {
       document.body.setAttribute('data-carbon-theme', theme);
     }, [theme]);
+
+    React.useEffect(() => {
+      document.documentElement.lang = locale;
+    }, [locale]);
 
     return <Story {...context} />;
   },

--- a/packages/carbon-react/.storybook/styles.scss
+++ b/packages/carbon-react/.storybook/styles.scss
@@ -5,7 +5,31 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+$feature-flags: (
+  enable-v11-release: true,
+);
+
+@use "~@ibm/plex/default" as sans;
+@use "~@ibm/plex/mono";
+@use "~@ibm/plex/arabic";
+
 @use '../index.scss' as styles;
+
+// For now, including all weights for testing
+@include arabic.all;
+// @include arabic.light;
+// @include arabic.regular;
+// @include arabic.semibold;
+
+@include sans.all;
+// @include sans.light;
+// @include sans.regular;
+// @include sans.semibold;
+
+@include mono.all;
+// @include mono.light;
+// @include mono.regular;
+// @include mono.semibold;
 
 body {
   @include styles.theme();
@@ -21,4 +45,17 @@ body {
 
 [data-carbon-theme='g100'] {
   @include styles.theme(styles.$g100);
+}
+
+html[lang='en'] body {
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+html[lang='ar'] body {
+  font-family: 'IBM Plex Sans Arabic', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.text-mono {
+  font-family: 'IBM Plex Mono', Menlo, 'DejaVu Sans Mono',
+    'Bitstream Vera Sans Mono', Courier, monospace;
 }

--- a/packages/carbon-react/.storybook/styles.scss
+++ b/packages/carbon-react/.storybook/styles.scss
@@ -17,19 +17,8 @@ $feature-flags: (
 
 // For now, including all weights for testing
 @include arabic.all;
-// @include arabic.light;
-// @include arabic.regular;
-// @include arabic.semibold;
-
 @include sans.all;
-// @include sans.light;
-// @include sans.regular;
-// @include sans.semibold;
-
 @include mono.all;
-// @include mono.light;
-// @include mono.regular;
-// @include mono.semibold;
 
 body {
   @include styles.theme();

--- a/packages/carbon-react/index.scss
+++ b/packages/carbon-react/index.scss
@@ -5,4 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@forward '@carbon/styles';
+@forward '@carbon/styles' with (
+  $css--font-face: false,
+  $css--default-type: false,
+);

--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -44,7 +44,8 @@
     "@carbon/icons-react": "^10.33.0",
     "@carbon/styles": "^0.7.0",
     "@carbon/telemetry": "0.0.0-alpha.6",
-    "carbon-components-react": "^7.36.0"
+    "carbon-components-react": "^7.36.0",
+    "@ibm/plex": "6.0.0-next.3"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",

--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -45,7 +45,7 @@
     "@carbon/styles": "^0.7.0",
     "@carbon/telemetry": "0.0.0-alpha.6",
     "carbon-components-react": "^7.36.0",
-    "@ibm/plex": "6.0.0-next.5"
+    "@ibm/plex": "6.0.0-next.6"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",

--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -45,7 +45,7 @@
     "@carbon/styles": "^0.7.0",
     "@carbon/telemetry": "0.0.0-alpha.6",
     "carbon-components-react": "^7.36.0",
-    "@ibm/plex": "6.0.0-next.3"
+    "@ibm/plex": "6.0.0-next.5"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",

--- a/packages/carbon-react/src/components/Plex/Plex.stories.js
+++ b/packages/carbon-react/src/components/Plex/Plex.stories.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+
+export default {
+  title: 'Components/Plex',
+  argTypes: {
+    fontWeight: {
+      defaultValue: 'Regular',
+      options: [
+        'Thin',
+        'Extra Light',
+        'Light',
+        'Regular',
+        'Text',
+        'Medium',
+        'SemiBold',
+        'Bold',
+      ],
+      mapping: {
+        Thin: 100,
+        'Extra Light': 200,
+        Light: 300,
+        Regular: 400,
+        Text: 450,
+        Medium: 500,
+        SemiBold: 600,
+        Bold: 700,
+      },
+      control: { type: 'radio' },
+    },
+    fontSize: {
+      defaultValue: 16,
+      control: { type: 'range', min: 12, max: 54, step: 4 },
+    },
+  },
+};
+
+export const English = (args) => {
+  return (
+    <p dir="auto" style={args}>
+      This paragraph is in English and correctly goes left to right.
+    </p>
+  );
+};
+
+export const Mono = (args) => {
+  return (
+    <code className="text-mono" style={args}>
+      This paragraph is in English and is monospaced.
+    </code>
+  );
+};
+
+export const Arabic = (args) => {
+  return (
+    <p dir="auto" style={args}>
+      هذه الفقرة باللغة العربية ، لذا يجب الانتقال من اليمين إلى اليسار.
+    </p>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,7 +1977,7 @@ __metadata:
     "@carbon/styles": ^0.7.0
     "@carbon/telemetry": 0.0.0-alpha.6
     "@carbon/themes": ^10.35.0
-    "@ibm/plex": 6.0.0-next.5
+    "@ibm/plex": 6.0.0-next.6
     "@rollup/plugin-babel": ^5.3.0
     "@rollup/plugin-commonjs": ^18.0.0
     "@rollup/plugin-node-resolve": ^11.2.1
@@ -2816,10 +2816,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex@npm:6.0.0-next.5":
-  version: 6.0.0-next.5
-  resolution: "@ibm/plex@npm:6.0.0-next.5"
-  checksum: 271a083f909f43a5631cf69f10c1b0099989dfb69c1de5ae3f2d8d7cab2bada7b287dcc5ca6f4bd22cc8049f8b62a61b4203f3f2fe0dd2fa0ad4b5d99fddcc26
+"@ibm/plex@npm:6.0.0-next.6":
+  version: 6.0.0-next.6
+  resolution: "@ibm/plex@npm:6.0.0-next.6"
+  checksum: cb7bece0f8688cf92a3fa37ab47c5921f22a2eb5e40dd72a3d6bbcd715910b0d79f9d160e229514a0c78c70679676746a93f4791a57407fc6aa636105aa11891
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,6 +2815,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ibm/plex@npm:6.0.0-next.3":
+  version: 6.0.0-next.3
+  resolution: "@ibm/plex@npm:6.0.0-next.3"
+  checksum: 72853234602a16a4fe8b934a8920584797802b96b82829cc822ef9abdba61d60dffcf391e7efc8854dca82927266b00db8ed18c758f06acc65ed9c428d0f3820
+  languageName: node
+  linkType: hard
+
 "@icons/material@npm:^0.2.4":
   version: 0.2.4
   resolution: "@icons/material@npm:0.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,6 +1977,7 @@ __metadata:
     "@carbon/styles": ^0.7.0
     "@carbon/telemetry": 0.0.0-alpha.6
     "@carbon/themes": ^10.35.0
+    "@ibm/plex": 6.0.0-next.5
     "@rollup/plugin-babel": ^5.3.0
     "@rollup/plugin-commonjs": ^18.0.0
     "@rollup/plugin-node-resolve": ^11.2.1
@@ -2815,10 +2816,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex@npm:6.0.0-next.4":
-  version: 6.0.0-next.4
-  resolution: "@ibm/plex@npm:6.0.0-next.4"
-  checksum: 188827f27431d561111dc39976de1b634deabfd29034074241a9f6f1ef48dee3b589d29e97ed4f65c8d1e1acfacf69577afe313f6042abcb574f85c63754b9e0
+"@ibm/plex@npm:6.0.0-next.5":
+  version: 6.0.0-next.5
+  resolution: "@ibm/plex@npm:6.0.0-next.5"
+  checksum: 271a083f909f43a5631cf69f10c1b0099989dfb69c1de5ae3f2d8d7cab2bada7b287dcc5ca6f4bd22cc8049f8b62a61b4203f3f2fe0dd2fa0ad4b5d99fddcc26
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,10 +2815,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex@npm:6.0.0-next.3":
-  version: 6.0.0-next.3
-  resolution: "@ibm/plex@npm:6.0.0-next.3"
-  checksum: 72853234602a16a4fe8b934a8920584797802b96b82829cc822ef9abdba61d60dffcf391e7efc8854dca82927266b00db8ed18c758f06acc65ed9c428d0f3820
+"@ibm/plex@npm:6.0.0-next.4":
+  version: 6.0.0-next.4
+  resolution: "@ibm/plex@npm:6.0.0-next.4"
+  checksum: 188827f27431d561111dc39976de1b634deabfd29034074241a9f6f1ef48dee3b589d29e97ed4f65c8d1e1acfacf69577afe313f6042abcb574f85c63754b9e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8711
Closes https://github.com/carbon-design-system/carbon/issues/8712

Adds in the `@ibm/plex` package, as well as enhancing the `locale` switcher to allow a user to change the locale to `Arabic`. This can be used to test that the `IBM Plex Sans Arabic` is properly loaded in. 

#### Changelog

**New**

- a `Plex` story, that shows the 3 font styles currently supported in the `@ibm/plex` package (`Sans`, `Mono`, and `Arabic`)
- A `fontWeight` and `fontSize` switcher, to test the different weights (and increase `font-size` for easier testing)


#### Testing / Reviewing

In the storybook, use the locale switcher to switch between `en` and `ar` and ensure the correct fonts are loaded when viewing the `Arabic` story
