### PR TITLE
chore: update type token usage in styles doc

### DIFF
--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -309,7 +309,7 @@ your project. The type package includes various type tokens and mixins.
 @use '@carbon/styles/scss/type';
 
 .my-selector {
-  @include type.style(type.$productive-heading-01);
+  @include type.type-style('productive-heading-01');
 }
 ```
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11335

This includes a small update to the type token usage example found [here](https://github.com/carbon-design-system/carbon/blob/main/packages/styles/docs/sass.md#type).

#### Changelog

**Changed**

- Update type token usage example

