### PR TITLE
fix(data-table): add position relative to InlineCheckbox to prevent scroll

### DIFF
--- a/packages/components/src/components/checkbox/_checkbox.scss
+++ b/packages/components/src/components/checkbox/_checkbox.scss
@@ -42,6 +42,7 @@
   // to match the specs.
   .#{$prefix}--checkbox {
     @include hidden;
+
     //even though its hidden, positioning is for native validation to be aligned to checkbox
     top: 1.25rem;
     left: 0.7rem;
@@ -197,6 +198,13 @@
 
     // Add extra spacing when label is present
     margin: rem(1px) 0 0 rem(6px);
+  }
+
+  //-----------------------------------------------
+  // InlineCheckbox
+  //-----------------------------------------------
+  .#{$prefix}--checkbox--inline {
+    position: relative;
   }
 }
 

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -975,21 +975,25 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                           name="select-all"
                           onClick={[Function]}
                         >
-                          <input
-                            checked={false}
-                            className="bx--checkbox"
-                            id="data-table-7__select-all"
-                            name="select-all"
-                            onChange={[Function]}
-                            onClick={[Function]}
-                            type="checkbox"
-                          />
-                          <label
-                            aria-label="Select all rows"
-                            className="bx--checkbox-label"
-                            htmlFor="data-table-7__select-all"
-                            onClick={[Function]}
-                          />
+                          <div
+                            className="bx--checkbox--inline"
+                          >
+                            <input
+                              checked={false}
+                              className="bx--checkbox"
+                              id="data-table-7__select-all"
+                              name="select-all"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              aria-label="Select all rows"
+                              className="bx--checkbox-label"
+                              htmlFor="data-table-7__select-all"
+                              onClick={[Function]}
+                            />
+                          </div>
                         </ForwardRef(InlineCheckbox)>
                       </th>
                     </TableSelectAll>
@@ -1371,21 +1375,25 @@ exports[`DataTable selection should render 1`] = `
                           name="select-all"
                           onClick={[Function]}
                         >
-                          <input
-                            checked={false}
-                            className="bx--checkbox"
-                            id="data-table-6__select-all"
-                            name="select-all"
-                            onChange={[Function]}
-                            onClick={[Function]}
-                            type="checkbox"
-                          />
-                          <label
-                            aria-label="Select all rows"
-                            className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-all"
-                            onClick={[Function]}
-                          />
+                          <div
+                            className="bx--checkbox--inline"
+                          >
+                            <input
+                              checked={false}
+                              className="bx--checkbox"
+                              id="data-table-6__select-all"
+                              name="select-all"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              aria-label="Select all rows"
+                              className="bx--checkbox-label"
+                              htmlFor="data-table-6__select-all"
+                              onClick={[Function]}
+                            />
+                          </div>
                         </ForwardRef(InlineCheckbox)>
                       </th>
                     </TableSelectAll>
@@ -1461,22 +1469,26 @@ exports[`DataTable selection should render 1`] = `
                           name="select-row-b"
                           onClick={[Function]}
                         >
-                          <input
-                            checked={false}
-                            className="bx--checkbox"
-                            disabled={false}
-                            id="data-table-6__select-row-b"
-                            name="select-row-b"
-                            onChange={[Function]}
-                            onClick={[Function]}
-                            type="checkbox"
-                          />
-                          <label
-                            aria-label="Select row"
-                            className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-row-b"
-                            onClick={[Function]}
-                          />
+                          <div
+                            className="bx--checkbox--inline"
+                          >
+                            <input
+                              checked={false}
+                              className="bx--checkbox"
+                              disabled={false}
+                              id="data-table-6__select-row-b"
+                              name="select-row-b"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              aria-label="Select row"
+                              className="bx--checkbox-label"
+                              htmlFor="data-table-6__select-row-b"
+                              onClick={[Function]}
+                            />
+                          </div>
                         </ForwardRef(InlineCheckbox)>
                       </td>
                     </TableSelectRow>
@@ -1520,22 +1532,26 @@ exports[`DataTable selection should render 1`] = `
                           name="select-row-a"
                           onClick={[Function]}
                         >
-                          <input
-                            checked={false}
-                            className="bx--checkbox"
-                            disabled={false}
-                            id="data-table-6__select-row-a"
-                            name="select-row-a"
-                            onChange={[Function]}
-                            onClick={[Function]}
-                            type="checkbox"
-                          />
-                          <label
-                            aria-label="Select row"
-                            className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-row-a"
-                            onClick={[Function]}
-                          />
+                          <div
+                            className="bx--checkbox--inline"
+                          >
+                            <input
+                              checked={false}
+                              className="bx--checkbox"
+                              disabled={false}
+                              id="data-table-6__select-row-a"
+                              name="select-row-a"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              aria-label="Select row"
+                              className="bx--checkbox-label"
+                              htmlFor="data-table-6__select-row-a"
+                              onClick={[Function]}
+                            />
+                          </div>
                         </ForwardRef(InlineCheckbox)>
                       </td>
                     </TableSelectRow>
@@ -1579,22 +1595,26 @@ exports[`DataTable selection should render 1`] = `
                           name="select-row-c"
                           onClick={[Function]}
                         >
