### PR TITLE
fix(CopyButton): removes additional fill on click animation

### DIFF
--- a/packages/styles/scss/components/copy-button/_copy-button.scss
+++ b/packages/styles/scss/components/copy-button/_copy-button.scss
@@ -67,6 +67,10 @@
       display: block;
     }
 
+    &.#{$prefix}--copy-btn--animating::before {
+      border: none;
+    }
+
     &.#{$prefix}--copy-btn--animating.#{$prefix}--copy-btn--fade-out::before,
     &.#{$prefix}--copy-btn--animating.#{$prefix}--copy-btn--fade-out
       .#{$prefix}--copy-btn__feedback {


### PR DESCRIPTION
Closes #11410 

#### Changelog

- Removes border that was getting added on pseudo element for animation on click

#### Testing / Reviewing

- Go to CopyButton story
    - switch to darker themes (to be able to see the fill easier, even though it exists on all themes)
    - click the copy button
    - animation should work without the additional fill in the icon
- Test out the same way for CodeSnippet multi + single stories