### PR TITLE
docs: index vanilla library getting started

### DIFF
--- a/packages/components/carbon.yml
+++ b/packages/components/carbon.yml
@@ -40,6 +40,9 @@ library:
       $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g90-figma
     carbon-g100-figma:
       $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g100-figma
+  navData:
+    - title: Get started
+      path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/frameworks/vanilla.mdx'
 assets:
   accordion:
     status: stable


### PR DESCRIPTION
As found in https://github.com/carbon-design-system/carbon-platform/issues/907, added a "Get started" page to the Carbon Vanilla library with https://carbondesignsystem.com/developing/frameworks/vanilla content.

#### Changelog

**New**

- N/A

**Changed**

- Indexed `navData` for Vanilla library

**Removed**

- N/A

#### Testing / Reviewing

N/A
