### PR TITLE
fix(radiobutton): apply value to the input

### DIFF
--- a/packages/react/src/components/RadioButton/next/RadioButton.js
+++ b/packages/react/src/components/RadioButton/next/RadioButton.js
@@ -52,6 +52,7 @@ const RadioButton = React.forwardRef(function RadioButton(
         id={uniqueId}
         ref={ref}
         disabled={disabled}
+        value={value}
       />
       <label htmlFor={uniqueId} className={`${prefix}--radio-button__label`}>
         <span className={`${prefix}--radio-button__appearance`} />


### PR DESCRIPTION
Reported on [slack](https://ibm-studios.slack.com/archives/C0M053VPT/p1649254930589189), we previously spread `value` onto the `input` via `...other`.

In v11 we added `value` to the prop destructure and it wasn't being applied to the `input` .

#### Changelog

**Changed**

- ensure `value` is applied to the `input`

#### Testing / Reviewing

- Go to [this story](https://deploy-preview-11160--carbon-components-react.netlify.app/iframe.html?id=components-radiobutton--default&args=&viewMode=story), open the console, copy/paste `document.querySelector("#radio-1").value`
- The return value should be `radio-1`, not `on`.
- View the inputs in the `elements` pane, they should all have a `value` attribute