### PR TITLE
Run `npx sass-migrator division **/*.scss`

### DIFF
--- a/packages/components/src/globals/scss/_typography.import.scss
+++ b/packages/components/src/globals/scss/_typography.import.scss
@@ -46,7 +46,7 @@ $base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $base-font-size) * 1rem;
   } @else {
-    @return ($px / $base-font-size) * 1rem;
+    @return math.div($px, $base-font-size) * 1rem;
   }
 }
 
@@ -66,7 +66,7 @@ $base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $base-font-size) * 1em;
   } @else {
-    @return ($px / $base-font-size) * 1em;
+    @return math.div($px, $base-font-size) * 1em;
   }
 }
 

--- a/packages/components/src/globals/scss/_typography.scss
+++ b/packages/components/src/globals/scss/_typography.scss
@@ -19,6 +19,8 @@
 // compatibility file to ensure we continue to support node-sass and dart-sass
 // in v10.
 
+@use "sass:math";
+
 @import 'vars';
 
 /// Base font size in px
@@ -41,7 +43,7 @@ $base-font-size: 16px !default;
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
-  @return ($px / $base-font-size) * 1rem;
+  @return math.div($px, $base-font-size) * 1rem;
 }
 
 /// Convert px to em
@@ -57,7 +59,7 @@ $base-font-size: 16px !default;
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
-  @return ($px / $base-font-size) * 1em;
+  @return math.div($px, $base-font-size) * 1em;
 }
 
 // 🔬 Experimental

--- a/packages/grid/scss/_mixins.import.scss
+++ b/packages/grid/scss/_mixins.import.scss
@@ -85,8 +85,8 @@
       max-width: percentage(math.div($span, $columns));
       flex: 0 0 percentage(math.div($span, $columns));
     } @else {
-      max-width: percentage(($span / $columns));
-      flex: 0 0 percentage(($span / $columns));
+      max-width: percentage(math.div($span, $columns));
+      flex: 0 0 percentage(math.div($span, $columns));
     }
   }
 }
@@ -101,7 +101,7 @@
   @if meta.function-exists('div', 'math') {
     $offset: math.div($span, $columns);
   } @else {
-    $offset: ($span / $columns);
+    $offset: math.div($span, $columns);
   }
   @if $offset == 0 {
     margin-left: 0;
@@ -313,7 +313,7 @@ $carbon--aspect-ratios: (
       @if meta.function-exists('div', 'math') {
         padding-top: percentage(math.div($height, $width));
       } @else {
-        padding-top: percentage(($height / $width));
+        padding-top: percentage(math.div($height, $width));
       }
     }
   }

--- a/packages/grid/scss/_mixins.scss
+++ b/packages/grid/scss/_mixins.scss
@@ -23,6 +23,8 @@
 // and often derived from, bootstrap:
 // https://github.com/twbs/bootstrap/blob/v4-dev/scss/mixins/_grid.scss
 
+@use "sass:math";
+
 @import '@carbon/layout/scss/breakpoint';
 @import 'prefix';
 
@@ -45,21 +47,21 @@
   // always setting `width: 100%;`. This works because we use `flex` values
   // later on to override this initial width.
   width: 100%;
-  padding-right: ($gutter / 2);
-  padding-left: ($gutter / 2);
+  padding-right: ($gutter * 0.5);
+  padding-left: ($gutter * 0.5);
 
   // For our condensed use-case, our gutters collapse to 2px solid, 1px on each
   // side.
   .#{$prefix}--row--condensed &,
   .#{$prefix}--grid--condensed & {
-    padding-right: ($condensed-gutter / 2);
-    padding-left: ($condensed-gutter / 2);
+    padding-right: ($condensed-gutter * 0.5);
+    padding-left: ($condensed-gutter * 0.5);
   }
 
   // For our narrow use-case, our container hangs 16px into the gutter
   .#{$prefix}--row--narrow &,
   .#{$prefix}--grid--narrow & {
-    padding-right: ($gutter / 2);
+    padding-right: ($gutter * 0.5);
     padding-left: 0;
   }
 }
@@ -79,8 +81,8 @@
     // Add a `max-width` to ensure content within each column does not blow out
     // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
     // do not appear to require this.
-    max-width: percentage($span / $columns);
-    flex: 0 0 percentage($span / $columns);
+    max-width: percentage(math.div($span, $columns));
+    flex: 0 0 percentage(math.div($span, $columns));
   }
 }
 
