### PR TITLE
fix(icons-react): remove pre bundle files -15k files on npm package!

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/builder.js
+++ b/packages/icon-build-helpers/src/builders/react/builder.js
@@ -161,6 +161,17 @@ const didWarnAboutDeprecation = {};`;
     };
 
     await bundle.write(outputOptions);
+
+    const delDirs = fs
+      .readdirSync(directory, { withFileTypes: true })
+      .filter(
+        (dirent) => dirent.isDirectory() && dirent.name !== '__generated__'
+      )
+      .map((dirent) => dirent.name);
+
+    delDirs.forEach((d) => {
+      fs.rmSync(path.join(directory, d), { recursive: true, force: true });
+    });
   }
 
   const umd = await rollup({


### PR DESCRIPTION
Problem:

**@carbon/icons-react** contains 15k+ js files used before rollup bundles to __generated__ folders.

Extracting 15k not used js small files (about 65MB hard disk space required) is not only a waste of time, 
but is very slow on CI for example building inside a docker container.

Solution:
remove them after build 



