### PR TITLE
feat(tabs): make auto-width the default behind v11 flag

### DIFF
--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -710,9 +710,7 @@
       @include focus-outline('reset');
       @include type-style('body-short-01');
 
-      @if feature-flag-enabled('enable-v11-release') {
-        width: auto;
-      } @else {
+      @if not feature-flag-enabled('enable-v11-release') {
         width: rem(160px);
       }
 

--- a/packages/components/src/components/tabs/_tabs.scss
+++ b/packages/components/src/components/tabs/_tabs.scss
@@ -710,8 +710,13 @@
       @include focus-outline('reset');
       @include type-style('body-short-01');
 
+      @if feature-flag-enabled('enable-v11-release') {
+        width: auto;
+      } @else {
+        width: rem(160px);
+      }
+
       overflow: hidden;
-      width: rem(160px);
       padding: $spacing-04 $spacing-05 $spacing-03;
       border-bottom: $tab-underline-color;
       color: $text-02;

--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -733,9 +733,7 @@
       @include focus-outline('reset');
       @include type-style('body-short-01');
 
-      @if feature-flag-enabled('enable-v11-release') {
-        width: auto;
-      } @else {
+      @if not feature-flag-enabled('enable-v11-release') {
         width: rem(160px);
       }
 

--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -733,8 +733,13 @@
       @include focus-outline('reset');
       @include type-style('body-short-01');
 
+      @if feature-flag-enabled('enable-v11-release') {
+        width: auto;
+      } @else {
+        width: rem(160px);
+      }
+
       overflow: hidden;
-      width: rem(160px);
       padding: $spacing-04 $spacing-05 $spacing-03;
       border-bottom: $tab-underline-color;
       color: $text-secondary;


### PR DESCRIPTION
Closes #10031 

Makes tabs have automatic width by default in v11 instead of the static `10rem` they have in v10.

#### Changelog

**Changed**

- tabs: add auto-width behind v11 flag

#### Testing / Reviewing

- The deploy previews should still show the v10 behavior of having a static `10rem` width
- Pull down and run storybook with `yarn start:v11` - tabs should have `width: auto`
