### PR TITLE
feat(ContentSwitcher): add icon only ContentSwitcher variant

### DIFF
--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -32,6 +32,15 @@
     height: rem(48px);
   }
 
+  .#{$prefix}--content-switcher--icon-only {
+    width: rem(160px);
+
+    .#{$prefix}--content-switcher-btn {
+      display: flex;
+      justify-content: center;
+    }
+  }
+
   .#{$prefix}--content-switcher-btn {
     @include reset;
     @include type-style('body-short-01');

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher-story.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher-story.js
@@ -11,6 +11,7 @@ import { withKnobs, boolean, select } from '@storybook/addon-knobs';
 import ContentSwitcher from '../ContentSwitcher';
 import Switch from '../Switch';
 import mdx from './ContentSwitcher.mdx';
+import { Sunrise16, Sun16, Sunset16 } from '@carbon/icons-react';
 
 const selectionModes = {
   'Change selection automatically upon focus (automatic)': 'automatic',
@@ -62,6 +63,20 @@ export const Default = () => (
     <Switch name="one" text="First section" />
     <Switch name="two" text="Second section" />
     <Switch name="three" text="Third section" />
+  </ContentSwitcher>
+);
+
+export const IconOnly = () => (
+  <ContentSwitcher hasIconOnly onChange={() => {}}>
+    <Switch name="one" aria-label="breakfast menu">
+      <Sunrise16 />
+    </Switch>
+    <Switch name="two" aria-label="lunch menu">
+      <Sun16 />
+    </Switch>
+    <Switch name="three" aria-label="dinner menu">
+      <Sunset16 />
+    </Switch>
   </ContentSwitcher>
 );
 

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.js
@@ -35,6 +35,11 @@ export default class ContentSwitcher extends React.Component {
     className: PropTypes.string,
 
     /**
+     * Specify if the button is an icon-only button
+     */
+    hasIconOnly: PropTypes.bool,
+
+    /**
      * `true` to use the light variant.
      */
     light: deprecate(
@@ -138,18 +143,21 @@ export default class ContentSwitcher extends React.Component {
       selectedIndex, // eslint-disable-line no-unused-vars
       selectionMode, // eslint-disable-line no-unused-vars
       size,
+      hasIconOnly,
       ...other
     } = this.props;
 
     const classes = classNames(`${prefix}--content-switcher`, className, {
       [`${prefix}--content-switcher--light`]: light,
       [`${prefix}--content-switcher--${size}`]: size,
+      [`${prefix}--content-switcher--icon-only`]: hasIconOnly,
     });
 
     return (
       <div {...other} className={classes} role="tablist">
         {React.Children.map(children, (child, index) =>
           React.cloneElement(child, {
+            hasIconOnly,
             index,
             onClick: composeEventHandlers([
               this.handleChildChange,

--- a/packages/react/src/components/Switch/Switch.js
+++ b/packages/react/src/components/Switch/Switch.js
@@ -14,6 +14,7 @@ const { prefix } = settings;
 
 const Switch = React.forwardRef(function Switch(props, tabRef) {
   const {
+    children,
     className,
     disabled,
     index,
@@ -22,6 +23,7 @@ const Switch = React.forwardRef(function Switch(props, tabRef) {
     onKeyDown,
     selected,
     text,
+    hasIconOnly,
     ...other
   } = props;
 
@@ -56,9 +58,17 @@ const Switch = React.forwardRef(function Switch(props, tabRef) {
       aria-selected={selected}
       {...other}
       {...commonProps}>
-      <span className={`${prefix}--content-switcher__label`} title={text}>
-        {text}
-      </span>
+      {hasIconOnly ? (
+        React.Children.map(children, (child) =>
+          React.cloneElement(child, {
+            className: `${prefix}--content-switcher__icon`,
+          })
+        )
+      ) : (
+        <span className={`${prefix}--content-switcher__label`} title={text}>
+          {text}
+        </span>
+      )}
     </button>
   );
 });
@@ -66,6 +76,11 @@ const Switch = React.forwardRef(function Switch(props, tabRef) {
 Switch.displayName = 'Switch';
 
 Switch.propTypes = {
+  /**
+   * Pass in an icon to be rendered in an iconOnly content switcher button
+   */
+  children: PropTypes.node,
+
   /**
    * Specify an optional className to be added to your Switch
    */
@@ -75,6 +90,18 @@ Switch.propTypes = {
    * Specify whether or not the Switch should be disabled
    */
   disabled: PropTypes.bool,
+
+  /**
+   * If specifying the `hasIconOnly` prop, provide an aria-label for each tab that can
+   * be read by screen readers
+   */
+  hasIconOnly: (props) => {
+    if (props.hasIconOnly && !props['aria-label']) {
+      return new Error(
+        'hasIconOnly property specified without also providing aria-labels.'
+      );
+    }
+  },
 
   /**
    * The index of your Switch in your ContentSwitcher that is used for event handlers.
@@ -107,12 +134,11 @@ Switch.propTypes = {
   /**
    * Provide the contents of your Switch
    */
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
 };
 
 Switch.defaultProps = {
   selected: false,
-  text: 'Provide text',
   onClick: () => {},
   onKeyDown: () => {},
 };


### PR DESCRIPTION
Closes #9843 

adds an icon-only variant of ContentSwitcher

#### Changelog

**Changed**

- adds `hasIconOnly` prop and `aria-label` requirement along with it with ContentSwitcher.js
- adds icon-only story to ContentSwitcher storybook 
- adds styling for `#{$prefix}--content-switcher--icon-only` in ContentSwitcher.scss

#### Testing / Reviewing

- [ ] WIP ensure added and existing tests are passing
- [ ] ensure icon-only content switcher meets design specification
- [ ] ensure changes don't cause styling regressions (or others) in existing Contentswitcher