### PR TITLE
fix(breakpoint): fixing calculation to have +/- 0.02 outside of map-get

### DIFF
--- a/packages/layout/scss/_breakpoint.scss
+++ b/packages/layout/scss/_breakpoint.scss
@@ -196,16 +196,14 @@ $carbon--grid-breakpoints: (
   $max: if($is-number-upper, $upper, map-get($breakpoints, $upper));
 
   @if $min and $max {
-    $min-width: if(not $is-number-lower and $min, map-get($min, width), $min);
-    $max-width: if(not $is-number-upper and $max, map-get($max, width), $max);
     $min-width: if(
       not $is-number-lower and $min,
-      map-get($min, width + 0.02),
+      map-get($min, width) + 0.02,
       $min
     );
     $max-width: if(
       not $is-number-upper and $max,
-      map-get($max, width - 0.02),
+      map-get($max, width) - 0.02,
       $max
     );
     @media (min-width: $min-width) and (max-width: $max-width) {

--- a/packages/layout/scss/_breakpoint.scss
+++ b/packages/layout/scss/_breakpoint.scss
@@ -196,6 +196,8 @@ $carbon--grid-breakpoints: (
   $max: if($is-number-upper, $upper, map-get($breakpoints, $upper));
 
   @if $min and $max {
+    $min-width: if(not $is-number-lower and $min, map-get($min, width), $min);
+    $max-width: if(not $is-number-upper and $max, map-get($max, width), $max);
     $min-width: if(
       not $is-number-lower and $min,
       map-get($min, width + 0.02),


### PR DESCRIPTION
This is fixing a change in the PR merge #8346, which breaks the mixin from
allowing entering any breakpoint names (sm, md, etc).

This issue was raised by an adopter for `Carbon for IBM.com` (https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6554), though when digging into the issue, we found that this stemmed from this change in `_breakpoint.scss`. 

Closes #

N/A

#### Changelog

**Changed**

- `_breakpoint.scss`

#### Testing / Reviewing

This can be tested by using the `carbon--breakpoint-between` mixin and applying breakpoint names into the range arguments.

Also, sassmeister link for testing (thank you @kennylam !):
https://www.sassmeister.com/gist/b42f3e8aa9a655f09928da09c6ad3451
