### PR TITLE
fix(Tooltip): avoid stealing focus when dismissing with mouseclick

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -300,7 +300,11 @@ class Tooltip extends Component {
       if (!open && tooltipBody && tooltipBody.id === this._tooltipId) {
         this._tooltipDismissed = true;
         const currentActiveNode = event?.relatedTarget;
-        if (!currentActiveNode && document.activeElement === document.body) {
+        if (
+          !currentActiveNode &&
+          document.activeElement === document.body &&
+          event?.type !== 'click'
+        ) {
           this._triggerRef?.current.focus();
         }
       }


### PR DESCRIPTION
Closes #8180

This PR updates the interactive tooltip's user initiated open/close logic to avoid stealing focus after dismissal via mouse click

#### Testing / Reviewing

Confirm that the interactive tooltip trigger does not steal focus only after the tooltip is dismissed by user click