### PR TITLE
feat(styles): add default-type export to _type.scss entrypoint

### DIFF
--- a/packages/styles/scss/__tests__/type-test.js
+++ b/packages/styles/scss/__tests__/type-test.js
@@ -25,6 +25,8 @@ describe('@carbon/styles/scss/type', () => {
         mixins: (
           reset: meta.mixin-exists('reset', 'type'),
           type-style: meta.mixin-exists('type-style', 'type'),
+          font-family: meta.mixin-exists('font-family', 'type'),
+          default-type: meta.mixin-exists('default-type', 'type'),
         ),
       ));
     `);
@@ -33,6 +35,8 @@ describe('@carbon/styles/scss/type', () => {
     expect(api.mixins).toEqual({
       reset: true,
       'type-style': true,
+      'font-family': true,
+      'default-type': true,
     });
     expect(api.variables).toMatchInlineSnapshot(`
       Array [

--- a/packages/styles/scss/_type.scss
+++ b/packages/styles/scss/_type.scss
@@ -11,6 +11,7 @@
   reset,
   type-style,
   font-family,
+  default-type,
 
   // Variables
   $caption-01,


### PR DESCRIPTION
Addresses this feedback from our v11 Beta 2 Discussion: https://github.com/carbon-design-system/carbon/discussions/9723

#### Changelog

**New**

**Changed**

- Update `_type.scss` entrypoint to re-export the `default-type` mixin from the type package

**Removed**

#### Testing / Reviewing

- Verify tests for `_type.scss` entrypoint include the added mixins and that test passes
