### PR TITLE
chore(ci): disable avt job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,44 +168,44 @@ jobs:
         if: ${{ needs.vrt-runner.result != 'success' }}
         run: exit 1
 
-  avt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            node_modules
-            */**/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dependencies
-        run: yarn install --immutable --immutable-cache
-      - name: Install browsers
-        run: yarn playwright install --with-deps
-      - name: Build project
-        run: yarn build --ignore '@carbon/sketch'
-      - name: Build storybook
-        run: yarn workspace @carbon/react build-storybook
-      - name: Run storybook
-        id: storybook
-        run: |
-          npx serve -l 3000 packages/react/storybook-static &
-          pid=$!
-          echo ::set-output name=pid::"$pid"
-      - name: Run VRT
-        if: github.repository == 'carbon-design-system/carbon'
-        run: |
-          yarn playwright test --project chromium --grep @avt
-      - name: Stop storybook
-        run: kill ${{ steps.storybook.outputs.pid }}
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: playwright-report
-          path: .playwright
+#   avt:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: Use Node.js 16.x
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: '16.x'
+#       - uses: actions/cache@v3
+#         id: cache
+#         with:
+#           path: |
+#             node_modules
+#             */**/node_modules
+#           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+#       - name: Install dependencies
+#         run: yarn install --immutable --immutable-cache
+#       - name: Install browsers
+#         run: yarn playwright install --with-deps
+#       - name: Build project
+#         run: yarn build --ignore '@carbon/sketch'
+#       - name: Build storybook
+#         run: yarn workspace @carbon/react build-storybook
+#       - name: Run storybook
+#         id: storybook
+#         run: |
+#           npx serve -l 3000 packages/react/storybook-static &
+#           pid=$!
+#           echo ::set-output name=pid::"$pid"
+#       - name: Run VRT
+#         if: github.repository == 'carbon-design-system/carbon'
+#         run: |
+#           yarn playwright test --project chromium --grep @avt
+#       - name: Stop storybook
+#         run: kill ${{ steps.storybook.outputs.pid }}
+#       - name: Upload test results
+#         if: always()
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: playwright-report
+#           path: .playwright


### PR DESCRIPTION
This PR updates our CI workflow to disable the avt job. This job started failing unexpectedly and so we should disable it and use https://github.com/carbon-design-system/carbon/issues/11444 as the issue to fix it and enable it as a required status check in the future

#### Changelog

**New**

**Changed**

- Disable the avt job in the CI workflow

**Removed**
