### PR TITLE
chore(TreeView): updated size props

### DIFF
--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import { keys, match, matches } from '../../internal/keyboard';
 import uniqueId from '../../tools/uniqueId';
+import * as FeatureFlags from '@carbon/feature-flags';
 
 const { prefix } = settings;
 
@@ -23,7 +24,7 @@ export default function TreeView({
   multiselect,
   onSelect,
   selected: preselected = [],
-  size = 'default',
+  size = FeatureFlags.enabled('enable-v11-release') ? 'sm' : 'default',
   ...rest
 }) {
   const { current: treeId } = useRef(rest.id || uniqueId());
@@ -219,5 +220,7 @@ TreeView.propTypes = {
   /**
    * Specify the size of the tree from a list of available sizes.
    */
-  size: PropTypes.oneOf(['default', 'compact']),
+  size: FeatureFlags.enabled('enable-v11-release')
+    ? PropTypes.oneOf(['xs', 'sm'])
+    : PropTypes.oneOf(['default', 'compact']),
 };

--- a/packages/react/src/components/TreeView/next/Treeview.stories.js
+++ b/packages/react/src/components/TreeView/next/Treeview.stories.js
@@ -206,7 +206,8 @@ export default {
 export const Default = (args) => (
   <>
     <InlineNotification kind="info">
-      Experimental component: An accessibility review of this component is in progress
+      Experimental component: An accessibility review of this component is in
+      progress
     </InlineNotification>
     <TreeView {...props()} {...args}>
       {renderTree({ nodes })}

--- a/packages/react/src/components/TreeView/next/Treeview.stories.js
+++ b/packages/react/src/components/TreeView/next/Treeview.stories.js
@@ -192,16 +192,27 @@ function renderTree({ nodes, expanded, withIcons = false }) {
 export default {
   title: 'Experimental/unstable_TreeView',
   component: TreeView,
+  argTypes: {
+    size: {
+      options: ['xs', 'sm'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    size: 'sm',
+  },
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <>
     <InlineNotification
       kind="info"
       title="Experimental component"
       subtitle="An accessibility review of this component is in progress"
     />
-    <TreeView {...props()}>{renderTree({ nodes })}</TreeView>
+    <TreeView {...props()} {...args}>
+      {renderTree({ nodes })}
+    </TreeView>
   </>
 );
 
@@ -212,20 +223,22 @@ Default.parameters = {
   },
 };
 
-export const WithIcons = () => (
+export const WithIcons = (args) => (
   <>
     <InlineNotification
       kind="info"
       title="Experimental component"
       subtitle="An accessibility review of this component is in progress"
     />
-    <TreeView {...props()}>{renderTree({ nodes, withIcons: true })}</TreeView>
+    <TreeView {...props()} {...args}>
+      {renderTree({ nodes, withIcons: true })}
+    </TreeView>
   </>
 );
 
 WithIcons.storyName = 'with icons';
 
-export const WithControlledExpansion = () => {
+export const WithControlledExpansion = (args) => {
   const [expanded, setExpanded] = useState(undefined);
   return (
     <>
@@ -242,7 +255,9 @@ export const WithControlledExpansion = () => {
           collapse all
         </button>
       </div>
-      <TreeView {...props()}>{renderTree({ nodes, expanded })}</TreeView>
+      <TreeView {...props()} {...args}>
+        {renderTree({ nodes, expanded })}
+      </TreeView>
     </>
   );
 };

--- a/packages/react/src/components/TreeView/next/Treeview.stories.js
+++ b/packages/react/src/components/TreeView/next/Treeview.stories.js
@@ -205,11 +205,9 @@ export default {
 
 export const Default = (args) => (
   <>
-    <InlineNotification
-      kind="info"
-      title="Experimental component"
-      subtitle="An accessibility review of this component is in progress"
-    />
+    <InlineNotification kind="info">
+      Experimental component: An accessibility review of this component is in progress
+    </InlineNotification>
     <TreeView {...props()} {...args}>
       {renderTree({ nodes })}
     </TreeView>

--- a/packages/styles/scss/components/treeview/_treeview.scss
+++ b/packages/styles/scss/components/treeview/_treeview.scss
@@ -171,7 +171,7 @@
     }
   }
 
-  .#{$prefix}--tree--compact .#{$prefix}--tree-node__label {
+  .#{$prefix}--tree--xs .#{$prefix}--tree-node__label {
     min-height: rem(24px);
   }
 }


### PR DESCRIPTION
REF #10295 

- Added FeatureFlag for `size` prop to only accept `xs` and `sm`
- Added FeatureFlag for `sm` as a default for the `size` prop.
- Added Controls functionality to Storybook story.
- Changed `compact` to `xs` in styles.

<img width="952" alt="image" src="https://user-images.githubusercontent.com/15822070/157959794-99750b3c-1287-46e8-a018-4f98e43295cd.png">


#### Testing
- Make sure everything is snappy in the v11 Storybook. Size controls should allow for `xs` and `sm`