### PR TITLE
fix(Modal): fix Formik bug in Modal

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -801,6 +801,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ColbyJohnIBM",
+      "name": "ColbyJohnIBM",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19613692?v=4",
+      "profile": "https://github.com/ColbyJohnIBM",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/adamalston"><img src="https://avatars.githubusercontent.com/u/18297826?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Adam Alston</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=adamalston" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/Kiittyka"><img src="https://avatars.githubusercontent.com/u/41021851?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Krithika S Udupa</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Kiittyka" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/egriff38"><img src="https://avatars.githubusercontent.com/u/6627718?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eshin Griffith</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=egriff38" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ColbyJohnIBM"><img src="https://avatars.githubusercontent.com/u/19613692?v=4?s=100" width="100px;" alt=""/><br /><sub><b>ColbyJohnIBM</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ColbyJohnIBM" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -419,7 +419,8 @@ export default class Modal extends Component {
         onClick={onRequestClose}
         title={iconDescription}
         aria-label={iconDescription}
-        ref={this.button}>
+        ref={this.button}
+      >
         <Close20
           aria-label={iconDescription}
           className={`${this.modalCloseButtonClass}__icon`}
@@ -451,32 +452,6 @@ export default class Modal extends Component {
       alertDialogProps['aria-describedby'] = this.modalBodyId;
     }
 
