### PR TITLE
fix(dropdown): make titleText required

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2796,6 +2796,7 @@ Map {
         "type": "oneOf",
       },
       "titleText": Object {
+        "isRequired": true,
         "type": "node",
       },
       "translateWithId": Object {

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -391,7 +391,7 @@ Dropdown.propTypes = {
    * Provide the title text that will be read by a screen reader when
    * visiting this control
    */
-  titleText: PropTypes.node,
+  titleText: PropTypes.node.isRequired,
 
   /**
    * Callback function for translating ListBoxMenuIcon SVG title


### PR DESCRIPTION
Closes #12809 

#### Changelog

**Changed**

- make `titleText` required in Dropdown

#### Testing / Reviewing

- Make sure the Dropdown stories all render properly and don't give proptype warnings locally