### PR TITLE
fix(react): removes v11 enabled check on ${prefix}--label and adjusts styles

### DIFF
--- a/packages/react/src/components/FormLabel/FormLabel.js
+++ b/packages/react/src/components/FormLabel/FormLabel.js
@@ -7,28 +7,28 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
+import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import * as FeatureFlags from '@carbon/feature-flags';
 
-const FormLabel = ({ className, children, id, ...other }) => {
+function FormLabel({ className: customClassName, children, id, ...rest }) {
   const prefix = usePrefix();
-  const classNames = classnames(
+  const className = cx(
+    `${prefix}--label`,
     {
-      [`${prefix}--label`]: !FeatureFlags.enabled('enable-v11-release'),
       [`${prefix}--label--no-margin`]: FeatureFlags.enabled(
         'enable-v11-release'
       ),
     },
-    className
+    customClassName
   );
 
   return (
-    <label htmlFor={id} className={classNames} {...other}>
+    <label htmlFor={id} className={className} {...rest}>
       {children}
     </label>
   );
-};
+}
 
 FormLabel.propTypes = {
   /**

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -21,16 +21,6 @@ $input-label-weight: 400 !default;
 @mixin form {
   .#{$prefix}--fieldset {
     @include reset;
-
-    @if not enabled('enable-v11-release') {
-      margin-bottom: $spacing-07;
-    }
-  }
-
-  @if not enabled('enable-v11-release') {
-    .#{$prefix}--fieldset--no-margin {
-      margin-bottom: 0;
-    }
   }
 
   .#{$prefix}--form-item {

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -50,17 +50,10 @@ $input-label-weight: 400 !default;
     @include type-style('label-01');
 
     display: inline-block;
-    margin-bottom: $spacing-03;
     color: $text-secondary;
     font-weight: $input-label-weight;
     line-height: 1rem;
     vertical-align: baseline;
-  }
-
-  @if enabled('enable-v11-release') {
-    .#{$prefix}--label--no-margin {
-      margin-bottom: 0;
-    }
   }
 
   .#{$prefix}--label .#{$prefix}--tooltip__trigger {

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -40,10 +40,15 @@ $input-label-weight: 400 !default;
     @include type-style('label-01');
 
     display: inline-block;
+    margin-bottom: $spacing-03;
     color: $text-secondary;
     font-weight: $input-label-weight;
     line-height: 1rem;
     vertical-align: baseline;
+  }
+
+  .#{$prefix}--label--no-margin {
+    margin-bottom: 0;
   }
 
   .#{$prefix}--label .#{$prefix}--tooltip__trigger {


### PR DESCRIPTION
Noticed that `FormLabel` was un-styled in v11. This PR removes the `enable-v11-release` flag check so that `${prefix}--label` isn't conditionally applied and updates `@carbon/styles` to make margin-bottom: 0 the default for `FormLabel` in v11. 

#### Changelog

**Changed**

- Minor code style updates

**Removed** 
 
- Unnecessary v11 flag checks in `_form.scss` 


#### Testing / Reviewing

Check that v10 FormLabel looks the same, with margin still applied. 

Verify that v11 FormLabel is now styled and has no margin-bottom.
