### PR TITLE
ci: add timeout to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Add a timeout of 60m to the release workflow. This is to prevent it hanging like it did in our last release cycle.

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

#### Changelog

**New**

**Changed**

- Update the release workflow to timeout after 60m

**Removed**
