### PR TITLE
feat(notificationstack): New hooks and components for NotificationStack

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -895,6 +895,15 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "cgirani",
+      "name": "Claudia Tejos",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22034430?v=4",
+      "profile": "https://github.com/cgirani",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="http://jakubfaliszewski.github.io/portfolio/"><img src="https://avatars.githubusercontent.com/u/25402419?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jakub Faliszewski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=jakubfaliszewski" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/francinelucca"><img src="https://avatars.githubusercontent.com/u/40550942?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Francine Lucca</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=francinelucca" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=francinelucca" title="Documentation">📖</a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/cgirani"><img src="https://avatars.githubusercontent.com/u/22034430?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Claudia Tejos</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=cgirani" title="Code">💻</a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-restore -->

--- a/packages/react/src/components/NotificationStack/NotificationStack-test.js
+++ b/packages/react/src/components/NotificationStack/NotificationStack-test.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import NotificationStack from './NotificationStack';
+import Button from '../Button/Button';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { triggerNotification } from '../../internal/useNotification/notification';
+
+describe('NotificationStack', () => {
+  it('should render a notification', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { container } = render(<NotificationStack />);
+    render(
+      <Button
+        onClick={() =>
+          triggerNotification({
+            role: 'alert',
+            kind: 'info',
+            caption: '00:00',
+            onCloseButtonClick: () => {},
+            lowContrast: false,
+            hideCloseButton: false,
+            iconDescription: 'Close',
+            title: 'Toast triggered',
+            subtitle: 'subtitle testing',
+          })
+        }
+      >
+        Trigger toast
+      </Button>
+    );
+
+    userEvent.click(screen.getByText('Trigger toast'));
+
+    // expect notification wrapper to exists
+    expect(container.firstChild).toHaveClass('cds-stack-notif-container');
+    expect(screen.findByText('Toast triggered')).toBeDefined();
+    spy.mockRestore();
+  });
+  it('should render muultiple notification', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<NotificationStack />);
+    render(
+      <Button
+        onClick={() =>
+          triggerNotification({
+            role: 'alert',
+            kind: 'info',
+            caption: '00:00',
+            onCloseButtonClick: () => {},
+            lowContrast: false,
+            hideCloseButton: false,
+            iconDescription: 'Close',
+            title: 'Toast triggered',
+            subtitle: 'subtitle testing',
+          })
+        }
+      >
+        Trigger toast
+      </Button>
+    );
+
+    userEvent.click(screen.getByText('Trigger toast'));
+    userEvent.click(screen.getByText('Trigger toast'));
+    userEvent.click(screen.getByText('Trigger toast'));
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Toast triggered')).toHaveLength(4);
+    });
+
+    spy.mockRestore();
+  });
+});

