### PR TITLE
fix(code-snippet): remove redundant text on icon

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -266,7 +266,6 @@ function CodeSnippet({
             {expandCodeBtnText}
           </span>
           <ChevronDown
-            aria-label={expandCodeBtnText}
             className={`${prefix}--icon-chevron--down ${prefix}--snippet__icon`}
             name="chevron--down"
             role="img"


### PR DESCRIPTION
closes #10528

#### Changelog


**Removed**

- remove aria-label on icon, not needed as the text inside the button is sufficient to describe what it does

#### Testing / Reviewing

Tests voiceover on show more/show less button on codesnippet and ensure it is only being read once
