### PR TITLE
fix(SelectableTile): fix a11y violations - v10

### DIFF
--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -287,7 +287,7 @@ export function SelectableTile(props) {
     <>
       <input
         ref={input}
-        tabIndex={-1}
+        tabIndex={!disabled ? tabIndex : null}
         id={id}
         className={inputClasses}
         value={value}
@@ -297,16 +297,11 @@ export function SelectableTile(props) {
         name={name}
         title={title}
         checked={isSelected}
-      />
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <label
-        htmlFor={id}
-        className={classes}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-        tabIndex={!disabled ? tabIndex : null}
-        {...rest}
         onClick={!disabled ? handleOnClick : null}
-        onKeyDown={!disabled ? handleOnKeyDown : null}>
+        onKeyDown={!disabled ? handleOnKeyDown : null}
+      />
+
+      <label htmlFor={id} className={classes} {...rest}>
         <span
           className={`${prefix}--tile__checkmark ${prefix}--tile__checkmark--persistent`}>
           {isSelected ? <CheckboxCheckedFilled16 /> : <Checkbox16 />}


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/12199
Refs https://github.com/carbon-design-system/carbon/pull/12200

Same as #12200 , just backporting to `v10`

#### Changelog

**Changed**

- Moved `tabIndex`, `onClick` and `onKeydown` handlers to the `input` rather than the label

**Removed**

- Removed unnecessary `eslint` comments 

#### Testing / Reviewing

Ensure `Selectable` and `Multiselect` `Tile` stories still work as expected (keyboard and click), and there are no regressions. Ensure there are no a11y violations.
