### PR TITLE
fix(slider): prevent step value from causing error in input

### DIFF
--- a/packages/react/src/components/Slider/Slider.js
+++ b/packages/react/src/components/Slider/Slider.js
@@ -545,7 +545,7 @@ export default class Slider extends PureComponent {
       maxLabel,
       formatLabel = defaultFormatLabel,
       labelText,
-      step,
+      step, // eslint-disable-line no-unused-vars
       stepMultiplier, // eslint-disable-line no-unused-vars
       inputType,
       required,
@@ -664,7 +664,7 @@ export default class Slider extends PureComponent {
                   required={required}
                   min={min}
                   max={max}
-                  step={step}
+                  step={1}
                   onChange={this.onChange}
                   onBlur={this.onBlur}
                   onKeyUp={this.onInputKeyUp}

--- a/packages/react/src/components/Slider/next/Slider.stories.js
+++ b/packages/react/src/components/Slider/next/Slider.stories.js
@@ -46,6 +46,33 @@ export const Default = (args) => (
   />
 );
 
+export const StepTest = (args) => (
+  <>
+    <Slider
+      {...args}
+      labelText="Slider Label"
+      value={50}
+      min={0}
+      max={100}
+      step={5}
+      stepMultiplier={2}
+      noValidate
+    />
+    <br />
+    <Slider
+      {...args}
+      hideTextInput
+      labelText="Slider Label"
+      value={50}
+      min={0}
+      max={100}
+      step={5}
+      stepMultiplier={2}
+      noValidate
+    />
+  </>
+);
+
 Default.story = {
   name: 'Slider',
 };

--- a/packages/react/src/components/Slider/next/Slider.stories.js
+++ b/packages/react/src/components/Slider/next/Slider.stories.js
@@ -46,32 +46,37 @@ export const Default = (args) => (
   />
 );
 
-export const StepTest = (args) => (
-  <>
-    <Slider
-      {...args}
-      labelText="Slider Label"
-      value={50}
-      min={0}
-      max={100}
-      step={5}
-      stepMultiplier={2}
-      noValidate
-    />
-    <br />
-    <Slider
-      {...args}
-      hideTextInput
-      labelText="Slider Label"
-      value={50}
-      min={0}
-      max={100}
-      step={5}
-      stepMultiplier={2}
-      noValidate
-    />
-  </>
-);
+export const StepTest = (args) => {
+  const [val, setVal] = useState(0.5);
+  return (
+    <>
+      <Slider
+        {...args}
+        labelText="Slider Label"
+        value={0.5}
+        min={0}
+        max={1}
+        step={0.1}
+        stepMultiplier={2}
+        noValidate
+      />
+      <br />
+      <p>Slider value: {val.toFixed(1)}</p>
+      <Slider
+        {...args}
+        onChange={(evt) => setVal(evt.value)}
+        hideTextInput
+        labelText="Slider Label"
+        value={val}
+        min={0}
+        max={1}
+        step={0.1}
+        stepMultiplier={2}
+        noValidate
+      />
+    </>
+  );
+};
 
 Default.story = {
   name: 'Slider',


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/10171

When an input is provided with `Slider`, all values inputted inside the slider range will no longer throw errors. Numbers below and above the min-max will still throw errors (as they are outside the allowed range).

#### Changelog

**Changed**

- - Previously, if the `step` was 10 and the range was `0-100`, and a user entered `55` inside the `Slider` input, it would error. This was wrong because the 55 is still inside the allowed value range of 0-100. The Slider input step will always be `1`, and the `step` will only apply to the slider handle itself. 

#### Testing / Reviewing

Take a look at the `Slider` `Step Test` story. The handle should still increment via step/step multiplier, but the input should allow any value inside the range. 
