### PR TITLE
fix(button): hcm for ghost icon color contrast

### DIFF
--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -285,6 +285,9 @@
     path:not([data-icon-path]):not([fill='none']),
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only .#{$prefix}--btn__icon {
     fill: $icon-01;
+    @include high-contrast-mode {
+      fill: $icon-03;
+    }
   }
 
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only[disabled]

--- a/packages/components/src/components/button/_button.scss
+++ b/packages/components/src/components/button/_button.scss
@@ -285,9 +285,6 @@
     path:not([data-icon-path]):not([fill='none']),
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only .#{$prefix}--btn__icon {
     fill: $icon-01;
-    @include high-contrast-mode {
-      fill: $icon-03;
-    }
   }
 
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only[disabled]
@@ -525,6 +522,15 @@
   // Windows HCM fix
   .#{$prefix}--btn:focus {
     @include high-contrast-mode('focus');
+  }
+
+  // Windows HCM fix
+  // stylelint-disable-next-line no-duplicate-selectors
+  .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only
+    .#{$prefix}--btn__icon
+    path:not([data-icon-path]):not([fill='none']),
+  .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only .#{$prefix}--btn__icon {
+    @include high-contrast-mode('icon-fill');
   }
 }
 

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -525,4 +525,13 @@
   .#{$prefix}--btn:focus {
     @include high-contrast-mode('focus');
   }
+
+  // Windows HCM fix
+  // stylelint-disable-next-line no-duplicate-selectors
+  .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only
+    .#{$prefix}--btn__icon
+    path:not([data-icon-path]):not([fill='none']),
+  .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only .#{$prefix}--btn__icon {
+    @include high-contrast-mode('icon-fill');
+  }
 }


### PR DESCRIPTION
Closes #9903

Add CSS specifically for Windows high contrast mode for the ghost style `<Button>`

#### Changelog

**Changed**

Added CSS specific to the ghost styling for the Button that will apply `fill: white` to the SVG.

#### Testing / Reviewing

# Before fix
![image](https://user-images.githubusercontent.com/31117513/137990839-9051174e-2fff-4f81-8f5b-1b8dacb8ab06.png)
# After fix
![image](https://user-images.githubusercontent.com/31117513/137990898-c1041233-68d1-496b-8c88-28c587c0cb5a.png)

