### PR TITLE
refactor(DropdownSkeleton): convert DropdownSkeleton to TypeScript

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1022,6 +1022,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "lewandom",
+      "name": "Marcin Lewandowski",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8779205?v=4",
+      "profile": "https://github.com/lewandom",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/jkap"><img src="https://avatars.githubusercontent.com/u/224587?v=4?s=100" width="100px;" alt=""/><br /><sub><b>jae kaplan</b></sub></a><br /><a href="#infra-jkap" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
     <td align="center"><a href="https://github.com/sierrawetmore"><img src="https://avatars.githubusercontent.com/u/107062203?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sierra Wetmore</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=sierrawetmore" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/kcprevatt"><img src="https://avatars.githubusercontent.com/u/68609306?v=4?s=100" width="100px;" alt=""/><br /><sub><b>kcprevatt</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=kcprevatt" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/lewandom"><img src="https://avatars.githubusercontent.com/u/8779205?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcin Lewandowski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=lewandom" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2016, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,10 +8,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { PropTypes as ListBoxPropTypes } from '../ListBox';
+import { ListBoxSize, PropTypes as ListBoxPropTypes } from '../ListBox';
 import { usePrefix } from '../../internal/usePrefix';
+import { ReactAttr } from '../../types/common';
 
-const DropdownSkeleton = ({ className, size, ...rest }) => {
+export interface DropdownSkeletonProps extends ReactAttr<HTMLDivElement> {
+
+  size?: ListBoxSize;
+
+}
+
+const DropdownSkeleton: React.FC<DropdownSkeletonProps> = ({
+  className,
+  size,
+  ...rest
+}: DropdownSkeletonProps) => {
   const prefix = usePrefix();
   const wrapperClasses = cx(
     className,


### PR DESCRIPTION
Closes #12543.

Convert React DropdownSkeleton component to .tsx to add TypeScript support.

#### Changelog

**New**

- added DropdownSkeletonProps interface

**Changed**

- converted DropdownSkeleton component to TypeScript format (.tsx)

#### Testing / Reviewing

The DropdownSkeleton component imports for the storybook should be valid and rendering. In a TypeScript environment, you should be able to import and reference the DropdownSkeleton component and its typings (DropdownSkeletonProps).