### PR TITLE
Fix <FlexGrid> closing tag

### DIFF
--- a/packages/react/src/components/Grid/next/FlexGrid.mdx
+++ b/packages/react/src/components/Grid/next/FlexGrid.mdx
@@ -193,7 +193,7 @@ function MyComponent() {
         <Column as="article">Example content</Column>
         <Column as="article">Example content</Column>
       </Row>
-    <FlexGrid>
+    </FlexGrid>
   );
 }
 ```


### PR DESCRIPTION
**Changed**

- Fix closing tag for <FlexGrid>, missing "/" (slash)

