### PR TITLE
fix(datatable): remove css to fix search icon alignement

### DIFF
--- a/packages/styles/scss/components/search/_search.scss
+++ b/packages/styles/scss/components/search/_search.scss
@@ -108,6 +108,10 @@
     padding: 0 $spacing-08;
   }
 
+  .#{$prefix}--search--md .#{$prefix}--search-magnifier-icon {
+    left: 0;
+  }
+
   // Large styles
   .#{$prefix}--search--lg .#{$prefix}--search-input,
   .#{$prefix}--search--lg.#{$prefix}--search--expandable.#{$prefix}--search--expanded
@@ -121,6 +125,7 @@
     position: absolute;
     z-index: 2;
     top: 50%;
+    left: $spacing-05;
     width: rem(16px);
     height: rem(16px);
     fill: $icon-secondary;

--- a/packages/styles/scss/components/search/_search.scss
+++ b/packages/styles/scss/components/search/_search.scss
@@ -108,10 +108,6 @@
     padding: 0 $spacing-08;
   }
 
-  .#{$prefix}--search--md .#{$prefix}--search-magnifier-icon {
-    left: rem(12px);
-  }
-
   // Large styles
   .#{$prefix}--search--lg .#{$prefix}--search-input,
   .#{$prefix}--search--lg.#{$prefix}--search--expandable.#{$prefix}--search--expanded
@@ -125,7 +121,6 @@
     position: absolute;
     z-index: 2;
     top: 50%;
-    left: $spacing-05;
     width: rem(16px);
     height: rem(16px);
     fill: $icon-secondary;


### PR DESCRIPTION
Closes #11446 https://github.com/carbon-design-system/carbon/issues/11446

Modified css to 0 to fix the issue.

#### Changelog


**Changed**

- `.#{$prefix}--search--md .#{$prefix}--search-magnifier-icon {
    left: 0;
  }`

#### Testing / Reviewing

check search icon on datatable is no longer misaligned