### PR TITLE
refactor(DataTable): rename sorting class name

### DIFF
--- a/packages/react/src/components/DataTable/TableHeader.js
+++ b/packages/react/src/components/DataTable/TableHeader.js
@@ -88,7 +88,7 @@ const TableHeader = React.forwardRef(function TableHeader(
     [`${prefix}--table-sort`]: true,
     [`${prefix}--table-sort--active`]:
       isSortHeader && sortDirection !== sortStates.NONE,
-    [`${prefix}--table-sort--ascending`]:
+    [`${prefix}--table-sort--descending`]:
       isSortHeader && sortDirection === sortStates.DESC,
   });
   const ariaSort = !isSortHeader ? 'none' : sortDirections[sortDirection];

--- a/packages/styles/scss/components/data-table/sort/_data-table-sort.scss
+++ b/packages/styles/scss/components/data-table/sort/_data-table-sort.scss
@@ -158,7 +158,7 @@
     opacity: 1;
   }
 
-  .#{$prefix}--table-sort--ascending .#{$prefix}--table-sort__icon {
+  .#{$prefix}--table-sort--descending .#{$prefix}--table-sort__icon {
     transform: rotate(180deg);
   }
 


### PR DESCRIPTION
Closes #11685 

This PR renames the `table-sort--ascending` class to `table-sort--descending` so it matches the table sort state. This is technically a breaking change but depending on how the team views this update I can put the old value in as a fallback if needed

#### Changelog

**Changed**

- `table-sort--descending` class

**Removed**

- `table-sort--ascending` class

#### Testing / Reviewing

observe the table header class names while toggling the column sort state
