### PR TITLE
fix(breadcrumb): prevent wrapping to second line

### DIFF
--- a/packages/components/src/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/src/components/breadcrumb/_breadcrumb.scss
@@ -21,8 +21,8 @@
     @include type-style('body-short-01');
 
     display: flex;
-    flex-wrap: nowrap;
     overflow: hidden;
+    flex-wrap: nowrap;
   }
 
   .#{$prefix}--breadcrumb-item {

--- a/packages/components/src/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/src/components/breadcrumb/_breadcrumb.scss
@@ -20,12 +20,9 @@
     @include reset;
     @include type-style('body-short-01');
 
-    display: inline;
-
-    @include carbon--breakpoint(md) {
-      display: flex;
-      flex-wrap: wrap;
-    }
+    display: flex;
+    flex-wrap: nowrap;
+    overflow: hidden;
   }
 
   .#{$prefix}--breadcrumb-item {


### PR DESCRIPTION
Closes #8779

Prevent breadcrumbs from wrapping to a second line. I do have some reservations on this change request and would like some feedback:

The initial issue points this out, but the [breadcrumb guidance](https://www.carbondesignsystem.com/components/breadcrumb/usage/#overflow-content) on the webstie states

> Breadcrumbs should never wrap onto a second line.

@carbon-design-system/design How literally should we interpret this? I _think_ the intent is that when breadcrumbs would be too long and begin wrapping, consumers should instead switch to the "overflow menu mode".  I'm not sure if we should force breadcrumbs to stay on a single line like this and use `overflow: hidden` to ensure they don't resize when they hit the browser edge on smaller screen sizes.

#### Changelog

**Changed**

- breadcrumb: prevent items from wrapping to second line

#### Testing / Reviewing

Breadcrumb items should not wrap at small screen sizes. Try adding double/triple the amount of breadcrumb item `li`'s and see how it clips the ones that are beyond the browser's edge.


https://user-images.githubusercontent.com/3360588/119901559-ae046080-bf0b-11eb-8d14-307ba20ab4d0.mov


