### PR TITLE
chore(ci): add applicable workflows for v10 branch

### DIFF
--- a/.github/workflows/add-review-labels.yml
+++ b/.github/workflows/add-review-labels.yml
@@ -1,0 +1,11 @@
+name: Add Review Labels
+on: pull_request_review
+jobs:
+  reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ./actions/add-review-labels
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTO_LABEL_USERS: 'asudoh,emyarod,tw15egan'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,30 @@
+name: 'codeql'
+
+on:
+  push:
+    branches: [main, v10]
+  pull_request:
+    branches: [main, v10]
+  schedule:
+    - cron: '0 12 * * 1'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: javascript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,31 @@
+name: "DCO Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "DCO Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO document and I hereby sign the DCO.') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.1.3-beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: "dco-signatures.json"
+          path-to-document: "https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md"
+          branch: "main"
+          allowlist: bot*
+          remote-organization-name: carbon-design-system
+          remote-repository-name: carbon-dco
+          create-file-commit-message: "chore: create file to store dco signatures"
+          signed-commit-message: "chore: $contributorName has signed the dco in #$pullRequestNo"
+          custom-notsigned-prcomment: "Thanks for your submission! We ask that $you sign our [Developer Certificate of Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md) before we can accept your contribution. You can sign the DCO by adding a comment below using this text:"
+          custom-pr-sign-comment: "I have read the DCO document and I hereby sign the DCO."
+          custom-allsigned-prcomment: "All contributors have signed the DCO."
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: true

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,31 +1,47 @@
-name: "DCO Assistant"
+name: 'DCO Assistant'
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types:
+      - opened
+      - closed
+      - synchronize
+    branches:
+      - 'v10'
 
 jobs:
   DCO:
     runs-on: ubuntu-latest
     steps:
-      - name: "DCO Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO document and I hereby sign the DCO.') || github.event_name == 'pull_request_target'
+      - name: 'DCO Assistant'
+        if:
+          (github.event.comment.body == 'recheck' || github.event.comment.body
+          == 'I have read the DCO document and I hereby sign the DCO.') ||
+          github.event_name == 'pull_request_target'
         uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-signatures: "dco-signatures.json"
-          path-to-document: "https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md"
-          branch: "main"
+          path-to-signatures: 'dco-signatures.json'
+          path-to-document: 'https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md'
+          branch: 'main'
           allowlist: bot*
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-dco
-          create-file-commit-message: "chore: create file to store dco signatures"
-          signed-commit-message: "chore: $contributorName has signed the dco in #$pullRequestNo"
-          custom-notsigned-prcomment: "Thanks for your submission! We ask that $you sign our [Developer Certificate of Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md) before we can accept your contribution. You can sign the DCO by adding a comment below using this text:"
-          custom-pr-sign-comment: "I have read the DCO document and I hereby sign the DCO."
-          custom-allsigned-prcomment: "All contributors have signed the DCO."
+          create-file-commit-message:
+            'chore: create file to store dco signatures'
+          signed-commit-message:
+            'chore: $contributorName has signed the dco in #$pullRequestNo'
+          custom-notsigned-prcomment:
+            'Thanks for your submission! We ask that $you sign our [Developer
+            Certificate of
+            Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md)
+            before we can accept your contribution. You can sign the DCO by
+            adding a comment below using this text:'
+          custom-pr-sign-comment:
+            'I have read the DCO document and I hereby sign the DCO.'
+          custom-allsigned-prcomment: 'All contributors have signed the DCO.'
           lock-pullrequest-aftermerge: false
           use-dco-flag: true

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,15 @@
+name: Issue Triage
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ./actions/issues
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          enabled: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: stale
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          any-of-issue-labels:
+            "status: waiting for author's response 💬,status: needs more info 🤷‍♀️"
+          only-pr-labels: ''
+          stale-issue-message: |
+            This issue has been marked as stale because it has required additional
+            info or a response from the author for over 7 days. When you get the
+            chance, please comment with the additional info requested.
+            Otherwise, this issue will be closed in 7 days.
+          close-issue-message: |
+            This issue has been closed because it has received no activity for
+            14 days.
+          stale-issue-label: 'status: stale 🍞'
+          days-before-stale: 7
+          days-before-close: 7
+          debug-only: true

