### PR TITLE
fix(side-nav-link): add missing `isActive` to prop types

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6521,6 +6521,9 @@ Map {
       "element": Object {
         "type": "elementType",
       },
+      "isActive": Object {
+        "type": "bool",
+      },
       "isSideNavExpanded": Object {
         "type": "bool",
       },

--- a/packages/react/src/components/UIShell/SideNavLink.js
+++ b/packages/react/src/components/UIShell/SideNavLink.js
@@ -61,6 +61,11 @@ SideNavLink.propTypes = {
   className: PropTypes.string,
 
   /**
+   * Specify whether the link is the current page
+   */
+  isActive: PropTypes.bool,
+
+  /**
    * Specify if this is a large variation of the SideNavLink
    */
   large: PropTypes.bool,


### PR DESCRIPTION
[Context in Discord](https://discord.com/channels/689212587170201628/756226107849834607/1062660418109177906)

A Discord user pointed out that the `isActive` prop in `SideNavLink` is missing in the prop types.

#### Changelog


**Changed**

- fix(side-nav-link): add missing `isActive` to prop types


#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
