### PR TITLE
fix(TextInput): remove duplicate class when custom class passed down

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1313,7 +1313,6 @@ Map {
   "ControlledPasswordInput" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {
-      "className": "\${prefix}--text__input",
       "disabled": false,
       "helperText": "",
       "invalid": false,
@@ -7639,7 +7638,6 @@ Map {
     "ControlledPasswordInput": Object {
       "$$typeof": Symbol(react.forward_ref),
       "defaultProps": Object {
-        "className": "\${prefix}--text__input",
         "disabled": false,
         "helperText": "",
         "invalid": false,

--- a/packages/react/src/components/TextInput/ControlledPasswordInput.js
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.js
@@ -262,7 +262,6 @@ ControlledPasswordInput.propTypes = {
 };
 
 ControlledPasswordInput.defaultProps = {
-  className: '${prefix}--text__input',
   disabled: false,
   onChange: () => {},
   onClick: () => {},

--- a/packages/react/src/components/TextInput/TextInput.js
+++ b/packages/react/src/components/TextInput/TextInput.js
@@ -63,12 +63,10 @@ const TextInput = React.forwardRef(function TextInput(
     warnText,
   });
 
-  const customClassName = className ?? `${prefix}--text__input`;
   const textInputClasses = classNames(
     `${prefix}--text-input`,
     [enabled ? null : className],
     {
-      [customClassName]: enabled,
       [`${prefix}--text-input--light`]: light,
       [`${prefix}--text-input--invalid`]: normalizedProps.invalid,
       [`${prefix}--text-input--warning`]: normalizedProps.warn,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12373

Removes some code causing a custom class to be passed down to the input itself. In V11, custom classes are always applied to the outer wrapper. 

#### Changelog

**Removed**

- Removed a ternary that was causing a custom class always to be passed to the input if using V11
- Removed an unused `${prefix}--text__input` that had no attached styles. `${prefix}--text-input` is the `input` class.

#### Testing / Reviewing

Change the `className` of the `TextInput` component. Ensure the class is only added to the external wrapper. 
