### PR TITLE
feat(ComboBox): add ability to forward ref

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -438,6 +438,7 @@ Map {
     },
   },
   "ComboBox" => Object {
+    "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {
       "ariaLabel": "Choose an item",
       "direction": "bottom",
@@ -692,6 +693,7 @@ Map {
         "type": "node",
       },
     },
+    "render": [Function],
   },
   "ComposedModal" => Object {
     "defaultProps": Object {

--- a/packages/react/src/components/ComboBox/ComboBox-story.js
+++ b/packages/react/src/components/ComboBox/ComboBox-story.js
@@ -70,9 +70,6 @@ export const combobox = () => (
       placeholder="Filter..."
       titleText="ComboBox title"
       helperText="Combobox helper text"
-      ref={() => {
-        console.log('some ref');
-      }}
     />
   </div>
 );

--- a/packages/react/src/components/ComboBox/ComboBox-story.js
+++ b/packages/react/src/components/ComboBox/ComboBox-story.js
@@ -70,6 +70,9 @@ export const combobox = () => (
       placeholder="Filter..."
       titleText="ComboBox title"
       helperText="Combobox helper text"
+      ref={() => {
+        console.log('some ref');
+      }}
     />
   </div>
 );

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -70,7 +70,7 @@ const findHighlightedIndex = ({ items, itemToString }, inputValue) => {
 
 const getInstanceId = setupGetInstanceId();
 
-const ComboBox = (props) => {
+const ComboBox = React.forwardRef((props, ref) => {
   const {
     ariaLabel,
     className: containerClassName,
@@ -308,7 +308,7 @@ const ComboBox = (props) => {
                   aria-controls={inputProps['aria-controls']}
                   {...inputProps}
                   {...rest}
-                  ref={mergeRefs(textInput, rootProps.ref)}
+                  ref={mergeRefs(textInput, ref)}
                 />
                 {invalid && (
                   <WarningFilled16
@@ -387,7 +387,7 @@ const ComboBox = (props) => {
       }}
     </Downshift>
   );
-};
+});
 
 ComboBox.propTypes = {
   /**


### PR DESCRIPTION
Closes #8744 

This PR updates the `ComboBox` component to use `forwardRef` since it's now a functional component, so that it can pass down any ref passed to it.

#### Changelog

**Changed**

- uses `forwardRef`
- adds ref example to the story for testing


#### Testing / Reviewing

In the `ComboBox` default story, you should now be able to see the ref being logged in the console and no warning. All tests should pass.
