### PR TITLE
chore(react): add exports to package.json

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,6 +5,22 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "exports": {
+    ".": {
+      "node": "./lib/index.js",
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "default": ["./lib/index.js", "./index.scss"]
+    },
+    "./scss": "./index.scss",
+    "./scss/*": "./scss/*",
+    "./icons": {
+      "node": "./icons/index.js",
+      "import": "./icons/index.esm.js",
+      "require": "./icons/index.js",
+      "default": "./icons/index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/carbon-design-system/carbon.git",


### PR DESCRIPTION
Closes (None)

## Changelog

Add an `"exports"` section to the `@carbon/react` package.json file.

From the Node.js docs:

> The ["exports"](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#exports) provides a modern alternative to ["main"](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#main) allowing multiple entry points to be defined, conditional entry resolution support between environments, and preventing any other entry points besides those defined in ["exports"](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#exports). This encapsulation allows module authors to clearly define the public interface for their package.

### Why?

In certain node environments (namely [ts-node](https://typestrong.org/ts-node/)), the `@carbon/react/icons` import is considered as a "directory import" and causes the ts-node/esm loader to fail with an error like this:

```
  Error: ERR_UNSUPPORTED_DIR_IMPORT /Users/jdharvey/code/carbon-design-system/carbon-platform/node_modules/@carbon/react/icons /Users/jdharvey/code/carbon-design-system/carbon-platform/packages/mdx-components/src/main/article-card/article-card.tsx
```

This behavioral inconsistency is documented in the Node docs [over here](https://nodejs.org/api/esm.html#customizing-esm-specifier-resolution-algorithm).

> The current specifier resolution does not support all default behavior of the CommonJS loader. One of the behavior differences is automatic resolution of file extensions and the ability to import directories that have an index file.

**Note:** I can also get around this issue by specifying the `--experimental-specifier-resolution=node` flag when invoking ts-node, but it seems like it might be a good idea to sprinkle in the newer exports syntax for even wider compatibility.

## Noteworthy stuff

- The order of the keys in the exports object matters! Earlier entries take precedence over later entries. This applies to the values within each export key as well (e.g. "import" takes precedence over "default").
- Sass exports are included to make JS-based loaders (such as css-loader) happy.

## v12 breaking consideration

I added a "new" export of `./scss`, which would be used via `@use '@carbon/react/scss';`. This is in addition to what you can currently do via `@use '@carbon/react';`, however to get the latter to work, I had to add two entries to the `"."` export as "fallbacks". To me, this is a bit of an anti-pattern to have the same export path mean something different depending on whether you're using JS or SCSS.

I'd advocate for deprecating the `@use '@carbon/react';` variant and instead moving users towards `@use '@carbon/react/scss';`. Once this is done (as a breaking change), it would mean that the existing top-level index.scss file could instead be renamed to something like `styles.scss` and [part of] the exports could be re-defined as:

```json
"exports": {
  ".": {
    "node": "./lib/index.js",
    "import": "./es/index.js",
    "require": "./lib/index.js",
    "default": "./lib/index.js",
  },
  "./scss": "./styles.scss",
  "./scss/*": "./scss/*",
  ...
},
```

## Testing / Reviewing

- Ensure the usual `@carbon/react` import still works in both a commonjs and esm import environment
- Ensure the `@carbon/react/icons` import still works in both a commonjs and esm import environment


