### PR TITLE
chore(themes): fix v11 token preview g100 color names

### DIFF
--- a/packages/themes/examples/preview-v11/src/pages/index.js
+++ b/packages/themes/examples/preview-v11/src/pages/index.js
@@ -277,7 +277,7 @@ export default function IndexPage() {
                           />
                           <div className="details">
                             <span>
-                              {getColorByValue(themes.g90[exportName], 'gray')}
+                              {getColorByValue(themes.g100[exportName], 'gray')}
                             </span>
                             <span className="hex-value">
                               {themes.g100[exportName]}


### PR DESCRIPTION
Closes #9886

The existing table was using the g90 name instead of the g100 name for the color 🤦  This PR updates it to use the correct name.

#### Changelog

**New**

**Changed**

- Update table row to use g100 instead of g90 for the name of the color

**Removed**

#### Testing / Reviewing

- Verify color names for g100 are correct
