### PR TITLE
fix(checkbox): do not propagate click event from label

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox-test.js
+++ b/packages/react/src/components/Checkbox/Checkbox-test.js
@@ -109,6 +109,17 @@ describe('Checkbox', () => {
       expect(call[2].target).toBe(inputElement);
     });
   });
+  it('should only propagate click events from the input', () => {
+    const onClick = jest.fn();
+    render(
+      /* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+      <div onClick={onClick}>
+        <Checkbox id="checkbox" labelText="checkbox" />
+      </div>
+    );
+    userEvent.click(screen.getByRole('checkbox'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('refs', () => {

--- a/packages/react/src/components/Checkbox/Checkbox.js
+++ b/packages/react/src/components/Checkbox/Checkbox.js
@@ -77,7 +77,14 @@ const Checkbox = React.forwardRef(function Checkbox(
           }
         }}
       />
-      <label htmlFor={id} className={labelClasses} title={title || null}>
+      {/* eslint-disable jsx-a11y/label-has-for,jsx-a11y/label-has-associated-control,jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions */}
+      <label
+        htmlFor={id}
+        className={labelClasses}
+        title={title || null}
+        onClick={(evt) => {
+          evt.stopPropagation();
+        }}>
         <Text className={innerLabelClasses}>{labelText}</Text>
       </label>
     </div>


### PR DESCRIPTION
Closes #10122 

Mirror Checkbox to have parity with recent changes to InlineCheckbox https://github.com/carbon-design-system/carbon/pull/10151 and only allow click events to propagate from the `input` and not the `label`. 

#### Changelog

**Changed**

- fix(checkbox): do not propagate click event from label

#### Testing / Reviewing

- Open the carbon-components-react storybook
- View the Checkbox default story - it should function as normal
- View the Checkbox Playground story
- Click a checkbox input, 2 events should fire: 
   1. `onChange`
   1. `onClick` with `event.target` indicating the `input`. 
       * Sometimes storybook actions addon won't show `target` appropriately. You may have to place a console.log or debugger in the dev tools to see the event.target for `onClick`
- Click a checkbox _label_, the same set of 2 events should fire
