### PR TITLE
fix(FileUploader): aria disabled placed on button instead of label

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploaderButton.js
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.js
@@ -78,10 +78,10 @@ function FileUploaderButton({
     <>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <label
-        htmlFor={inputId}
         tabIndex={disabled ? -1 : tabIndex || 0}
         className={classes}
         onKeyDown={onKeyDown}
+        htmlFor={inputId}
         {...other}>
         <span role={role} aria-disabled={disabled}>
           {labelText}

--- a/packages/react/src/components/FileUploader/FileUploaderButton.js
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.js
@@ -78,13 +78,14 @@ function FileUploaderButton({
     <>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <label
+        htmlFor={inputId}
         tabIndex={disabled ? -1 : tabIndex || 0}
-        aria-disabled={disabled}
         className={classes}
         onKeyDown={onKeyDown}
-        htmlFor={inputId}
         {...other}>
-        <span role={role}>{labelText}</span>
+        <span role={role} aria-disabled={disabled}>
+          {labelText}
+        </span>
       </label>
       <input
         className={`${prefix}--visually-hidden`}


### PR DESCRIPTION
Closes #8996 

**Changed**

- Moved `aria-disabled` to the `span` since that's the button (`role="button"`)

#### Testing / Reviewing

- Run accessibility check for the FileUploader w/ button story, make sure error is no longer there
