### PR TITLE
docs(react): change import to populate props table for notification

### DIFF
--- a/packages/react/src/components/Notification/Notification-story.js
+++ b/packages/react/src/components/Notification/Notification-story.js
@@ -18,7 +18,7 @@ import {
   ToastNotification,
   InlineNotification,
   NotificationActionButton,
-} from '../Notification';
+} from './Notification';
 import mdx from './Notification.mdx';
 
 const kinds = {


### PR DESCRIPTION
Updates where the notification components are imported from so that the props table populates as expected. 

### Testing/Reviewing ### 

Go to notification story docs and check that the props shows notification's props for `Toast` and `Inline` 