### PR TITLE
docs(styles): add sass.md docs and README docs

### DIFF
--- a/packages/cli/src/commands/sync/readme.js
+++ b/packages/cli/src/commands/sync/readme.js
@@ -18,6 +18,7 @@ const packageDenyList = new Set([
   'carbon-components',
   'carbon-components-react',
   '@carbon/sketch',
+  '@carbon/styles',
 ]);
 
 function run({ root, packagePaths }) {

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -20,23 +20,118 @@ yarn add @carbon/styles
 
 ## Usage
 
-### Sass entrypoints
+HOW DO WE ANTICIPATE PEOPLE USING THIS PACKAGE?
 
-| Entrypoint                   | Description                                                                                                  |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `index.scss`                 | Entrypoint that brings in all of the CSS for the Carbon Design System                                        |
-| `scss/_breakpoint.scss`      | Use helpers to easily create breakpoints in your product that align to the 16 column grid                    |
-| `scss/_colors.scss`          | Provides access to colors from the IBM Design Language                                                       |
-| `scss/_config.scss`          | Allows you to configure various behaviors of Carbon                                                          |
-| `scss/_feature-flags.scss`   | Enable or disable various feature flags to try out experiments within Carbon                                 |
-| `scss/_grid.scss`            | Provides access to grid mixins and helpers for working with the 16 column grid                               |
-| `scss/_motion.scss`          | Provides access to motion easing curves and durations from the IBM Design Language                           |
-| `scss/_reset.scss`           | Brings in a CSS reset to enable consistent styles across browsers                                            |
-| `scss/_themes.scss`          | Provides access to the default themes used with Carbon                                                       |
-| `scss/_theme.scss`           | Provides access to the current theme and theme helpers to use in your project                                |
-| `scss/_type.scss`            | Provides access to type tokens configured for use with IBM Plex                                              |
-| `scss/components/*`          | Bring in a single component, or several that you need for your project. Great for optimizing CSS bundle size |
-| `scss/components/index.scss` | Bring in all component styles                                                                                |
+WHAT ARE THE TOP 5 USE-CASES THAT WE EXPECT PEOPLE TO HAVE?
+
+WHERE WILL THEY GO IF THEY CANNOT FIND ONE OF THOSE USE-CASES?
+
+You can bring in all the styles for the Carbon Design System by including
+`@carbon/styles` in your Sass files. For example:
+
+```scss
+@use '@carbon/styles';
+```
+
+If you only would like to bring in specific components from Carbon, you can
+import them in a similar way:
+
+```scss
+@use '@carbon/styles/scss/components/accordion';
+@use '@carbon/styles/scss/components/button';
+@use '@carbon/styles/scss/components/checkbox';
+```
+
+You can configure various parts of the `@carbon/styles` package using the `with`
+syntax alongside `@use`. For example, you can change the default theme used by
+Carbon by writing the following:
+
+```scss
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/theme' with (
+  $theme: themes.$g100,
+);
+@use '@carbon/styles/scss/components/accordion';
+```
+
+In the above code snippet, we set the default theme to the `g100` theme from the
+`themes` file provided by `@carbon/styles`.
+
+Finally, to define the tokens for the theme you will need to call the `theme`
+mixin in the `:root` selector. For example:
+
+```scss
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/theme' with (
+  $theme: themes.$g100,
+);
+@use '@carbon/styles/scss/components/accordion';
+
+:root {
+  @include theme.theme();
+}
+```
+
+### Design tokens
+
+You can access the design tokens defined by the Carbon Design System through the
+`@carbon/styles/scss/theme` entrypoint. This file will allow you to refer to
+tokens using Sass Variables as well as get the current value for any token in
+the current theme. For example:
+
+```scss
+@use '@carbon/styles/scss/theme';
+
+body {
+  background: theme.$background;
+}
+```
+
+Under the hood, the value of the `$background` Sass Variable will map to the CSS
+Custom Property `var(--cds-background)`. It's important to note that if you're
+manipulating the value of a token that you will now need to use the `calc()` CSS
+function.
+
+```scss
+@use '@carbon/styles/scss/theme';
+
+.my-component {
+  // Before
+  margin: theme.$spacing-05 / 2;
+
+  // After
+  background: calc(#{theme.$spacing-05} / 2);
+}
+```
+
+This file also includes [contextual tokens](#todo-link) like `$field`, `$layer`,
+or `border-strong` for you to use, as well.
+
+If you would like to change a specific [component token](#todo-link), then you
+will need to configure the component import itself.
+
+```scss
+@use '@carbon/styles/scss/components/button' with (
+  $button-separator: #e0e0e0,
+);
+```
+
+### Theming
+
+- How to apply a theme (a set of design tokens) to a page or component?
+- how do I add my own design tokens?
+
+#### Design Tokens
+
+- How a value is represented, how it can be used or redefined for a project?
+  - Represented: static vs CSS Custom property
+  - Used:
+    - @use
+    - var(--cds-token-01), or $token-01
+  - Changing
+    - Theming
+- Extending
+  - how do I add my own design tokens?
 
 ### Optimizing CSS bundle size
 
@@ -61,6 +156,30 @@ components then you would do the following:
 @use '@carbon/styles/scss/components/accordion';
 @use '@carbon/styles/scss/components/breadcrumb';
 ```
+
+### Sass entrypoints
+
+| Entrypoint                   | Description                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `index.scss`                 | Entrypoint that brings in all of the CSS for the Carbon Design System                                        |
+| `scss/_breakpoint.scss`      | Use helpers to easily create breakpoints in your product that align to the 16 column grid                    |
+| `scss/_colors.scss`          | Provides access to colors from the IBM Design Language                                                       |
+| `scss/_config.scss`          | Allows you to configure various behaviors of Carbon                                                          |
+| `scss/_feature-flags.scss`   | Enable or disable various feature flags to try out experiments within Carbon                                 |
+| `scss/_grid.scss`            | Provides access to grid mixins and helpers for working with the 16 column grid                               |
+| `scss/_motion.scss`          | Provides access to motion easing curves and durations from the IBM Design Language                           |
+| `scss/_reset.scss`           | Brings in a CSS reset to enable consistent styles across browsers                                            |
+| `scss/_themes.scss`          | Provides access to the default themes used with Carbon                                                       |
+| `scss/_theme.scss`           | Provides access to the current theme and theme helpers to use in your project                                |
+| `scss/_type.scss`            | Provides access to type tokens configured for use with IBM Plex                                              |
+| `scss/components/*`          | Bring in a single component, or several that you need for your project. Great for optimizing CSS bundle size |
+| `scss/components/index.scss` | Bring in all component styles                                                                                |
+
+## 📖 API Documentation
+
+If you're looking for `@carbon/styles` API documentation, check out:
+
+- [Sass](./docs/sass.md)
 
 ## 🙌 Contributing
 

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -18,13 +18,28 @@ instead:
 yarn add @carbon/styles
 ```
 
+This package requires [Dart Sass](http://npmjs.com/package/sass) in order to
+compile. It uses
+[Sass modules](https://css-tricks.com/introducing-sass-modules/) to organize the
+codebase and provide exports to use.
+
+If you're new to Sass, or are wondering how to configure Sass for your project,
+we recommend checking out the following resources and links:
+
+- [Sass Basics](https://sass-lang.com/guide)
+- [Webpack with Sass](https://webpack.js.org/loaders/sass-loader/)
+- [Next.js with Sass](https://nextjs.org/docs/basic-features/built-in-css-support#sass-support)
+- [Create React App with Sass](https://create-react-app.dev/docs/adding-a-sass-stylesheet/)
+- [Parcel with Sass](https://v2.parceljs.org/languages/sass/)
+- [Vite with Sass](https://vitejs.dev/guide/features.html#css-pre-processors)
+- [Snowpack with Sass](https://www.snowpack.dev/guides/sass/)
+
+Once you get Sass up and running in your project, make sure to configure Sass to
+include `node_modules` in its `includePaths` option. For more information,
+checkout the [configuration](./docs/sass.md#configuration) section in our Sass
+docs.
+
 ## Usage
-
-HOW DO WE ANTICIPATE PEOPLE USING THIS PACKAGE?
-
-WHAT ARE THE TOP 5 USE-CASES THAT WE EXPECT PEOPLE TO HAVE?
-
-WHERE WILL THEY GO IF THEY CANNOT FIND ONE OF THOSE USE-CASES?
 
 You can bring in all the styles for the Carbon Design System by including
 `@carbon/styles` in your Sass files. For example:
@@ -37,39 +52,62 @@ If you only would like to bring in specific components from Carbon, you can
 import them in a similar way:
 
 ```scss
+@use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/components/accordion';
 @use '@carbon/styles/scss/components/button';
 @use '@carbon/styles/scss/components/checkbox';
 ```
 
-You can configure various parts of the `@carbon/styles` package using the `with`
-syntax alongside `@use`. For example, you can change the default theme used by
-Carbon by writing the following:
+There are various helpers that you can include from Carbon, as well, such as a
+CSS reset, grid, breakpoint helpers, and more. You can include these similar to
+how you bring in components:
 
 ```scss
-@use '@carbon/styles/scss/themes';
-@use '@carbon/styles/scss/theme' with (
-  $theme: themes.$g100,
-);
-@use '@carbon/styles/scss/components/accordion';
+// Bring in the CSS Reset
+@use '@carbon/styles/scss/reset';
+
+// Bring in the CSS Grid
+@use '@carbon/styles/scss/grid';
 ```
 
-In the above code snippet, we set the default theme to the `g100` theme from the
-`themes` file provided by `@carbon/styles`.
+To learn more about the various helpers that `@carbon/styles` provides, checkout
+the overview of the files available to use in our
+[Sass docs](./docs/sass.md#files).
 
-Finally, to define the tokens for the theme you will need to call the `theme`
-mixin in the `:root` selector. For example:
+## Theming
+
+You can change the default theme of Carbon by doing the following:
 
 ```scss
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme' with (
   $theme: themes.$g100,
 );
-@use '@carbon/styles/scss/components/accordion';
+```
 
-:root {
-  @include theme.theme();
-}
+This example uses a built-in theme from Carbon provided by the `scss/themes`
+entrypoint. You can also use a custom theme, or add your own custom tokens to
+extend the theme.
+
+```scss
+// Configure with a custom theme
+@use '@carbon/styles/scss/theme' with (
+  $theme: (
+    background: #e2e2e2,
+    text-primary: #ffffff,
+  ),
+);
+```
+
+```scss
+// Extend the g100 theme with your own tokens
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/theme' with (
+  $fallback: themes.$g100,
+  $theme: (
+    custom-token-01: #000000,
+  ),
+);
 ```
 
 ### Design tokens
@@ -88,92 +126,9 @@ body {
 ```
 
 Under the hood, the value of the `$background` Sass Variable will map to the CSS
-Custom Property `var(--cds-background)`. It's important to note that if you're
-manipulating the value of a token that you will now need to use the `calc()` CSS
-function.
-
-```scss
-@use '@carbon/styles/scss/theme';
-
-.my-component {
-  // Before
-  margin: theme.$spacing-05 / 2;
-
-  // After
-  background: calc(#{theme.$spacing-05} / 2);
-}
-```
-
-This file also includes [contextual tokens](#todo-link) like `$field`, `$layer`,
-or `border-strong` for you to use, as well.
-
-If you would like to change a specific [component token](#todo-link), then you
-will need to configure the component import itself.
-
-```scss
-@use '@carbon/styles/scss/components/button' with (
-  $button-separator: #e0e0e0,
-);
-```
-
-### Theming
-
-- How to apply a theme (a set of design tokens) to a page or component?
-- how do I add my own design tokens?
-
-#### Design Tokens
-
-- How a value is represented, how it can be used or redefined for a project?
-  - Represented: static vs CSS Custom property
-  - Used:
-    - @use
-    - var(--cds-token-01), or $token-01
-  - Changing
-    - Theming
-- Extending
-  - how do I add my own design tokens?
-
-### Optimizing CSS bundle size
-
-When you bring in `@carbon/styles` directly, it will include all of the styles
-available for the Carbon Design System. If you would like to bring in only the
-styles that you use, then we recommend structuring your imports in the following
-way:
-
-```scss
-// Bring in top-level / global styles
-@use '@carbon/styles/reset';
-
-// Bring in each component that you use
-@use '@carbon/styles/scss/components/<component>';
-```
-
-For example, if your project is only using the Accordion and Breadcrumb
-components then you would do the following:
-
-```scss
-@use '@carbon/styles/reset';
-@use '@carbon/styles/scss/components/accordion';
-@use '@carbon/styles/scss/components/breadcrumb';
-```
-
-### Sass entrypoints
-
-| Entrypoint                   | Description                                                                                                  |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `index.scss`                 | Entrypoint that brings in all of the CSS for the Carbon Design System                                        |
-| `scss/_breakpoint.scss`      | Use helpers to easily create breakpoints in your product that align to the 16 column grid                    |
-| `scss/_colors.scss`          | Provides access to colors from the IBM Design Language                                                       |
-| `scss/_config.scss`          | Allows you to configure various behaviors of Carbon                                                          |
-| `scss/_feature-flags.scss`   | Enable or disable various feature flags to try out experiments within Carbon                                 |
-| `scss/_grid.scss`            | Provides access to grid mixins and helpers for working with the 16 column grid                               |
-| `scss/_motion.scss`          | Provides access to motion easing curves and durations from the IBM Design Language                           |
-| `scss/_reset.scss`           | Brings in a CSS reset to enable consistent styles across browsers                                            |
-| `scss/_themes.scss`          | Provides access to the default themes used with Carbon                                                       |
-| `scss/_theme.scss`           | Provides access to the current theme and theme helpers to use in your project                                |
-| `scss/_type.scss`            | Provides access to type tokens configured for use with IBM Plex                                              |
-| `scss/components/*`          | Bring in a single component, or several that you need for your project. Great for optimizing CSS bundle size |
-| `scss/components/index.scss` | Bring in all component styles                                                                                |
+Custom Property `var(--cds-background)`. This file also includes
+[contextual tokens](#todo-link) like `$field`, `$layer`, or `border-strong` for
+you to use, as well.
 
 ## 📖 API Documentation
 

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -125,10 +125,8 @@ body {
 }
 ```
 
-Under the hood, the value of the `$background` Sass Variable will map to the CSS
-Custom Property `var(--cds-background)`. This file also includes
-[contextual tokens](#todo-link) like `$field`, `$layer`, or `border-strong` for
-you to use, as well.
+For a full list of tokens available for you to use, check out our
+[theming documentation](../themes/docs/sass.md#tokens).
 
 ## 📖 API Documentation
 

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -33,26 +33,6 @@ The `@carbon/styles` package provides the Sass files needed to include every
 style for the Carbon Design System. It includes entrypoints for themes, tokens,
 CSS helpers, components, and more.
 
-This package requires [Dart Sass](http://npmjs.com/package/sass) in order to
-compile. It uses
-[Sass modules](https://css-tricks.com/introducing-sass-modules/) to organize the
-codebase and provide exports to use.
-
-If you're new to Sass, or are wondering how to configure Sass for your project,
-we recommend checking out the following resources and links:
-
-- [Sass Basics](https://sass-lang.com/guide)
-- [Webpack with Sass](https://webpack.js.org/loaders/sass-loader/)
-- [Next.js with Sass](https://nextjs.org/docs/basic-features/built-in-css-support#sass-support)
-- [Create React App with Sass](https://create-react-app.dev/docs/adding-a-sass-stylesheet/)
-- [Parcel with Sass](https://v2.parceljs.org/languages/sass/)
-- [Vite with Sass](https://vitejs.dev/guide/features.html#css-pre-processors)
-- [Snowpack with Sass](https://www.snowpack.dev/guides/sass/)
-
-Once you get Sass up and running in your project, make sure to configure Sass to
-include `node_modules` in its `includePaths` option. For more information,
-checkout the [configuration](#configuration) section below.
-
 ### Files
 
 The following is a table of all files that are available to use. While there may

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -8,14 +8,15 @@
 - [Overview](#overview)
   - [Files](#files)
 - [Breakpoint](#breakpoint)
+- [Colors](#colors)
 - [Config](#config)
-- [Color](#color)
 - [Feature Flags](#feature-flags)
 - [Grid](#grid)
 - [Motion](#motion)
 - [Reset](#reset)
 - [Spacing](#spacing)
-- [Theming](#theming)
+- [Themes](#themes)
+- [Theme](#theme)
 - [Type](#type)
 - [Components](#components)
 - [Utilities](#utilities)
@@ -50,8 +51,8 @@ between version updates.
 | [`scss/motion`](#motion)               | Helper function, mixins, and tokens for motion             |
 | [`scss/reset`](#reset)                 | A CSS Reset                                                |
 | [`scss/spacing`](#spacing)             | Variables for the spacing scale                            |
-| [`scss/theme`](#theming)               | Tokens for the current theme                               |
-| [`scss/themes`](#theming)              | Reference the default themes from the Carbon Design System |
+| [`scss/theme`](#theme)                 | Tokens for the current theme                               |
+| [`scss/themes`](#themes)               | Reference the default themes from the Carbon Design System |
 | [`scss/type`](#type)                   | Type tokens and helpers                                    |
 | [`scss/components/`](#components)      | A directory containing component styles                    |
 | [`scss/utilities/`](#utilities)        | A directory containing common CSS utilities                |
@@ -104,12 +105,85 @@ between version updates.
 | :------------------------------------ | :------------------- |
 | `@use '@carbon/styles/scss/spacing';` | `scss/_spacing.scss` |
 
-## Theming
+## Themes
 
 | Import                               | Filepath            |
 | :----------------------------------- | :------------------ |
-| `@use '@carbon/styles/scss/theme';`  | `scss/_theme.scss`  |
 | `@use '@carbon/styles/scss/themes';` | `scss/_themes.scss` |
+
+This entrypoint re-exports the `themes` entrypoint from the `@carbon/themes`. it
+provides access to the theme variables built for the Carbon Design System.
+
+These theme variables can be used in the following way:
+
+```scss
+@use '@carbon/styles/scss/themes';
+
+// themes.$white
+// themes.$g10
+// themes.$g90
+// themes.$g100
+```
+
+## Theme
+
+| Import                              | Filepath           |
+| :---------------------------------- | :----------------- |
+| `@use '@carbon/styles/scss/theme';` | `scss/_theme.scss` |
+
+This entrypoint re-exports the `theme` entrypoint from the `@carbon/themes`.
+This entrypoint exports all of the design tokens as Sass Variables, as well as
+helpers for you to interact with the theme.
+
+To use a design token from this entrypoint, you can include the filepath and
+reference it as a variable.
+
+```scss
+@use '@carbon/styles/scss/theme';
+
+body {
+  background: theme.$background;
+}
+```
+
+The value of the `theme.$background` token is a CSS Custom Property. For
+example, `theme.$background` would have the value `var(--cds-background)`. To
+get the value of a token, you will need to use the `theme.get` function
+described below.
+
+For a full list of tokens available, check out our
+[themes documentation](../../themes/docs/sass.md#tokens).
+
+There are also some helpers that you can use from this entrypoint. These
+include:
+
+- `theme.get` to get access to the value of a token from the theme
+- `theme.extend` to extend the current theme with new values
+
+You can use these in the following way:
+
+```scss
+@use '@carbon/styles/scss/theme';
+
+@include theme.extend(
+  (
+    custom-token: #000000,
+  )
+);
+
+.my-selector {
+  background: rgba(theme.get('custom-token'), 0.1);
+}
+```
+
+**Configuration**
+
+The `@carbon/styles/scss/theme` entrypoint can be configured with the following
+options:
+
+- `$theme` to set the current theme
+- `$fallback` to set the fallback theme. This value is used to get values of
+  tokens if they are not defined in the current `$theme`
 
 ## Type
 
@@ -118,6 +192,24 @@ between version updates.
 | `@use '@carbon/styles/scss/type';` | `scss/_type.scss` |
 
 ## Components
+
+All of the styles for the components in the Carbon Design System live in the
+`scss/components` directory. You can include all of the styles for a component
+by including its entrypoint file. For a full list of component styles that you
+can import, check out the files table below.
+
+**Component tokens**
+
+In some situations, you may want to change the tokens for a specific component.
+To do so you will need to configure the module and provide the tokens you would
+like to see changed. For example, if you wanted to change the component token
+`button-separator` for `button` you would do the following:
+
+```scss
+@use '@carbon/styles/scss/components/button' with (
+  $button-separator: #e4e4e4,
+);
+```
 
 **Files**
 

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -1,0 +1,222 @@
+# `@carbon/styles`
+
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Overview](#overview)
+  - [Files](#files)
+- [Breakpoint](#breakpoint)
+- [Config](#config)
+- [Color](#color)
+- [Feature Flags](#feature-flags)
+- [Grid](#grid)
+- [Motion](#motion)
+- [Reset](#reset)
+- [Spacing](#spacing)
+- [Theming](#theming)
+- [Type](#type)
+- [Components](#components)
+- [Utilities](#utilities)
+- [Configuration](#configuration)
+  - [`sass-loader`](#sass-loader)
+  - [Parcel](#parcel)
+  - [Vite](#vite)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
+
+## Overview
+
+The `@carbon/styles` package provides the Sass files needed to include every
+style for the Carbon Design System. It includes entrypoints for themes, tokens,
+CSS helpers, components, and more.
+
+This package requires [Dart Sass](http://npmjs.com/package/sass) in order to
+compile. It uses
+[Sass modules](https://css-tricks.com/introducing-sass-modules/) to organize the
+codebase and provide exports to use.
+
+If you're new to Sass, or are wondering how to configure Sass for your project,
+we recommend checking out the following resources and links:
+
+- [Sass Basics](https://sass-lang.com/guide)
+- [Webpack with Sass](https://webpack.js.org/loaders/sass-loader/)
+- [Next.js with Sass](https://nextjs.org/docs/basic-features/built-in-css-support#sass-support)
+- [Create React App with Sass](https://create-react-app.dev/docs/adding-a-sass-stylesheet/)
+- [Parcel with Sass](https://v2.parceljs.org/languages/sass/)
+- [Vite with Sass](https://vitejs.dev/guide/features.html#css-pre-processors)
+- [Snowpack with Sass](https://www.snowpack.dev/guides/sass/)
+
+Once you get Sass up and running in your project, make sure to configure Sass to
+include `node_modules` in its `includePaths` option. For more information,
+checkout the [configuration](#configuration) section below.
+
+### Files
+
+The following is a table of all files that are available to use. While there may
+be additional files that you can import from directly within the package, these
+are the public entrypoints that are maintained and follow semantic versioning
+between version updates.
+
+| File                 | Description                                                |
+| :------------------- | :--------------------------------------------------------- |
+| `scss/breakpoint`    | Helper functions and mixins for working with breakpoints   |
+| `scss/colors`        | Access colors from every swatch in the IBM Design Language |
+| `scss/config`        | Configure various options for the package                  |
+| `scss/feature-flags` | Configure various feature flags for experiments            |
+| `scss/grid`          | Access and use the CSS Grid built-in to Carbon             |
+| `scss/motion`        | Helper function, mixins, and tokens for motion             |
+| `scss/reset`         | A CSS Reset                                                |
+| `scss/spacing`       | Variables for the spacing scale                            |
+| `scss/theme`         | Tokens for the current theme                               |
+| `scss/themes`        | Reference the default themes from the Carbon Design System |
+| `scss/type`          | Type tokens and helpers                                    |
+| `scss/components/`   | A directory containing component styles                    |
+| `scss/utilities/`    | A directory containing common CSS utilities                |
+
+## Breakpoint
+
+| Import                            | Filepath                |
+| :-------------------------------- | :---------------------- |
+| `@use '@carbon/scss/breakpoint';` | `scss/_breakpoint.scss` |
+
+## Config
+
+| Import                        | Filepath            |
+| :---------------------------- | :------------------ |
+| `@use '@carbon/scss/config';` | `scss/_config.scss` |
+
+## Color
+
+| Import                        | Filepath            |
+| :---------------------------- | :------------------ |
+| `@use '@carbon/scss/colors';` | `scss/_colors.scss` |
+
+## Feature Flags
+
+| Import                               | Filepath                   |
+| :----------------------------------- | :------------------------- |
+| `@use '@carbon/scss/feature-flags';` | `scss/_feature-flags.scss` |
+
+## Grid
+
+| Import                      | Filepath          |
+| :-------------------------- | :---------------- |
+| `@use '@carbon/scss/grid';` | `scss/_grid.scss` |
+
+## Motion
+
+| Import                        | Filepath            |
+| :---------------------------- | :------------------ |
+| `@use '@carbon/scss/motion';` | `scss/_motion.scss` |
+
+## Reset
+
+| Import                       | Filepath           |
+| :--------------------------- | :----------------- |
+| `@use '@carbon/scss/reset';` | `scss/_reset.scss` |
+
+## Spacing
+
+| Import                         | Filepath             |
+| :----------------------------- | :------------------- |
+| `@use '@carbon/scss/spacing';` | `scss/_spacing.scss` |
+
+## Theming
+
+| Import                        | Filepath            |
+| :---------------------------- | :------------------ |
+| `@use '@carbon/scss/theme';`  | `scss/_theme.scss`  |
+| `@use '@carbon/scss/themes';` | `scss/_themes.scss` |
+
+## Type
+
+| Import                      | Filepath          |
+| :-------------------------- | :---------------- |
+| `@use '@carbon/scss/type';` | `scss/_type.scss` |
+
+## Components
+
+**Files**
+
+| Component | File                                                        |
+| :-------- | :---------------------------------------------------------- |
+| Accordion | [`scss/components/accordion`](../scss/components/accordion) |
+
+## Utilities
+
+**Files**
+
+| File                           | Description |
+| :----------------------------- | :---------- |
+| `scss/utilities/focus-outline` |             |
+
+## Configuration
+
+You will need to configure Sass to be able to lookup packages from your
+`node_modules` folder. To do this, use the `includePaths` option and set its
+value to an array of locations where Sass should look to find `node_modules`
+folders.
+
+For most teams, this configuration will look like:
+
+```json
+{
+  "includePaths": ["node_modules"]
+}
+```
+
+For bundler specific solutions, check out the sections below for your bundler of
+choice. If you can't find what you're looking for, please make an
+[issue](https://github.com/carbon-design-system/carbon/issues/new/choose) and
+we'll try to get instructions for it added!
+
+### `sass-loader`
+
+[Link](https://www.npmjs.com/package/sass-loader)
+
+Update your `webpack.config.js` that uses `sass-loader` with the following
+options passed into `sassOptions`:
+
+```js
+{
+  loader: 'sass-loader',
+  options: {
+    sassOptions: {
+      includePaths: ['node_modules'],
+    },
+  },
+}
+```
+
+### Parcel
+
+[Link](https://www.npmjs.com/package/parcel)
+
+Create a `.sassrc` file with the following configuration:
+
+```json
+{
+  "includePaths": ["node_modules"]
+}
+```
+
+### Vite
+
+[Link](https://vitejs.dev/)
+
+Create a `vite.config.js` file with the following configuration:
+
+```js
+export default {
+  css: {
+    preprocessorOptions: {
+      scss: {
+        includePaths: ['node_modules'],
+      },
+    },
+  },
+};
+```

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -60,82 +60,82 @@ be additional files that you can import from directly within the package, these
 are the public entrypoints that are maintained and follow semantic versioning
 between version updates.
 
-| File                 | Description                                                |
-| :------------------- | :--------------------------------------------------------- |
-| `scss/breakpoint`    | Helper functions and mixins for working with breakpoints   |
-| `scss/colors`        | Access colors from every swatch in the IBM Design Language |
-| `scss/config`        | Configure various options for the package                  |
-| `scss/feature-flags` | Configure various feature flags for experiments            |
-| `scss/grid`          | Access and use the CSS Grid built-in to Carbon             |
-| `scss/motion`        | Helper function, mixins, and tokens for motion             |
-| `scss/reset`         | A CSS Reset                                                |
-| `scss/spacing`       | Variables for the spacing scale                            |
-| `scss/theme`         | Tokens for the current theme                               |
-| `scss/themes`        | Reference the default themes from the Carbon Design System |
-| `scss/type`          | Type tokens and helpers                                    |
-| `scss/components/`   | A directory containing component styles                    |
-| `scss/utilities/`    | A directory containing common CSS utilities                |
+| File                                   | Description                                                |
+| :------------------------------------- | :--------------------------------------------------------- |
+| [`scss/breakpoint`](#breakpoint)       | Helper functions and mixins for working with breakpoints   |
+| [`scss/colors`](#colors)               | Access colors from every swatch in the IBM Design Language |
+| [`scss/config`](#config)               | Configure various options for the package                  |
+| [`scss/feature-flags`](#feature-flags) | Configure various feature flags for experiments            |
+| [`scss/grid`](#grid)                   | Access and use the CSS Grid built-in to Carbon             |
+| [`scss/motion`](#motion)               | Helper function, mixins, and tokens for motion             |
+| [`scss/reset`](#reset)                 | A CSS Reset                                                |
+| [`scss/spacing`](#spacing)             | Variables for the spacing scale                            |
+| [`scss/theme`](#theming)               | Tokens for the current theme                               |
+| [`scss/themes`](#theming)              | Reference the default themes from the Carbon Design System |
+| [`scss/type`](#type)                   | Type tokens and helpers                                    |
+| [`scss/components/`](#components)      | A directory containing component styles                    |
+| [`scss/utilities/`](#utilities)        | A directory containing common CSS utilities                |
 
 ## Breakpoint
 
-| Import                            | Filepath                |
-| :-------------------------------- | :---------------------- |
-| `@use '@carbon/scss/breakpoint';` | `scss/_breakpoint.scss` |
+| Import                                   | Filepath                |
+| :--------------------------------------- | :---------------------- |
+| `@use '@carbon/styles/scss/breakpoint';` | `scss/_breakpoint.scss` |
+
+## Colors
+
+| Import                               | Filepath            |
+| :----------------------------------- | :------------------ |
+| `@use '@carbon/styles/scss/colors';` | `scss/_colors.scss` |
 
 ## Config
 
-| Import                        | Filepath            |
-| :---------------------------- | :------------------ |
-| `@use '@carbon/scss/config';` | `scss/_config.scss` |
-
-## Color
-
-| Import                        | Filepath            |
-| :---------------------------- | :------------------ |
-| `@use '@carbon/scss/colors';` | `scss/_colors.scss` |
+| Import                               | Filepath            |
+| :----------------------------------- | :------------------ |
+| `@use '@carbon/styles/scss/config';` | `scss/_config.scss` |
 
 ## Feature Flags
 
-| Import                               | Filepath                   |
-| :----------------------------------- | :------------------------- |
-| `@use '@carbon/scss/feature-flags';` | `scss/_feature-flags.scss` |
+| Import                                      | Filepath                   |
+| :------------------------------------------ | :------------------------- |
+| `@use '@carbon/styles/scss/feature-flags';` | `scss/_feature-flags.scss` |
 
 ## Grid
 
-| Import                      | Filepath          |
-| :-------------------------- | :---------------- |
-| `@use '@carbon/scss/grid';` | `scss/_grid.scss` |
+| Import                             | Filepath          |
+| :--------------------------------- | :---------------- |
+| `@use '@carbon/styles/scss/grid';` | `scss/_grid.scss` |
 
 ## Motion
 
-| Import                        | Filepath            |
-| :---------------------------- | :------------------ |
-| `@use '@carbon/scss/motion';` | `scss/_motion.scss` |
+| Import                               | Filepath            |
+| :----------------------------------- | :------------------ |
+| `@use '@carbon/styles/scss/motion';` | `scss/_motion.scss` |
 
 ## Reset
 
-| Import                       | Filepath           |
-| :--------------------------- | :----------------- |
-| `@use '@carbon/scss/reset';` | `scss/_reset.scss` |
+| Import                              | Filepath           |
+| :---------------------------------- | :----------------- |
+| `@use '@carbon/styles/scss/reset';` | `scss/_reset.scss` |
 
 ## Spacing
 
-| Import                         | Filepath             |
-| :----------------------------- | :------------------- |
-| `@use '@carbon/scss/spacing';` | `scss/_spacing.scss` |
+| Import                                | Filepath             |
+| :------------------------------------ | :------------------- |
+| `@use '@carbon/styles/scss/spacing';` | `scss/_spacing.scss` |
 
 ## Theming
 
-| Import                        | Filepath            |
-| :---------------------------- | :------------------ |
-| `@use '@carbon/scss/theme';`  | `scss/_theme.scss`  |
-| `@use '@carbon/scss/themes';` | `scss/_themes.scss` |
+| Import                               | Filepath            |
+| :----------------------------------- | :------------------ |
+| `@use '@carbon/styles/scss/theme';`  | `scss/_theme.scss`  |
+| `@use '@carbon/styles/scss/themes';` | `scss/_themes.scss` |
 
 ## Type
 
-| Import                      | Filepath          |
-| :-------------------------- | :---------------- |
-| `@use '@carbon/scss/type';` | `scss/_type.scss` |
+| Import                             | Filepath          |
+| :--------------------------------- | :---------------- |
+| `@use '@carbon/styles/scss/type';` | `scss/_type.scss` |
 
 ## Components
 

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -141,17 +141,17 @@ between version updates.
 
 **Files**
 
-| Component | File                                                        |
-| :-------- | :---------------------------------------------------------- |
-| Accordion | [`scss/components/accordion`](../scss/components/accordion) |
+| Component | Import                                             | File                                                        |
+| :-------- | :------------------------------------------------- | :---------------------------------------------------------- |
+| Accordion | `@use '@carbon/styles/scss/components/accordion';` | [`scss/components/accordion`](../scss/components/accordion) |
 
 ## Utilities
 
 **Files**
 
-| File                           | Description |
-| :----------------------------- | :---------- |
-| `scss/utilities/focus-outline` |             |
+| Import                                                | Description |
+| :---------------------------------------------------- | :---------- |
+| `@use '@carbon/styles/scss/utilities/focus-outline';` |             |
 
 ## Configuration
 

--- a/packages/themes/docs/sass.md
+++ b/packages/themes/docs/sass.md
@@ -72,6 +72,10 @@ You can also extend the theme with your own custom tokens:
 );
 ```
 
+## Tokens
+
+TODO
+
 ## FAQ
 
 ### Why are the themes not exported in `@carbon/themes`?


### PR DESCRIPTION
Closes #9178

This PR is a documentation PR for:

- Updating the README for `@carbon/styles`
- Providing documentation on how to use tokens from the package
- Providing documentation on how to use component tokens from the package

It also includes a skeleton `docs/sass.md` file for describing additional entry points in the future

#### Changelog

**New**

- Add `docs/sass.md` for styles

**Changed**

- Update README for styles

**Removed**

#### Testing / Reviewing

- Read through the `packages/styles/README.md` file and see if it makes sense to you and is accurate
- Read through the docs available in `packages/styles/docs/sass.md` and see if it makes sense to you and is accurate
