### PR TITLE
fix(slider): correct input width

### DIFF
--- a/packages/components/src/components/slider/_slider.scss
+++ b/packages/components/src/components/slider/_slider.scss
@@ -116,7 +116,7 @@
 
   .#{$prefix}--slider-text-input,
   .#{$prefix}-slider-text-input {
-    width: auto;
+    width: rem(64px);
     height: rem(40px);
     -moz-appearance: textfield;
     text-align: center;

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -124,7 +124,7 @@
 
   .#{$prefix}--slider-text-input,
   .#{$prefix}-slider-text-input {
-    width: auto;
+    width: rem(64px);
     height: rem(40px);
     -moz-appearance: textfield;
     text-align: center;


### PR DESCRIPTION
Closes #9823 

Corrects the slider number input width to be a fixed 64px per the spec in the issue from @laurenmrice 

#### Changelog

**Changed**

- slider: correct input width

#### Testing / Reviewing

- View the slider story in both chrome and firefox, the number input should be the same width between both browsers.
