### PR TITLE
feat(Button): add as prop to IconButton inside of the Button component

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -977,6 +977,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "matkrzy",
+      "name": "Mateusz Krzyżanowski",
+      "avatar_url": "https://avatars.githubusercontent.com/u/14991661?v=4",
+      "profile": "https://github.com/matkrzy",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   <tr>
     <td align="center"><a href="https://github.com/Shankar-CodeJunkie"><img src="https://avatars.githubusercontent.com/u/56068832?v=4?s=100" width="100px;" alt=""/><br /><sub><b>ShankarV-CodeJunkie</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Shankar-CodeJunkie" title="Code">💻</a></td>
     <td align="center"><a href="http://darioplatania.github.io/"><img src="https://avatars.githubusercontent.com/u/11682859?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dario platania</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=darioplatania" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/matkrzy"><img src="https://avatars.githubusercontent.com/u/14991661?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mateusz Krzyżanowski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=matkrzy" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Button/Button.js
+++ b/packages/react/src/components/Button/Button.js
@@ -158,6 +158,7 @@ const Button = React.forwardRef(function Button(
 
     return (
       <IconButton
+        as={as}
         align={align}
         label={iconDescription}
         kind={kind}

--- a/packages/react/src/components/Button/__tests__/Button-test.js
+++ b/packages/react/src/components/Button/__tests__/Button-test.js
@@ -151,5 +151,22 @@ describe('Button', () => {
       render(<Button hasIconOnly iconDescription="test" renderIcon={Add} />);
       expect(screen.getByLabelText('test')).toHaveClass('cds--btn--icon-only');
     });
+
+    it('should support rendering as a custom element with the `as` prop', () => {
+      function CustomComponent(props) {
+        return <div data-testid="custom-component" {...props} />;
+      }
+
+      render(
+        <Button
+          hasIconOnly
+          iconDescription="test"
+          renderIcon={Add}
+          as={CustomComponent}
+        />
+      );
+      expect(screen.getByTestId('custom-component')).toBeInTheDocument();
+      expect(screen.getByLabelText('test')).toHaveClass('cds--btn--icon-only');
+    });
   });
 });


### PR DESCRIPTION
Button with flag `hasIconOnly` renders Button component without `as` prop so we are not able to pass custom render component

#### Changelog

**Changed**

- IconButton inside of the Button component has new prop `as`

#### Testing / Reviewing

1. set flag `hasIconOnly`
2. pass custom component via `as` property
3. custom component should render instead default button