### PR TITLE
fix(switch): allow children to render (#11791) (v10)

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6142,7 +6142,6 @@ Map {
       "onClick": [Function],
       "onKeyDown": [Function],
       "selected": false,
-      "text": "Provide text",
     },
     "propTypes": Object {
       "children": Object {

--- a/packages/react/src/components/ContentSwitcher/next/ContentSwitcher.stories.js
+++ b/packages/react/src/components/ContentSwitcher/next/ContentSwitcher.stories.js
@@ -21,7 +21,7 @@ export default {
 export const Default = () => (
   <ContentSwitcher onChange={() => {}}>
     <Switch name="one" text="First section" />
-    <Switch name="two" text="Second section" />
+    <Switch name="two">Second section</Switch>
     <Switch name="three" text="Third section" />
   </ContentSwitcher>
 );

--- a/packages/react/src/components/Switch/Switch.js
+++ b/packages/react/src/components/Switch/Switch.js
@@ -117,7 +117,6 @@ Switch.propTypes = {
 
 Switch.defaultProps = {
   selected: false,
-  text: 'Provide text',
   onClick: () => {},
   onKeyDown: () => {},
 };


### PR DESCRIPTION
Cherry picking #11791 into v10 per [request on slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1657643382973669)

#### Changelog

**Changed**

- update switch to allow children to render
