### PR TITLE
fix(batchToolTips): make tooltips on batch action visible

### DIFF
--- a/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { TrashCan, Save, Download } from '@carbon/icons-react';
+import { TrashCan, Save, Download, Add } from '@carbon/icons-react';
 
 import Button from '../../Button';
 import DataTable, {
@@ -89,6 +89,18 @@ export const Default = () => (
                 Delete
               </TableBatchAction>
               <TableBatchAction
+                hasIconOnly
+                iconDescription="Add"
+                tooltipPosition="bottom"
+                tabIndex={batchActionProps.shouldShowBatchActions ? 0 : -1}
+                renderIcon={Add}
+                onClick={batchActionClick(selectedRows)}>
+                Delete
+              </TableBatchAction>
+              <TableBatchAction
+                hasIconOnly
+                iconDescription="Save"
+                tooltipPosition="bottom"
                 tabIndex={batchActionProps.shouldShowBatchActions ? 0 : -1}
                 renderIcon={Save}
                 onClick={batchActionClick(selectedRows)}>

--- a/packages/styles/scss/components/data-table/action/_data-table-action.scss
+++ b/packages/styles/scss/components/data-table/action/_data-table-action.scss
@@ -393,10 +393,9 @@
   .#{$prefix}--batch-actions:focus {
     @include focus-outline;
   }
-
+  // 200% to allow tooltips
   .#{$prefix}--batch-actions--active {
-    overflow: auto hidden;
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+    clip-path: polygon(0 0, 200% 0, 200% 200%, 0 200%);
     pointer-events: all;
     transform: translate3d(0, 0, 0);
   }


### PR DESCRIPTION
Closes # very minor fix and issue, didn't think a whole issue needed to be opened for this. If it does then I will open one upon request. This solves an issue on our IBM DataStage repo where we need tooltips for the batch action icons

Enables tooltips on batch action icons



#### Changelog

**New**

Enables tooltips on batch action icons

**Changed**

Tool tips to be visible when batch action items are in view. 

**Removed**

overflow 

#### Testing / Reviewing

![Screenshot 2023-03-09 at 6 38 25 PM](https://user-images.githubusercontent.com/10100397/224210554-d417140d-6734-4006-bf85-9b2882128d32.png)
![Screenshot 2023-03-09 at 6 54 53 PM](https://user-images.githubusercontent.com/10100397/224212366-64802167-bd26-4b54-b352-b2ab1395a2f8.png)

![Screenshot 2023-03-09 at 6 45 04 PM](https://user-images.githubusercontent.com/10100397/224210566-413e931c-bc83-4eea-8734-28735991de2f.png)

Only issue I saw was with `tooltipPosition` the value `top` won't work because of how it clips. But I think this is ok because the `bottom` will be used more in usage. `left` and `right` will work just fine, I tested and didn't see issue. Thanks!


Batch actions with tooltips should be able to be visible now. 
