### PR TITLE
fix(eslint-config): include rules in files source array

### DIFF
--- a/config/eslint-config-carbon/package.json
+++ b/config/eslint-config-carbon/package.json
@@ -12,6 +12,7 @@
   "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "plugins",
+    "rules",
     "base.js",
     "index.js",
     "react.js",


### PR DESCRIPTION
Closes #8774 

Adds the `rules` folder to the files source array in `package.json`. 

#### Changelog

**New**

**Changed**

- Add the `rules` folder to the files source array in `package.json`

**Removed**
