### PR TITLE
refactor(typescript): add TextInputSkeleton types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1076,6 +1076,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "davesteinberg",
+      "name": "Dave Steinberg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3935584?v=4",
+      "profile": "https://github.com/davesteinberg",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/awarrier99"><img src="https://avatars.githubusercontent.com/u/17476235?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ashvin Warrier</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=awarrier99" title="Code">💻</a></td>
     <td align="center"><a href="https://galvingao.com/"><img src="https://avatars.githubusercontent.com/u/12567059?v=4?s=100" width="100px;" alt=""/><br /><sub><b>GalvinGao</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=GalvinGao" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/bianca-sparxs"><img src="https://avatars.githubusercontent.com/u/33003148?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bianca Sparxs</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=bianca-sparxs" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/davesteinberg"><img src="https://avatars.githubusercontent.com/u/3935584?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Dave Steinberg</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=davesteinberg" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/TextInput/TextInput.Skeleton.tsx
+++ b/packages/react/src/components/TextInput/TextInput.Skeleton.tsx
@@ -10,7 +10,24 @@ import React from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 
-const TextInputSkeleton = ({ hideLabel, className, ...rest }) => {
+export interface TextInputSkeletonProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Specify an optional className to add to the form item wrapper.
+   */
+  className?: string;
+
+  /**
+   * Specify whether the label should be hidden or not.
+   */
+  hideLabel?: boolean;
+}
+
+const TextInputSkeleton = ({
+  hideLabel,
+  className,
+  ...rest
+}: TextInputSkeletonProps) => {
   const prefix = usePrefix();
   return (
     <div className={cx(`${prefix}--form-item`, className)} {...rest}>


### PR DESCRIPTION
Closes #12562

Convert TextInputSkeleton to TypeScript.

#### Changelog

**Changed**

- TextInput.Skeleton.js converted to tsx, types defined
- .all-contributorsrc and README.md updated (I'm new!)

#### Testing / Reviewing

- Run yarn build; yarn storybook in packages/react. Confirm that the TextInput > Skeleton story works as expected.
- Add a TextInputSkeleton element to bottom of TextInput.Skeleton.tsx and confirm no type errors. Add a prop with an invalid value and confirm the error is reported.