--- a/.github/workflows/v10-ci.yml
+++ b/.github/workflows/v10-ci.yml
@@ -1,0 +1,122 @@
+name: v10 - ci
+on:
+  push:
+    branches:
+      - v10
+  pull_request:
+    branches:
+      - v10
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Run yarn dedupe
+        run: yarn dedupe --check
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Check formatting of project files
+        run: yarn format:diff
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Lint JavaScript files
+        run: yarn lint
+      - name: Lint Sass files
+        run: yarn lint:styles
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - uses: actions/cache@v2.1.7
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Build project
+        run: yarn build --ignore '@carbon/sketch'
+      - name: Check generated styles
+        run: |
+          yarn carbon-cli check --ignore '**/@(node_modules|examples|components|react|fixtures|compat)/**' 'packages/**/*.scss'
+      - name: Run tests
+        run: yarn test --ci
+
+  e2e:
+    name: 'test:e2e'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - uses: actions/cache@v2.1.7
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - uses: dorny/paths-filter@v2.10.2
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'e2e/**'
+              - 'packages/icons/**'
+              - 'packages/icons-react/**'
+              - 'packages/icons-vue/**'
+              - 'packages/pictograms/**'
+              - 'packages/pictograms-react/**'
+              - 'packages/icon-build-helpers/**'
+      - name: Build project
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
+        run: yarn build --ignore '@carbon/sketch'
+      - name: Run e2e tests
+        if: ${{ steps.filter.outputs.e2e == 'true' }}
+        run: yarn test:e2e

--- a/.github/workflows/v10-deploy-react-storybook.yml
+++ b/.github/workflows/v10-deploy-react-storybook.yml
@@ -1,0 +1,52 @@
+name: v10 - Deploy React storybook to IBM Cloud
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      # Matches tags that have the shape `v10.Y.Z`. Reference:
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
+      - 'v10.[0-9]+.[0-9]+'
+
+      # Ignore tags that use a preid after `vX.Y.Z`, for example: vX.Y.Z-alpha.0
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns
+      - '!v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: Build project
+        run: yarn build
+      - name: Install ibmcloud CLI
+        run: curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
+      - name: Login to IBM Cloud
+        env:
+          CLOUD_API_KEY: ${{ secrets.CLOUD_API_KEY}}
+        run: |
+          ibmcloud login \
+            -a 'https://cloud.ibm.com' \
+            --apikey "$CLOUD_API_KEY" \
+            -r 'us-south'
+          ibmcloud target -o 'carbon-design-system' -s 'production'
+      - name: Install IBM Cloud plugins
+        run: |
+          ibmcloud cf install
+          ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+          ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
+      - name: Deploy React storybook
+        run: |
+          cd packages/react
+          yarn build-storybook
+          ibmcloud cf blue-green-deploy carbon-storybook \
+            -f manifest.yml \
+            --delete-old-apps

--- a/.github/workflows/v10-release.yml
+++ b/.github/workflows/v10-release.yml
@@ -1,0 +1,63 @@
+name: v10 - Release
+
+on:
+  push:
+    tags:
+      # Push events to matching v10*, i.e. v10.55.0, v10.55.1
+      - 'v10*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v10
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Build project
+        run: yarn build
+
+      - name: Run Continuous Integration checks
+        run: yarn ci-check
+
+      - name: Publish packages under the `next` dist tag
+        run: yarn lerna publish from-package --dist-tag next --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Prepare artifacts for release
+        run: |
+          zip -r --junk-paths carbon-elements.sketchplugin.zip packages/sketch/carbon-elements.sketchplugin
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./carbon-elements.sketchplugin.zip
+          asset_name: carbon-elements.sketchplugin.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Ref #10879 

This mirrors the applicable workflows over from the `main` branch in https://github.com/carbon-design-system/carbon/pull/11013 into the `v10` branch.

Workflows weren't being triggered on PRs aiming to be merged into `v10`. From the [docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#about-workflow-triggers), it sounds like we have to have the workflows in the default branch (`main`) in order for them to trigger.

#### Changelog

**New**

- mirror applicable workflows to the `v10` branch from `main`

#### Testing / Reviewing

* I don't think there's a clear way to test these unfortunately until they're actually in `v10`