### PR TITLE
fix(UIShellHeader): update action buttons to use TooltipIcon

### DIFF
--- a/packages/react/src/components/UIShell/HeaderGlobalAction.js
+++ b/packages/react/src/components/UIShell/HeaderGlobalAction.js
@@ -9,7 +9,7 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-import Button from '../Button';
+import TooltipIcon from '../TooltipIcon';
 import { usePrefix } from '../../internal/usePrefix';
 
 /**
@@ -44,19 +44,17 @@ const HeaderGlobalAction = React.forwardRef(function HeaderGlobalAction(
     'aria-labelledby': ariaLabelledBy,
   };
   return (
-    <Button
+    <TooltipIcon
       {...rest}
       {...accessibilityLabel}
-      className={className}
+      tooltipText={ariaLabel}
       onClick={onClick}
-      type="button"
-      hasIconOnly
-      iconDescription={ariaLabel}
-      tooltipPosition="bottom"
-      tooltipAlignment={tooltipAlignment}
+      className={className}
+      direction="bottom"
+      alignment={tooltipAlignment}
       ref={ref}>
       {children}
-    </Button>
+    </TooltipIcon>
   );
 });
 

--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -36,7 +36,6 @@
   .#{$prefix}--header__action {
     @include button-reset.reset();
 
-    display: inline-flex;
     width: mini-units(6);
     height: mini-units(6);
     border: rem(1px) solid transparent;


### PR DESCRIPTION
partially closes #10717 

updates uishell header action buttons and switcher to use TooltipIcon component. also updates styling so the icons sit right in the new component