### PR TITLE
fix(ComposedModal): allow text to be selected

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.js
@@ -241,8 +241,7 @@ const ComposedModal = React.forwardRef(function ComposedModal(
       onBlur={handleBlur}
       onMouseDown={handleMousedown}
       onKeyDown={handleKeyDown}
-      className={modalClass}
-      tabIndex="-1">
+      className={modalClass}>
       <div
         className={containerClass}
         role="dialog"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12952

The negative `tabIndex` was causing the `wrapFocus` to misfire and always set focus back on the button, even when trying to select text.

#### Changelog

**Removed**

- Removed `tabIndex="-1"`

#### Testing / Reviewing

Ensure focus first initially goes to the element with `data-modal-primary-focus` on it, and then text can successfully be copied, and that focus does not keep being stolen by the button. 
