### PR TITLE
fix(FilterableMultiselect): close menu on blur

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -297,6 +297,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
                 setInputFocused(true);
               },
               onBlur: () => {
+                handleOnMenuChange(false);
                 setInputFocused(false);
               },
             });

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -292,12 +292,15 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
                 if (match(event, keys.Space)) {
                   event.stopPropagation();
                 }
+
+                if (match(event, keys.Tab)) {
+                  handleOnMenuChange(false);
+                }
               },
               onFocus: () => {
                 setInputFocused(true);
               },
               onBlur: () => {
-                handleOnMenuChange(false);
                 setInputFocused(false);
               },
             });

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -250,15 +250,6 @@ export const _Filterable = () => {
         itemToString={(item) => (item ? item.text : '')}
         selectionFeedback="top-after-reopen"
       />
-
-      <FilterableMultiSelect
-        id="carbon-multiselect-example-4"
-        titleText="Multiselect title"
-        helperText="This is helper text"
-        items={items}
-        itemToString={(item) => (item ? item.text : '')}
-        selectionFeedback="top-after-reopen"
-      />
     </div>
   );
 };

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -250,6 +250,15 @@ export const _Filterable = () => {
         itemToString={(item) => (item ? item.text : '')}
         selectionFeedback="top-after-reopen"
       />
+
+      <FilterableMultiSelect
+        id="carbon-multiselect-example-4"
+        titleText="Multiselect title"
+        helperText="This is helper text"
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+        selectionFeedback="top-after-reopen"
+      />
     </div>
   );
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12130

Closes the `FilterableMultiSelect` menu when tabbing to another `FilterableMultiSelect` or close button

#### Changelog

**Changed**

- Calls the menu close function when the input loses focus

#### Testing / Reviewing

Go to the `FilterableMultiselect` story and type `2`. Then tab to the next `FilterableMultiSelect`. The previous menu should close. 

(I'll update this PR to remove the duplicate `FilterableMultiselect` once approved)
