### PR TITLE
fix(icon-build-helpers): use camelCase for SVG props

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next/convert.js
+++ b/packages/icon-build-helpers/src/builders/react/next/convert.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const t = require('@babel/types');
+const { camelCase } = require('change-case');
 
 function jsToAST(value) {
   if (typeof value === 'string') {
@@ -65,11 +66,15 @@ function svgToJSX(node) {
         return attributeDenylist.every((prefix) => !key.startsWith(prefix));
       })
       .map(([key, value]) => {
+        const formatted = attributeAllowlist.has(key) ? key : camelCase(key);
         if (typeof value === 'string') {
-          return t.jSXAttribute(t.jSXIdentifier(key), t.stringLiteral(value));
+          return t.jSXAttribute(
+            t.jSXIdentifier(formatted),
+            t.stringLiteral(value)
+          );
         }
         return t.jSXAttribute(
-          t.jSXIdentifier(key),
+          t.jSXIdentifier(formatted),
           t.jSXExpressionContainer(jsToAST(value))
         );
       });


### PR DESCRIPTION
This PR updates our icon builder to camelCase props of SVG components. This is to correct an issue we were seeing for keys like `fill-rule` which should be `fillRule`

#### Changelog

**New**

**Changed**

- Update icon builder to camelCase props of SVG components

**Removed**
