### PR TITLE
feat(Modal): add isFullWidth prop

### DIFF
--- a/e2e/components/ComposedModal/ComposedModal-test.e2e.js
+++ b/e2e/components/ComposedModal/ComposedModal-test.e2e.js
@@ -37,6 +37,13 @@ test.describe('ComposedModal', () => {
           theme,
         });
       });
+      test('full width modal @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'ComposedModal',
+          id: 'components-composedmodal--full-width',
+          theme,
+        });
+      });
     });
   });
 

--- a/e2e/components/Modal/Modal-test.e2e.js
+++ b/e2e/components/Modal/Modal-test.e2e.js
@@ -29,6 +29,14 @@ test.describe('Modal', () => {
           theme,
         });
       });
+
+      test('full width modal @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'Modal',
+          id: 'components-modal--full-width',
+          theme,
+        });
+      });
     });
   });
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1254,6 +1254,9 @@ Map {
       "danger": Object {
         "type": "bool",
       },
+      "isFullWidth": Object {
+        "type": "bool",
+      },
       "onClose": Object {
         "type": "func",
       },
@@ -4059,6 +4062,9 @@ Map {
       },
       "id": Object {
         "type": "string",
+      },
+      "isFullWidth": Object {
+        "type": "bool",
       },
       "modalAriaLabel": Object {
         "type": "string",

--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -89,6 +89,7 @@ const ComposedModal = React.forwardRef(function ComposedModal(
     className: customClassName,
     containerClassName,
     danger,
+    isFullWidth,
     onClose,
     onKeyDown,
     open,
@@ -169,6 +170,7 @@ const ComposedModal = React.forwardRef(function ComposedModal(
   const containerClass = cx({
     [`${prefix}--modal-container`]: true,
     [`${prefix}--modal-container--${size}`]: size,
+    [`${prefix}--modal-container--full-width`]: isFullWidth,
     [containerClassName]: containerClassName,
   });
 
@@ -300,6 +302,11 @@ ComposedModal.propTypes = {
    * Note that this prop is not applied if you render primary/danger button by yourself
    */
   danger: PropTypes.bool,
+
+  /**
+   * Specify whether or not the Modal content should have any inner padding.
+   */
+  isFullWidth: PropTypes.bool,
 
   /**
    * Specify an optional handler for closing modal.

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -14,6 +14,13 @@ import Select from '../Select';
 import SelectItem from '../SelectItem';
 import TextInput from '../TextInput';
 import Button from '../Button';
+import {
+  StructuredListWrapper,
+  StructuredListHead,
+  StructuredListBody,
+  StructuredListRow,
+  StructuredListCell,
+} from '../StructuredList';
 import mdx from './ComposedModal.mdx';
 
 export default {
@@ -52,6 +59,67 @@ export const Default = () => {
           <SelectItem value="us-south" text="US South" />
           <SelectItem value="us-east" text="US East" />
         </Select>
+      </ModalBody>
+      <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
+    </ComposedModal>
+  );
+};
+
+export const FullWidth = () => {
+  return (
+    <ComposedModal open isFullWidth>
+      <ModalHeader
+        label="An example of a modal with no padding"
+        title="Full Width Modal"
+      />
+      <ModalBody>
+        <StructuredListWrapper>
+          <StructuredListHead>
+            <StructuredListRow head>
+              <StructuredListCell head noWrap>
+                Column A
+              </StructuredListCell>
+              <StructuredListCell head noWrap>
+                Column B
+              </StructuredListCell>
+              <StructuredListCell head noWrap>
+                Column C
+              </StructuredListCell>
+            </StructuredListRow>
+          </StructuredListHead>
+          <StructuredListBody>
+            <StructuredListRow>
+              <StructuredListCell noWrap>Row 1</StructuredListCell>
+              <StructuredListCell>Row 1</StructuredListCell>
+              <StructuredListCell>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc
+                dui magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+                posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+                Pellentesque vulputate nisl a porttitor interdum.
+              </StructuredListCell>
+            </StructuredListRow>
+            <StructuredListRow>
+              <StructuredListCell noWrap>Row 2</StructuredListCell>
+              <StructuredListCell>Row 2</StructuredListCell>
+              <StructuredListCell>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc
+                dui magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+                posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+                Pellentesque vulputate nisl a porttitor interdum.
+              </StructuredListCell>
+            </StructuredListRow>
+            <StructuredListRow>
+              <StructuredListCell noWrap>Row 3</StructuredListCell>
+              <StructuredListCell>Row 3</StructuredListCell>
+              <StructuredListCell>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc
+                dui magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+                posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+                Pellentesque vulputate nisl a porttitor interdum.
+              </StructuredListCell>
+            </StructuredListRow>
+          </StructuredListBody>
+        </StructuredListWrapper>
       </ModalBody>
       <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
     </ComposedModal>

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -46,6 +46,7 @@ const Modal = React.forwardRef(function Modal(
     hasScrollingContent,
     closeButtonLabel,
     preventCloseOnClickOutside, // eslint-disable-line
+    isFullWidth,
     ...rest
   },
   ref
@@ -127,6 +128,7 @@ const Modal = React.forwardRef(function Modal(
 
   const containerClasses = classNames(`${prefix}--modal-container`, {
     [`${prefix}--modal-container--${size}`]: size,
+    [`${prefix}--modal-container--full-width`]: isFullWidth,
   });
 
   const contentClasses = classNames(`${prefix}--modal-content`, {
@@ -353,6 +355,11 @@ Modal.propTypes = {
    * Specify the DOM element ID of the top-level node.
    */
   id: PropTypes.string,
+
+  /**
+   * Specify whether or not the Modal content should have any inner padding.
+   */
+  isFullWidth: PropTypes.bool,
 
   /**
    * Specify a label to be read by screen readers on the modal root node

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -15,6 +15,13 @@ import Dropdown from '../Dropdown';
 import SelectItem from '../SelectItem';
 import TextInput from '../TextInput';
 import mdx from './Modal.mdx';
+import {
+  StructuredListWrapper,
+  StructuredListHead,
+  StructuredListBody,
+  StructuredListRow,
+  StructuredListCell,
+} from '../StructuredList';
 
 export default {
   title: 'Components/Modal',
@@ -75,6 +82,66 @@ export const Default = () => {
         ]}
         itemToString={(item) => (item ? item.text : '')}
       />
+    </Modal>
+  );
+};
+
+export const FullWidth = () => {
+  return (
+    <Modal
+      open
+      isFullWidth
+      modalHeading="Full Width Modal"
+      modalLabel="An example of a modal with no padding"
+      primaryButtonText="Add"
+      secondaryButtonText="Cancel">
+      <StructuredListWrapper>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head noWrap>
+              Column A
+            </StructuredListCell>
+            <StructuredListCell head noWrap>
+              Column B
+            </StructuredListCell>
+            <StructuredListCell head noWrap>
+              Column C
+            </StructuredListCell>
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          <StructuredListRow>
+            <StructuredListCell noWrap>Row 1</StructuredListCell>
+            <StructuredListCell>Row 1</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+          <StructuredListRow>
+            <StructuredListCell noWrap>Row 2</StructuredListCell>
+            <StructuredListCell>Row 2</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+          <StructuredListRow>
+            <StructuredListCell noWrap>Row 3</StructuredListCell>
+            <StructuredListCell>Row 3</StructuredListCell>
+            <StructuredListCell>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui
+              magna, finibus id tortor sed, aliquet bibendum augue. Aenean
+              posuere sem vel euismod dignissim. Nulla ut cursus dolor.
+              Pellentesque vulputate nisl a porttitor interdum.
+            </StructuredListCell>
+          </StructuredListRow>
+        </StructuredListBody>
+      </StructuredListWrapper>
     </Modal>
   );
 };

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -385,6 +385,12 @@
     z-index: z('modal');
   }
 
+  // Fluid Modal (No padding)
+  .#{$prefix}--modal-container--full-width .#{$prefix}--modal-content {
+    padding: 0;
+    margin: 0;
+  }
+
   // Windows HCM fix
   /* stylelint-disable */
   .#{$prefix}--modal-close__icon {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11933

Adds a new `isFullWIdth` prop that removes any margin and padding placed on the `modal-content` class. 

#### Changelog

**New**

- `isFullWidth` prop and associated styles for `Modal` and `ComposedModal` that removes margin and padding. 
- e2e tests added to catch regressions
- updated snapshots

#### Testing / Reviewing
Was unsure if we also wanted to remove the padding/margin from the headers; for now they are still there because they match the spec images

- Go to `ComposedModal` and `Modal` and ensure the `Full Width` example matches the spec images. 
