### PR TITLE
fix(DatePicker): avoid unknown attribute on div

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -596,6 +596,7 @@ export default class DatePicker extends Component {
 
   render() {
     const {
+      allowInput, // eslint-disable-line
       appendTo, // eslint-disable-line
       children,
       className,


### PR DESCRIPTION
Closes #8743
related #7037

This PR avoids adding the `allowInput` prop as an unknown attribute on the date picker container

#### Testing / Reviewing

Confirm that no prop warnings are emitted after setting a value for `allowInput` on `<DatePicker />`