### PR TITLE
fix(TableToolbarSearch): fix rendering issues with TableToolbarSearch

### DIFF
--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -58,7 +58,8 @@
   //-------------------------------------------------
   //HIDDEN SEARCH - DEFAULT TOOLBAR
   //-------------------------------------------------
-  .#{$prefix}--toolbar-search-container-expandable {
+  .#{$prefix}--toolbar-content
+    .#{$prefix}--toolbar-search-container-expandable {
     position: relative;
     width: $spacing-09;
     height: $spacing-09;
@@ -85,6 +86,7 @@
     width: $spacing-09;
     height: $spacing-09;
     padding: $spacing-05;
+    fill: $icon-primary;
   }
 
   .#{$prefix}--toolbar-search-container-expandable.#{$prefix}--search--disabled

--- a/packages/components/src/components/data-table/_data-table-action.scss
+++ b/packages/components/src/components/data-table/_data-table-action.scss
@@ -481,6 +481,14 @@
       width: 100%;
     }
 
+    // Adjust icon positioning since small has less padding
+    .#{$prefix}--toolbar-search-container-active
+      .#{$prefix}--search-magnifier-icon,
+    .#{$prefix}--toolbar-search-container-persistent
+      .#{$prefix}--search-magnifier-icon {
+      left: $spacing-03;
+    }
+
     //hidden
     .#{$prefix}--toolbar-search-container-expandable {
       width: rem(32px);

--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -98,7 +98,6 @@ const TableToolbarSearch = ({
   return (
     <Search
       disabled={disabled}
-      size="sm"
       className={searchClasses}
       value={value}
       id={typeof id !== 'undefined' ? id : uniqueId.toString()}

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2329,14 +2329,13 @@ exports[`DataTable should render 1`] = `
                   onChange={[Function]}
                   onFocus={[Function]}
                   placeholder="Filter table"
-                  size="sm"
                   tabIndex="0"
                   type="text"
                   value=""
                 >
                   <div
                     aria-labelledby="custom-id-search"
-                    className="bx--search bx--search--sm bx--toolbar-search-container-persistent"
+                    className="bx--search bx--toolbar-search-container-persistent"
                     role="search"
                   >
                     <div
@@ -3391,14 +3390,13 @@ exports[`DataTable sticky header should render 1`] = `
                   onChange={[Function]}
                   onFocus={[Function]}
                   placeholder="Filter table"
-                  size="sm"
                   tabIndex="0"
                   type="text"
                   value=""
                 >
                   <div
                     aria-labelledby="custom-id-search"
-                    className="bx--search bx--search--sm bx--toolbar-search-container-persistent"
+                    className="bx--search bx--toolbar-search-container-persistent"
                     role="search"
                   >
                     <div

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -18,14 +18,13 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Filter table"
-    size="sm"
     tabIndex="0"
     type="text"
     value=""
   >
     <div
       aria-labelledby="custom-id-search"
-      className="bx--search bx--search--sm custom-class bx--toolbar-search-container-expandable"
+      className="bx--search custom-class bx--toolbar-search-container-expandable"
       role="search"
     >
       <div

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -177,7 +177,7 @@ export default class Search extends Component {
       labelText,
       closeButtonLabelText,
       small,
-      size = !small ? 'xl' : 'sm',
+      size = !small ? '' : 'sm',
       light,
       disabled,
       onChange,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8784 
Closes https://github.com/carbon-design-system/carbon/issues/8598 
Ref https://github.com/carbon-design-system/carbon/pull/8101 & https://github.com/carbon-design-system/carbon/pull/8435

Fixes an issue with `TableToolbarSearch` rendering with an incorrect height and expanding in the wrong direction

#### Changelog

**Changed**

- Increased `TableToolbarSearch` specific selector to prevent newer `Search` styles from overriding the behavior

**Removed**

- Removed hardcoded `sm` size from the internal `Search` used in `TableToolbarSearch`
- No longer add the `xl` class by default to `Search`

#### Testing / Reviewing

Check the `Batch Actions` and `With Toolbar` stories and ensure they are rendering correctly 
