### PR TITLE
fix(grid): explicitly set width: 100%

### DIFF
--- a/packages/grid/scss/_css-grid.scss
+++ b/packages/grid/scss/_css-grid.scss
@@ -94,6 +94,7 @@
     --cds-grid-column-hang: calc(var(--cds-grid-gutter) / 2);
 
     display: grid;
+    width: 100%;
     max-width: get-grid-width(
       $breakpoints,
       largest-breakpoint-name($breakpoints)


### PR DESCRIPTION
This PR sets the width to `100%` in order to make sure CSS Grid works in containers that determine width based on content (like flexbox containers)

#### Changelog

**New**

**Changed**

- Update `css-grid` styles to use `width: 100%`

**Removed**
