### PR TITLE
chore(IconSkeleton): move story to components

### DIFF
--- a/packages/react/src/components/Icon/Icon-story.js
+++ b/packages/react/src/components/Icon/Icon-story.js
@@ -9,7 +9,6 @@ import React from 'react';
 import { iconAdd, iconAddSolid, iconAddOutline } from 'carbon-icons';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import Icon from '../Icon';
-import IconSkeleton from '../Icon/Icon.Skeleton';
 
 const icons = {
   'Add (iconAdd from `carbon-icons`)': 'iconAdd',
@@ -49,20 +48,6 @@ const props = () => {
   };
 };
 
-const propsSkeleton = {
-  style: {
-    margin: '50px',
-  },
-};
-
-const propsSkeleton2 = {
-  style: {
-    margin: '50px',
-    width: '24px',
-    height: '24px',
-  },
-};
-
 export default {
   title: 'Deprecated/Icon',
   component: Icon,
@@ -76,21 +61,6 @@ export const Default = () => (
 );
 
 Default.parameters = {
-  info: {
-    text: `
-        Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see https://www.carbondesignsystem.com/guidelines/iconography/library
-      `,
-  },
-};
-
-export const Skeleton = () => (
-  <div>
-    <IconSkeleton {...propsSkeleton} />
-    <IconSkeleton {...propsSkeleton2} />
-  </div>
-);
-
-Skeleton.parameters = {
   info: {
     text: `
         Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see https://www.carbondesignsystem.com/guidelines/iconography/library

--- a/packages/react/src/components/Icon/IconSkeleton-story.js
+++ b/packages/react/src/components/Icon/IconSkeleton-story.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import IconSkeleton from '../Icon/Icon.Skeleton';
+
+const propsSkeleton = {
+  style: {
+    margin: '50px',
+  },
+};
+
+const propsSkeleton2 = {
+  style: {
+    margin: '50px',
+    width: '24px',
+    height: '24px',
+  },
+};
+
+export default {
+  title: 'Components/IconSkeleton',
+  component: IconSkeleton,
+};
+
+export const Default = () => (
+  <>
+    <IconSkeleton {...propsSkeleton} />
+    <IconSkeleton {...propsSkeleton2} />
+  </>
+);
+
+Default.parameters = {
+  info: {
+    text: `
+        Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see https://www.carbondesignsystem.com/guidelines/iconography/library
+      `,
+  },
+};


### PR DESCRIPTION
No related issue, brought up in [slack thread](https://ibm-studios.slack.com/archives/GD8JG6JR3/p1645721046871839)

#### Changelog

- Moves `IconSkeleton` from the deprecated section to the components section.


#### Testing / Reviewing

Review both the v10 and v11 deploy previews:
- `Icon` should still be in the deprecated section, but `IconSkeleton` should no longer be included in those stories
- `IconSkeleton` should have it's own story now in the component section
- make sure styles are matching and tests pass