### PR TITLE
fix(checkbox): remove cursor: pointer for checkbox skeleton

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
+++ b/packages/react/src/components/Checkbox/Checkbox.Skeleton.js
@@ -17,11 +17,15 @@ const CheckboxSkeleton = ({ className, ...rest }) => {
       className={cx(
         `${prefix}--form-item`,
         `${prefix}--checkbox-wrapper`,
-        `${prefix}--checkbox-label`,
+        `${prefix}--checkbox-skeleton`,
         className
       )}
       {...rest}>
-      <span className={`${prefix}--checkbox-label-text ${prefix}--skeleton`} />
+      <div className={`${prefix}--checkbox-label`}>
+        <span
+          className={`${prefix}--checkbox-label-text ${prefix}--skeleton`}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -187,6 +187,9 @@
   //-----------------------------------------------
   // Skeleton
   //-----------------------------------------------
+  .#{$prefix}--checkbox-skeleton .#{$prefix}--checkbox-label {
+    cursor: default;
+  }
 
   .#{$prefix}--checkbox-label-text.#{$prefix}--skeleton {
     @include skeleton;


### PR DESCRIPTION
Closes #11475 

Update checkbox skeleton state to not have `cursor: pointer`

#### Changelog

**New**

**Changed**

- Update markup of Checkbox skeleton
- Update styles of checkbox to specify cursor default in skeleton variants

**Removed**

#### Testing / Reviewing

- Verify the skeleton state for Checkbox no longer has `cursor: pointer` set. Instead, it should use the default cursor
