### PR TITLE
fix(slider): ensure slider and input are both labelled by the label

### DIFF
--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -603,10 +603,7 @@ export default class Slider extends PureComponent {
             ? classNames(`${prefix}--form-item`, className)
             : `${prefix}--form-item`
         }>
-        <label
-          htmlFor={`${id}-input-for-slider`}
-          className={labelClasses}
-          id={labelId}>
+        <label htmlFor={id} className={labelClasses} id={labelId}>
           {labelText}
         </label>
         <div className={`${prefix}--slider-container`}>
@@ -630,7 +627,6 @@ export default class Slider extends PureComponent {
               role="slider"
               id={id}
               tabIndex={0}
-              aria-labelledby={labelId}
               aria-valuemax={max}
               aria-valuemin={min}
               aria-valuenow={value}
@@ -657,6 +653,7 @@ export default class Slider extends PureComponent {
             name={name}
             className={inputClasses}
             value={value}
+            aria-labelledby={!ariaLabelInput ? labelId : null}
             aria-label={ariaLabelInput ? ariaLabelInput : null}
             disabled={disabled}
             required={required}


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/10252 #10172

1. The `label` is associated with the slider via `htmlFor`
1. The slider no longer has the redundant `aria-labelledby`
1. The input is `aria-labelledby` the `label` when a more explicit `ariaLabelInput` is not passed
1. If a `ariaLabelInput` is passed, the `input` does not receive `aria-labelledby` and instead receives `aria-label={ariaLabelInput}`

#### Changelog

**Changed**

- slider: improve aria labels

#### Testing / Reviewing

- View the storybook to see that the above bullet list statements are true. It'll be slightly different with the v11 flag since the `ariaLabelInput` doesn't receive a default. 
