### PR TITLE
feat(tag): add outline variant

### DIFF
--- a/packages/carbon-react/src/components/Tag/Tag.stories.js
+++ b/packages/carbon-react/src/components/Tag/Tag.stories.js
@@ -42,13 +42,25 @@ export const Default = () => {
       <Tag className="some-class" type="gray" size="sm" title="Clear Filter">
         {'Tag content'}
       </Tag>
-      <Tag className="some-class" type="cool-gray" size="sm" title="Clear Filter">
+      <Tag
+        className="some-class"
+        type="cool-gray"
+        size="sm"
+        title="Clear Filter">
         {'Tag content'}
       </Tag>
-      <Tag className="some-class" type="warm-gray" size="sm" title="Clear Filter">
+      <Tag
+        className="some-class"
+        type="warm-gray"
+        size="sm"
+        title="Clear Filter">
         {'Tag content'}
       </Tag>
-      <Tag className="some-class" type="high-contrast" size="sm" title="Clear Filter">
+      <Tag
+        className="some-class"
+        type="high-contrast"
+        size="sm"
+        title="Clear Filter">
         {'Tag content'}
       </Tag>
       <Tag className="some-class" type="outline" size="sm" title="Clear Filter">

--- a/packages/carbon-react/src/components/Tag/Tag.stories.js
+++ b/packages/carbon-react/src/components/Tag/Tag.stories.js
@@ -42,6 +42,18 @@ export const Default = () => {
       <Tag className="some-class" type="gray" size="sm" title="Clear Filter">
         {'Tag content'}
       </Tag>
+      <Tag className="some-class" type="cool-gray" size="sm" title="Clear Filter">
+        {'Tag content'}
+      </Tag>
+      <Tag className="some-class" type="warm-gray" size="sm" title="Clear Filter">
+        {'Tag content'}
+      </Tag>
+      <Tag className="some-class" type="high-contrast" size="sm" title="Clear Filter">
+        {'Tag content'}
+      </Tag>
+      <Tag className="some-class" type="outline" size="sm" title="Clear Filter">
+        {'Tag content'}
+      </Tag>
     </>
   );
 };

--- a/packages/components/src/components/tag/_tag.scss
+++ b/packages/components/src/components/tag/_tag.scss
@@ -130,6 +130,12 @@
     @include tag-theme($inverse-02, $inverse-01, $inverse-hover-ui);
   }
 
+  .#{$prefix}--tag--outline {
+    @include tag-theme($background, $text-01, $hover-ui);
+
+    box-shadow: inset 0 0 0 1px $inverse-02;
+  }
+
   .#{$prefix}--tag--disabled,
   .#{$prefix}--tag--filter.#{$prefix}--tag--disabled,
   .#{$prefix}--tag--interactive.#{$prefix}--tag--disabled {

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6040,6 +6040,7 @@ Map {
             "cool-gray",
             "warm-gray",
             "high-contrast",
+            "outline",
           ],
         ],
         "type": "oneOf",

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -25,6 +25,7 @@ const TYPES = {
   'cool-gray': 'Cool-Gray',
   'warm-gray': 'Warm-Gray',
   'high-contrast': 'High-Contrast',
+  outline: 'Outline',
 };
 
 const Tag = ({

--- a/packages/styles/scss/components/tag/_tag.scss
+++ b/packages/styles/scss/components/tag/_tag.scss
@@ -114,6 +114,12 @@
     );
   }
 
+  .#{$prefix}--tag--outline {
+    @include tag-theme($background, $text-primary, $layer-hover);
+
+    box-shadow: inset 0 0 0 1px $background-inverse;
+  }
+
   .#{$prefix}--tag--disabled,
   .#{$prefix}--tag--filter.#{$prefix}--tag--disabled,
   .#{$prefix}--tag--interactive.#{$prefix}--tag--disabled {


### PR DESCRIPTION
Closes #9670

Added an `outline` variant for the `Tag` component.
Background: `$background`
Outline: `$background-inverse`
Text: `$text-primary`
Hover: `$layer-hover`

#### Changelog

**New**

- Added `outline` variant to tag
- Added `cool-gray`, `warm-gray`, `high-contrast` and `outline` demos to @carbon/react storybook

**Changed**

- Updated API snapshot

#### Testing / Reviewing

Verify visual appearance is as expected
