### PR TITLE
fix(tabs): left align tab text in both contained and line tabs

### DIFF
--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -283,6 +283,7 @@ $icon-tab-size: custom-property.get-var('icon-tab-size', rem(40px));
       padding: $spacing-04 $spacing-05 $spacing-03;
       border-bottom: $tab-underline-color;
       color: $text-secondary;
+      text-align: left;
       text-decoration: none;
       text-overflow: ellipsis;
       transition: border $duration-fast-01 motion(standard, productive),
@@ -301,7 +302,6 @@ $icon-tab-size: custom-property.get-var('icon-tab-size', rem(40px));
       border-bottom: 0;
       // height - vertical padding
       line-height: calc(#{rem(48px)} - (#{$spacing-03} * 2));
-      text-align: left;
     }
 
     //-----------------------------


### PR DESCRIPTION
Surfaced in [slack](https://ibm-studios.slack.com/archives/GD8JG6JR3/p1647871328075859) - Corrects a minor error where line (default) tab text wasn't staying left aligned.

#### Changelog

**Changed**

- use `text-align: left` for both line and contained tabs

#### Testing / Reviewing

- View the carbon-react-next storybook
- Go to line (default) tabs story
- Change the container width to be 100% and verify that the tab text stays left aligned
- Do the same for contained tabs story