### PR TITLE
feat(Heading): add prop to override level of a section

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1031,6 +1031,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "remolueoend",
+      "name": "remolueoend",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7881606?v=4",
+      "profile": "https://github.com/remolueoend",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/jkap"><img src="https://avatars.githubusercontent.com/u/224587?v=4?s=100" width="100px;" alt=""/><br /><sub><b>jae kaplan</b></sub></a><br /><a href="#infra-jkap" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
     <td align="center"><a href="https://github.com/sierrawetmore"><img src="https://avatars.githubusercontent.com/u/107062203?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sierra Wetmore</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=sierrawetmore" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/kcprevatt"><img src="https://avatars.githubusercontent.com/u/68609306?v=4?s=100" width="100px;" alt=""/><br /><sub><b>kcprevatt</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=kcprevatt" title="Code">💻</a></td>
+  </tr>
+  <tr>
     <td align="center"><a href="https://github.com/lewandom"><img src="https://avatars.githubusercontent.com/u/8779205?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcin Lewandowski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=lewandom" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/remolueoend"><img src="https://avatars.githubusercontent.com/u/7881606?v=4?s=100" width="100px;" alt=""/><br /><sub><b>remolueoend</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=remolueoend" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6157,6 +6157,9 @@ Map {
       "className": Object {
         "type": "string",
       },
+      "level": Object {
+        "type": "number",
+      },
     },
   },
   "Select" => Object {

--- a/packages/react/src/components/Heading/Heading-story.js
+++ b/packages/react/src/components/Heading/Heading-story.js
@@ -35,3 +35,17 @@ export const Default = () => {
     </>
   );
 };
+
+export const CustomLevel = () => {
+  return (
+    <>
+      <Heading>h1</Heading>
+      <Section level={5}>
+        <Heading>h5</Heading>
+        <Section>
+          <Heading>h6</Heading>
+        </Section>
+      </Section>
+    </>
+  );
+};

--- a/packages/react/src/components/Heading/Heading.mdx
+++ b/packages/react/src/components/Heading/Heading.mdx
@@ -53,6 +53,17 @@ For example, to render an `article` you could use `as="article"`:
 </Section>
 ```
 
+### Custom level
+You can use the `level` prop to override the level of a section:
+```jsx
+<Section level={5}>
+  <Heading>rendered as h5</Heading>
+  <Section>
+    <Heading>rendered as h6</Heading>
+  </Section>
+</Section>
+```
+
 ## Feedback
 
 Help us improve this component by providing feedback, asking questions on Slack,

--- a/packages/react/src/components/Heading/__tests__/Heading-test.js
+++ b/packages/react/src/components/Heading/__tests__/Heading-test.js
@@ -49,6 +49,31 @@ describe('Heading', () => {
     }
   });
 
+  it('should override heading levels when specifing the level of a section', () => {
+    render(
+      <>
+        <Heading data-testid="h1">h1</Heading>
+        <Section level={4}>
+          <Heading data-testid="h4">h4</Heading>
+          <Section>
+            <Heading data-testid="h5">h5</Heading>
+            <Section level={2}>
+              <Heading data-testid="h2">h2</Heading>
+            </Section>
+          </Section>
+        </Section>
+      </>
+    );
+
+    const levels = [1, 2, 4, 5];
+
+    for (const level of levels) {
+      const testId = `h${level}`;
+      const element = screen.getByTestId(testId);
+      expect(element.tagName).toBe(testId.toUpperCase());
+    }
+  });
+
   it('should stop increment heading levels past level 6', () => {
     render(
       <>

--- a/packages/react/src/components/Heading/index.js
+++ b/packages/react/src/components/Heading/index.js
@@ -10,11 +10,18 @@ import React from 'react';
 
 const HeadingContext = React.createContext(1);
 
-function Section({ as: BaseComponent = 'section', children, ...rest }) {
-  const level = React.useContext(HeadingContext);
+function Section({
+  as: BaseComponent = 'section',
+  level: levelOverride,
+  children,
+  ...rest
+}) {
+  const parentLevel = React.useContext(HeadingContext);
+  const level =
+    typeof levelOverride !== 'undefined' ? levelOverride : parentLevel + 1;
 
   return (
-    <HeadingContext.Provider value={Math.min(level + 1, 6)}>
+    <HeadingContext.Provider value={Math.min(level, 6)}>
       <BaseComponent {...rest}>{children}</BaseComponent>
     </HeadingContext.Provider>
   );
@@ -36,6 +43,11 @@ Section.propTypes = {
    * Specify a class name for the outermost node of the component
    */
   className: PropTypes.string,
+
+  /**
+   * Overrides the level of the section
+   */
+  level: PropTypes.number,
 };
 
 function Heading(props) {


### PR DESCRIPTION
In certain situations, such as when rendering headings as part of the content of a modal, one may wish to set the start level of the first section explicitly. This PR introduces the optional property `level` on section components, allowing users to override the level of a section.

#### Changelog

The Section component accepts an optional property `level`, allowing users to set the section's level explicitly.

#### Testing / Reviewing

This feature is tested using component tests and available as storybook component.
