### PR TITLE
chore(release): v11.23.1

### DIFF
--- a/config/eslint-config-carbon/package.json
+++ b/config/eslint-config-carbon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-carbon",
   "description": "ESLint configuration for Carbon",
-  "version": "2.20.0",
+  "version": "3.0.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": {

--- a/config/jest-config-carbon/package.json
+++ b/config/jest-config-carbon/package.json
@@ -2,7 +2,7 @@
   "name": "jest-config-carbon",
   "private": true,
   "description": "Jest configuration and preset for Carbon",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": {

--- a/examples/codesandbox-styles/package.json
+++ b/examples/codesandbox-styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codesandbox-styles",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.26.1",
   "scripts": {
     "develop": "vite"
   },
@@ -9,7 +9,7 @@
     "vite": "^2.8.0"
   },
   "dependencies": {
-    "@carbon/styles": "^1.23.0",
+    "@carbon/styles": "^1.23.1",
     "sass": "^1.51.0"
   }
 }

--- a/examples/codesandbox-with-sass-compilation/package.json
+++ b/examples/codesandbox-with-sass-compilation/package.json
@@ -1,9 +1,9 @@
 {
   "name": "codesandbox-with-sass-compilation",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/examples/codesandbox/package.json
+++ b/examples/codesandbox/package.json
@@ -1,9 +1,9 @@
 {
   "name": "codesandbox",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/examples/custom-theme/package.json
+++ b/examples/custom-theme/package.json
@@ -1,14 +1,14 @@
 {
   "name": "custom-theme",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.21.1",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/examples/incremental-migration/package.json
+++ b/examples/incremental-migration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "incremental-migration",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.23.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@carbon/icons-react": "^10.49.0",
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "carbon-components": "^10.57.0",
     "carbon-components-react": "^7.57.0",
     "carbon-icons": "^7.0.7",

--- a/examples/light-dark-mode/package.json
+++ b/examples/light-dark-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples-light-dark",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.21.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev",
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "next": "12.1.4",
     "react": "18.0.0",
     "react-dom": "18.0.0"

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples-nextjs",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.23.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev",
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "next": "12.1.4",
     "react": "18.0.0",
     "react-dom": "18.0.0"

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -1,14 +1,14 @@
 {
   "name": "vite",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.21.1",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/packages/carbon-components-react/package.json
+++ b/packages/carbon-components-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components-react",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "8.23.0",
+  "version": "8.23.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -39,8 +39,8 @@
     "sass": "^1.33.0"
   },
   "dependencies": {
-    "@carbon/react": "^1.23.0",
-    "@carbon/styles": "^1.23.0",
+    "@carbon/react": "^1.23.1",
+    "@carbon/styles": "^1.23.1",
     "@carbon/telemetry": "0.1.0"
   },
   "devDependencies": {

--- a/packages/carbon-components/package.json
+++ b/packages/carbon-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carbon-components",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
-  "version": "11.23.0",
+  "version": "11.23.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "sass": "^1.33.0"
   },
   "dependencies": {
-    "@carbon/styles": "^1.23.0",
+    "@carbon/styles": "^1.23.1",
     "@carbon/telemetry": "0.1.0"
   },
   "devDependencies": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/elements",
   "description": "A collection of design elements in code for the IBM Design Language",
-  "version": "11.19.0",
+  "version": "11.19.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -37,7 +37,7 @@
   "dependencies": {
     "@carbon/colors": "^11.12.0",
     "@carbon/grid": "^11.11.0",
-    "@carbon/icons": "^11.16.0",
+    "@carbon/icons": "^11.16.1",
     "@carbon/layout": "^11.11.0",
     "@carbon/motion": "^11.9.0",
     "@carbon/themes": "^11.16.0",

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/icons-react",
   "description": "React components for icons in digital and software products using the Carbon Design System",
-  "version": "11.16.0",
+  "version": "11.16.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@carbon/icon-build-helpers": "^1.10.0",
-    "@carbon/icons": "^11.16.0",
+    "@carbon/icons": "^11.16.1",
     "rimraf": "^4.0.0"
   },
   "sideEffects": false

--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/icons-vue",
   "description": "Vue components for icons in digital and software products using the Carbon Design System",
-  "version": "10.65.0",
+  "version": "10.65.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@carbon/cli-reporter": "^10.5.0",
-    "@carbon/icons": "^11.16.0",
+    "@carbon/icons": "^11.16.1",
     "fs-extra": "^10.0.0",
     "prettier": "^2.7.1",
     "rimraf": "^4.0.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/icons",
   "description": "Icons for digital and software products using the Carbon Design System",
-  "version": "11.16.0",
+  "version": "11.16.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/react",
   "description": "React components for the Carbon Design System",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -44,9 +44,9 @@
   "dependencies": {
     "@babel/runtime": "^7.18.3",
     "@carbon/feature-flags": "^0.12.0",
-    "@carbon/icons-react": "^11.16.0",
+    "@carbon/icons-react": "^11.16.1",
     "@carbon/layout": "^11.11.0",
-    "@carbon/styles": "^1.23.0",
+    "@carbon/styles": "^1.23.1",
     "@carbon/telemetry": "0.1.0",
     "classnames": "2.3.2",
     "copy-to-clipboard": "^3.3.1",

--- a/packages/sketch/package.json
+++ b/packages/sketch/package.json
@@ -2,7 +2,7 @@
   "name": "@carbon/sketch",
   "private": true,
   "description": "Tooling for generating a sketch plugin to bring code to design",
-  "version": "11.19.0",
+  "version": "11.19.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@carbon/colors": "^11.12.0",
     "@carbon/icon-helpers": "^10.38.0",
-    "@carbon/icons": "^11.16.0",
+    "@carbon/icons": "^11.16.1",
     "@carbon/themes": "^11.16.0",
     "@carbon/type": "^11.15.0",
     "@skpm/builder": "^0.8.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/styles",
   "description": "Styles for the Carbon Design System",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/upgrade",
   "description": "A tool for upgrading Carbon versions",
-  "version": "11.6.0",
+  "version": "11.6.1",
   "license": "Apache-2.0",
   "bin": {
     "carbon-upgrade": "./bin/carbon-upgrade.js"

--- a/www/package.json
+++ b/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "www",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.23.0",
+    "@carbon/react": "^1.23.1",
     "@octokit/core": "^4.0.0",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,7 +1826,7 @@ __metadata:
     "@carbon/cli": ^11.8.0
     "@carbon/colors": ^11.12.0
     "@carbon/grid": ^11.11.0
-    "@carbon/icons": ^11.16.0
+    "@carbon/icons": ^11.16.1
     "@carbon/layout": ^11.11.0
     "@carbon/motion": ^11.9.0
     "@carbon/themes": ^11.16.0
@@ -1920,13 +1920,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icons-react@^11.16.0, @carbon/icons-react@workspace:packages/icons-react":
+"@carbon/icons-react@^11.16.1, @carbon/icons-react@workspace:packages/icons-react":
   version: 0.0.0-use.local
   resolution: "@carbon/icons-react@workspace:packages/icons-react"
   dependencies:
     "@carbon/icon-build-helpers": ^1.10.0
     "@carbon/icon-helpers": ^10.38.0
-    "@carbon/icons": ^11.16.0
+    "@carbon/icons": ^11.16.1
     "@carbon/telemetry": 0.1.0
     prop-types: ^15.7.2
     rimraf: ^4.0.0
@@ -1954,7 +1954,7 @@ __metadata:
   dependencies:
     "@carbon/cli-reporter": ^10.5.0
     "@carbon/icon-helpers": ^10.38.0
-    "@carbon/icons": ^11.16.0
+    "@carbon/icons": ^11.16.1
     fs-extra: ^10.0.0
     prettier: ^2.7.1
     rimraf: ^4.0.0
@@ -1963,7 +1963,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icons@^11.16.0, @carbon/icons@workspace:packages/icons":
+"@carbon/icons@^11.16.1, @carbon/icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@carbon/icons@workspace:packages/icons"
   dependencies:
@@ -2025,7 +2025,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/react@^1.23.0, @carbon/react@workspace:packages/react":
+"@carbon/react@^1.23.1, @carbon/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@carbon/react@workspace:packages/react"
   dependencies:
@@ -2038,9 +2038,9 @@ __metadata:
     "@babel/preset-react": ^7.17.12
     "@babel/runtime": ^7.18.3
     "@carbon/feature-flags": ^0.12.0
-    "@carbon/icons-react": ^11.16.0
+    "@carbon/icons-react": ^11.16.1
     "@carbon/layout": ^11.11.0
-    "@carbon/styles": ^1.23.0
+    "@carbon/styles": ^1.23.1
     "@carbon/telemetry": 0.1.0
     "@carbon/test-utils": ^10.26.0
     "@carbon/themes": ^11.16.0
@@ -2126,7 +2126,7 @@ __metadata:
   dependencies:
     "@carbon/colors": ^11.12.0
     "@carbon/icon-helpers": ^10.38.0
-    "@carbon/icons": ^11.16.0
+    "@carbon/icons": ^11.16.1
     "@carbon/themes": ^11.16.0
     "@carbon/type": ^11.15.0
     "@skpm/builder": ^0.8.0
@@ -2139,7 +2139,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/styles@^1.23.0, @carbon/styles@workspace:packages/styles":
+"@carbon/styles@^1.23.1, @carbon/styles@workspace:packages/styles":
   version: 0.0.0-use.local
   resolution: "@carbon/styles@workspace:packages/styles"
   dependencies:
@@ -11286,8 +11286,8 @@ __metadata:
     "@babel/plugin-transform-react-constant-elements": ^7.17.12
     "@babel/preset-env": ^7.18.2
     "@babel/preset-react": ^7.17.12
-    "@carbon/react": ^1.23.0
-    "@carbon/styles": ^1.23.0
+    "@carbon/react": ^1.23.1
+    "@carbon/styles": ^1.23.1
     "@carbon/telemetry": 0.1.0
     "@carbon/test-utils": ^10.26.0
     "@rollup/plugin-babel": ^6.0.0
@@ -11325,7 +11325,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "carbon-components@workspace:packages/carbon-components"
   dependencies:
-    "@carbon/styles": ^1.23.0
+    "@carbon/styles": ^1.23.1
     "@carbon/telemetry": 0.1.0
     "@carbon/test-utils": ^10.26.0
     fs-extra: ^10.0.0
@@ -12049,7 +12049,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "codesandbox-styles@workspace:examples/codesandbox-styles"
   dependencies:
-    "@carbon/styles": ^1.23.0
+    "@carbon/styles": ^1.23.1
     sass: ^1.51.0
     vite: ^2.8.0
   languageName: unknown
@@ -12059,7 +12059,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "codesandbox-with-sass-compilation@workspace:examples/codesandbox-with-sass-compilation"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     react: ^17.0.0
     react-dom: ^17.0.0
     react-scripts: 5.0.0
@@ -12071,7 +12071,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "codesandbox@workspace:examples/codesandbox"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     react: ^17.0.0
     react-dom: ^17.0.0
     react-scripts: 5.0.0
@@ -13369,7 +13369,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "custom-theme@workspace:examples/custom-theme"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": 1.1.3
@@ -15957,7 +15957,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "examples-light-dark@workspace:examples/light-dark-mode"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     eslint: 8.12.0
     next: 12.1.4
     react: 18.0.0
@@ -15970,7 +15970,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "examples-nextjs@workspace:examples/nextjs"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     eslint: 8.12.0
     eslint-config-next: 12.1.4
     next: 12.1.4
@@ -18657,7 +18657,7 @@ fsevents@^1.2.7:
   resolution: "incremental-migration@workspace:examples/incremental-migration"
   dependencies:
     "@carbon/icons-react": ^10.49.0
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     carbon-components: ^10.57.0
     carbon-components-react: ^7.57.0
     carbon-icons: ^7.0.7
@@ -32730,7 +32730,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "vite@workspace:examples/vite"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": 1.1.3
@@ -33821,7 +33821,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "www@workspace:www"
   dependencies:
-    "@carbon/react": ^1.23.0
+    "@carbon/react": ^1.23.1
     "@octokit/core": ^4.0.0
     "@octokit/plugin-retry": ^3.0.9
     "@octokit/plugin-throttling": ^4.0.0


### PR DESCRIPTION
This release contains a new major version for `eslint-config-carbon` due to https://github.com/carbon-design-system/carbon/pull/13132 and a new patch version for all other packages with changes since `v11.23.0`.