### PR TITLE
fix(uishell): header action icon placement and theme

### DIFF
--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -80,21 +80,20 @@
     background-color: $background-active;
   }
 
-  .#{$prefix}--header__action.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger {
+  .#{$prefix}--header__action.#{$prefix}--btn--icon-only {
     align-items: center;
     justify-content: center;
   }
 
-  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger.#{$prefix}--header__action
-    svg {
+  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--header__action svg {
     fill: $icon-secondary;
   }
 
-  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger.#{$prefix}--header__action:hover
+  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--header__action:hover
     svg,
-  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger.#{$prefix}--header__action:active
+  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--header__action:active
     svg,
-  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--tooltip__trigger.#{$prefix}--header__action--active
+  .#{$prefix}--btn.#{$prefix}--btn--icon-only.#{$prefix}--header__action--active
     svg {
     fill: $icon-primary;
   }


### PR DESCRIPTION
Closes #11151

Fixes UIShell header actions to have proper alignment and color/theme values.

#### Changelog

**Changed**

- Removed unnecessary tooltip trigger class that is no longer placed on the actions in v11

#### Testing / Reviewing

- All UIShell header stories, including the ones with various actions, should render appropriately in all themes via the storybook theme switcher.