### PR TITLE
chore(storybook): update fast-sass-loader path

### DIFF
--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -112,7 +112,10 @@ module.exports = {
           );
         `,
         implementation: require('sass'),
-        includePaths: [path.resolve(__dirname, '..', '..', 'node_modules')],
+        includePaths: [
+          path.resolve(__dirname, '..', 'node_modules'),
+          path.resolve(__dirname, '..', '..', '..', 'node_modules'),
+        ],
         sourceMap: true,
       },
     };


### PR DESCRIPTION
Fixes an issue with the v10 storybook building locally when using `fast-sass-loader`. This mimics the `includePaths` from the `@carbon/react` storybook config

#### Changelog

**Changed**

- Updated the `includePaths` to match what we have in `@carbon/react` 

#### Testing / Reviewing

Pull down locally and try and run the v10 storybook (`packages/react`)
