### PR TITLE
chore(modal): added deprecation warning for iconDescription

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3778,9 +3778,7 @@ Map {
       "hasScrollingContent": Object {
         "type": "bool",
       },
-      "iconDescription": Object {
-        "type": "string",
-      },
+      "iconDescription": [Function],
       "id": Object {
         "type": "string",
       },

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -47,18 +47,18 @@ describe('Modal', () => {
       expect(getModal(modal).props().id).toEqual('modal-1');
     });
 
-    it('has the expected default iconDescription', () => {
-      expect(mounted.props().iconDescription).toEqual('Close');
+    it('has the expected default ariaLabel', () => {
+      expect(mounted.props().ariaLabel).toEqual('Close');
     });
 
-    it('adds new iconDescription when passed via props', () => {
-      mounted.setProps({ iconDescription: 'new description' });
-      expect(mounted.props().iconDescription).toEqual('new description');
+    it('adds new ariaLabel when passed via props', () => {
+      mounted.setProps({ ariaLabel: 'new description' });
+      expect(mounted.props().ariaLabel).toEqual('new description');
     });
 
-    it('should have iconDescription match Icon component description prop', () => {
+    it('should have ariaLabel match Icon component description prop', () => {
       const description = mounted.find(Close20).props()['aria-label'];
-      const matches = mounted.props().iconDescription === description;
+      const matches = mounted.props().ariaLabel === description;
       expect(matches).toEqual(true);
     });
 

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -75,9 +75,12 @@ export default class Modal extends Component {
     hasScrollingContent: PropTypes.bool,
 
     /**
-     * Provide a description for "close" icon that can be read by screen readers
+     * The iconDescription prop is deprecated. Use aria-label, aria-labelledby, or aria-describedby to label your component.
      */
-    iconDescription: PropTypes.string,
+    iconDescription: deprecate(
+      PropTypes.string,
+      'The iconDescription prop is no longer needed and can be safely removed. This prop will be removed in the next major release of Carbon.'
+    ),
 
     /**
      * Specify the DOM element ID of the top-level node.

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -220,6 +220,7 @@ export default class Modal extends Component {
     primaryButtonDisabled: false,
     onKeyDown: () => {},
     passiveModal: false,
+    // iconDescription is deprecated in v11 use aria-label instead
     iconDescription: 'Close',
     modalHeading: '',
     modalLabel: '',
@@ -412,15 +413,21 @@ export default class Modal extends Component {
         Array.isArray(secondaryButtons) && secondaryButtons.length === 2,
     });
 
+    // ['aria-label']: ariaLabel,
+
     const modalButton = (
       <button
         className={this.modalCloseButtonClass}
         type="button"
         onClick={onRequestClose}
-        title={iconDescription}
-        aria-label={iconDescription}
+        // iconDescription is deprecated in v11. Use ariaLabel instead.
+        title={ariaLabel ? ariaLabel : iconDescription}
+        // iconDescription is deprecated in v11. Use ariaLabel instead.
+        aria-label={ariaLabel ? ariaLabel : iconDescription}
         ref={this.button}>
         <Close20
+          aria-hidden="true"
+          // iconDescription is deprecated in v11. Use aria-hidden="true" instead.
           aria-label={iconDescription}
           className={`${this.modalCloseButtonClass}__icon`}
         />

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -221,7 +221,7 @@ export default class Modal extends Component {
     onKeyDown: () => {},
     passiveModal: false,
     // iconDescription is deprecated in v11 use aria-label instead
-    iconDescription: 'Close',
+    // iconDescription: 'Close',
     modalHeading: '',
     modalLabel: '',
     preventCloseOnClickOutside: false,
@@ -427,8 +427,6 @@ export default class Modal extends Component {
         ref={this.button}>
         <Close20
           aria-hidden="true"
-          // iconDescription is deprecated in v11. Use aria-hidden="true" instead.
-          aria-label={iconDescription}
           className={`${this.modalCloseButtonClass}__icon`}
         />
       </button>

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -75,7 +75,7 @@ export default class Modal extends Component {
     hasScrollingContent: PropTypes.bool,
 
     /**
-     * The iconDescription prop is deprecated. Use aria-label, aria-labelledby, or aria-describedby to label your component.
+     * The iconDescription prop is deprecated. Use aria-label, aria-labelledby, or aria-describedby to label your component
      */
     iconDescription: deprecate(
       PropTypes.string,

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -56,7 +56,6 @@ exports[`ModalWrapper should render 1`] = `
     <Modal
       aria-label="test modal"
       hasScrollingContent={false}
-      iconDescription="Close"
       id="modal"
       modalHeading="Transactional Modal"
       modalLabel="Test Modal Label"
@@ -110,20 +109,16 @@ exports[`ModalWrapper should render 1`] = `
               Transactional Modal
             </h3>
             <button
-              aria-label="Close"
               className="bx--modal-close"
               onClick={[Function]}
-              title="Close"
               type="button"
             >
               <ForwardRef(Close20)
                 aria-hidden="true"
-                aria-label="Close"
                 className="bx--modal-close__icon"
               >
                 <Icon
                   aria-hidden="true"
-                  aria-label="Close"
                   className="bx--modal-close__icon"
                   fill="currentColor"
                   height={20}
@@ -133,14 +128,12 @@ exports[`ModalWrapper should render 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <svg
-                    aria-hidden="true"
-                    aria-label="Close"
+                    aria-hidden={true}
                     className="bx--modal-close__icon"
                     fill="currentColor"
                     focusable="false"
                     height={20}
                     preserveAspectRatio="xMidYMid meet"
-                    role="img"
                     viewBox="0 0 32 32"
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -117,10 +117,12 @@ exports[`ModalWrapper should render 1`] = `
               type="button"
             >
               <ForwardRef(Close20)
+                aria-hidden="true"
                 aria-label="Close"
                 className="bx--modal-close__icon"
               >
                 <Icon
+                  aria-hidden="true"
                   aria-label="Close"
                   className="bx--modal-close__icon"
                   fill="currentColor"
@@ -131,6 +133,7 @@ exports[`ModalWrapper should render 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <svg
+                    aria-hidden="true"
                     aria-label="Close"
                     className="bx--modal-close__icon"
                     fill="currentColor"


### PR DESCRIPTION
REF #9624 

Added deprecation warnings for `iconDescription` for v11.

- `Title` and `aria-label` attributes now use the `ariaLabel` prop instead of `iconDescription`.
- The close button now gets an `aria-hidden="true"`

#### Testing

Review Modal in Storybook and ensure tests are firing off correctly.

#### Feedback

Unclear on why the tests are failing because of the deprecation warning. Feedback welcome.