### PR TITLE
feat(react): add option to closeOnSelect

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2157,6 +2157,9 @@ Map {
       "className": Object {
         "type": "string",
       },
+      "closeOnSelect": Object {
+        "type": "bool",
+      },
       "dateFormat": Object {
         "type": "string",
       },

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -179,6 +179,7 @@ function DatePicker({
   appendTo,
   children,
   className,
+  closeOnSelect = true,
   dateFormat = 'm/d/Y',
   datePickerType,
   disable,
@@ -286,6 +287,7 @@ function DatePicker({
       inline: inline ?? false,
       disableMobile: true,
       defaultDate: value,
+      closeOnSelect: closeOnSelect,
       mode: datePickerType,
       allowInput: allowInput ?? true,
       dateFormat: dateFormat,
@@ -487,6 +489,11 @@ DatePicker.propTypes = {
    * The CSS class names.
    */
   className: PropTypes.string,
+
+  /**
+   * flatpickr prop passthrough. Controls whether the calendar dropdown closes upon selection.
+   */
+  closeOnSelect: PropTypes.bool,
 
   /**
    * The date format.


### PR DESCRIPTION
Adds prop from flatpickr to control whether or not DatePicker with range close on selection.


#### Testing / Reviewing

Go to DatePicker story and toggle 'closeOnSelect' to make sure it works as expected. If it is true, then the calendar should close on selection, if it's false then it should stay open. 