### PR TITLE
fix(DataTable): add sorting null values

### DIFF
--- a/packages/react/src/components/DataTable/tools/sorting.js
+++ b/packages/react/src/components/DataTable/tools/sorting.js
@@ -20,6 +20,10 @@ import { sortStates } from '../state/sortStates';
  * @returns {number}
  */
 export const compare = (a, b, locale = 'en') => {
+  // prevent multiple null values in one column (sorting breaks)
+  a === null ? (a = '') : null;
+  b === null ? (b = '') : null;
+
   if (typeof a === 'number' && typeof b === 'number') {
     return a - b;
   }


### PR DESCRIPTION
Closes #

Fix for Issue [#12696](https://github.com/carbon-design-system/carbon/issues/12696)

#### Changelog

**New**

- fix ability to sort data even if it has null values in rows

**Changed**

- n/a

**Removed**

- n/a

#### Testing / Reviewing

My basic findings BEFORE fix
- A: single null value in one column did NOT break sorting
- B: multiple null values in one column DID break sorting

1. open `packages/react/src/components/DataTable/stories/shared.js`
2. under `const rows` set various values to `null` (i.e. multiple `name` keys set to null for column sorting)
3. open the Storybook site to test in browser: `Storybook > DataTable > Sorting > Default` (or anywhere that has sorting enabled)
4. test the sort feature: hover over column headers and cycle clicks at least **3 times** (3 different sorting comparison types), but also a bunch of times 💪 
5. confirm both A and B findings (above) sort as expected now


