### PR TITLE
fix(CodeSnippet): overflow indicators updated onResize

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import classNames from 'classnames';
 import useResizeObserver from 'use-resize-observer/polyfilled';
-import debounce from 'lodash.debounce';
 import { ChevronDown16 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
 import Copy from '../Copy';
@@ -130,7 +129,7 @@ function CodeSnippet({
           (codeContentRef?.current && type === 'multi') ||
           (codeContainerRef?.current && type === 'single')
         ) {
-          debounce(handleScroll, 200);
+          handleScroll();
         }
       },
     },


### PR DESCRIPTION
Closes #8441

Codesnippet had a bug that did not update the "overflow indicator" (gradient) when window was resized. This PR addresses that bug.

**Removed**

- removed the `debounce` callback in the `resizeObserver` because I realized it wasn't actually running the callback after 200ms. I _think_ this is a lodash bug but I couldn't find any helpful issues related to this bug. 

**How I came to this conclusion**
1. I realized we were updating the overflow indicator (bool) states within `handleScroll()`
2. I then looked at where `handleScroll` was being used
    a. within a `useEffect` hook
    b. within `useResizeObserver` which has an `onResize` callback that updates several states for multi & single line snippets
    c. within `onScroll` for the single & multiline `div`s
3. debugging then involved a lot of console logs to see if the overflow indicator states `hasLeftOverflow` `hasRightOverflow` were being updated properly each time `handleScroll` was being called
    -  The overflow states were being updated/consoled properly on initial mount which meant the useEffect instance was working fine
    - Overflow states were also being updated properly when I scrolled on the codesnippet
    - Overflow states were not being updated when I resized the window
7. Once I realized it was just the window resizing that wasn't updating properly, I added a `console.log` within the `onResize` conditional where `handleScroll` was being called to see if we were even getting within that conditional when resizing. 
```js
  if (
    (codeContentRef?.current && type === 'multi') ||
    (codeContainerRef?.current && type === 'single')
  ) {
    console.log('are we even getting here?');
    debounce(handleScroll, 200);
  }
```
 We were "getting there". Which then led me to realize that for some reason, the debounce callback wasn't working. 

8. I removed the debounce callback and directly called `handleScroll` instead and tested resizing the window. This time the overflow indicator states were updated properly.
9. Once I confirmed it was the debounce issue, I tried some optional configs for it to see if it would make a difference (maxWait, leading, trailing). But it still wasn't working. So I stuck with just removing it. Since we don't use debounce on the other updates within `onResize`, I figured it was ok.
   

#### Testing / Reviewing

1. check out PR locally or open deploy preview
2. in the codesnippet single line story:
    a. check that right overflow indicator displays initially 
    b. scroll slightly right and check that left and right indicators display
    c. scroll all the way right, and right indicator should go away
    d. now resize the window so that the codesnippet component becomes smaller. The resizing should update the overflow indicators. 

You can test it against this video (recording of bug) and notice the overflow indicator working on window resize.

https://user-images.githubusercontent.com/32556167/132113011-7f243d25-804c-489b-b9c3-cd4859107801.mov


