### PR TITLE
fix(code-snippet): scrollbar not clickable on muliline

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -164,6 +164,8 @@ function CodeSnippet({
     [`${prefix}--snippet--light`]: light,
     [`${prefix}--snippet--no-copy`]: hideCopyButton,
     [`${prefix}--snippet--wraptext`]: wrapText,
+    [`${prefix}--snippet--has-right-overflow`]:
+      type == 'multi' && hasRightOverflow,
   });
 
   const expandCodeBtnText = expandedCode ? showLessText : showMoreText;
@@ -243,7 +245,7 @@ function CodeSnippet({
       {hasLeftOverflow && (
         <div className={`${prefix}--snippet__overflow-indicator--left`} />
       )}
-      {hasRightOverflow && (
+      {hasRightOverflow && type !== 'multi' && (
         <div className={`${prefix}--snippet__overflow-indicator--right`} />
       )}
       {!hideCopyButton && (

--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -234,14 +234,15 @@ $copy-btn-feedback: $background-inverse !default;
     overflow-x: auto;
   }
 
-  .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {
+  .#{$prefix}--snippet--multi.#{$prefix}--snippet--has-right-overflow
+    .#{$prefix}--snippet-container
+    pre::after {
     position: absolute;
     top: 0;
     right: 0;
     width: rem(16px);
     height: 100%;
-    // Safari interprets `transparent` differently, so make color token value transparent instead:
-    background-image: linear-gradient(to right, rgba($layer, 0), $layer);
+    background-image: linear-gradient(to right, transparent, $layer);
     content: '';
   }
 


### PR DESCRIPTION
closes #9946

Scrollbar wasn't clickable when there was an overflow on the multiline code snippet because the overflow-indicator-right div was being rendered to sit directly on top of it. This removes that div and adds the overflow gradient to the pre:after element instead. 

#### Changelog

**New**

- add class for multiline when hasRightOverflow is true
- update styles for overflow gradient to show up on after element of pre to not interfere with scrollbar

**Changed**

- Only render overflow-indicator-right div for single line code snippet

#### Testing / Reviewing

Make sure you can scroll with the mouse all directions in multiline codesnippet and that the gradient shows up correctly. Check that single line didn't change at all. 

Test with scrollbars on and off in your system settings. 
![Screenshot 2022-11-11 at 1 16 19 PM](https://user-images.githubusercontent.com/2753488/201414136-8ac52a55-6179-45ab-a36d-97e4b0b89853.png)
