### PR TITLE
fix(form-group): remove default `hasMargin` prop

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3259,7 +3259,6 @@ Map {
   },
   "FormGroup" => Object {
     "defaultProps": Object {
-      "hasMargin": true,
       "invalid": false,
       "message": false,
       "messageText": "",

--- a/packages/react/src/components/FormGroup/FormGroup.js
+++ b/packages/react/src/components/FormGroup/FormGroup.js
@@ -85,7 +85,6 @@ FormGroup.defaultProps = {
   invalid: false,
   message: false,
   messageText: '',
-  hasMargin: true,
 };
 
 export default FormGroup;


### PR DESCRIPTION
This PR removes the `hasMargin` prop from `defaultProps` in `FormGroup`. This prop used to be available in v10 but is no longer used as part of the `className` in v11

#### Changelog

**New**

**Changed**

**Removed**

- Remove the defaultProp value for `hasMargin`
