### PR TITLE
docs(icons): update slisor icon name

### DIFF
--- a/packages/icons/icons.yml
+++ b/packages/icons/icons.yml
@@ -15668,9 +15668,11 @@
   sizes:
     - 32
 - name: slisor
-  friendly_name: slisor
+  friendly_name: slicestor
   aliases:
     - analysis
+    - slisor
+    - slicestor
     - communication
     - messaging
     - systems


### PR DESCRIPTION
changed friendly name of slisor to slicestor as per feedback from cloud IT architects. added slisor and slicestor as aliases.