### PR TITLE
fix(ListBox): Standardize `ListBox` menu open behavior

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -121,7 +121,7 @@ Playground.argTypes = {
     control: {
       type: 'text',
     },
-    defaultValue: 'this is an example label',
+    defaultValue: 'This is an example label',
   },
   warn: {
     control: {
@@ -139,7 +139,7 @@ Playground.argTypes = {
     control: {
       type: 'text',
     },
-    defaultValue: 'this is an example title',
+    defaultValue: 'This is an example title',
   },
   size: {
     options: ['sm', 'md', 'lg'],
@@ -158,7 +158,6 @@ export const Default = () => (
       id="default"
       titleText="Dropdown label"
       helperText="This is some helper text"
-      initialSelectedItem={items[0]}
       label="Dropdown menu options"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
@@ -171,7 +170,6 @@ export const Inline = () => (
     <Dropdown
       id="inline"
       titleText="Inline dropdown label"
-      initialSelectedItem={items[0]}
       label="Dropdown menu options"
       type="inline"
       items={items}
@@ -186,7 +184,6 @@ export const WithLayer = () => (
       id="default"
       titleText="First Layer"
       helperText="This is some helper text"
-      initialSelectedItem={items[0]}
       label="Dropdown menu options"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
@@ -196,7 +193,6 @@ export const WithLayer = () => (
         id="default"
         titleText="Second Layer"
         helperText="This is some helper text"
-        initialSelectedItem={items[0]}
         label="Dropdown menu options"
         items={items}
         itemToString={(item) => (item ? item.text : '')}
@@ -206,7 +202,6 @@ export const WithLayer = () => (
           id="default"
           titleText="Third Layer"
           helperText="This is some helper text"
-          initialSelectedItem={items[0]}
           label="Dropdown menu options"
           items={items}
           itemToString={(item) => (item ? item.text : '')}
@@ -221,7 +216,6 @@ export const InlineWithLayer = () => (
     <Dropdown
       id="inline"
       titleText="First Layer"
-      initialSelectedItem={items[0]}
       label="Dropdown menu options"
       type="inline"
       items={items}
@@ -231,7 +225,6 @@ export const InlineWithLayer = () => (
       <Dropdown
         id="inline"
         titleText="Second Layer"
-        initialSelectedItem={items[0]}
         label="Dropdown menu options"
         type="inline"
         items={items}
@@ -241,7 +234,6 @@ export const InlineWithLayer = () => (
         <Dropdown
           id="inline"
           titleText="Third Layer"
-          initialSelectedItem={items[0]}
           label="Dropdown menu options"
           type="inline"
           items={items}

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -302,6 +302,10 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
                   event.stopPropagation();
                 }
 
+                if (match(event, keys.Enter)) {
+                  handleOnMenuChange(true);
+                }
+
                 if (!disabled) {
                   if (match(event, keys.Delete) || match(event, keys.Escape)) {
                     if (isOpen) {

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -302,7 +302,6 @@ export const _FilterableWithLayer = () => {
   return (
     <div style={{ width: 300 }}>
       <FilterableMultiSelect
-        invalid
         id="carbon-multiselect-example-3"
         titleText="First Layer"
         helperText="This is helper text"

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -302,6 +302,7 @@ export const _FilterableWithLayer = () => {
   return (
     <div style={{ width: 300 }}>
       <FilterableMultiSelect
+        invalid
         id="carbon-multiselect-example-3"
         titleText="First Layer"
         helperText="This is helper text"

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -478,6 +478,10 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
         clearSelection();
         e.stopPropagation();
       }
+
+      if (match(e, keys.Space) || match(e, keys.ArrowDown)) {
+        setIsOpenWrapper(true);
+      }
     }
   };
 

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -409,6 +409,8 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     [`${prefix}--form__helper-text--disabled`]: disabled,
   });
 
+  console.log(inputFocused);
+
   const className = cx(
     `${prefix}--multi-select`,
     [enabled ? null : containerClassName],

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -409,8 +409,6 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     [`${prefix}--form__helper-text--disabled`]: disabled,
   });
 
-  console.log(inputFocused);
-
   const className = cx(
     `${prefix}--multi-select`,
     [enabled ? null : containerClassName],


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/13185
Refs https://github.com/carbon-design-system/carbon/pull/13173

Aligns `ComboBox`, `Dropdown`, `MultiSelect`, and `FilterableMultiSelect` so that they all open on the same keys.

The keys that can be used:
- <kbd>Space</kbd>
- <kbd>Enter</kbd>
- <kbd>ArrowDown</kbd>

They can all be closed via <kbd>Escape</kbd> or by making a selection.

#### Changelog

**New**

- `MultiSelect`: Add open on  <kbd>Space</kbd> and  <kbd>ArrowDown</kbd>
- `FilterableMultiSelect`: Add open on  <kbd>Enter</kbd>

**Changed**

- Lots of whitespace formatting changes due to TS updates. (Anyway we can automate these?)

**Removed**

- Updated `Dropdown` stories to not have an initial item set, as it was making the open with <kbd>ArrowDown</kbd> seem like it was progressing to the 2nd item on the first enter. It should now go to the first item when opened with <kbd>ArrowDown</kbd> 

#### Testing / Reviewing

Go to `ComboBox`, `Dropdown`, `MultiSelect`, and `FilterableMultiSelect` and make sure they can all open with <kbd>Space</kbd>,<kbd>Enter</kbd>, <kbd>ArrowDown</kbd> and that they can all close with <kbd>Escape</kbd>
