### PR TITLE
fix(styles): include CSS files in side effects

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -56,6 +56,6 @@
   "sideEffects": [
     "index.scss",
     "scss/**/*.scss",
-    "scss/**/*.css"
+    "css/**/*.css"
   ]
 }


### PR DESCRIPTION
Closes #11599

This PR includes the CSS files in the side effects of `@carbon/styles`.

#### Changelog


**Changed**

fix(styles): include CSS files in side effects


#### Testing / Reviewing

I tested this locally in my webpack app. Without the CSS files included in the side effects, webpack was ignoring the styles. With the CSS files included, the styles appeared as expected.
