### PR TITLE
chore(release):v10.37.0

### DIFF
--- a/config/eslint-config-carbon/package.json
+++ b/config/eslint-config-carbon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-carbon",
   "description": "ESLint configuration for Carbon",
-  "version": "2.5.0-rc.0",
+  "version": "2.5.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": {

--- a/config/stylelint-config-carbon/package.json
+++ b/config/stylelint-config-carbon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint-config-carbon",
   "description": "Stylelint configuration for Carbon",
-  "version": "1.6.0-rc.0",
+  "version": "1.6.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": {

--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/react",
   "private": true,
   "description": "React components for the Carbon Design System",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -42,10 +42,10 @@
   "dependencies": {
     "@carbon/feature-flags": "^0.5.0",
     "@carbon/icons-react": "^10.33.0",
-    "@carbon/styles": "^0.8.0-rc.0",
+    "@carbon/styles": "^0.8.0",
     "@carbon/telemetry": "0.0.0-alpha.6",
     "@ibm/plex": "6.0.0-next.6",
-    "carbon-components-react": "^7.37.0-rc.0"
+    "carbon-components-react": "^7.37.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",
@@ -56,7 +56,7 @@
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-react": "^7.13.13",
     "@carbon/styles": "^0.8.0-rc.0",
-    "@carbon/themes": "^10.35.0",
+    "@carbon/themes": "^10.36.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "10.37.0-rc.0",
+  "version": "10.37.0",
   "license": "Apache-2.0",
   "main": "umd/index.js",
   "module": "es/index.js",
@@ -81,7 +81,7 @@
     "@babel/preset-react": "^7.13.13",
     "@babel/runtime": "^7.14.0",
     "@carbon/cli": "^10.24.0",
-    "@carbon/elements": "^10.36.0-rc.0",
+    "@carbon/elements": "^10.36.0",
     "@carbon/icons-handlebars": "^10.33.0",
     "@carbon/icons-react": "^10.33.0",
     "@carbon/test-utils": "^10.16.0",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/elements",
   "description": "A collection of design elements in code for the IBM Design Language",
-  "version": "10.36.0-rc.0",
+  "version": "10.36.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -36,12 +36,12 @@
   },
   "dependencies": {
     "@carbon/colors": "^10.26.0",
-    "@carbon/grid": "^10.29.0-rc.0",
+    "@carbon/grid": "^10.29.0",
     "@carbon/icons": "^10.33.0",
     "@carbon/import-once": "^10.6.0",
     "@carbon/layout": "^10.25.0",
     "@carbon/motion": "^10.19.0",
-    "@carbon/themes": "^10.35.0",
+    "@carbon/themes": "^10.36.0",
     "@carbon/type": "^10.29.0"
   },
   "devDependencies": {

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/grid",
   "description": "Grid for digital and software products using the Carbon Design System",
-  "version": "10.29.0-rc.0",
+  "version": "10.29.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components-react",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "7.37.0-rc.0",
+  "version": "7.37.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -99,7 +99,7 @@
     "babel-plugin-react-docgen": "^4.2.1",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "browserslist-config-carbon": "^10.6.1",
-    "carbon-components": "^10.37.0-rc.0",
+    "carbon-components": "^10.37.0",
     "carbon-icons": "^7.0.5",
     "chalk": "^2.3.0",
     "cli-table": "^0.3.0",

--- a/packages/sketch/package.json
+++ b/packages/sketch/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/sketch",
   "private": true,
   "description": "Tooling for generating a sketch plugin to bring code to design",
-  "version": "10.34.0",
+  "version": "10.35.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "@carbon/colors": "^10.26.0",
     "@carbon/icon-helpers": "^10.18.0",
     "@carbon/icons": "^10.33.0",
-    "@carbon/themes": "^10.35.0",
+    "@carbon/themes": "^10.36.0",
     "@carbon/type": "^10.29.0",
     "@skpm/builder": "^0.7.0",
     "color-string": "^1.5.3",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/styles",
   "private": true,
   "description": "Styles for the Carbon Design System",
-  "version": "0.8.0-rc.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -20,10 +20,10 @@
   "dependencies": {
     "@carbon/colors": "^10.26.0",
     "@carbon/feature-flags": "^0.5.0",
-    "@carbon/grid": "^10.29.0-rc.0",
+    "@carbon/grid": "^10.29.0",
     "@carbon/layout": "^10.25.0",
     "@carbon/motion": "^10.19.0",
-    "@carbon/themes": "^10.35.0",
+    "@carbon/themes": "^10.36.0",
     "@carbon/type": "^10.29.0"
   },
   "devDependencies": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/themes",
   "description": "Themes for applying color in the Carbon Design System",
-  "version": "10.35.0",
+  "version": "10.36.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/upgrade",
   "description": "A tool for upgrading Carbon versions",
-  "version": "10.12.0-rc.0",
+  "version": "10.12.0",
   "license": "Apache-2.0",
   "bin": {
     "carbon-upgrade": "./bin/carbon-upgrade.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,18 +1750,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/elements@^10.36.0-rc.0, @carbon/elements@workspace:packages/elements":
+"@carbon/elements@^10.36.0, @carbon/elements@workspace:packages/elements":
   version: 0.0.0-use.local
   resolution: "@carbon/elements@workspace:packages/elements"
   dependencies:
     "@carbon/cli": ^10.24.0
     "@carbon/colors": ^10.26.0
-    "@carbon/grid": ^10.29.0-rc.0
+    "@carbon/grid": ^10.29.0
     "@carbon/icons": ^10.33.0
     "@carbon/import-once": ^10.6.0
     "@carbon/layout": ^10.25.0
     "@carbon/motion": ^10.19.0
-    "@carbon/themes": ^10.35.0
+    "@carbon/themes": ^10.36.0
     "@carbon/type": ^10.29.0
     fs-extra: ^8.1.0
     klaw-sync: ^6.0.0
@@ -1787,7 +1787,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/grid@^10.29.0-rc.0, @carbon/grid@workspace:packages/grid":
+"@carbon/grid@^10.29.0, @carbon/grid@workspace:packages/grid":
   version: 0.0.0-use.local
   resolution: "@carbon/grid@workspace:packages/grid"
   dependencies:
@@ -1976,7 +1976,7 @@ __metadata:
     "@carbon/icons-react": ^10.33.0
     "@carbon/styles": ^0.8.0-rc.0
     "@carbon/telemetry": 0.0.0-alpha.6
-    "@carbon/themes": ^10.35.0
+    "@carbon/themes": ^10.36.0
     "@ibm/plex": 6.0.0-next.6
     "@rollup/plugin-babel": ^5.3.0
     "@rollup/plugin-commonjs": ^18.0.0
@@ -1991,7 +1991,7 @@ __metadata:
     babel-plugin-dev-expression: ^0.2.2
     babel-preset-carbon: ^0.1.0
     browserslist-config-carbon: ^10.6.1
-    carbon-components-react: ^7.37.0-rc.0
+    carbon-components-react: ^7.37.0
     css-loader: ^5.2.4
     mini-css-extract-plugin: ^1.6.0
     postcss: ^8.2.14
@@ -2030,7 +2030,7 @@ __metadata:
     "@carbon/colors": ^10.26.0
     "@carbon/icon-helpers": ^10.18.0
     "@carbon/icons": ^10.33.0
-    "@carbon/themes": ^10.35.0
+    "@carbon/themes": ^10.36.0
     "@carbon/type": ^10.29.0
     "@skpm/builder": ^0.7.0
     color-string: ^1.5.3
@@ -2048,11 +2048,11 @@ __metadata:
   dependencies:
     "@carbon/colors": ^10.26.0
     "@carbon/feature-flags": ^0.5.0
-    "@carbon/grid": ^10.29.0-rc.0
+    "@carbon/grid": ^10.29.0
     "@carbon/layout": ^10.25.0
     "@carbon/motion": ^10.19.0
     "@carbon/test-utils": ^10.16.0
-    "@carbon/themes": ^10.35.0
+    "@carbon/themes": ^10.36.0
     "@carbon/type": ^10.29.0
   languageName: unknown
   linkType: soft
@@ -2094,7 +2094,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/themes@^10.35.0, @carbon/themes@workspace:packages/themes":
+"@carbon/themes@^10.36.0, @carbon/themes@workspace:packages/themes":
   version: 0.0.0-use.local
   resolution: "@carbon/themes@workspace:packages/themes"
   dependencies:
@@ -10976,7 +10976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components-react@^7.37.0-rc.0, carbon-components-react@workspace:packages/react":
+"carbon-components-react@^7.37.0, carbon-components-react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "carbon-components-react@workspace:packages/react"
   dependencies:
@@ -11019,7 +11019,7 @@ __metadata:
     babel-plugin-react-docgen: ^4.2.1
     babel-plugin-transform-inline-environment-variables: ^0.4.3
     browserslist-config-carbon: ^10.6.1
-    carbon-components: ^10.37.0-rc.0
+    carbon-components: ^10.37.0
     carbon-icons: ^7.0.5
     chalk: ^2.3.0
     classnames: 2.3.1
@@ -11102,7 +11102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@^10.37.0-rc.0, carbon-components@workspace:packages/components":
+"carbon-components@^10.37.0, carbon-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "carbon-components@workspace:packages/components"
   dependencies:
@@ -11115,7 +11115,7 @@ __metadata:
     "@babel/preset-react": ^7.13.13
     "@babel/runtime": ^7.14.0
     "@carbon/cli": ^10.24.0
-    "@carbon/elements": ^10.36.0-rc.0
+    "@carbon/elements": ^10.36.0
     "@carbon/icons-handlebars": ^10.33.0
     "@carbon/icons-react": ^10.33.0
     "@carbon/telemetry": 0.0.0-alpha.6


### PR DESCRIPTION
Stable release for `v10.37.0`
closes #8866 