--- a/packages/react/src/components/NotificationStack/NotificationStack.js
+++ b/packages/react/src/components/NotificationStack/NotificationStack.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import { ToastNotification } from '../Notification';
+import { useNotification } from '../../internal/useNotification/useNotification';
+import { usePrefix } from '../../internal/usePrefix';
+
+/**
+ * Component to wrapper the notification children
+ * Used for update the element height
+ */
+const NotificationWrapper = ({
+  children,
+  className,
+  style,
+  id,
+  onHeightUpdate,
+}) => {
+  const [height, setHeight] = React.useState();
+  const ref = React.useCallback(
+    (el) => {
+      if (el) {
+        const updateHeight = () => {
+          const height = el.firstChild.getBoundingClientRect().height;
+          setHeight(height);
+          onHeightUpdate(id, height);
+        };
+        updateHeight();
+      }
+    },
+    [id, onHeightUpdate]
+  );
+
+  return (
+    <div ref={ref} className={className} style={{ ...style, height }}>
+      {children}
+    </div>
+  );
+};
+NotificationWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  onHeightUpdate: PropTypes.func.isRequired,
+  style: PropTypes.object,
+};
+NotificationWrapper.defaultProps = {
+  className: null,
+  style: null,
+};
+
+/**
+ * NotificationStack component
+ */
+const NotificationStack = ({ className }) => {
+  const prefix = usePrefix();
+  const { notifications, handlers } = useNotification();
+
+  return (
+    <div className={cx(`${prefix}-stack-notif-container`, className)}>
+      {notifications?.map((notif) => {
+        return !notif.destroyed ? (
+          <NotificationWrapper
+            id={notif.id}
+            key={notif.id}
+            onHeightUpdate={handlers.updateHeight}
+            className={cx(`${prefix}-stack-notif-container--inner-container`, {
+              [`${prefix}-stack-notif-container--inner-container--open`]: notif.isOpen,
+            })}
+          >
+            <ToastNotification
+              className={cx('inner-toast', {
+                'inner-toast--open': notif.isOpen,
+                'inner-toast--closed': notif.isOpen === false,
+              })}
+              onTransitionEnd={(e) => {
+                // Check if the transition that ended is the one that happens when the notification
+                //  is closed. If that's the case, destroy the notification afterwards.
+                if (
+                  Array.from(e.target.classList).includes('inner-toast') &&
+                  e.propertyName === 'transform' &&
+                  !Array.from(e.target.classList).includes(
+                    'inner-toast--open'
+                  ) &&
+                  !notif.destroyed
+                ) {
+                  handlers.destroyNotification(notif.id);
+                }
+              }}
+              kind={notif.kind}
+              title={notif.title}
+              subtitle={notif.subtitle}
+              caption={notif.caption}
+              lowContrast={!!notif.lowContrast}
+              onClose={() => false}
+              onCloseButtonClick={(e) => {
+                if (notif.onCloseButtonClick) {
+                  notif.onCloseButtonClick(e);
+                }
+                handlers.closeNotification(notif.id);
+              }}
+              iconDescription={notif.iconDescription}
+              hideCloseButton={notif.hideCloseButton}
+              role={notif.role}
+            >
+              {notif.children}
+            </ToastNotification>
+          </NotificationWrapper>
+        ) : null;
+      })}
+    </div>
+  );
+};
+NotificationStack.propTypes = {
+  className: PropTypes.string,
+};
+NotificationStack.defaultProps = { className: null };
+export default NotificationStack;

--- a/packages/react/src/components/NotificationStack/NotificationStack.stories.js
+++ b/packages/react/src/components/NotificationStack/NotificationStack.stories.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import NotificationStack from './NotificationStack';
+import { triggerNotification } from '../../internal/useNotification/notification';
+import Button from '../Button/Button';
+
+export default {
+  title: 'Components/NotificationStack',
+  component: Button,
+  args: {
+    kind: 'error',
+    lowContrast: false,
+    hideCloseButton: false,
+    ariaLabel: 'closes notification',
+    statusIconDescription: 'notification',
+    onClose: action('onClose'),
+    onCloseButtonClick: action('onCloseButtonClick'),
+  },
+};
+
+export const StandardToast = () => (
+  <div style={{ width: 300 }}>
+    <NotificationStack />
+
+    <Button
+      onClick={() =>
+        triggerNotification({
+          role: 'alert',
+          kind: 'info',
+          caption: '00:00',
+          onCloseButtonClick: () => {},
+          lowContrast: false,
+          hideCloseButton: false,
+          iconDescription: 'Close',
+          title: 'Toast triggered',
+          subtitle: 'subtitle testing',
+          timeout: 5000,
+        })
+      }
+    >
+      Trigger toast
+    </Button>
+  </div>
+);
+
+export const Playground = (args) => (
+  <div style={{ width: 300 }}>
+    <NotificationStack />
+
+    <Button onClick={() => triggerNotification({ ...args })}>
+      Trigger toast
+    </Button>
+  </div>
+);
+
+Playground.argTypes = {
+  actionButtonLabel: {
+    table: {
+      disable: true,
+    },
+  },
+  ariaLabel: {
+    table: {
+      disable: true,
+    },
+  },
+  onActionButtonClick: {
+    table: {
+      disable: true,
+    },
+  },
+  onClose: {
+    action: 'clicked',
+  },
+  onCloseButtonClick: {
+    action: 'clicked',
+  },
+  children: {
+    table: {
+      disable: true,
+    },
+  },
+  className: {
+    table: {
+      disable: true,
+    },
+  },
+};
+Playground.args = {
+  role: 'status',
+  caption: '00:00:00 AM',
+  timeout: 0,
+  title: 'Notification title',
+  subtitle: 'Subtitle text goes here',
+};

