### PR TITLE
feat(datatable): limit description widths

### DIFF
--- a/packages/react/src/components/DataTable/next/DataTable-batch-actions.stories.js
+++ b/packages/react/src/components/DataTable/next/DataTable-batch-actions.stories.js
@@ -91,7 +91,7 @@ export const Default = (args) => (
       return (
         <TableContainer
           title="DataTable"
-          description="With batch actions"
+          description="With batch actions. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas accumsan mauris sed congue egestas. Integer varius mauris vel arcu pulvinar bibendum non sit amet ligula. Nullam ut nisi eu tellus aliquet vestibulum vel sit amet odio."
           {...getTableContainerProps()}>
           <TableToolbar {...getToolbarProps()}>
             <TableBatchActions {...batchActionProps}>

--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -8,6 +8,7 @@
 @use 'mixins' as *;
 @use 'vars' as *;
 @use '../../config' as *;
+@use '../../breakpoint' as *;
 @use '../../motion' as *;
 @use '../../spacing' as *;
 @use '../../theme' as *;
@@ -52,6 +53,14 @@
     @include type-style('body-compact-01');
 
     color: $text-secondary;
+
+    @include breakpoint(md) {
+      max-width: 50ch;
+    }
+
+    @include breakpoint(lg) {
+      max-width: 80ch;
+    }
   }
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11360 

#### Changelog

**New**

- provide a character-length-based max-width for data table descriptions per breakpoint

**Changed**

- lengthen the table description on batch actions story

#### Testing / Reviewing

* View the datatable/with batch actions story, review the description width at different breakpoints
* Review and approve snapshot changes in Percy status check

https://user-images.githubusercontent.com/3360588/183143344-c0775d59-8644-4d8e-ac92-2f25f4c05aab.mov


