### PR TITLE
chore(carbon-react): update storybook config and update es entrypoint

### DIFF
--- a/packages/carbon-react/.storybook/main.js
+++ b/packages/carbon-react/.storybook/main.js
@@ -30,6 +30,24 @@ module.exports = {
     '../src/**/*.stories.mdx',
   ],
   webpack(config) {
+    const babelLoader = config.module.rules.find((rule) => {
+      return rule.use.some(({ loader }) => {
+        return loader.includes('babel-loader');
+      });
+    });
+
+    // This is a temporary trick to get `babel-loader` to ignore packages that
+    // are brought in that have an es, lib, or umd directory.
+    //
+    // Typically this is covered by /node_modules/ (which is the default), but
+    // in our case it seems like these dependencies are resolving to where their
+    // symlink points to. In other words, `@carbon/icons-react` becomes
+    // `../icons-react/es/index.js`.
+    //
+    // This results in these files being included in `babel-loader` and causing
+    // the build times to increase dramatically
+    babelLoader.exclude = [/node_modules/, /packages\/.*\/(es|lib|umd)/];
+
     config.module.rules.push({
       test: /\.s?css$/,
       sideEffects: true,

--- a/packages/carbon-react/src/components/Grid/Grid.stories.js
+++ b/packages/carbon-react/src/components/Grid/Grid.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Grid, Column } from 'carbon-components-react/es/components/Grid';
+import { Grid, Column } from 'carbon-components-react';
 import React from 'react';
 import mdx from './Grid.mdx';
 


### PR DESCRIPTION
This updates our storybook config to ignore `packages/**/(es|lib|umd)` paths in `babel-loader`.

This change is being made because currently when we use the entrypoint of `carbon-components-react` the build times for Storybook v6 skyrocket. It seems like this is because `babel-loader` under the hood is receiving paths to the dependency itself versus a path that uses `node_modules`.

By default, storybook's babel-loader config will ignore anything in `node_modules`. However, in our case, `@carbon/icons-react` was being transformed to `../icons-react/es/index.js` which caused `babel-loader` to try and parse the file directly.

This PR updates our storybook config to include these es/lib/umd folders by finding the existing babel-loader config and updating its `extend` option. It also updates our existing story for Grid to use the `carbon-components-react` entrypoint.

#### Changelog

**New**

**Changed**

- Update storybook config for `babel-loader` to exclude `packages/**/(es|lib|umd)` paths to prevent compilation problems when using the `carbon-components-react` entrypoint

**Removed**

#### Testing / Reviewing

- Pull down the pull request
- Run `cd packages/carbon-react`
- Run `yarn storybook`
- Verify that it compiles in <1min30s
- Verify that the storybook runs as expected