### PR TITLE
style(styles): make width auto on Tabs

### DIFF
--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -54,7 +54,7 @@ $icon-tab-size: custom-property.get-var('icon-tab-size', rem(40px));
 
     .#{$prefix}--tab--list {
       display: flex;
-      width: 100%;
+      width: auto;
       overflow-x: auto;
       scroll-behavior: smooth;
       scrollbar-width: none;


### PR DESCRIPTION
Closes #

Updates Tabs to be auto-width instead of fixed.

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

Go to Tabs story and verify that the Tabs aren't a fixed width. 
