### PR TITLE
fix(tooltip): prevent escape keydown from bubbling

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -159,32 +159,23 @@ export default {
   },
 };
 
-export const DefaultBottom = () => {
-  return (
-    <>
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      <div
-        style={containerStyles}
-        onKeyDown={() => {
-          console.log(`this should not be logged to the console`);
-        }}>
-        <Tooltip {...props.withIcon()} tooltipBodyId="tooltip-body">
-          <p id="tooltip-body">
-            This is some tooltip text. This box shows the maximum amount of text
-            that should appear inside. If more room is needed please use a modal
-            instead.
-          </p>
-          <div className={`${prefix}--tooltip__footer`}>
-            <a href="/" className={`${prefix}--link`}>
-              Learn More
-            </a>
-            <Button size="small">Create</Button>
-          </div>
-        </Tooltip>
+export const DefaultBottom = () => (
+  <div style={containerStyles}>
+    <Tooltip {...props.withIcon()} tooltipBodyId="tooltip-body">
+      <p id="tooltip-body">
+        This is some tooltip text. This box shows the maximum amount of text
+        that should appear inside. If more room is needed please use a modal
+        instead.
+      </p>
+      <div className={`${prefix}--tooltip__footer`}>
+        <a href="/" className={`${prefix}--link`}>
+          Learn More
+        </a>
+        <Button size="small">Create</Button>
       </div>
-    </>
-  );
-};
+    </Tooltip>
+  </div>
+);
 
 DefaultBottom.storyName = 'default (bottom)';
 

--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -159,23 +159,32 @@ export default {
   },
 };
 
-export const DefaultBottom = () => (
-  <div style={containerStyles}>
-    <Tooltip {...props.withIcon()} tooltipBodyId="tooltip-body">
-      <p id="tooltip-body">
-        This is some tooltip text. This box shows the maximum amount of text
-        that should appear inside. If more room is needed please use a modal
-        instead.
-      </p>
-      <div className={`${prefix}--tooltip__footer`}>
-        <a href="/" className={`${prefix}--link`}>
-          Learn More
-        </a>
-        <Button size="small">Create</Button>
+export const DefaultBottom = () => {
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div
+        style={containerStyles}
+        onKeyDown={() => {
+          console.log(`this should not be logged to the console`);
+        }}>
+        <Tooltip {...props.withIcon()} tooltipBodyId="tooltip-body">
+          <p id="tooltip-body">
+            This is some tooltip text. This box shows the maximum amount of text
+            that should appear inside. If more room is needed please use a modal
+            instead.
+          </p>
+          <div className={`${prefix}--tooltip__footer`}>
+            <a href="/" className={`${prefix}--link`}>
+              Learn More
+            </a>
+            <Button size="small">Create</Button>
+          </div>
+        </Tooltip>
       </div>
-    </Tooltip>
-  </div>
-);
+    </>
+  );
+};
 
 DefaultBottom.storyName = 'default (bottom)';
 

--- a/packages/react/src/components/Tooltip/Tooltip-test.js
+++ b/packages/react/src/components/Tooltip/Tooltip-test.js
@@ -6,22 +6,26 @@
  */
 
 import React, { Component } from 'react';
-import debounce from 'lodash.debounce';
+import debounce from 'lodash.debounce'; // eslint-disable-line no-unused-vars
 import FloatingMenu from '../../internal/FloatingMenu';
 import Tooltip from '../Tooltip';
 import { mount } from 'enzyme';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   Information16 as Information,
   Add16 as Add,
   OverflowMenuVertical16,
 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
+import '@testing-library/jest-dom';
 
 const { prefix } = settings;
 
-jest.mock('lodash.debounce');
-
-debounce.mockImplementation((fn) => fn);
+jest.mock('lodash.debounce', () => (fn) => {
+  fn.cancel = jest.fn();
+  return fn;
+});
 
 describe('Tooltip', () => {
   // An icon component class
@@ -190,5 +194,22 @@ describe('Tooltip', () => {
       // Enzyme doesn't seem to allow state() in a forwardRef-wrapped class component
       expect(rootWrapper.find('Tooltip').instance().state.open).toEqual(false);
     });
+  });
+
+  it('escape key keyDown should not bubble outside the tooltip', () => {
+    const onKeyDown = jest.fn();
+    render(
+      <>
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div onKeyDown={onKeyDown}>
+          <Tooltip triggerText="Tooltip" />
+        </div>
+      </>
+    );
+
+    userEvent.click(screen.getAllByRole('button')[0]);
+    userEvent.keyboard('{esc}');
+
+    expect(onKeyDown).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -703,8 +703,16 @@ class Tooltip extends Component {
               this._tooltipEl = node;
             }}
             updateOrientation={this.updateOrientation}>
+            {/* This rule is disabled becuase the onKeyDown event handler is only
+             * being used to capture and prevent the event from bubbling: */}
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
             <div
               className={tooltipClasses}
+              onKeyDown={(event) => {
+                if (keyDownMatch(event, [keys.Escape])) {
+                  event.stopPropagation();
+                }
+              }}
               {...other}
               id={this._tooltipId}
               data-floating-menu-direction={storedDirection}

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -703,7 +703,7 @@ class Tooltip extends Component {
               this._tooltipEl = node;
             }}
             updateOrientation={this.updateOrientation}>
-            {/* This rule is disabled becuase the onKeyDown event handler is only
+            {/* This rule is disabled because the onKeyDown event handler is only
              * being used to capture and prevent the event from bubbling: */}
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
             <div


### PR DESCRIPTION
Closes #8502 

Prevents the `escape` from bubbling through `onKeyDown` on `Tooltip`. Includes a new test to cover this functionality. I had to more thoroughly mock the debounce to include the `cancel()` Tooltip uses.

#### Changelog

**Changed**

- tooltip: prevent escape keydown from bubbling

#### Testing / Reviewing

- The default bottom tooltip story has been modified to include a handler mimicing the bug reproduction from the original issue. It should _not_ get fired. Kind of silly, but we're explicitly trying to prevent something from happening.
- If you pull down locally and revert my changes to Tooltip, the handler in storybook will incorrectly fire reproducing the initial problem.
- ~⚠️  The story needs reverted before this is merged⚠️~ Edit: removed ✅ 
