### PR TITLE
fix(Storybook): improve filtered search text contrast

### DIFF
--- a/packages/carbon-react/.storybook/manager-head.html
+++ b/packages/carbon-react/.storybook/manager-head.html
@@ -68,4 +68,8 @@
   a.sidebar-item[data-selected='true'] svg {
     color: #161616;
   }
+
+  mark[class*='css-'] {
+    color: #0f62fe;
+  }
 </style>

--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -80,4 +80,8 @@
   a.sidebar-item[data-selected='true'] svg {
     color: #161616;
   }
+
+  mark[class*='css-'] {
+    color: #0f62fe;
+  }
 </style>


### PR DESCRIPTION
Fixes an issue with text contrast in the storybook when searching for items

<img width="306" alt="Screen Shot 2021-07-12 at 3 30 13 PM" src="https://user-images.githubusercontent.com/11928039/125345103-1bd2e300-e326-11eb-8faa-4f2990aa6632.png">


#### Changelog

**Changed**

- Changed highlight color to blue

#### Testing / Reviewing

Search for a component in the storybook and ensure the text is legible 
