### PR TITLE
fix(elements): add index.scss to files array

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -14,9 +14,9 @@
   "files": [
     "es",
     "lib",
-    "scss",
     "src",
-    "umd"
+    "umd",
+    "index.scss"
   ],
   "keywords": [
     "ibm",


### PR DESCRIPTION
This PR updates `packages/elements/package.json` to guarantee that `index.scss` is available in the package.

#### Changelog

**New**

**Changed**

- Update `package.json` to include `index.scss` in the `filfes` array

**Removed**

#### Testing / Reviewing

- Verify `index.scss` is listed in the `files` array of `packages/elements/package.json`
