### PR TITLE
feat(react): deprecate light prop everywhere

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -563,9 +563,7 @@ Map {
       "hideCopyButton": Object {
         "type": "bool",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "maxCollapsedNumberOfRows": Object {
         "type": "number",
       },
@@ -977,7 +975,6 @@ Map {
       "disabled": false,
       "itemToElement": null,
       "itemToString": [Function],
-      "light": false,
       "shouldFilterItem": [Function],
       "type": "default",
     },
@@ -1162,9 +1159,7 @@ Map {
         "isRequired": true,
         "type": "array",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "onChange": Object {
         "isRequired": true,
         "type": "func",
@@ -1323,7 +1318,6 @@ Map {
       "helperText": "",
       "invalid": false,
       "invalidText": "",
-      "light": false,
       "onChange": [Function],
       "onClick": [Function],
       "size": "",
@@ -1371,9 +1365,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "onChange": Object {
         "type": "func",
       },
@@ -2272,9 +2264,7 @@ Map {
       "inline": Object {
         "type": "bool",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "locale": Object {
         "args": Array [
           Array [
@@ -2537,7 +2527,6 @@ Map {
       "helperText": "",
       "itemToElement": null,
       "itemToString": [Function],
-      "light": false,
       "titleText": "",
       "type": "default",
     },
@@ -2609,9 +2598,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "onChange": Object {
         "type": "func",
       },
@@ -3063,7 +3050,6 @@ Map {
       "filterItems": [Function],
       "initialSelectedItems": Array [],
       "itemToString": [Function],
-      "light": false,
       "locale": "en",
       "open": false,
       "selectionFeedback": "top-after-reopen",
@@ -3238,9 +3224,7 @@ Map {
         "isRequired": true,
         "type": "array",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "locale": Object {
         "type": "string",
       },
@@ -4291,7 +4275,6 @@ Map {
         "filterItems": [Function],
         "initialSelectedItems": Array [],
         "itemToString": [Function],
-        "light": false,
         "locale": "en",
         "open": false,
         "selectionFeedback": "top-after-reopen",
@@ -4466,9 +4449,7 @@ Map {
           "isRequired": true,
           "type": "array",
         },
-        "light": Object {
-          "type": "bool",
-        },
+        "light": [Function],
         "locale": Object {
           "type": "string",
         },
@@ -4534,7 +4515,6 @@ Map {
       "disabled": false,
       "initialSelectedItems": Array [],
       "itemToString": [Function],
-      "light": false,
       "locale": "en",
       "open": false,
       "selectedItems": null,
@@ -4719,9 +4699,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "locale": Object {
         "type": "string",
       },
@@ -5284,9 +5262,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "onChange": Object {
         "type": "func",
       },
@@ -7462,7 +7438,6 @@ Map {
       "helperText": "",
       "invalid": false,
       "invalidText": "",
-      "light": false,
       "maxCount": undefined,
       "onChange": [Function],
       "onClick": [Function],
@@ -7514,9 +7489,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "maxCount": Object {
         "type": "number",
       },
@@ -7568,7 +7541,6 @@ Map {
         "helperText": "",
         "invalid": false,
         "invalidText": "",
-        "light": false,
         "onChange": [Function],
         "onClick": [Function],
         "size": "",
@@ -7616,9 +7588,7 @@ Map {
           "isRequired": true,
           "type": "node",
         },
-        "light": Object {
-          "type": "bool",
-        },
+        "light": [Function],
         "onChange": Object {
           "type": "func",
         },
@@ -7726,9 +7696,7 @@ Map {
           "isRequired": true,
           "type": "node",
         },
-        "light": Object {
-          "type": "bool",
-        },
+        "light": [Function],
         "onChange": Object {
           "type": "func",
         },
@@ -7852,9 +7820,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "maxCount": Object {
         "type": "number",
       },
@@ -9377,9 +9343,7 @@ Map {
         "isRequired": true,
         "type": "node",
       },
-      "light": Object {
-        "type": "bool",
-      },
+      "light": [Function],
       "maxCount": Object {
         "type": "number",
       },

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -15,6 +15,7 @@ import Button from '../Button';
 import CopyButton from '../CopyButton';
 import getUniqueId from '../../tools/uniqueId';
 import copy from 'copy-to-clipboard';
+import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 
 const rowHeightInPixels = 16;
@@ -328,7 +329,12 @@ CodeSnippet.propTypes = {
    * Specify whether you are using the light variant of the Code Snippet,
    * typically used for inline snippet to display an alternate color
    */
-  light: PropTypes.bool,
+
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `CodeSnippet` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Specify the maximum number of rows to be shown when in collapsed view

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.stories.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.stories.js
@@ -18,6 +18,13 @@ export default {
       page: mdx,
     },
   },
+  argTypes: {
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const Inline = () => (

--- a/packages/react/src/components/ComboBox/ComboBox-test.e2e.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.e2e.js
@@ -96,18 +96,6 @@ describe('ComboBox', () => {
             items={items}
             itemToString={(item) => (item ? item.text : '')}
             placeholder="Filter..."
-            titleText="Light combobox"
-            helperText="Combobox helper text"
-            light
-          />
-        </div>
-        <div style={{ marginBottom: '2rem' }}>
-          <ComboBox
-            onChange={() => {}}
-            id="carbon-combobox"
-            items={items}
-            itemToString={(item) => (item ? item.text : '')}
-            placeholder="Filter..."
             titleText="Combobox with warning state"
             helperText="Combobox helper text"
             warn

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -21,6 +21,7 @@ import { match, keys } from '../../internal/keyboard';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import mergeRefs from '../../tools/mergeRefs';
 import { useFeatureFlag } from '../FeatureFlags';
+import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 
 const defaultItemToString = (item) => {
@@ -485,7 +486,11 @@ ComboBox.propTypes = {
   /**
    * should use "light theme" (white background)?
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `Combobox` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * `onChange` is a utility for this controlled component to communicate to a
@@ -575,7 +580,6 @@ ComboBox.defaultProps = {
   shouldFilterItem: defaultShouldFilterItem,
   type: 'default',
   ariaLabel: 'Choose an item',
-  light: false,
   direction: 'bottom',
 };
 

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -46,6 +46,11 @@ export default {
       options: ['sm', 'md', 'lg'],
       control: { type: 'select' },
     },
+    light: {
+      table: {
+        disable: true,
+      },
+    },
   },
   parameters: {
     docs: {
@@ -169,11 +174,6 @@ Playground.argTypes = {
     },
   },
   itemToString: {
-    table: {
-      disable: true,
-    },
-  },
-  light: {
     table: {
       disable: true,
     },

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -14,6 +14,7 @@ import DatePickerInput from '../DatePickerInput';
 import carbonFlatpickrAppendToPlugin from './plugins/appendToPlugin';
 import carbonFlatpickrFixEventsPlugin from './plugins/fixEventsPlugin';
 import carbonFlatpickrRangePlugin from './plugins/rangePlugin';
+import deprecate from '../../prop-types/deprecate';
 import { match, keys } from '../../internal/keyboard';
 import { usePrefix } from '../../internal/usePrefix';
 import { useSavedCallback } from '../../internal/useSavedCallback';
@@ -185,7 +186,7 @@ function DatePicker({
   disable,
   enable,
   inline,
-  light = false,
+  light,
   locale = 'en',
   maxDate,
   minDate,
@@ -529,8 +530,11 @@ DatePicker.propTypes = {
   /**
    * `true` to use the light version.
    */
-  light: PropTypes.bool,
-
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `DatePicker` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
   /**
    *  The language locale used to format the days of the week, months, and numbers. The full list of supported locales can be found here https://github.com/flatpickr/flatpickr/tree/master/src/l10n
    */

--- a/packages/react/src/components/DatePicker/DatePicker.stories.js
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.js
@@ -24,6 +24,13 @@ export default {
       page: mdx,
     },
   },
+  argTypes: {
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const Simple = () => (
@@ -240,11 +247,6 @@ Playground.argTypes = {
     },
   },
   inline: {
-    table: {
-      disable: true,
-    },
-  },
-  light: {
     table: {
       disable: true,
     },

--- a/packages/react/src/components/Dropdown/Dropdown-test.e2e.js
+++ b/packages/react/src/components/Dropdown/Dropdown-test.e2e.js
@@ -51,15 +51,6 @@ describe('Dropdown', () => {
           invalid
           invalidText="This is invalid text"
         />
-        <Dropdown style={style} items={items} label={label} light />
-        <Dropdown
-          style={style}
-          items={items}
-          label={label}
-          light
-          invalid
-          invalidText="This is invalid text"
-        />
         <Dropdown style={style} items={items} label={label} type="inline" />
         <DropdownSkeleton style={style} size="sm" />
         <DropdownSkeleton style={style} size="md" />

--- a/packages/react/src/components/Dropdown/Dropdown-test.js
+++ b/packages/react/src/components/Dropdown/Dropdown-test.js
@@ -122,14 +122,6 @@ describe('Dropdown', () => {
     });
   });
 
-  it('should specify light version as expected', () => {
-    render(<Dropdown light={true} {...mockProps} />);
-
-    expect(document.querySelector('.cds--list-box')).toHaveClass(
-      'cds--dropdown--light'
-    );
-  });
-
   it('should let the user select an option by clicking on the option node', () => {
     render(<Dropdown {...mockProps} />);
     openMenu();

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -16,6 +16,7 @@ import {
 } from '@carbon/icons-react';
 import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
 import mergeRefs from '../../tools/mergeRefs';
+import deprecate from '../../prop-types/deprecate';
 import { useFeatureFlag } from '../FeatureFlags';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
@@ -328,7 +329,11 @@ Dropdown.propTypes = {
   /**
    * `true` to use the light version.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `Dropdown` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * `onChange` is a utility for this controlled component to communicate to a
@@ -388,7 +393,6 @@ Dropdown.defaultProps = {
   type: 'default',
   itemToString: defaultItemToString,
   itemToElement: null,
-  light: false,
   titleText: '',
   helperText: '',
   direction: 'bottom',

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -227,11 +227,12 @@ an array of objects, you'll need to pass in an `itemToString` function as well.
 />
 ```
 
-### Dropdown `light`
+### Dropdown `light` **deprecated**
 
 In certain circumstances, a `Dropdown` will exist on a container element with
 the same background color. To improve contrast, you can use the `light` property
-to toggle the light variant of the `Dropdown`.
+to toggle the light variant of the `Dropdown`. `light` is now deprecated, we
+recommend using the new `Layer` component instead.
 
 ```jsx
 <Dropdown light>...</Dropdown>

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -32,6 +32,11 @@ export default {
     id: {
       table: { disable: true },
     },
+    light: {
+      table: {
+        disable: true,
+      },
+    },
   },
   parameters: {
     docs: {

--- a/packages/react/src/components/FluidTextArea/FluidTextArea.js
+++ b/packages/react/src/components/FluidTextArea/FluidTextArea.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import TextArea from '../TextArea';
+import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm/FormContext';
 
@@ -85,7 +86,11 @@ FluidTextArea.propTypes = {
    * `true` to use the light version. For use on $ui-01 backgrounds only.
    * Don't use this to make tile background color same as container background color.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `FluidTextArea` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Max character count allowed for the textarea. This is needed in order for enableCounter to display

--- a/packages/react/src/components/ListBox/ListBox.js
+++ b/packages/react/src/components/ListBox/ListBox.js
@@ -8,6 +8,7 @@
 import cx from 'classnames';
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import deprecate from '../../prop-types/deprecate';
 import { ListBoxType, ListBoxSize } from './ListBoxPropTypes';
 import { usePrefix } from '../../internal/usePrefix';
 import ListBoxField from './ListBoxField';
@@ -123,7 +124,11 @@ ListBox.propTypes = {
    * `true` to use the light version. For use on $ui-01 backgrounds only.
    * Don't use this to make tile background color same as container background color.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `ListBox` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.

--- a/packages/react/src/components/ListBox/__tests__/ListBox-test.js
+++ b/packages/react/src/components/ListBox/__tests__/ListBox-test.js
@@ -20,11 +20,6 @@ describe('ListBox', () => {
     expect(container.firstChild).toHaveClass('cds--list-box--disabled');
   });
 
-  it('should set the light class when `light` is true', () => {
-    const { container } = render(<ListBox light />);
-    expect(container.firstChild).toHaveClass('cds--list-box--light');
-  });
-
   it('should set the expanded class when `isOpen` is true', () => {
     const { container } = render(<ListBox isOpen />);
     expect(container.firstChild).toHaveClass('cds--list-box--expanded');

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -19,6 +19,7 @@ import { match, keys } from '../../internal/keyboard';
 import Selection from '../../internal/Selection';
 import { defaultItemToString } from './tools/itemToString';
 import mergeRefs from '../../tools/mergeRefs';
+import deprecate from '../../prop-types/deprecate';
 import { useId } from '../../internal/useId';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 import { useFeatureFlag } from '../FeatureFlags';
@@ -513,7 +514,11 @@ FilterableMultiSelect.propTypes = {
   /**
    * `true` to use the light version.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `FilterableMultiSelect` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Specify the locale of the control. Used for the default `compareItems`
@@ -596,7 +601,6 @@ FilterableMultiSelect.defaultProps = {
   itemToString: defaultItemToString,
   locale: 'en',
   sortItems: defaultSortItems,
-  light: false,
   open: false,
   selectionFeedback: 'top-after-reopen',
 };

--- a/packages/react/src/components/MultiSelect/MultiSelect.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.js
@@ -18,6 +18,7 @@ import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 import { useSelection } from '../../internal/Selection';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import mergeRefs from '../../tools/mergeRefs';
+import deprecate from '../../prop-types/deprecate';
 import { keys, match } from '../../internal/keyboard';
 import { useFeatureFlag } from '../FeatureFlags';
 import { usePrefix } from '../../internal/usePrefix';
@@ -405,7 +406,11 @@ MultiSelect.propTypes = {
   /**
    * `true` to use the light version.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `MultiSelect` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Specify the locale of the control. Used for the default `compareItems`
@@ -488,7 +493,6 @@ MultiSelect.defaultProps = {
   initialSelectedItems: [],
   sortItems: defaultSortItems,
   type: 'default',
-  light: false,
   title: false,
   open: false,
   selectionFeedback: 'top-after-reopen',

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -39,6 +39,11 @@ export default {
     items: {
       table: { disable: true },
     },
+    light: {
+      table: {
+        disable: true,
+      },
+    },
     local: {
       table: { disable: true },
     },
@@ -152,12 +157,6 @@ Playground.argTypes = {
     defaultValue: false,
   },
   invalid: {
-    control: {
-      type: 'boolean',
-    },
-    defaultValue: false,
-  },
-  light: {
     control: {
       type: 'boolean',
     },

--- a/packages/react/src/components/MultiSelect/__tests__/FilterableMultiSelect-test.e2e.js
+++ b/packages/react/src/components/MultiSelect/__tests__/FilterableMultiSelect-test.e2e.js
@@ -83,18 +83,6 @@ describe('FilterableMultiSelect', () => {
         <WrappedFilterableMultiSelect
           items={items}
           placeholder={placeholder}
-          light
-        />
-        <WrappedFilterableMultiSelect
-          items={items}
-          placeholder={placeholder}
-          light
-          invalid
-          invalidText="This is invalid text"
-        />
-        <WrappedFilterableMultiSelect
-          items={items}
-          placeholder={placeholder}
           type="inline"
         />
       </>

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.e2e.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.e2e.js
@@ -52,14 +52,6 @@ describe('MultiSelect', () => {
           invalid
           invalidText="This is invalid text"
         />
-        <WrappedMultiSelect items={items} label={label} light />
-        <WrappedMultiSelect
-          items={items}
-          label={label}
-          light
-          invalid
-          invalidText="This is invalid text"
-        />
         <WrappedMultiSelect items={items} label={label} type="inline" />
       </>
     );

--- a/packages/react/src/components/OverflowMenu/next/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/next/OverflowMenu.stories.js
@@ -19,6 +19,11 @@ export default {
       options: ['sm', 'md', 'lg'],
       control: { type: 'select' },
     },
+    light: {
+      table: {
+        disable: true,
+      },
+    },
   },
   args: {
     size: 'md',

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -70,12 +70,6 @@ describe('TextArea', () => {
         expect(textarea().props().defaultValue).toEqual('default value');
       });
 
-      it('should specify light version as expected', () => {
-        expect(wrapper.props().light).toEqual(false);
-        wrapper.setProps({ light: true });
-        expect(wrapper.props().light).toEqual(true);
-      });
-
       it('should set enableCounter as expected', () => {
         wrapper.setProps({ enableCounter: true });
         expect(wrapper.props().enableCounter).toEqual(true);

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 import React, { useState, useContext } from 'react';
 import classNames from 'classnames';
+import deprecate from '../../prop-types/deprecate';
 import { WarningFilled } from '@carbon/icons-react';
 import { useFeatureFlag } from '../FeatureFlags';
 import { usePrefix } from '../../internal/usePrefix';
@@ -209,7 +210,11 @@ TextArea.propTypes = {
    * `true` to use the light version. For use on $ui-01 backgrounds only.
    * Don't use this to make tile background color same as container background color.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `TextArea` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Max character count allowed for the textarea. This is needed in order for enableCounter to display
@@ -254,7 +259,6 @@ TextArea.defaultProps = {
   invalid: false,
   invalidText: '',
   helperText: '',
-  light: false,
   enableCounter: false,
   maxCount: undefined,
 };

--- a/packages/react/src/components/TextArea/next/TextArea.stories.js
+++ b/packages/react/src/components/TextArea/next/TextArea.stories.js
@@ -15,6 +15,13 @@ export default {
   subcomponents: {
     TextAreaSkeleton,
   },
+  argTypes: {
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const Default = () => (

--- a/packages/react/src/components/TextInput/ControlledPasswordInput.js
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { View, ViewOff, WarningFilled } from '@carbon/icons-react';
 import { textInputProps } from './util';
 import { warning } from '../../internal/warning';
+import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 
 let didWarnAboutDeprecation = false;
@@ -209,7 +210,11 @@ ControlledPasswordInput.propTypes = {
    * `true` to use the light version. For use on $ui-01 backgrounds only.
    * Don't use this to make tile background color same as container background color.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `ControlledPasswordInput` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Optionally provide an `onChange` handler that is called whenever `<input>`
@@ -264,7 +269,6 @@ ControlledPasswordInput.defaultProps = {
   invalid: false,
   invalidText: '',
   helperText: '',
-  light: false,
   size: '',
 };
 

--- a/packages/react/src/components/TextInput/PasswordInput-test.js
+++ b/packages/react/src/components/TextInput/PasswordInput-test.js
@@ -12,7 +12,6 @@ describe('PasswordInput', () => {
         className="extra-class"
         labelText="testlabel"
         helperText="testHelper"
-        light
         showPasswordLabel="Show password"
         hidePasswordLabel="Hide password"
       />
@@ -62,13 +61,6 @@ describe('PasswordInput', () => {
 
       it('should add extra classes that are passed via className', () => {
         expect(passwordInput().hasClass('extra-class')).toEqual(true);
-      });
-
-      it('has the expected classes for light', () => {
-        wrapper.setProps({ light: true });
-        expect(
-          passwordInput().hasClass(`${prefix}--text-input--light`)
-        ).toEqual(true);
       });
 
       it('should set type as expected', () => {

--- a/packages/react/src/components/TextInput/PasswordInput.js
+++ b/packages/react/src/components/TextInput/PasswordInput.js
@@ -6,6 +6,7 @@ import { useNormalizedInputProps } from '../../internal/useNormalizedInputProps'
 import { textInputProps } from './util';
 import { FormContext } from '../FluidForm';
 import * as FeatureFlags from '@carbon/feature-flags';
+import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 
 const PasswordInput = React.forwardRef(function PasswordInput(
@@ -20,7 +21,7 @@ const PasswordInput = React.forwardRef(function PasswordInput(
     invalid = false,
     invalidText,
     labelText,
-    light = false,
+    light,
     onChange = () => {},
     onClick = () => {},
     onTogglePasswordVisibility,
@@ -268,7 +269,11 @@ PasswordInput.propTypes = {
    * `true` to use the light version. For use on $ui-01 backgrounds only.
    * Don't use this to make tile background color same as container background color.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `PasswordInput` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Optionally provide an `onChange` handler that is called whenever `<input>`

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import { useNormalizedInputProps } from '../../internal/useNormalizedInputProps';
 import PasswordInput from './PasswordInput';
 import ControlledPasswordInput from './ControlledPasswordInput';
+import deprecate from '../../prop-types/deprecate';
 import { textInputProps } from './util';
 import { FormContext } from '../FluidForm';
 import { useFeatureFlag } from '../FeatureFlags';
@@ -28,7 +29,7 @@ const TextInput = React.forwardRef(function TextInput(
     invalid = false,
     invalidText,
     labelText,
-    light = false,
+    light,
     onChange = () => {},
     onClick = () => {},
     placeholder,
@@ -278,7 +279,11 @@ TextInput.propTypes = {
    * `true` to use the light version. For use on $ui-01 backgrounds only.
    * Don't use this to make tile background color same as container background color.
    */
-  light: PropTypes.bool,
+  light: deprecate(
+    PropTypes.bool,
+    'The `light` prop for `TextInput` has ' +
+      'been deprecated in favor of the new `Layer` component. It will be removed in the next major release.'
+  ),
 
   /**
    * Max character count allowed for the input. This is needed in order for enableCounter to display

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -17,6 +17,13 @@ export default {
     TextInputSkeleton,
     'TextInput.PasswordInput': TextInput.PasswordInput,
   },
+  argTypes: {
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const Default = () => (

--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -33,19 +33,6 @@ describe('Tile', () => {
     it('renders extra classes passed in via className', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
-
-    it('supports light version', () => {
-      const wrapper = mount(<Tile>Test</Tile>);
-      expect(wrapper.props().light).toEqual(false);
-      expect(wrapper.childAt(0).hasClass(`${prefix}--tile--light`)).toEqual(
-        false
-      );
-      wrapper.setProps({ light: true });
-      expect(wrapper.props().light).toEqual(true);
-      expect(wrapper.childAt(0).hasClass(`${prefix}--tile--light`)).toEqual(
-        true
-      );
-    });
   });
 
   describe('Renders clickable tile as expected', () => {
@@ -107,19 +94,6 @@ describe('Tile', () => {
       wrapper.setState({ clicked: false });
       wrapper.setProps({ clicked: true });
       expect(wrapper.state().clicked).toEqual(false);
-    });
-
-    it('supports light version', () => {
-      const wrapper = mount(<ClickableTile>Test</ClickableTile>);
-      expect(wrapper.props().light).toEqual(false);
-      expect(wrapper.childAt(0).hasClass(`${prefix}--tile--light`)).toEqual(
-        false
-      );
-      wrapper.setProps({ light: true });
-      expect(wrapper.props().light).toEqual(true);
-      expect(wrapper.childAt(0).hasClass(`${prefix}--tile--light`)).toEqual(
-        true
-      );
     });
   });
 
@@ -190,15 +164,6 @@ describe('Tile', () => {
       label.simulate('click');
       wrapper.setProps({ selected: true });
       expect(wrapper.hasClass(`${prefix}--tile--is-selected`)).toEqual(false);
-    });
-
-    it('supports light version', () => {
-      const wrapper = mount(<SelectableTile>Test</SelectableTile>);
-      expect(wrapper.props().light).toEqual(false);
-      expect(wrapper.childAt(1).hasClass('cds--tile--light')).toEqual(false);
-      wrapper.setProps({ light: true });
-      expect(wrapper.props().light).toEqual(true);
-      expect(wrapper.childAt(1).hasClass('cds--tile--light')).toEqual(true);
     });
 
     it('should call onChange when the checkbox value changes', () => {
@@ -380,19 +345,6 @@ describe('Tile', () => {
       wrapper.setState({ tilePadding: 1 });
       wrapper.setProps({ tilePadding: 2 });
       expect(wrapper.state().tilePadding).toEqual(1);
-    });
-
-    it('supports light version', () => {
-      const wrapper = mount(<ExpandableTile>Test</ExpandableTile>);
-      expect(wrapper.props().light).toEqual(false);
-      expect(wrapper.childAt(0).hasClass(`${prefix}--tile--light`)).toEqual(
-        false
-      );
-      wrapper.setProps({ light: true });
-      expect(wrapper.props().light).toEqual(true);
-      expect(wrapper.childAt(0).hasClass(`${prefix}--tile--light`)).toEqual(
-        true
-      );
     });
   });
 });

--- a/packages/react/src/components/TimePicker/next/TimePicker.stories.js
+++ b/packages/react/src/components/TimePicker/next/TimePicker.stories.js
@@ -11,46 +11,6 @@ import TimePicker from '../';
 import TimePickerSelect from '../../TimePickerSelect';
 import { Layer } from '../../Layer';
 
-// const props = {
-//   timepicker: () => ({
-//     pattern: text(
-//       'Regular expression for the value (pattern in <TimePicker>)',
-//       '(1[012]|[1-9]):[0-5][0-9](\\s)?'
-//     ),
-//     placeholder: text(
-//       'Placeholder text (placeholder in <TimePicker>)',
-//       'hh:mm'
-//     ),
-//     disabled: boolean('Disabled (disabled in <TimePicker>)', false),
-//     light: boolean('Light variant (light in <TimePicker>)', false),
-//     labelText: text('Label text (labelText in <TimePicker>)', 'Select a time'),
-//     invalid: boolean(
-//       'Show form validation UI (invalid in <TimePicker>)',
-//       false
-//     ),
-//     invalidText: text(
-//       'Form validation UI content (invalidText in <TimePicker>)',
-//       'A valid value is required'
-//     ),
-//     maxLength: number('Maximum length (maxLength in <TimePicker>)', 5),
-//     size: select('Field size (size)', sizes, undefined) || undefined,
-//     onClick: action('onClick'),
-//     onChange: action('onChange'),
-//     onBlur: action('onBlur'),
-//   }),
-//   select: () => ({
-//     disabled: boolean('Disabled (disabled in <TimePickerSelect>)', false),
-//     labelText: text(
-//       'Label text (labelText in <TimePickerSelect>)',
-//       'Please select'
-//     ),
-//     iconDescription: text(
-//       'Trigger icon description (iconDescription in <TimePickerSelect>)',
-//       'open list of options'
-//     ),
-//   }),
-// };
-
 export default {
   title: 'Components/TimePicker',
   component: TimePicker,
@@ -58,6 +18,11 @@ export default {
     size: {
       options: ['sm', 'md', 'lg'],
       control: { type: 'select' },
+    },
+    light: {
+      table: {
+        disable: true,
+      },
     },
   },
   args: {


### PR DESCRIPTION
I think due to confusion on whether or not we would deprecate `light` before or after v11 was released, we were inconsistent with deprecating it. This PR deprecates `light` in all components and removes it from the props table in storybook. Lemme know if we would prefer to have it show up in the props table but just with a note saying it's deprecated instead! 

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

Verify that the light prop is deprecated as expected and that the docs changes are consistent across the components. 
