### PR TITLE
fix(layer): use correct prefix

### DIFF
--- a/packages/carbon-react/src/components/Layer/index.js
+++ b/packages/carbon-react/src/components/Layer/index.js
@@ -8,6 +8,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
 
 export function Layer({
   as: BaseComponent = 'div',
@@ -15,7 +18,7 @@ export function Layer({
   children,
   ...rest
 }) {
-  const className = cx('bx--layer', customClassName);
+  const className = cx(`${prefix}--layer`, customClassName);
   return (
     <BaseComponent {...rest} className={className}>
       {children}


### PR DESCRIPTION
Removes the hard-coded `bx` prefix from the `<Layer>` component, ensuring that is uses the correct prefix defined in the settings.

#### Changelog

**Changed**

- Updated hard-coded prefix with prefix from `carbon-components`

#### Testing / Reviewing

Ensure correct prefix is emitted based on the `carbon-components` settings
