### PR TITLE
docs(migration): correct specified path for scss config

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -591,7 +591,7 @@ can configure Carbon on the main entrypoint:
 Or you can configure the `scss/_config.scss` directly:
 
 ```scss
-@use '@carbon/styles/config' with (
+@use '@carbon/styles/scss/config' with (
   $prefix: 'cds'
 );
 ```


### PR DESCRIPTION
The specified path for the config module was wrong in the migration guide