### PR TITLE
feat(styles): add component stylesheets

### DIFF
--- a/packages/styles/scss/__tests__/__snapshots__/motion-test.js.snap
+++ b/packages/styles/scss/__tests__/__snapshots__/motion-test.js.snap
@@ -15,6 +15,8 @@ Object {
     "duration-moderate-02": "240ms",
     "duration-slow-01": "400ms",
     "duration-slow-02": "700ms",
+    "ease-in": "cubic-bezier(0, 0, 0.38, 0.9)",
+    "ease-out": "cubic-bezier(0.2, 0, 1, 0.9)",
     "easings": Object {
       "entrance": Object {
         "expressive": "cubic-bezier(0, 0, 0.3, 1)",
@@ -29,6 +31,9 @@ Object {
         "productive": "cubic-bezier(0.2, 0, 0.38, 0.9)",
       },
     },
+    "standard-easing": "cubic-bezier(0.2, 0, 0.38, 0.9)",
+    "transition--base": "110ms",
+    "transition--expansion": "240ms",
   },
 }
 `;

--- a/packages/styles/scss/_motion.scss
+++ b/packages/styles/scss/_motion.scss
@@ -6,3 +6,62 @@
 //
 
 @forward '@carbon/motion';
+@use '@carbon/motion';
+
+/// Used primarily for removing elements from the screen
+/// @type Function
+/// @access public
+/// @group global-motion
+$ease-in: cubic-bezier(0.25, 0, 1, 1);
+
+/// Used for adding elements to the screen or changing on-screen states at a users's input
+/// @type Function
+/// @access public
+/// @group global-motion
+$ease-out: cubic-bezier(0, 0, 0.25, 1);
+
+/// Used for the majority of animations
+/// @type Function
+/// @access public
+/// @group global-motion
+$standard-easing: cubic-bezier(0.5, 0, 0.1, 1);
+
+/// Base transition duration
+/// @type Number
+/// @access public
+/// @group global-motion
+$transition--base: 250ms;
+
+/// Expansion duration
+/// @type Number
+/// @access public
+/// @group global-motion
+$transition--expansion: 300ms;
+
+/// Default ease-in for components
+/// @access public
+/// @type Function
+/// @group global-motion
+$ease-in: cubic-bezier(0, 0, 0.38, 0.9);
+
+/// Default ease-out for components
+/// @access public
+/// @type Function
+/// @group global-motion
+$ease-out: cubic-bezier(0.2, 0, 1, 0.9);
+
+/// Default easing for components
+/// @access public
+/// @type Function
+/// @group global-motion
+$standard-easing: cubic-bezier(0.2, 0, 0.38, 0.9);
+
+/// @access public
+/// @group global-motion
+/// @alias duration--fast-02
+$transition--base: motion.$duration-fast-02;
+
+/// @access public
+/// @group global-motion
+/// @alias duration--moderate-02
+$transition--expansion: motion.$duration-moderate-02;

--- a/packages/styles/scss/components/__tests__/link-test.js
+++ b/packages/styles/scss/components/__tests__/link-test.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const { SassRenderer } = require('@carbon/test-utils/scss');
+
+const { render } = SassRenderer.create(__dirname);
+
+describe('scss/components/link', () => {
+  test('Public API', async () => {
+    const { unwrap } = await render(`
+      @use 'sass:meta';
+      @use '../link';
+
+      $_: get('mixin', meta.mixin-exists('link', 'link'));
+    `);
+    expect(unwrap('mixin')).toBe(true);
+  });
+});

--- a/packages/styles/scss/components/__tests__/list-test.js
+++ b/packages/styles/scss/components/__tests__/list-test.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const { SassRenderer } = require('@carbon/test-utils/scss');
+
+const { render } = SassRenderer.create(__dirname);
+
+describe('scss/components/list', () => {
+  test('Public API', async () => {
+    const { unwrap } = await render(`
+      @use 'sass:meta';
+      @use '../list';
+
+      $_: get('mixin', meta.mixin-exists('list', 'list'));
+    `);
+    expect(unwrap('mixin')).toBe(true);
+  });
+});

--- a/packages/styles/scss/components/__tests__/loading-test.js
+++ b/packages/styles/scss/components/__tests__/loading-test.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2018, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+const { SassRenderer } = require('@carbon/test-utils/scss');
+
+const { render } = SassRenderer.create(__dirname);
+
+describe('scss/components/loading', () => {
+  test('Public API', async () => {
+    const { unwrap } = await render(`
+      @use 'sass:meta';
+      @use '../loading';
+
+      $_: get('mixin', meta.mixin-exists('loading', 'loading'));
+    `);
+    expect(unwrap('mixin')).toBe(true);
+  });
+});

--- a/packages/styles/scss/components/link/_index.scss
+++ b/packages/styles/scss/components/link/_index.scss
@@ -5,5 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use 'accordion';
+@forward 'link';
 @use 'link';
+
+@include link.link;

--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -1,0 +1,112 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+//-----------------------------
+// Link
+//-----------------------------
+
+// @import '../../globals/scss/colors';
+// @import '../../globals/scss/vars';
+// @import '../../globals/scss/theme';
+// @import '../../globals/scss/typography';
+// @import '../../globals/scss/helper-mixins';
+
+@use '../../config' as *;
+@use '../../motion' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type';
+
+// @import '../../globals/scss/css--reset';
+@use '../../utilities/component-reset';
+@use '../../utilities/focus-outline' as *;
+
+/// Link styles
+/// @access private
+/// @group link
+@mixin link {
+  .#{$prefix}--link {
+    @include component-reset.reset;
+    @include type.type-style('body-short-01');
+
+    display: inline-flex;
+    color: $link-primary;
+    outline: none;
+    text-decoration: none;
+    transition: color $duration-fast-01 motion(standard, productive);
+
+    &:hover {
+      color: $link-primary-hover;
+      text-decoration: underline;
+    }
+
+    &:active,
+    &:active:visited,
+    &:active:visited:hover {
+      color: $text-primary;
+      text-decoration: underline;
+    }
+
+    &:focus {
+      @include focus-outline;
+    }
+
+    &:visited {
+      color: $link-primary;
+    }
+
+    &:visited:hover {
+      color: $link-primary-hover;
+    }
+  }
+
+  .#{$prefix}--link--disabled,
+  .#{$prefix}--link--disabled:hover {
+    @include component-reset.reset;
+    @include type.type-style('body-short-01');
+
+    color: $text-disabled;
+    cursor: not-allowed;
+    font-weight: 400;
+    text-decoration: none;
+  }
+
+  .#{$prefix}--link.#{$prefix}--link--visited:visited {
+    color: $link-visited;
+  }
+
+  .#{$prefix}--link.#{$prefix}--link--visited:visited:hover {
+    color: $link-primary-hover;
+  }
+
+  .#{$prefix}--link.#{$prefix}--link--inline {
+    text-decoration: underline;
+
+    &:focus,
+    &:visited {
+      text-decoration: none;
+    }
+  }
+
+  .#{$prefix}--link--disabled.#{$prefix}--link--inline {
+    text-decoration: underline;
+  }
+
+  .#{$prefix}--link--sm {
+    @include type.type-style('helper-text-01');
+  }
+
+  .#{$prefix}--link--lg {
+    @include type.type-style('body-short-02');
+  }
+
+  .#{$prefix}--link__icon {
+    display: inline-flex;
+    align-self: center;
+    margin-left: $spacing-03;
+  }
+}

--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -5,28 +5,16 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-//-----------------------------
-// Link
-//-----------------------------
-
-// @import '../../globals/scss/colors';
-// @import '../../globals/scss/vars';
-// @import '../../globals/scss/theme';
-// @import '../../globals/scss/typography';
-// @import '../../globals/scss/helper-mixins';
-
 @use '../../config' as *;
 @use '../../motion' as *;
 @use '../../spacing' as *;
 @use '../../theme' as *;
 @use '../../type';
-
-// @import '../../globals/scss/css--reset';
 @use '../../utilities/component-reset';
 @use '../../utilities/focus-outline' as *;
 
 /// Link styles
-/// @access private
+/// @access public
 /// @group link
 @mixin link {
   .#{$prefix}--link {

--- a/packages/styles/scss/components/list/_index.scss
+++ b/packages/styles/scss/components/list/_index.scss
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use 'accordion';
-@use 'link';
+@forward 'list';
 @use 'list';
+
+@include list.list;

--- a/packages/styles/scss/components/list/_list.scss
+++ b/packages/styles/scss/components/list/_list.scss
@@ -1,0 +1,94 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+//-----------------------------
+// List
+//-----------------------------
+
+@use '../../config' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type';
+@use '../../utilities/component-reset';
+@use '../../utilities/convert';
+
+/// List styles
+/// @access public
+/// @group list
+@mixin list {
+  .#{$prefix}--list--nested,
+  .#{$prefix}--list--unordered,
+  .#{$prefix}--list--ordered,
+  .#{$prefix}--list--ordered--native {
+    @include component-reset.reset;
+    @include type.type-style('body-long-01');
+
+    list-style: none;
+  }
+
+  .#{$prefix}--list--expressive,
+  .#{$prefix}--list--expressive .#{$prefix}--list--nested {
+    @include type.type-style('body-long-02');
+  }
+
+  .#{$prefix}--list--ordered--native {
+    list-style: decimal;
+  }
+
+  .#{$prefix}--list__item {
+    color: $text-primary;
+  }
+
+  .#{$prefix}--list--nested {
+    margin-left: convert.rem(32px);
+  }
+
+  .#{$prefix}--list--nested .#{$prefix}--list__item {
+    padding-left: $spacing-02;
+  }
+
+  .#{$prefix}--list--ordered:not(.#{$prefix}--list--nested) {
+    counter-reset: item;
+  }
+
+  .#{$prefix}--list--ordered:not(.#{$prefix}--list--nested)
+    > .#{$prefix}--list__item {
+    position: relative;
+  }
+
+  .#{$prefix}--list--ordered:not(.#{$prefix}--list--nested)
+    > .#{$prefix}--list__item::before {
+    position: absolute;
+    left: convert.rem(-24px);
+    content: counter(item) '.';
+    counter-increment: item;
+  }
+
+  .#{$prefix}--list--ordered.#{$prefix}--list--nested,
+  .#{$prefix}--list--ordered--native.#{$prefix}--list--nested {
+    list-style-type: lower-latin;
+  }
+
+  .#{$prefix}--list--unordered > .#{$prefix}--list__item {
+    position: relative;
+
+    &::before {
+      position: absolute;
+      left: calc(-1 * #{$spacing-05});
+      // – en dash
+      content: '\002013';
+    }
+  }
+
+  .#{$prefix}--list--unordered.#{$prefix}--list--nested
+    > .#{$prefix}--list__item::before {
+    // offset to account for smaller ▪ vs –
+    left: calc(-1 * #{$spacing-04});
+    // ▪ square
+    content: '\0025AA';
+  }
+}

--- a/packages/styles/scss/components/loading/_animation.scss
+++ b/packages/styles/scss/components/loading/_animation.scss
@@ -1,0 +1,39 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../motion';
+
+@mixin spin {
+  // Animate the container
+  animation-duration: 690ms;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: rotate;
+  animation-timing-function: linear;
+
+  // Animate the stroke
+  svg circle {
+    animation-duration: 10ms;
+    animation-name: init-stroke;
+    animation-timing-function: motion.$standard-easing;
+  }
+}
+
+@mixin stop {
+  // Animate the container
+  animation: rotate-end-p1 700ms motion.$ease-out forwards,
+    rotate-end-p2 700ms motion.$ease-out 700ms forwards;
+
+  // Animate the stroke
+  svg circle {
+    animation-delay: 700ms;
+    animation-duration: 700ms;
+    animation-fill-mode: forwards;
+    animation-name: stroke-end;
+    animation-timing-function: motion.$ease-out;
+  }
+}

--- a/packages/styles/scss/components/loading/_index.scss
+++ b/packages/styles/scss/components/loading/_index.scss
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use 'accordion';
-@use 'link';
-@use 'list';
+@forward 'loading';
 @use 'loading';
+
+@include loading.loading;

--- a/packages/styles/scss/components/loading/_loading.scss
+++ b/packages/styles/scss/components/loading/_loading.scss
@@ -1,0 +1,153 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../config' as *;
+@use '../../motion' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../utilities/component-reset';
+@use '../../utilities/convert';
+@use '../../utilities/z-index' as *;
+@use 'animation';
+
+/// @type Number
+/// @access private
+/// @group loading
+$-loading-gap: 16;
+
+/// @type Number
+/// @access private
+/// @group loading
+$-loading-gap-small: 110;
+
+/// @type Number
+/// @access private
+/// @group loading
+$-loading-size: 5.5rem;
+
+/// Loading styles
+/// @access private
+/// @group loading
+@mixin loading {
+  .#{$prefix}--loading {
+    @include component-reset.reset;
+    @include animation.spin;
+
+    width: $-loading-size;
+    height: $-loading-size;
+  }
+
+  // Animation (Spin by default)
+  .#{$prefix}--loading__svg {
+    fill: transparent;
+  }
+
+  .#{$prefix}--loading__svg circle {
+    stroke-dasharray: 240;
+    stroke-linecap: butt;
+    stroke-width: 10;
+  }
+
+  .#{$prefix}--loading__stroke {
+    stroke: $interactive;
+    stroke-dashoffset: $-loading-gap;
+  }
+
+  .#{$prefix}--loading--small .#{$prefix}--loading__stroke {
+    stroke-dashoffset: $-loading-gap-small;
+  }
+
+  .#{$prefix}--loading--stop {
+    @include animation.stop;
+  }
+
+  .#{$prefix}--loading--small {
+    width: convert.rem(16px);
+    height: convert.rem(16px);
+
+    circle {
+      stroke-width: 16;
+    }
+  }
+
+  .#{$prefix}--loading--small .#{$prefix}--loading__svg {
+    stroke: $interactive;
+  }
+
+  .#{$prefix}--loading__background {
+    stroke: $layer-accent;
+    stroke-dashoffset: -22;
+  }
+
+  // Negative values for `stroke-dashoffset` are not supported in Safari
+  @media not all and (min-resolution: 0.001dpcm) {
+    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+      circle.#{$prefix}--loading__background {
+        stroke-dasharray: 265;
+        stroke-dashoffset: 0;
+      }
+    }
+  }
+
+  .#{$prefix}--loading-overlay {
+    position: fixed;
+    z-index: z('overlay');
+    top: 0;
+    left: 0;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    background-color: $overlay;
+    transition: background-color $duration-slow-02 motion(standard, expressive);
+  }
+
+  .#{$prefix}--loading-overlay--stop {
+    display: none;
+  }
+
+  @keyframes rotate {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes rotate-end-p1 {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes rotate-end-p2 {
+    100% {
+      transform: rotate(-360deg);
+    }
+  }
+
+  /* Stroke animations */
+  @keyframes init-stroke {
+    0% {
+      stroke-dashoffset: 240;
+    }
+    100% {
+      stroke-dashoffset: $-loading-gap;
+    }
+  }
+
+  @keyframes stroke-end {
+    0% {
+      stroke-dashoffset: $-loading-gap;
+    }
+    100% {
+      stroke-dashoffset: 240;
+    }
+  }
+}


### PR DESCRIPTION
Closes part of #8555 

This PR adds in the component style sheets for: Link, List, and Loading to `@carbon/styles`

#### Changelog

**New**

- Add component stylesheets for Link, List, and Loading to `@carbon/styles`

**Changed**

**Removed**

#### Testing / Reviewing

- Verify that the tests pass in CI for the newly stylesheets
- Verify that each new stylesheet is included in `styles/scss/components/_index.scss`
- Verify each new stylesheet in `components` has an `_index.scss` that uses the component mixin to emit styles
- Verify that there are no functions being used in styles that has no corresponding import (for example, `z` requires `utilities/z-index` to be included (for some reason sass won't fail to compile if a function does not exist)