### PR TITLE
fix(styles): re-export type-classes

### DIFF
--- a/packages/styles/scss/_type.scss
+++ b/packages/styles/scss/_type.scss
@@ -12,6 +12,7 @@
   type-style,
   font-family,
   default-type,
+  type-classes,
 
   // Variables
   $caption-01,


### PR DESCRIPTION
Ran into an issue migrating GTC where we needed a type mixin we forgot to re-export in the v11 styles package. This just adds it to the exports.

https://github.com/carbon-design-system/carbon/blob/63dbd536b0e24e3d29d447fbf084fbcb26d7aa42/packages/type/scss/_classes.scss#L15-L21

internal slack thread for reviewers: https://ibm-studios.slack.com/archives/GCQ5R263T/p1642631874020800

### Testing
- make sure CI passes as expected