### PR TITLE
ci(storybook): update deploy to github pages

### DIFF
--- a/.github/workflows/deploy-react-storybook.yml
+++ b/.github/workflows/deploy-react-storybook.yml
@@ -1,4 +1,4 @@
-name: Deploy React storybook to IBM Cloud
+name: Deploy React storybook to GitHub Pages
 
 on:
   workflow_dispatch:
@@ -37,29 +37,10 @@ jobs:
         run: yarn install --immutable --immutable-cache
       - name: Build project
         run: yarn build
-      - name: Install ibmcloud CLI
-        run: curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
-      - name: Login to IBM Cloud
-        env:
-          CLOUD_API_KEY: ${{ secrets.CLOUD_API_KEY}}
-        run: |
-          ibmcloud login \
-            -a 'https://cloud.ibm.com' \
-            --apikey "$CLOUD_API_KEY" \
-            -r 'us-south'
-          ibmcloud target -o 'carbon-design-system' -s 'production'
-      - name: Install IBM Cloud plugins
-        run: |
-          ibmcloud cf install
-          ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-          ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
-      - name: Deploy React storybook
+      - name: Build React storybook
         run: |
           cd packages/react
           yarn build-storybook
-          ibmcloud cf blue-green-deploy carbon-storybook \
-            -f manifest.yml \
-            --delete-old-apps
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact

--- a/docs/release.md
+++ b/docs/release.md
@@ -424,3 +424,10 @@ name to ensure unpkg resolves to the latest v10 version:
 
 `https://unpkg.com/carbon-components@10/css/carbon-components.min.css`
 `https://unpkg.com/carbon-components@10/scripts/carbon-components.min.js`
+
+### When running the v10 storybook deploy manually, the v11 storybook is being published to v7-react.carbondesignsystem.com
+
+The workflow needs to be ran from the `v10` branch. Select `v10` from the
+dropdown when you run it.
+
+<img width="342" alt="image" src="https://user-images.githubusercontent.com/3360588/214062284-94065d87-5949-43a7-844b-0d1eb25aba16.png">

--- a/packages/react/manifest.yml
+++ b/packages/react/manifest.yml
@@ -1,8 +1,0 @@
----
-applications:
-- name: carbon-storybook
-  memory: 64M
-  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-  routes:
-  - route: react.carbondesignsystem.com
-  - route: carbon-react-storybook.mybluemix.net


### PR DESCRIPTION
Closes #12169
Closes #12860 
Ref https://github.com/carbon-design-system/carbon/issues/10834

This moreso _removes_ the Cloudfoundry (CF) deploy, rather than add the GitHub Pages deploy. 

The GitHub pages deployment was added over [a series of commits directly to `main`](https://github.com/carbon-design-system/carbon/compare/973b935..bcf5b63) on January 20, 2023. It's difficult to test workflows without having them in `main`, so @tw15egan and I just made these changes directly to `main`.

The changes to move the v10 deploy to GitHub pages were mirrored into `v10` branch across this [series of commits directly to `v10`](https://github.com/carbon-design-system/carbon/compare/850e554..82ae0b3).

#### Changelog

**New**

- Add GitHub Pages deployment and some brief docs

**Removed**

- remove `mainfest.yml`
- IBM Cloud deployment
