### PR TITLE
style(DataTable): set correct text-align based on align property

### DIFF
--- a/packages/components/src/components/data-table/_data-table-core.scss
+++ b/packages/components/src/components/data-table/_data-table-core.scss
@@ -103,6 +103,16 @@
     vertical-align: middle;
   }
 
+  .#{$prefix}--data-table th[align='right'],
+  .#{$prefix}--data-table td[align='right'] {
+    text-align: right;
+  }
+
+  .#{$prefix}--data-table th[align='center'],
+  .#{$prefix}--data-table td[align='center'] {
+    text-align: center;
+  }
+
   .#{$prefix}--data-table th {
     padding-right: $spacing-05;
     padding-left: $spacing-05;
@@ -114,10 +124,6 @@
     // Do not use `position: relative`, as its behavior is undefined for many table elements: https://www.w3.org/TR/CSS21/visuren.html#propdef-position
     position: static;
     width: auto;
-  }
-
-  .#{$prefix}--data-table .#{$prefix}--table-header-label {
-    text-align: left;
   }
 
   .#{$prefix}--data-table td,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8800

Changes the `text-align` property based on the `align` property provided to `TableCell` or `TableHeader`. Simply removing the text-align styles did not work, as some header elements have internal divs / button that the `align` property gets spread to. 

#### Changelog

**New**

- Sets the correct `text-align` property based on the user-provided `align` property


#### Testing / Reviewing

Provide `align="right"` or `align="center"` to `TableCell` and `TableHeader` and ensure the text changes alignment 
