### PR TITLE
fix(ui-shell): remove HeaderMenu href prop on menuitem

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -182,26 +182,26 @@ class HeaderMenu extends React.Component {
     });
 
     // Notes on eslint comments and based on the examples in:
-    // https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html#
+    // https://w3c.github.io/aria-practices/examples/menubar/menubar-navigation.html
     // - The focus is handled by the <a> menuitem, onMouseOver is for mouse
     // users
     // - aria-haspopup can definitely have the value "menu"
     // - aria-expanded is on their example node with role="menuitem"
-    // - href can be set to javascript:void(0), ideally this will be a button
     return (
-      <li // eslint-disable-line jsx-a11y/mouse-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+      <li
         {...rest}
         className={className}
         onKeyDown={this.handleMenuClose}
         onClick={this.handleOnClick}
-        onBlur={this.handleOnBlur}>
-        <a // eslint-disable-line jsx-a11y/role-supports-aria-props,jsx-a11y/anchor-is-valid
-          aria-haspopup="menu" // eslint-disable-line jsx-a11y/aria-proptypes
+        onBlur={this.handleOnBlur}
+        role="none">
+        <a
+          aria-haspopup="menu"
           aria-expanded={this.state.expanded}
           className={`${prefix}--header__menu-item ${prefix}--header__menu-title`}
-          href="#"
           onKeyDown={this.handleOnKeyDown}
           ref={this.handleMenuButtonRef}
+          role="menuitem"
           tabIndex={0}
           {...accessibilityLabel}>
           {menuLinkName}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/10946

This PR attempts to address the `href` issue on HeaderMenu's. This is a draft for now while we try and double-check that this makes sense from an accessibility perspective

#### Changelog

**New**

**Changed**

- Update `HeaderMenu` to no longer pass in `href="#"`
- update role of `HeaderMenu`

**Removed**