### PR TITLE
ci: add stale workflow in debug mode

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: stale
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          any-of-issue-labels:
+            "status: waiting for author's response 💬,status: needs more info 🤷‍♀️"
+          stale-issue-message: |
+            This issue has been marked as stale because it has required additional
+            info or a response from the author for over 7 days. When you get the
+            chance, please comment with the additional info requested.
+            Otherwise, this issue will be closed in 7 days.
+          close-issue-message: |
+            This issue has been closed because it has received no activity for
+            14 days
+          stale-issue-label: 'status: stale 🍞'
+          days-before-stale: 7
+          days-before-close: 7
+          debug-only: true


### PR DESCRIPTION
This adds in a stale workflow for two issue labels:

- Waiting for author's response
- Needs steps to reproduce

This workflow is in debug mode. It will close these issues after 14 days, leaving a comment after 7 days of inactivity for a stale message and then 7 days after when closing.

#### Changelog

**New**

- Add stale workflow in debug mode

**Changed**

**Removed**