@@ -90,7 +92,7 @@
 /// @access private
 /// @group @carbon/grid
 @mixin carbon--make-col-offset($span, $columns) {
-  $offset: $span / $columns;
+  $offset: math.div($span, $columns);
   @if $offset == 0 {
     margin-left: 0;
   } @else {
@@ -172,8 +174,8 @@
 @mixin carbon--make-row($gutter: $carbon--grid-gutter) {
   display: flex;
   flex-wrap: wrap;
-  margin-right: -1 * $gutter / 2;
-  margin-left: -1 * $gutter / 2;
+  margin-right: -1 * $gutter * 0.5;
+  margin-left: -1 * $gutter * 0.5;
 }
 
 // -----------------------------------------------------------------------------
@@ -224,20 +226,20 @@
 /// @group @carbon/grid
 @mixin carbon--hang($gutter: $carbon--grid-gutter) {
   .#{$prefix}--hang--start {
-    padding-left: ($gutter / 2);
+    padding-left: ($gutter * 0.5);
   }
 
   .#{$prefix}--hang--end {
-    padding-right: ($gutter / 2);
+    padding-right: ($gutter * 0.5);
   }
 
   // Deprecated ☠️
   .#{$prefix}--hang--left {
-    padding-left: ($gutter / 2);
+    padding-left: ($gutter * 0.5);
   }
 
   .#{$prefix}--hang--right {
-    padding-right: ($gutter / 2);
+    padding-right: ($gutter * 0.5);
   }
 }
 
@@ -298,7 +300,7 @@ $carbon--aspect-ratios: (
     $height: nth($aspect-ratio, 2);
 
     .#{$prefix}--aspect-ratio--#{$width}x#{$height}::before {
-      padding-top: percentage($height / $width);
+      padding-top: percentage(math.div($height, $width));
     }
   }
 
@@ -335,14 +337,14 @@ $carbon--aspect-ratios: (
       $prev-margin: map-get($prev-breakpoint, margin);
       @if $prev-margin != $margin {
         @include carbon--breakpoint($name) {
-          padding-right: #{($carbon--grid-gutter / 2) + $margin};
-          padding-left: #{($carbon--grid-gutter / 2) + $margin};
+          padding-right: #{($carbon--grid-gutter * 0.5) + $margin};
+          padding-left: #{($carbon--grid-gutter * 0.5) + $margin};
         }
       }
     } @else {
       @include carbon--breakpoint($name) {
-        padding-right: #{($carbon--grid-gutter / 2) + $margin};
-        padding-left: #{($carbon--grid-gutter / 2) + $margin};
+        padding-right: #{($carbon--grid-gutter * 0.5) + $margin};
+        padding-left: #{($carbon--grid-gutter * 0.5) + $margin};
       }
     }
   }
@@ -399,13 +401,13 @@ $carbon--aspect-ratios: (
 
   .#{$prefix}--row-padding [class*='#{$prefix}--col'],
   .#{$prefix}--col-padding {
-    padding-top: $grid-gutter / 2;
-    padding-bottom: $grid-gutter / 2;
+    padding-top: $grid-gutter * 0.5;
+    padding-bottom: $grid-gutter * 0.5;
   }
 
   .#{$prefix}--grid--condensed [class*='#{$prefix}--col'] {
-    padding-top: $condensed-gutter / 2;
-    padding-bottom: $condensed-gutter / 2;
+    padding-top: $condensed-gutter * 0.5;
+    padding-bottom: $condensed-gutter * 0.5;
   }
 
   @include carbon--make-grid-columns($breakpoints, $grid-gutter);

--- a/packages/grid/scss/modules/_css-grid.scss
+++ b/packages/grid/scss/modules/_css-grid.scss
@@ -246,21 +246,21 @@
         $span: $columns * 0.75;
         --cds-grid-columns: #{$span};
 
-        grid-column: span #{$span} / span #{$span};
+        grid-column: span list.slash($span, span) #{$span};
       }
 
       .#{$prefix}--#{$name}\:col-span-50 {
         $span: $columns * 0.5;
         --cds-grid-columns: #{$span};
 
-        grid-column: span #{$span} / span #{$span};
+        grid-column: span list.slash($span, span) #{$span};
       }
 
       .#{$prefix}--#{$name}\:col-span-25 {
         $span: $columns * 0.25;
         --cds-grid-columns: #{$span};
 
