### PR TITLE
feat(upgrade): refactor jscodeshift usage and migrations path

### DIFF
--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -40,11 +40,12 @@
     "change-case": "^4.1.2",
     "esbuild": "^0.14.10",
     "execa": "^5.1.1",
-    "fast-glob": "^3.2.7",
+    "fast-glob": "^3.2.11",
     "fs-extra": "^10.0.0",
     "inquirer": "^8.1.0",
     "is-git-clean": "^1.1.0",
     "jest-diff": "^27.4.6",
+    "jscodeshift": "^0.13.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "memfs": "^3.4.0",
@@ -53,8 +54,5 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "yargs": "^17.0.1"
-  },
-  "dependencies": {
-    "jscodeshift": "^0.13.1"
   }
 }

--- a/packages/upgrade/src/cli.js
+++ b/packages/upgrade/src/cli.js
@@ -60,7 +60,7 @@ export async function main({ argv, cwd }) {
   );
 
   cli.command(
-    'migrate <migration>',
+    'migrate <migration> [paths...]',
     'run a Carbon migration on your source files',
     async (cli) => {
       cli.command(
@@ -75,12 +75,13 @@ export async function main({ argv, cwd }) {
       );
     },
     run(async (args) => {
-      const { verbose, migration, write } = args;
+      const { verbose, migration, write, paths } = args;
       const options = {
         cwd: cwd(),
         verbose,
         write,
         migration,
+        paths,
       };
       await migrate(options, upgrades);
     })

--- a/packages/upgrade/src/jscodeshift.js
+++ b/packages/upgrade/src/jscodeshift.js
@@ -5,56 +5,63 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import execa from 'execa';
-
-let _jscodeshift;
-
-function getBinPath() {
-  if (!_jscodeshift) {
-    const directory = path.dirname(require.resolve('jscodeshift'));
-    _jscodeshift = path.join(directory, 'bin', 'jscodeshift.js');
-  }
-  return _jscodeshift;
-}
+import * as Runner from 'jscodeshift/src/Runner';
 
 export async function run(options) {
   const {
-    cwd,
-    stdio = 'inherit',
-    parser = 'babel',
+    dry,
+    parser = 'babylon',
     paths,
+    print = dry,
     transform,
+    verbose,
   } = options;
-  const args = [
-    paths,
-    `-t=${transform}`,
-    `--parser=${parser}`,
-    `--ignore-pattern=**/build/**`,
-    `--ignore-pattern=**/dist/**`,
-    `--ignore-pattern=**/es/**`,
-    `--ignore-pattern=**/lib/**`,
-    `--ignore-pattern=**/node_modules/**`,
-    `--ignore-pattern=**/storybook-static/**`,
-    `--ignore-pattern=**/umd/**`,
-  ];
-
-  if (options.print) {
-    args.push('--print');
-  }
-
-  if (options.verbose) {
-    args.push('-v');
-  }
-
-  if (options.dry) {
-    args.push('--dry');
-  }
-
-  console.log(args);
-
-  return await execa(getBinPath(), args, {
-    cwd,
-    stdio,
+  await Runner.run(transform, paths, {
+    dry,
+    parser,
+    parserConfig: {
+      sourceType: 'module',
+      allowHashBang: true,
+      ecmaVersion: Infinity,
+      allowImportExportEverywhere: true,
+      allowReturnOutsideFunction: true,
+      startLine: 1,
+      tokens: true,
+      plugins: [
+        'estree',
+        'jsx',
+        'typescript',
+        'asyncGenerators',
+        'classProperties',
+        'doExpressions',
+        'exportDefaultFrom',
+        'exportExtensions',
+        'functionBind',
+        'functionSent',
+        'objectRestSpread',
+        'dynamicImport',
+        'nullishCoalescingOperator',
+        'optionalChaining',
+        ['decorators', { decoratorsBeforeExport: false }],
+      ],
+    },
+    print,
+    ignorePattern: [
+      '**/build/**',
+      '**/dist/**',
+      '**/es/**',
+      '**/lib/**',
+      '**/node_modules/**',
+      '**/storybook-static/**',
+      '**/umd/**',
+      '*.md',
+      '*.mdx',
+      '*.css',
+      '*.scss',
+      '.DS_Store',
+      '.gitignore',
+      'yarn.lock',
+    ],
+    verbose: verbose === true ? 2 : 0,
   });
 }

--- a/packages/upgrade/src/upgrades.js
+++ b/packages/upgrade/src/upgrades.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import glob from 'fast-glob';
 import path from 'path';
 import { run } from './jscodeshift';
 
@@ -146,17 +147,31 @@ export const upgrades = [
     migrations: [
       {
         name: 'icons-react-size-prop',
-        description: 'Update imports and size usage for @carbon/icons',
+        description: 'Update imports and size usage for @carbon/icons-react',
         migrate: async (options) => {
           const transform = path.join(
             TRANSFORM_DIR,
             'icons-react-size-prop.js'
           );
+          const paths =
+            Array.isArray(options.paths) && options.paths.length > 0
+              ? options.paths
+              : await glob(['**/*.js', '**/*.jsx'], {
+                  cwd: options.workspaceDir,
+                  ignore: [
+                    '**/es/**',
+                    '**/lib/**',
+                    '**/umd/**',
+                    '**/node_modules/**',
+                    '**/storybook-static/**',
+                  ],
+                });
+
           await run({
-            transform: transform,
-            paths: options.workspaceDir,
             dry: !options.write,
-            ...options,
+            transform,
+            paths,
+            verbose: options.verbose,
           });
         },
       },
@@ -169,11 +184,25 @@ export const upgrades = [
             TRANSFORM_DIR,
             'update-carbon-components-react-import-to-scoped.js'
           );
+          const paths =
+            Array.isArray(options.paths) && options.paths.length > 0
+              ? options.paths
+              : await glob(['**/*.js', '**/*.jsx'], {
+                  cwd: options.workspaceDir,
+                  ignore: [
+                    '**/es/**',
+                    '**/lib/**',
+                    '**/umd/**',
+                    '**/node_modules/**',
+                    '**/storybook-static/**',
+                  ],
+                });
+
           await run({
-            transform: transform,
-            paths: options.workspaceDir,
             dry: !options.write,
-            ...options,
+            transform,
+            paths,
+            verbose: options.verbose,
           });
         },
       },

--- a/packages/upgrade/transforms/update-carbon-components-react-import-to-scoped.js
+++ b/packages/upgrade/transforms/update-carbon-components-react-import-to-scoped.js
@@ -15,9 +15,7 @@
  * import { Button } from "@carbon/react";
  */
 
-export const parser = 'babel';
-
-export default function transformer(file, api) {
+function transformer(file, api) {
   const j = api.jscodeshift;
 
   return j(file.source)
@@ -31,3 +29,5 @@ export default function transformer(file, api) {
     })
     .toSource();
 }
+
+module.exports = transformer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,7 +2194,7 @@ __metadata:
     change-case: ^4.1.2
     esbuild: ^0.14.10
     execa: ^5.1.1
-    fast-glob: ^3.2.7
+    fast-glob: ^3.2.11
     fs-extra: ^10.0.0
     inquirer: ^8.1.0
     is-git-clean: ^1.1.0


### PR DESCRIPTION
This PR updates our upgrade CLI by:

- Updating how we run jscodeshift by using it's JS-based runner API
- Updating our migrate command to:
  - Allow passing in custom paths for better filtering
- Updating our migrations to:
  - Support the correct options for the Runner API from jscodeshift
  - Determine relevant JS paths from a workspace instead of globbing on all files in a workspace

#### Changelog

**New**

**Changed**

- Update jscodeshift to use their Runner API
- Update our import codemod to CommonJS syntax to avoid parser errors
- Update how paths are passed to jscodeshift to glob on JS or JSX files from the workspace directory
- Provide a way to customize the paths passed to a migration

**Removed**

#### Testing / Reviewing

- Run `yarn build` in `packages/upgrade`
- Using the sample project in the fixtures directory:
  - Run the default upgrade command: `../../bin/carbon-upgrade.js`
  - Choose the sample-project directory
  - Choose the default path
  - Verify no errors occur and that changes are printed to the console (in this case import changes)
  - Run the migration command: `../../bin/carbon-upgrade.js migrate update-carbon-components-react-import-to-scoped`
  - Choose the sample-project directory
  - Verify no errors occur and that changes are printed to the console