### PR TITLE
fix(react): add sideEffects to icons entrypoint

### DIFF
--- a/packages/react/icons/package.json
+++ b/packages/react/icons/package.json
@@ -1,4 +1,5 @@
 {
   "main": "lib/index.js",
-  "module": "es/index.js"
+  "module": "es/index.js",
+  "sideEffects": false
 }


### PR DESCRIPTION
Reference #11146

#### Changelog

**New**

**Changed**

- Add the `sideEffects` flag to the icons entrypoint to help bundlers tree shake this entrypoint

**Removed**