-    const SecondaryButtonSet = () => {
-      if (Array.isArray(secondaryButtons) && secondaryButtons.length <= 2) {
-        return secondaryButtons.map(
-          ({ buttonText, onClick: onButtonClick }, i) => (
-            <Button
-              key={`${buttonText}-${i}`}
-              kind="secondary"
-              onClick={onButtonClick}>
-              {buttonText}
-            </Button>
-          )
-        );
-      }
-      if (secondaryButtonText) {
-        return (
-          <Button
-            kind="secondary"
-            onClick={onSecondaryButtonClick}
-            ref={this.secondaryButton}>
-            {secondaryButtonText}
-          </Button>
-        );
-      }
-      return null;
-    };
-
     const modalBody = (
       <div
         ref={this.innerModal}
@@ -485,19 +460,22 @@ export default class Modal extends Component {
         className={containerClasses}
         aria-label={ariaLabel}
         aria-modal="true"
-        tabIndex="-1">
+        tabIndex="-1"
+      >
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}
           {modalLabel && (
             <h2
               id={this.modalLabelId}
-              className={`${prefix}--modal-header__label`}>
+              className={`${prefix}--modal-header__label`}
+            >
               {modalLabel}
             </h2>
           )}
           <h3
             id={this.modalHeadingId}
-            className={`${prefix}--modal-header__heading`}>
+            className={`${prefix}--modal-header__heading`}
+          >
             {modalHeading}
           </h3>
           {!passiveModal && modalButton}
@@ -506,7 +484,8 @@ export default class Modal extends Component {
           id={this.modalBodyId}
           className={contentClasses}
           {...hasScrollingContentProps}
-          aria-labelledby={getAriaLabelledBy}>
+          aria-labelledby={getAriaLabelledBy}
+        >
           {this.props.children}
         </div>
         {hasScrollingContent && (
@@ -514,12 +493,33 @@ export default class Modal extends Component {
         )}
         {!passiveModal && (
           <ButtonSet className={footerClasses}>
-            <SecondaryButtonSet />
+            {Array.isArray(secondaryButtons) && secondaryButtons.length <= 2
+              ? secondaryButtons.map(
+                  ({ buttonText, onClick: onButtonClick }, i) => (
+                    <Button
+                      key={`${buttonText}-${i}`}
+                      kind="secondary"
+                      onClick={onButtonClick}
+                    >
+                      {buttonText}
+                    </Button>
+                  )
+                )
+              : secondaryButtonText && (
+                  <Button
+                    kind="secondary"
+                    onClick={onSecondaryButtonClick}
+                    ref={this.secondaryButton}
+                  >
+                    {secondaryButtonText}
+                  </Button>
+                )}
             <Button
               kind={danger ? 'danger' : 'primary'}
               disabled={primaryButtonDisabled}
               onClick={onRequestSubmit}
-              ref={this.button}>
+              ref={this.button}
+            >
               {primaryButtonText}
             </Button>
           </ButtonSet>
@@ -536,13 +536,15 @@ export default class Modal extends Component {
         className={modalClasses}
         role="presentation"
         onTransitionEnd={this.props.open ? this.handleTransitionEnd : undefined}
-        ref={this.outerModal}>
+        ref={this.outerModal}
+      >
         {/* Non-translatable: Focus-wrap code makes this `<span>` not actually read by screen readers */}
         <span
           ref={this.startTrap}
           tabIndex="0"
           role="link"
-          className={`${prefix}--visually-hidden`}>
+          className={`${prefix}--visually-hidden`}
+        >
           Focus sentinel
         </span>
         {modalBody}
@@ -551,7 +553,8 @@ export default class Modal extends Component {
           ref={this.endTrap}
           tabIndex="0"
           role="link"
-          className={`${prefix}--visually-hidden`}>
+          className={`${prefix}--visually-hidden`}
+        >
           Focus sentinel
         </span>
       </div>

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -419,8 +419,7 @@ export default class Modal extends Component {
         onClick={onRequestClose}
         title={iconDescription}
         aria-label={iconDescription}
-        ref={this.button}
-      >
+        ref={this.button}>
         <Close20
           aria-label={iconDescription}
           className={`${this.modalCloseButtonClass}__icon`}
@@ -460,22 +459,19 @@ export default class Modal extends Component {
         className={containerClasses}
         aria-label={ariaLabel}
         aria-modal="true"
-        tabIndex="-1"
-      >
+        tabIndex="-1">
         <div className={`${prefix}--modal-header`}>
           {passiveModal && modalButton}
           {modalLabel && (
             <h2
               id={this.modalLabelId}
-              className={`${prefix}--modal-header__label`}
-            >
+              className={`${prefix}--modal-header__label`}>
               {modalLabel}
             </h2>
           )}
           <h3
             id={this.modalHeadingId}
-            className={`${prefix}--modal-header__heading`}
-          >
+            className={`${prefix}--modal-header__heading`}>
             {modalHeading}
           </h3>
           {!passiveModal && modalButton}
@@ -484,8 +480,7 @@ export default class Modal extends Component {
           id={this.modalBodyId}
           className={contentClasses}
           {...hasScrollingContentProps}
-          aria-labelledby={getAriaLabelledBy}
-        >
+          aria-labelledby={getAriaLabelledBy}>
           {this.props.children}
         </div>
         {hasScrollingContent && (
@@ -499,8 +494,7 @@ export default class Modal extends Component {
                     <Button
                       key={`${buttonText}-${i}`}
                       kind="secondary"
-                      onClick={onButtonClick}
-                    >
+                      onClick={onButtonClick}>
                       {buttonText}
                     </Button>
                   )
@@ -509,8 +503,7 @@ export default class Modal extends Component {
                   <Button
                     kind="secondary"
                     onClick={onSecondaryButtonClick}
-                    ref={this.secondaryButton}
-                  >
+                    ref={this.secondaryButton}>
                     {secondaryButtonText}
                   </Button>
                 )}
@@ -518,8 +511,7 @@ export default class Modal extends Component {
               kind={danger ? 'danger' : 'primary'}
               disabled={primaryButtonDisabled}
               onClick={onRequestSubmit}
-              ref={this.button}
-            >
+              ref={this.button}>
               {primaryButtonText}
             </Button>
           </ButtonSet>
@@ -536,15 +528,13 @@ export default class Modal extends Component {
         className={modalClasses}
         role="presentation"
         onTransitionEnd={this.props.open ? this.handleTransitionEnd : undefined}
-        ref={this.outerModal}
-      >
+        ref={this.outerModal}>
         {/* Non-translatable: Focus-wrap code makes this `<span>` not actually read by screen readers */}
         <span
           ref={this.startTrap}
           tabIndex="0"
           role="link"
-          className={`${prefix}--visually-hidden`}
-        >
+          className={`${prefix}--visually-hidden`}>
           Focus sentinel
         </span>
         {modalBody}
@@ -553,8 +543,7 @@ export default class Modal extends Component {
           ref={this.endTrap}
           tabIndex="0"
           role="link"
-          className={`${prefix}--visually-hidden`}
-        >
+          className={`${prefix}--visually-hidden`}>
           Focus sentinel
         </span>
       </div>

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -167,36 +167,34 @@ exports[`ModalWrapper should render 1`] = `
             <div
               className="bx--modal-footer bx--btn-set"
             >
-              <SecondaryButtonSet>
-                <Button
-                  dangerDescription="danger"
+              <Button
+                dangerDescription="danger"
+                disabled={false}
+                isExpressive={false}
+                kind="secondary"
+                onClick={[Function]}
+                size="default"
+                tabIndex={0}
+                tooltipAlignment="center"
+                tooltipPosition="top"
+                type="button"
+              >
+                <button
+                  aria-describedby={null}
+                  aria-pressed={null}
+                  className="bx--btn bx--btn--secondary"
                   disabled={false}
-                  isExpressive={false}
-                  kind="secondary"
+                  onBlur={[Function]}
                   onClick={[Function]}
-                  size="default"
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                   tabIndex={0}
-                  tooltipAlignment="center"
-                  tooltipPosition="top"
                   type="button"
                 >
-                  <button
-                    aria-describedby={null}
-                    aria-pressed={null}
-                    className="bx--btn bx--btn--secondary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </Button>
-              </SecondaryButtonSet>
+                  Cancel
+                </button>
+              </Button>
               <Button
                 dangerDescription="danger"
                 disabled={false}


### PR DESCRIPTION
Closes #9523 

Breaking the secondary buttons out into their own sub-component [(here)](https://github.com/carbon-design-system/carbon/commit/647ec1e75#diff-22f235c4784785309ea4abec2fa146f38d2be0d56b42466af68a247a0fe898b3R437) created the bug described in the above issue. I understand that this was probably done for readability / maintainability, but it also is causing additional re-renders when used with Formik that are resulting in incorrect behavior.

#### Changelog

**Changed**

- Directly build out the secondary button set rather than using a sub-component

**Removed**

- Remove SecondaryButtonSet sub-component

#### Testing / Reviewing
I tested this by linking my local version of Carbon to my local version of our application, but a more generic way to test would be to run [this CodeSandbox](https://codesandbox.io/s/carbon-react-modal-formik-bug-2bho4) locally, linked to a local version of Carbon on this branch.
