### PR TITLE
fix(slider): update color tokens

### DIFF
--- a/packages/react/src/components/Slider/next/Slider.stories.js
+++ b/packages/react/src/components/Slider/next/Slider.stories.js
@@ -21,6 +21,11 @@ export default {
   subcomponents: {
     SliderSkeleton,
   },
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+    },
+  },
   parameters: {
     docs: {
       page: mdx,
@@ -28,8 +33,9 @@ export default {
   },
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Slider
+    {...args}
     labelText="Slider Label"
     value={50}
     min={0}

--- a/packages/react/src/components/Tile/Tile.mdx
+++ b/packages/react/src/components/Tile/Tile.mdx
@@ -1,4 +1,4 @@
-import { Props } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
 
 # Tile
 
@@ -11,6 +11,40 @@ import { Props } from '@storybook/addon-docs/blocks';
 ## Table of Contents
 
 ## Overview
+
+<Preview>
+  <Story id="components-tile--default" />
+</Preview>
+
+## Clickable
+
+<Preview>
+  <Story id="components-tile--clickable" />
+</Preview>
+
+## Expandable
+
+<Preview>
+  <Story id="components-tile--expandable" />
+</Preview>
+
+## Expandable with Tnteractive
+
+<Preview>
+  <Story id="components-tile--expandable-with-interactive" />
+</Preview>
+
+## Multi Select
+
+<Preview>
+  <Story id="components-tile--multi-select" />
+</Preview>
+
+## Radio
+
+<Preview>
+  <Story id="components-tile--radio" />
+</Preview>
 
 ## Component API
 

--- a/packages/react/src/components/Tile/next/Tile.stories.js
+++ b/packages/react/src/components/Tile/next/Tile.stories.js
@@ -21,6 +21,7 @@ import {
 import TileGroup from '../../TileGroup/TileGroup';
 import { Layer } from '../../Layer';
 import './tile-story.scss';
+import mdx from '../Tile.mdx';
 
 export default {
   title: 'Components/Tile',
@@ -33,6 +34,11 @@ export default {
     TileGroup,
     TileAboveTheFoldContent,
     TileBelowTheFoldContent,
+  },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -154,7 +154,7 @@
   }
 
   .#{$prefix}--slider--disabled .#{$prefix}--slider__thumb {
-    background-color: $border-subtle;
+    background-color: $border-disabled;
 
     &:hover {
       cursor: not-allowed;
@@ -162,14 +162,14 @@
     }
 
     &:focus {
-      background-color: $border-subtle;
+      background-color: $border-disabled;
       box-shadow: none;
       outline: none;
       transform: translate(-50%, -50%);
     }
 
     &:active {
-      background: $border-subtle;
+      background: $border-disabled;
       transform: translate(-50%, -50%);
     }
   }
@@ -179,7 +179,7 @@
   .#{$prefix}--slider--disabled
     .#{$prefix}--slider__thumb:focus
     ~ .#{$prefix}--slider__filled-track {
-    background-color: $border-subtle;
+    background-color: $border-disabled;
   }
 
   .#{$prefix}--slider--disabled


### PR DESCRIPTION
Reference: https://github.com/carbon-design-system/carbon/issues/10431#issuecomment-1027108460

Update color tokens (does not include skeleton)

#### Changelog

**New**

- adds disabled control

**Changed**

- updated color tokens to match audit

#### Testing / Reviewing

Go to controls and turn on disabled to see color changes. Make sure tokens are updated in the appropriate places and match the audit ask from the link above.
