### PR TITLE
fix(carbon-react): update storybook to use mini-css plugin

### DIFF
--- a/packages/carbon-react/.gitignore
+++ b/packages/carbon-react/.gitignore
@@ -1,0 +1,1 @@
+storybook-static

--- a/packages/carbon-react/.storybook/main.js
+++ b/packages/carbon-react/.storybook/main.js
@@ -98,6 +98,14 @@ module.exports = {
       ],
     });
 
+    if (process.env.NODE_ENV === 'production') {
+      config.plugins.push(
+        new MiniCssExtractPlugin({
+          filename: '[name].[contenthash].css',
+        })
+      );
+    }
+
     return config;
   },
 };


### PR DESCRIPTION
This is a small fix so that `yarn build-storybook` works with `packages/carbon-react`.

#### Changelog

**New**

**Changed**

- Update webpack config for `packages/carbon-react`

**Removed**

#### Testing / Reviewing

- Run `cd packages/carbon-react`
- Run `yarn build-storybook` and make sure it passes
- Run `npx serve storybook-static` and view the URL to make sure the storybook built successfully
- Run `yarn develop` and make sure that development is not impacted by changing a scss file