### PR TITLE
style(styles): update border values for tile

### DIFF
--- a/packages/react/src/components/Tile/next/Tile.stories.js
+++ b/packages/react/src/components/Tile/next/Tile.stories.js
@@ -150,7 +150,10 @@ export const Radio = () => {
       <RadioTile value="standard" style={{ marginBottom: '.5rem' }}>
         Option 1
       </RadioTile>
-      <RadioTile value="default-selected" id="tile-2">
+      <RadioTile
+        value="default-selected"
+        style={{ marginBottom: '.5rem' }}
+        id="tile-2">
         Option 2
       </RadioTile>
       <RadioTile value="selected" id="tile-3">

--- a/packages/styles/scss/components/tile/_tile.scss
+++ b/packages/styles/scss/components/tile/_tile.scss
@@ -48,12 +48,11 @@
 
   .#{$prefix}--tile--clickable,
   .#{$prefix}--tile--selectable {
-    border: 1px solid $border-subtle;
+    border: 1px solid $border-strong;
     cursor: pointer;
     transition: $duration-moderate-01 motion(standard, productive);
 
     &:hover {
-      border: 1px solid $border-subtle-selected;
       background: $layer-hover;
     }
   }
@@ -185,7 +184,7 @@
     position: relative;
     overflow: hidden;
     width: 100%;
-    border: 1px solid $border-subtle;
+    border: 1px solid $border-strong;
     color: inherit;
     cursor: pointer;
     font-family: inherit;
@@ -196,12 +195,11 @@
     @include type-style('body-compact-01');
 
     &:hover {
-      border: 1px solid $border-subtle-selected;
       background: $layer-hover;
     }
 
     &:active {
-      border: 1px solid $border-strong;
+      border: 1px solid $border-inverse;
     }
   }
 

--- a/packages/styles/scss/components/tile/_tile.scss
+++ b/packages/styles/scss/components/tile/_tile.scss
@@ -48,10 +48,12 @@
 
   .#{$prefix}--tile--clickable,
   .#{$prefix}--tile--selectable {
+    border: 1px solid $border-subtle;
     cursor: pointer;
     transition: $duration-moderate-01 motion(standard, productive);
 
     &:hover {
+      border: 1px solid $border-subtle-selected;
       background: $layer-hover;
     }
   }
@@ -71,6 +73,10 @@
       .#{$prefix}--tile__checkmark {
         opacity: 1;
       }
+    }
+
+    &:active {
+      border: 1px solid transparent;
     }
   }
 
@@ -98,7 +104,6 @@
 
   .#{$prefix}--tile--selectable {
     padding-right: $spacing-09;
-    border: 1px solid transparent;
   }
 
   .#{$prefix}--tile__checkmark {
@@ -180,7 +185,7 @@
     position: relative;
     overflow: hidden;
     width: 100%;
-    border: 0;
+    border: 1px solid $border-subtle;
     color: inherit;
     cursor: pointer;
     font-family: inherit;
@@ -191,11 +196,17 @@
     @include type-style('body-compact-01');
 
     &:hover {
+      border: 1px solid $border-subtle-selected;
       background: $layer-hover;
+    }
+
+    &:active {
+      border: 1px solid $border-strong;
     }
   }
 
   .#{$prefix}--tile--expandable.#{$prefix}--tile--expandable--interactive {
+    border: 0;
     cursor: default;
     transition: max-height $duration-moderate-01 motion(standard, productive);
 


### PR DESCRIPTION
Closes #11351 

Adds borders to Selectable/Clickable/Expandable(no interactive) tiles to increase visual contrast. 

The borders should match this spec: 
![image (3)](https://user-images.githubusercontent.com/17281178/176750101-bd49c2a0-d845-40c7-a34c-4f34a5738d70.png)


#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

Verify that the new borders match the above specs 
 Clickable/Selectable/Expandable(non-interactive) stories 