### PR TITLE
ci: add yarn cache stage for `node_modules`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,16 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: '14.x'
+      - name: Get yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2.1.6
+        id: cache
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: yarn install --immutable --immutable-cache
       - name: Check formatting of project files
         run: yarn format:diff
@@ -36,7 +45,16 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: '14.x'
+      - name: Get yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2.1.6
+        id: cache
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: yarn install --immutable --immutable-cache
       - name: Lint JavaScript files
         run: yarn lint


### PR DESCRIPTION
This PR adds some cache detection to our `node_modules` folder based on our `yarn.lock` files. This should improve some of our GitHub-based workflows by ~5min depending on how long it takes for the cache to load/save and how long it takes dependencies to install.

This is a little exploratory in terms of CI times so we'll have to see if it manages to help more than hurt in this PR and subsequent PRs after merge.

#### Changelog

**New**

**Changed**

- Update `ci.yml` workflow to use actions/cache to cache the `yarn install` stage of the project.

**Removed**

#### Testing / Reviewing

- Verify actions work as expected
- Check-in follow-up PRs after merge that the node modules have been cached