### PR TITLE
fix(components): import tooltip from progress indicator

### DIFF
--- a/packages/components/src/components/progress-indicator/_progress-indicator.scss
+++ b/packages/components/src/components/progress-indicator/_progress-indicator.scss
@@ -11,6 +11,7 @@
 @import '../../globals/scss/typography';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../button/button';
+@import '../tooltip/tooltip';
 
 /// Progress indicator styles
 /// @access private


### PR DESCRIPTION
Closes #8783 

Update import order for progress indicator to include tooltip so that tooltip styles do not override progress indicator styles.

#### Changelog

**New**

**Changed**

- Update import order for progress indicator stylesheet

**Removed**

#### Testing / Reviewing

- Visit the default progress indicator story and verify that the text is the correct size and not the smaller size coming from tooltip