### PR TITLE
fix(carbon-react): update icons to use icons next, fix docs import

### DIFF
--- a/packages/carbon-react/icons/index.js
+++ b/packages/carbon-react/icons/index.js
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from '@carbon/icons-react';
+export * from '@carbon/icons-react/next';

--- a/packages/carbon-react/src/components/Icons/Icons.stories.js
+++ b/packages/carbon-react/src/components/Icons/Icons.stories.js
@@ -4,9 +4,10 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
-import { Bee, Bicycle, ChevronUp } from '@carbon/icons-react/next';
+
 import './Icons.stories.scss';
+import React from 'react';
+import { Bee, Bicycle, ChevronUp } from '../../../icons';
 
 export default {
   title: 'Elements/Icons',


### PR DESCRIPTION
Updates our elements pages for icons so that the build no longer stalls.

#### Changelog

**New**

**Changed**

- Update `carbon-react/icons` to point to icons-react/next
- Update stories import to resolve from local `icons` folder

**Removed**

#### Testing / Reviewing

- Verify deploy preview for Carbon React Next deploys successfully