### PR TITLE
fix(components): add HCM support to notificiation close icon

### DIFF
--- a/packages/components/src/components/notification/_inline-notification.scss
+++ b/packages/components/src/components/notification/_inline-notification.scss
@@ -314,6 +314,10 @@
   .#{$prefix}--inline-notification__icon {
     @include high-contrast-mode('icon-fill');
   }
+
+  .#{$prefix}--inline-notification__close-icon {
+    @include high-contrast-mode('icon-fill');
+  }
   /* stylelint-enable */
 }
 

--- a/packages/components/src/components/notification/_toast-notification.scss
+++ b/packages/components/src/components/notification/_toast-notification.scss
@@ -237,10 +237,16 @@
   .#{$prefix}--toast-notification {
     @include high-contrast-mode('outline');
   }
+
   .#{$prefix}--toast-notification__close-button:focus {
     @include high-contrast-mode('focus');
   }
+
   .#{$prefix}--toast-notification__icon {
+    @include high-contrast-mode('icon-fill');
+  }
+
+  .#{$prefix}--inline-notification__close-icon {
     @include high-contrast-mode('icon-fill');
   }
   /* stylelint-enable */


### PR DESCRIPTION
Closes #10586 
Closes #10585 
REF #10199 

Adds HCM for close icon in notification to `/components` as a part of the styles audit. Was previously added in `/styles`. 

#### Testing / Reviewing

If you have a Windows computer, using HCM, check that notifications have an accessible close X icon. 
