### PR TITLE
docs(Toggletip): improve distinction between tooltip and toggletip

### DIFF
--- a/packages/react/src/components/Toggletip/Toggletip.mdx
+++ b/packages/react/src/components/Toggletip/Toggletip.mdx
@@ -19,10 +19,11 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs';
 
 ## Overview
 
-The Toggletip component provides an accessible way to render interactive content
-within a popover. To use this component, you'll need to include a `Toggletip`,
-`ToggletipButton` for the trigger, and `ToggletipContent` for the content you
-would like to render within the popover.
+The `Toggletip` component provides an accessible way to render interactive
+content within a popover. If you do not have any interactive content inside of
+your `Toggletip`, consider using `Tooltip` instead. To use this component,
+you'll need to include a `Toggletip`, `ToggletipButton` for the trigger, and
+`ToggletipContent` for the content you would like to render within the popover.
 
 ```jsx
 import { Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';

--- a/packages/react/src/components/Toggletip/Toggletip.mdx
+++ b/packages/react/src/components/Toggletip/Toggletip.mdx
@@ -12,6 +12,7 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs';
 ## Table of Contents
 
 - [Overview](#overview)
+  - [Toggletips vs Tooltips](#toggletips-vs-tooltips)
 - [Component API](#component-api)
 - [Feedback](#feedback)
 
@@ -39,9 +40,19 @@ import { Information } from '@carbon/react/icons';
 </Toggletip>;
 ```
 
+### Toggletips vs Tooltips
+
+Toggletips and tooltips are similar visually and both contain a popover and
+interactive trigger element. The two components differ in the way they are
+invoked and dismissed and if the user must interact with the contents. A tooltip
+is exposed on hover or focus when you need to expose brief, supplemental
+information that is not interactive. A toggletip is used on click or enter when
+you need to expose interactive elements, such as button, that a user needs to
+interact with.
+
 ## Alignment
 
-The Toggletip component provies four options for alignment: `top`, `bottom`,
+The Toggletip component provides four options for alignment: `top`, `bottom`,
 `left`, and `right`. These options will correspond to where the popover will
 render relative to the ToggletipButton. For example, when choosing `align="top"`
 the ToggletipContent will render above the ToggletipButton.

--- a/packages/react/src/components/Tooltip/next/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/next/Tooltip.mdx
@@ -14,6 +14,7 @@ import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
 ## Table of Contents
 
 - [Overview](#overview)
+  - [Toggletips vs Tooltips](#toggletips-vs-tooltips)
   - [Customizing the content of a tooltip](#customizing-the-content-of-a-tooltip)
   - [Tooltip alignment](#tooltip-alignment)
   - [Customizing the duration of a tooltip](#customizing-the-duration-of-a-tooltip)
@@ -42,6 +43,16 @@ specify the contents of the popup through the `label` or `description` prop.
 <Canvas>
   <Story id="components-tooltip--default" />
 </Canvas>
+
+### Toggletips vs Tooltips
+
+Toggletips and tooltips are similar visually and both contain a popover and
+interactive trigger element. The two components differ in the way they are
+invoked and dismissed and if the user must interact with the contents. A tooltip
+is exposed on hover or focus when you need to expose brief, supplemental
+information that is not interactive. A toggletip is used on click or enter when
+you need to expose interactive elements, such as button, that a user needs to
+interact with.
 
 ### Customizing the content of a tooltip
 

--- a/packages/react/src/components/Tooltip/next/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/next/Tooltip.mdx
@@ -24,9 +24,10 @@ import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
 
 ## Overview
 
-You can use the `Tooltip` component to display a popup for an interactive
-element that you provide. You can provide the interactive element as a child to
-`Tooltip`, for example:
+You can use the `Tooltip` component as a wrapper to display a popup for an
+interactive element that you provide. If you are trying to place interactive
+content inside of the `Tooltip` itself, consider using `Toggletip` instead. You
+can provide the interactive element as a child to `Tooltip`, for example:
 
 ```jsx
 <Tooltip label="Close">


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/11598

Adds a little bit more clarity on when to use `Tooltip` vs `Toggletip`. I've currently added it into the `Overview` section, but let me know if you think we should add it to its own section for an improved callout. Will also shoot up a PR to the website mirroring these changes. 

#### Changelog

**Changed**

- Improved clarity on when to use `Tooltip` vs `Toggletip`

#### Testing / Reviewing

Make sure it makes sense and the guidance is correct 
