### PR TITLE
fix(NumberInput): change font-weight to 400

### DIFF
--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -51,7 +51,7 @@
     border-radius: 0;
     color: $text-primary;
     font-family: font-family('mono');
-    font-weight: 300;
+    font-weight: 400;
     transition: background-color $duration-fast-01 motion(standard, productive),
       outline $duration-fast-01 motion(standard, productive);
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11301

Updates the `NumberInput` text to the correct `font-weight`

#### Changelog

**Changed**

- `font-weight` for the input bumped from `300` to `400`

#### Testing / Reviewing

Go to `NumberInput` and ensure the font-weight is `400`