-                          <input
-                            checked={false}
-                            className="bx--checkbox"
-                            disabled={false}
-                            id="data-table-6__select-row-c"
-                            name="select-row-c"
-                            onChange={[Function]}
-                            onClick={[Function]}
-                            type="checkbox"
-                          />
-                          <label
-                            aria-label="Select row"
-                            className="bx--checkbox-label"
-                            htmlFor="data-table-6__select-row-c"
-                            onClick={[Function]}
-                          />
+                          <div
+                            className="bx--checkbox--inline"
+                          >
+                            <input
+                              checked={false}
+                              className="bx--checkbox"
+                              disabled={false}
+                              id="data-table-6__select-row-c"
+                              name="select-row-c"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              aria-label="Select row"
+                              className="bx--checkbox-label"
+                              htmlFor="data-table-6__select-row-c"
+                              onClick={[Function]}
+                            />
+                          </div>
                         </ForwardRef(InlineCheckbox)>
                       </td>
                     </TableSelectRow>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
@@ -34,21 +34,25 @@ exports[`DataTable.TableSelectAll should render 1`] = `
                     name="select-all"
                     onClick={[MockFunction]}
                   >
-                    <input
-                      checked={false}
-                      className="bx--checkbox"
-                      id="id"
-                      name="select-all"
-                      onChange={[Function]}
-                      onClick={[MockFunction]}
-                      type="checkbox"
-                    />
-                    <label
-                      aria-label="Select all rows in the table"
-                      className="bx--checkbox-label"
-                      htmlFor="id"
-                      onClick={[Function]}
-                    />
+                    <div
+                      className="bx--checkbox--inline"
+                    >
+                      <input
+                        checked={false}
+                        className="bx--checkbox"
+                        id="id"
+                        name="select-all"
+                        onChange={[Function]}
+                        onClick={[MockFunction]}
+                        type="checkbox"
+                      />
+                      <label
+                        aria-label="Select all rows in the table"
+                        className="bx--checkbox-label"
+                        htmlFor="id"
+                        onClick={[Function]}
+                      />
+                    </div>
                   </ForwardRef(InlineCheckbox)>
                 </th>
               </TableSelectAll>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
@@ -33,21 +33,25 @@ exports[`DataTable.TableSelectRow should render 1`] = `
                     name="select-all"
                     onClick={[MockFunction]}
                   >
-                    <input
-                      checked={false}
-                      className="bx--checkbox"
-                      id="id"
-                      name="select-all"
-                      onChange={[Function]}
-                      onClick={[MockFunction]}
-                      type="checkbox"
-                    />
-                    <label
-                      aria-label="Aria label"
-                      className="bx--checkbox-label"
-                      htmlFor="id"
-                      onClick={[Function]}
-                    />
+                    <div
+                      className="bx--checkbox--inline"
+                    >
+                      <input
+                        checked={false}
+                        className="bx--checkbox"
+                        id="id"
+                        name="select-all"
+                        onChange={[Function]}
+                        onClick={[MockFunction]}
+                        type="checkbox"
+                      />
+                      <label
+                        aria-label="Aria label"
+                        className="bx--checkbox-label"
+                        htmlFor="id"
+                        onClick={[Function]}
+                      />
+                    </div>
                   </ForwardRef(InlineCheckbox)>
                 </td>
               </TableSelectRow>

--- a/packages/react/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/packages/react/src/components/InlineCheckbox/InlineCheckbox.js
@@ -54,7 +54,7 @@ const InlineCheckbox = React.forwardRef(function InlineCheckbox(
   }, [indeterminate]);
 
   return (
-    <>
+    <div className={`${prefix}--checkbox--inline`}>
       <input {...inputProps} />
       {
         /* eslint-disable jsx-a11y/label-has-for,jsx-a11y/label-has-associated-control,jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions */
@@ -68,7 +68,7 @@ const InlineCheckbox = React.forwardRef(function InlineCheckbox(
           }}
         />
       }
-    </>
+    </div>
   );
 });
 


### PR DESCRIPTION
Closes #6521
Closes #10307

This issue was reported over on Slack: https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1643032172186100

It details a problem that occurs in the `DataTable` where clicking on a checkbox will cause the page to scroll to the top. This problem occurs because of a change made to `InlineCheckbox` where we no longer have the checkbox within a parent that is `position: relative`.

As a result, the `position: absolute` that comes from our `hidden` mixin (and applied to `bx--checkbox`) is being used in conjunction with `top` in `bx--checkbox` to place the native checkbox at the top of the page. This results in the page jumping because the browser is attempting to put this control in the visible part of the page.

This PR attempts to address this by adding back in a `position: relative` container so that the native checkbox is placed inline instead of the top of the nearest `position: relative` parent.

#### Changelog

**New**

**Changed**

- Add `position: relative` helper for inline checkbox

**Removed**

#### Testing / Reviewing

- View the Data Table story for selection that includes checkboxes
- Decrease the height of the page until you have a vertical scrollbar
- Click on a checkbox
- Verify the page does not jump to the top
