### PR TITLE
fix(themes): update themes mixin to use derived variables

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -41,6 +41,7 @@
     "@carbon/test-utils": "^10.16.0",
     "change-case": "^4.1.1",
     "core-js": "^3.6.5",
+    "css": "^3.0.0",
     "fs-extra": "^8.1.0",
     "js-yaml": "^3.13.0",
     "node-sass": "^4.13.1",

--- a/packages/themes/tasks/builders/mixins.js
+++ b/packages/themes/tasks/builders/mixins.js
@@ -123,6 +123,41 @@ function buildMixinsFile(themes, tokens, defaultTheme, defaultThemeMapName) {
         }),
         t.IfStatement({
           test: t.LogicalExpression({
+            left: t.Identifier('emit-custom-properties'),
+            operator: '==',
+            right: t.SassBoolean(true),
+          }),
+          consequent: t.BlockStatement(
+            Object.keys(tokens).flatMap((group) => {
+              return tokens[group].flatMap((token) => {
+                const name = formatTokenName(token);
+                return [
+                  t.Newline(),
+                  t.IfStatement({
+                    test: t.SassFunctionCall(t.Identifier('should-emit'), [
+                      t.Identifier('theme'),
+                      t.Identifier('parent-carbon-theme'),
+                      t.SassString(name),
+                      t.Identifier('emit-difference'),
+                    ]),
+                    consequent: t.BlockStatement([
+                      t.SassMixinCall(t.Identifier('custom-property'), [
+                        t.SassString(name),
+                        t.Identifier(name),
+                        // t.SassFunctionCall(t.Identifier('map-get'), [
+                        // t.Identifier('theme'),
+                        // t.SassString(name),
+                        // ]),
+                      ]),
+                    ]),
+                  }),
+                ];
+              });
+            })
+          ),
+        }),
+        t.IfStatement({
+          test: t.LogicalExpression({
             left: t.SassFunctionCall(t.Identifier('global-variable-exists'), [
               t.SassString('feature-flags'),
             ]),
@@ -151,52 +186,19 @@ function buildMixinsFile(themes, tokens, defaultTheme, defaultThemeMapName) {
                         t.SassValue({
                           value: `--#{$custom-property-prefix}-${name}`,
                         }),
-                        t.CallExpression({
-                          callee: t.Identifier('map-get'),
-                          arguments: [
-                            t.Identifier('theme'),
-                            t.SassString(name),
-                          ],
-                        }),
+                        t.Identifier(name),
+                        // t.CallExpression({
+                        // callee: t.Identifier('map-get'),
+                        // arguments: [
+                        // t.Identifier('theme'),
+                        // t.SassString(name),
+                        // ],
+                        // }),
                       ],
                     }),
                     global: true,
                   });
                 });
-            })
-          ),
-        }),
-        t.IfStatement({
-          test: t.LogicalExpression({
-            left: t.Identifier('emit-custom-properties'),
-            operator: '==',
-            right: t.SassBoolean(true),
-          }),
-          consequent: t.BlockStatement(
-            Object.keys(tokens).flatMap((group) => {
-              return tokens[group].flatMap((token) => {
-                const name = formatTokenName(token);
-                return [
-                  t.Newline(),
-                  t.IfStatement({
-                    test: t.SassFunctionCall(t.Identifier('should-emit'), [
-                      t.Identifier('theme'),
-                      t.Identifier('parent-carbon-theme'),
-                      t.SassString(name),
-                      t.Identifier('emit-difference'),
-                    ]),
-                    consequent: t.BlockStatement([
-                      t.SassMixinCall(t.Identifier('custom-property'), [
-                        t.SassString(name),
-                        t.SassFunctionCall(t.Identifier('map-get'), [
-                          t.Identifier('theme'),
-                          t.SassString(name),
-                        ]),
-                      ]),
-                    ]),
-                  }),
-                ];
-              });
             })
           ),
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,6 +2117,7 @@ __metadata:
     change-case: ^4.1.1
     color: ^3.1.2
     core-js: ^3.6.5
+    css: ^3.0.0
     fs-extra: ^8.1.0
     js-yaml: ^3.13.0
     node-sass: ^4.13.1


### PR DESCRIPTION
This is a draft PR for a potential fix for #9055 

This is option one that we could take, the other option is a full revert of our token changes in `carbon-components`.

The problem comes from us getting the value in custom property scenarios from the theme itself and _not_ the `$button-primary` variable that is re-initialized. This PR updates our theme builder to instead use the variables that have been initialized (or re-initialized) instead of reading from the theme itself.

cc @tw15egan 
