### PR TITLE
fix(tabs): debounce scroll handler

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -153,6 +153,15 @@ export default class Tabs extends React.Component {
 
   _handleWindowResize = this.handleScroll;
 
+  /**
+   * The debounced version of the `scroll` event handler.
+   * @type {Function}
+   * @private
+   */
+  _debouncedHandleScroll = null;
+
+  _handleScroll = this.handleScroll;
+
   componentDidMount() {
     if (!this._debouncedHandleWindowResize) {
       this._debouncedHandleWindowResize = debounce(
@@ -163,6 +172,10 @@ export default class Tabs extends React.Component {
 
     this._handleWindowResize();
     window.addEventListener('resize', this._debouncedHandleWindowResize);
+
+    if (!this._debouncedHandleScroll) {
+      this._debouncedHandleScroll = debounce(this._handleScroll, 125);
+    }
 
     // scroll selected tab into view on mount
     const {
@@ -516,7 +529,7 @@ export default class Tabs extends React.Component {
             tabIndex={-1}
             className={classes.tablist}
             ref={this.tablist}
-            onScroll={this.handleScroll}>
+            onScroll={this._debouncedHandleScroll}>
             {tabsWithProps}
           </ul>
           {!rightOverflowNavButtonHidden && (


### PR DESCRIPTION
Closes #9698 

Updates Tabs to debounce the scroll handler. 

@carbon-design-system/release this will need to be cut into a new patch release for v10.48. I'm more than happy to assist!

#### Changelog

**Changed**

- tabs: debounce scroll handler

#### Testing / Reviewing

- The original issue was only present in Safari. 
- In Safari, Check the `tabs` stories in the `carbon-components-react` storybook. 
- Scroll back and forth multiple times (10-20 times) and ensure that React does not throw an error; `Error: Maximum update depth exceeded.`