### PR TITLE
fix(codesandbox): remove yarn v3 specification from the project

### DIFF
--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -30,6 +30,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "packageManager": "yarn@3.2.0"
+  }
 }


### PR DESCRIPTION
Attempting to fix transpilation issues after seeing this https://github.com/codesandbox/codesandbox-client/issues/6607#issuecomment-1098993096

#### Changelog

**Removed**

- yarn v3 specification from codesandbox example

#### Testing / Reviewing

- I don't think there's a way to test this until we merge it into main