### PR TITLE
fix(structured-list): change role of structured list

### DIFF
--- a/packages/react/src/components/StructuredList/next/StructuredList.js
+++ b/packages/react/src/components/StructuredList/next/StructuredList.js
@@ -36,7 +36,7 @@ export function StructuredListWrapper(props) {
   return (
     <GridSelectedRowStateContext.Provider value={selectedRow}>
       <GridSelectedRowDispatchContext.Provider value={setSelectedRow}>
-        <div role="grid" className={classes} {...other} aria-label={ariaLabel}>
+        <div role="table" className={classes} {...other} aria-label={ariaLabel}>
           {children}
         </div>
       </GridSelectedRowDispatchContext.Provider>


### PR DESCRIPTION
Updates the role of our structured list to `table` instead of `grid`

#### Changelog

**New**

**Changed**

- Change the role of structured list to table

**Removed**

#### Testing / Reviewing

- View the storybook for structured list and verify this violation no longer occurs

<img width="859" alt="Screen Shot 2022-05-19 at 2 48 27 PM" src="https://user-images.githubusercontent.com/3901764/169390996-dc51f824-e989-40b8-a5f6-b7d34d31d0cc.png">

