### PR TITLE
feat(popover): updating popover alignments

### DIFF
--- a/packages/components/src/components/popover/_popover.scss
+++ b/packages/components/src/components/popover/_popover.scss
@@ -91,41 +91,41 @@
   // content, while the other is rendered above of the popover content.
 
   //-----------------------------------------------------------------------------
-  // Top
+  // Bottom
   //-----------------------------------------------------------------------------
-  .#{$prefix}--popover--top {
+  .#{$prefix}--popover--bottom {
     bottom: 0;
     left: 50%;
     transform: translate(-50%, calc(100% + var(--cds-popover-offset)));
   }
 
-  @include place-caret(top) {
+  @include place-caret(bottom) {
     top: 0;
     left: 50%;
     transform: translate(-50%, -50%) rotate(45deg);
   }
 
-  // Top-left
-  .#{$prefix}--popover--top-left {
+  // Bottom left
+  .#{$prefix}--popover--bottom-left {
     bottom: 0;
     left: 0;
     transform: translateY(calc(100% + var(--cds-popover-offset)));
   }
 
-  @include place-caret(top-left) {
+  @include place-caret(bottom-left) {
     top: 0;
     left: 0;
     transform: translate(var(--cds-popover-caret-offset), -50%) rotate(45deg);
   }
 
-  // Top-right
-  .#{$prefix}--popover--top-right {
+  // Bottom right
+  .#{$prefix}--popover--bottom-right {
     right: 0;
     bottom: 0;
     transform: translateY(calc(100% + var(--cds-popover-offset)));
   }
 
-  @include place-caret(top-right) {
+  @include place-caret(bottom-right) {
     top: 0;
     right: 0;
     transform: translate(calc(-1 * var(--cds-popover-caret-offset)), -50%)
@@ -133,9 +133,9 @@
   }
 
   // Hover area
-  .#{$prefix}--popover--top.#{$prefix}--popover::before,
-  .#{$prefix}--popover--top-left.#{$prefix}--popover::before,
-  .#{$prefix}--popover--top-right.#{$prefix}--popover::before {
+  .#{$prefix}--popover--bottom.#{$prefix}--popover::before,
+  .#{$prefix}--popover--bottom-left.#{$prefix}--popover::before,
+  .#{$prefix}--popover--bottom-right.#{$prefix}--popover::before {
     top: 0;
     right: 0;
     left: 0;
@@ -144,41 +144,41 @@
   }
 
   //-----------------------------------------------------------------------------
-  // Bottom
+  // TOP
   //-----------------------------------------------------------------------------
-  .#{$prefix}--popover--bottom {
+  .#{$prefix}--popover--top {
     bottom: 100%;
     left: 50%;
     transform: translate(-50%, calc(-1 * var(--cds-popover-offset)));
   }
 
-  @include place-caret(bottom) {
+  @include place-caret(top) {
     bottom: 0;
     left: 50%;
     transform: translate(-50%, 50%) rotate(45deg);
   }
 
-  // Bottom left
-  .#{$prefix}--popover--bottom-left {
+  // Top left
+  .#{$prefix}--popover--top-left {
     bottom: 100%;
     left: 0;
     transform: translateY(calc(-1 * var(--cds-popover-offset)));
   }
 
-  @include place-caret(bottom-left) {
+  @include place-caret(top-left) {
     bottom: 0;
     left: 0;
     transform: translate(var(--cds-popover-caret-offset), 50%) rotate(45deg);
   }
 
-  // Bottom right
-  .#{$prefix}--popover--bottom-right {
+  // Top right
+  .#{$prefix}--popover--top-right {
     right: 0;
     bottom: 100%;
     transform: translateY(calc(-1 * var(--cds-popover-offset)));
   }
 
-  @include place-caret(bottom-right) {
+  @include place-caret(top-right) {
     right: 0;
     bottom: 0;
     transform: translate(calc(-1 * var(--cds-popover-caret-offset)), 50%)
@@ -186,9 +186,9 @@
   }
 
   // Hover area
-  .#{$prefix}--popover--bottom.#{$prefix}--popover::before,
-  .#{$prefix}--popover--bottom-left.#{$prefix}--popover::before,
-  .#{$prefix}--popover--bottom-right.#{$prefix}--popover::before {
+  .#{$prefix}--popover--top.#{$prefix}--popover::before,
+  .#{$prefix}--popover--top-left.#{$prefix}--popover::before,
+  .#{$prefix}--popover--top-right.#{$prefix}--popover::before {
     right: 0;
     bottom: 0;
     left: 0;
@@ -197,41 +197,41 @@
   }
 
   //-----------------------------------------------------------------------------
-  // Left
+  // Right
   //-----------------------------------------------------------------------------
