### PR TITLE
fix(index): added layer to the list

### DIFF
--- a/packages/carbon-react/__tests__/index-test.js
+++ b/packages/carbon-react/__tests__/index-test.js
@@ -75,6 +75,7 @@ Array [
   "IconSkeleton",
   "InlineLoading",
   "InlineNotification",
+  "Layer",
   "Link",
   "ListItem",
   "Loading",

--- a/packages/carbon-react/src/index.js
+++ b/packages/carbon-react/src/index.js
@@ -203,3 +203,5 @@ export {
 } from './components/Grid';
 
 export { Theme, useTheme } from './components/Theme';
+
+export { Layer } from './components/Layer';


### PR DESCRIPTION
Currently can't import `Layer` from carbon-react when trying to make our example for Layer.