### PR TITLE
fix(Search): restore default component size

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2335,7 +2335,7 @@ exports[`DataTable should render 1`] = `
                 >
                   <div
                     aria-labelledby="custom-id-search"
-                    className="bx--search bx--toolbar-search-container-persistent"
+                    className="bx--search bx--search--xl bx--toolbar-search-container-persistent"
                     role="search"
                   >
                     <div
@@ -3396,7 +3396,7 @@ exports[`DataTable sticky header should render 1`] = `
                 >
                   <div
                     aria-labelledby="custom-id-search"
-                    className="bx--search bx--toolbar-search-container-persistent"
+                    className="bx--search bx--search--xl bx--toolbar-search-container-persistent"
                     role="search"
                   >
                     <div

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -24,7 +24,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
   >
     <div
       aria-labelledby="custom-id-search"
-      className="bx--search custom-class bx--toolbar-search-container-expandable"
+      className="bx--search bx--search--xl custom-class bx--toolbar-search-container-expandable"
       role="search"
     >
       <div

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -177,7 +177,7 @@ export default class Search extends Component {
       labelText,
       closeButtonLabelText,
       small,
-      size = !small ? '' : 'sm',
+      size = !small ? 'xl' : 'sm',
       light,
       disabled,
       onChange,


### PR DESCRIPTION
Closes #8900
related #8824

This PR restores the default size prop on the Search component

#### Testing / Reviewing

Confirm the Search component renders as expected in all stories including Form and DataTable w/Toolbar and that there are no regressions related to  #8784 or #8598