### PR TITLE
fix(getInteractiveContent): add null checks

### DIFF
--- a/packages/react/src/internal/useNoInteractiveChildren.js
+++ b/packages/react/src/internal/useNoInteractiveChildren.js
@@ -33,6 +33,10 @@ export function useNoInteractiveChildren(
  * @returns {HTMLElement}
  */
 export function getInteractiveContent(node) {
+  if (!node || !node.childNodes) {
+    return null;
+  }
+
   if (isFocusable(node)) {
     return node;
   }


### PR DESCRIPTION
Based on some conversations with @fbarroso24: When using `react-test-renderer` to test components using this hook/function, the component will error with

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
```

This PR adds some null checks to avoid iterating over non-iterable Symbols passed to this function stemming from the `react-test-renderer` environment.

#### Changelog

**Changed**

- modify `getInteractiveContent` to include null checks

#### Testing / Reviewing

- Check to make sure Popover, Tooltip, IconButton stories are not be impacted and work as intended
- @fbarroso24 has already tested this fix locally to ensure it fixes the issue he's reported