### PR TITLE
fix(TextInput): use disabled token

### DIFF
--- a/packages/components/src/components/text-input/_text-input.scss
+++ b/packages/components/src/components/text-input/_text-input.scss
@@ -214,7 +214,7 @@
     color: $text-disabled;
     cursor: not-allowed;
     // Needed to fix disabled text in Safari #6673
-    -webkit-text-fill-color: currentColor;
+    -webkit-text-fill-color: $disabled-02;
   }
 
   .#{$prefix}--text-input--light:disabled {

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -220,7 +220,7 @@
     color: $text-disabled;
     cursor: not-allowed;
     // Needed to fix disabled text in Safari #6673
-    -webkit-text-fill-color: currentColor;
+    -webkit-text-fill-color: $text-disabled;
   }
 
   // V11: Possibly deprecate


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/6673
Ref https://github.com/carbon-design-system/carbon/pull/6680

Uses the `disabled-02` token directly, as the initial value of `-webkit-text-fill-color` is `currentColor` and not solving the issue. Fixed the issue in the `components` package as well as `@carbon/styles`

#### Changelog

**Changed**

- Changed `currentColor` to `disabled-02` 

#### Testing / Reviewing

Ensure disabled text in safari renders as the correct color