### PR TITLE
feat(styles): add css folder to sideEffects

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -56,6 +56,7 @@
   "sideEffects": [
     "index.scss",
     "scss/**/*.scss",
-    "scss/**/*.css"
+    "scss/**/*.css",
+    "css/**/*.css"
   ]
 }


### PR DESCRIPTION
Closes #11599

Add the `css` folder and files to `sideEffects` in `package.json`

#### Changelog

**New**

**Changed**

- The `sideEffects` field in `package.json` now includes the `css` folder

**Removed**
