### PR TITLE
fix(NumberInput.js): replaced pipe character with || operator

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.js
+++ b/packages/react/src/components/NumberInput/NumberInput.js
@@ -195,7 +195,7 @@ const NumberInput = React.forwardRef(function NumberInput(props, forwardRef) {
               <button
                 aria-label={decrementNumLabel || iconDescription}
                 className={`${prefix}--number__control-btn down-icon`}
-                disabled={disabled | readOnly}
+                disabled={disabled || readOnly}
                 onClick={(event) => {
                   const state = {
                     value: clamp(max, min, parseInt(value) - step),
@@ -220,7 +220,7 @@ const NumberInput = React.forwardRef(function NumberInput(props, forwardRef) {
               <button
                 aria-label={incrementNumLabel || iconDescription}
                 className={`${prefix}--number__control-btn up-icon`}
-                disabled={disabled | readOnly}
+                disabled={disabled || readOnly}
                 onClick={(event) => {
                   const state = {
                     value: clamp(max, min, parseInt(value) + step),


### PR DESCRIPTION
* fixed syntax error.

Closes #12661

ReadOnly prop not being recognised correctly. Changed pipe (`|`) character to OR (`||`). Now works. 

#### Changelog

**New**

-  N/A

**Changed**

- NumberInput.js

**Removed**

- N/A

#### Testing / Reviewing

View the code. This is a syntax error fix. 