-        grid-column: span #{$span} / span #{$span};
+        grid-column: span list.slash($span, span) #{$span};
       }
     } @else {
       @include breakpoint($name) {
@@ -278,21 +278,21 @@
           $span: $columns * 0.75;
           --cds-grid-columns: #{$span};
 
-          grid-column: span #{$span} / span #{$span};
+          grid-column: span list.slash($span, span) #{$span};
         }
 
         .#{$prefix}--#{$name}\:col-span-50 {
           $span: $columns * 0.5;
           --cds-grid-columns: #{$span};
 
-          grid-column: span #{$span} / span #{$span};
+          grid-column: span list.slash($span, span) #{$span};
         }
 
         .#{$prefix}--#{$name}\:col-span-25 {
           $span: $columns * 0.25;
           --cds-grid-columns: #{$span};
 
-          grid-column: span #{$span} / span #{$span};
+          grid-column: span list.slash($span, span) #{$span};
         }
       }
     }
@@ -425,7 +425,7 @@
     @if is-smallest-breakpoint($key, $breakpoints) {
       --cds-grid-columns: #{$span};
 
-      grid-column: span #{$span} / span #{$span};
+      grid-column: span list.slash($span, span) #{$span};
     } @else {
       $previous-breakpoint: breakpoint-prev($key, $breakpoints);
       $previous-column-count: get-column-count(
@@ -438,7 +438,7 @@
         @include breakpoint($key) {
           --cds-grid-columns: #{$span};
 
-          grid-column: span #{$span} / span #{$span};
+          grid-column: span list.slash($span, span) #{$span};
         }
       }
     }

--- a/packages/grid/scss/modules/_flex-grid.scss
+++ b/packages/grid/scss/modules/_flex-grid.scss
@@ -74,8 +74,8 @@
       max-width: math.percentage(math.div($span, $columns));
       flex: 0 0 math.percentage(math.div($span, $columns));
     } @else {
-      max-width: math.percentage(($span / $columns));
-      flex: 0 0 math.percentage(($span / $columns));
+      max-width: math.percentage(math.div($span, $columns));
+      flex: 0 0 math.percentage(math.div($span, $columns));
     }
   }
 }
@@ -90,7 +90,7 @@
   @if meta.function-exists('div', 'math') {
     $offset: math.div($span, $columns);
   } @else {
-    $offset: ($span / $columns);
+    $offset: math.div($span, $columns);
   }
   @if $offset == 0 {
     margin-left: 0;

--- a/packages/grid/scss/modules/_mixins.scss
+++ b/packages/grid/scss/modules/_mixins.scss
@@ -68,8 +68,8 @@
       max-width: math.percentage(math.div($span, $columns));
       flex: 0 0 math.percentage(math.div($span, $columns));
     } @else {
-      max-width: math.percentage(($span / $columns));
-      flex: 0 0 math.percentage(($span / $columns));
+      max-width: math.percentage(math.div($span, $columns));
+      flex: 0 0 math.percentage(math.div($span, $columns));
     }
   }
 }
@@ -84,7 +84,7 @@
   @if meta.function-exists('div', 'math') {
     $offset: math.div($span, $columns);
   } @else {
-    $offset: ($span / $columns);
+    $offset: math.div($span, $columns);
   }
   @if $offset == 0 {
     margin-left: 0;

--- a/packages/layout/scss/_convert.import.scss
+++ b/packages/layout/scss/_convert.import.scss
@@ -42,7 +42,7 @@ $carbon--base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $carbon--base-font-size) * 1rem;
   } @else {
-    @return ($px / $carbon--base-font-size) * 1rem;
+    @return math.div($px, $carbon--base-font-size) * 1rem;
   }
 }
 
@@ -60,6 +60,6 @@ $carbon--base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $carbon--base-font-size) * 1em;
   } @else {
-    @return ($px / $carbon--base-font-size) * 1em;
+    @return math.div($px, $carbon--base-font-size) * 1em;
   }
 }

--- a/packages/layout/scss/_convert.scss
+++ b/packages/layout/scss/_convert.scss
@@ -23,6 +23,8 @@
 /// @type Number
 /// @access public
 /// @group @carbon/layout
+@use "sass:math";
+
 $carbon--base-font-size: 16px !default;
 
 /// Convert a given px unit to a rem unit
@@ -36,7 +38,7 @@ $carbon--base-font-size: 16px !default;
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
-  @return ($px / $carbon--base-font-size) * 1rem;
+  @return math.div($px, $carbon--base-font-size) * 1rem;
 }
 
 /// Convert a given px unit to a em unit