-  .#{$prefix}--popover--left {
+  .#{$prefix}--popover--right {
     top: 50%;
     left: 100%;
     transform: translate(var(--cds-popover-offset), -50%);
   }
 
-  @include place-caret(left) {
+  @include place-caret(right) {
     top: 50%;
     left: 0;
     transform: translate(-50%, -50%) rotate(45deg);
   }
 
-  // Left top
-  .#{$prefix}--popover--left-top {
+  // Right top
+  .#{$prefix}--popover--right-top {
     top: 0;
     left: 100%;
     transform: translateX($popover-offset);
   }
 
-  @include place-caret(left-top) {
+  @include place-caret(right-top) {
     top: 0;
     left: 0;
     transform: translate(-50%, var(--cds-popover-caret-offset)) rotate(45deg);
   }
 
-  // Left bottom
-  .#{$prefix}--popover--left-bottom {
+  // Right bottom
+  .#{$prefix}--popover--right-bottom {
     bottom: 0;
     left: 100%;
     transform: translateX(var(--cds-popover-offset));
   }
 
-  @include place-caret(left-bottom) {
+  @include place-caret(right-bottom) {
     bottom: 0;
     left: 0;
     transform: translate(-50%, calc(-1 * var(--cds-popover-caret-offset)))
@@ -239,9 +239,9 @@
   }
 
   // Hover area
-  .#{$prefix}--popover--left.#{$prefix}--popover::before,
-  .#{$prefix}--popover--left-top.#{$prefix}--popover::before,
-  .#{$prefix}--popover--left-bottom.#{$prefix}--popover::before {
+  .#{$prefix}--popover--right.#{$prefix}--popover::before,
+  .#{$prefix}--popover--right-top.#{$prefix}--popover::before,
+  .#{$prefix}--popover--right-bottom.#{$prefix}--popover::before {
     top: 0;
     bottom: 0;
     left: 0;
@@ -250,41 +250,41 @@
   }
 
   //-----------------------------------------------------------------------------
-  // Right
+  // Left
   //-----------------------------------------------------------------------------
-  .#{$prefix}--popover--right {
+  .#{$prefix}--popover--left {
     top: 50%;
     right: 100%;
     transform: translate(calc(-1 * var(--cds-popover-offset)), -50%);
   }
 
-  @include place-caret(right) {
+  @include place-caret(left) {
     top: 50%;
     right: 0;
     transform: translate(50%, -50%) rotate(45deg);
   }
 
-  // Right top
-  .#{$prefix}--popover--right-top {
+  // Left top
+  .#{$prefix}--popover--left-top {
     top: 0;
     right: 100%;
     transform: translateX(calc(-1 * var(--cds-popover-offset)));
   }
 
-  @include place-caret(right-top) {
+  @include place-caret(left-top) {
     top: 0;
     right: 0;
     transform: translate(50%, var(--cds-popover-caret-offset)) rotate(45deg);
   }
 
-  // Right bottom
-  .#{$prefix}--popover--right-bottom {
+  // Left bottom
+  .#{$prefix}--popover--left-bottom {
     right: 100%;
     bottom: 0;
     transform: translateX(calc(-1 * var(--cds-popover-offset)));
   }
 
