### PR TITLE
chore(project): add quietDeps for sass tests

### DIFF
--- a/packages/test-utils/src/renderer.js
+++ b/packages/test-utils/src/renderer.js
@@ -34,6 +34,7 @@ const SassRenderer = {
           },
         },
         includePaths: [cwd, ...nodeModules],
+        quietDeps: true,
       });
 
       return {


### PR DESCRIPTION
Our test output is pretty noisy with warnings for `/` in sass tests. This adds the `quietDeps` flag to the sass test renderer so these no longer are emitted as part of the test. We will still see these warnings during development, however.

#### Changelog

**New**

**Changed**

- Add `quietDeps` to sass renderer

**Removed**

#### Testing / Reviewing

- Verify that in the tests that we don't see any sass deprecation notices in the output