@@ -50,5 +52,5 @@ $carbon--base-font-size: 16px !default;
     @warn "Expected argument $px to be of type `px`, instead received: `#{unit($px)}`";
   }
 
-  @return ($px / $carbon--base-font-size) * 1em;
+  @return math.div($px, $carbon--base-font-size) * 1em;
 }

--- a/packages/layout/scss/_key-height.import.scss
+++ b/packages/layout/scss/_key-height.import.scss
@@ -43,7 +43,7 @@
     @if meta.function-exists('div', 'math') {
       @return math.div($width - (2 * $margin), $columns);
     } @else {
-      @return (($width - (2 * $margin)) / $columns);
+      @return math.div($width - (2 * $margin), $columns);
     }
   } @else {
     @warn 'Breakpoint: `#{$breakpoint}` is not a valid breakpoint.';

--- a/packages/layout/scss/_key-height.scss
+++ b/packages/layout/scss/_key-height.scss
@@ -19,6 +19,8 @@
 // compatibility file to ensure we continue to support node-sass and dart-sass
 // in v10.
 
+@use "sass:math";
+
 @import 'breakpoint';
 @import 'utilities';
 
@@ -38,7 +40,7 @@
     $margin: map-get($values, margin);
     $columns: map-get($values, columns);
 
-    @return ($width - (2 * $margin)) / $columns;
+    @return math.div($width - (2 * $margin), $columns);
   } @else {
     @warn 'Breakpoint: `#{$breakpoint}` is not a valid breakpoint.';
   }

--- a/packages/layout/scss/modules/_convert.scss
+++ b/packages/layout/scss/modules/_convert.scss
@@ -28,7 +28,7 @@ $base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $base-font-size) * 1rem;
   } @else {
-    @return ($px / $base-font-size) * 1rem;
+    @return math.div($px, $base-font-size) * 1rem;
   }
 }
 
@@ -46,6 +46,6 @@ $base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $base-font-size) * 1em;
   } @else {
-    @return ($px / $base-font-size) * 1em;
+    @return math.div($px, $base-font-size) * 1em;
   }
 }

--- a/packages/styles/scss/components/aspect-ratio/_aspect-ratio.scss
+++ b/packages/styles/scss/components/aspect-ratio/_aspect-ratio.scss
@@ -66,7 +66,7 @@ $carbon--aspect-ratios: (
       @if meta.function-exists('div', 'math') {
         padding-top: math.percentage(math.div($height, $width));
       } @else {
-        padding-top: math.percentage(($height / $width));
+        padding-top: math.percentage(math.div($height, $width));
       }
     }
   }

--- a/packages/styles/scss/utilities/_convert.scss
+++ b/packages/styles/scss/utilities/_convert.scss
@@ -27,7 +27,7 @@ $base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $base-font-size) * 1rem;
   } @else {
-    @return ($px / $base-font-size) * 1rem;
+    @return math.div($px, $base-font-size) * 1rem;
   }
 }
 
@@ -45,6 +45,6 @@ $base-font-size: 16px !default;
   @if meta.function-exists('div', 'math') {
     @return math.div($px, $base-font-size) * 1em;
   } @else {
-    @return ($px / $base-font-size) * 1em;
+    @return math.div($px, $base-font-size) * 1em;
   }
 }

--- a/packages/type/scss/_styles.import.scss
+++ b/packages/type/scss/_styles.import.scss
@@ -586,7 +586,7 @@ $tokens: (
   @if meta.function-exists('div', 'math') {
     @return math.div($value, $value * 0 + 1);
   } @else {
-    @return $value / ($value * 0 + 1);
+    @return math.div($value, $value * 0 + 1);
   }
 }
 

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -21,6 +21,8 @@
 
 // stylelint-disable number-max-precision
 
+@use "sass:math";
+
 @import '@carbon/layout/scss/breakpoint';
 @import 'font-family';
 @import 'scale';
@@ -745,7 +747,7 @@ $tokens: (
 /// @access public
 /// @group @carbon/type
 @function strip-unit($value) {
-  @return $value / ($value * 0 + 1);
+  @return math.div($value, $value * 0 + 1);
 }
 
 /// This helper includes fluid type styles for the given token value. Fluid type


### PR DESCRIPTION
Closes #11752

Remove deprecated uses of / as division in Sass code using the automated migration tool.

#### Changelog

**Changed**

- Remove deprecated uses of / as division in Sass code.
