### PR TITLE
feat(FilterableMultiselect): add optional autoComplete prop

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3578,6 +3578,9 @@ Map {
         "ariaLabel": Object {
           "type": "string",
         },
+        "autoComplete": Object {
+          "type": "string",
+        },
         "compareItems": Object {
           "isRequired": true,
           "type": "func",

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -36,6 +36,11 @@ export default class FilterableMultiSelect extends React.Component {
     ariaLabel: PropTypes.string,
 
     /**
+     * Specify autocomplete attribute value. Defaults to 'off'
+     */
+    autoComplete: PropTypes.string,
+
+    /**
      * Specify the direction of the multiselect dropdown. Can be either top or bottom.
      */
     direction: PropTypes.oneOf(['top', 'bottom']),
@@ -282,6 +287,7 @@ export default class FilterableMultiSelect extends React.Component {
     const { highlightedIndex, isOpen, inputValue } = this.state;
     const {
       ariaLabel,
+      autoComplete,
       className: containerClassName,
       direction,
       disabled,
@@ -432,6 +438,7 @@ export default class FilterableMultiSelect extends React.Component {
                 // Remove excess aria `aria-labelledby`. HTML <label for>
                 // provides this aria information.
                 'aria-labelledby': null,
+                autoComplete: autoComplete ? autoComplete : 'off',
                 disabled,
                 placeholder,
                 onClick: () => {


### PR DESCRIPTION
Closes #8993 

[Chrome no longer supports the HTML5 attribute autocomplete's `off` configuration](https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164).  

As a workaround this PR adds an optional prop to FilterableMultiselect called `autoComplete` allowing Chrome users to utilize the _unique_ browser feature of passing a string describing the expected input (eg `autoComplete="super-secret-password"`) in order to disable autocomplete. A method described in the bug report closure above as
> ...if you have an address input field in your CRM tool that you don't want Chrome to Autofill, you can give it semantic meaning that makes sense relative to what you're asking for: e.g. autocomplete="new-user-street-address".  If Chrome encounters that, it won't try and autofill the field.

#### Testing / Reviewing

1. pull down and checkout the PR
2. start the react Storybook and observe `autocomplete="false"` on the Filterable Multiselect's input
3. in react/.../Multiselect/MultiSelect-story.js on line 195 add the prop `autoComplete="user-input"
4. in the React Storybook observe `autocomplete="user-input"` on the Filterable Multiselect's input

@abbeyhrt _maybe have your user give this spin and see if they can still recreate the issue_
