### PR TITLE
fix(Icons): update incremental-migration example to use v11 icons

### DIFF
--- a/examples/incremental-migration/package.json
+++ b/examples/incremental-migration/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/icons-react": "10.49.0",
+    "@carbon/icons-react": "11.7.0",
     "@carbon/react": "^1.12.0",
     "carbon-components": "^10.57.0",
     "carbon-components-react": "^7.57.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,7 +2033,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icons-react@^11.7.0, @carbon/icons-react@workspace:packages/icons-react":
+"@carbon/icons-react@11.7.0, @carbon/icons-react@^11.7.0, @carbon/icons-react@workspace:packages/icons-react":
   version: 0.0.0-use.local
   resolution: "@carbon/icons-react@workspace:packages/icons-react"
   dependencies:
@@ -2048,7 +2048,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icons-react@npm:10.49.0, @carbon/icons-react@npm:^10.49.0":
+"@carbon/icons-react@npm:^10.49.0":
   version: 10.49.0
   resolution: "@carbon/icons-react@npm:10.49.0"
   dependencies:
@@ -18016,7 +18016,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "incremental-migration@workspace:examples/incremental-migration"
   dependencies:
-    "@carbon/icons-react": 10.49.0
+    "@carbon/icons-react": 11.7.0
     "@carbon/react": ^1.12.0
     carbon-components: ^10.57.0
     carbon-components-react: ^7.57.0


### PR DESCRIPTION
Fixes an issue where the icon build process was resolving to the v10 icon package.

#### Changelog

**Changed**

- Updated the `incremental-migration` example project to use the v11 icon package

#### Testing / Reviewing

Ensure the `incremental-migration` example still renders as expected 
