### PR TITLE
fix: add title to clear button for Search

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -885,6 +885,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "pooniena2",
+      "name": "Anh Tuan Pham",
+      "avatar_url": "https://avatars.githubusercontent.com/u/55847291?v=4",
+      "profile": "https://github.com/pooniena2",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/dezkareid"><img src="https://avatars.githubusercontent.com/u/1269896?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joel Humberto Gómez Paredes</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=dezkareid" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/NashJames"><img src="https://avatars.githubusercontent.com/u/37304960?v=4?s=100" width="100px;" alt=""/><br /><sub><b>James Nash</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=NashJames" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=NashJames" title="Documentation">📖</a></td>
     <td align="center"><a href="http://jakubfaliszewski.github.io/portfolio/"><img src="https://avatars.githubusercontent.com/u/25402419?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jakub Faliszewski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=jakubfaliszewski" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/pooniena2"><img src="https://avatars.githubusercontent.com/u/55847291?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anh Tuan Pham</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=pooniena2" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Search/next/Search-test.js
+++ b/packages/react/src/components/Search/next/Search-test.js
@@ -125,7 +125,7 @@ describe('Search', () => {
           expect(type2).toEqual('button');
         });
 
-        it('button should have title', () => {
+        it('button should have clear title', () => {
           expect(btns.prop('title')).toBe('Clear');
         });
       });

--- a/packages/react/src/components/Search/next/Search-test.js
+++ b/packages/react/src/components/Search/next/Search-test.js
@@ -124,6 +124,10 @@ describe('Search', () => {
           expect(type1).toEqual('button');
           expect(type2).toEqual('button');
         });
+
+        it('button should have title', () => {
+          expect(btns.prop('title')).toBe('Clear');
+        });
       });
 
       describe('icons', () => {

--- a/packages/react/src/components/Search/next/Search.js
+++ b/packages/react/src/components/Search/next/Search.js
@@ -135,7 +135,8 @@ const Search = React.forwardRef(function Search(
         className={clearClasses}
         disabled={disabled}
         onClick={clearInput}
-        type="button">
+        type="button"
+        title="Clear">
         <Close />
       </button>
     </div>


### PR DESCRIPTION
Adding title to clear button in Search Component. The clear button now has the same type of of title that was created in the NumberInput component.


Changed

* Add title ="Clear" in button element
* Update test case for clear button

Testing / Reviewing
* Based on issue https://github.com/carbon-design-system/carbon/issues/11367
