### PR TITLE
ci(percy): update vrt step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,8 @@ jobs:
       - name: Build project
         run: yarn build --ignore '@carbon/sketch'
       - name: Run VRT
+        if: github.repository == 'carbon-design-system/carbon'
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN: c9a21a3fde4fda0a0f822d633426ab26e2ab2c1cba55221d342d4047744c8c24
         run: |
           yarn run percy exec -- yarn workspace carbon-components-react test:e2e


### PR DESCRIPTION
Update our Percy setup to only run when the action is running against the monorepo.

#### Changelog

**New**

**Changed**

- Update the VRT step to only run if `github.repository` is set to this project

**Removed**

#### Testing / Reviewing

- Verify the Percy status check is being run (and passes) against this PR
