### PR TITLE
fix(styles): assign relative position to expandable tile

### DIFF
--- a/packages/components/src/components/tile/_tile.scss
+++ b/packages/components/src/components/tile/_tile.scss
@@ -166,6 +166,7 @@
   }
 
   .#{$prefix}--tile--expandable {
+    position: relative;
     overflow: hidden;
     width: 100%;
     border: 0;

--- a/packages/styles/scss/components/tile/_tile.scss
+++ b/packages/styles/scss/components/tile/_tile.scss
@@ -162,6 +162,7 @@
   }
 
   .#{$prefix}--tile--expandable {
+    position: relative;
     overflow: hidden;
     width: 100%;
     border: 0;


### PR DESCRIPTION
Closes #10063

This PR assigns a relative position to the `bx--tile-expandable` selector.

#### Changelog

**New**

- add `position: relative` to `.bx--tile-expandable`
