### PR TITLE
fix(text-input): fix typo in `maxCount` prop description

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -281,7 +281,7 @@ TextInput.propTypes = {
   light: PropTypes.bool,
 
   /**
-   * Max character count allowed for the textarea. This is needed in order for enableCounter to display
+   * Max character count allowed for the input. This is needed in order for enableCounter to display
    */
   maxCount: PropTypes.number,
 


### PR DESCRIPTION
Follows #12139

Fixes a typo in the `maxCount` prop type description.

#### Changelog

**Changed**

- fix(text-input): fix typo in `maxCount` prop description

