### PR TITLE
chore: update codeowners to point to the correct SVG files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 * @carbon-design-system/developers-system
 
 # Core icons and pictograms
-/packages/icons/svg/ @laurenmrice @conradennis @dudley-ibm @carbon-design-system/developers-system
-/packages/pictograms/svg/ @laurenmrice @conradennis @dudley-ibm @carbon-design-system/developers-system
+/packages/icons/src/svg/ @laurenmrice @conradennis @dudley-ibm @carbon-design-system/developers-system
+/packages/pictograms/src/svg/ @laurenmrice @conradennis @dudley-ibm @carbon-design-system/developers-system
 
 # Angular icons
 /packages/icons-angular/ @cal-smith @carbon-design-system/developers-system


### PR DESCRIPTION
This PR updates our CODEOWNERS to point to the correct SVG source path

#### Changelog

**New**

**Changed**

- Update our CODEOWNERS to point to the correct SVG source path

**Removed**


