### PR TITLE
fix(icon-build-helpers): wrap propTypes in __DEV__ check

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next/templates.js
+++ b/packages/icon-build-helpers/src/builders/react/next/templates.js
@@ -40,7 +40,9 @@ const component = template(
       }
     );
 
-    %%moduleName%%.propTypes = iconPropTypes;
+    if (__DEV__) {
+      %%moduleName%%.propTypes = iconPropTypes;
+    }
   `,
   {
     plugins: ['jsx'],


### PR DESCRIPTION
Closes #11543

Wraps prop types in a `__DEV__` check to trigger dead code removal in production mode.

#### Changelog

**New**

**Changed**

- Update `icon-build-helper` to emit components where `IconName.propTypes = iconPropTypes` is wrapped in a dev check

**Removed**

#### Testing / Reviewing

- Verify components still render as intended in storybook
- Verify propType check still occur for the component (best way is probably editing icon usage in a component or story to see if it will through an error)
