### PR TITLE
fix(TreeView): make `onToggle` call optional in keydown handler

### DIFF
--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -95,7 +95,7 @@ export default function TreeNode({
         return findParentTreeNode(node.parentNode);
       };
       if (children && expanded) {
-        onToggle(event, { id, isExpanded: false, label, value });
+        onToggle?.(event, { id, isExpanded: false, label, value });
         setExpanded(false);
       } else {
         /**
@@ -113,7 +113,7 @@ export default function TreeNode({
          */
         currentNode.current.lastChild.firstChild.focus();
       } else {
-        onToggle(event, { id, isExpanded: true, label, value });
+        onToggle?.(event, { id, isExpanded: true, label, value });
         setExpanded(true);
       }
     }

--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -61,23 +61,15 @@ export default function TreeNode({
     [`${prefix}--tree-parent-node__toggle-icon--expanded`]: expanded,
   });
   function handleToggleClick(event) {
-    if (onToggle) {
-      onToggle(event, { id, isExpanded: !expanded, label, value });
-    }
+    onToggle?.(event, { id, isExpanded: !expanded, label, value });
     setExpanded(!expanded);
   }
   function handleClick(event) {
     event.stopPropagation();
     if (!disabled) {
-      if (onTreeSelect) {
-        onTreeSelect(event, { id, label, value });
-      }
-      if (onNodeSelect) {
-        onNodeSelect(event, { id, label, value });
-      }
-      if (rest.onClick) {
-        rest.onClick(event);
-      }
+      onTreeSelect?.(event, { id, label, value });
+      onNodeSelect?.(event, { id, label, value });
+      rest?.onClick?.(event);
     }
   }
   function handleKeyDown(event) {
@@ -121,18 +113,16 @@ export default function TreeNode({
       event.preventDefault();
       handleClick(event);
     }
-    if (rest.onKeyDown) {
-      rest.onKeyDown(event);
-    }
+    rest?.onKeyDown?.(event);
   }
   function handleFocusEvent(event) {
-    if (event.type === 'blur' && rest.onBlur) {
-      rest.onBlur(event);
+    if (event.type === 'blur') {
+      rest?.onBlur?.(event);
     }
-    if (event.type === 'focus' && rest.onFocus) {
-      rest.onFocus(event);
+    if (event.type === 'focus') {
+      rest?.onFocus?.(event);
     }
-    onNodeFocusEvent && onNodeFocusEvent(event);
+    onNodeFocusEvent?.(event);
   }
 
   useEffect(() => {

--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -54,9 +54,7 @@ export default function TreeView({
       setSelected([nodeId]);
       setActive(nodeId);
     }
-    if (onSelect) {
-      onSelect(event, node);
-    }
+    onSelect?.(event, node);
   }
   function handleFocusEvent(event) {
     if (event.type === 'blur') {
@@ -117,9 +115,7 @@ export default function TreeView({
       nextFocusNode.tabIndex = 0;
       nextFocusNode.focus();
     }
-    if (rest.onKeyDown) {
-      rest.onKeyDown(event);
-    }
+    rest?.onKeyDown?.(event);
   }
 
   useEffect(() => {

--- a/packages/react/src/components/TreeView/next/story.scss
+++ b/packages/react/src/components/TreeView/next/story.scss
@@ -5,6 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-.bx--tree {
+.cds--tree {
   width: 16rem;
 }


### PR DESCRIPTION
Closes #11273

This PR makes the `onToggle` call optional in the keydown handler for tree nodes so that default expand/collapse behavior is restored

#### Changelog

**Changed**

- make tree node keydown handler `onToggle` optional
- use optional chaining for method calls
- update story SCSS prefix

#### Testing / Reviewing

* expanding and collapsing tree nodes in the storybook should now work again as expected
* the tree width should be 16rem again in the storybook