### PR TITLE
(fix) fix typo in migration guide

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -62,7 +62,7 @@ There are two major areas of changes in the package, namely:
 
 The majority of the files currently available under `/scss/globals/scss` are now
 available directly under the `scss` directory, or through our new utilities
-folder in `scss/utilties`.
+folder in `scss/utilities`.
 
 Below, you'll find an overview of files that are a part of our Public API and
 where they have moved to in v11. Each row also contains a link to a section


### PR DESCRIPTION
Fixes a small typo in the v11 migration guide.