--- a/packages/react/src/internal/useNotification/notification-store.js
+++ b/packages/react/src/internal/useNotification/notification-store.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { useState, useEffect } from 'react';
+export const ActionType = {
+  ADD_NOTIFICATION: 'ADD_NOTIFICATION',
+  OPEN_NOTIFICATION: 'OPEN_NOTIFICATION',
+  UPDATE_NOTIFICATION: 'UPDATE_NOTIFICATION',
+  CLOSE_NOTIFICATION: 'CLOSE_NOTIFICATION',
+  DESTROY_NOTIFICATION: 'DETROY_NOTIFICATION',
+};
+
+const setStates = [];
+
+let memoryState = { notifications: [] };
+
+/**
+ * Functions that its behavior is just like a reducer map actions type and update the state
+ * @param {*} state - initial state
+ * @param {*} action - reducer actions
+ * @returns - returns state updated
+ */
+const reducer = (state, action) => {
+  switch (action.type) {
+    case ActionType.ADD_NOTIFICATION: {
+      return {
+        ...state,
+        notifications: [...state.notifications, action.toast],
+      };
+    }
+    case ActionType.OPEN_NOTIFICATION: {
+      const { id, timeout } = action.toast;
+      if (timeout) {
+        setTimeout(
+          () =>
+            dispatch({ type: ActionType.CLOSE_NOTIFICATION, payload: { id } }),
+          timeout
+        );
+      }
+      return {
+        ...state,
+        notifications: state.notifications.map((n) =>
+          n.id === id ? { ...n, isOpen: true } : n
+        ),
+      };
+    }
+    case ActionType.CLOSE_NOTIFICATION: {
+      const { id } = action.payload;
+      return {
+        ...state,
+        notifications: state.notifications.map((n) =>
+          n.id === id ? { ...n, isOpen: false } : n
+        ),
+      };
+    }
+
+    case ActionType.UPDATE_NOTIFICATION: {
+      const { id } = action.payload;
+
+      return {
+        ...state,
+        notifications: state.notifications.map((t) =>
+          t.id === id ? { ...t, ...action.payload } : t
+        ),
+      };
+    }
+    // Action responsible for removing the notification from the state or
+    // to simply add a 'destroyed' prop to prevent it from being rendered
+    // (depending on the preserveNotifications prop value)
+    case ActionType.DESTROY_NOTIFICATION: {
+      const { id } = action.payload;
+      return {
+        ...state,
+        notifications:
+          // preserveNotifications
+          //   ? state.notifications.map((n) =>
+          //       n.id !== id ? n : { ...n, destroyed: true }
+          //     )
+          //   :
+          state.notifications.filter((n) => n.id !== id),
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+/**
+ * Function that dispatch the action to the reducer
+ * @param {*} action
+ */
+export const dispatch = (action) => {
+  memoryState = reducer(memoryState, action);
+  setStates.forEach((listener) => {
+    listener(memoryState);
+  });
+};
+
+/**
+ * Function where we hold the state of notifications
+ * @returns the memoryState with the notifications added to array
+ */
+export const useStore = () => {
+  const [state, setState] = useState(memoryState);
+
+  useEffect(() => {
+    setStates.push(setState);
+    return () => {
+      const index = setStates.indexOf(setState);
+      if (index > -1) {
+        setStates.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return state;
+};

--- a/packages/react/src/internal/useNotification/notification.js
+++ b/packages/react/src/internal/useNotification/notification.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import uid from '../../tools/uniqueId';
+import { dispatch, ActionType } from './notification-store';
+
+/**
+ * Function to dispatch the creation of notifications.
+ * options - same options accepted in Notifications components
+ */
+const triggerNotification = (options) => {
+  // Create notification id and add notification to store state
+  const id = uid();
+  dispatch({
+    type: ActionType.ADD_NOTIFICATION,
+    toast: { id, ...options },
+  });
+  // Asynchronously set the notification open so that its height is calculated
+  // before the notification is opened
+  setTimeout(
+    () =>
+      dispatch({
+        type: ActionType.OPEN_NOTIFICATION,
+        toast: { id, timeout: options.timeout },
+      }),
+    0
+  );
+};
+
+export { triggerNotification };

--- a/packages/react/src/internal/useNotification/useNotification.js
+++ b/packages/react/src/internal/useNotification/useNotification.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { useStore, dispatch, ActionType } from './notification-store';
+
+/** Functions to trigger notifications dispatch actions */
+const updateHeight = (toastId, height) =>
+  dispatch({
+    type: ActionType.UPDATE_NOTIFICATION,
+    payload: { id: toastId, height },
+  });
+const destroyNotification = (id) =>
+  dispatch({ type: ActionType.DESTROY_NOTIFICATION, payload: { id } });
+
+const closeNotification = (id) =>
+  dispatch({ type: ActionType.CLOSE_NOTIFICATION, payload: { id } });
+
+/**
+ * Hook to have notification data
+ * @returns object with {notifications <data>, handlers <helpers functions>}
+ */
+export const useNotification = () => {
+  const { notifications } = useStore();
+
+  const handlers = {
+    updateHeight,
+    destroyNotification,
+    closeNotification,
+  };
+
+  return { notifications, handlers };
+};

--- a/packages/styles/scss/components/_index.scss
+++ b/packages/styles/scss/components/_index.scss
@@ -58,3 +58,4 @@
 @use 'tooltip';
 @use 'treeview';
 @use 'ui-shell';
+@use 'notification-stack';

--- a/packages/styles/scss/components/notification-stack/_index.scss
+++ b/packages/styles/scss/components/notification-stack/_index.scss
@@ -1,0 +1,65 @@
+//
+// Copyright IBM Corp. 2016, 2018
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../config' as *;
+@use '../../breakpoint' as *;
+@use '../../motion' as *;
+@use '../../spacing' as *;
+@use '../../theme' as *;
+@use '../../type' as *;
+@use '../../utilities/convert' as *;
+@use '../../utilities/focus-outline' as *;
+@use '../../utilities/skeleton' as *;
+@use '../..//utilities/button-reset';
+
+.#{$prefix}-stack-notif-container {
+  position: fixed;
+  z-index: 9999;
+  top: $spacing-05;
+  right: $spacing-03;
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.#{$prefix}-stack-notif-container--inner-container {
+  position: relative;
+  width: rem(288px);
+  height: 0;
+  margin: 0;
+  transition: all $duration-slow-01 ease-out;
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.#{$prefix}-stack-notif-container--inner-container--open {
+  margin-bottom: $spacing-03;
+}
+
+.#{$prefix}-stack-notif-container--inner-container .inner-toast {
+  position: absolute;
+  top: 0;
+  right: 0;
+  max-width: rem(288px);
+  margin: 0;
+  transform: translateX(calc(rem(288px) + $spacing-03));
+  transition: transform $duration-moderate-02 ease-out,
+    opacity $duration-moderate-02 ease-out;
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.#{$prefix}-stack-notif-container--inner-container .inner-toast--open {
+  transform: translateX(0);
+}
+
+.#{$prefix}-stack-notif-container--inner-container .inner-toast--closed {
+  opacity: 0;
+}


### PR DESCRIPTION
Reference: #8405

New hooks and components to render NotificationStack. 

#### Components/hooks and their use/purpose:
**`NotificationStack`** - Component to be used in begin of the application, it's a wrapper of all notifications
**`notification-store`** - Function where we hold the state of notifications, along with functions that act like dispatch/reducer
**`notification`** - Export a function to trigger the notification, this function can be imported in any file in the application
**`useNotification`** - Hook with notifications info from the store and some handlers (actions/dispatch) to be used, this one is used in the component `NotificationStack`

Even files are aligned about Notifications hooks, trigger function and store are generic enough for future uses of any other component...

#### Changelog

**New**

- New files to support notification stack headless
   - NotificationStack
   - notification-store
   - notification
   - useNotification
   - css file for NotificationStack

**Changed**

- `Index.css` to add new css files

**Removed**

- None

#### Testing / Reviewing

At the storybook test the NotificationStack component.
- If opens multiple notifications
- If closes correctly with the timeout
- Animation worksas expected
