### PR TITLE
fix(react): spread args onto onChange from props

### DIFF
--- a/packages/react/src/components/DatePicker/next/DatePicker.js
+++ b/packages/react/src/components/DatePicker/next/DatePicker.js
@@ -328,7 +328,11 @@ function DatePicker({
       clickOpens: true,
       nextArrow: rightArrowHTML,
       prevArrow: leftArrowHTML,
-      onChange: savedOnChange,
+      onChange: (...args) => {
+        if (savedOnChange) {
+          savedOnChange(...args);
+        }
+      },
       onClose: savedOnClose,
       onReady: onHook,
       onMonthChange: onHook,


### PR DESCRIPTION
Closes #11181 

Spread `...args` onto onChange from props so info is available to users. 

