### PR TITLE
ci(release): remove deprecated action, call github release API directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,14 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v6
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: true
+          script: |
+            github.rest.repos.createRelease({
+              tag_name: context.ref,
+              name: context.ref,
+              draft: false,
+              prerelease: true,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });

--- a/.github/workflows/v10-release.yml
+++ b/.github/workflows/v10-release.yml
@@ -42,14 +42,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v6
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: true
+          script: |
+            github.rest.repos.createRelease({
+              tag_name: context.ref,
+              name: context.ref,
+              draft: false,
+              prerelease: true,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
 
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12500
v10 counterpart: https://github.com/carbon-design-system/carbon/pull/13018

#### Changelog

**Changed**

- Update the release workflow to directly call the GitHub API to create a new release

**Removed**

- Remove unmaintained `create-release` action

#### Testing / Reviewing

- Make sure the syntax looks correct for using the [`github-script` action](https://github.com/actions/github-script)
- Make sure I'm not leaving out any required fields for the [`createRelease` API endpoint](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)