### PR TITLE
fix(FormGroup): only place className on outer wrapper

### DIFF
--- a/packages/react/src/components/FormGroup/FormGroup-story.js
+++ b/packages/react/src/components/FormGroup/FormGroup-story.js
@@ -13,6 +13,7 @@ import RadioButtonGroup from '../RadioButtonGroup';
 import RadioButton from '../RadioButton';
 import Button from '../Button';
 import mdx from './FormGroup.mdx';
+import { FeatureFlags } from '../FeatureFlags';
 
 const props = () => ({
   disabled: boolean('Disabled (disabled)', false),
@@ -53,6 +54,37 @@ export const _Default = () => (
       <RadioButton labelText="Option 3" value="radio-3" id="radio-3" />
     </RadioButtonGroup>
   </FormGroup>
+);
+
+export const classNameChangeTest = () => (
+  <>
+    <FormGroup
+      className="TEST__CLASS"
+      legendId="formgroup-legend-id"
+      legendText="This group should place the same class on the fieldset and legend (existing behavior)"
+      style={{ maxWidth: '400px' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        <TextInput id="one" labelText="First Name" />
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <TextInput id="two" labelText="Last Name" />
+      </div>
+    </FormGroup>
+    <FeatureFlags flags={{ 'enable-v11-release': true }}>
+      <FormGroup
+        className="TEST__CLASS"
+        legendId="formgroup-legend-id-2"
+        legendText="This group should only have the class placed on the fieldset"
+        style={{ maxWidth: '400px' }}>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextInput id="one" labelText="First Name" />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <TextInput id="two" labelText="Last Name" />
+        </div>
+      </FormGroup>
+    </FeatureFlags>
+  </>
 );
 
 _Default.story = {

--- a/packages/react/src/components/FormGroup/FormGroup-story.js
+++ b/packages/react/src/components/FormGroup/FormGroup-story.js
@@ -13,7 +13,6 @@ import RadioButtonGroup from '../RadioButtonGroup';
 import RadioButton from '../RadioButton';
 import Button from '../Button';
 import mdx from './FormGroup.mdx';
-import { FeatureFlags } from '../FeatureFlags';
 
 const props = () => ({
   disabled: boolean('Disabled (disabled)', false),
@@ -54,37 +53,6 @@ export const _Default = () => (
       <RadioButton labelText="Option 3" value="radio-3" id="radio-3" />
     </RadioButtonGroup>
   </FormGroup>
-);
-
-export const classNameChangeTest = () => (
-  <>
-    <FormGroup
-      className="TEST__CLASS"
-      legendId="formgroup-legend-id"
-      legendText="This group should place the same class on the fieldset and legend (existing behavior)"
-      style={{ maxWidth: '400px' }}>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextInput id="one" labelText="First Name" />
-      </div>
-      <div style={{ marginBottom: '1rem' }}>
-        <TextInput id="two" labelText="Last Name" />
-      </div>
-    </FormGroup>
-    <FeatureFlags flags={{ 'enable-v11-release': true }}>
-      <FormGroup
-        className="TEST__CLASS"
-        legendId="formgroup-legend-id-2"
-        legendText="This group should only have the class placed on the fieldset"
-        style={{ maxWidth: '400px' }}>
-        <div style={{ marginBottom: '1rem' }}>
-          <TextInput id="one" labelText="First Name" />
-        </div>
-        <div style={{ marginBottom: '1rem' }}>
-          <TextInput id="two" labelText="Last Name" />
-        </div>
-      </FormGroup>
-    </FeatureFlags>
-  </>
 );
 
 _Default.story = {

--- a/packages/react/src/components/FormGroup/FormGroup.js
+++ b/packages/react/src/components/FormGroup/FormGroup.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { settings } from 'carbon-components';
+import { useFeatureFlag } from '../FeatureFlags';
 
 const { prefix } = settings;
 
@@ -23,7 +24,10 @@ const FormGroup = ({
   hasMargin,
   ...other
 }) => {
-  const classNamesLegend = classnames(`${prefix}--label`, className);
+  const enabled = useFeatureFlag('enable-v11-release');
+  const classNamesLegend = classnames(`${prefix}--label`, [
+    enabled ? null : className,
+  ]);
   const classNamesFieldset = classnames(`${prefix}--fieldset`, className, {
     [`${prefix}--fieldset--no-margin`]: !hasMargin,
   });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/4572

This ensures the `className` prop is only placed on the outer wrapper, and not duplicated. I've placed this behind a feature flag, but we may just want to go ahead and make this change as it would be difficult to style them independently as-is

#### Changelog

**New**

- Test story in `FormGroup`

**Changed**

- `className` prop is only placed on the outer wrapping `fieldset` element

#### Testing / Reviewing

Go to the test story and ensure the custom class is only placed on the outer wrapper
