### PR TITLE
fix(modal): ensure only text has margin-right in modals

### DIFF
--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -91,8 +91,7 @@
       height: auto;
       max-height: 90%;
 
-      .#{$prefix}--modal-header,
-      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content p,
       .#{$prefix}--modal-content__regular-content {
         padding-right: 20%;
       }
@@ -176,8 +175,7 @@
     @include breakpoint(xlg) {
       width: 36%;
 
-      .#{$prefix}--modal-header,
-      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content p,
       .#{$prefix}--modal-content__regular-content {
         padding-right: 20%;
       }
@@ -203,8 +201,7 @@
     @include breakpoint(md) {
       width: 96%;
 
-      .#{$prefix}--modal-header,
-      .#{$prefix}--modal-content,
+      .#{$prefix}--modal-content p,
       .#{$prefix}--modal-content__regular-content {
         padding-right: 20%;
       }


### PR DESCRIPTION
Closes #10324 

Mirroring the fix from #9700 over into `@carbon/styles`

#### Changelog

**Changed**

- modal: ensure only text has margin-right

#### Testing / Reviewing
- Check out the default modal story in the carbon-react-next storybook. It should behave the same as it does in the carbon-components-react storybook.

| breakpoint | expected behavior |
| - | - |
| `xs` | everything spans full width, at all breakpoints |
| `sm` | text gets 20% padding above 1056 (`lg`) breakpoint, everything spans full width below 1056 breakpoint |
| `md`, `lg`, `xl` | text gets 20% right padding, everything else spans full width |


