### PR TITLE
fix(icon-build-helpers): use bucket approach for icons-react

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next.js
+++ b/packages/icon-build-helpers/src/builders/react/next.js
@@ -118,8 +118,6 @@ async function builder(metadata, { output }) {
   for (const m of modules) {
     files[m.filepath] = m.entrypoint;
     input[m.filepath] = m.filepath;
-    // files['index.js'].push(...m.source);
-    // files['index.js'].push(template.ast(`export { ${m.name} };`));
   }
 
   for (const bucket of buckets) {

--- a/packages/icon-build-helpers/src/builders/react/next.js
+++ b/packages/icon-build-helpers/src/builders/react/next.js
@@ -126,6 +126,7 @@ async function builder(metadata, { output }) {
     input[filename] = filename;
     files[filename] = template.ast(`
       import React from 'react';
+      import Icon from './Icon.js';
       import { iconPropTypes } from './iconPropTypes.js';
       const didWarnAboutDeprecation = {};
     `);


### PR DESCRIPTION
Reference: https://github.com/carbon-design-system/carbon/issues/11146

#### Changelog

**New**

**Changed**

- Update our icon builder to use our bucket index approach to correctly tree shake icon components

**Removed**

#### Testing / Reviewing

- Pull down the PR
- Run `yarn build` in `packages/icons-react`
- Create a new project using create-react-app
  - `yarn create react-app test-icons`
- Run `yarn add @carbon/icons-react`
- Update the `package.json` to the following for `@carbon/icons-react`:

```
"@carbon/icons-react": "file:../monorepo/packages/icons-react",
```

Note, make sure to replace that with your folder path ^

- Update `src/App.js` to be:

```jsx
import { Bee } from '@carbon/icons-react';

function App() {
  return (
    <Bee />
  );
}

export default App;
```

- Run `yarn build`
- Verify the main JS bundle size is ~64kb
