### PR TITLE
feat(TreeView): enable focus on disabled nodes

### DIFF
--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -73,6 +73,9 @@ export default function TreeNode({
     }
   }
   function handleKeyDown(event) {
+    if (disabled) {
+      return;
+    }
     if (matches(event, [keys.ArrowLeft, keys.ArrowRight, keys.Enter])) {
       event.stopPropagation();
     }

--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -43,7 +43,7 @@ export default function TreeNode({
         disabled,
         onTreeSelect,
         selected,
-        tabIndex: (!node.props.disabled && -1) || null,
+        tabIndex: -1,
       });
     }
   });

--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -127,7 +127,12 @@ export default function TreeView({
       const nodeIds = [];
 
       if (matches(event, [keys.Home, keys.End])) {
-        if (multiselect && event.shiftKey && event.ctrlKey) {
+        if (
+          multiselect &&
+          event.shiftKey &&
+          event.ctrlKey &&
+          !treeWalker.current.currentNode.getAttribute('aria-disabled')
+        ) {
           nodeIds.push(treeWalker.current.currentNode?.id);
         }
         while (
@@ -137,7 +142,12 @@ export default function TreeView({
         ) {
           nextFocusNode = treeWalker.current.currentNode;
 
-          if (multiselect && event.shiftKey && event.ctrlKey) {
+          if (
+            multiselect &&
+            event.shiftKey &&
+            event.ctrlKey &&
+            !nextFocusNode.getAttribute('aria-disabled')
+          ) {
             nodeIds.push(nextFocusNode?.id);
           }
         }

--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -89,9 +89,9 @@ export default function TreeView({
       onNodeFocusEvent: handleFocusEvent,
       onTreeSelect: handleTreeSelect,
       selected,
-      tabIndex: (!node.props.disabled && -1) || null,
+      tabIndex: -1,
     };
-    if (!focusTarget && !node.props.disabled) {
+    if (!focusTarget) {
       sharedNodeProps.tabIndex = 0;
       focusTarget = true;
     }
@@ -163,10 +163,7 @@ export default function TreeView({
     treeWalker.current =
       treeWalker.current ??
       document.createTreeWalker(treeRootRef?.current, NodeFilter.SHOW_ELEMENT, {
-        acceptNode: function (node) {
-          if (node.classList.contains(`${prefix}--tree-node--disabled`)) {
-            return NodeFilter.FILTER_REJECT;
-          }
+        acceptNode(node) {
           if (node.matches(`li.${prefix}--tree-node`)) {
             return NodeFilter.FILTER_ACCEPT;
           }

--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -146,7 +146,9 @@ export default function TreeView({
         treeWalker.current.currentNode = treeWalker.current.root;
 
         while (treeWalker.current.nextNode()) {
-          nodeIds.push(treeWalker.current.currentNode?.id);
+          if (!treeWalker.current.currentNode.getAttribute('aria-disabled')) {
+            nodeIds.push(treeWalker.current.currentNode?.id);
+          }
         }
       }
       setSelected(selected.concat(nodeIds));

--- a/packages/styles/scss/components/treeview/_treeview.scss
+++ b/packages/styles/scss/components/treeview/_treeview.scss
@@ -20,154 +20,154 @@
 @mixin treeview {
   .#{$prefix}--tree {
     overflow: hidden;
+  }
 
-    .#{$prefix}--tree-node {
-      padding-left: $spacing-05;
-      background-color: $layer-01;
-      color: $text-secondary;
+  .#{$prefix}--tree-node {
+    padding-left: $spacing-05;
+    background-color: $layer-01;
+    color: $text-secondary;
 
-      &:focus {
-        outline: none;
-      }
-    }
-
-    .#{$prefix}--tree-node:focus > .#{$prefix}--tree-node__label {
-      @include focus-outline('outline');
-    }
-
-    .#{$prefix}--tree-node--disabled:focus > .#{$prefix}--tree-node__label {
+    &:focus {
       outline: none;
     }
+  }
 
-    .#{$prefix}--tree-node--disabled,
-    .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__label:hover,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-node__label__details {
-      background-color: $field-01;
-      color: $text-disabled;
-    }
+  .#{$prefix}--tree-node:focus > .#{$prefix}--tree-node__label {
+    @include focus-outline('outline');
+  }
 
-    .#{$prefix}--tree-node--disabled .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__icon,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-node__icon {
-      fill: $icon-disabled;
-    }
+  .#{$prefix}--tree-node--disabled:focus > .#{$prefix}--tree-node__label {
+    outline: none;
+  }
 
-    .#{$prefix}--tree-node--disabled,
-    .#{$prefix}--tree-node--disabled
-      .#{$prefix}--tree-parent-node__toggle-icon:hover {
-      cursor: not-allowed;
-    }
-
-    .#{$prefix}--tree-node__label {
-      @include type-style('body-compact-01');
-
-      display: flex;
-      min-height: rem(32px);
-      flex: 1;
-      align-items: center;
-
-      &:hover {
-        background-color: $layer-hover-01;
-        color: $text-primary;
-      }
-    }
-
-    .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__label__details {
-      color: $text-primary;
-    }
-
+  .#{$prefix}--tree-node--disabled,
+  .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__label:hover,
+  .#{$prefix}--tree-node--disabled
     .#{$prefix}--tree-node__label:hover
-      .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__icon {
-      fill: $icon-primary;
-    }
-
-    .#{$prefix}--tree-leaf-node {
-      display: flex;
-      padding-left: $spacing-08;
-    }
-
-    .#{$prefix}--tree-leaf-node.#{$prefix}--tree-node--with-icon {
-      padding-left: $spacing-07;
-    }
-
     .#{$prefix}--tree-node__label__details {
-      display: flex;
-      align-items: center;
-    }
+    background-color: $field-01;
+    color: $text-disabled;
+  }
 
-    .#{$prefix}--tree-node--with-icon .#{$prefix}--tree-parent-node__toggle {
-      margin-right: 0;
-    }
-
-    .#{$prefix}--tree-parent-node__toggle {
-      padding: 0;
-      border: 0;
-      margin-right: $spacing-03;
-
-      &:hover {
-        cursor: pointer;
-      }
-
-      &:focus {
-        outline: none;
-      }
-    }
-
-    .#{$prefix}--tree-parent-node__toggle-icon {
-      fill: $icon-secondary;
-      transform: rotate(-90deg);
-      transition: all $duration-fast-02 motion(standard, productive);
-    }
-
-    .#{$prefix}--tree-parent-node__toggle-icon--expanded {
-      transform: rotate(0);
-    }
-
+  .#{$prefix}--tree-node--disabled .#{$prefix}--tree-parent-node__toggle-icon,
+  .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__icon,
+  .#{$prefix}--tree-node--disabled
+    .#{$prefix}--tree-node__label:hover
+    .#{$prefix}--tree-parent-node__toggle-icon,
+  .#{$prefix}--tree-node--disabled
+    .#{$prefix}--tree-node__label:hover
     .#{$prefix}--tree-node__icon {
