### PR TITLE
fix(themes): add conditional to fallback guard

### DIFF
--- a/packages/themes/__tests__/mixins-test.js
+++ b/packages/themes/__tests__/mixins-test.js
@@ -9,22 +9,20 @@
 
 'use strict';
 
-const { convert, createSassRenderer } = require('@carbon/test-utils/scss');
+const { SassRenderer } = require('@carbon/test-utils/scss');
 const { themes } = require('../src');
 
-const render = createSassRenderer(__dirname);
+const { render } = SassRenderer.create(__dirname);
 
 describe('_mixins.scss', () => {
   it('should export a carbon--theme mixin', async () => {
-    const { calls } = await render(`
+    const { unwrap } = await render(`
       @import '../scss/mixins';
 
-      $t: test(mixin-exists(carbon--theme));
+      $_: get('mixin', mixin-exists(carbon--theme));
     `);
 
-    for (const call of calls) {
-      expect(call[0].getValue()).toBe(true);
-    }
+    expect(unwrap('mixin')).toBe(true);
   });
 
   it('should set token variables for the given theme', async () => {
@@ -32,21 +30,22 @@ describe('_mixins.scss', () => {
       const variable = `$carbon--theme--${key}`;
       const test = `
         @include carbon--theme(${variable}) {
-          $t: test($interactive-01);
+          $_: get('${variable}', $interactive-01);
         }
       `;
       return [variable, themes[key].interactive01, test];
     });
+
     const tests = themeTests
       .map(([_variable, _expectedColor, test]) => test)
       .join('\n');
-    const { calls } = await render(`
+    const { unwrap } = await render(`
       @import '../scss/themes';
       ${tests}
     `);
 
-    themeTests.forEach(([_variable, expectedColor], i) => {
-      expect(convert(calls[i][0])).toBe(expectedColor);
+    themeTests.forEach(([variable, expectedColor]) => {
+      expect(unwrap(variable)).toBe(expectedColor);
     });
   });
 
@@ -56,7 +55,7 @@ describe('_mixins.scss', () => {
       const test = `
         $feature-flags: (enable-css-custom-properties: true);
         @include carbon--theme(${variable}) {
-          $t: test($field-01);
+          $_: get('${variable}', $field-01);
         }
       `;
       return [variable, themes[key].interactive01, test];
@@ -64,40 +63,38 @@ describe('_mixins.scss', () => {
     const tests = themeTests
       .map(([_variable, _expectedColor, test]) => test)
       .join('\n');
-    const { calls } = await render(`
+    const { unwrap } = await render(`
       @import '../scss/themes';
       ${tests}
     `);
-    const colors = calls.map(([call]) => convert(call));
-    themeTests.forEach((_, i) => {
-      expect(convert(calls[i][0])).toBe(`${colors[i]}`);
+    themeTests.forEach(([variable]) => {
+      expect(unwrap(variable)).toBeDefined();
     });
   });
 
   it('should reset token variables after using the theme', async () => {
-    const { calls } = await render(`
+    const { unwrap } = await render(`
       @import '../scss/themes';
 
       $custom-theme: map-merge($carbon--theme--white, (
         interactive-01: #ffffff,
       ));
 
-      $t: test($interactive-01);
+      $_: get('before', $interactive-01);
 
       @include carbon--theme($custom-theme) {
-        $t: test($interactive-01);
+        $_: get('mixin', $interactive-01);
       }
 
-      $t: test($interactive-01);
+      $_: get('after', $interactive-01);
     `);
 
-    const colors = calls.map((call) => convert(call[0]));
-    expect(colors[0]).toEqual(colors[2]);
-    expect(colors[1]).toBe('#ffffff');
+    expect(unwrap('before')).toBe(unwrap('after'));
+    expect(unwrap('mixin')).toBe('#ffffff');
   });
 
   it('should reset token variables after using the theme with css custom properties', async () => {
-    const { calls } = await render(`
+    const { unwrap } = await render(`
       $feature-flags: (enable-css-custom-properties: true);
 
       @import '../scss/themes';
@@ -106,36 +103,39 @@ describe('_mixins.scss', () => {
         interactive-01: #ffffff,
       ));
 
-      $t: test($interactive-01);
+      $_: get('before', $interactive-01);
 
       @include carbon--theme($custom-theme) {
-        $t: test($interactive-01);
+        $_: get('mixin', $interactive-01);
       }
 
-      $t: test($interactive-01);
+      $_: get('after', $interactive-01);
     `);
 
-    const colors = calls.map(([call]) => convert(call));
-    expect(colors[1]).toBe('var(--cds-interactive-01, #ffffff)');
-    expect(colors[2]).toBe(`var(--cds-interactive-01, ${colors[0]})`);
+    expect(unwrap('mixin')).toBe('var(--cds-interactive-01, #ffffff)');
+    expect(unwrap('after')).toBe(
+      `var(--cds-interactive-01, ${unwrap('before')})`
+    );
   });
 
   it('should set the global carbon--theme to match the given theme', async () => {
-    const { calls } = await render(`
+    const { unwrap } = await render(`
       @import '../scss/themes';
       $carbon--theme: ( value-01: #000000 );
       $custom-theme: ( value-01: #ffffff );
 
       @include carbon--theme($custom-theme) {
-        $t: test($carbon--theme);
+        $_: get('mixin', $carbon--theme);
       }
 
-      $t: test($carbon--theme);
+      $_: get('after', $carbon--theme);
     `);
 
-    const [custom, reset] = calls.map(([call]) => convert(call));
-    expect(custom['value-01']).toBe('#ffffff');
-    expect(reset['value-01']).toBe('#000000');
+    const mixin = unwrap('mixin');
+    const after = unwrap('after');
+
+    expect(mixin['value-01']).toBe('#ffffff');
+    expect(after['value-01']).toBe('#000000');
   });
 
   describe('@mixin custom-property', () => {
@@ -175,7 +175,7 @@ describe('_mixins.scss', () => {
 
   describe('@function should-emit', () => {
     it('should emit a value only if they are different', async () => {
-      const { calls } = await render(`
+      const { unwrap } = await render(`
         @import '../scss/mixins';
 
         $theme-a: (
@@ -200,18 +200,18 @@ describe('_mixins.scss', () => {
         );
 
         // The properties are different, so should emit
-        $t: test(should-emit($theme-a, $theme-b, 'property-01', true));
-        $t: test(should-emit($theme-a, $theme-b, 'property-04', true));
+        $_: get('first', should-emit($theme-a, $theme-b, 'property-01', true));
+        $_: get('second', should-emit($theme-a, $theme-b, 'property-04', true));
 
         // The properties are the same so should not emit
-        $t: test(should-emit($theme-a, $theme-b, 'property-02', true));
-        $t: test(should-emit($theme-a, $theme-b, 'property-03', true));
+        $_: get('third', should-emit($theme-a, $theme-b, 'property-02', true));
+        $_: get('fourth', should-emit($theme-a, $theme-b, 'property-03', true));
       `);
 
-      expect(convert(calls[0][0])).toBe(true);
-      expect(convert(calls[1][0])).toBe(true);
-      expect(convert(calls[2][0])).toBe(false);
-      expect(convert(calls[3][0])).toBe(false);
+      expect(unwrap('first')).toBe(true);
+      expect(unwrap('second')).toBe(true);
+      expect(unwrap('third')).toBe(false);
+      expect(unwrap('fourth')).toBe(false);
     });
   });
 });

--- a/packages/themes/__tests__/mixins-test.js
+++ b/packages/themes/__tests__/mixins-test.js
@@ -214,4 +214,23 @@ describe('_mixins.scss', () => {
       expect(unwrap('fourth')).toBe(false);
     });
   });
+
+  describe('v11', () => {
+    it('should use fallback values for v11 tokens', async () => {
+      const { unwrap } = await render(`
+        @import '../scss/mixins';
+        @import '../scss/theme-maps';
+
+        $carbon--theme: (
+          ui-background: #ffffff,
+        );
+        @include carbon--theme();
+
+        $_: get('token', $background);
+      `);
+
+      // `ui-background` is the fallback for `background`
+      expect(unwrap('token')).toBe('#ffffff');
+    });
+  });
 });

--- a/packages/themes/tasks/builders/mixins.js
+++ b/packages/themes/tasks/builders/mixins.js
@@ -81,18 +81,34 @@ function buildMixinsFile(themes, tokens, defaultTheme, defaultThemeMapName) {
           });
         }),
         t.IfStatement({
+          // global-variable-exists('feature-flags') == false or
+          //   global-variable-exists('feature-flags') and
+          //     map-get($feature-flags, 'enable-v11-release') == true
           test: t.LogicalExpression({
-            left: t.SassFunctionCall(t.Identifier('global-variable-exists'), [
-              t.SassString('feature-flags'),
-            ]),
-            operator: 'and',
-            right: t.LogicalExpression({
-              left: t.SassFunctionCall(t.Identifier('map-get'), [
-                t.Identifier('feature-flags'),
-                t.SassString('enable-v11-release'),
+            // global-variable-exists('feature-flags') == false
+            left: t.LogicalExpression({
+              left: t.SassFunctionCall(t.Identifier('global-variable-exists'), [
+                t.SassString('feature-flags'),
               ]),
-              operator: '!=',
-              right: t.SassBoolean(true),
+              operator: '==',
+              right: t.SassBoolean(false),
+            }),
+            operator: 'or',
+            // global-variable-exists('feature-flags') and
+            //   map-get($feature-flags, 'enable-v11-release') == true
+            right: t.LogicalExpression({
+              left: t.SassFunctionCall(t.Identifier('global-variable-exists'), [
+                t.SassString('feature-flags'),
+              ]),
+              operator: 'and',
+              right: t.LogicalExpression({
+                left: t.SassFunctionCall(t.Identifier('map-get'), [
+                  t.Identifier('feature-flags'),
+                  t.SassString('enable-v11-release'),
+                ]),
+                operator: '!=',
+                right: t.SassBoolean(true),
+              }),
             }),
           }),
           consequent: t.BlockStatement(


### PR DESCRIPTION
This PR addresses a use-case with custom theming that can also impact IBM customers. To re-create the issue today, imagine the following scenario:

```scss
@import '@carbon/themes/scss/themes';

// Custom theme
$carbon--theme: (
  ui-background: #ffffff,
);
@include carbon--theme();

// Here, $ui-background is defined but our new token $background is not
```

`$background` not being defined causes issues in our components since they rely on that token to render correctly.

The `$background` fallback is not applied because our `@if` uses the following checks:

```scss
@if global-variable-exists('feature-flags') and map-get($feature-flags, 'enable-v11-release') != true {
  // ...
}
```

As a result, if `$feature-flags` does not exist as a global variable then we will not hit this branch. The build command now generates:

```scss
@if global-variable-exists('feature-flags') ==  false or
  global-variable-exists('feature-flags') and map-get($feature-flags, 'enable-v11-release') !=  true
{
  // ...
}
```

This will now emit the fallback in two situations:

- `$feature-flags` is not defined
- `$feature-flags` exists but `enable-v11-release` is not true

Both situations will skip emitting the fallbacks if `$feature-flags` exist and `enable-v11-release` is true.

#### Changelog

**New**

**Changed**

- Update builder with new conditional logic
- Update test file for mixins to new sass renderer
- Add v11 test for this bug and make sure builder passes the test

**Removed**

#### Testing / Reviewing

- Verify v11 test passes as expected in `mixins-test.js`
- Double-check my logic in case I'm missing anything 😅 