### PR TITLE
fix(menu): prevent hover color flash when opening

### DIFF
--- a/packages/components/src/components/menu/_menu.scss
+++ b/packages/components/src/components/menu/_menu.scss
@@ -36,6 +36,7 @@
 
   .#{$prefix}--menu--invisible {
     opacity: 0;
+    pointer-events: none;
   }
 
   .#{$prefix}--menu-option {

--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -41,6 +41,7 @@
 
   .#{$prefix}--menu--invisible {
     opacity: 0;
+    pointer-events: none;
   }
 
   .#{$prefix}--menu-option {


### PR DESCRIPTION
Reported by @tay1orjones: https://github.com/carbon-design-system/carbon/pull/9528#pullrequestreview-738706421

Currently, there is a slight chance that a menu item will flash its hover color when opening the menu. It's most noticeable with danger options.

It's because the menu is placed at the coordinates 0,0 initially before being moved accordingly. In this state, the menu is invisible (opacity: 0), but could already react to pointer events. Once the it moves (and becomes visible), the cursor is no longer on any menu item and the background color of a potentially previously hovered item fades to `$layer`.

#### Changelog

**Changed**

- Add `pointer-events: none` to `.bx--menu--invisible`

#### Testing / Reviewing

Ensure there is no color flash when opening the menu in the "unstable_Menu/OverflowMenu/Overflow Menu" story.

![Screen Recording 2021-08-27 at 11 33 13](https://user-images.githubusercontent.com/28265588/131107891-90b1f579-627f-4bc5-9bdc-c1da0a6fe87c.gif)

