### PR TITLE
fix(react): IconButton prop types for danger kind

### DIFF
--- a/packages/react/src/components/IconButton/index.js
+++ b/packages/react/src/components/IconButton/index.js
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Button from '../Button';
+import { ButtonKinds } from '../../prop-types/types';
 import { Tooltip } from '../Tooltip/next';
 import { usePrefix } from '../../internal/usePrefix';
 import cx from 'classnames';
@@ -85,7 +86,7 @@ IconButton.propTypes = {
   /**
    * Specify the type of button to be used as the base for the IconButton
    */
-  kind: PropTypes.oneOf(['primary', 'secondary', 'ghost', 'tertiary']),
+  kind: PropTypes.oneOf(ButtonKinds),
 
   /**
    * Provide the label to be rendered inside of the Tooltip. The label will use


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11892

Use `ButtonKinds` as possible values for `kind` property of IconButton component (just like how Button does), instead of the hardcoded string values that do not include any of the `danger` kind.

#### Changelog

**Removed**

- False alarm when using IconButton as a `danger` button

#### Testing / Reviewing

Using an IconButton with `kind` set to any of those values `['danger',  'danger--primary',  'danger--ghost',  'danger--tertiary']` should no longer trigger a warning in the console
