### PR TITLE
fix(CodeSnippet): a11y tabstop + attributes

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -226,10 +226,14 @@ function CodeSnippet({
     <div {...rest} className={codeSnippetClasses}>
       <div
         ref={codeContainerRef}
-        role={type === 'single' ? 'textbox' : null}
-        tabIndex={type === 'single' && !disabled ? 0 : null}
+        role={type === 'single' || type === 'multi' ? 'textbox' : null}
+        tabIndex={
+          type === 'single' || (type === 'multi' && !disabled) ? 0 : null
+        }
         className={`${prefix}--snippet-container`}
         aria-label={ariaLabel || 'code-snippet'}
+        aria-readonly={type === 'single' || type === 'multi' ? true : null}
+        aria-multiline={type === 'multi' ? true : null}
         onScroll={(type === 'single' && handleScroll) || null}
         {...containerStyle}>
         <pre

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -228,7 +228,7 @@ function CodeSnippet({
         ref={codeContainerRef}
         role={type === 'single' || type === 'multi' ? 'textbox' : null}
         tabIndex={
-          type === 'single' || (type === 'multi' && !disabled) ? 0 : null
+          (type === 'single' || type === 'multi') && !disabled ? 0 : null
         }
         className={`${prefix}--snippet-container`}
         aria-label={ariaLabel || 'code-snippet'}

--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -201,6 +201,12 @@ $copy-btn-feedback: $background-inverse !default;
     order: 1;
     overflow-y: auto;
     transition: max-height $duration-moderate-01 motion(standard, productive);
+
+    &:focus {
+      @include focus-outline('outline');
+
+      outline-offset: 0;
+    }
   }
 
   // expanded snippet container


### PR DESCRIPTION
Closes #10527

**The following changes are only for the `Singleline` and `Multiline` snippets, but do not include `Inline`.

Primary fix: add tab stop for `Multiline` `CodeSnippet`
I also added a few more `aria` attributes as requested in #10527 comments.
___

I would like confirmation on `aria-multiline`. Documentation suggests that without it, screen readers assume it is a single line. Obviously it's now `readonly` so they won't edit, but I thought it may help inform users that they can/should scroll since it is not one line. 

Thoughts on keeping/not?

#### Changelog

**New**

- add tabstop to `Multiline` snippets
- add `role='textbox'` to multi (single currently has)
- add `aria-readonly` to single/multi (users cannot interact with the "textarea")
- add `aria-multiline` for multi (single will never have)

**Changed**

- n/a

**Removed**

- n/a

#### Testing / Reviewing

Visit Storybook > `CodeSnippet` to compare `aria` changes for Single and Multi line snippets. Check for the following:
1. Multiline tab stop is working (tab selects + allows keyboard scrolling)
2. Single/Multi both show a `role` of 'textbox'
3. Single/Multi have are `aria-readonly`
4. Multi now has `aria-multiline` added

Multiline example:
![image](https://user-images.githubusercontent.com/9935383/223766660-a10bd116-0029-4731-9287-c588ceb077b0.png)

