### PR TITLE
ci(release-v10): remove deprecated action, call github API directly

### DIFF
--- a/.github/workflows/v10-release.yml
+++ b/.github/workflows/v10-release.yml
@@ -42,14 +42,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v6
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: true
+          script: |
+            github.rest.repos.createRelease({
+              tag_name: context.ref,
+              name: context.ref,
+              draft: false,
+              prerelease: true,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
 
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
Ref https://github.com/carbon-design-system/carbon/issues/12500

Same as https://github.com/carbon-design-system/carbon/pull/13017, just for the v10 branch