### PR TITLE
fix: wifi icon name in icon index

### DIFF
--- a/packages/icons/icons.yml
+++ b/packages/icons/icons.yml
@@ -16056,14 +16056,14 @@
   sizes:
     - 32
 - name: wifi
-  friendly_name: WiFi
+  friendly_name: Wifi
   aliases:
     - wifi
     - internet
   sizes:
     - 32
 - name: wifi--off
-  friendly_name: WiFi off
+  friendly_name: Wifi off
   sizes:
     - 32
   aliases:


### PR DESCRIPTION
Closes [#2406](https://github.com/carbon-design-system/carbon-website/issues/2406)

This PR corrects the wifi icon name when copied from the icon index on the CDS site. Currently, the icon index copies (< WiFi32 />) instead of (< Wifi32 />) which causes an import error.  The friendlyname for these icons retain the capital "F" despite going through pascalcase so I changed it to "f". 


#### Testing / Reviewing
-Make sure the icon index copies Wifi32 for the Wifi icon
-Make sure the icon index copies WifiOff32 for the Wifi off icon

