### PR TITLE
fix(styles): import z-index into overflow-menu in @carbon/styles

### DIFF
--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -16,6 +16,7 @@
 @use '../../utilities/focus-outline' as *;
 @use '../../utilities/high-contrast-mode' as *;
 @use '../../utilities/convert' as *;
+@use '../../utilities/z-index' as *;
 
 /// Overflow menu styles
 /// @access public


### PR DESCRIPTION
Closes #10105

adds the missing `@use` for the z-index function.

#### Changelog

**New**

- adds the missing `@use` for the z-index function.

**Changed**

- n/a

**Removed**

- n/a

#### Testing / Reviewing

the compiled output of overflow-menu should now set the actual z-index.
