### PR TITLE
reenable safeguarding missing enable-v11-release feature flag

### DIFF
--- a/packages/components/src/globals/scss/_theme-tokens.scss
+++ b/packages/components/src/globals/scss/_theme-tokens.scss
@@ -15,6 +15,104 @@
 // to make sure that they're in sync if one has diverged from the other.
 @include carbon--theme();
 
+
+//If the feature flag enable-v11-release is not enabled tokens will not work correctly.
+@if not feature-flag-enabled('enable-v11-release') {
+  $background: $ui-background;
+  $layer: $ui-01;
+  $layer-accent: $ui-03;
+  $field: $field-01;
+  $background-inverse: $inverse-02;
+  $background-brand: $interactive-01;
+  $interactive: $interactive-04;
+
+  $border-subtle: $ui-03;
+  $border-strong: $ui-04;
+  $border-inverse: $ui-05;
+  $border-interactive: $interactive-04;
+
+  $text-primary: $text-01;
+  $text-secondary: $text-02;
+  $text-placeholder: $text-03;
+  $text-helper: $text-05;
+  $text-on-color: $text-04;
+  $text-inverse: $inverse-01;
+
+  $link-primary: $link-01;
+  $link-secondary: $link-02;
+  $link-visited: $visited-link;
+  $link-inverse: $inverse-link;
+
+  $icon-primary: $icon-01;
+  $icon-secondary: $icon-02;
+  $icon-on-color: $icon-03;
+  $icon-inverse: $inverse-01;
+
+  $support-error: $support-01;
+  $support-success: $support-02;
+  $support-warning: $support-03;
+  $support-info: $support-04;
+  $support-error-inverse: $inverse-support-01;
+  $support-success-inverse: $inverse-support-02;
+  $support-warning-inverse: $inverse-support-03;
+  $support-info-inverse: $inverse-support-04;
+
+  $overlay: $overlay-01;
+  $toggle-off: $ui-04;
+
+  $button-primary: $interactive-01;
+  $button-secondary: $interactive-02;
+  $button-tertiary: $interactive-03;
+  $button-danger-primary: $danger-01;
+  $button-danger-secondary: $danger-02;
+
+  $background-active: $active-ui;
+  $layer-active: $active-ui;
+
+  $button-danger-active: $active-danger;
+  $button-primary-active: $active-primary;
+  $button-secondary-active: $active-secondary;
+  $button-tertiary-active: $active-tertiary;
+
+  $focus-inset: $inverse-01;
+  $focus-inverse: $inverse-focus-ui;
+
+  $background-hover: $hover-ui;
+  $layer-hover: $hover-ui;
+  $field-hover: $hover-ui;
+  $background-inverse-hover: $inverse-hover-ui;
+  $link-primary-hover: $hover-primary-text;
+  $button-danger-hover: $hover-danger;
+  $button-primary-hover: $hover-primary;
+  $button-secondary-hover: $hover-secondary;
+  $button-tertiary-hover: $hover-tertiary;
+
+  $background-selected: $selected-ui;
+  $background-selected-hover: $hover-selected-ui;
+  $layer-selected: $selected-ui;
+  $layer-selected-hover: $hover-selected-ui;
+  $layer-selected-inverse: $ui-05;
+  $border-subtle-selected: $active-ui;
+
+  $layer-disabled: $disabled-01;
+  $field-disabled: $disabled-01;
+  $border-disabled: $disabled-01;
+
+  $text-disabled: $disabled-02;
+  $button-disabled: $disabled-02;
+  $icon-disabled: $disabled-02;
+
+  $text-on-color-disabled: $disabled-03;
+  $icon-on-color-disabled: $disabled-03;
+  $layer-selected-disabled: $disabled-03;
+
+  $skeleton-background: $skeleton-01;
+  $skeleton-element: $skeleton-02;
+}
+
+
+
+
 /// Theme variables
 
 /// @type Value


### PR DESCRIPTION
In the recent carbon-components package update 10.38.0, this safeguard was disabled resulting in theme tokens not being applied to components. This occurs when not using v11 flag.  There is no obvious documentation specifying that you need the feature flag for tokens to work so reenabling this until V11 would help other devs.

Tested in a local repo, tokens now applying.

Resolves #9055 