### PR TITLE
Add TypeScript annotations to MultiSelect

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1040,6 +1040,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "awarrier99",
+      "name": "Ashvin Warrier",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17476235?v=4",
+      "profile": "https://github.com/awarrier99",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   <tr>
     <td align="center"><a href="https://github.com/lewandom"><img src="https://avatars.githubusercontent.com/u/8779205?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcin Lewandowski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=lewandom" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/remolueoend"><img src="https://avatars.githubusercontent.com/u/7881606?v=4?s=100" width="100px;" alt=""/><br /><sub><b>remolueoend</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=remolueoend" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/awarrier99"><img src="https://avatars.githubusercontent.com/u/17476235?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ashvin Warrier</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=awarrier99" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4820,7 +4820,127 @@ Map {
         "type": "bool",
       },
       "downshiftProps": Object {
-        "type": "object",
+        "args": Array [
+          Object {
+            "children": Object {
+              "type": "func",
+            },
+            "defaultHighlightedIndex": Object {
+              "type": "number",
+            },
+            "defaultIsOpen": Object {
+              "type": "bool",
+            },
+            "environment": Object {
+              "args": Array [
+                Object {
+                  "addEventListener": Object {
+                    "type": "func",
+                  },
+                  "document": Object {
+                    "args": Array [
+                      Object {
+                        "activeElement": Object {
+                          "type": "any",
+                        },
+                        "body": Object {
+                          "type": "any",
+                        },
+                        "getElementById": Object {
+                          "type": "func",
+                        },
+                      },
+                    ],
+                    "type": "shape",
+                  },
+                  "removeEventListener": Object {
+                    "type": "func",
+                  },
+                },
+              ],
+              "type": "shape",
+            },
+            "getA11yStatusMessage": Object {
+              "type": "func",
+            },
+            "getItemId": Object {
+              "type": "func",
+            },
+            "highlightedIndex": Object {
+              "type": "number",
+            },
+            "id": Object {
+              "type": "string",
+            },
+            "initialHighlightedIndex": Object {
+              "type": "number",
+            },
+            "initialInputValue": Object {
+              "type": "string",
+            },
+            "initialIsOpen": Object {
+              "type": "bool",
+            },
+            "initialSelectedItem": Object {
+              "type": "any",
+            },
+            "inputId": Object {
+              "type": "string",
+            },
+            "inputValue": Object {
+              "type": "string",
+            },
+            "isOpen": Object {
+              "type": "bool",
+            },
+            "itemCount": Object {
+              "type": "number",
+            },
+            "itemToString": Object {
+              "type": "func",
+            },
+            "labelId": Object {
+              "type": "string",
+            },
+            "menuId": Object {
+              "type": "string",
+            },
+            "onChange": Object {
+              "type": "func",
+            },
+            "onInputValueChange": Object {
+              "type": "func",
+            },
+            "onOuterClick": Object {
+              "type": "func",
+            },
+            "onSelect": Object {
+              "type": "func",
+            },
+            "onStateChange": Object {
+              "type": "func",
+            },
+            "onUserAction": Object {
+              "type": "func",
+            },
+            "scrollIntoView": Object {
+              "type": "func",
+            },
+            "selectedItem": Object {
+              "type": "any",
+            },
+            "selectedItemChanged": Object {
+              "type": "func",
+            },
+            "stateReducer": Object {
+              "type": "func",
+            },
+            "suppressRefError": Object {
+              "type": "bool",
+            },
+          },
+        ],
+        "type": "shape",
       },
       "helperText": Object {
         "type": "node",

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4787,10 +4787,10 @@ Map {
       "itemToString": [Function],
       "locale": "en",
       "open": false,
-      "selectedItems": null,
+      "selectedItems": undefined,
       "selectionFeedback": "top-after-reopen",
       "sortItems": [Function],
-      "title": false,
+      "titleText": false,
       "type": "default",
     },
     "propTypes": Object {
@@ -4820,127 +4820,10 @@ Map {
         "type": "bool",
       },
       "downshiftProps": Object {
-        "args": Array [
-          Object {
-            "children": Object {
-              "type": "func",
-            },
-            "defaultHighlightedIndex": Object {
-              "type": "number",
-            },
-            "defaultIsOpen": Object {
-              "type": "bool",
-            },
-            "environment": Object {
-              "args": Array [
-                Object {
-                  "addEventListener": Object {
-                    "type": "func",
-                  },
-                  "document": Object {
-                    "args": Array [
-                      Object {
-                        "activeElement": Object {
-                          "type": "any",
-                        },
-                        "body": Object {
-                          "type": "any",
-                        },
-                        "getElementById": Object {
-                          "type": "func",
-                        },
-                      },
-                    ],
-                    "type": "shape",
-                  },
-                  "removeEventListener": Object {
-                    "type": "func",
-                  },
-                },
-              ],
-              "type": "shape",
-            },
-            "getA11yStatusMessage": Object {
-              "type": "func",
-            },
-            "getItemId": Object {
-              "type": "func",
-            },
-            "highlightedIndex": Object {
-              "type": "number",
-            },
-            "id": Object {
-              "type": "string",
-            },
-            "initialHighlightedIndex": Object {
-              "type": "number",
-            },
-            "initialInputValue": Object {
-              "type": "string",
-            },
-            "initialIsOpen": Object {
-              "type": "bool",
-            },
-            "initialSelectedItem": Object {
-              "type": "any",
-            },
-            "inputId": Object {
-              "type": "string",
-            },
-            "inputValue": Object {
-              "type": "string",
-            },
-            "isOpen": Object {
-              "type": "bool",
-            },
-            "itemCount": Object {
-              "type": "number",
-            },
-            "itemToString": Object {
-              "type": "func",
-            },
-            "labelId": Object {
-              "type": "string",
-            },
-            "menuId": Object {
-              "type": "string",
-            },
-            "onChange": Object {
-              "type": "func",
-            },
-            "onInputValueChange": Object {
-              "type": "func",
-            },
-            "onOuterClick": Object {
-              "type": "func",
-            },
-            "onSelect": Object {
-              "type": "func",
-            },
-            "onStateChange": Object {
-              "type": "func",
-            },
-            "onUserAction": Object {
-              "type": "func",
-            },
-            "scrollIntoView": Object {
-              "type": "func",
-            },
-            "selectedItem": Object {
-              "type": "any",
-            },
-            "selectedItemChanged": Object {
-              "type": "func",
-            },
-            "stateReducer": Object {
-              "type": "func",
-            },
-            "suppressRefError": Object {
-              "type": "bool",
-            },
-          },
-        ],
-        "type": "shape",
+        "type": "object",
+      },
+      "helperText": Object {
+        "type": "node",
       },
       "hideLabel": Object {
         "type": "bool",

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -232,6 +232,7 @@ export const WithInitialSelectedItems = () => {
   return (
     <div style={{ width: 300 }}>
       <MultiSelect
+        label="Multiselect Label"
         id="carbon-multiselect-example-2"
         titleText="Multiselect title"
         helperText="This is helper text"

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -7,7 +7,7 @@
 
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import cx from 'classnames';
-import {
+import Downshift, {
   useSelect,
   UseSelectInterface,
   UseSelectProps,
@@ -654,7 +654,8 @@ MultiSelect.propTypes = {
   /**
    * Additional props passed to Downshift
    */
-  downshiftProps: PropTypes.object as React.Validator<UseSelectProps<unknown>>,
+  // @ts-ignore
+  downshiftProps: PropTypes.shape(Downshift.propTypes),
 
   /**
    * Provide helper text that is used alongside the control label for

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -7,11 +7,20 @@
 
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import cx from 'classnames';
-import { useSelect, UseSelectInterface, UseSelectProps, UseSelectStateChangeTypes } from 'downshift';
+import {
+  useSelect,
+  UseSelectInterface,
+  UseSelectProps,
+  UseSelectStateChangeTypes,
+} from 'downshift';
 import isEqual from 'lodash.isequal';
 import PropTypes from 'prop-types';
 import React, { ForwardedRef, useContext, useRef, useState } from 'react';
-import ListBox, { ListBoxSize, ListBoxType, PropTypes as ListBoxPropTypes } from '../ListBox';
+import ListBox, {
+  ListBoxSize,
+  ListBoxType,
+  PropTypes as ListBoxPropTypes,
+} from '../ListBox';
 import { sortingPropTypes } from './MultiSelectPropTypes';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 import { useSelection } from '../../internal/Selection';
@@ -36,24 +45,30 @@ const {
   MenuKeyDownEscape,
   MenuKeyDownSpaceButton,
   ToggleButtonClick,
-} = useSelect.stateChangeTypes as UseSelectInterface['stateChangeTypes'] & { ToggleButtonClick: UseSelectStateChangeTypes.ToggleButtonClick };
+} = useSelect.stateChangeTypes as UseSelectInterface['stateChangeTypes'] & {
+  ToggleButtonClick: UseSelectStateChangeTypes.ToggleButtonClick;
+};
 
 const defaultItemToString = <ItemType,>(item?: ItemType): string => {
   if (typeof item === 'string') {
     return item;
   }
   if (typeof item === 'number') {
-    return `${item}`
+    return `${item}`;
   }
-  if (item !== null && typeof item === 'object'
-    && 'label' in item && typeof item['label'] === 'string') {
-    return item['label']
+  if (
+    item !== null &&
+    typeof item === 'object' &&
+    'label' in item &&
+    typeof item['label'] === 'string'
+  ) {
+    return item['label'];
   }
   return '';
 };
 
 interface SharedOptions {
-  locale: string,
+  locale: string;
 }
 
 interface DownshiftTypedProps<ItemType> {
@@ -64,182 +79,197 @@ interface InternationalProps<MID = string, ARGS = Record<string, unknown>> {
   translateWithId?(messageId: MID, args?: ARGS): string;
 }
 
-interface SortItemsOptions<ItemType> extends SharedOptions, DownshiftTypedProps<ItemType> {
-  compareItems(item1: ItemType, item2: ItemType, options: SharedOptions): number,
-  selectedItems: ItemType[],
+interface SortItemsOptions<ItemType>
+  extends SharedOptions,
+    DownshiftTypedProps<ItemType> {
+  compareItems(
+    item1: ItemType,
+    item2: ItemType,
+    options: SharedOptions
+  ): number;
+  selectedItems: ItemType[];
 }
 
 interface MultiSelectSortingProps<ItemType> {
-  compareItems?(item1: ItemType, item2: ItemType, options: SharedOptions): number, // required but has default value
-  sortItems?(items: ReadonlyArray<ItemType>, options: SortItemsOptions<ItemType>): ItemType[], // required but has default value
+  compareItems?(
+    item1: ItemType,
+    item2: ItemType,
+    options: SharedOptions
+  ): number; // required but has default value
+  sortItems?(
+    items: ReadonlyArray<ItemType>,
+    options: SortItemsOptions<ItemType>
+  ): ItemType[]; // required but has default value
 }
 
 export interface MultiSelectProps<ItemType>
-    extends MultiSelectSortingProps<ItemType>,
-        InternationalProps<'close.menu' | 'open.menu' | 'clear.all' | 'clear.selection'> {
-    className?: string;
-    
-    /**
-     * Specify the text that should be read for screen readers that describes total items selected
-     */
-    clearSelectionDescription?: string;
+  extends MultiSelectSortingProps<ItemType>,
+    InternationalProps<
+      'close.menu' | 'open.menu' | 'clear.all' | 'clear.selection'
+    > {
+  className?: string;
 
-    /**
-     * Specify the text that should be read for screen readers to clear selection.
-     */
-    clearSelectionText?: string;
+  /**
+   * Specify the text that should be read for screen readers that describes total items selected
+   */
+  clearSelectionDescription?: string;
 
-    /**
-     * Specify the direction of the multiselect dropdown. Can be either top or bottom.
-     */
-    direction?: 'bottom' | 'top';
-    
-    /**
-     * Disable the control
-     */
-    disabled?: ListBoxProps['disabled'];
+  /**
+   * Specify the text that should be read for screen readers to clear selection.
+   */
+  clearSelectionText?: string;
 
-    /**
-     * Additional props passed to Downshift
-     */
-    downshiftProps?: Partial<UseSelectProps<ItemType>>;
+  /**
+   * Specify the direction of the multiselect dropdown. Can be either top or bottom.
+   */
+  direction?: 'bottom' | 'top';
 
-    /**
-     * Provide helper text that is used alongside the control label for
-     * additional help
-     */
-    helperText?: React.ReactNode;
+  /**
+   * Disable the control
+   */
+  disabled?: ListBoxProps['disabled'];
 
-    /**
-     * Specify whether the title text should be hidden or not
-     */
-    hideLabel?: boolean;
+  /**
+   * Additional props passed to Downshift
+   */
+  downshiftProps?: Partial<UseSelectProps<ItemType>>;
 
-    /**
-     * Specify a custom `id`
-     */
-    id: string;
+  /**
+   * Provide helper text that is used alongside the control label for
+   * additional help
+   */
+  helperText?: React.ReactNode;
 
-    /**
-     * Allow users to pass in arbitrary items from their collection that are
-     * pre-selected
-     */
-    initialSelectedItems?: ItemType[];
+  /**
+   * Specify whether the title text should be hidden or not
+   */
+  hideLabel?: boolean;
 
-    /**
-     * Is the current selection invalid?
-     */
-    invalid?: boolean;
+  /**
+   * Specify a custom `id`
+   */
+  id: string;
 
-    /**
-     * If invalid, what is the error?
-     */
-    invalidText?: React.ReactNode;
+  /**
+   * Allow users to pass in arbitrary items from their collection that are
+   * pre-selected
+   */
+  initialSelectedItems?: ItemType[];
 
-    /**
-     * Function to render items as custom components instead of strings.
-     * Defaults to null and is overridden by a getter
-     */
-    itemToElement?: React.JSXElementConstructor<ItemType>;
+  /**
+   * Is the current selection invalid?
+   */
+  invalid?: boolean;
 
-    /**
-     * Helper function passed to downshift that allows the library to render a
-     * given item to a string label. By default, it extracts the `label` field
-     * from a given item to serve as the item label in the list.
-     */
-    itemToString?(item: ItemType): string;
+  /**
+   * If invalid, what is the error?
+   */
+  invalidText?: React.ReactNode;
 
-    /**
-     * We try to stay as generic as possible here to allow individuals to pass
-     * in a collection of whatever kind of data structure they prefer
-     */
-    items: ItemType[];
+  /**
+   * Function to render items as custom components instead of strings.
+   * Defaults to null and is overridden by a getter
+   */
+  itemToElement?: React.JSXElementConstructor<ItemType>;
 
-    /**
-     * Generic `label` that will be used as the textual representation of what
-     * this field is for
-     */
-    label: NonNullable<React.ReactNode>;
+  /**
+   * Helper function passed to downshift that allows the library to render a
+   * given item to a string label. By default, it extracts the `label` field
+   * from a given item to serve as the item label in the list.
+   */
+  itemToString?(item: ItemType): string;
 
-    /**
-     * `true` to use the light version.
-     *
-     * @deprecated The `light` prop for `MultiSelect` has
-     *     been deprecated in favor of the new `Layer` component. It will be removed in the next major release.
-     */
-    light?: boolean;
+  /**
+   * We try to stay as generic as possible here to allow individuals to pass
+   * in a collection of whatever kind of data structure they prefer
+   */
+  items: ItemType[];
 
-    /**
-     * Specify the locale of the control. Used for the default `compareItems`
-     * used for sorting the list of items in the control.
-     */
-    locale?: string;
+  /**
+   * Generic `label` that will be used as the textual representation of what
+   * this field is for
+   */
+  label: NonNullable<React.ReactNode>;
 
-    /**
-     * `onChange` is a utility for this controlled component to communicate to a
-     * consuming component what kind of internal state changes are occurring.
-     */
-    onChange?(data: OnChangeData<ItemType>): void;
+  /**
+   * `true` to use the light version.
+   *
+   * @deprecated The `light` prop for `MultiSelect` has
+   *     been deprecated in favor of the new `Layer` component. It will be removed in the next major release.
+   */
+  light?: boolean;
 
-    /**
-     * `onMenuChange` is a utility for this controlled component to communicate to a
-     * consuming component that the menu was opend(`true`)/closed(`false`).
-     */
-    onMenuChange?(open: boolean): void;
+  /**
+   * Specify the locale of the control. Used for the default `compareItems`
+   * used for sorting the list of items in the control.
+   */
+  locale?: string;
 
-    /**
-     * Initialize the component with an open(`true`)/closed(`false`) menu.
-     */
-    open?: boolean;
+  /**
+   * `onChange` is a utility for this controlled component to communicate to a
+   * consuming component what kind of internal state changes are occurring.
+   */
+  onChange?(data: OnChangeData<ItemType>): void;
 
-    /**
-     * Whether or not the Dropdown is readonly
-     */
-    readOnly?: boolean;
+  /**
+   * `onMenuChange` is a utility for this controlled component to communicate to a
+   * consuming component that the menu was opend(`true`)/closed(`false`).
+   */
+  onMenuChange?(open: boolean): void;
 
-    /**
-     * For full control of the selected items
-     */
-    selectedItems?: ItemType[];
+  /**
+   * Initialize the component with an open(`true`)/closed(`false`) menu.
+   */
+  open?: boolean;
 
-    /**
-     * Specify feedback (mode) of the selection.
-     * `top`: selected item jumps to top
-     * `fixed`: selected item stays at it's position
-     * `top-after-reopen`: selected item jump to top after reopen dropdown
-     */
-    selectionFeedback?: 'fixed' | 'top' | 'top-after-reopen';
+  /**
+   * Whether or not the Dropdown is readonly
+   */
+  readOnly?: boolean;
 
-    /**
-     * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
-     */
-    size?: ListBoxSize;
+  /**
+   * For full control of the selected items
+   */
+  selectedItems?: ItemType[];
 
-    /**
-     * Provide text to be used in a `<label>` element that is tied to the
-     * multiselect via ARIA attributes.
-     */
-    titleText?: React.ReactNode;
+  /**
+   * Specify feedback (mode) of the selection.
+   * `top`: selected item jumps to top
+   * `fixed`: selected item stays at it's position
+   * `top-after-reopen`: selected item jump to top after reopen dropdown
+   */
+  selectionFeedback?: 'fixed' | 'top' | 'top-after-reopen';
 
-    /**
-     * Specify 'inline' to create an inline multi-select.
-     */
-    type?: ListBoxType;
+  /**
+   * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+   */
+  size?: ListBoxSize;
 
-    /**
-     * Specify title to show title on hover
-     */
-    useTitleInItem?: boolean;
+  /**
+   * Provide text to be used in a `<label>` element that is tied to the
+   * multiselect via ARIA attributes.
+   */
+  titleText?: React.ReactNode;
 
-    /**
-     * Specify whether the control is currently in warning state
-     */
-    warn?: boolean;
+  /**
+   * Specify 'inline' to create an inline multi-select.
+   */
+  type?: ListBoxType;
 
-    /**
-     * Provide the text that is displayed when the control is in warning state
-     */
-    warnText?: React.ReactNode;
+  /**
+   * Specify title to show title on hover
+   */
+  useTitleInItem?: boolean;
+
+  /**
+   * Specify whether the control is currently in warning state
+   */
+  warn?: boolean;
+
+  /**
+   * Provide the text that is displayed when the control is in warning state
+   */
+  warnText?: React.ReactNode;
 }
 
 const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
@@ -276,7 +306,7 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     direction,
     selectedItems: selected,
     readOnly,
-    locale
+    locale,
   }: MultiSelectProps<ItemType>,
   ref: ForwardedRef<HTMLButtonElement>
 ) {
@@ -393,7 +423,7 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     selectedItems: controlledSelectedItems,
     itemToString,
     compareItems,
-    locale
+    locale,
   };
 
   if (selectionFeedback === 'fixed') {
@@ -521,49 +551,54 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
           <span id={fieldLabelId} className={`${prefix}--list-box__label`}>
             {label}
           </span>
-          <ListBox.MenuIcon isOpen={!!isOpen} translateWithId={translateWithId} />
+          <ListBox.MenuIcon
+            isOpen={!!isOpen}
+            translateWithId={translateWithId}
+          />
         </button>
         <ListBox.Menu aria-multiselectable="true" {...getMenuProps()}>
           {isOpen &&
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            sortItems!(items, sortOptions as SortItemsOptions<ItemType>).map((item, index) => {
-              const isChecked =
-              selectedItems.filter((selected) => isEqual(selected, item))
-                  .length > 0;
+            sortItems!(items, sortOptions as SortItemsOptions<ItemType>).map(
+              (item, index) => {
+                const isChecked =
+                  selectedItems.filter((selected) => isEqual(selected, item))
+                    .length > 0;
 
-              const itemProps = getItemProps({
-                item,
-                // we don't want Downshift to set aria-selected for us
-                // we also don't want to set 'false' for reader verbosity's sake
-                ['aria-selected']: isChecked ? true : undefined,
-                disabled: (item as any).disabled,
-              });
-              const itemText = itemToString(item);
-              
-              return (
-                <ListBox.MenuItem
-                  key={itemProps.id}
-                  isActive={isChecked}
-                  aria-label={itemText}
-                  isHighlighted={highlightedIndex === index}
-                  title={itemText}
-                  {...itemProps}>
-                  <div className={`${prefix}--checkbox-wrapper`}>
-                    <span
-                      title={useTitleInItem ? itemText : undefined}
-                      className={`${prefix}--checkbox-label`}
-                      data-contained-checkbox-state={isChecked}
-                      id={`${itemProps.id}__checkbox`}>
-                      {itemToElement ? (
-                        <ItemToElement key={itemProps.id} {...item} />
-                      ) : (
-                        itemText
-                      )}
-                    </span>
-                  </div>
-                </ListBox.MenuItem>
-              );
-            })}
+                const itemProps = getItemProps({
+                  item,
+                  // we don't want Downshift to set aria-selected for us
+                  // we also don't want to set 'false' for reader verbosity's sake
+                  ['aria-selected']: isChecked ? true : undefined,
+                  disabled: (item as any).disabled,
+                });
+                const itemText = itemToString(item);
+
+                return (
+                  <ListBox.MenuItem
+                    key={itemProps.id}
+                    isActive={isChecked}
+                    aria-label={itemText}
+                    isHighlighted={highlightedIndex === index}
+                    title={itemText}
+                    {...itemProps}>
+                    <div className={`${prefix}--checkbox-wrapper`}>
+                      <span
+                        title={useTitleInItem ? itemText : undefined}
+                        className={`${prefix}--checkbox-label`}
+                        data-contained-checkbox-state={isChecked}
+                        id={`${itemProps.id}__checkbox`}>
+                        {itemToElement ? (
+                          <ItemToElement key={itemProps.id} {...item} />
+                        ) : (
+                          itemText
+                        )}
+                      </span>
+                    </div>
+                  </ListBox.MenuItem>
+                );
+              }
+            )}
         </ListBox.Menu>
       </ListBox>
       {!inline && !invalid && !warn && helperText && (
@@ -575,11 +610,15 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
   );
 });
 
-type MultiSelectComponentProps<ItemType> = React.PropsWithChildren<MultiSelectProps<ItemType>> 
-  & React.RefAttributes<HTMLButtonElement>
+type MultiSelectComponentProps<ItemType> = React.PropsWithChildren<
+  MultiSelectProps<ItemType>
+> &
+  React.RefAttributes<HTMLButtonElement>;
 
 interface MultiSelectComponent {
-  <ItemType>(props: MultiSelectComponentProps<ItemType>): React.ReactElement | null
+  <ItemType>(
+    props: MultiSelectComponentProps<ItemType>
+  ): React.ReactElement | null;
 }
 
 MultiSelect.displayName = 'MultiSelect';

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -276,6 +276,7 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     direction,
     selectedItems: selected,
     readOnly,
+    locale
   }: MultiSelectProps<ItemType>,
   ref: ForwardedRef<HTMLButtonElement>
 ) {
@@ -392,7 +393,7 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     selectedItems: controlledSelectedItems,
     itemToString,
     compareItems,
-    locale: 'en',
+    locale
   };
 
   if (selectionFeedback === 'fixed') {

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -7,13 +7,12 @@
 
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import cx from 'classnames';
-import Downshift, { useSelect } from 'downshift';
+import { useSelect, UseSelectInterface, UseSelectProps, UseSelectStateChangeTypes } from 'downshift';
 import isEqual from 'lodash.isequal';
 import PropTypes from 'prop-types';
-import React, { useContext, useRef, useState } from 'react';
-import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
+import React, { ForwardedRef, useContext, useRef, useState } from 'react';
+import ListBox, { ListBoxSize, ListBoxType, PropTypes as ListBoxPropTypes } from '../ListBox';
 import { sortingPropTypes } from './MultiSelectPropTypes';
-import { defaultItemToString } from './tools/itemToString';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 import { useSelection } from '../../internal/Selection';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
@@ -23,6 +22,8 @@ import { keys, match } from '../../internal/keyboard';
 import { useFeatureFlag } from '../FeatureFlags';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
+import { ListBoxProps } from '../ListBox/ListBox';
+import { OnChangeData } from '../Dropdown';
 
 const noop = () => {};
 const getInstanceId = setupGetInstanceId();
@@ -35,15 +36,219 @@ const {
   MenuKeyDownEscape,
   MenuKeyDownSpaceButton,
   ToggleButtonClick,
-} = useSelect.stateChangeTypes;
+} = useSelect.stateChangeTypes as UseSelectInterface['stateChangeTypes'] & { ToggleButtonClick: UseSelectStateChangeTypes.ToggleButtonClick };
 
-const MultiSelect = React.forwardRef(function MultiSelect(
+const defaultItemToString = <ItemType,>(item?: ItemType): string => {
+  if (typeof item === 'string') {
+    return item;
+  }
+  if (typeof item === 'number') {
+    return `${item}`
+  }
+  if (item !== null && typeof item === 'object'
+    && 'label' in item && typeof item['label'] === 'string') {
+    return item['label']
+  }
+  return '';
+};
+
+interface SharedOptions {
+  locale: string,
+}
+
+interface DownshiftTypedProps<ItemType> {
+  itemToString?(item: ItemType): string;
+}
+
+interface InternationalProps<MID = string, ARGS = Record<string, unknown>> {
+  translateWithId?(messageId: MID, args?: ARGS): string;
+}
+
+interface SortItemsOptions<ItemType> extends SharedOptions, DownshiftTypedProps<ItemType> {
+  compareItems(item1: ItemType, item2: ItemType, options: SharedOptions): number,
+  selectedItems: ItemType[],
+}
+
+interface MultiSelectSortingProps<ItemType> {
+  compareItems?(item1: ItemType, item2: ItemType, options: SharedOptions): number, // required but has default value
+  sortItems?(items: ReadonlyArray<ItemType>, options: SortItemsOptions<ItemType>): ItemType[], // required but has default value
+}
+
+export interface MultiSelectProps<ItemType>
+    extends MultiSelectSortingProps<ItemType>,
+        InternationalProps<'close.menu' | 'open.menu' | 'clear.all' | 'clear.selection'> {
+    className?: string;
+    
+    /**
+     * Specify the text that should be read for screen readers that describes total items selected
+     */
+    clearSelectionDescription?: string;
+
+    /**
+     * Specify the text that should be read for screen readers to clear selection.
+     */
+    clearSelectionText?: string;
+
+    /**
+     * Specify the direction of the multiselect dropdown. Can be either top or bottom.
+     */
+    direction?: 'bottom' | 'top';
+    
+    /**
+     * Disable the control
+     */
+    disabled?: ListBoxProps['disabled'];
+
+    /**
+     * Additional props passed to Downshift
+     */
+    downshiftProps?: Partial<UseSelectProps<ItemType>>;
+
+    /**
+     * Provide helper text that is used alongside the control label for
+     * additional help
+     */
+    helperText?: React.ReactNode;
+
+    /**
+     * Specify whether the title text should be hidden or not
+     */
+    hideLabel?: boolean;
+
+    /**
+     * Specify a custom `id`
+     */
+    id: string;
+
+    /**
+     * Allow users to pass in arbitrary items from their collection that are
+     * pre-selected
+     */
+    initialSelectedItems?: ItemType[];
+
+    /**
+     * Is the current selection invalid?
+     */
+    invalid?: boolean;
+
+    /**
+     * If invalid, what is the error?
+     */
+    invalidText?: React.ReactNode;
+
+    /**
+     * Function to render items as custom components instead of strings.
+     * Defaults to null and is overridden by a getter
+     */
+    itemToElement?: React.JSXElementConstructor<ItemType>;
+
+    /**
+     * Helper function passed to downshift that allows the library to render a
+     * given item to a string label. By default, it extracts the `label` field
+     * from a given item to serve as the item label in the list.
+     */
+    itemToString?(item: ItemType): string;
+
+    /**
+     * We try to stay as generic as possible here to allow individuals to pass
+     * in a collection of whatever kind of data structure they prefer
+     */
+    items: ItemType[];
+
+    /**
+     * Generic `label` that will be used as the textual representation of what
+     * this field is for
+     */
+    label: NonNullable<React.ReactNode>;
+
+    /**
+     * `true` to use the light version.
+     *
+     * @deprecated The `light` prop for `MultiSelect` has
+     *     been deprecated in favor of the new `Layer` component. It will be removed in the next major release.
+     */
+    light?: boolean;
+
+    /**
+     * Specify the locale of the control. Used for the default `compareItems`
+     * used for sorting the list of items in the control.
+     */
+    locale?: string;
+
+    /**
+     * `onChange` is a utility for this controlled component to communicate to a
+     * consuming component what kind of internal state changes are occurring.
+     */
+    onChange?(data: OnChangeData<ItemType>): void;
+
+    /**
+     * `onMenuChange` is a utility for this controlled component to communicate to a
+     * consuming component that the menu was opend(`true`)/closed(`false`).
+     */
+    onMenuChange?(open: boolean): void;
+
+    /**
+     * Initialize the component with an open(`true`)/closed(`false`) menu.
+     */
+    open?: boolean;
+
+    /**
+     * Whether or not the Dropdown is readonly
+     */
+    readOnly?: boolean;
+
+    /**
+     * For full control of the selected items
+     */
+    selectedItems?: ItemType[];
+
+    /**
+     * Specify feedback (mode) of the selection.
+     * `top`: selected item jumps to top
+     * `fixed`: selected item stays at it's position
+     * `top-after-reopen`: selected item jump to top after reopen dropdown
+     */
+    selectionFeedback?: 'fixed' | 'top' | 'top-after-reopen';
+
+    /**
+     * Specify the size of the ListBox. Currently supports either `sm`, `md` or `lg` as an option.
+     */
+    size?: ListBoxSize;
+
+    /**
+     * Provide text to be used in a `<label>` element that is tied to the
+     * multiselect via ARIA attributes.
+     */
+    titleText?: React.ReactNode;
+
+    /**
+     * Specify 'inline' to create an inline multi-select.
+     */
+    type?: ListBoxType;
+
+    /**
+     * Specify title to show title on hover
+     */
+    useTitleInItem?: boolean;
+
+    /**
+     * Specify whether the control is currently in warning state
+     */
+    warn?: boolean;
+
+    /**
+     * Provide the text that is displayed when the control is in warning state
+     */
+    warnText?: React.ReactNode;
+}
+
+const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
   {
     className: containerClassName,
     id,
     items,
     itemToElement,
-    itemToString,
+    itemToString = defaultItemToString,
     titleText,
     hideLabel,
     helperText,
@@ -71,13 +276,13 @@ const MultiSelect = React.forwardRef(function MultiSelect(
     direction,
     selectedItems: selected,
     readOnly,
-  },
-  ref
+  }: MultiSelectProps<ItemType>,
+  ref: ForwardedRef<HTMLButtonElement>
 ) {
   const prefix = usePrefix();
   const { isFluid } = useContext(FormContext);
   const { current: multiSelectInstanceId } = useRef(getInstanceId());
-  const [highlightedIndex, setHighlightedIndex] = useState(null);
+  const [highlightedIndex, setHighlightedIndex] = useState();
   const [isFocused, setIsFocused] = useState(false);
   const [isOpen, setIsOpen] = useState(open);
   const [prevOpenProp, setPrevOpenProp] = useState(open);
@@ -98,18 +303,23 @@ const MultiSelect = React.forwardRef(function MultiSelect(
     getLabelProps,
     getMenuProps,
     getItemProps,
-    selectedItem: selectedItems,
-  } = useSelect({
+    selectedItem,
+  } = useSelect<ItemType>({
     ...downshiftProps,
     highlightedIndex,
     isOpen,
     itemToString: (items) => {
-      return items.map((item) => itemToString(item)).join(', ');
+      return (items as ItemType[]).map((item) => itemToString(item)).join(', ');
     },
     onStateChange,
     selectedItem: controlledSelectedItems,
     items,
   });
+
+  const toggleButtonProps = getToggleButtonProps();
+  const mergedRef = mergeRefs(toggleButtonProps.ref, ref);
+
+  const selectedItems = selectedItem as ItemType[];
 
   /**
    * wrapper function to forward changes to consumer
@@ -175,7 +385,8 @@ const MultiSelect = React.forwardRef(function MultiSelect(
   );
 
   // needs to be capitalized for react to render it correctly
-  const ItemToElement = itemToElement;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const ItemToElement = itemToElement!;
 
   const sortOptions = {
     selectedItems: controlledSelectedItems,
@@ -228,9 +439,7 @@ const MultiSelect = React.forwardRef(function MultiSelect(
     }
   };
 
-  const toggleButtonProps = getToggleButtonProps();
-
-  const handleFocus = (evt) => {
+  const handleFocus = (evt: React.FocusEvent<HTMLDivElement>) => {
     evt.target.classList.contains(`${prefix}--tag__close-icon`)
       ? setIsFocused(false)
       : setIsFocused(evt.type === 'focus' ? true : false);
@@ -238,13 +447,15 @@ const MultiSelect = React.forwardRef(function MultiSelect(
 
   const readOnlyEventHandlers = readOnly
     ? {
-        onClick: (evt) => {
+        onClick: (evt: React.MouseEvent<HTMLButtonElement>) => {
           // NOTE: does not prevent click
           evt.preventDefault();
           // focus on the element as per readonly input behavior
-          evt.target.focus();
+          if (mergedRef.current !== undefined) {
+            mergedRef.current.focus();
+          }
         },
-        onKeyDown: (evt) => {
+        onKeyDown: (evt: React.KeyboardEvent<HTMLButtonElement>) => {
           const selectAccessKeys = ['ArrowDown', 'ArrowUp', ' ', 'Enter'];
           // This prevents the select from opening for the above keys
           if (selectAccessKeys.includes(evt.key)) {
@@ -266,13 +477,12 @@ const MultiSelect = React.forwardRef(function MultiSelect(
         )}
       </label>
       <ListBox
-        onFocus={isFluid ? handleFocus : null}
-        onBlur={isFluid ? handleFocus : null}
+        onFocus={isFluid ? handleFocus : undefined}
+        onBlur={isFluid ? handleFocus : undefined}
         type={type}
         size={size}
         className={className}
         disabled={disabled}
-        readOnly={readOnly}
         light={light}
         invalid={invalid}
         invalidText={invalidText}
@@ -294,7 +504,7 @@ const MultiSelect = React.forwardRef(function MultiSelect(
           disabled={disabled}
           aria-disabled={disabled || readOnly}
           {...toggleButtonProps}
-          ref={mergeRefs(toggleButtonProps.ref, ref)}
+          ref={mergedRef}
           onKeyDown={onKeyDown}
           {...readOnlyEventHandlers}>
           {selectedItems.length > 0 && (
@@ -302,29 +512,33 @@ const MultiSelect = React.forwardRef(function MultiSelect(
               readOnly={readOnly}
               clearSelection={!disabled && !readOnly ? clearSelection : noop}
               selectionCount={selectedItems.length}
-              translateWithId={translateWithId}
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              translateWithId={translateWithId!}
               disabled={disabled}
             />
           )}
           <span id={fieldLabelId} className={`${prefix}--list-box__label`}>
             {label}
           </span>
-          <ListBox.MenuIcon isOpen={isOpen} translateWithId={translateWithId} />
+          <ListBox.MenuIcon isOpen={!!isOpen} translateWithId={translateWithId} />
         </button>
         <ListBox.Menu aria-multiselectable="true" {...getMenuProps()}>
           {isOpen &&
-            sortItems(items, sortOptions).map((item, index) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            sortItems!(items, sortOptions as SortItemsOptions<ItemType>).map((item, index) => {
+              const isChecked =
+              selectedItems.filter((selected) => isEqual(selected, item))
+                  .length > 0;
+
               const itemProps = getItemProps({
                 item,
                 // we don't want Downshift to set aria-selected for us
                 // we also don't want to set 'false' for reader verbosity's sake
-                ['aria-selected']: isChecked ? true : null,
-                disabled: item.disabled,
+                ['aria-selected']: isChecked ? true : undefined,
+                disabled: (item as any).disabled,
               });
               const itemText = itemToString(item);
-              const isChecked =
-                selectedItems.filter((selected) => isEqual(selected, item))
-                  .length > 0;
+              
               return (
                 <ListBox.MenuItem
                   key={itemProps.id}
@@ -335,7 +549,7 @@ const MultiSelect = React.forwardRef(function MultiSelect(
                   {...itemProps}>
                   <div className={`${prefix}--checkbox-wrapper`}>
                     <span
-                      title={useTitleInItem ? itemText : null}
+                      title={useTitleInItem ? itemText : undefined}
                       className={`${prefix}--checkbox-label`}
                       data-contained-checkbox-state={isChecked}
                       id={`${itemProps.id}__checkbox`}>
@@ -359,6 +573,13 @@ const MultiSelect = React.forwardRef(function MultiSelect(
     </div>
   );
 });
+
+type MultiSelectComponentProps<ItemType> = React.PropsWithChildren<MultiSelectProps<ItemType>> 
+  & React.RefAttributes<HTMLButtonElement>
+
+interface MultiSelectComponent {
+  <ItemType>(props: MultiSelectComponentProps<ItemType>): React.ReactElement | null
+}
 
 MultiSelect.displayName = 'MultiSelect';
 MultiSelect.propTypes = {
@@ -393,7 +614,13 @@ MultiSelect.propTypes = {
   /**
    * Additional props passed to Downshift
    */
-  downshiftProps: PropTypes.shape(Downshift.propTypes),
+  downshiftProps: PropTypes.object as React.Validator<UseSelectProps<unknown>>,
+
+  /**
+   * Provide helper text that is used alongside the control label for
+   * additional help
+   */
+  helperText: PropTypes.node,
 
   /**
    * Specify whether the title text should be hidden or not
@@ -539,15 +766,15 @@ MultiSelect.defaultProps = {
   locale: 'en',
   itemToString: defaultItemToString,
   initialSelectedItems: [],
-  sortItems: defaultSortItems,
+  sortItems: defaultSortItems as MultiSelectProps<unknown>['sortItems'],
   type: 'default',
-  title: false,
+  titleText: false,
   open: false,
   selectionFeedback: 'top-after-reopen',
   direction: 'bottom',
   clearSelectionText: 'To clear selection, press Delete or Backspace,',
   clearSelectionDescription: 'Total items selected: ',
-  selectedItems: null,
+  selectedItems: undefined,
 };
 
-export default MultiSelect;
+export default MultiSelect as MultiSelectComponent;

--- a/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/packages/react/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -344,7 +344,7 @@ describe('MultiSelect', () => {
                 </span>
               </span>
             ) : (
-              ''
+              <span></span>
             )
           }
         />


### PR DESCRIPTION
Closes #12547 

Convert existing propType definitions to TypeScript annotations on the MultiSelect component. This is part of a broader effort to add TypeScript annotations to components, tracked in #12513.

#### Changelog

**Changed**

- `MultiSelect.js` has been converted to `MultiSelect.tsx`
- Added awarrier99 to contributor list
- Changed a `MultiSelect` story to include required prop `label`
- Changed a `MultiSelect` test to return an empty span instead of an empty string for `itemToElement` (a string is not valid as a JSX constructor, which is how the prop is used in the component)
- Changed `MultiSelect` sorting options to use `locale` prop, rather than hardcoded 'en'

#### Testing / Reviewing

- In the `packages/react` directory, run `yarn build`, `yarn storybook`. In the storybook, navigate to `MultiSelect` and confirm that the component's behavior remains unchanged.
- In `MultiSelect.stories.js` and `MultiSelect-test.js`, add `// @ts-check` as the first line in the file (temporarily, for the sake of this test). Confirm that the files do not have compilation errors (related to the `MultiSelect` component). Make changes to the components in those files - change number to string, etc - and confirm that compilation errors appear.
