### PR TITLE
test(menu): add vrt and avt

### DIFF
--- a/e2e/components/Menu/Menu-test.e2e.js
+++ b/e2e/components/Menu/Menu-test.e2e.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright IBM Corp. 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { themes } = require('../../test-utils/env');
+const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+
+test.describe('Menu', () => {
+  themes.forEach((theme) => {
+    test.describe(theme, () => {
+      test('menu @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'Menu',
+          id: 'experimental-unstable-menu--playground',
+          theme,
+        });
+      });
+    });
+  });
+
+  test('accessibility-checker @avt', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Menu',
+      id: 'experimental-unstable-menu--playground',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Menu');
+  });
+});

--- a/packages/react/src/components/Menu/MenuItem.js
+++ b/packages/react/src/components/Menu/MenuItem.js
@@ -215,7 +215,7 @@ const MenuItemSelectable = React.forwardRef(function MenuItemSelectable(
   const [checked, setChecked] = useControllableState({
     value: selected,
     onChange,
-    defaultValue: defaultSelected,
+    defaultValue: defaultSelected ?? false,
   });
 
   function handleClick(e) {


### PR DESCRIPTION
Contributes to #11770

Adds VRT and AVT for `Menu` component

#### Changelog

**New**

- Added `Menu-test.e2e.js` to enable VRT and AVT

**Changed**

- Provided default `false` to `MenuItemSelectable` `selected` state to avoid `aria-checked` not being populated when neither `defaultSelected` nor `selected` is passed

---

@tay1orjones Is there a way to create stories that are not indexed by storybook but can be picked up by percy? That way we could have separate tests for each of the subcomponents (`MenuItem*`). Or would you say covering the Playground story is sufficient?