-      min-width: 1rem;
-      min-height: 1rem;
-      margin-right: $spacing-03;
-      fill: $icon-secondary;
-    }
+    fill: $icon-disabled;
+  }
 
-    .#{$prefix}--tree-node--selected > .#{$prefix}--tree-node__label {
-      background-color: $layer-selected-01;
+  .#{$prefix}--tree-node--disabled,
+  .#{$prefix}--tree-node--disabled
+    .#{$prefix}--tree-parent-node__toggle-icon:hover {
+    cursor: not-allowed;
+  }
+
+  .#{$prefix}--tree-node__label {
+    @include type-style('body-compact-01');
+
+    display: flex;
+    min-height: rem(32px);
+    flex: 1;
+    align-items: center;
+
+    &:hover {
+      background-color: $layer-hover-01;
       color: $text-primary;
+    }
+  }
 
-      &:hover {
-        background-color: $layer-selected-hover-01;
-      }
+  .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__label__details {
+    color: $text-primary;
+  }
+
+  .#{$prefix}--tree-node__label:hover
+    .#{$prefix}--tree-parent-node__toggle-icon,
+  .#{$prefix}--tree-node__label:hover .#{$prefix}--tree-node__icon {
+    fill: $icon-primary;
+  }
+
+  .#{$prefix}--tree-leaf-node {
+    display: flex;
+    padding-left: $spacing-08;
+  }
+
+  .#{$prefix}--tree-leaf-node.#{$prefix}--tree-node--with-icon {
+    padding-left: $spacing-07;
+  }
+
+  .#{$prefix}--tree-node__label__details {
+    display: flex;
+    align-items: center;
+  }
+
+  .#{$prefix}--tree-node--with-icon .#{$prefix}--tree-parent-node__toggle {
+    margin-right: 0;
+  }
+
+  .#{$prefix}--tree-parent-node__toggle {
+    padding: 0;
+    border: 0;
+    margin-right: $spacing-03;
+
+    &:hover {
+      cursor: pointer;
     }
 
