### PR TITLE
fix(sketch): hide shared color styles sync command

### DIFF
--- a/packages/sketch/src/commands/colors/index.js
+++ b/packages/sketch/src/commands/colors/index.js
@@ -5,5 +5,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { sync, syncColorVars } from './sync';
+export { syncColorVars } from './sync';
 export { generate } from './generate';

--- a/packages/sketch/src/commands/colors/sync.js
+++ b/packages/sketch/src/commands/colors/sync.js
@@ -7,16 +7,10 @@
 
 import { Document } from 'sketch/dom';
 import { command } from '../command';
-import { syncColorStyles, syncColorVariables } from '../../sharedStyles/colors';
-
-export function sync() {
-  command('commands/colors/sync', () => {
-    syncColorStyles({ document: Document.getSelectedDocument() });
-  });
-}
+import { syncColorVariables } from '../../sharedStyles/colors';
 
 export function syncColorVars() {
-  command('commands/colors/syncvars', () => {
+  command('commands/colors/syncColorVars', () => {
     syncColorVariables({ document: Document.getSelectedDocument() });
   });
 }

--- a/packages/sketch/src/commands/index.js
+++ b/packages/sketch/src/commands/index.js
@@ -12,11 +12,7 @@ import 'regenerator-runtime/runtime';
 // triggered by having separate entrypoints. Most notably we would encounter
 // parse errors because the bundlers were being generated incorrectly during
 // incremental rebuilds.
-export {
-  sync as syncColors,
-  syncColorVars,
-  generate as generateColors,
-} from './colors';
+export { syncColorVars, generate as generateColors } from './colors';
 export { generate as generateIcons } from './icons';
 export { syncSmallIcons, syncLargeIcons } from './icons';
 export { sync as syncThemes, generate as generateThemes } from './themes';

--- a/packages/sketch/src/commands/test/sync-shared-styles.js
+++ b/packages/sketch/src/commands/test/sync-shared-styles.js
@@ -45,14 +45,14 @@ export function testSyncSharedStyles() {
     const sharedStyle = syncColorStyle({
       document,
       name: 'black',
-      value: '#000000',
+      color: '#000000',
     });
 
     if (document.sharedLayerStyles.length !== 1) {
       throw new Error('Expected sync command to generate a shared layer style');
     }
 
-    syncColorStyle({ document, name: 'black', value: '#000000' });
+    syncColorStyle({ document, name: 'black', color: '#000000' });
 
     if (document.sharedLayerStyles.length !== 1) {
       throw new Error(
@@ -122,7 +122,7 @@ export function testSyncSharedStyles() {
       throw new Error('The layer is not in sync with the shared style');
     }
 
-    syncColorStyle({ document, name: 'black', value: '#dedede' });
+    syncColorStyle({ document, name: 'black', color: '#dedede' });
 
     if (getLayerFillColor() !== '#dededeff') {
       throw new Error('The layer did not update to the new shared style');

--- a/packages/sketch/src/manifest.json
+++ b/packages/sketch/src/manifest.json
@@ -5,14 +5,8 @@
   "name": "Carbon Elements 🎨",
   "commands": [
     {
-      "name": "Sync shared layer styles",
-      "identifier": "carbon.elements.colors.sync",
-      "script": "commands/index.js",
-      "handler": "syncColors"
-    },
-    {
       "name": "Sync color variables",
-      "identifier": "carbon.elements.colors.syncvars",
+      "identifier": "carbon.elements.colors.syncColorVars",
       "script": "commands/index.js",
       "handler": "syncColorVars"
     },
@@ -82,8 +76,7 @@
       {
         "title": "Colors",
         "items": [
-          "carbon.elements.colors.sync",
-          "carbon.elements.colors.syncvars",
+          "carbon.elements.colors.syncColorVars",
           "carbon.elements.colors.generate"
         ]
       },

--- a/packages/sketch/src/sharedStyles/colors.js
+++ b/packages/sketch/src/sharedStyles/colors.js
@@ -47,6 +47,8 @@ function formatColorName({ name, grade, formatFor }) {
  * the result
  * @param {object} params - syncColors parameters
  * @param {Document} params.document
+ * @param {string} params.formatFor - one of 'colorVariable' or
+ * 'sharedLayerStyle'
  * @returns {Array<SharedStyle|Swatch>}
  */
 export function syncColors({ document, formatFor }) {

--- a/packages/sketch/src/sharedStyles/colors.js
+++ b/packages/sketch/src/sharedStyles/colors.js
@@ -55,7 +55,7 @@ export function syncColorStyles({ document }) {
       return syncColorStyle({
         document,
         name: formatColorName({ name, grade, formatFor: 'sharedLayerStyle' }),
-        value: swatches[swatchName][grade],
+        color: swatches[swatchName][grade],
       });
     });
     return result;
@@ -66,11 +66,11 @@ export function syncColorStyles({ document }) {
     ['white', white['0']],
     ['orange', orange['40']],
     ['yellow', yellow['30']],
-  ].map(([name, value]) => {
+  ].map(([name, color]) => {
     return syncColorStyle({
       document,
       name: formatColorName({ name, formatFor: 'sharedLayerStyle' }),
-      value,
+      color,
     });
   });
 

--- a/packages/sketch/src/sharedStyles/themes.js
+++ b/packages/sketch/src/sharedStyles/themes.js
@@ -46,7 +46,7 @@ export function syncThemeColorStyles(document) {
         return syncColorStyle({
           document,
           name,
-          value: themes[theme][token],
+          color: themes[theme][token],
         });
       });
   });

--- a/packages/sketch/src/tools/colorVariables.js
+++ b/packages/sketch/src/tools/colorVariables.js
@@ -15,7 +15,7 @@ import { Swatch } from 'sketch/dom';
  * @param {Document} params.document
  * @param {string} params.name - color name
  * @param {string} params.color - color hex
- * @returns {void}
+ * @returns {Array<Swatch>}
  */
 export function syncColorVariable({ document, name, color }) {
   // check existing color variables
@@ -64,4 +64,6 @@ export function syncColorVariable({ document, name, color }) {
       .sharedSwatches();
     swatchContainer.updateReferencesToSwatch(colorVariable.sketchObject);
   }
+
+  return document.swatches;
 }

--- a/packages/sketch/src/tools/sharedStyles.js
+++ b/packages/sketch/src/tools/sharedStyles.js
@@ -84,14 +84,14 @@ export function syncSharedStyle({
  * @param {string} params.value
  * @returns {SharedStyle}
  */
-export function syncColorStyle({ document, name, value }) {
+export function syncColorStyle({ document, name, color }) {
   return syncSharedStyle({
     document,
     name,
     style: {
       fills: [
         {
-          color: value,
+          color,
           fillType: Style.FillType.Color,
         },
       ],

--- a/packages/sketch/src/tools/sharedStyles.js
+++ b/packages/sketch/src/tools/sharedStyles.js
@@ -81,7 +81,7 @@ export function syncSharedStyle({
  * @param {object} params - syncColorStyle parameters
  * @param {Document} params.document
  * @param {string} params.name
- * @param {string} params.value
+ * @param {string} params.color
  * @returns {SharedStyle}
  */
 export function syncColorStyle({ document, name, color }) {


### PR DESCRIPTION
Closes #8766

This PR introduces a new `syncColors` function to handle syncing of shared layer color styles and color variables. The sync shared styles command for colors is also hidden from the plugin menu now and kept as an internal shared function only

#### Testing / Reviewing

Confirm that color variables still sync as expected, and there are no regressions with commands that rely on the color shared styles commands e.g. icons sync

[carbon-elements.sketchplugin.zip](https://github.com/carbon-design-system/carbon/files/6549172/carbon-elements.sketchplugin.zip)

