### PR TITLE
9619 Introduce PrefixContext/usePrefix()

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.Skeleton.js
+++ b/packages/react/src/components/Accordion/Accordion.Skeleton.js
@@ -9,13 +9,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import { ChevronRight16 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
 import SkeletonText from '../SkeletonText';
 import deprecate from '../../prop-types/deprecate';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function AccordionSkeleton({ align, open, count, className, ...rest }) {
+  const prefix = usePrefix();
   const classes = cx(`${prefix}--accordion`, `${prefix}--skeleton`, className, {
     [`${prefix}--accordion--${align}`]: align,
   });
@@ -77,6 +76,7 @@ AccordionSkeleton.defaultProps = {
 };
 
 function AccordionSkeletonItem() {
+  const prefix = usePrefix();
   return (
     <li className={`${prefix}--accordion__item`}>
       <span className={`${prefix}--accordion__heading`}>

--- a/packages/react/src/components/Accordion/Accordion.js
+++ b/packages/react/src/components/Accordion/Accordion.js
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
+import { usePrefix } from '../../internal/usePrefix';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
 
 function Accordion({
   align,
@@ -20,6 +18,7 @@ function Accordion({
   size,
   ...rest
 }) {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--accordion`, customClassName, {
     [`${prefix}--accordion--${align}`]: align,
     [`${prefix}--accordion--${size}`]: size,

--- a/packages/react/src/components/AspectRatio/AspectRatio.js
+++ b/packages/react/src/components/AspectRatio/AspectRatio.js
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
+import { usePrefix } from '../../internal/usePrefix';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
 
 /**
  * The AspectRatio component provides a `ratio` prop that will be used to
@@ -25,6 +23,7 @@ function AspectRatio({
   ratio = '1x1',
   ...rest
 }) {
+  const prefix = usePrefix();
   const className = cx(
     containerClassName,
     `${prefix}--aspect-ratio`,

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.Skeleton.js
@@ -8,24 +8,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
+const item = () => {
+  const prefix = usePrefix();
 
-const item = (
-  <div className={`${prefix}--breadcrumb-item`}>
-    <span className={`${prefix}--link`}>&nbsp;</span>
-  </div>
-);
+  return (
+    <div className={`${prefix}--breadcrumb-item`}>
+      <span className={`${prefix}--link`}>&nbsp;</span>
+    </div>
+  );
+};
 
 function BreadcrumbSkeleton({ className, ...rest }) {
+  const prefix = usePrefix();
   const classes = cx(`${prefix}--breadcrumb`, `${prefix}--skeleton`, className);
 
   return (
     <div className={classes} {...rest}>
-      {item}
-      {item}
-      {item}
+      {item()}
+      {item()}
+      {item()}
     </div>
   );
 }

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.js
@@ -8,9 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Breadcrumb = React.forwardRef(function Breadcrumb(
   {
@@ -22,6 +20,7 @@ const Breadcrumb = React.forwardRef(function Breadcrumb(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const className = cx({
     [`${prefix}--breadcrumb`]: true,
     [`${prefix}--breadcrumb--no-trailing-slash`]: noTrailingSlash,

--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -8,13 +8,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const ButtonSkeleton = ({ className, small, href, size, ...rest }) => {
   const enabled = useFeatureFlag('enable-v11-release');
+  const prefix = usePrefix(); 
 
   const buttonClasses = cx(className, {
     [`${prefix}--skeleton`]: true,

--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -8,16 +8,15 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { ButtonKinds } from '../../prop-types/types';
 import deprecate from '../../prop-types/deprecate';
 import { composeEventHandlers } from '../../tools/events';
 import { keys, matches } from '../../internal/keyboard';
+import { usePrefix } from '../../internal/usePrefix';
 import { useId } from '../../internal/useId';
 import toggleClass from '../../tools/toggleClass';
 import { useFeatureFlag } from '../FeatureFlags';
 
-const { prefix } = settings;
 const Button = React.forwardRef(function Button(
   {
     children,
@@ -52,6 +51,7 @@ const Button = React.forwardRef(function Button(
   const [isFocused, setIsFocused] = useState(false);
   const tooltipRef = useRef(null);
   const tooltipTimeout = useRef(null);
+  const prefix = usePrefix();
 
   const closeTooltips = (evt) => {
     const tooltipNode = document?.querySelectorAll(`.${prefix}--tooltip--a11y`);

--- a/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
+++ b/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
@@ -8,22 +8,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
-
-const CheckboxSkeleton = ({ className, ...rest }) => (
-  <div
-    className={cx(
-      `${prefix}--form-item`,
-      `${prefix}--checkbox-wrapper`,
-      `${prefix}--checkbox-label`,
-      className
-    )}
-    {...rest}>
-    <span className={`${prefix}--checkbox-label-text ${prefix}--skeleton`} />
-  </div>
-);
+const CheckboxSkeleton = ({ className, ...rest }) => {
+  const prefix = usePrefix();
+  return (
+    <div
+      className={cx(
+        `${prefix}--form-item`,
+        `${prefix}--checkbox-wrapper`,
+        `${prefix}--checkbox-label`,
+        className
+      )}
+      {...rest}>
+      <span className={`${prefix}--checkbox-label-text ${prefix}--skeleton`} />
+    </div>
+  );
+};
 
 CheckboxSkeleton.propTypes = {
   /**

--- a/packages/react/src/components/Checkbox/Checkbox.js
+++ b/packages/react/src/components/Checkbox/Checkbox.js
@@ -9,10 +9,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { useFeatureFlag } from '../FeatureFlags';
-import { settings } from 'carbon-components';
 import deprecate from '../../prop-types/deprecate';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Checkbox = React.forwardRef(function Checkbox(
   {
@@ -29,6 +27,7 @@ const Checkbox = React.forwardRef(function Checkbox(
   ref
 ) {
   const enabled = useFeatureFlag('enable-v11-release');
+  const prefix = usePrefix();
 
   const labelClasses = classNames(`${prefix}--checkbox-label`, [
     enabled ? null : className,

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.Skeleton.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.Skeleton.js
@@ -5,18 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function CodeSnippetSkeleton({
   className: containerClassName,
   type = 'single',
   ...rest
 }) {
+  const prefix = usePrefix();
   const className = cx(containerClassName, {
     [`${prefix}--snippet`]: true,
     [`${prefix}--skeleton`]: true,

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -16,8 +16,7 @@ import Button from '../Button';
 import CopyButton from '../CopyButton';
 import getUniqueId from '../../tools/uniqueId';
 import copy from 'copy-to-clipboard';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const rowHeightInPixels = 16;
 const defaultMaxCollapsedNumberOfRows = 15;
@@ -62,6 +61,7 @@ function CodeSnippet({
       return codeContentRef;
     }
   }, [type]);
+  const prefix = usePrefix();
 
   const getCodeRefDimensions = useCallback(() => {
     const {

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -22,8 +22,7 @@ import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import { mapDownshiftProps } from '../../tools/createPropAdapter';
 import mergeRefs from '../../tools/mergeRefs';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const defaultItemToString = (item) => {
   if (typeof item === 'string') {
@@ -101,6 +100,7 @@ const ComboBox = React.forwardRef((props, ref) => {
     warnText,
     ...rest
   } = props;
+  const prefix = usePrefix();
 
   const textInput = useRef();
   const comboBoxInstanceId = getInstanceId();

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -10,22 +10,22 @@ import PropTypes from 'prop-types';
 import Button from '../Button';
 import ButtonSet from '../ButtonSet';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { Close20 } from '@carbon/icons-react';
 import toggleClass from '../../tools/toggleClass';
 import requiredIfGivenPropIsTruthy from '../../prop-types/requiredIfGivenPropIsTruthy';
 import wrapFocus from '../../internal/wrapFocus';
-
-const { prefix } = settings;
+import { usePrefix, PrefixContext } from '../../internal/usePrefix';
 
 export default class ComposedModal extends Component {
   state = {};
 
+  static contextType = PrefixContext;
   static defaultProps = {
     onKeyDown: () => {},
     selectorPrimaryFocus: '[data-modal-primary-focus]',
   };
 
+  prefix = this.context;
   outerModal = React.createRef();
   innerModal = React.createRef();
   button = React.createRef();
@@ -164,7 +164,7 @@ export default class ComposedModal extends Component {
     if (prevState.open !== this.state.open) {
       toggleClass(
         document.body,
-        `${prefix}--body--with-modal-open`,
+        `${this.prefix}--body--with-modal-open`,
         this.state.open
       );
     }
@@ -186,13 +186,13 @@ export default class ComposedModal extends Component {
   };
 
   componentWillUnmount() {
-    toggleClass(document.body, `${prefix}--body--with-modal-open`, false);
+    toggleClass(document.body, `${this.prefix}--body--with-modal-open`, false);
   }
 
   componentDidMount() {
     toggleClass(
       document.body,
-      `${prefix}--body--with-modal-open`,
+      `${this.prefix}--body--with-modal-open`,
       this.props.open
     );
     if (!this.props.open) {
@@ -225,6 +225,7 @@ export default class ComposedModal extends Component {
 
   render() {
     const { open } = this.state;
+    const prefix = this.context;
     const {
       ['aria-labelledby']: ariaLabelledBy,
       ['aria-label']: ariaLabel,
@@ -370,6 +371,8 @@ export class ModalHeader extends Component {
     titleClassName: PropTypes.string,
   };
 
+  static contextType = PrefixContext;
+
   static defaultProps = {
     iconDescription: 'Close',
     buttonOnClick: () => {},
@@ -396,6 +399,8 @@ export class ModalHeader extends Component {
       preventCloseOnClickOutside, // eslint-disable-line
       ...other
     } = this.props;
+
+    const prefix = this.context;
 
     const headerClass = classNames({
       [`${prefix}--modal-header`]: true,
@@ -452,6 +457,7 @@ export function ModalBody(props) {
     preventCloseOnClickOutside, // eslint-disable-line
     ...other
   } = props;
+  const prefix = usePrefix();
   const contentClass = classNames({
     [`${prefix}--modal-content`]: true,
     [`${prefix}--modal-content--with-form`]: hasForm,
@@ -618,6 +624,8 @@ export class ModalFooter extends Component {
     onRequestSubmit: () => {},
   };
 
+  static contextType = PrefixContext;
+
   handleRequestClose = (evt) => {
     this.props.closeModal(evt);
     this.props.onRequestClose(evt);
@@ -640,6 +648,8 @@ export class ModalFooter extends Component {
       inputref,
       ...other
     } = this.props;
+
+    const prefix = this.context;
 
     const footerClass = classNames({
       [`${prefix}--modal-footer`]: true,

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -8,12 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { composeEventHandlers } from '../../tools/events';
 import { getNextIndex, matches, keys } from '../../internal/keyboard';
 import deprecate from '../../prop-types/deprecate';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 export default class ContentSwitcher extends React.Component {
   /**
@@ -67,6 +65,8 @@ export default class ContentSwitcher extends React.Component {
      */
     size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
   };
+
+  static contextType = PrefixContext;
 
   static defaultProps = {
     selectedIndex: 0,
@@ -130,6 +130,7 @@ export default class ContentSwitcher extends React.Component {
   };
 
   render() {
+    const prefix = this.context;
     const {
       children,
       className,

--- a/packages/react/src/components/CopyButton/CopyButton.js
+++ b/packages/react/src/components/CopyButton/CopyButton.js
@@ -8,13 +8,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
 import { Copy16 } from '@carbon/icons-react';
 import Copy from '../Copy';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 export default function CopyButton({ iconDescription, className, ...other }) {
+  const prefix = usePrefix();
   return (
     <Copy
       className={classnames(className, `${prefix}--copy-btn`)}

--- a/packages/react/src/components/DatePicker/DatePicker.Skeleton.js
+++ b/packages/react/src/components/DatePicker/DatePicker.Skeleton.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import {usePrefix} from '../../internal/usePrefix';
 
 const DatePickerSkeleton = ({ range, id, className, ...rest }) => {
+  const prefix = usePrefix();
   const dateInput = (
     <div className={`${prefix}--date-picker-container`}>
       {

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -10,15 +10,13 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import flatpickr from 'flatpickr';
 import l10n from 'flatpickr/dist/l10n/index';
-import { settings } from 'carbon-components';
 import DatePickerInput from '../DatePickerInput';
 import carbonFlatpickrAppendToPlugin from './plugins/appendToPlugin';
 import carbonFlatpickrFixEventsPlugin from './plugins/fixEventsPlugin';
 import carbonFlatpickrRangePlugin from './plugins/rangePlugin';
 import { match, keys } from '../../internal/keyboard';
 import { FeatureFlagContext } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 // Weekdays shorthand for english locale
 l10n.en.weekdays.shorthand.forEach((day, index) => {
@@ -523,31 +521,34 @@ export default class DatePicker extends Component {
     }
   };
 
+  static contextType = PrefixContext;
+  prefix = this.context;
+
   updateClassNames = (calendar) => {
     const calendarContainer = calendar.calendarContainer;
     const daysContainer = calendar.days;
     if (calendarContainer && daysContainer) {
       // calendarContainer and daysContainer are undefined if flatpickr detects a mobile device
-      calendarContainer.classList.add(`${prefix}--date-picker__calendar`);
+      calendarContainer.classList.add(`${this.prefix}--date-picker__calendar`);
       calendarContainer
         .querySelector('.flatpickr-month')
-        .classList.add(`${prefix}--date-picker__month`);
+        .classList.add(`${this.prefix}--date-picker__month`);
       calendarContainer
         .querySelector('.flatpickr-weekdays')
-        .classList.add(`${prefix}--date-picker__weekdays`);
+        .classList.add(`${this.prefix}--date-picker__weekdays`);
       calendarContainer
         .querySelector('.flatpickr-days')
-        .classList.add(`${prefix}--date-picker__days`);
+        .classList.add(`${this.prefix}--date-picker__days`);
       forEach.call(
         calendarContainer.querySelectorAll('.flatpickr-weekday'),
         (item) => {
           const currentItem = item;
           currentItem.innerHTML = currentItem.innerHTML.replace(/\s+/g, '');
-          currentItem.classList.add(`${prefix}--date-picker__weekday`);
+          currentItem.classList.add(`${this.prefix}--date-picker__weekday`);
         }
       );
       forEach.call(daysContainer.querySelectorAll('.flatpickr-day'), (item) => {
-        item.classList.add(`${prefix}--date-picker__day`);
+        item.classList.add(`${this.prefix}--date-picker__day`);
         if (
           item.classList.contains('today') &&
           calendar.selectedDates.length > 0
@@ -568,7 +569,7 @@ export default class DatePicker extends Component {
       ? null
       : // Child is a regular DOM node, seen in tests
       node.nodeType === Node.ELEMENT_NODE
-      ? node.querySelector(`.${prefix}--date-picker__input`)
+      ? node.querySelector(`.${this.prefix}--date-picker__input`)
       : // Child is a React component
       node.input && node.input.nodeType === Node.ELEMENT_NODE
       ? node.input
@@ -580,7 +581,7 @@ export default class DatePicker extends Component {
       ? null
       : // Child is a regular DOM node, seen in tests
       node.nodeType === Node.ELEMENT_NODE
-      ? node.querySelector(`.${prefix}--date-picker__input`)
+      ? node.querySelector(`.${this.prefix}--date-picker__input`)
       : // Child is a React component
       node.input && node.input.nodeType === Node.ELEMENT_NODE
       ? node.input
@@ -616,20 +617,20 @@ export default class DatePicker extends Component {
     }
 
     const datePickerClasses = classNames(
-      `${prefix}--date-picker`,
+      `${this.prefix}--date-picker`,
       [enabled ? null : className],
       {
-        [`${prefix}--date-picker--short`]: short,
-        [`${prefix}--date-picker--light`]: light,
-        [`${prefix}--date-picker--simple`]: datePickerType === 'simple',
-        [`${prefix}--date-picker--single`]: datePickerType === 'single',
-        [`${prefix}--date-picker--range`]: datePickerType === 'range',
-        [`${prefix}--date-picker--nolabel`]:
+        [`${this.prefix}--date-picker--short`]: short,
+        [`${this.prefix}--date-picker--light`]: light,
+        [`${this.prefix}--date-picker--simple`]: datePickerType === 'simple',
+        [`${this.prefix}--date-picker--single`]: datePickerType === 'single',
+        [`${this.prefix}--date-picker--range`]: datePickerType === 'range',
+        [`${this.prefix}--date-picker--nolabel`]:
           datePickerType === 'range' && this.isLabelTextEmpty(children),
       }
     );
 
-    const wrapperClasses = classNames(`${prefix}--form-item`, [
+    const wrapperClasses = classNames(`${this.prefix}--form-item`, [
       enabled ? className : null,
     ]);
 

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.js
@@ -8,11 +8,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
 import deprecate from '../../prop-types/deprecate';
 import { PropTypes as ListBoxPropTypes } from '../ListBox';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const DropdownSkeleton = ({
   className,
@@ -22,6 +20,7 @@ const DropdownSkeleton = ({
   inline,
   ...rest
 }) => {
+  const prefix = usePrefix();
   const wrapperClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--dropdown-v2`]: true,

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -7,7 +7,6 @@
 
 import React, { useRef } from 'react';
 import { useSelect } from 'downshift';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import {
@@ -20,8 +19,7 @@ import { mapDownshiftProps } from '../../tools/createPropAdapter';
 import mergeRefs from '../../tools/mergeRefs';
 import deprecate from '../../prop-types/deprecate';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import {usePrefix} from '../../internal/usePrefix';
 
 const defaultItemToString = (item) => {
   if (typeof item === 'string') {
@@ -61,6 +59,7 @@ const Dropdown = React.forwardRef(function Dropdown(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const selectProps = mapDownshiftProps({
     ...downshiftProps,
     items,

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.js
@@ -8,13 +8,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
 import SkeletonText from '../SkeletonText';
 import ButtonSkeleton from '../Button/Button.Skeleton';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function FileUploaderSkeleton({ className, ...rest }) {
+  const prefix = usePrefix();
   return (
     <div className={cx(`${prefix}--form-item`, className)} {...rest}>
       <SkeletonText heading width="100px" />

--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,8 +12,7 @@ import Filename from './Filename';
 import FileUploaderButton from './FileUploaderButton';
 import { ButtonKinds } from '../../prop-types/types';
 import { keys, matches } from '../../internal/keyboard';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 export default class FileUploader extends React.Component {
   static propTypes = {
@@ -96,6 +94,9 @@ export default class FileUploader extends React.Component {
     size: PropTypes.oneOf(['default', 'field', 'small', 'sm', 'md', 'lg']),
   };
 
+  static contextType = PrefixContext;
+  prefix = this.context;
+
   static defaultProps = {
     iconDescription: 'Provide icon description',
     filenameStatus: 'uploading',
@@ -173,6 +174,8 @@ export default class FileUploader extends React.Component {
       onDelete, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
+
+    const prefix = this.prefix;
 
     const classes = classNames({
       [`${prefix}--form-item`]: true,

--- a/packages/react/src/components/FileUploader/FileUploaderButton.js
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.js
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { matches, keys } from '../../internal/keyboard';
 import { ButtonKinds } from '../../prop-types/types';
 import uid from '../../tools/uniqueId';
-
-const { prefix } = settings;
+import {usePrefix} from '../../internal/usePrefix';
 
 function noop() {}
 
@@ -33,6 +31,7 @@ function FileUploaderButton({
   tabIndex = 0,
   ...other
 }) {
+  const prefix = usePrefix();
   const [labelText, setLabelText] = useState(ownerLabelText);
   const [prevOwnerLabelText, setPrevOwnerLabelText] = useState(ownerLabelText);
   const { current: inputId } = useRef(id || uid());

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.js
@@ -8,11 +8,9 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { keys, matches } from '../../internal/keyboard';
 import uniqueId from '../../tools/uniqueId';
-
-const { prefix } = settings;
+import {usePrefix} from '../../internal/usePrefix';
 
 function FileUploaderDropContainer({
   accept,
@@ -27,6 +25,7 @@ function FileUploaderDropContainer({
   tabIndex,
   ...rest
 }) {
+  const prefix = usePrefix(); 
   const inputRef = useRef(null);
   const { current: uid } = useRef(id || uniqueId());
   const [isActive, setActive] = useState(false);

--- a/packages/react/src/components/FileUploader/FileUploaderItem.js
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.js
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useRef } from 'react';
 import Filename from './Filename';
 import { keys, matches } from '../../internal/keyboard';
 import uid from '../../tools/uniqueId';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function FileUploaderItem({
   uuid,
@@ -27,6 +25,7 @@ function FileUploaderItem({
   size,
   ...other
 }) {
+  const prefix = usePrefix();
   const { current: id } = useRef(uuid || uid());
   const classes = cx(`${prefix}--file__selected-file`, {
     [`${prefix}--file__selected-file--invalid`]: invalid,

--- a/packages/react/src/components/Form/Form.js
+++ b/packages/react/src/components/Form/Form.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import {usePrefix } from '../../internal/usePrefix';
 
 const Form = ({ className, children, ...other }) => {
+  const prefix = usePrefix();
   const classNames = classnames(`${prefix}--form`, className);
   return (
     <form className={classNames} {...other}>

--- a/packages/react/src/components/FormGroup/FormGroup.js
+++ b/packages/react/src/components/FormGroup/FormGroup.js
@@ -8,10 +8,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const FormGroup = ({
   legendId,
@@ -24,6 +22,7 @@ const FormGroup = ({
   hasMargin,
   ...other
 }) => {
+  const prefix = usePrefix();
   const enabled = useFeatureFlag('enable-v11-release');
   const classNamesLegend = classnames(`${prefix}--label`, [
     enabled ? null : className,

--- a/packages/react/src/components/FormLabel/FormLabel.js
+++ b/packages/react/src/components/FormLabel/FormLabel.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const FormLabel = ({ className, children, id, ...other }) => {
+  const prefix = usePrefix(); 
   const classNames = classnames(`${prefix}--label`, className);
 
   return (

--- a/packages/react/src/components/Grid/Column.js
+++ b/packages/react/src/components/Grid/Column.js
@@ -5,13 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function Column({
   as: BaseComponent = 'div',
@@ -24,6 +22,7 @@ function Column({
   max,
   ...rest
 }) {
+  const prefix = usePrefix();
   const hasCSSGrid = useFeatureFlag('enable-css-grid');
   const columnClassName = hasCSSGrid
     ? getClassNameForBreakpoints([sm, md, lg, xlg, max])

--- a/packages/react/src/components/Grid/Grid.js
+++ b/packages/react/src/components/Grid/Grid.js
@@ -5,13 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SubgridContext = React.createContext(false);
 
@@ -25,6 +23,7 @@ function Grid({
   children,
   ...rest
 }) {
+  const prefix = usePrefix();
   const hasCSSGrid = useFeatureFlag('enable-css-grid');
   const isSubgrid = useContext(SubgridContext);
 

--- a/packages/react/src/components/Grid/Row.js
+++ b/packages/react/src/components/Grid/Row.js
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function Row({
   as: BaseComponent = 'div',
@@ -20,6 +18,7 @@ function Row({
   children,
   ...rest
 }) {
+  const prefix = usePrefix();
   const className = cx(containerClassName, {
     [`${prefix}--row`]: true,
     [`${prefix}--row--condensed`]: condensed,

--- a/packages/react/src/components/InlineLoading/InlineLoading.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading.js
@@ -9,11 +9,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { CheckmarkFilled16, ErrorFilled16 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
 import deprecate from '../../prop-types/deprecate';
 import Loading from '../Loading';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 export default function InlineLoading({
   className,
@@ -25,6 +23,7 @@ export default function InlineLoading({
   successDelay,
   ...other
 }) {
+  const prefix = usePrefix();
   const loadingClasses = classNames(`${prefix}--inline-loading`, className);
   const getLoading = () => {
     if (status === 'error') {

--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -8,9 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Link = ({
   children,
@@ -23,6 +21,7 @@ const Link = ({
   size,
   ...other
 }) => {
+  const prefix = usePrefix();
   const classNames = classnames(`${prefix}--link`, className, {
     [`${prefix}--link--disabled`]: disabled,
     [`${prefix}--link--inline`]: inline,

--- a/packages/react/src/components/Loading/Loading.js
+++ b/packages/react/src/components/Loading/Loading.js
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useRef } from 'react';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 
 function Loading({
@@ -23,6 +22,7 @@ function Loading({
   description,
   ...rest
 }) {
+  const prefix = usePrefix();
   const { current: instanceId } = useRef(getInstanceId());
   const loadingClassName = cx(customClassName, {
     [`${prefix}--loading`]: true,

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -8,7 +8,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { Close20 } from '@carbon/icons-react';
 import toggleClass from '../../tools/toggleClass';
 import Button from '../Button';
@@ -19,8 +18,8 @@ import wrapFocus, {
   elementOrParentIsFloatingMenu,
 } from '../../internal/wrapFocus';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { PrefixContext } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 
 export default class Modal extends Component {
@@ -211,6 +210,9 @@ export default class Modal extends Component {
     size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
   };
 
+  static contextType = PrefixContext;
+  prefix = this.context;
+
   static defaultProps = {
     onRequestClose: () => {},
     onRequestSubmit: () => {},
@@ -232,10 +234,10 @@ export default class Modal extends Component {
   startTrap = React.createRef();
   endTrap = React.createRef();
   modalInstanceId = `modal-${getInstanceId()}`;
-  modalLabelId = `${prefix}--modal-header__label--${this.modalInstanceId}`;
-  modalHeadingId = `${prefix}--modal-header__heading--${this.modalInstanceId}`;
-  modalBodyId = `${prefix}--modal-body--${this.modalInstanceId}`;
-  modalCloseButtonClass = `${prefix}--modal-close`;
+  modalLabelId = `${this.prefix}--modal-header__label--${this.modalInstanceId}`;
+  modalHeadingId = `${this.prefix}--modal-header__heading--${this.modalInstanceId}`;
+  modalBodyId = `${this.prefix}--modal-body--${this.modalInstanceId}`;
+  modalCloseButtonClass = `${this.prefix}--modal-close`;
 
   isCloseButton = (element) => {
     return (
@@ -302,7 +304,7 @@ export default class Modal extends Component {
     }
     toggleClass(
       document.body,
-      `${prefix}--body--with-modal-open`,
+      `${this.prefix}--body--with-modal-open`,
       this.props.open
     );
   }
@@ -328,13 +330,13 @@ export default class Modal extends Component {
   };
 
   componentWillUnmount() {
-    toggleClass(document.body, `${prefix}--body--with-modal-open`, false);
+    toggleClass(document.body, `${this.prefix}--body--with-modal-open`, false);
   }
 
   componentDidMount() {
     toggleClass(
       document.body,
-      `${prefix}--body--with-modal-open`,
+      `${this.prefix}--body--with-modal-open`,
       this.props.open
     );
     if (!this.props.open) {
@@ -357,6 +359,7 @@ export default class Modal extends Component {
   };
 
   render() {
+    const prefix = this.prefix;
     const {
       modalHeading,
       modalLabel,

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -6,8 +6,7 @@
  */
 
 import { WarningFilled16, WarningAltFilled16 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
-import cx from 'classnames';
+import { settings } from 'carbon-components'; import cx from 'classnames';
 import Downshift from 'downshift';
 import isEqual from 'lodash.isequal';
 import PropTypes from 'prop-types';

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -6,7 +6,6 @@
  */
 
 import { WarningFilled16, WarningAltFilled16 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import Downshift, { useSelect } from 'downshift';
 import isEqual from 'lodash.isequal';
@@ -22,8 +21,8 @@ import { mapDownshiftProps } from '../../tools/createPropAdapter';
 import mergeRefs from '../../tools/mergeRefs';
 import { keys, match } from '../../internal/keyboard';
 import { useFeatureFlag } from '../FeatureFlags';
+import {usePrefix} from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const noop = () => {};
 const getInstanceId = setupGetInstanceId();
 const {
@@ -71,6 +70,7 @@ const MultiSelect = React.forwardRef(function MultiSelect(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const { current: multiSelectInstanceId } = useRef(getInstanceId());
   const [highlightedIndex, setHighlightedIndex] = useState(null);
   const [isOpen, setIsOpen] = useState(open);

--- a/packages/react/src/components/Notification/Notification.js
+++ b/packages/react/src/components/Notification/Notification.js
@@ -8,7 +8,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
 import {
   Close20,
   ErrorFilled20,
@@ -18,10 +17,8 @@ import {
   InformationFilled20,
   InformationSquareFilled20,
 } from '@carbon/icons-react';
-
 import Button from '../Button';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 export function NotificationActionButton({
   children,
@@ -29,6 +26,7 @@ export function NotificationActionButton({
   onClick,
   ...rest
 }) {
+  const prefix = usePrefix();
   const className = cx(
     customClassName,
     `${prefix}--inline-notification__action-button`
@@ -73,6 +71,7 @@ export function NotificationButton({
   notificationType,
   ...rest
 }) {
+  const prefix = usePrefix();
   const buttonClassName = cx(className, {
     [`${prefix}--${notificationType}-notification__close-button`]: notificationType,
   });
@@ -150,6 +149,7 @@ export function NotificationTextDetails({
   children,
   ...rest
 }) {
+  const prefix = usePrefix();
   if (notificationType === 'toast') {
     return (
       <div {...rest} className={`${prefix}--toast-notification__details`}>
@@ -218,6 +218,7 @@ const iconTypes = {
 };
 
 function NotificationIcon({ iconDescription, kind, notificationType }) {
+  const prefix = usePrefix();
   const IconForKind = iconTypes[kind];
   if (!IconForKind) {
     return null;
@@ -261,6 +262,7 @@ export function ToastNotification({
   timeout,
   ...rest
 }) {
+  const prefix = usePrefix();
   const [isOpen, setIsOpen] = useState(true);
   const containerClassName = cx(className, {
     [`${prefix}--toast-notification`]: true,
@@ -444,6 +446,7 @@ export function InlineNotification({
   children,
   ...rest
 }) {
+  const prefix = usePrefix();
   const [isOpen, setIsOpen] = useState(true);
   const containerClassName = cx(className, {
     [`${prefix}--inline-notification`]: true,

--- a/packages/react/src/components/OrderedList/OrderedList.js
+++ b/packages/react/src/components/OrderedList/OrderedList.js
@@ -8,9 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const OrderedList = ({
   children,
@@ -20,6 +18,7 @@ const OrderedList = ({
   isExpressive,
   ...other
 }) => {
+  const prefix = usePrefix();
   const classNames = classnames(
     {
       [`${prefix}--list--ordered`]: !native,

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -9,7 +9,6 @@ import invariant from 'invariant';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import ClickListener from '../../internal/ClickListener';
 import FloatingMenu, {
   DIRECTION_TOP,
@@ -18,8 +17,7 @@ import FloatingMenu, {
 import { OverflowMenuVertical16 } from '@carbon/icons-react';
 import { keys, matches as keyCodeMatches } from '../../internal/keyboard';
 import mergeRefs from '../../tools/mergeRefs';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 const on = (element, ...args) => {
   element.addEventListener(...args);
@@ -216,6 +214,9 @@ class OverflowMenu extends Component {
      */
     size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
   };
+
+  static contextType = PrefixContext;
+  prefix = this.context;
 
   static defaultProps = {
     ariaLabel: 'open and close list of options',
@@ -416,7 +417,7 @@ class OverflowMenu extends Component {
               !menuBody.contains(target) &&
               triggerEl &&
               !target.matches(
-                `.${prefix}--overflow-menu,.${prefix}--overflow-menu-options`
+                `.${this.prefix}--overflow-menu,.${this.prefix}--overflow-menu-options`
               )
             ) {
               this.closeMenu();
@@ -441,6 +442,7 @@ class OverflowMenu extends Component {
   };
 
   render() {
+    const prefix = this.prefix;
     const {
       id,
       ariaLabel,

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.Skeleton.js
@@ -8,33 +8,35 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
-
-const step = (
-  <li
-    className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
-    <div
-      className={`${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable`}>
-      <svg>
-        <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
-      </svg>
-      <p className={`${prefix}--progress-label`} />
-      <span className={`${prefix}--progress-line`} />
-    </div>
-  </li>
-);
+const step = () => {
+  const prefix = usePrefix();
+  return (
+    <li
+      className={`${prefix}--progress-step ${prefix}--progress-step--incomplete`}>
+      <div
+        className={`${prefix}--progress-step-button ${prefix}--progress-step-button--unclickable`}>
+        <svg>
+          <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
+        </svg>
+        <p className={`${prefix}--progress-label`} />
+        <span className={`${prefix}--progress-line`} />
+      </div>
+    </li>
+  );
+};
 
 function ProgressIndicatorSkeleton({ className, ...rest }) {
+  const prefix = usePrefix();
   return (
     <ul
       className={cx(`${prefix}--progress`, `${prefix}--skeleton`, className)}
       {...rest}>
-      {step}
-      {step}
-      {step}
-      {step}
+      {step()}
+      {step()}
+      {step()}
+      {step()}
     </ul>
   );
 }

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -8,7 +8,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
 import {
   CheckmarkOutline16,
   Warning16,
@@ -16,8 +15,7 @@ import {
   CircleFilled16,
 } from '@carbon/icons-react';
 import { keys, matches } from '../../internal/keyboard';
-
-const { prefix } = settings;
+import { usePrefix, PrefixContext } from '../../internal/usePrefix';
 
 const defaultRenderLabel = (props) => <p {...props} />;
 
@@ -46,6 +44,7 @@ export function ProgressStep({
   translateWithId: t,
   ...rest
 }) {
+  const prefix = usePrefix();
   const classes = classnames({
     [`${prefix}--progress-step`]: true,
     [`${prefix}--progress-step--current`]: current,
@@ -252,6 +251,9 @@ export class ProgressIndicator extends Component {
      */
     vertical: PropTypes.bool,
   };
+  
+  static contextType = PrefixContext;
+  prefix = this.context;
 
   static defaultProps = {
     currentIndex: 0,
@@ -306,6 +308,7 @@ export class ProgressIndicator extends Component {
       spaceEqually,
       ...other
     } = this.props;
+    const prefix = this.prefix;
     const classes = classnames({
       [`${prefix}--progress`]: true,
       [`${prefix}--progress--vertical`]: vertical,

--- a/packages/react/src/components/RadioButton/RadioButton.js
+++ b/packages/react/src/components/RadioButton/RadioButton.js
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { warning } from '../../internal/warning';
 import uid from '../../tools/uniqueId';
 import { Text } from '../Text';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 class RadioButton extends React.Component {
   static propTypes = {
@@ -81,6 +79,9 @@ class RadioButton extends React.Component {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   };
 
+  static contextType = PrefixContext;
+  prefix = this.context;
+
   static defaultProps = {
     labelText: '',
     labelPosition: 'right',
@@ -95,6 +96,7 @@ class RadioButton extends React.Component {
   };
 
   render() {
+    const prefix = this.prefix;
     const {
       className,
       labelText,

--- a/packages/react/src/components/Select/Select.Skeleton.js
+++ b/packages/react/src/components/Select/Select.Skeleton.js
@@ -8,18 +8,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
-
-const SelectSkeleton = ({ hideLabel, className, ...rest }) => (
-  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
-    {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
-    <div className={`${prefix}--select ${prefix}--skeleton`}>
-      <div className={`${prefix}--select-input`} />
+const SelectSkeleton = ({ hideLabel, className, ...rest }) => {
+  const prefix = usePrefix();
+  return (
+    <div className={cx(`${prefix}--form-item`, className)} {...rest}>
+      {!hideLabel && (
+        <span className={`${prefix}--label ${prefix}--skeleton`} />
+      )}
+      <div className={`${prefix}--select ${prefix}--skeleton`}>
+        <div className={`${prefix}--select-input`} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 SelectSkeleton.propTypes = {
   /**

--- a/packages/react/src/components/Select/Select.js
+++ b/packages/react/src/components/Select/Select.js
@@ -8,7 +8,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import {
   ChevronDown16,
   WarningFilled16,
@@ -16,8 +15,7 @@ import {
 } from '@carbon/icons-react';
 import deprecate from '../../prop-types/deprecate';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Select = React.forwardRef(function Select(
   {
@@ -43,6 +41,7 @@ const Select = React.forwardRef(function Select(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const enabled = useFeatureFlag('enable-v11-release');
 
   const selectClasses = classNames(

--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.js
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.js
@@ -8,11 +8,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SkeletonPlaceholder = ({ className, ...other }) => {
+  const prefix = usePrefix();
   const skeletonPlaceholderClasses = classNames({
     [`${prefix}--skeleton__placeholder`]: true,
     [className]: className,

--- a/packages/react/src/components/SkeletonText/SkeletonText.js
+++ b/packages/react/src/components/SkeletonText/SkeletonText.js
@@ -8,9 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const randoms = [0.973051493507435, 0.15334737213558558, 0.5671034553053769];
 
@@ -26,6 +24,7 @@ const SkeletonText = ({
   className,
   ...other
 }) => {
+  const prefix = usePrefix();
   const skeletonTextClasses = classNames({
     [`${prefix}--skeleton__text`]: true,
     [`${prefix}--skeleton__heading`]: heading,

--- a/packages/react/src/components/StructuredList/StructuredList.Skeleton.js
+++ b/packages/react/src/components/StructuredList/StructuredList.Skeleton.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const StructuredListSkeleton = ({ rowCount, border, className, ...rest }) => {
+  const prefix = usePrefix();
   const StructuredListSkeletonClasses = cx(className, {
     [`${prefix}--skeleton`]: true,
     [`${prefix}--structured-list`]: true,

--- a/packages/react/src/components/StructuredList/StructuredList.js
+++ b/packages/react/src/components/StructuredList/StructuredList.js
@@ -8,11 +8,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import deprecate from '../../prop-types/deprecate';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 
 export function StructuredListWrapper(props) {
@@ -26,6 +25,7 @@ export function StructuredListWrapper(props) {
     border: _border,
     ...other
   } = props;
+  const prefix = usePrefix();
   const classes = classNames(`${prefix}--structured-list`, className, {
     [`${prefix}--structured-list--selection`]: selection,
     [`${prefix}--structured-list--condensed`]: isCondensed,
@@ -88,6 +88,7 @@ StructuredListWrapper.defaultProps = {
 
 export function StructuredListHead(props) {
   const { children, className, ...other } = props;
+  const prefix = usePrefix();
   const classes = classNames(`${prefix}--structured-list-thead`, className);
 
   return (
@@ -111,6 +112,7 @@ StructuredListHead.propTypes = {
 
 export function StructuredListBody(props) {
   const { children, className, ...other } = props;
+  const prefix = usePrefix();
   const classes = classNames(`${prefix}--structured-list-tbody`, className);
 
   return (
@@ -153,6 +155,7 @@ export function StructuredListRow(props) {
     label,
     ...other
   } = props;
+  const prefix = usePrefix();
   const classes = classNames(`${prefix}--structured-list-row`, className, {
     [`${prefix}--structured-list-row--header-row`]: head,
   });
@@ -215,6 +218,7 @@ StructuredListRow.defaultProps = {
 
 export function StructuredListInput(props) {
   const { className, value, name, title, id, ...other } = props;
+  const prefix = usePrefix();
   const classes = classNames(`${prefix}--structured-list-input`, className);
   const instanceId = id || getInstanceId();
 
@@ -277,6 +281,7 @@ StructuredListInput.defaultProps = {
 
 export function StructuredListCell(props) {
   const { children, className, head, noWrap, ...other } = props;
+  const prefix = usePrefix();
   const classes = classNames(className, {
     [`${prefix}--structured-list-th`]: head,
     [`${prefix}--structured-list-td`]: !head,

--- a/packages/react/src/components/Tabs/Tabs.Skeleton.js
+++ b/packages/react/src/components/Tabs/Tabs.Skeleton.js
@@ -8,19 +8,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
+// const tab = (
+//   <li className={`${prefix}--tabs--scrollable__nav-item`}>
+//     <div className={`${prefix}--tabs__nav-link`}>
+//       <span></span>
+//     </div>
+//   </li>
+// );
 
-const tab = (
-  <li className={`${prefix}--tabs--scrollable__nav-item`}>
-    <div className={`${prefix}--tabs__nav-link`}>
-      <span></span>
-    </div>
-  </li>
-);
+function Tab() {
+  const prefix = usePrefix();
+  return (
+    <li className={`${prefix}--tabs--scrollable__nav-item`}>
+      <div className={`${prefix}--tabs__nav-link`}>
+        <span></span>
+      </div>
+    </li>
+  );
+}
 
 function TabsSkeleton({ className, type, ...rest }) {
+  const prefix = usePrefix();
   const tabClasses = cx(
     className,
     `${prefix}--tabs`,
@@ -33,11 +43,11 @@ function TabsSkeleton({ className, type, ...rest }) {
   return (
     <div className={tabClasses} {...rest}>
       <ul className={`${prefix}--tabs--scrollable__nav`}>
-        {tab}
-        {tab}
-        {tab}
-        {tab}
-        {tab}
+        {Tab()}
+        {Tab()}
+        {Tab()}
+        {Tab()}
+        {Tab()}
       </ul>
     </div>
   );

--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -8,13 +8,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { ChevronLeft16, ChevronRight16 } from '@carbon/icons-react';
 import debounce from 'lodash.debounce';
 import { keys, match, matches } from '../../internal/keyboard';
 import TabContent from '../TabContent';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 export default class Tabs extends React.Component {
   static propTypes = {
@@ -102,6 +100,9 @@ export default class Tabs extends React.Component {
     selected: 0,
     selectionMode: 'automatic',
   };
+
+  static contextType = PrefixContext;
+  prefix = this.context;
 
   state = {
     horizontalOverflow: false,
@@ -405,6 +406,8 @@ export default class Tabs extends React.Component {
       rightOverflowButtonProps,
       ...other
     } = this.props;
+
+    const prefix = this.prefix;
 
     /**
      * The tab panel acts like a tab panel when the screen is wider, but acts

--- a/packages/react/src/components/Tag/Tag.Skeleton.js
+++ b/packages/react/src/components/Tag/Tag.Skeleton.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function TagSkeleton({ className, size, ...rest }) {
+  const prefix = usePrefix();
   return (
     <span
       className={cx(`${prefix}--tag`, `${prefix}--skeleton`, className, {

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { Close16 } from '@carbon/icons-react';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 const TYPES = {
   red: 'Red',
@@ -41,6 +40,7 @@ const Tag = ({
   size,
   ...other
 }) => {
+  const prefix = usePrefix();
   const tagId = id || `tag-${getInstanceId()}`;
   const tagClasses = classNames(`${prefix}--tag`, className, {
     [`${prefix}--tag--disabled`]: disabled,

--- a/packages/react/src/components/TextArea/TextArea.Skeleton.js
+++ b/packages/react/src/components/TextArea/TextArea.Skeleton.js
@@ -8,16 +8,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
-
-const TextAreaSkeleton = ({ hideLabel, className, ...rest }) => (
-  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
-    {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
-    <div className={`${prefix}--skeleton ${prefix}--text-area`} />
-  </div>
-);
+const TextAreaSkeleton = ({ hideLabel, className, ...rest }) => {
+  const prefix = usePrefix();
+  return (
+    <div className={cx(`${prefix}--form-item`, className)} {...rest}>
+      {!hideLabel && (
+        <span className={`${prefix}--label ${prefix}--skeleton`} />
+      )}
+      <div className={`${prefix}--skeleton ${prefix}--text-area`} />
+    </div>
+  );
+};
 
 TextAreaSkeleton.propTypes = {
   /**

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -8,11 +8,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { WarningFilled16 } from '@carbon/icons-react';
 import { useFeatureFlag } from '../FeatureFlags';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const TextArea = React.forwardRef(function TextArea(
   {
@@ -31,6 +29,7 @@ const TextArea = React.forwardRef(function TextArea(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const enabled = useFeatureFlag('enable-v11-release');
 
   const textareaProps = {

--- a/packages/react/src/components/TextInput/TextInput.Skeleton.js
+++ b/packages/react/src/components/TextInput/TextInput.Skeleton.js
@@ -8,16 +8,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { settings } from 'carbon-components';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
-
-const TextInputSkeleton = ({ hideLabel, className, ...rest }) => (
-  <div className={cx(`${prefix}--form-item`, className)} {...rest}>
-    {!hideLabel && <span className={`${prefix}--label ${prefix}--skeleton`} />}
-    <div className={`${prefix}--skeleton ${prefix}--text-input`} />
-  </div>
-);
+const TextInputSkeleton = ({ hideLabel, className, ...rest }) => {
+  const prefix = usePrefix();
+  return (
+    <div className={cx(`${prefix}--form-item`, className)} {...rest}>
+      {!hideLabel && (
+        <span className={`${prefix}--label ${prefix}--skeleton`} />
+      )}
+      <div className={`${prefix}--skeleton ${prefix}--text-input`} />
+    </div>
+  );
+};
 
 TextInputSkeleton.propTypes = {
   /**

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -8,19 +8,18 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import { useNormalizedInputProps } from '../../internal/useNormalizedInputProps';
 import PasswordInput from './PasswordInput';
 import ControlledPasswordInput from './ControlledPasswordInput';
 import { textInputProps } from './util';
 import { FormContext } from '../FluidForm';
 import { useFeatureFlag } from '../FeatureFlags';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const TextInput = React.forwardRef(function TextInput(
   {
     labelText,
-    className = `${prefix}--text__input`,
+    className,
     id,
     placeholder,
     type,
@@ -41,6 +40,10 @@ const TextInput = React.forwardRef(function TextInput(
   },
   ref
 ) {
+  const prefix = usePrefix();
+  if (!className) {
+    className = `${prefix}--text__input`;
+  }
   const enabled = useFeatureFlag('enable-v11-release');
 
   const normalizedProps = useNormalizedInputProps({

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -8,7 +8,6 @@
 import React, { Component, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import Link from '../Link';
 import {
   Checkbox16,
@@ -18,8 +17,7 @@ import {
 import { keys, matches } from '../../internal/keyboard';
 import deprecate from '../../prop-types/deprecate';
 import { composeEventHandlers } from '../../tools/events';
-
-const { prefix } = settings;
+import { PrefixContext, usePrefix } from '../../internal/usePrefix';
 
 export class Tile extends Component {
   static propTypes = {
@@ -40,11 +38,14 @@ export class Tile extends Component {
     light: PropTypes.bool,
   };
 
+  static contextType = PrefixContext;
+
   static defaultProps = {
     light: false,
   };
 
   render() {
+    const prefix = this.context;
     const { children, className, light, ...other } = this.props;
     const tileClasses = classNames(
       `${prefix}--tile`,
@@ -102,6 +103,8 @@ export class ClickableTile extends Component {
     rel: PropTypes.string,
   };
 
+  static contextType = PrefixContext;
+
   static defaultProps = {
     clicked: false,
     handleClick: () => {},
@@ -149,6 +152,7 @@ export class ClickableTile extends Component {
   }
 
   render() {
+    const prefix = this.context;
     const {
       children,
       href,
@@ -204,6 +208,8 @@ export function SelectableTile(props) {
     selected,
     ...other
   } = props;
+
+  const prefix = usePrefix();
 
   // TODO: replace with onClick when handleClick prop is deprecated
   const clickHandler = handleClick || onClick;
@@ -465,6 +471,8 @@ export class ExpandableTile extends Component {
     tileExpandedLabel: PropTypes.string,
   };
 
+  static contextType = PrefixContext;
+
   static defaultProps = {
     tabIndex: 0,
     expanded: false,
@@ -585,6 +593,8 @@ export class ExpandableTile extends Component {
       ...other
     } = this.props;
 
+    const prefix = this.context;
+
     const { expanded: isExpanded } = this.state;
 
     const classes = classNames(
@@ -650,7 +660,10 @@ export class TileAboveTheFoldContent extends Component {
     children: PropTypes.node,
   };
 
+  static contextType = PrefixContext;
+
   render() {
+    const prefix = this.context;
     const { children } = this.props;
 
     return (
@@ -669,8 +682,11 @@ export class TileBelowTheFoldContent extends Component {
     children: PropTypes.node,
   };
 
+  static contextType = PrefixContext;
+
   render() {
     const { children } = this.props;
+    const prefix = this.context;
 
     return (
       <span className={`${prefix}--tile-content__below-the-fold`}>

--- a/packages/react/src/components/Toggle/Toggle.js
+++ b/packages/react/src/components/Toggle/Toggle.js
@@ -8,11 +8,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { settings } from 'carbon-components';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import { keys, match } from '../../internal/keyboard';
+import { PrefixContext } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 
 class Toggle extends React.Component {
@@ -69,6 +68,8 @@ class Toggle extends React.Component {
      */
     toggled: PropTypes.bool,
   };
+  static contextType = PrefixContext;
+  prefix = this.context;
 
   static defaultProps = {
     defaultToggled: false,
@@ -79,6 +80,7 @@ class Toggle extends React.Component {
   };
 
   render() {
+    const prefix = this.prefix;
     const {
       className,
       defaultToggled,

--- a/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
+++ b/packages/react/src/components/TooltipDefinition/TooltipDefinition.js
@@ -8,13 +8,12 @@
 import cx from 'classnames';
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
 import debounce from 'lodash.debounce';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import { composeEventHandlers } from '../../tools/events';
 import { keys, matches } from '../../internal/keyboard';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 const TooltipDefinition = ({
   id,
@@ -30,6 +29,7 @@ const TooltipDefinition = ({
   tooltipText,
   ...rest
 }) => {
+  const prefix = usePrefix();
   const [allowTooltipVisibility, setAllowTooltipVisibility] = useState(true);
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const tooltipId = id || `definition-tooltip-${getInstanceId()}`;

--- a/packages/react/src/components/TooltipIcon/TooltipIcon.js
+++ b/packages/react/src/components/TooltipIcon/TooltipIcon.js
@@ -8,13 +8,12 @@
 import cx from 'classnames';
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { settings } from 'carbon-components';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import { composeEventHandlers } from '../../tools/events';
 import { keys, matches } from '../../internal/keyboard';
 import toggleClass from '../../tools/toggleClass';
+import { usePrefix } from '../../internal/usePrefix';
 
-const { prefix } = settings;
 const getInstanceId = setupGetInstanceId();
 const TooltipIcon = ({
   id,
@@ -32,6 +31,7 @@ const TooltipIcon = ({
   tooltipText,
   ...rest
 }) => {
+  const prefix = usePrefix();
   const [allowTooltipVisibility, setAllowTooltipVisibility] = useState(true);
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);

--- a/packages/react/src/components/UIShell/Content.js
+++ b/packages/react/src/components/UIShell/Content.js
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Content = ({
   className: customClassName,
@@ -18,6 +16,7 @@ const Content = ({
   tagName,
   ...rest
 }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--content`, customClassName);
   return React.createElement(
     tagName,

--- a/packages/react/src/components/UIShell/Header.js
+++ b/packages/react/src/components/UIShell/Header.js
@@ -5,15 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Header = ({ className: customClassName, children, ...rest }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--header`, customClassName);
 
   return (

--- a/packages/react/src/components/UIShell/HeaderGlobalAction.js
+++ b/packages/react/src/components/UIShell/HeaderGlobalAction.js
@@ -5,14 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import Button from '../Button';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 /**
  * HeaderGlobalAction is used as a part of the `HeaderGlobalBar`. It is
@@ -35,6 +33,7 @@ const HeaderGlobalAction = React.forwardRef(function HeaderGlobalAction(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const className = cx({
     [customClassName]: !!customClassName,
     [`${prefix}--header__action`]: true,

--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -6,18 +6,12 @@
  */
 
 import { ChevronDown16 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keys, matches } from '../../internal/keyboard';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-
-const { prefix } = settings;
-
-const defaultRenderMenuContent = () => (
-  <ChevronDown16 className={`${prefix}--header__menu-arrow`} />
-);
+import { PrefixContext } from '../../internal/usePrefix';
 
 /**
  * `HeaderMenu` is used to render submenu's in the `Header`. Most often children
@@ -53,8 +47,13 @@ class HeaderMenu extends React.Component {
     tabIndex: PropTypes.number,
   };
 
+  static contextType = PrefixContext;
+  prefix = this.context;
+
   static defaultProps = {
-    renderMenuContent: defaultRenderMenuContent,
+    renderMenuContent: (
+      <ChevronDown16 className={`${this.prefix}--header__menu-arrow`} />
+    ),
   };
 
   _subMenus = React.createRef();
@@ -166,6 +165,7 @@ class HeaderMenu extends React.Component {
   };
 
   render() {
+    const prefix = this.prefix;
     const {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,

--- a/packages/react/src/components/UIShell/HeaderMenuButton.js
+++ b/packages/react/src/components/UIShell/HeaderMenuButton.js
@@ -7,13 +7,11 @@
 
 import { Close20, Menu20 } from '@carbon/icons-react';
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const HeaderMenuButton = ({
   'aria-label': ariaLabel,
@@ -26,6 +24,7 @@ const HeaderMenuButton = ({
   isCollapsible,
   ...rest
 }) => {
+  const prefix = usePrefix();
   const className = cx({
     [customClassName]: !!customClassName,
     [`${prefix}--header__action`]: true,

--- a/packages/react/src/components/UIShell/HeaderMenuItem.js
+++ b/packages/react/src/components/UIShell/HeaderMenuItem.js
@@ -5,13 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import Link, { LinkPropTypes } from './Link';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const HeaderMenuItem = React.forwardRef(function HeaderMenuItem(
   {
@@ -24,6 +22,7 @@ const HeaderMenuItem = React.forwardRef(function HeaderMenuItem(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const linkClassName = cx({
     [`${prefix}--header__menu-item`]: true,
     // We set the current class only if `isCurrentPage` is passed in and we do

--- a/packages/react/src/components/UIShell/HeaderName.js
+++ b/packages/react/src/components/UIShell/HeaderName.js
@@ -4,14 +4,11 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link, { LinkPropTypes } from './Link';
-
-const { prefix: selectorPrefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const HeaderName = ({
   children,
@@ -20,6 +17,7 @@ const HeaderName = ({
   href,
   ...rest
 }) => {
+  const selectorPrefix = usePrefix();
   const className = cx(`${selectorPrefix}--header__name`, customClassName);
   return (
     <Link {...rest} className={className} href={href}>

--- a/packages/react/src/components/UIShell/HeaderNavigation.js
+++ b/packages/react/src/components/UIShell/HeaderNavigation.js
@@ -5,13 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-
-const { prefix } = settings;
+import { PrefixContext } from '../../internal/usePrefix';
 
 export default class HeaderNavigation extends React.Component {
   static propTypes = {
@@ -40,6 +38,8 @@ export default class HeaderNavigation extends React.Component {
     };
   }
 
+  static contextType = PrefixContext;
+  prefix = this.context;
   /**
    * Handles individual menuitem refs. We assign them to a class instance
    * property so that we can properly manage focus of our children.
@@ -49,6 +49,7 @@ export default class HeaderNavigation extends React.Component {
   };
 
   render() {
+    const prefix = this.prefix;
     const {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,

--- a/packages/react/src/components/UIShell/HeaderPanel.js
+++ b/packages/react/src/components/UIShell/HeaderPanel.js
@@ -6,12 +6,10 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const HeaderPanel = React.forwardRef(function HeaderPanel(
   {
@@ -24,6 +22,7 @@ const HeaderPanel = React.forwardRef(function HeaderPanel(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const accessibilityLabel = {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,

--- a/packages/react/src/components/UIShell/HeaderSideNavItems.js
+++ b/packages/react/src/components/UIShell/HeaderSideNavItems.js
@@ -5,18 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const HeaderSideNavItems = ({
   className: customClassName,
   children,
   hasDivider,
 }) => {
+  const prefix = usePrefix();
   const className = cx(
     {
       [`${prefix}--side-nav__header-navigation`]: true,

--- a/packages/react/src/components/UIShell/SideNav.js
+++ b/packages/react/src/components/UIShell/SideNav.js
@@ -6,15 +6,13 @@
  */
 
 import React, { useState, useRef } from 'react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import { CARBON_SIDENAV_ITEMS } from './_utils';
+import { usePrefix } from '../../internal/usePrefix';
 // TO-DO: comment back in when footer is added for rails
 // import SideNavFooter from './SideNavFooter';
-
-const { prefix } = settings;
 
 const SideNav = React.forwardRef(function SideNav(props, ref) {
   const {
@@ -37,6 +35,7 @@ const SideNav = React.forwardRef(function SideNav(props, ref) {
     ...other
   } = props;
 
+  const prefix = usePrefix();
   const { current: controlled } = useRef(expandedProp !== undefined);
   const [expandedState, setExpandedState] = useState(defaultExpanded);
   const [expandedViaHoverState, setExpandedViaHoverState] = useState(

--- a/packages/react/src/components/UIShell/SideNavDetails.js
+++ b/packages/react/src/components/UIShell/SideNavDetails.js
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavDetails = ({ children, className: customClassName, title }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--side-nav__details`, customClassName);
   return (
     <div className={className}>

--- a/packages/react/src/components/UIShell/SideNavDivider.js
+++ b/packages/react/src/components/UIShell/SideNavDivider.js
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 function SideNavDivider({ className }) {
+  const prefix = usePrefix();
   const classNames = cx(`${prefix}--side-nav__divider`, className);
   return <li role="separator" className={classNames} />;
 }

--- a/packages/react/src/components/UIShell/SideNavFooter.js
+++ b/packages/react/src/components/UIShell/SideNavFooter.js
@@ -7,12 +7,10 @@
 
 import { Close20, ChevronRight20 } from '@carbon/icons-react';
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 /**
  * SideNavFooter is used for rendering the button at the bottom of the side
@@ -25,6 +23,7 @@ const SideNavFooter = ({
   expanded,
   onToggle,
 }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--side-nav__footer`, customClassName);
   return (
     <footer className={className}>

--- a/packages/react/src/components/UIShell/SideNavHeader.js
+++ b/packages/react/src/components/UIShell/SideNavHeader.js
@@ -5,19 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SideNavIcon from './SideNavIcon';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavHeader = ({
   className: customClassName,
   children,
   renderIcon: IconElement,
 }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--side-nav__header`, customClassName);
   return (
     <header className={className}>

--- a/packages/react/src/components/UIShell/SideNavIcon.js
+++ b/packages/react/src/components/UIShell/SideNavIcon.js
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavIcon = ({ children, className: customClassName, small }) => {
+  const prefix = usePrefix();
   const className = cx({
     [`${prefix}--side-nav__icon`]: true,
     [`${prefix}--side-nav__icon--small`]: small,

--- a/packages/react/src/components/UIShell/SideNavItem.js
+++ b/packages/react/src/components/UIShell/SideNavItem.js
@@ -5,18 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavItem = ({
   className: customClassName,
   children,
   large = false,
 }) => {
+  const prefix = usePrefix();
   const className = cx({
     [`${prefix}--side-nav__item`]: true,
     [`${prefix}--side-nav__item--large`]: large,

--- a/packages/react/src/components/UIShell/SideNavItems.js
+++ b/packages/react/src/components/UIShell/SideNavItems.js
@@ -5,19 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CARBON_SIDENAV_ITEMS } from './_utils';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavItems = ({
   className: customClassName,
   children,
   isSideNavExpanded,
 }) => {
+  const prefix = usePrefix();
   const className = cx([`${prefix}--side-nav__items`], customClassName);
   const childrenWithExpandedState = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {

--- a/packages/react/src/components/UIShell/SideNavLink.js
+++ b/packages/react/src/components/UIShell/SideNavLink.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,8 +12,7 @@ import Link, { LinkPropTypes } from './Link';
 import SideNavIcon from './SideNavIcon';
 import SideNavItem from './SideNavItem';
 import SideNavLinkText from './SideNavLinkText';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavLink = React.forwardRef(function SideNavLink(
   {
@@ -27,6 +25,7 @@ const SideNavLink = React.forwardRef(function SideNavLink(
   },
   ref
 ) {
+  const prefix = usePrefix();
   const className = cx({
     [`${prefix}--side-nav__link`]: true,
     [`${prefix}--side-nav__link--current`]: isActive,

--- a/packages/react/src/components/UIShell/SideNavLinkText.js
+++ b/packages/react/src/components/UIShell/SideNavLinkText.js
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavLinkText = ({ className: customClassName, children, ...rest }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--side-nav__link-text`, customClassName);
   return (
     <span {...rest} className={className}>

--- a/packages/react/src/components/UIShell/SideNavMenuItem.js
+++ b/packages/react/src/components/UIShell/SideNavMenuItem.js
@@ -5,16 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SideNavLinkText from './SideNavLinkText';
 import Link from './Link';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavMenuItem = React.forwardRef(function SideNavMenuItem(props, ref) {
+  const prefix = usePrefix();
   const { children, className: customClassName, isActive, ...rest } = props;
   const className = cx(`${prefix}--side-nav__menu-item`, customClassName);
   const linkClassName = cx({

--- a/packages/react/src/components/UIShell/SideNavSwitcher.js
+++ b/packages/react/src/components/UIShell/SideNavSwitcher.js
@@ -6,14 +6,13 @@
  */
 
 import { ChevronDown20 } from '@carbon/icons-react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SideNavSwitcher = React.forwardRef(function SideNavSwitcher(props, ref) {
+  const prefix = usePrefix();
   const { className: customClassName, labelText, onChange, options } = props;
   const className = cx(`${prefix}--side-nav__switcher`, customClassName);
   // Note for usage around `onBlur`: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md

--- a/packages/react/src/components/UIShell/SkipToContent.js
+++ b/packages/react/src/components/UIShell/SkipToContent.js
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SkipToContent = ({
   children,
@@ -19,6 +17,7 @@ const SkipToContent = ({
   tabIndex,
   ...rest
 }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--skip-to-content`, customClassName);
   return (
     <a {...rest} className={className} href={href} tabIndex={tabIndex}>

--- a/packages/react/src/components/UIShell/Switcher.js
+++ b/packages/react/src/components/UIShell/Switcher.js
@@ -6,14 +6,13 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const Switcher = React.forwardRef(function Switcher(props, ref) {
+  const prefix = usePrefix();
   const {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,

--- a/packages/react/src/components/UIShell/SwitcherDivider.js
+++ b/packages/react/src/components/UIShell/SwitcherDivider.js
@@ -6,13 +6,12 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SwitcherDivider = ({ className: customClassName, ...other }) => {
+  const prefix = usePrefix();
   const className = cx(`${prefix}--switcher__item--divider`, {
     [customClassName]: !!customClassName,
   });

--- a/packages/react/src/components/UIShell/SwitcherItem.js
+++ b/packages/react/src/components/UIShell/SwitcherItem.js
@@ -6,15 +6,14 @@
  */
 
 import React from 'react';
-import { settings } from 'carbon-components';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import Link from './Link';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const SwitcherItem = React.forwardRef(function SwitcherItem(props, ref) {
+  const prefix = usePrefix();
   const {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,

--- a/packages/react/src/components/UnorderedList/UnorderedList.js
+++ b/packages/react/src/components/UnorderedList/UnorderedList.js
@@ -8,9 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
+import { usePrefix } from '../../internal/usePrefix';
 
 const UnorderedList = ({
   children,
@@ -19,6 +17,7 @@ const UnorderedList = ({
   isExpressive,
   ...other
 }) => {
+  const prefix = usePrefix();
   const classNames = classnames(`${prefix}--list--unordered`, className, {
     [`${prefix}--list--nested`]: nested,
     [`${prefix}--list--expressive`]: isExpressive,

--- a/packages/react/src/internal/usePrefix.js
+++ b/packages/react/src/internal/usePrefix.js
@@ -1,0 +1,9 @@
+import { settings } from 'carbon-components';
+import React from 'react';
+
+export const PrefixContext = React.createContext(settings.prefix);
+
+export function usePrefix() {
+  return React.useContext(PrefixContext);
+}
+


### PR DESCRIPTION
Closes #9619

removes per component `carbon-components` dependency in React components

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}

#### Still to do
these components need to be changes, but I ran into complications, typically either: a) pre-existing use of React.context or some weird breaking styles
- multiselect
- numberinput
- Search
- Slider
- timepicker
- Tooltip
- headerglobalbar
- Pagination
- Sidenavmenu