### PR TITLE
test(project): add moduleNameMapper and test:next ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,29 @@ jobs:
       - name: Run tests
         run: yarn test --ci
 
+  next:
+    name: 'test:next'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: '14.x'
+      - uses: actions/cache@v2.1.7
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Build project
+        run: yarn build --ignore '@carbon/sketch'
+      - name: Run tests
+        run: CARBON_ENABLE_V11_RELEASE=true yarn test --ci
+
   e2e:
     name: 'test:e2e'
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,8 @@
 
 'use strict';
 
+const path = require('path');
+
 module.exports = {
   preset: 'jest-config-carbon',
   collectCoverageFrom: [
@@ -17,5 +19,28 @@ module.exports = {
     '!**/*.stories.js',
     '!**/*-test.e2e.js',
   ],
+  moduleNameMapper: {
+    '@carbon/react': path.join(
+      __dirname,
+      'packages',
+      'carbon-react',
+      'src',
+      'index.js'
+    ),
+    '@carbon/react/icons': path.join(
+      __dirname,
+      'packages',
+      'carbon-react',
+      'icons',
+      'index.js'
+    ),
+    'carbon-components-react': path.join(
+      __dirname,
+      'packages',
+      'react',
+      'src',
+      'index.js'
+    ),
+  },
   reporters: ['default', 'jest-junit'],
 };

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as Carbon from '../index';
+import * as Carbon from 'carbon-components-react';
 
 describe('Carbon Components React', () => {
   it('can be imported using the correct path', () => {

--- a/packages/react/src/components/Accordion/__tests__/Accordion-test.js
+++ b/packages/react/src/components/Accordion/__tests__/Accordion-test.js
@@ -5,14 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { default as Accordion, AccordionItem } from '../';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Accordion, AccordionItem } from 'carbon-components-react';
+import React from 'react';
 
 describe('Accordion', () => {
-  afterEach(cleanup);
-
   it('should render', () => {
     const { asFragment } = render(
       <Accordion className="extra-class">

--- a/packages/react/src/components/Accordion/__tests__/Accordion.Skeleton-test.js
+++ b/packages/react/src/components/Accordion/__tests__/Accordion.Skeleton-test.js
@@ -6,10 +6,9 @@
  */
 
 import { settings } from 'carbon-components';
+import { AccordionSkeleton, SkeletonText } from 'carbon-components-react';
 import { mount } from 'enzyme';
 import React from 'react';
-import AccordionSkeleton from '../Accordion.Skeleton';
-import SkeletonText from '../../SkeletonText';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/AspectRatio/__tests__/AspectRatio-test.js
+++ b/packages/react/src/components/AspectRatio/__tests__/AspectRatio-test.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { AspectRatio } from 'carbon-components-react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Simulate } from 'react-dom/test-utils';
-import { AspectRatio } from '../';
 
 describe('AspectRatio', () => {
   it('should support rendering content in different aspect ratios', () => {

--- a/packages/react/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
+++ b/packages/react/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
@@ -17,9 +17,9 @@ describe('Breadcrumb', () => {
   let BreadcrumbItem;
 
   beforeEach(() => {
-    const BreadcrumbEntrypoint = require('../');
-    Breadcrumb = BreadcrumbEntrypoint.Breadcrumb;
-    BreadcrumbItem = BreadcrumbEntrypoint.BreadcrumbItem;
+    const Carbon = require('carbon-components-react');
+    Breadcrumb = Carbon.Breadcrumb;
+    BreadcrumbItem = Carbon.BreadcrumbItem;
   });
 
   it('should render', () => {

--- a/packages/react/src/components/Breadcrumb/__tests__/Breadcrumb.Skeleton-test.js
+++ b/packages/react/src/components/Breadcrumb/__tests__/Breadcrumb.Skeleton-test.js
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { BreadcrumbSkeleton } from '../';
+import { BreadcrumbSkeleton } from 'carbon-components-react';
 import { mount } from 'enzyme';
+import React from 'react';
 
 describe('BreadcrumbSkeleton', () => {
   it('should render', () => {

--- a/packages/react/src/components/Breadcrumb/__tests__/BreadcrumbItem-test.js
+++ b/packages/react/src/components/Breadcrumb/__tests__/BreadcrumbItem-test.js
@@ -5,13 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { BreadcrumbItem } from 'carbon-components-react';
 import React from 'react';
-import { BreadcrumbItem } from '../../Breadcrumb';
 
 describe('BreadcrumbItem', () => {
-  afterEach(cleanup);
-
   describe('Component API', () => {
     it('should accept a `ref` for the outermost node', () => {
       const ref = jest.fn(() => React.createRef());

--- a/packages/react/src/components/Button/Button-test.js
+++ b/packages/react/src/components/Button/Button-test.js
@@ -5,15 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
 import { Search16 } from '@carbon/icons-react';
-import Button from '../Button';
-import Link from '../Link';
-import ButtonSkeleton from '../Button/Button.Skeleton';
-import { shallow, mount } from 'enzyme';
-import { settings } from 'carbon-components';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { settings } from 'carbon-components';
+import { Button, ButtonSkeleton, Link } from 'carbon-components-react';
+import { shallow, mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 
@@ -420,8 +418,6 @@ describe('Small ButtonSkeleton', () => {
 });
 
 describe('Button accessibility', () => {
-  afterEach(cleanup);
-
   it('should have no Axe violations', async () => {
     render(<Button>Button Label</Button>);
 

--- a/packages/react/src/components/ButtonSet/ButtonSet-test.js
+++ b/packages/react/src/components/ButtonSet/ButtonSet-test.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import ButtonSet from '../ButtonSet';
-import { shallow } from 'enzyme';
 import { settings } from 'carbon-components';
+import { ButtonSet } from 'carbon-components-react';
+import { shallow } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/Checkbox/Checkbox-test.js
+++ b/packages/react/src/components/Checkbox/Checkbox-test.js
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import Checkbox from '../Checkbox';
-import CheckboxSkeleton from '../Checkbox/Checkbox.Skeleton';
-import { mount } from 'enzyme';
-import { settings } from 'carbon-components';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { settings } from 'carbon-components';
+import { Checkbox, CheckboxSkeleton } from 'carbon-components-react';
+import { mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 
@@ -194,8 +193,6 @@ describe('CheckboxSkeleton', () => {
 });
 
 describe('Checkbox accessibility', () => {
-  afterEach(cleanup);
-
   it('should have no Axe violations', async () => {
     render(<Checkbox labelText="Checkbox label" id="test_id" />);
     await expect(

--- a/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js
+++ b/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet-test.js
@@ -5,13 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import Button from '../../Button';
-import CodeSnippet from '../';
-import Copy from '../../Copy';
-import CopyButton from '../../CopyButton';
-import { shallow, mount } from 'enzyme';
 import { settings } from 'carbon-components';
+import { Button, CodeSnippet, Copy, CopyButton } from 'carbon-components-react';
+import { shallow, mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet.Skeleton-test.js
+++ b/packages/react/src/components/CodeSnippet/__tests__/CodeSnippet.Skeleton-test.js
@@ -5,17 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { render, cleanup } from '@carbon/test-utils/react';
+import { render } from '@carbon/test-utils/react';
 import { settings } from 'carbon-components';
+import { CodeSnippetSkeleton } from 'carbon-components-react';
 import React from 'react';
-import { CodeSnippetSkeleton } from '../';
 
 const { prefix } = settings;
 const snippetTypes = ['single', 'multi'];
 
 describe('CodeSnippetSkeleton', () => {
-  afterEach(cleanup);
-
   describe('automated accessibility testing', () => {
     it.each(snippetTypes)(
       'should have no Axe violations with type="%s"',

--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { mount } from 'enzyme';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { settings } from 'carbon-components';
+import { ComboBox } from 'carbon-components-react';
+import { mount } from 'enzyme';
+import React from 'react';
 import {
   findListBoxNode,
   findMenuNode,
@@ -17,8 +19,6 @@ import {
   generateItems,
   generateGenericItem,
 } from '../ListBox/test-helpers';
-import ComboBox from '../ComboBox';
-import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 const findInputNode = (wrapper) => wrapper.find(`.${prefix}--text-input`);

--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { shallow, mount } from 'enzyme';
-import Button from '../Button';
-import ComposedModal, {
+import { settings } from 'carbon-components';
+import {
+  Button,
+  ComposedModal,
+  InlineLoading,
   ModalHeader,
   ModalBody,
   ModalFooter,
-} from '../ComposedModal';
-import InlineLoading from '../InlineLoading';
-import { settings } from 'carbon-components';
+} from 'carbon-components-react';
+import { shallow, mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/ComposedModal/next/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/next/ComposedModal-test.js
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { mount } from 'enzyme';
-import ComposedModal from './ComposedModal';
-import { ModalHeader } from './ModalHeader';
-import { ModalFooter } from '../ComposedModal';
 import { settings } from 'carbon-components';
+import {
+  ComposedModal,
+  ModalHeader,
+  ModalFooter,
+} from 'carbon-components-react';
+import { mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/ComposedModal/next/ModalFooter-test.js
+++ b/packages/react/src/components/ComposedModal/next/ModalFooter-test.js
@@ -1,9 +1,14 @@
-import React from 'react';
-import { shallow, mount } from 'enzyme';
-import Button from '../../Button';
-import { ModalFooter } from './ModalFooter';
-import InlineLoading from '../../InlineLoading';
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { settings } from 'carbon-components';
+import { Button, InlineLoading, ModalFooter } from 'carbon-components-react';
+import { shallow, mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/ComposedModal/next/ModalHeader-test.js
+++ b/packages/react/src/components/ComposedModal/next/ModalHeader-test.js
@@ -5,22 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { render } from '@testing-library/react';
+import { ModalHeader } from 'carbon-components-react';
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { ModalHeader } from './ModalHeader';
 
 describe('ModalHeader', () => {
-  afterEach(cleanup);
-
   it('should render title if has title text', () => {
     const { container } = render(<ModalHeader title="Carbon" />);
-
     expect(container.firstChild).toHaveTextContent('Carbon');
   });
 
   it('should label if has label text', () => {
     const { container } = render(<ModalHeader label="Carbon label" />);
-
     expect(container.firstChild).toHaveTextContent('Carbon label');
   });
 });

--- a/packages/react/src/components/ComposedModal/next/__snapshots__/ComposedModal-test.js.snap
+++ b/packages/react/src/components/ComposedModal/next/__snapshots__/ComposedModal-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ComposedModal /> renders 1`] = `
-<ForwardRef(ComposedModal)
+<ComposedModal
   onKeyDown={[Function]}
   open={true}
   selectorPrimaryFocus="[data-modal-primary-focus]"
@@ -11,6 +11,8 @@ exports[`<ComposedModal /> renders 1`] = `
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
+    onTransitionEnd={[Function]}
+    open={true}
     role="presentation"
   >
     <span
@@ -33,5 +35,5 @@ exports[`<ComposedModal /> renders 1`] = `
       Focus sentinel
     </span>
   </div>
-</ForwardRef(ComposedModal)>
+</ComposedModal>
 `;

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import ContentSwitcher from '../ContentSwitcher';
-import Switch from '../Switch';
 import { mount, shallow } from 'enzyme';
+import { ContentSwitcher, Switch } from 'carbon-components-react';
+import React from 'react';
 
 describe('ContentSwitcher', () => {
   describe('component initial rendering', () => {

--- a/packages/react/src/components/Copy/Copy-test.js
+++ b/packages/react/src/components/Copy/Copy-test.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import Copy from '../Copy';
 import { shallow, mount } from 'enzyme';
 import { settings } from 'carbon-components';
+import { Copy } from 'carbon-components-react';
+import React from 'react';
 
 const { prefix } = settings;
 

--- a/packages/react/src/components/CopyButton/CopyButton-test.js
+++ b/packages/react/src/components/CopyButton/CopyButton-test.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import CopyButton from '../CopyButton';
 import { Copy16 } from '@carbon/icons-react';
 import { shallow, mount } from 'enzyme';
 import { settings } from 'carbon-components';
+import { CopyButton } from 'carbon-components-react';
+import React from 'react';
 
 const { prefix } = settings;
 jest.useFakeTimers();

--- a/packages/react/src/components/DangerButton/DangerButton-test.js
+++ b/packages/react/src/components/DangerButton/DangerButton-test.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import DangerButton from '../DangerButton';
-import { shallow, mount } from 'enzyme';
 import { Search16 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
+import { DangerButton } from 'carbon-components-react';
+import { shallow, mount } from 'enzyme';
+import React from 'react';
 
 const { prefix } = settings;
 


### PR DESCRIPTION
This PR contains the proof-of-concept for adding the `moduleNameMapper` options to our jest config along with running our tests with the v11 flag enabled in CI.

#### Changelog

**New**

**Changed**

- Update test files to use `carbon-components-react` if they are testing a component
- Update `ci.yml` workflow to include a `test:next` job
- Update `jest.config.js` to include the following modules mapped to files locally:
  - `carbon-components-react`
  - `@carbon/react`
  - `@carbon/react/icons`

**Removed**


#### Testing / Reviewing

- Verify tests work and pass as expected
- Verify a `test:next` job is running in CI and that it is running tests with the v11 feature flag turned on
