### PR TITLE
feat(styles,carbon-react): switch to cds prefix

### DIFF
--- a/packages/carbon-react/.storybook/preview.js
+++ b/packages/carbon-react/.storybook/preview.js
@@ -11,6 +11,9 @@ import { configureActions } from '@storybook/addon-actions';
 import { white, g10, g90, g100 } from '@carbon/themes';
 import React from 'react';
 import { breakpoints } from '@carbon/layout';
+import { settings } from 'carbon-components';
+
+settings.prefix = 'cds';
 
 export const globalTypes = {
   locale: {

--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -92,6 +92,8 @@
   },
   "sideEffects": [
     "es/feature-flags.js",
-    "lib/feature-flags.js"
+    "lib/feature-flags.js",
+    "es/prefix.js",
+    "lib/prefix.js"
   ]
 }

--- a/packages/carbon-react/src/index.js
+++ b/packages/carbon-react/src/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import './prefix';
 import './feature-flags';
 
 export {

--- a/packages/carbon-react/src/prefix.js
+++ b/packages/carbon-react/src/prefix.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { settings } from 'carbon-components';
+
+settings.prefix = 'cds';

--- a/packages/carbon-react/tasks/build.js
+++ b/packages/carbon-react/tasks/build.js
@@ -109,6 +109,12 @@ function getRollupConfig(input) {
               moduleSideEffects: true,
             };
           }
+
+          if (id === path.join(__dirname, '..', 'src', 'prefix.js')) {
+            return {
+              moduleSideEffects: true,
+            };
+          }
         },
       },
     ],

--- a/packages/styles/scss/__tests__/__snapshots__/config-test.js.snap
+++ b/packages/styles/scss/__tests__/__snapshots__/config-test.js.snap
@@ -6,6 +6,6 @@ Object {
   "css--font-face": true,
   "css--plex-arabic": false,
   "css--reset": true,
-  "prefix": "bx",
+  "prefix": "cds",
 }
 `;

--- a/packages/styles/scss/_config.scss
+++ b/packages/styles/scss/_config.scss
@@ -10,7 +10,7 @@
 /// @access public
 /// @type String
 /// @group config
-$prefix: 'bx' !default;
+$prefix: 'cds' !default;
 
 /// If true, includes font face mixins in `_css--font-face.scss` depending on the `css--plex` feature flag
 /// @access public


### PR DESCRIPTION
Update our beta packages to use `cds` as the default prefix instead of `bx`. This PR includes two significant changes:

- Update the default `$prefix` variable in `@carbon/styles` to be `cds`. It is still configurable under `scss/_config.scss`
- Add a temporary `src/prefix.js` file in `@carbon/react` that changes the prefix in `carbon-components`. This will be removed in v11 and replaced by `PrefixContext`

#### Changelog

**New**

**Changed**

- Switch default prefix from `bx` to `cds` for styles and React

**Removed**

#### Testing / Reviewing

- View the deployed v11 storybook and verify that:
  - Styles are using the cds prefix
  - CSS Custom Properties are using the cds prefix
  - React components are using the cds prefix
