### PR TITLE
fix(overflowmenu-v10): convert icon description to sentence case

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4533,11 +4533,11 @@ Map {
       "$$typeof": Symbol(react.context),
     },
     "defaultProps": Object {
-      "ariaLabel": "open and close list of options",
+      "ariaLabel": "Open and close list of options",
       "direction": "bottom",
       "flipped": false,
       "focusTrap": true,
-      "iconDescription": "open and close list of options",
+      "iconDescription": "Open and close list of options",
       "light": false,
       "menuOffset": [Function],
       "menuOffsetFlip": [Function],

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -235,8 +235,8 @@ class OverflowMenu extends Component {
   static defaultProps = {
     ariaLabel: FeatureFlags.enabled('enable-v11-release')
       ? null
-      : 'open and close list of options',
-    iconDescription: 'open and close list of options',
+      : 'Open and close list of options',
+    iconDescription: 'Open and close list of options',
     open: false,
     direction: DIRECTION_BOTTOM,
     flipped: false,


### PR DESCRIPTION
Ref #12293

v10 mirror of https://github.com/carbon-design-system/carbon/pull/12299