### PR TITLE
fix(content-switcher): omit transition if prefers-reduced-motion is enabled

### DIFF
--- a/packages/components/src/components/content-switcher/_content-switcher.scss
+++ b/packages/components/src/components/content-switcher/_content-switcher.scss
@@ -66,6 +66,10 @@
       transform: scaleY(0);
       transform-origin: bottom;
       transition: all $duration--moderate-01 motion(standard, productive);
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
     }
 
     &:disabled::after {

--- a/packages/styles/scss/components/content-switcher/_content-switcher.scss
+++ b/packages/styles/scss/components/content-switcher/_content-switcher.scss
@@ -67,6 +67,10 @@
       transform: scaleY(0);
       transform-origin: bottom;
       transition: all $duration-moderate-01 motion(standard, productive);
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
     }
 
     &:disabled::after {


### PR DESCRIPTION
Related #10148

#10148 introduced a "fade up" motion to `ContentSwitcher`. Although the interaction is indeed delightful, the transition should be omitted if the consumer prefers reduced motion.

#### Changelog

**Changed**

- fix(content-switcher): omit transition if prefers-reduced-motion is enabled

#### Testing / Reviewing

1. Visit the `ContentSwitcher`
2. Enable "reduced motion" in your system settings
3. Click the tabs
4. Verify that the fade transition does not occur
