### PR TITLE
fix(radiobuttongroup): support checked prop in radiobutton

### DIFF
--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup-test.js
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup-test.js
@@ -140,6 +140,34 @@ describe('RadioButtonGroup', () => {
       );
     });
 
+    it('should support `checked` prop in RadioButton when there is no `defaultSelected` or `valueSelected`', () => {
+      const { rerender } = render(
+        <RadioButtonGroup name="test" legendText="test">
+          <RadioButton labelText="test-1" value="test-1" checked />
+          <RadioButton labelText="test-2" value="test-2" />
+        </RadioButtonGroup>
+      );
+
+      expect(screen.getByLabelText('test-1')).toEqual(
+        screen.getByRole('radio', {
+          checked: true,
+        })
+      );
+
+      rerender(
+        <RadioButtonGroup name="test" legendText="test">
+          <RadioButton labelText="test-1" value="test-1" />
+          <RadioButton labelText="test-2" value="test-2" checked />
+        </RadioButtonGroup>
+      );
+
+      expect(screen.getByLabelText('test-2')).toEqual(
+        screen.getByRole('radio', {
+          checked: true,
+        })
+      );
+    });
+
     it('should support a 0 value for `valueSelected` (#9041)', () => {
       render(
         <RadioButtonGroup valueSelected={0} name="test" legendText="test">

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -43,13 +43,20 @@ const RadioButtonGroup = React.forwardRef(function RadioButtonGroup(
   function getRadioButtons() {
     const mappedChildren = React.Children.map(children, (radioButton) => {
       const { value } = radioButton.props;
-      return React.cloneElement(radioButton, {
+
+      const newProps = {
         name: name,
         key: value,
         value: value,
         onChange: handleOnChange,
         checked: value === selected,
-      });
+      };
+
+      if (!selected && radioButton.props.checked) {
+        newProps.checked = true;
+      }
+
+      return React.cloneElement(radioButton, newProps);
     });
 
     return mappedChildren;


### PR DESCRIPTION
Closes #12425 

Support the `checked` prop in the RadioButton when it's wrapped by a RadioButtonGroup
