### PR TITLE
fix(ActionableNotification): rm experimental prop

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1040,6 +1040,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "jsehull",
+      "name": "Jesse Hull",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9935383?v=4",
+      "profile": "https://jsehull.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   <tr>
     <td align="center"><a href="https://github.com/lewandom"><img src="https://avatars.githubusercontent.com/u/8779205?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcin Lewandowski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=lewandom" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/remolueoend"><img src="https://avatars.githubusercontent.com/u/7881606?v=4?s=100" width="100px;" alt=""/><br /><sub><b>remolueoend</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=remolueoend" title="Code">💻</a></td>
+    <td align="center"><a href="https://jsehull.com/"><img src="https://avatars.githubusercontent.com/u/9935383?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jesse Hull</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=jsehull" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -114,9 +114,6 @@ Map {
       "ariaLabel": Object {
         "type": "string",
       },
-      "caption": Object {
-        "type": "string",
-      },
       "children": Object {
         "type": "node",
       },

--- a/packages/react/src/components/Notification/Notification.js
+++ b/packages/react/src/components/Notification/Notification.js
@@ -658,11 +658,6 @@ ActionableNotification.propTypes = {
   ariaLabel: PropTypes.string,
 
   /**
-   * Specify the caption
-   */
-  caption: PropTypes.string,
-
-  /**
    * Specify the content
    */
   children: PropTypes.node,


### PR DESCRIPTION
Closes #13075 

Removed last part of experimental propType that was used in testing but not adopted.

#### Changelog

**New**

- n/a

**Changed**

- n/a

**Removed**

- `caption` propType

#### Testing / Reviewing

- visit Storybook > Notifications > Actionable > Default/Playground
- confirm that `caption` is no longer listed as part of the component API
