### PR TITLE
fix(FlexGrid): scope styles to FlexGrid story

### DIFF
--- a/packages/react/src/components/Grid/next/FlexGrid.stories.scss
+++ b/packages/react/src/components/Grid/next/FlexGrid.stories.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/colors' as *;
 
 // base of project work area
-#root > div:first-child > div:first-child {
+#root > #templates > div:first-child {
   width: 100%;
 }
 


### PR DESCRIPTION
The issue surfaced in Slack. Scopes the `FlexGrid` story scss to the Flex Grid examples

#### Changelog

**Changed**

- changed from `:first-child` selector to the `FlexGrid` story `id` selector

#### Testing / Reviewing

Check `FlexGrid` and ensure all stories render correctly
Check `Search` and see if component renders correctly 
