### PR TITLE
fix(Filename): remove tabindex when status is complete

### DIFF
--- a/packages/react/src/components/FileUploader/Filename.js
+++ b/packages/react/src/components/FileUploader/Filename.js
@@ -36,7 +36,8 @@ function Filename({ iconDescription, status, invalid, ...rest }) {
         <CheckmarkFilled
           aria-label={iconDescription}
           className={`${prefix}--file-complete`}
-          {...rest}>
+          {...rest}
+          tabIndex={null}>
           {iconDescription && <title>{iconDescription}</title>}
         </CheckmarkFilled>
       );

--- a/packages/styles/scss/components/file-uploader/_file-uploader.scss
+++ b/packages/styles/scss/components/file-uploader/_file-uploader.scss
@@ -271,7 +271,6 @@
   }
 
   .#{$prefix}--file__state-container .#{$prefix}--file-complete {
-    cursor: pointer;
     fill: $interactive;
 
     &:focus {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12101

Removes the `tabindex` when the status is `complete`, as this is just a status icon, and no action can be taken by clicking the icon in this state

#### Changelog


**Changed**

- Removed the default tabIndex when the status is `complete`
- Removed cursor styles when the status is `complete`

#### Testing / Reviewing

Run a11y checker on the `Filename` example when the status is `complete`. No violations should appear
