### PR TITLE
fix(FilterableMultiselect): remove extra invalid border

### DIFF
--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -111,7 +111,8 @@ $input-label-weight: 400 !default;
   .#{$prefix}--select-input__wrapper[data-invalid]
     .#{$prefix}--select-input:not(:focus),
   .#{$prefix}--list-box[data-invalid]:not(:focus),
-  .#{$prefix}--combo-box[data-invalid] .#{$prefix}--text-input:not(:focus) {
+  .#{$prefix}--combo-box[data-invalid]:not(.#{$prefix}--multi-select--selected)
+    .#{$prefix}--text-input:not(:focus) {
     @include focus-outline('invalid');
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11875

Removes double border when an item is selected in `FilterableMultiselect`

#### Changelog

**Changed**

- added a `:not` to the form invalid styles logic 

#### Testing / Reviewing

Go to `FilterableMultiselect` playground, set `invalid`, and then select an item. There should only be one `invalid` border.
