### PR TITLE
fix(InlineLoading): add iconDescription to error and finished SVGs

### DIFF
--- a/packages/react/src/components/InlineLoading/InlineLoading.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading.js
@@ -28,7 +28,11 @@ export default function InlineLoading({
   const loadingClasses = classNames(`${prefix}--inline-loading`, className);
   const getLoading = () => {
     if (status === 'error') {
-      return <ErrorFilled16 className={`${prefix}--inline-loading--error`} />;
+      return (
+        <ErrorFilled16 className={`${prefix}--inline-loading--error`}>
+          <title>{iconDescription}</title>
+        </ErrorFilled16>
+      );
     }
     if (status === 'finished') {
       setTimeout(() => {
@@ -38,8 +42,9 @@ export default function InlineLoading({
       }, successDelay);
       return (
         <CheckmarkFilled16
-          className={`${prefix}--inline-loading__checkmark-container`}
-        />
+          className={`${prefix}--inline-loading__checkmark-container`}>
+          <title>{iconDescription}</title>
+        </CheckmarkFilled16>
       );
     }
     if (status === 'inactive' || status === 'active') {


### PR DESCRIPTION
Closes #8828

This PR adds `iconDescription` to the success and error icons in InlineLoading

#### Testing / Reviewing

Set the InlineLoading `status` to `'error'` or `'finished'` and confirm that the provided `iconDescription` is still visible