### PR TITLE
chore: remove husky object from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,12 +71,6 @@
     "rimraf": "^3.0.0",
     "stylelint": "^13.13.1"
   },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
-    }
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"


### PR DESCRIPTION
The `husky` configuration object is removed from the `package.json` file in this PR. The `.husky` directory will be used to manage husky hooks.

#### Changelog

**New**

NA

**Changed**

NA

**Removed**

- Remove husky script from package.json file as `.husky` folder will handle hooks. Reference: #9369 

#### Testing / Reviewing

Follow the same steps as in #9369.