### PR TITLE
docs: update storybook docs

### DIFF
--- a/packages/react/src/components/Accordion/next/Accordion.stories.js
+++ b/packages/react/src/components/Accordion/next/Accordion.stories.js
@@ -8,21 +8,7 @@
 /* eslint-disable no-console */
 
 import React from 'react';
-import { action } from '@storybook/addon-actions';
-import {
-  withKnobs,
-  boolean,
-  number,
-  select,
-  text,
-} from '@storybook/addon-knobs';
-import {
-  default as Accordion,
-  AccordionItem,
-  AccordionSkeleton,
-} from '../../Accordion';
-import Button from '../../Button';
-import mdx from '../Accordion.mdx';
+import { default as Accordion, AccordionItem, AccordionSkeleton } from '../';
 
 export default {
   title: 'Components/Accordion',
@@ -31,16 +17,22 @@ export default {
     AccordionItem,
     AccordionSkeleton,
   },
-  decorators: [withKnobs],
-  parameters: {
-    docs: {
-      page: mdx,
+  argTypes: {
+    children: {
+      control: false,
+    },
+    className: {
+      control: false,
+    },
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'select' },
     },
   },
 };
 
-export const AccordionStory = () => (
-  <Accordion>
+export const AccordionStory = (args) => (
+  <Accordion {...args}>
     <AccordionItem title="Section 1 title">
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -79,85 +71,3 @@ export const AccordionStory = () => (
 AccordionStory.storyName = 'Accordion';
 
 export const Skeleton = () => <AccordionSkeleton open count={4} />;
-
-Skeleton.decorators = [
-  (story) => <div style={{ width: '500px' }}>{story()}</div>,
-];
-
-const props = {
-  onClick: action('onClick'),
-  onHeadingClick: action('onHeadingClick'),
-};
-
-const sizes = {
-  'Small  (sm)': 'sm',
-  'Medium (md) - default': undefined,
-  'Large  (lg)': 'lg',
-};
-
-export const Playground = () => (
-  <Accordion
-    disabled={boolean('Disable entire Accordion (disabled)', false)}
-    size={
-      select('Accordion heading size (size)', sizes, undefined) || undefined
-    }
-    align={select(
-      'Accordion heading alignment (align)',
-      ['start', 'end'],
-      'end'
-    )}>
-    <AccordionItem
-      title={text('The title (title)', 'Section 1 title')}
-      open={boolean('Open the section (open)', false)}
-      {...props}>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-      </p>
-    </AccordionItem>
-    <AccordionItem title="Section 2 title" {...props}>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-      </p>
-    </AccordionItem>
-    <AccordionItem
-      title="Section 3 title"
-      {...props}
-      disabled={boolean('Disable Section 3 (disabled)', true)}>
-      <Button>This is a button.</Button>
-    </AccordionItem>
-    <AccordionItem
-      title={
-        <span>
-          Section 4 title (<em>the title can be a node</em>)
-        </span>
-      }
-      {...props}>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-      </p>
-    </AccordionItem>
-  </Accordion>
-);
-
-export const SkeletonPlayground = () => (
-  <div style={{ width: '500px' }}>
-    <AccordionSkeleton
-      align={select(
-        'Accordion heading alignment (align)',
-        ['start', 'end'],
-        'end'
-      )}
-      open={boolean('Show first item opened (open)', true)}
-      count={number('Set number of items (count)', 4)}
-    />
-  </div>
-);

--- a/packages/react/src/components/AspectRatio/next/AspectRatio.stories.js
+++ b/packages/react/src/components/AspectRatio/next/AspectRatio.stories.js
@@ -10,7 +10,6 @@ import '../AspectRatio-story.scss';
 import React from 'react';
 import { Grid, Column } from '../../Grid';
 import { AspectRatio } from '../';
-import mdx from '../AspectRatio.mdx';
 
 export default {
   title: 'Components/AspectRatio',
@@ -22,11 +21,6 @@ export default {
       </div>
     ),
   ],
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
 };
 
 export const AspectRatioStory = () => {

--- a/packages/react/src/components/FileUploader/next/FileUploader.stories.js
+++ b/packages/react/src/components/FileUploader/next/FileUploader.stories.js
@@ -17,7 +17,6 @@ import {
   FileUploaderItem,
   FileUploaderSkeleton,
 } from '../';
-import mdx from './FileUploader.mdx';
 import './FileUploader-story.scss';
 
 const filenameStatuses = ['edit', 'complete', 'uploading'];
@@ -31,11 +30,6 @@ export default {
     FileUploaderItem,
     FileUploaderDropContainer,
   },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
 };
 
 export const _FileUploader = (args) => {
@@ -47,6 +41,7 @@ export const _FileUploader = (args) => {
     </div>
   );
 };
+
 _FileUploader.args = {
   labelTitle: 'Upload files',
   labelDescription: 'Max file size is 500mb. Only .jpg files are supported.',

--- a/packages/react/src/components/Grid/next/FlexGrid.stories.js
+++ b/packages/react/src/components/Grid/next/FlexGrid.stories.js
@@ -1,7 +1,6 @@
 import './FlexGrid.stories.scss';
 import React from 'react';
 import { FlexGrid, Row, Column } from '../';
-import mdx from './FlexGrid.mdx';
 
 export default {
   title: 'Components/FlexGrid',
@@ -11,11 +10,6 @@ export default {
     Column,
   },
   decorators: [(storyFn) => <div id="templates">{storyFn()}</div>],
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
 };
 
 function DemoContent({ children }) {

--- a/packages/react/src/components/Grid/next/Grid.stories.js
+++ b/packages/react/src/components/Grid/next/Grid.stories.js
@@ -8,8 +8,7 @@
 import './Grid.stories.scss';
 
 import React from 'react';
-import { Grid, Column, ColumnHang } from '../../Grid';
-import mdx from './Grid.mdx';
+import { Grid, Column, ColumnHang } from '../';
 
 export default {
   title: 'Elements/Grid',
@@ -20,9 +19,6 @@ export default {
   parameters: {
     controls: {
       hideNoControlsWarning: true,
-    },
-    docs: {
-      page: mdx,
     },
   },
   decorators: [

--- a/packages/react/src/components/OverflowMenu/next/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/next/OverflowMenu.stories.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import OverflowMenu from '../OverflowMenu';
 import OverflowMenuItem from '../../OverflowMenuItem';
-import mdx from '../OverflowMenu.mdx';
 import { Filter } from '@carbon/icons-react';
 
 export default {
@@ -25,11 +24,6 @@ export default {
   },
   subcomponents: {
     OverflowMenuItem,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
   },
 };
 

--- a/packages/react/src/components/Popover/next/Popover.stories.js
+++ b/packages/react/src/components/Popover/next/Popover.stories.js
@@ -9,7 +9,6 @@ import './story.scss';
 import { Checkbox } from '@carbon/icons-react';
 import React from 'react';
 import { Popover, PopoverContent } from '../../Popover';
-import mdx from './Popover.mdx';
 
 export default {
   title: 'Components/Popover',
@@ -42,9 +41,6 @@ export default {
   parameters: {
     controls: {
       hideNoControlsWarning: true,
-    },
-    docs: {
-      page: mdx,
     },
   },
 };

--- a/packages/react/src/components/StructuredList/next/StructuredList.stories.js
+++ b/packages/react/src/components/StructuredList/next/StructuredList.stories.js
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { CheckmarkFilled } from '@carbon/icons-react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
 
 import {
   StructuredListWrapper,
@@ -18,30 +17,18 @@ import {
   StructuredListCell,
   StructuredListSkeleton,
 } from '../../StructuredList';
-import mdx from './StructuredList.mdx';
 
 const prefix = 'cds';
-
-const props = () => ({
-  isCondensed: boolean('Condensed', false),
-  isFlush: boolean('Flush alignment', false),
-});
 
 export default {
   title: 'Components/StructuredList',
   component: StructuredListWrapper,
-  decorators: [withKnobs],
   subcomponents: {
     StructuredListHead,
     StructuredListBody,
     StructuredListRow,
     StructuredListInput,
     StructuredListCell,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
   },
 };
 
@@ -88,7 +75,7 @@ Simple.parameters = {
 };
 
 export const Playground = () => (
-  <StructuredListWrapper {...props()}>
+  <StructuredListWrapper>
     <StructuredListHead>
       <StructuredListRow head>
         <StructuredListCell head>ColumnA</StructuredListCell>
@@ -159,7 +146,7 @@ export const Selection = () => {
     ));
   };
   return (
-    <StructuredListWrapper selection {...props()}>
+    <StructuredListWrapper selection>
       <StructuredListHead>
         <StructuredListRow head>
           <StructuredListCell head>ColumnA</StructuredListCell>

--- a/packages/react/src/components/TextInput/next/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/next/TextInput.stories.js
@@ -9,7 +9,6 @@ import React from 'react';
 import FluidForm from '../../FluidForm';
 import { default as TextInput, TextInputSkeleton } from '../../TextInput';
 import { Layer } from '../../Layer';
-import mdx from './TextInput.mdx';
 
 export default {
   title: 'Components/TextInput',
@@ -17,11 +16,6 @@ export default {
   subcomponents: {
     TextInputSkeleton,
     'TextInput.PasswordInput': TextInput.PasswordInput,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
   },
 };
 

--- a/packages/react/src/components/TimePicker/next/TimePicker.stories.js
+++ b/packages/react/src/components/TimePicker/next/TimePicker.stories.js
@@ -11,46 +11,6 @@ import TimePicker from '../';
 import TimePickerSelect from '../../TimePickerSelect';
 import { Layer } from '../../Layer';
 
-// const props = {
-//   timepicker: () => ({
-//     pattern: text(
-//       'Regular expression for the value (pattern in <TimePicker>)',
-//       '(1[012]|[1-9]):[0-5][0-9](\\s)?'
-//     ),
-//     placeholder: text(
-//       'Placeholder text (placeholder in <TimePicker>)',
-//       'hh:mm'
-//     ),
-//     disabled: boolean('Disabled (disabled in <TimePicker>)', false),
-//     light: boolean('Light variant (light in <TimePicker>)', false),
-//     labelText: text('Label text (labelText in <TimePicker>)', 'Select a time'),
-//     invalid: boolean(
-//       'Show form validation UI (invalid in <TimePicker>)',
-//       false
-//     ),
-//     invalidText: text(
-//       'Form validation UI content (invalidText in <TimePicker>)',
-//       'A valid value is required'
-//     ),
-//     maxLength: number('Maximum length (maxLength in <TimePicker>)', 5),
-//     size: select('Field size (size)', sizes, undefined) || undefined,
-//     onClick: action('onClick'),
-//     onChange: action('onChange'),
-//     onBlur: action('onBlur'),
-//   }),
-//   select: () => ({
-//     disabled: boolean('Disabled (disabled in <TimePickerSelect>)', false),
-//     labelText: text(
-//       'Label text (labelText in <TimePickerSelect>)',
-//       'Please select'
-//     ),
-//     iconDescription: text(
-//       'Trigger icon description (iconDescription in <TimePickerSelect>)',
-//       'open list of options'
-//     ),
-//   }),
-// };
-
 export default {
   title: 'Components/TimePicker',
   component: TimePicker,

--- a/packages/react/src/components/Toggletip/next/Toggletip.stories.js
+++ b/packages/react/src/components/Toggletip/next/Toggletip.stories.js
@@ -15,8 +15,7 @@ import {
   ToggletipButton,
   ToggletipContent,
   ToggletipActions,
-} from '../../Toggletip';
-import mdx from './Toggletip.mdx';
+} from '../';
 
 export default {
   title: 'Components/Toggletip',
@@ -40,11 +39,6 @@ export default {
       table: {
         disable: true,
       },
-    },
-  },
-  parameters: {
-    docs: {
-      page: mdx,
     },
   },
 };


### PR DESCRIPTION
References #11097 
Couldn't figure these remaining ones out.

Updating storybook docs for some components that weren't showing previews.

#### Changelog

**New**

- {{new thing}}

**Changed**

- Removing the .mdx is what helped the missing stories show up. 

- https://storybook.js.org/docs/react/writing-docs/mdx I found that the way mdx are used in storybook has changed. We would need to revamp that if we would like to use it. Unless I am misunderstanding the issue with them. 


#### Testing / Reviewing

Please make sure the following components are showing previews in docs.
- Accordion
- AspectRatio
- FileUploader
- FlexGrid
- Grid
- OverflowMenu
- Popover
- StructuredList
- TimePicker
- Toggletip
