### PR TITLE
fix(button): fix icon color on disabled icon only ghost buttons

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -289,7 +289,7 @@
 
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only[disabled]
     .#{$prefix}--btn__icon
-    path,
+    path:not([data-icon-path]):not([fill='none']),
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only[disabled]
     .#{$prefix}--btn__icon,
   .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--btn--ghost[disabled]:hover


### PR DESCRIPTION
With the recent selector change in #8585 regarding the icon color on buttons, the specificity increased and caused disabled icon-only ghost buttons to use `$icon-primary` instead of `$icon-on-color-disabled`. This PR adds the same selector addition to the disabled icon-only ghost buttons.

Before
![image](https://user-images.githubusercontent.com/28265588/120292292-7b1feb00-c2c4-11eb-8572-41d7a9f4c23c.png)

After
![image](https://user-images.githubusercontent.com/28265588/120292362-8a9f3400-c2c4-11eb-8233-6f1bcdc6dbeb.png)


#### Changelog

**Changed**

- Increased css specificity for icon color fill on disabled icon-only ghost buttond

#### Testing / Reviewing

- Ensure the icon color on disabled icon-only ghost buttons matches `$icon-on-color-disabled`
