### PR TITLE
fix(Accordion): update Accordion styles to match spec

### DIFF
--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -88,7 +88,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
     }
 
     &:hover::before {
-      background-color: $layer-hover;
+      background-color: $background-hover;
     }
 
     &:focus {
@@ -103,6 +103,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
   // Size styles
   .#{$prefix}--accordion--lg .#{$prefix}--accordion__heading {
     min-height: convert.rem(48px);
+    align-items: center;
   }
 
   .#{$prefix}--accordion--sm .#{$prefix}--accordion__heading {

--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -157,6 +157,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
 
     z-index: 1;
     width: 100%;
+    padding-right: $spacing-05;
     margin: $title-margin;
     text-align: left;
   }

--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -88,7 +88,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
     }
 
     &:hover::before {
-      background-color: $background-hover;
+      background-color: $layer-hover;
     }
 
     &:focus {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12141
Closes https://github.com/carbon-design-system/carbon/issues/12223

Fixes a few style issues with `Accordion`

#### Changelog

**Changed**

- `lg` size `Accordion` is now center aligned
- Background hover color is now `$background-hover`, not `$layer-hover`

#### Testing / Reviewing

- Go to the Playground story and set the size to `lg`, ensure the text and chevron are aligned
- Hover over the `AccordionItem` and ensure the token is `$background-hover` on the `::before` element


cc @shixiedesign 