### PR TITLE
style(OverflowMenu): change hover token

### DIFF
--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -43,7 +43,7 @@
     }
 
     &:hover {
-      background-color: $background-hover;
+      background-color: $layer-hover;
     }
   }
 


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/12621

Makes a change based on [comment](https://github.com/carbon-design-system/carbon/pull/12621#issuecomment-1318750373) in #12621

> I believe this is a bug in our own code and the overflow menu hover should be updated to use $layer-hover instead.

#### Changelog

**Changed**

- Changes the `OverflowMenu` to use the correct token when hovered

#### Testing / Reviewing

Hover over the `OverflowMenu` button and make sure the token is correct
