### PR TITLE
fix(Datepicker v10): change role on calendar container to 'application'

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -467,14 +467,12 @@ export default class DatePicker extends Component {
     }
   };
 
-  /**
-   * Flatpickr's calendar dialog is not rendered in a landmark causing an
-   * error with IBM Equal Access Accessibility Checker so we add an aria
-   * role to the container div.
-   */
+  // Flatpickr's calendar dialog is not rendered in a landmark causing an
+  // error with IBM Equal Access Accessibility Checker so we add an aria
+  // role to the container div.
   addRoleAttributeToDialog = () => {
     if (this.inputField) {
-      this.cal.calendarContainer.setAttribute('role', 'region');
+      this.cal.calendarContainer.setAttribute('role', 'application');
       // IBM EAAC requires an aria-label on a role='region'
       this.cal.calendarContainer.setAttribute(
         'aria-label',


### PR DESCRIPTION
Back-porting #11570

[Surfaced on slack](https://ibm-studios.slack.com/archives/C046Y0YUD/p1658322532419249)

#### Changelog

**Changed**

- update datepicker role to `application`

#### Testing / Reviewing

- Ensure datepicker works as expected
