### PR TITLE
chore(release): v10.57.2-rc.0

### DIFF
--- a/examples/codesandbox-styles/package.json
+++ b/examples/codesandbox-styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codesandbox-styles",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2-rc.0",
   "scripts": {
     "develop": "vite"
   },
@@ -9,7 +9,7 @@
     "vite": "^2.8.0"
   },
   "dependencies": {
-    "@carbon/styles": "^0.18.1",
+    "@carbon/styles": "^0.18.2-rc.0",
     "sass": "^1.49.7"
   }
 }

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -1,12 +1,12 @@
 {
   "name": "codesandbox",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2-rc.0",
   "scripts": {
     "develop": "vite"
   },
   "dependencies": {
-    "@carbon/react": "^0.18.1",
+    "@carbon/react": "^0.18.2-rc.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/carbon-react/package.json
+++ b/packages/carbon-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/react",
   "description": "React components for the Carbon Design System",
-  "version": "0.18.1",
+  "version": "0.18.2-rc.0",
   "private": true,
   "license": "Apache-2.0",
   "main": "lib/index.js",
@@ -45,10 +45,10 @@
   "dependencies": {
     "@carbon/feature-flags": "^0.7.0",
     "@carbon/icons-react": "^10.49.0",
-    "@carbon/styles": "^0.18.1",
+    "@carbon/styles": "^0.18.2-rc.0",
     "@carbon/telemetry": "0.1.0",
-    "carbon-components": "^10.57.1",
-    "carbon-components-react": "^7.57.1",
+    "carbon-components": "^10.57.2-rc.0",
+    "carbon-components-react": "^7.57.3-rc.0",
     "carbon-icons": "^7.0.7"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "10.57.1",
+  "version": "10.57.2-rc.0",
   "license": "Apache-2.0",
   "main": "umd/index.js",
   "module": "es/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components-react",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "7.57.2",
+  "version": "7.57.3-rc.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -107,7 +107,7 @@
     "babel-plugin-react-docgen": "^4.2.1",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "browserslist-config-carbon": "^10.6.1",
-    "carbon-components": "^10.57.1",
+    "carbon-components": "^10.57.2-rc.0",
     "carbon-icons": "^7.0.5",
     "chalk": "^4.1.1",
     "cli-table": "^0.3.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components-react",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "7.57.1",
+  "version": "7.57.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/styles",
   "description": "Styles for the Carbon Design System",
-  "version": "0.18.1",
+  "version": "0.18.2-rc.0",
   "private": true,
   "license": "Apache-2.0",
   "repository": {

--- a/www/package.json
+++ b/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "www",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.2-rc.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^0.18.1",
+    "@carbon/react": "^0.18.2-rc.0",
     "@octokit/core": "^3.5.1",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,7 +2089,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/react@^0.18.1, @carbon/react@workspace:packages/carbon-react":
+"@carbon/react@^0.18.2-rc.0, @carbon/react@workspace:packages/carbon-react":
   version: 0.0.0-use.local
   resolution: "@carbon/react@workspace:packages/carbon-react"
   dependencies:
@@ -2102,7 +2102,7 @@ __metadata:
     "@babel/preset-react": ^7.16.7
     "@carbon/feature-flags": ^0.7.0
     "@carbon/icons-react": ^10.49.0
-    "@carbon/styles": ^0.18.1
+    "@carbon/styles": ^0.18.2-rc.0
     "@carbon/telemetry": 0.1.0
     "@carbon/themes": ^10.54.0
     "@rollup/plugin-babel": ^5.3.0
@@ -2122,8 +2122,8 @@ __metadata:
     babel-plugin-dev-expression: ^0.2.3
     babel-preset-carbon: ^0.2.0
     browserslist-config-carbon: ^10.6.1
-    carbon-components: ^10.57.1
-    carbon-components-react: ^7.57.1
+    carbon-components: ^10.57.2-rc.0
+    carbon-components-react: ^7.57.3-rc.0
     carbon-icons: ^7.0.7
     css-loader: ^6.5.1
     fast-glob: ^3.2.7
@@ -2176,7 +2176,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/styles@^0.18.1, @carbon/styles@workspace:packages/styles":
+"@carbon/styles@^0.18.2-rc.0, @carbon/styles@workspace:packages/styles":
   version: 0.0.0-use.local
   resolution: "@carbon/styles@workspace:packages/styles"
   dependencies:
@@ -11624,7 +11624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components-react@^7.57.1, carbon-components-react@workspace:packages/react":
+"carbon-components-react@^7.57.3-rc.0, carbon-components-react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "carbon-components-react@workspace:packages/react"
   dependencies:
@@ -11673,7 +11673,7 @@ __metadata:
     babel-plugin-react-docgen: ^4.2.1
     babel-plugin-transform-inline-environment-variables: ^0.4.3
     browserslist-config-carbon: ^10.6.1
-    carbon-components: ^10.57.1
+    carbon-components: ^10.57.2-rc.0
     carbon-icons: ^7.0.5
     chalk: ^4.1.1
     classnames: 2.3.1
@@ -11760,7 +11760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@^10.57.1, carbon-components@workspace:packages/components":
+"carbon-components@^10.57.2-rc.0, carbon-components@workspace:packages/components":
   version: 0.0.0-use.local
   resolution: "carbon-components@workspace:packages/components"
   dependencies:
@@ -12747,7 +12747,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "codesandbox-styles@workspace:examples/codesandbox-styles"
   dependencies:
-    "@carbon/styles": ^0.18.1
+    "@carbon/styles": ^0.18.2-rc.0
     sass: ^1.49.7
     vite: ^2.8.0
   languageName: unknown
@@ -12757,7 +12757,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "codesandbox@workspace:examples/codesandbox"
   dependencies:
-    "@carbon/react": ^0.18.1
+    "@carbon/react": ^0.18.2-rc.0
     "@vitejs/plugin-react": ^1.0.7
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -39111,7 +39111,7 @@ resolve@^2.0.0-next.3:
   version: 0.0.0-use.local
   resolution: "www@workspace:www"
   dependencies:
-    "@carbon/react": ^0.18.1
+    "@carbon/react": ^0.18.2-rc.0
     "@octokit/core": ^3.5.1
     "@octokit/plugin-retry": ^3.0.9
     "@octokit/plugin-throttling": ^3.5.2


### PR DESCRIPTION
This PR updates the v10 branch to `v10.57.2-rc.0`

# [HEAD](https://github.com/carbon-design-system/carbon/compare/v10.57.1...HEAD) (2022-5-24)
## `carbon-components@10.57.1`

### Bug fixes :bug:
- fix(ComposedModal): fix focus trap and refocus to trigger element when closed (#11418) ([`94be72ccd`](https://github.com/carbon-design-system/carbon/commit/94be72ccd))

### Housekeeping :house:
- chore(release): v10.57.1 ([`3c9316220`](https://github.com/carbon-design-system/carbon/commit/3c9316220))

## `carbon-components-react@7.57.2`

### Bug fixes :bug:
- fix(ComposedModal): fix focus trap and refocus to trigger element when closed (#11418) ([`94be72ccd`](https://github.com/carbon-design-system/carbon/commit/94be72ccd))

### Housekeeping :house:
- chore(release): v10.57.2-rc.0 ([`3b0ba943a`](https://github.com/carbon-design-system/carbon/commit/3b0ba943a))
- chore(react): update cloud foundry manifest (#11345) ([`ecaf9b382`](https://github.com/carbon-design-system/carbon/commit/ecaf9b382))
- chore(release): v10.57.1 ([`3c9316220`](https://github.com/carbon-design-system/carbon/commit/3c9316220))
