### PR TITLE
chore(plex): update plex package, add git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-
 # These files should have specific line endings
 *.sh	text eol=lf
 *.bat	text eol=crlf
-
 # These files are binary and should be left untouched
 # (binary is a macro for -text -diff)
 *.jpeg	binary
+.yarn/cache/@ibm-plex-npm-* filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          lfs: true
+      - name: Fetch LFS objects
+        run: git lfs fetch
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Check formatting of project files
@@ -44,6 +49,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          lfs: true
+      - name: Fetch LFS objects
+        run: git lfs fetch
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Lint JavaScript files
@@ -59,6 +69,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          lfs: true
       - uses: actions/cache@v3
         id: cache
         with:
@@ -66,6 +77,10 @@ jobs:
             node_modules
             */**/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Fetch LFS objects
+        run: git lfs fetch
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Build project
@@ -85,6 +100,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          lfs: true
       - uses: actions/cache@v3
         id: cache
         with:
@@ -92,6 +108,10 @@ jobs:
             node_modules
             */**/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Fetch LFS objects
+        run: git lfs fetch
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - uses: dorny/paths-filter@v2.11.1
@@ -124,6 +144,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          lfs: true
       - uses: actions/cache@v3
         id: cache
         with:
@@ -131,6 +152,10 @@ jobs:
             node_modules
             */**/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Fetch LFS objects
+        run: git lfs fetch
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Install browsers
@@ -182,6 +207,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          lfs: true
       - uses: actions/cache@v3
         id: cache
         with:
@@ -189,6 +215,10 @@ jobs:
             node_modules
             */**/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Fetch LFS objects
+        run: git lfs fetch
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
       - name: Install browsers

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\n"; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-commit.\n"; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\n"; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\n"; exit 2; }
+git lfs pre-push "$@"

--- a/.yarn/cache/@ibm-plex-npm-6.0.2-3a1e016bce-5053d5958c.zip
+++ b/.yarn/cache/@ibm-plex-npm-6.0.2-3a1e016bce-5053d5958c.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b1f785b856206c71b0909c31f45bbe64797d763323d8dae370991a310da9625
+size 179235351

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -39,7 +39,7 @@
     "@carbon/motion": "^11.5.0",
     "@carbon/themes": "^11.12.0",
     "@carbon/type": "^11.11.0",
-    "@ibm/plex": "6.0.0-next.6"
+    "@ibm/plex": "6.0.2"
   },
   "devDependencies": {
     "@carbon/test-utils": "^10.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,7 +2279,7 @@ __metadata:
     "@carbon/test-utils": ^10.26.0
     "@carbon/themes": ^11.12.0
     "@carbon/type": ^11.11.0
-    "@ibm/plex": 6.0.0-next.6
+    "@ibm/plex": 6.0.2
     autoprefixer: ^10.4.7
     browserslist-config-carbon: ^11.0.0
     css: ^3.0.0
@@ -2938,10 +2938,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex@npm:6.0.0-next.6":
-  version: 6.0.0-next.6
-  resolution: "@ibm/plex@npm:6.0.0-next.6"
-  checksum: cb7bece0f8688cf92a3fa37ab47c5921f22a2eb5e40dd72a3d6bbcd715910b0d79f9d160e229514a0c78c70679676746a93f4791a57407fc6aa636105aa11891
+"@ibm/plex@npm:6.0.2":
+  version: 6.0.2
+  resolution: "@ibm/plex@npm:6.0.2"
+  checksum: 5053d5958c8911d77b8959d0559cf2f1e9fae55e72d746925f96cee04fb23b98ec0277fe5de7282285c0e3e5d167db871d0e2ce76fd684315371663d1f6a5528
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/12614
Closes https://github.com/carbon-design-system/carbon/issues/12608

Updates `@ibm/plex` to the latest and configures Git Large File Storage to handle the large `.yarn-cache` Plex file.

#### Changelog

**New**

- Git LFS configured

**Changed**

- Bumped `@ibm/plex` to `v6.1.1`

#### Testing / Reviewing

@tay1orjones is there a reason why there is such a large file size increase in the package? ANy way we can reduce this or is this okay as-is
