### PR TITLE
fix(OverflowMenu): add stopPropagation call to handleClick method

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
@@ -160,6 +160,15 @@ describe('OverflowMenu', () => {
       );
     });
 
+    it('fires onClick only once per button click', () => {
+      const mockOnClick = jest.fn();
+      const rootWrapper = mount(<OverflowMenu onClick={mockOnClick} />);
+
+      rootWrapper.find('button').simulate('click');
+
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
     it('should NOT toggle state in response to Enter or Space when the menu is open', () => {
       const enterKey = 13;
       const spaceKey = 32;

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -278,6 +278,7 @@ class OverflowMenu extends Component {
   }
 
   handleClick = (evt) => {
+    evt.stopPropagation();
     if (!this._menuBody || !this._menuBody.contains(evt.target)) {
       this.setState({ open: !this.state.open });
       this.props.onClick(evt);


### PR DESCRIPTION
Closes #9744 

To fix the issue I added an [event.stopPropagation()](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) call to the handleClick method in OverflowMenu which stops it from happening. The event method appears to prevent propagation and bubbling up of events which is probably what happens with the click in OverflowMenu. 

I have also added a unit test.

Thanks!