-    .#{$prefix}--tree-node--selected
-      > .#{$prefix}--tree-node__label
-      .#{$prefix}--tree-parent-node__toggle-icon,
-    .#{$prefix}--tree-node--selected
-      > .#{$prefix}--tree-node__label
-      .#{$prefix}--tree-node__icon {
-      fill: $icon-primary;
+    &:focus {
+      outline: none;
     }
+  }
 
-    .#{$prefix}--tree-node--active > .#{$prefix}--tree-node__label {
-      position: relative;
+  .#{$prefix}--tree-parent-node__toggle-icon {
+    fill: $icon-secondary;
+    transform: rotate(-90deg);
+    transition: all $duration-fast-02 motion(standard, productive);
+  }
 
-      &::before {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: rem(4px);
-        height: 100%;
-        background-color: $interactive;
-        content: '';
-      }
+  .#{$prefix}--tree-parent-node__toggle-icon--expanded {
+    transform: rotate(0);
+  }
+
+  .#{$prefix}--tree-node__icon {
+    min-width: 1rem;
+    min-height: 1rem;
+    margin-right: $spacing-03;
+    fill: $icon-secondary;
+  }
+
+  .#{$prefix}--tree-node--selected > .#{$prefix}--tree-node__label {
+    background-color: $layer-selected-01;
+    color: $text-primary;
+
+    &:hover {
+      background-color: $layer-selected-hover-01;
+    }
+  }
+
+  .#{$prefix}--tree-node--selected
+    > .#{$prefix}--tree-node__label
+    .#{$prefix}--tree-parent-node__toggle-icon,
+  .#{$prefix}--tree-node--selected
+    > .#{$prefix}--tree-node__label
+    .#{$prefix}--tree-node__icon {
+    fill: $icon-primary;
+  }
+
+  .#{$prefix}--tree-node--active > .#{$prefix}--tree-node__label {
+    position: relative;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: rem(4px);
+      height: 100%;
+      background-color: $interactive;
+      content: '';
     }
   }
 

--- a/packages/styles/scss/components/treeview/_treeview.scss
+++ b/packages/styles/scss/components/treeview/_treeview.scss
@@ -36,10 +36,6 @@
     @include focus-outline('outline');
   }
 
-  .#{$prefix}--tree-node--disabled:focus > .#{$prefix}--tree-node__label {
-    outline: none;
-  }
-
   .#{$prefix}--tree-node--disabled,
   .#{$prefix}--tree-node--disabled .#{$prefix}--tree-node__label:hover,
   .#{$prefix}--tree-node--disabled


### PR DESCRIPTION
Related #6792

This PR enables focus on disabled tree nodes to match the APG recommendations on keyboard controls for disabled items in a tree

#### Changelog

**New**

- disabled tree nodes can now be focused with the mouse or keyboard

**Changed**

- unnest tree node styles

#### Testing / Reviewing

confirm that disabled tree nodes receive focus 

reviewers can also hide whitespace changes in GitHub for a cleaner diff on the style changes