### PR TITLE
style(Modal): ensure modal close click target is not obscured

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -336,6 +336,7 @@
 
   .#{$prefix}--modal-close {
     position: absolute;
+    z-index: 2;
     top: 0;
     right: 0;
     overflow: hidden;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8802

Ensures that the modal close button is not obscured it no heading / label are provided to `Modal`

#### Changelog

**New**

- `z-index: 2;` added to the close button

#### Testing / Reviewing

Remove the `modalHeading` and `modalLabel` from `Modal` and ensure you can still click the entire close button