### PR TITLE
fix(progress-indicator): correct prefix value from context

### DIFF
--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -309,7 +309,7 @@ export class ProgressIndicator extends Component {
       spaceEqually,
       ...other
     } = this.props;
-    const prefix = this.prefix;
+    const prefix = this.context;
     const classes = classnames({
       [`${prefix}--progress`]: true,
       [`${prefix}--progress--vertical`]: vertical,


### PR DESCRIPTION
The wrapper `ul` in progress indicator wasn't getting the prefix, so styles were broken. Just a minor correction to `this.context` from `this.prefix`

#### Changelog

**Changed**

- progress-indicator: fix prefix

#### Testing / Reviewing

Storybook should show that the wrapper ul in progress indicator gets the prefix in it's class:
```diff
- <ul class="undefined--progress">
+ <ul class="bx--progress">
```
