### PR TITLE
test: add testing for Switcher, SwitcherDivider and SwitcherItem

### DIFF
--- a/packages/react/src/components/UIShell/__tests__/Switcher-test.js
+++ b/packages/react/src/components/UIShell/__tests__/Switcher-test.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright IBM Corp. 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Switcher from '../Switcher';
+import { render, screen } from '@testing-library/react';
+
+describe('Switcher', () => {
+  describe('renders as expected - Component API', () => {
+    it('should respect aria-label prop', () => {
+      const { container } = render(
+        <Switcher aria-label="test-aria-label">Dummy child</Switcher>
+      );
+
+      expect(container.firstChild).toHaveAttribute(
+        'aria-label',
+        'test-aria-label'
+      );
+    });
+
+    it('should respect aria-labelledby prop', () => {
+      const { container } = render(
+        <Switcher aria-labelledby="test-aria-labelledby">Dummy child</Switcher>
+      );
+
+      expect(container.firstChild).toHaveAttribute(
+        'aria-labelledby',
+        'test-aria-labelledby'
+      );
+    });
+
+    it('should render children as expected', () => {
+      render(<Switcher aria-label="dummy-aria-label">text child</Switcher>);
+
+      expect(screen.getByText('text child')).toBeInTheDocument();
+    });
+
+    it('should support a custom `className` prop on the outermost element', () => {
+      const { container } = render(
+        <Switcher aria-label="dummy-aria-label" className="custom-class">
+          Dummy child
+        </Switcher>
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+  });
+});

--- a/packages/react/src/components/UIShell/__tests__/Switcher-test.js
+++ b/packages/react/src/components/UIShell/__tests__/Switcher-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/UIShell/__tests__/SwitcherDivider-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SwitcherDivider-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/UIShell/__tests__/SwitcherDivider-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SwitcherDivider-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright IBM Corp. 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import SwitcherDivider from '../SwitcherDivider';
+import { render } from '@testing-library/react';
+
+describe('SwitcherDivider', () => {
+  describe('renders as expected - Component API', () => {
+    it('should spread extra props onto outermost element', () => {
+      const { container } = render(<SwitcherDivider data-testid="test-id" />);
+
+      expect(container.firstChild).toHaveAttribute('data-testid', 'test-id');
+    });
+
+    it('should support a custom `className` prop on the outermost element', () => {
+      const { container } = render(
+        <SwitcherDivider className="custom-class" />
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+  });
+});

--- a/packages/react/src/components/UIShell/__tests__/SwitcherItem-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SwitcherItem-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/react/src/components/UIShell/__tests__/SwitcherItem-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SwitcherItem-test.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright IBM Corp. 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import SwitcherItem from '../SwitcherItem';
+import { render, screen } from '@testing-library/react';
+
+describe('SwitcherItem', () => {
+  describe('renders as expected - Component API', () => {
+    it('should spread extra props onto Link element', () => {
+      render(
+        <SwitcherItem data-testid="test-id" aria-label="dummy-aria-label">
+          Dummy child
+        </SwitcherItem>
+      );
+
+      expect(screen.getByRole('listitem').firstChild).toHaveAttribute(
+        'data-testid',
+        'test-id'
+      );
+    });
+
+    it('should respect aria-label prop', () => {
+      render(
+        <SwitcherItem aria-label="aria-label-test">Dummy child</SwitcherItem>
+      );
+
+      expect(screen.getByRole('listitem').firstChild).toHaveAttribute(
+        'aria-label',
+        'aria-label-test'
+      );
+    });
+
+    it('should respect aria-labelledby prop', () => {
+      render(
+        <SwitcherItem aria-labelledby="aria-labelledby-test">
+          Dummy child
+        </SwitcherItem>
+      );
+
+      expect(screen.getByRole('listitem').firstChild).toHaveAttribute(
+        'aria-labelledby',
+        'aria-labelledby-test'
+      );
+    });
+
+    it('should render children as expected', () => {
+      render(
+        <SwitcherItem aria-label="dummy-aria-label">Text child</SwitcherItem>
+      );
+
+      expect(screen.getByText('Text child')).toBeInTheDocument();
+    });
+
+    it('should support a custom `className` prop on the outermost element', () => {
+      const { container } = render(
+        <SwitcherItem className="custom-class" aria-label="dummy-aria-label">
+          Text child
+        </SwitcherItem>
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+
+    it('should respect tabIndex prop', () => {
+      render(
+        <SwitcherItem tabIndex={-1} aria-label="dummy-aria-label">
+          Dummy child
+        </SwitcherItem>
+      );
+
+      expect(screen.getByRole('listitem').firstChild).toHaveAttribute(
+        'tabIndex',
+        '-1'
+      );
+    });
+  });
+});

--- a/packages/react/tasks/build-test-rtl.js
+++ b/packages/react/tasks/build-test-rtl.js
@@ -16,13 +16,13 @@ function writeTestFile(props, componentName, isSubComponent) {
       test = `it('should render children as expected', () => {
                 render(<${componentName}>add appropriate children</${componentName}>)
 
-                expect(); 
+                expect();
             });\n\n`;
     } else if (prop === 'className') {
       test = `it('should support a custom \`className\` prop on the outermost element', () => {
             const { container } = render(<${componentName} className="custom-class" />)
 
-            expect(container.firstChild).toHaveClass('custom-class'); 
+            expect(container.firstChild).toHaveClass('custom-class');
         });\n\n`;
     } else if (
       prop === 'onClick' ||
@@ -39,12 +39,12 @@ function writeTestFile(props, componentName, isSubComponent) {
 
             // perform action to call ${prop}
 
-            expect(${prop}).toHaveBeenCalled(); 
+            expect(${prop}).toHaveBeenCalled();
         });\n\n`;
     } else {
       test = `it('should respect ${prop} prop', () => {
-            render(<${componentName} ${prop} />); 
-    
+            render(<${componentName} ${prop} />);
+
             expect();
         });\n\n`;
     }
@@ -54,23 +54,23 @@ function writeTestFile(props, componentName, isSubComponent) {
 
   const testFile = isSubComponent
     ? `/**
-    * Copyright IBM Corp. 2022
+    * Copyright IBM Corp. ${new Date().getFullYear()}
     *
     * This source code is licensed under the Apache-2.0 license found in the
     * LICENSE file in the root directory of this source tree.
     */
-   
+
   import React from 'react';
   import ${componentName} from '../${componentName}';
   import userEvent from '@testing-library/user-event';
   import { render, screen } from '@testing-library/react';
-  
+
   describe('${componentName}', () => {
     describe('renders as expected - Component API', () => {
       it('should spread extra props onto outermost element', () => {
         const { container } = render(<${componentName} data-testid="test-id" />)
 
-        expect(container.firstChild).toHaveAttribute('data-testid', 'test-id'); 
+        expect(container.firstChild).toHaveAttribute('data-testid', 'test-id');
       })
 
       ${propTests}
@@ -82,25 +82,25 @@ function writeTestFile(props, componentName, isSubComponent) {
   });
   `
     : `/**
-    * Copyright IBM Corp. 2022
+    * Copyright IBM Corp. ${new Date().getFullYear()}
     *
     * This source code is licensed under the Apache-2.0 license found in the
     * LICENSE file in the root directory of this source tree.
     */
-   
+
   import React from 'react';
   import ${componentName} from './${componentName}';
   import userEvent from '@testing-library/user-event';
   import { render, screen } from '@testing-library/react';
-  
+
   describe('${componentName}', () => {
     describe('renders as expected - Component API', () => {
       it('should spread extra props onto outermost element', () => {
         const { container } = render(<${componentName} data-testid="test-id" />)
 
-        expect(container.firstChild).toHaveAttribute('data-testid', 'test-id'); 
+        expect(container.firstChild).toHaveAttribute('data-testid', 'test-id');
       })
-      
+
       ${propTests}
     });
 


### PR DESCRIPTION
Closes #12859 

Adds testing for `Switcher`, `SwitcherDivider` and `SwitcherItem`. 
Also refactors test generator script to generate IBM Copyright header using current year.

#### Changelog

**New**

- packages/react/src/components/UIShell/__tests__/Switcher-test.js: add test file for `Switcher`
- packages/react/src/components/UIShell/__tests__/SwitcherDivider-test.js: add test file for `SwitcherDivider`
- packages/react/src/components/UIShell/__tests__/SwitcherItem-test.js: add. test file for `SwitcherItem`
- packages/react/tasks/build-test-rtl.js: generate IBM copyright header based on current year


#### Testing / Reviewing

Should test every prop in `Switcher`, `SwitcherItem` and `SwitcherDivider` and all tests should pass

