### PR TITLE
ci(workflows): add deploy packages workflow for the website

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -1,0 +1,57 @@
+name: deploy-packages
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  # workflow_run:
+  # workflows: [Release]
+  # types:
+  # - completed
+
+jobs:
+  carbon-website:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: carbon-design-system/carbon-website
+          ref: main
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Update dependencies
+        run: |
+          yarn upgrade \
+            @carbon/elements@next \
+            @carbon/pictograms@next \
+            @carbon/pictograms-react@next \
+            @carbon/icons-react@next \
+            @carbon/react@next
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: 'release/update-carbon-deps'
+          commit-message: 'chore(release): update carbon deps'
+          delete-branch: true
+          title: 'chore(release): update carbon deps'
+          token: ${{ steps.generate_token.outputs.token }}
+          body: |
+            Automated release PR for Carbon on the website
+
+            **Checklist**
+
+            - [ ] Verify package version bumps are accurate
+            - [ ] Verify CI passes as expected
+            - [ ] Verify no regressions on the website in the deploy preview


### PR DESCRIPTION
This workflow allows us to manually dispatch a job that will update the Carbon Website with the latest carbon dependencies. In the future, this job should be triggered on the completion of the release workflow

#### Changelog

**New**

- Add `deploy-packages.yml` as a workflow

**Changed**

**Removed**
