### PR TITLE
feat(menu): add support for different sizes

### DIFF
--- a/packages/components/src/components/menu/_menu.scss
+++ b/packages/components/src/components/menu/_menu.scss
@@ -6,6 +6,7 @@
 //
 
 @import '../../globals/scss/vars';
+@import '../../globals/scss/vendor/@carbon/layout/scss/generated/size';
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
 @import '../../globals/scss/helper-mixins';
 
@@ -39,7 +40,7 @@
 
   .#{$prefix}--menu-option {
     position: relative;
-    height: $spacing-07;
+    height: $size-sm;
     background-color: $layer;
     color: $text-primary;
     cursor: pointer;
@@ -119,6 +120,17 @@
     height: 1px;
     margin: $spacing-02 0;
     background-color: $border-subtle;
+  }
+
+  $supported-sizes: (
+    'md': $size-md,
+    'lg': $size-lg,
+  );
+
+  @each $size, $value in $supported-sizes {
+    .#{$prefix}--menu--#{$size} .#{$prefix}--menu-option {
+      height: $value;
+    }
   }
 }
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7730,6 +7730,16 @@ Map {
       "open": Object {
         "type": "bool",
       },
+      "size": Object {
+        "args": Array [
+          Array [
+            "sm",
+            "md",
+            "lg",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "x": Object {
         "args": Array [
           Array [

--- a/packages/react/src/components/Menu/Menu.js
+++ b/packages/react/src/components/Menu/Menu.js
@@ -33,6 +33,7 @@ import MenuSelectableItem from './MenuSelectableItem';
 const { prefix } = settings;
 
 const margin = 16; // distance to keep to body edges, in px
+const defaultSize = 'sm';
 
 const Menu = function Menu({
   autoclose = true,
@@ -40,6 +41,7 @@ const Menu = function Menu({
   id,
   level = 1,
   open,
+  size = defaultSize,
   x = 0,
   y = 0,
   onClose = () => {},
@@ -263,12 +265,16 @@ const Menu = function Menu({
     }
   });
 
-  const classes = classnames(`${prefix}--menu`, {
-    [`${prefix}--menu--open`]: open,
-    [`${prefix}--menu--invisible`]:
-      open && position[0] === 0 && position[1] === 0,
-    [`${prefix}--menu--root`]: isRootMenu,
-  });
+  const classes = classnames(
+    `${prefix}--menu`,
+    {
+      [`${prefix}--menu--open`]: open,
+      [`${prefix}--menu--invisible`]:
+        open && position[0] === 0 && position[1] === 0,
+      [`${prefix}--menu--root`]: isRootMenu,
+    },
+    size !== defaultSize && `${prefix}--menu--${size}`
+  );
 
   const ulAttributes = {
     id,
@@ -354,6 +360,11 @@ Menu.propTypes = {
    * Specify whether the Menu is currently open
    */
   open: PropTypes.bool,
+
+  /**
+   * Specify the size of the menu, from a list of available sizes.
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
 
   /**
    * Specify the x position where this menu is rendered

--- a/packages/react/src/components/OverflowMenu/next/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/next/OverflowMenu.js
@@ -15,9 +15,12 @@ import Menu from '../../Menu';
 
 const { prefix } = settings;
 
+const defaultSize = 'md';
+
 function OverflowMenu({
   children,
   renderIcon: IconElement = OverflowMenuVertical16,
+  size = defaultSize,
   ...rest
 }) {
   const id = useId('overflowmenu');
@@ -67,9 +70,13 @@ function OverflowMenu({
 
   const containerClasses = classNames(`${prefix}--overflow-menu__container`);
 
-  const triggerClasses = classNames(`${prefix}--overflow-menu`, {
-    [`${prefix}--overflow-menu--open`]: open,
-  });
+  const triggerClasses = classNames(
+    `${prefix}--overflow-menu`,
+    {
+      [`${prefix}--overflow-menu--open`]: open,
+    },
+    size !== defaultSize && `${prefix}--overflow-menu--${size}`
+  );
 
   return (
     <div className={containerClasses} aria-owns={id}>
@@ -86,6 +93,7 @@ function OverflowMenu({
       </button>
       <Menu
         id={id}
+        size={size}
         open={open}
         onClose={closeMenu}
         x={position[0]}
@@ -106,6 +114,11 @@ OverflowMenu.propTypes = {
    * Function called to override icon rendering.
    */
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+
+  /**
+   * Specify the size of the menu, from a list of available sizes.
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
 };
 
 export default OverflowMenu;

--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -45,7 +45,8 @@
 
   .#{$prefix}--menu-option {
     position: relative;
-    height: $spacing-07;
+    // $size-sm
+    height: 2rem;
     background-color: $layer;
     color: $text-primary;
     cursor: pointer;
@@ -125,5 +126,18 @@
     height: 1px;
     margin: $spacing-02 0;
     background-color: $border-subtle;
+  }
+
+  $supported-sizes: (
+    // $size-md
+    'md': 2.5rem,
+    // $size-lg
+    'lg': 3rem
+  );
+
+  @each $size, $value in $supported-sizes {
+    .#{$prefix}--menu--#{$size} .#{$prefix}--menu-option {
+      height: $value;
+    }
   }
 }


### PR DESCRIPTION
Adds support for a `size` prop to `Menu` and `OverflowMenu/next` with the following options: `sm`, `md`, `lg`.

#### Changelog

**New**

- Add `size` prop to `Menu` and `OverflowMenu/next`

#### Testing / Reviewing

- Context menu
  - Test by adding `size="md"` and `size="lg"` to the Menu props
  - Default should be `sm`
  - Individual menu items should reflect size (`sm`: 32px, `md`: 40px, `lg`: 48px)
- OverflowMenu/next
  - Test by adding `size="sm"` and `size="lg"` to the OverflowMenu props  
  - Default should be `md`
  - Individual menu items should reflect size (`sm`: 32px, `md`: 40px, `lg`: 48px)
  - The trigger button should change in size accordingly