### PR TITLE
fix(Storybook): move margin to wrapper

### DIFF
--- a/packages/react/src/components/FormGroup/FormGroup-story.js
+++ b/packages/react/src/components/FormGroup/FormGroup-story.js
@@ -37,16 +37,12 @@ export const _Default = () => (
     legendId="formgroup-legend-id"
     legendText="FormGroup Legend"
     style={{ maxWidth: '400px' }}>
-    <TextInput
-      id="one"
-      labelText="First Name"
-      style={{ marginBottom: '1rem' }}
-    />
-    <TextInput
-      id="two"
-      labelText="Last Name"
-      style={{ marginBottom: '1rem' }}
-    />
+    <div style={{ marginBottom: '1rem' }}>
+      <TextInput id="one" labelText="First Name" />
+    </div>
+    <div style={{ marginBottom: '1rem' }}>
+      <TextInput id="two" labelText="Last Name" />
+    </div>
 
     <RadioButtonGroup
       legendText="Radio button heading"


### PR DESCRIPTION
https://github.com/carbon-design-system/carbon/issues/9150

Moves `marginBottom` to the wrapping `div` so invalid styles are not affected when present

#### Testing / Reviewing

Ensure invalid styles work correctly in the `FormGroup` story
