### PR TITLE
fix(DataTable): backport aria-label fix to v10

### DIFF
--- a/packages/react/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/packages/react/src/components/InlineCheckbox/InlineCheckbox.js
@@ -46,7 +46,6 @@ const InlineCheckbox = React.forwardRef(function InlineCheckbox(
 
   if (indeterminate) {
     inputProps.checked = false;
-    inputProps['aria-checked'] = 'mixed';
   }
 
   useEffect(() => {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11532
Refs https://github.com/carbon-design-system/carbon/pull/11908

Backports a DataTable a11y fix to v10

#### Changelog

**Changed**

- remove `aria-checked`

#### Testing / Reviewing

Go to DataTable with selection, select all and make sure no a11y violations are shown