-  @include place-caret(right-bottom) {
+  @include place-caret(left-bottom) {
     right: 0;
     bottom: 0;
     transform: translate(50%, calc(-1 * var(--cds-popover-caret-offset)))
@@ -292,9 +292,9 @@
   }
 
   // Hover area
-  .#{$prefix}--popover--right.#{$prefix}--popover::before,
-  .#{$prefix}--popover--right-top.#{$prefix}--popover::before,
-  .#{$prefix}--popover--right-bottom.#{$prefix}--popover::before {
+  .#{$prefix}--popover--left.#{$prefix}--popover::before,
+  .#{$prefix}--popover--left-top.#{$prefix}--popover::before,
+  .#{$prefix}--popover--left-bottom.#{$prefix}--popover::before {
     top: 0;
     right: 0;
     bottom: 0;

--- a/packages/react/src/components/Popover/Popover-story.js
+++ b/packages/react/src/components/Popover/Popover-story.js
@@ -226,14 +226,14 @@ export const Examples = () => {
       <Example
         className="position-relative mb-3"
         icon={CaretDown32}
-        align="top-left">
+        align="bottom-left">
         This is some text
       </Example>
 
       <Example
         className="position-relative mb-3"
         icon={CaretDown32}
-        align="top-left"
+        align="bottom-left"
         size="sm">
         This is some text
       </Example>
@@ -256,59 +256,59 @@ export const Examples = () => {
       <Example
         className="flex justify-end position-relative mb-3"
         icon={CaretDown32}
-        align="top-right">
-        This is some text
-      </Example>
-
-      <Example
-        className="flex justify-end position-relative mb-3"
-        icon={CaretDown32}
-        align="top-right"
-        size="sm">
-        This is some text
-      </Example>
-
-      <Example
-        className="position-relative mb-3"
-        icon={CaretUp32}
-        align="bottom-left">
-        This is some text
-      </Example>
-
-      <Example
-        className="position-relative mb-3"
-        icon={CaretUp32}
-        align="bottom-left"
-        size="sm">
-        This is some text
-      </Example>
-
-      <Example
-        className="flex justify-center position-relative mb-3"
-        icon={CaretUp32}
-        align="bottom">
-        This is some text
-      </Example>
-
-      <Example
-        className="flex justify-center position-relative mb-3"
-        icon={CaretUp32}
-        align="bottom"
-        size="sm">
-        This is some text
-      </Example>
-
-      <Example
-        className="flex justify-end position-relative mb-3"
-        icon={CaretUp32}
         align="bottom-right">
         This is some text
       </Example>
 
       <Example
         className="flex justify-end position-relative mb-3"
-        icon={CaretUp32}
+        icon={CaretDown32}
         align="bottom-right"
+        size="sm">
+        This is some text
+      </Example>
+
+      <Example
+        className="position-relative mb-3"
+        icon={CaretUp32}
+        align="top-left">
+        This is some text
+      </Example>
+
+      <Example
+        className="position-relative mb-3"
+        icon={CaretUp32}
+        align="top-left"
+        size="sm">
+        This is some text
+      </Example>
+
+      <Example
+        className="flex justify-center position-relative mb-3"
+        icon={CaretUp32}
+        align="top">
+        This is some text
+      </Example>
+
+      <Example
+        className="flex justify-center position-relative mb-3"
+        icon={CaretUp32}
+        align="top"
+        size="sm">
+        This is some text
+      </Example>
+
+      <Example
+        className="flex justify-end position-relative mb-3"
+        icon={CaretUp32}
+        align="top-right">
+        This is some text
+      </Example>
+
+      <Example
+        className="flex justify-end position-relative mb-3"
+        icon={CaretUp32}
+        align="top-right"
         size="sm">
         This is some text
       </Example>
@@ -318,7 +318,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretRight32}
-            align="left"
+            align="right"
             relative>
             This is some text
           </Example>
@@ -326,7 +326,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretRight32}
-            align="left"
+            align="right"
             size="sm"
             relative>
             This is some text
@@ -337,7 +337,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretRight32}
-            align="left-top"
+            align="right-top"
             relative>
             This is some text
           </Example>
@@ -345,7 +345,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretRight32}
-            align="left-top"
+            align="right-top"
             size="sm"
             relative>
             This is some text
@@ -356,7 +356,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretRight32}
-            align="left-bottom"
+            align="right-bottom"
             relative>
             This is some text
           </Example>
@@ -364,7 +364,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretRight32}
-            align="left-bottom"
+            align="right-bottom"
             size="sm"
             relative>
             This is some text
@@ -377,7 +377,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretLeft32}
-            align="right"
+            align="left"
             relative
             flip>
             This is some text
@@ -386,7 +386,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretLeft32}
-            align="right"
+            align="left"
             size="sm"
             relative
             flip>
@@ -398,7 +398,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretLeft32}
-            align="right-top"
+            align="left-top"
             relative
             flip>
             This is some text
@@ -407,7 +407,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretLeft32}
-            align="right-top"
+            align="left-top"
             size="sm"
             relative
             flip>
@@ -419,7 +419,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretLeft32}
-            align="right-bottom"
+            align="left-bottom"
             relative
             flip>
             This is some text
@@ -428,7 +428,7 @@ export const Examples = () => {
           <Example
             className="position-relative flex align-center mb-3"
             icon={CaretLeft32}
-            align="right-bottom"
+            align="left-bottom"
             size="sm"
             relative
             flip>
@@ -440,7 +440,7 @@ export const Examples = () => {
       <Example
         className="position-relative mb-3"
         icon={CaretDown32}
-        align="top-left">
+        align="bottom-left">
         Consectetur et sit accusamus laboriosam pariatur. Asperiores eius
         expedita eligendi beatae vero commodi harum Illo hic accusamus fugit
         commodi cupiditate Explicabo distinctio quisquam culpa fugit eius


### PR DESCRIPTION
Closes #8873 

This feature updates the alignments on `Popover` to be similar to that of tooltip / aligned to how a reader would view the popover placement

#### Testing

- [ ] Make sure all of the alignments follow visual flow `ex: bottom` the text box moves below the caret
- [ ] `ex: right` the popover moves all the way to the right of the screen
