### PR TITLE
test(numberinput): document and test onChange event signature

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -914,6 +914,9 @@ spacing.
 
 - The deprecated prop `isMobile` is no longer needed and has been removed
 - The `className` prop is now applied to the outermost element of `NumberInput`
+- `imaginaryTarget` is no longer available on the `onChange` event
+  - The signature for `onChange` is `onChange(event, {value, direction})`
+  - To fully control a NumberInput, use `value` to track internal state updates
 
 ### OverflowMenu
 

--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -319,9 +319,9 @@ NumberInput.propTypes = {
   min: PropTypes.number,
 
   /**
-   * The new value is available in 'imaginaryTarget.value'
-   * i.e. to get the value: evt.imaginaryTarget.value
-   *
+   * Provide an optional handler that is called when the internal state of
+   * NumberInput changes. This handler is called with event and state info.
+   * `(event, { value, direction }) => void`
    */
   onChange: PropTypes.func,
 

--- a/packages/react/src/components/NumberInput/__tests__/NumberInput-test.js
+++ b/packages/react/src/components/NumberInput/__tests__/NumberInput-test.js
@@ -160,6 +160,15 @@ describe('NumberInput', () => {
 
     userEvent.click(screen.getByLabelText('increment'));
     expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.any(Object),
+      }),
+      expect.objectContaining({
+        value: 11,
+        direction: 'up',
+      })
+    );
 
     userEvent.click(screen.getByLabelText('decrement'));
     expect(onChange).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Closes #11925
Closes #11926 

#### Changelog

**New**

- document `onChange` event signature in v11 release notes/migration guide
- cover `onChange` event signature in a test

**Changed**

- updated prop description for `onChange`

#### Testing / Reviewing

* Make sure the NumberInput prop table in storybook docs no longer references the old interface that was removed, `imaginaryTarget`
