### PR TITLE
fix(react): remove aria-hidden since buttons are alway accessible

### DIFF
--- a/packages/react/src/components/UIShell/SideNav.js
+++ b/packages/react/src/components/UIShell/SideNav.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import { CARBON_SIDENAV_ITEMS } from './_utils';
 import { usePrefix } from '../../internal/usePrefix';
-import { useMatchMedia } from '../../internal/useMatchMedia';
 // TO-DO: comment back in when footer is added for rails
 // import SideNavFooter from './SideNavFooter';
 
@@ -121,9 +120,6 @@ const SideNav = React.forwardRef(function SideNav(props, ref) {
     eventHandlers.onMouseLeave = () => handleToggle(false, false);
   }
 
-  const isSideNavCollapsed = useMatchMedia(`(max-width: 1055px)`);
-  const ariaHidden = expanded === false && isSideNavCollapsed;
-
   return (
     <>
       {isFixedNav ? null : (
@@ -131,7 +127,6 @@ const SideNav = React.forwardRef(function SideNav(props, ref) {
         <div className={overlayClassName} onClick={onOverlayClick} />
       )}
       <nav
-        aria-hidden={ariaHidden}
         ref={ref}
         className={`${prefix}--side-nav__navigation ${className}`}
         {...accessibilityLabel}

--- a/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
+++ b/packages/react/src/components/UIShell/__tests__/__snapshots__/SideNav-test.js.snap
@@ -14,7 +14,6 @@ exports[`SideNav should render 1`] = `
     className="bx--side-nav__overlay"
   />
   <nav
-    aria-hidden={false}
     aria-label="Navigation"
     className="bx--side-nav__navigation bx--side-nav bx--side-nav--ux"
     onBlur={[Function]}


### PR DESCRIPTION
Partially addresses #11987 

Removes `aria-hidden` from SideNav. Since the buttons and links in the SideNav are always accessible via keyboard, even when the menu is closed, the SideNav is never actually hidden from screenreaders or keyboard users. 

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

Verify that the "Subelements of elements with attribute "aria-hidden-"true"" should not be focusable" violation is no longer happening on any story that uses SideNav (other violations will still exist, I'll address those in other PRs) 
