### PR TITLE
refactor(vite): simplify example scss

### DIFF
--- a/examples/vite/src/index.scss
+++ b/examples/vite/src/index.scss
@@ -1,11 +1,3 @@
-@use '@carbon/react/scss/compat/themes' as compat;
-@use '@carbon/react/scss/themes';
-@use '@carbon/react/scss/theme' with (
-  $fallback: compat.$g100,
-  $theme: themes.$g100
+@use '@carbon/react' with (
+  $font-path: '@ibm/plex'
 );
-@use '@carbon/react';
-
-:root {
-  @include theme.theme();
-}


### PR DESCRIPTION
#### Changelog

**Changed**

- simplify the vite template/example scss to no longer unnecessarily configure a theme
- fix plex path resolution issue by configuring font-path to not include a tilde
