### PR TITLE
fix(text-area): cols attribute

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7636,7 +7636,6 @@ Map {
   "TextArea" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {
-      "cols": 50,
       "disabled": false,
       "enableCounter": false,
       "helperText": "",

--- a/packages/react/src/components/Form/Form.stories.js
+++ b/packages/react/src/components/Form/Form.stories.js
@@ -97,7 +97,6 @@ const textareaProps = {
   className: 'some-class',
   placeholder: 'Placeholder text',
   id: 'test5',
-  cols: 50,
   rows: 4,
 };
 

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -44,7 +44,7 @@ describe('TextArea', () => {
       });
 
       it('should set cols as expected', () => {
-        expect(textarea().props().cols).toEqual(50);
+        expect(textarea().props().style).toEqual({ width: '100%' });
         wrapper.setProps({ cols: 200 });
         expect(textarea().props().cols).toEqual(200);
       });

--- a/packages/react/src/components/TextArea/TextArea.js
+++ b/packages/react/src/components/TextArea/TextArea.js
@@ -128,6 +128,13 @@ const TextArea = React.forwardRef(function TextArea(
       aria-invalid={invalid || null}
       aria-describedby={invalid ? errorId : null}
       disabled={other.disabled}
+      style={
+        other.cols
+          ? {}
+          : {
+              width: `100%`,
+            }
+      }
     />
   );
 
@@ -268,7 +275,6 @@ TextArea.defaultProps = {
   onClick: () => {},
   placeholder: '',
   rows: 4,
-  cols: 50,
   invalid: false,
   invalidText: '',
   helperText: '',

--- a/packages/react/src/components/TextArea/TextArea.stories.js
+++ b/packages/react/src/components/TextArea/TextArea.stories.js
@@ -21,7 +21,6 @@ export const Default = () => (
   <TextArea
     labelText="Text Area label"
     helperText="Optional helper text"
-    cols={50}
     rows={4}
     id="text-area-1"
   />
@@ -33,7 +32,6 @@ export const WithLayer = () => {
       <TextArea
         labelText="First layer"
         helperText="Optional helper text"
-        cols={50}
         rows={4}
         id="text-area-1"
       />
@@ -41,7 +39,6 @@ export const WithLayer = () => {
         <TextArea
           labelText="Second layer"
           helperText="Optional helper text"
-          cols={50}
           rows={4}
           id="text-area-1"
         />
@@ -49,7 +46,6 @@ export const WithLayer = () => {
           <TextArea
             labelText="Third layer"
             helperText="Optional helper text"
-            cols={50}
             rows={4}
             id="text-area-1"
           />
@@ -73,7 +69,6 @@ Playground.argTypes = {
     control: {
       type: 'number',
     },
-    defaultValue: 50,
   },
   defaultValue: {
     control: {

--- a/packages/styles/scss/components/text-area/_text-area.scss
+++ b/packages/styles/scss/components/text-area/_text-area.scss
@@ -25,7 +25,6 @@
     @include type-style('body-01');
     @include focus-outline('reset');
 
-    width: 100%;
     min-width: 10rem;
     height: 100%;
     min-height: rem(40px);
@@ -108,6 +107,7 @@
   .#{$prefix}--text-area.#{$prefix}--skeleton {
     @include skeleton;
 
+    width: 100%;
     height: rem(100px);
 
     &::placeholder {


### PR DESCRIPTION
Closes #

#12465 

- cols was not working as expected. The `width: 100%` style was not letting user's set the amount of `cols`

#### Changelog

**Changed**

- Change the `width: 100%` to be an inline style, so now it's a conditional on if the `cols` value is set or not

**Removed**

- removed the default value of `cols: 50` because if there is no number assigned to `cols` then it should just be 100% width

#### Testing / Reviewing

- Check that all the TextArea stories show initially 100% width with no `cols` value.
- then go to the playground story and try updating the number set to `cols`
![Nov-04-2022 15-41-40](https://user-images.githubusercontent.com/20210594/200085240-4efd697e-49d6-4975-8587-54980e8addff.gif)


