### PR TITLE
chore(Pagination): updated size prop for v11

### DIFF
--- a/packages/react/src/components/Pagination/next/Pagination.js
+++ b/packages/react/src/components/Pagination/next/Pagination.js
@@ -69,7 +69,7 @@ const Pagination = React.forwardRef(function Pagination(
     pageSizes: controlledPageSizes,
     pageText = (page) => `page ${page}`,
     pagesUnknown = false,
-    size,
+    size = 'md',
     totalItems,
     ...rest
   },
@@ -377,7 +377,7 @@ Pagination.propTypes = {
   pagesUnknown: PropTypes.bool,
 
   /**
-   * Specify the size of the Pagination. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
+   * Specify the size of the Pagination.
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
 

--- a/packages/react/src/components/Pagination/next/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/next/Pagination.stories.js
@@ -13,21 +13,13 @@ import {
   array,
   boolean,
   number,
-  select,
   text,
 } from '@storybook/addon-knobs';
 import Pagination from './Pagination';
 import mdx from '../Pagination.mdx';
 
-const sizes = {
-  'Small  (sm)': 'sm',
-  'Medium (md) - default': undefined,
-  'Large  (lg)': 'lg',
-};
-
 const props = () => ({
   disabled: boolean('Disable page inputs (disabled)', false),
-  size: select('Size (size)', sizes, undefined) || undefined,
   page: number('The current page (page)', 1),
   totalItems: number('Total number of items (totalItems)', 103),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
@@ -59,6 +51,15 @@ const props = () => ({
 export default {
   title: 'Components/Pagination',
   component: Pagination,
+  argTypes: {
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    size: 'md',
+  },
   decorators: [
     withKnobs,
     (story) => <div style={{ maxWidth: '800px' }}>{story()}</div>,
@@ -70,7 +71,7 @@ export default {
   },
 };
 
-export const _Pagination = () => <Pagination {...props()} />;
+export const _Pagination = (args) => <Pagination {...props()} {...args} />;
 
 _Pagination.parameters = {
   info: {
@@ -80,11 +81,11 @@ _Pagination.parameters = {
   },
 };
 
-export const MultiplePaginationComponents = () => {
+export const MultiplePaginationComponents = (args) => {
   return (
     <div>
-      <Pagination {...props()} />
-      <Pagination {...props()} />
+      <Pagination {...props()} {...args} />
+      <Pagination {...props()} {...args} />
     </div>
   );
 };
@@ -97,7 +98,7 @@ MultiplePaginationComponents.parameters = {
   },
 };
 
-export const PaginationWithCustomPageSizesLabel = () => {
+export const PaginationWithCustomPageSizesLabel = (args) => {
   return (
     <div>
       <Pagination
@@ -109,6 +110,7 @@ export const PaginationWithCustomPageSizesLabel = () => {
           { text: 'Forty', value: 40 },
           { text: 'Fifty', value: 50 },
         ]}
+        {...args}
       />
     </div>
   );


### PR DESCRIPTION
REF #10295 

- Added `md` as a default for the `size` prop.
- Added Controls functionality to Storybook story.

#### Testing
- Make sure everything is snappy in the v11 Storybook. Size controls should allow for `sm`,`md`, `lg`. 