### PR TITLE
fix(slider): add labelledby to slider div

### DIFF
--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -632,7 +632,7 @@ export default class Slider extends PureComponent {
                     aria-valuemin={min}
                     aria-valuenow={value}
                     style={thumbStyle}
-                    aria-labelledby={!ariaLabelInput ? labelId : null}
+                    aria-labelledby={labelId}
                   />
                   <div
                     className={`${prefix}--slider__track`}

--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -632,6 +632,7 @@ export default class Slider extends PureComponent {
                     aria-valuemin={min}
                     aria-valuenow={value}
                     style={thumbStyle}
+                    aria-labelledby={!ariaLabelInput ? labelId : null}
                   />
                   <div
                     className={`${prefix}--slider__track`}


### PR DESCRIPTION
Closes #11676
Reference: https://github.com/carbon-design-system/carbon/pull/11797 for v11 fix as well

#### Changelog

v10 fix 

**New**

- add `aria-labelledby` to slider div `role=slider`


#### Testing / Reviewing

Make sure slider is working as intended. Make sure the label a11y error is gone.