### PR TITLE
feat(react): add unstable_IconButton

### DIFF
--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -42,7 +42,7 @@ const Button = React.forwardRef(function Button(
     onFocus,
     onMouseEnter,
     onMouseLeave,
-    ...other
+    ...rest
   },
   ref
 ) {
@@ -213,6 +213,21 @@ const Button = React.forwardRef(function Button(
     otherProps = anchorProps;
   }
 
+  if (enabled) {
+    return React.createElement(
+      component,
+      {
+        onMouseEnter,
+        onMouseLeave,
+        onFocus,
+        onBlur,
+        ...rest,
+        ...commonProps,
+      },
+      children
+    );
+  }
+
   return React.createElement(
     component,
     {
@@ -221,7 +236,7 @@ const Button = React.forwardRef(function Button(
       onFocus: composeEventHandlers([onFocus, handleFocus]),
       onBlur: composeEventHandlers([onBlur, handleBlur]),
       onClick: composeEventHandlers([onClick, handleClick]),
-      ...other,
+      ...rest,
       ...commonProps,
       ...otherProps,
     },

--- a/packages/react/src/components/Tooltip/next/IconButton-story.js
+++ b/packages/react/src/components/Tooltip/next/IconButton-story.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Add16 } from '@carbon/icons-react';
+import React from 'react';
+import { IconButton } from './IconButton';
+import { FeatureFlags } from '../../FeatureFlags';
+
+export default {
+  title: 'Experimental/unstable_IconButton',
+  component: IconButton,
+  includeStories: [],
+  decorators: [
+    (Story) => {
+      return (
+        <FeatureFlags flags={{ 'enable-v11-release': true }}>
+          <Story />
+        </FeatureFlags>
+      );
+    },
+  ],
+};
+
+export const Default = () => {
+  return (
+    <IconButton label="Create">
+      <Add16 />
+    </IconButton>
+  );
+};

--- a/packages/react/src/components/Tooltip/next/IconButton.js
+++ b/packages/react/src/components/Tooltip/next/IconButton.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import Button from '../../Button';
+import { Tooltip } from './Tooltip';
+
+function IconButton({ align, children, label, description, ...rest }) {
+  return (
+    <Tooltip align={align} description={description} label={label}>
+      <Button {...rest} hasIconOnly>
+        {children}
+      </Button>
+    </Tooltip>
+  );
+}
+
+IconButton.propTypes = {
+  /**
+   * Specify how the trigger should align with the tooltip
+   */
+  align: PropTypes.oneOf([
+    'top',
+    'top-left',
+    'top-right',
+
+    'bottom',
+    'bottom-left',
+    'bottom-right',
+
+    'left',
+    'left-bottom',
+    'left-top',
+
+    'right',
+    'right-bottom',
+    'right-top',
+  ]),
+
+  /**
+   * Provide an icon or asset to be rendered inside of the IconButton
+   */
+  children: PropTypes.node,
+
+  /**
+   * Provide the description to be rendered inside of the Tooltip. The
+   * description will use `aria-describedby` and will describe the child node
+   * in addition to the text rendered inside of the child. This means that if you
+   * have text in the child node, that it will be announced alongside the
+   * description to the screen reader.
+   *
+   * Note: if label and description are both provided, label will be used and
+   * description will not be used
+   */
+  description: PropTypes.node,
+
+  /**
+   * Provide the label to be rendered inside of the Tooltip. The label will use
+   * `aria-labelledby` and will fully describe the child node that is provided.
+   * This means that if you have text in the child node, that it will not be
+   * announced to the screen reader.
+   *
+   * Note: if label and description are both provided, description will not be
+   * used
+   */
+  label: PropTypes.node,
+};
+
+export { IconButton };


### PR DESCRIPTION
This PR adds in support for `IconButton` by combining our new `Tooltip` component and our existing `Button` component.

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
