### PR TITLE
feat(Popover): add `isTabTip` prop to `Popover`

### DIFF
--- a/e2e/components/Popover/Popover-test.e2e.js
+++ b/e2e/components/Popover/Popover-test.e2e.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright IBM Corp. 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { themes } = require('../../test-utils/env');
+const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+
+test.describe('Popover', () => {
+  themes.forEach((theme) => {
+    test.describe(theme, () => {
+      test('Popover - auto align @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'Popover',
+          id: 'components-popover--auto-align',
+          theme,
+        });
+      });
+
+      test('Popover - isTabTip @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'Popover',
+          id: 'components-popover--tab-tip',
+          theme,
+        });
+      });
+    });
+  });
+
+  test('accessibility-checker @avt', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Popover',
+      id: 'components-popover--auto-align',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Popover');
+  });
+});

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5667,6 +5667,9 @@ Map {
       "highContrast": Object {
         "type": "bool",
       },
+      "isTabTip": Object {
+        "type": "bool",
+      },
       "open": Object {
         "isRequired": true,
         "type": "bool",

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -14,6 +14,7 @@ import RadioButtonGroup from '../RadioButtonGroup';
 import { default as Checkbox } from '../Checkbox';
 import mdx from './Popover.mdx';
 import { Settings } from '@carbon/icons-react';
+import { keys, match } from '../../internal/keyboard';
 
 const prefix = 'cds';
 
@@ -82,7 +83,14 @@ export const TabTip = () => {
   const [openTwo, setOpenTwo] = useState(false);
   return (
     <div className="popover-tabtip-story" style={{ display: 'flex' }}>
-      <Popover open={open} isTabTip>
+      <Popover
+        open={open}
+        onKeyDown={(evt) => {
+          if (match(evt, keys.Escape)) {
+            setOpen(false);
+          }
+        }}
+        isTabTip>
         <button
           aria-label="Settings"
           type="button"

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -6,11 +6,16 @@
  */
 
 import './story.scss';
-import { Checkbox } from '@carbon/icons-react';
+import { Checkbox as CheckboxIcon } from '@carbon/icons-react';
 import React, { useState } from 'react';
 import { Popover, PopoverContent } from '../Popover';
+import RadioButton from '../RadioButton';
+import RadioButtonGroup from '../RadioButtonGroup';
+import { default as Checkbox } from '../Checkbox';
 import mdx from './Popover.mdx';
 import { Settings } from '@carbon/icons-react';
+
+const prefix = 'cds';
 
 export default {
   title: 'Components/Popover',
@@ -60,7 +65,7 @@ const PlaygroundStory = (props) => {
       highContrast={highContrast}
       open={open}>
       <div className="playground-trigger">
-        <Checkbox />
+        <CheckboxIcon />
       </div>
       <PopoverContent className="p-3">
         <p className="popover-title">Available storage</p>
@@ -74,23 +79,91 @@ const PlaygroundStory = (props) => {
 
 export const TabTip = () => {
   const [open, setOpen] = useState(false);
+  const [openTwo, setOpenTwo] = useState(false);
   return (
-    <Popover open={open} isTabTip autoAlign>
-      <button
-        type="button"
-        onClick={() => {
-          setOpen(!open);
-        }}>
-        <Settings />
-      </button>
+    <div
+      className="popover-tabtip-story"
+      style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Popover open={open} isTabTip>
+        <button
+          aria-label="Settings"
+          type="button"
+          onClick={() => {
+            setOpen(!open);
+          }}>
+          <Settings />
+        </button>
+        <PopoverContent className="p-3">
+          <RadioButtonGroup
+            style={{ alignItems: 'flex-start', flexDirection: 'column' }}
+            legendText="Row height"
+            name="radio-button-group"
+            defaultSelected="small">
+            <RadioButton labelText="Small" value="small" id="radio-small" />
+            <RadioButton labelText="Large" value="large" id="radio-large" />
+          </RadioButtonGroup>
+          <hr />
+          <fieldset className={`${prefix}--fieldset`}>
+            <legend className={`${prefix}--label`}>Edit columns</legend>
+            <Checkbox defaultChecked labelText="Name" id="checkbox-label-1" />
+            <Checkbox defaultChecked labelText="Type" id="checkbox-label-2" />
+            <Checkbox
+              defaultChecked
+              labelText="Location"
+              id="checkbox-label-3"
+            />
+            <Checkbox
+              defaultChecked
+              labelText="Public IP"
+              id="checkbox-label-4"
+            />
+            <Checkbox labelText="Private IP" id="checkbox-label-5" />
+            <Checkbox labelText="Start date" id="checkbox-label-6" />
+            <Checkbox labelText="Description" id="checkbox-label-7" />
+          </fieldset>
+        </PopoverContent>
+      </Popover>
 
-      <PopoverContent className="p-3">
-        <p className="popover-title">Available storage</p>
-        <p className="popover-details">
-          This server has 150 GB of block storage remaining.
-        </p>
-      </PopoverContent>
-    </Popover>
+      <Popover open={openTwo} isTabTip align="bottom-right">
+        <button
+          aria-label="Settings"
+          type="button"
+          onClick={() => {
+            setOpenTwo(!openTwo);
+          }}>
+          <Settings />
+        </button>
+        <PopoverContent className="p-3">
+          <RadioButtonGroup
+            style={{ alignItems: 'flex-start', flexDirection: 'column' }}
+            legendText="Row height"
+            name="radio-button-group-2"
+            defaultSelected="small-2">
+            <RadioButton labelText="Small" value="small-2" id="radio-small-2" />
+            <RadioButton labelText="Large" value="large-2" id="radio-large-2" />
+          </RadioButtonGroup>
+          <hr />
+          <fieldset className={`${prefix}--fieldset`}>
+            <legend className={`${prefix}--label`}>Edit columns</legend>
+            <Checkbox defaultChecked labelText="Name" id="checkbox-label-8" />
+            <Checkbox defaultChecked labelText="Type" id="checkbox-label-9" />
+            <Checkbox
+              defaultChecked
+              labelText="Location"
+              id="checkbox-label-10"
+            />
+            <Checkbox
+              defaultChecked
+              labelText="Public IP"
+              id="checkbox-label-11"
+            />
+            <Checkbox labelText="Private IP" id="checkbox-label-12" />
+            <Checkbox labelText="Start date" id="checkbox-label-13" />
+            <Checkbox labelText="Description" id="checkbox-label-14" />
+          </fieldset>
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 };
 
@@ -164,7 +237,7 @@ export const AutoAlign = () => {
         }}>
         <Popover open={open} autoAlign>
           <div className="playground-trigger">
-            <Checkbox
+            <CheckboxIcon
               onClick={() => {
                 setOpen(!open);
               }}
@@ -180,7 +253,7 @@ export const AutoAlign = () => {
       </div>
       <Popover open autoAlign>
         <div className="playground-trigger">
-          <Checkbox />
+          <CheckboxIcon />
         </div>
         <PopoverContent className="p-3">
           <p className="popover-title">Available storage</p>
@@ -192,7 +265,7 @@ export const AutoAlign = () => {
       <div style={{ position: 'absolute', top: 0, right: 0, margin: '3rem' }}>
         <Popover open autoAlign>
           <div className="playground-trigger">
-            <Checkbox />
+            <CheckboxIcon />
           </div>
           <PopoverContent className="p-3">
             <p className="popover-title">Available storage</p>
@@ -206,7 +279,7 @@ export const AutoAlign = () => {
         style={{ position: 'absolute', bottom: 0, right: 0, margin: '3rem' }}>
         <Popover open autoAlign>
           <div className="playground-trigger">
-            <Checkbox />
+            <CheckboxIcon />
           </div>
           <PopoverContent className="p-3">
             <p className="popover-title">Available storage</p>
@@ -219,7 +292,7 @@ export const AutoAlign = () => {
       <div style={{ position: 'absolute', bottom: 0, left: 0, margin: '3rem' }}>
         <Popover open autoAlign>
           <div className="playground-trigger">
-            <Checkbox />
+            <CheckboxIcon />
           </div>
           <PopoverContent className="p-3">
             <p className="popover-title">Available storage</p>

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -81,9 +81,7 @@ export const TabTip = () => {
   const [open, setOpen] = useState(true);
   const [openTwo, setOpenTwo] = useState(false);
   return (
-    <div
-      className="popover-tabtip-story"
-      style={{ display: 'flex', justifyContent: 'space-between' }}>
+    <div className="popover-tabtip-story" style={{ display: 'flex' }}>
       <Popover open={open} isTabTip>
         <button
           aria-label="Settings"
@@ -112,14 +110,6 @@ export const TabTip = () => {
               labelText="Location"
               id="checkbox-label-3"
             />
-            <Checkbox
-              defaultChecked
-              labelText="Public IP"
-              id="checkbox-label-4"
-            />
-            <Checkbox labelText="Private IP" id="checkbox-label-5" />
-            <Checkbox labelText="Start date" id="checkbox-label-6" />
-            <Checkbox labelText="Description" id="checkbox-label-7" />
           </fieldset>
         </PopoverContent>
       </Popover>
@@ -152,14 +142,6 @@ export const TabTip = () => {
               labelText="Location"
               id="checkbox-label-10"
             />
-            <Checkbox
-              defaultChecked
-              labelText="Public IP"
-              id="checkbox-label-11"
-            />
-            <Checkbox labelText="Private IP" id="checkbox-label-12" />
-            <Checkbox labelText="Start date" id="checkbox-label-13" />
-            <Checkbox labelText="Description" id="checkbox-label-14" />
           </fieldset>
         </PopoverContent>
       </Popover>

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -10,6 +10,7 @@ import { Checkbox } from '@carbon/icons-react';
 import React, { useState } from 'react';
 import { Popover, PopoverContent } from '../Popover';
 import mdx from './Popover.mdx';
+import { Settings } from '@carbon/icons-react';
 
 export default {
   title: 'Components/Popover',
@@ -61,6 +62,28 @@ const PlaygroundStory = (props) => {
       <div className="playground-trigger">
         <Checkbox />
       </div>
+      <PopoverContent className="p-3">
+        <p className="popover-title">Available storage</p>
+        <p className="popover-details">
+          This server has 150 GB of block storage remaining.
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const TabTip = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} isTabTip autoAlign>
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(!open);
+        }}>
+        <Settings />
+      </button>
+
       <PopoverContent className="p-3">
         <p className="popover-title">Available storage</p>
         <p className="popover-details">

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -78,7 +78,7 @@ const PlaygroundStory = (props) => {
 };
 
 export const TabTip = () => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const [openTwo, setOpenTwo] = useState(false);
   return (
     <div

--- a/packages/react/src/components/Popover/__tests__/Popover-test.js
+++ b/packages/react/src/components/Popover/__tests__/Popover-test.js
@@ -9,6 +9,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Popover, PopoverContent } from '../../Popover';
 
+const prefix = 'cds';
+
 describe('Popover', () => {
   it('should support a ref on the outermost element', () => {
     const ref = jest.fn();
@@ -74,6 +76,32 @@ describe('Popover', () => {
         </PopoverContent>
       );
       expect(container.firstChild).toHaveAttribute('id', 'test');
+    });
+
+    // Tab Tip tests
+    it('should respect isTabTip prop', () => {
+      const { container } = render(
+        <Popover open isTabTip>
+          <button type="button">Settings</button>
+          <PopoverContent>test</PopoverContent>
+        </Popover>
+      );
+      expect(container.firstChild).toHaveClass(`${prefix}--popover--tab-tip`);
+    });
+
+    it('should not allow other alignments than bottom-left or bottom-right when isTabTip is present', () => {
+      const { container } = render(
+        <Popover open isTabTip align="top-left">
+          <button type="button">Settings</button>
+          <PopoverContent data-testid="test">test</PopoverContent>
+        </Popover>
+      );
+      expect(container.firstChild).not.toHaveClass(
+        `${prefix}--popover--top-left`
+      );
+      expect(container.firstChild).toHaveClass(
+        `${prefix}--popover--bottom-left`
+      );
     });
   });
 });

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -44,7 +44,7 @@ interface PopoverBaseProps {
   align?: PopoverAlignment;
 
   /**
-   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to futurue changes.
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
    */
   autoAlign?: boolean;
 

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -335,7 +335,7 @@ Popover.propTypes = {
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
 
   /**
-   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to futurue changes.
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
    */
   autoAlign: PropTypes.bool,
 

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -366,6 +366,11 @@ Popover.propTypes = {
   highContrast: PropTypes.bool,
 
   /**
+   * Render the component using the tab tip variant
+   */
+  isTabTip: PropTypes.bool,
+
+  /**
    * Specify whether the component is currently open or closed
    */
   open: PropTypes.bool.isRequired,

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -140,7 +140,7 @@ const Popover = React.forwardRef(
         [`${prefix}--popover--open`]: open,
         [`${prefix}--popover--${autoAlignment}`]: autoAligned && !isTabTip,
         [`${prefix}--popover--${align}`]: !autoAligned,
-        [`${prefix}--popover--tabtip`]: isTabTip,
+        [`${prefix}--popover--tab-tip`]: isTabTip,
       },
       customClassName
     );
@@ -272,10 +272,28 @@ const Popover = React.forwardRef(
     }, [autoAligned, align, autoAlign, prefix, open, isTabTip]);
 
     const BaseComponent: React.ElementType<any> = as ?? 'span';
+
+    const mappedChildren = React.Children.map(children, (child) => {
+      const item = child as any;
+
+      if (item?.type === 'button') {
+        const { className } = item.props;
+        const tabTipClasses = cx(
+          `${prefix}--popover--tab-tip__button`,
+          className
+        );
+        return React.cloneElement(item, {
+          className: tabTipClasses,
+        });
+      } else {
+        return item;
+      }
+    });
+
     return (
       <PopoverContext.Provider value={value}>
         <BaseComponent {...rest} className={className} ref={ref}>
-          {children}
+          {isTabTip ? mappedChildren : children}
         </BaseComponent>
       </PopoverContext.Provider>
     );

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -75,6 +75,11 @@ interface PopoverBaseProps {
   highContrast?: boolean;
 
   /**
+   * Render the component using the tab tip variant
+   */
+  isTabTip?: boolean;
+
+  /**
    * Specify whether the component is currently open or closed
    */
   open: boolean;
@@ -88,10 +93,11 @@ export type PopoverProps<T extends React.ElementType> = PolymorphicProps<
 const Popover = React.forwardRef(
   <T extends React.ElementType>(
     {
-      align = 'bottom',
+      isTabTip,
+      align = isTabTip ? 'bottom-left' : 'bottom',
       as,
       autoAlign = false,
-      caret = true,
+      caret = isTabTip ? false : true,
       className: customClassName,
       children,
       dropShadow = true,
@@ -111,6 +117,17 @@ const Popover = React.forwardRef(
       };
     }, []);
 
+    if (isTabTip) {
+      const tabTipAlignments: PopoverAlignment[] = [
+        'bottom-left',
+        'bottom-right',
+      ];
+
+      if (!tabTipAlignments.includes(align)) {
+        align = 'bottom-left';
+      }
+    }
+
     const ref = useMergedRefs([forwardRef, popover]);
     const [autoAligned, setAutoAligned] = useState(false);
     const [autoAlignment, setAutoAlignment] = useState(align);
@@ -121,8 +138,9 @@ const Popover = React.forwardRef(
         [`${prefix}--popover--drop-shadow`]: dropShadow,
         [`${prefix}--popover--high-contrast`]: highContrast,
         [`${prefix}--popover--open`]: open,
-        [`${prefix}--popover--${autoAlignment}`]: autoAligned,
+        [`${prefix}--popover--${autoAlignment}`]: autoAligned && !isTabTip,
         [`${prefix}--popover--${align}`]: !autoAligned,
+        [`${prefix}--popover--tabtip`]: isTabTip,
       },
       customClassName
     );
@@ -132,7 +150,7 @@ const Popover = React.forwardRef(
         return;
       }
 
-      if (!autoAlign) {
+      if (!autoAlign || isTabTip) {
         setAutoAligned(false);
         return;
       }
@@ -251,7 +269,7 @@ const Popover = React.forwardRef(
         setAutoAligned(true);
         setAutoAlignment(alignment);
       }
-    }, [autoAligned, align, autoAlign, prefix, open]);
+    }, [autoAligned, align, autoAlign, prefix, open, isTabTip]);
 
     const BaseComponent: React.ElementType<any> = as ?? 'span';
     return (

--- a/packages/react/src/components/Popover/story.scss
+++ b/packages/react/src/components/Popover/story.scss
@@ -98,3 +98,17 @@
   display: flex;
   flex-direction: column;
 }
+
+.popover-tabtip-story .cds--popover-content {
+  width: 16rem;
+}
+
+.popover-tabtip-story .cds--radio-button-wrapper {
+  margin-bottom: 0.25rem;
+}
+
+.popover-tabtip-story hr {
+  border: none;
+  background: theme.$border-subtle;
+  height: 1px;
+}

--- a/packages/react/src/components/Popover/story.scss
+++ b/packages/react/src/components/Popover/story.scss
@@ -104,11 +104,16 @@
 }
 
 .popover-tabtip-story .cds--radio-button-wrapper {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.5rem;
 }
 
 .popover-tabtip-story hr {
   border: none;
   background: theme.$border-subtle;
   height: 1px;
+  margin: 8px 0 16px;
+}
+
+.popover-tabtip-story .cds--popover-container:last-of-type {
+  margin-left: 15rem;
 }

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -26,6 +26,7 @@ const RadioButtonGroup = React.forwardRef(function RadioButtonGroup(
     orientation = 'horizontal',
     readOnly,
     valueSelected,
+    ...rest
   },
   ref
 ) {
@@ -88,7 +89,8 @@ const RadioButtonGroup = React.forwardRef(function RadioButtonGroup(
       <fieldset
         className={fieldsetClasses}
         disabled={disabled}
-        aria-readonly={readOnly}>
+        aria-readonly={readOnly}
+        {...rest}>
         {legendText && (
           <Legend className={`${prefix}--label`}>{legendText}</Legend>
         )}

--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -8,6 +8,7 @@
 @use '../../config' as *;
 @use '../../theme';
 @use '../../utilities/box-shadow' as *;
+@use '../../utilities/button-reset';
 @use '../../utilities/custom-property';
 @use '../../utilities/high-contrast-mode' as *;
 @use '../../utilities/focus-outline' as *;
@@ -369,5 +370,52 @@ $popover-caret-height: custom-property.get-var(
     height: $popover-caret-width;
     clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
     transform: translate(calc(-1 * $popover-offset + 100%), -50%);
+  }
+
+  //-----------------------------------------------------------------------------
+  // Tab Tip Variant
+  //-----------------------------------------------------------------------------
+  .#{$prefix}--popover--tab-tip .#{$prefix}--popover-content {
+    border-radius: 0;
+  }
+
+  .#{$prefix}--popover--tab-tip__button {
+    @include button-reset.reset;
+
+    position: relative;
+    display: inline-flex;
+    width: rem(32px);
+    height: rem(32px);
+    align-items: center;
+    justify-content: center;
+
+    &:focus {
+      @include focus-outline('outline');
+    }
+
+    &:hover {
+      background-color: theme.$layer-hover;
+    }
+  }
+
+  .#{$prefix}--popover--tab-tip.#{$prefix}--popover--open
+    .#{$prefix}--popover--tab-tip__button {
+    background: theme.$layer;
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+  }
+
+  .#{$prefix}--popover--tab-tip.#{$prefix}--popover--open
+    .#{$prefix}--popover--tab-tip__button:not(:focus)::after {
+    position: absolute;
+    z-index: z('floating') + 1;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: theme.$layer;
+    content: '';
+  }
+
+  .#{$prefix}--popover--tab-tip__button svg {
+    fill: theme.$icon-primary;
   }
 }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/11038

Adds in `isTabTip` prop and associated styles to `Popover`

#### Changelog

**New**

- `isTabTip` `bool` prop added to `Popover`
- Restricts `align` to `bottom-left` and `bottom-right` if `isTabTip` is present
- Disallows `autoAlign` if `isTabTip` is present
- Styles added for `TabTip` variant
- `TabTip` story added
- Snapshot / a11y tests created in `e2e/components/Popover`
- Tests for the new `isTabTip` prop

**Changed**

- added `...rest` to `RadioButtonGroup` to conform with other components
- Changed storybook stories to use `Checkbox as CheckboxIcon` since I added in the `Checkbox` component for the `isTabTip` story

#### Testing / Reviewing

Go to `Tab Tip` story under `Popover` and ensure the story matches the spec. Also, make sure all tests pass and there is sufficient coverage
