### PR TITLE
feat(Breadcrumb): add breadcrumb styles and tests

### DIFF
--- a/packages/carbon-react/.storybook/main.js
+++ b/packages/carbon-react/.storybook/main.js
@@ -71,7 +71,6 @@ module.exports = {
             postcssOptions: {
               plugins: [
                 require('postcss-custom-properties')(),
-                require('rtlcss')(),
                 require('autoprefixer')({
                   overrideBrowserslist: ['last 1 version'],
                 }),

--- a/packages/carbon-react/.storybook/manager-head.html
+++ b/packages/carbon-react/.storybook/manager-head.html
@@ -53,7 +53,7 @@
     color: #161616;
   }
 
-  .simplebar-content .sidebar-item.selected {
+  a.sidebar-item[data-selected='true'] {
     color: #161616;
   }
 </style>

--- a/packages/carbon-react/.storybook/preview-head.html
+++ b/packages/carbon-react/.storybook/preview-head.html
@@ -12,7 +12,18 @@
   }
 
   .sbdocs-wrapper .sbdocs-h2 {
-    margin-bottom: 0;
     padding-bottom: 12px;
+    margin-bottom: 0;
+  }
+
+  .sb-show-main.sb-main-padded {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 42px;
+  }
+
+  body #root {
+    width: 100%;
   }
 </style>

--- a/packages/carbon-react/src/components/Accordion/Accordion.stories.js
+++ b/packages/carbon-react/src/components/Accordion/Accordion.stories.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// import Accordion, {
+//   AccordionItem,
+// } from 'carbon-components-react/es/components/Accordion';
+import React from 'react';
+
+export default {
+  title: 'Components/Accordion',
+};
+
+export const Default = () => {
+  return (
+    <p>Test</p>
+    // <Accordion>
+    //   <AccordionItem title="Section 1 title">
+    //     <p>
+    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+    //       aliquip ex ea commodo consequat.
+    //     </p>
+    //   </AccordionItem>
+    //   <AccordionItem title="Section 2 title">
+    //     <p>
+    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+    //       aliquip ex ea commodo consequat.
+    //     </p>
+    //   </AccordionItem>
+    //   <AccordionItem title="Section 3 title">
+    //     <p>
+    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+    //       aliquip ex ea commodo consequat.
+    //     </p>
+    //   </AccordionItem>
+    //   <AccordionItem title="Section 4 title">
+    //     <p>
+    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+    //       aliquip ex ea commodo consequat.
+    //     </p>
+    //   </AccordionItem>
+    // </Accordion>
+  );
+};

--- a/packages/carbon-react/src/components/Accordion/Accordion.stories.js
+++ b/packages/carbon-react/src/components/Accordion/Accordion.stories.js
@@ -5,9 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// import Accordion, {
-//   AccordionItem,
-// } from 'carbon-components-react/es/components/Accordion';
+import { Accordion, AccordionItem } from 'carbon-components-react';
 import React from 'react';
 
 export default {
@@ -16,40 +14,39 @@ export default {
 
 export const Default = () => {
   return (
-    <p>Test</p>
-    // <Accordion>
-    //   <AccordionItem title="Section 1 title">
-    //     <p>
-    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-    //       aliquip ex ea commodo consequat.
-    //     </p>
-    //   </AccordionItem>
-    //   <AccordionItem title="Section 2 title">
-    //     <p>
-    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-    //       aliquip ex ea commodo consequat.
-    //     </p>
-    //   </AccordionItem>
-    //   <AccordionItem title="Section 3 title">
-    //     <p>
-    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-    //       aliquip ex ea commodo consequat.
-    //     </p>
-    //   </AccordionItem>
-    //   <AccordionItem title="Section 4 title">
-    //     <p>
-    //       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    //       eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-    //       minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-    //       aliquip ex ea commodo consequat.
-    //     </p>
-    //   </AccordionItem>
-    // </Accordion>
+    <Accordion>
+      <AccordionItem title="Section 1 title">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </AccordionItem>
+      <AccordionItem title="Section 2 title">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </AccordionItem>
+      <AccordionItem title="Section 3 title">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </AccordionItem>
+      <AccordionItem title="Section 4 title">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </AccordionItem>
+    </Accordion>
   );
 };

--- a/packages/carbon-react/src/components/Accordion/index.js
+++ b/packages/carbon-react/src/components/Accordion/index.js
@@ -1,0 +1,1 @@
+export { Accordion, AccordionItem } from 'carbon-components-react';

--- a/packages/carbon-react/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/packages/carbon-react/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// import {
+//   Breadcrumb,
+//   BreadcrumbItem,
+// } from 'carbon-components-react/es/components/Breadcrumb';
+import React from 'react';
+
+export default {
+  title: 'Components/Breadcrumb',
+};
+
+export const Default = () => {
+  return (
+    // <Breadcrumb>
+    //   <BreadcrumbItem>
+    //     <a href="/#">Breadcrumb 1</a>
+    //   </BreadcrumbItem>
+    //   <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+    //   <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
+    // </Breadcrumb>
+    <p>Test</p>
+  );
+};

--- a/packages/carbon-react/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/packages/carbon-react/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -5,10 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// import {
-//   Breadcrumb,
-//   BreadcrumbItem,
-// } from 'carbon-components-react/es/components/Breadcrumb';
+import { Breadcrumb, BreadcrumbItem } from 'carbon-components-react';
 import React from 'react';
 
 export default {
@@ -17,13 +14,12 @@ export default {
 
 export const Default = () => {
   return (
-    // <Breadcrumb>
-    //   <BreadcrumbItem>
-    //     <a href="/#">Breadcrumb 1</a>
-    //   </BreadcrumbItem>
-    //   <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-    //   <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
-    // </Breadcrumb>
-    <p>Test</p>
+    <Breadcrumb>
+      <BreadcrumbItem>
+        <a href="/#">Breadcrumb 1</a>
+      </BreadcrumbItem>
+      <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+      <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
+    </Breadcrumb>
   );
 };

--- a/packages/carbon-react/src/components/Breadcrumb/index.js
+++ b/packages/carbon-react/src/components/Breadcrumb/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { Breadcrumb, BreadcrumbItem } from 'carbon-components-react';

--- a/packages/styles/scss/components/__tests__/breadcrumb-test.js
+++ b/packages/styles/scss/components/__tests__/breadcrumb-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const { SassRenderer } = require('@carbon/test-utils/scss');
+
+const { render } = SassRenderer.create(__dirname);
+
+describe('scss/components/breadcrumb', () => {
+  test('Public API', async () => {
+    const { unwrap } = await render(`
+      @use 'sass:map';
+      @use 'sass:meta';
+      @use '../breadcrumb';
+
+      $_: get('mixin', meta.mixin-exists('breadcrumb', 'breadcrumb'));
+    `);
+    expect(unwrap('mixin')).toBe(true);
+  });
+});

--- a/packages/styles/scss/components/breadcrumb/_breadcrumb.scss
+++ b/packages/styles/scss/components/breadcrumb/_breadcrumb.scss
@@ -11,13 +11,12 @@
 @use '../../spacing' as *;
 @use '../../theme' as *;
 @use '../../type' as *;
-@use '../../utilities/component-reset';
-@use '../../utilities/convert';
+@use '../../utilities/convert' as *;
 @use '../../utilities/skeleton' as *;
 
 @mixin breadcrumb {
   .#{$prefix}--breadcrumb {
-    @include component-reset.reset;
+    @include reset;
     @include type-style('body-short-01');
 
     display: inline;
@@ -127,7 +126,7 @@
     outline: none;
   }
 
-  $caret-size: convert.rem(7px);
+  $caret-size: rem(7px);
   .#{$prefix}--breadcrumb-menu-options.#{$prefix}--overflow-menu-options::after {
     top: -$caret-size;
     left: $caret-size * 2;

--- a/packages/styles/scss/components/breadcrumb/_breadcrumb.scss
+++ b/packages/styles/scss/components/breadcrumb/_breadcrumb.scss
@@ -1,0 +1,150 @@
+//
+// Copyright IBM Corp. 2018, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../breakpoint' as *;
+@use '../../config' as *;
+@use '../../motion' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type' as *;
+@use '../../utilities/component-reset';
+@use '../../utilities/convert';
+@use '../../utilities/skeleton' as *;
+
+@mixin breadcrumb {
+  .#{$prefix}--breadcrumb {
+    @include component-reset.reset;
+    @include type-style('body-short-01');
+
+    display: inline;
+
+    @include breakpoint(md) {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  }
+
+  .#{$prefix}--breadcrumb-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin-right: $spacing-03;
+  }
+
+  .#{$prefix}--breadcrumb-item .#{$prefix}--link:visited {
+    color: $link-primary;
+
+    &:hover {
+      color: $link-primary-hover;
+    }
+  }
+
+  .#{$prefix}--breadcrumb-item::after {
+    margin-left: $spacing-03;
+    color: $text-primary;
+    content: '/';
+  }
+
+  .#{$prefix}--breadcrumb--no-trailing-slash
+    .#{$prefix}--breadcrumb-item:last-child::after {
+    content: '';
+  }
+
+  .#{$prefix}--breadcrumb-item:last-child,
+  .#{$prefix}--breadcrumb-item:last-child::after {
+    margin-right: 0;
+  }
+
+  .#{$prefix}--breadcrumb .#{$prefix}--link {
+    white-space: nowrap;
+  }
+
+  .#{$prefix}--breadcrumb-item [aria-current='page'],
+  .#{$prefix}--breadcrumb-item.#{$prefix}--breadcrumb-item--current
+    .#{$prefix}--link {
+    color: $text-primary;
+    cursor: auto;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  // Overflow Menu overrides
+  .#{$prefix}--breadcrumb-item .#{$prefix}--overflow-menu {
+    position: relative;
+    width: rem(20px);
+    height: rem(18px);
+
+    &:focus {
+      outline: 1px solid $focus;
+    }
+
+    &:hover {
+      background: transparent;
+    }
+
+    // Used to mimic link underline
+    &::after {
+      position: absolute;
+      bottom: 2px;
+      width: rem(12px);
+      height: 1px;
+      background: $link-primary-hover;
+      content: '';
+      opacity: 0;
+      transition: opacity $duration-fast-01 motion(standard, productive);
+    }
+  }
+
+  .#{$prefix}--breadcrumb-item .#{$prefix}--overflow-menu:hover::after {
+    opacity: 1;
+  }
+
+  .#{$prefix}--breadcrumb-item
+    .#{$prefix}--overflow-menu.#{$prefix}--overflow-menu--open {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .#{$prefix}--breadcrumb-item .#{$prefix}--overflow-menu__icon {
+    position: relative;
+    fill: $link-primary;
+    transform: translateY(4px);
+  }
+
+  .#{$prefix}--breadcrumb-item
+    .#{$prefix}--overflow-menu:hover
+    .#{$prefix}--overflow-menu__icon {
+    fill: $link-primary-hover;
+  }
+
+  .#{$prefix}--breadcrumb-menu-options:focus {
+    outline: none;
+  }
+
+  $caret-size: convert.rem(7px);
+  .#{$prefix}--breadcrumb-menu-options.#{$prefix}--overflow-menu-options::after {
+    top: -$caret-size;
+    left: $caret-size * 2;
+    width: 0;
+    height: 0;
+    border-right: $caret-size solid transparent;
+    border-bottom: $caret-size solid $field;
+    border-left: $caret-size solid transparent;
+    margin: 0 auto;
+    background: transparent;
+  }
+
+  // Skeleton State
+  .#{$prefix}--breadcrumb.#{$prefix}--skeleton .#{$prefix}--link {
+    @include skeleton;
+
+    width: rem(100px);
+    height: 1rem;
+  }
+}

--- a/packages/styles/scss/components/breadcrumb/_index.scss
+++ b/packages/styles/scss/components/breadcrumb/_index.scss
@@ -5,8 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use 'accordion';
+@forward 'breadcrumb';
 @use 'breadcrumb';
-@use 'link';
-@use 'list';
-@use 'loading';
+
+@include breadcrumb.breadcrumb;

--- a/packages/styles/scss/utilities/_skeleton.scss
+++ b/packages/styles/scss/utilities/_skeleton.scss
@@ -6,6 +6,7 @@
 //
 
 @use 'keyframes';
+@use '../theme' as *;
 
 /// Skeleton loading animation
 /// @access public


### PR DESCRIPTION
Refs #8555 

Begins work on bringing `Breadcrumb` to the `@carbon/styles` package

#### Changelog

**New**

- Styles added for `Breadcrumb`
- Stories added for `Accordion` and `Breadcrumb` (WIP: storybook is not working properly with them in)

**Changed**

- Added a necessary import to `skeleton` utility file

#### Testing / Reviewing

Pull down the PR locally, go to `carbon-react` folder and run `yarn storybook`. Ensure `Accordion` and `Breadcrumb` render properly