### PR TITLE
ci(release): update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Prepare artifacts for release
-        run: |
-          zip -r --junk-paths carbon-elements.sketchplugin.zip packages/sketch/carbon-elements.sketchplugin
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
@@ -50,14 +46,3 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: true
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./carbon-elements.sketchplugin.zip
-          asset_name: carbon-elements.sketchplugin.zip
-          asset_content_type: application/zip


### PR DESCRIPTION
This PR updates our release workflow to work around the asset upload issue we ran into

#### Changelog

**New**

**Changed**

- Update the workflow to not upload assets to the GitHub release

**Removed**
