### PR TITLE
fix(ListBox): add title attribute to selected item

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -306,6 +306,7 @@ const ComboBox = React.forwardRef((props, ref) => {
                   aria-expanded={rootProps['aria-expanded']}
                   aria-haspopup="listbox"
                   aria-controls={inputProps['aria-controls']}
+                  title={textInput?.current?.value}
                   {...inputProps}
                   {...rest}
                   ref={mergeRefs(textInput, ref)}

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -132,7 +132,6 @@ const Dropdown = React.forwardRef(function Dropdown(
 
   const menuItemOptionRefs = useRef(items.map((_) => React.createRef()));
 
-  console.log();
   return (
     <div className={wrapperClasses} {...other}>
       {titleText && (

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -132,6 +132,7 @@ const Dropdown = React.forwardRef(function Dropdown(
 
   const menuItemOptionRefs = useRef(items.map((_) => React.createRef()));
 
+  console.log();
   return (
     <div className={wrapperClasses} {...other}>
       {titleText && (
@@ -163,6 +164,7 @@ const Dropdown = React.forwardRef(function Dropdown(
           className={`${prefix}--list-box__field`}
           disabled={disabled}
           aria-disabled={disabled}
+          title={selectedItem ? itemToString(selectedItem) : label}
           {...toggleButtonProps}
           ref={mergeRefs(toggleButtonProps.ref, ref)}>
           <span className={`${prefix}--list-box__label`}>

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -72,6 +72,7 @@ exports[`Dropdown should render 1`] = `
           id="downshift-0-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          title="input"
           type="button"
         >
           <span
@@ -222,6 +223,7 @@ exports[`Dropdown should render custom item components 1`] = `
           id="downshift-6-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          title="input"
           type="button"
         >
           <span
@@ -530,6 +532,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           id="downshift-4-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          title="input"
           type="button"
         >
           <span


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/9397

Adds title attribute so that long text can be revealed when it is the currently selected item

![Screen Shot 2021-08-03 at 2 06 14 PM](https://user-images.githubusercontent.com/11928039/128064503-0049ace8-fdbf-4d27-9f59-abd5b234ca59.png)


#### Changelog

**New**

- Adds in `title` attribute to the selected item `span` / `input`

#### Testing / Reviewing

- [ ] ComboBox
- [ ] Dropdown 

Pick the text the longest text/text that is truncated. When the Dropdown / Combobox is closed, ensure the text is shown on hover 
