### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   dedupe:
     runs-on: ubuntu-latest
@@ -75,6 +78,9 @@ jobs:
         run: yarn test --ci
 
   e2e:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: 'test:e2e'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-react-storybook.yml
+++ b/.github/workflows/deploy-react-storybook.yml
@@ -13,6 +13,9 @@ on:
       - '!v[0-9]+.[0-9]+.[0-9]+-*'
       - '!v10*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macOS-latest

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,6 +5,9 @@ on:
     # Run every week day at 01:00 (24hr format)
     - cron: '0 1 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: macOS-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,13 @@ on:
       # Ignore tags for v10, there is a separate v10-release.yml workflow for v10
       - '!v10*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Create Release
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   comment:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5

--- a/.github/workflows/sync-generated-files.yml
+++ b/.github/workflows/sync-generated-files.yml
@@ -3,8 +3,13 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/v10-ci.yml
+++ b/.github/workflows/v10-ci.yml
@@ -9,6 +9,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   dedupe:
     runs-on: ubuntu-latest
@@ -82,6 +85,9 @@ jobs:
         run: yarn test --ci
 
   e2e:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: 'test:e2e'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/v10-deploy-react-storybook.yml
+++ b/.github/workflows/v10-deploy-react-storybook.yml
@@ -12,6 +12,9 @@ on:
       # https://help.github.com/en/articles/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns
       - '!v[0-9]+.[0-9]+.[0-9]+-*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macOS-latest

--- a/.github/workflows/v10-release.yml
+++ b/.github/workflows/v10-release.yml
@@ -6,8 +6,13 @@ on:
       # Push events to matching v10*, i.e. v10.55.0, v10.55.1
       - 'v10*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Create Release
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -20,6 +20,9 @@ on:
         description: 'Specify the tag for this release'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
