### PR TITLE
refactor(Button): TEST icon for wrap alignment

### DIFF
--- a/packages/react/src/components/Button/Button.stories.js
+++ b/packages/react/src/components/Button/Button.stories.js
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+// TODO - remove extra icons
+import { Add, ArrowRight, Search } from '@carbon/icons-react';
 import { default as Button, ButtonSkeleton } from '../Button';
 import ButtonSet from '../ButtonSet';
 import mdx from './Button.mdx';
@@ -59,7 +60,53 @@ export default {
 };
 
 export const Default = (args) => {
-  return <Button {...args}>Button</Button>;
+  // TODO - delete test zone + restore this line
+  // return <Button {...args}>Button</Button>;
+
+  // TEST ZONE
+  return (
+    <>
+      {/* SMALL */}
+      <Button renderIcon={Search} size="sm" {...args}>
+        SMALL with long text that will wrap at
+      </Button>
+      <div style={{ height: '5px' }}></div>
+      <Button renderIcon={Search} size="sm" kind="secondary" {...args}>
+        SMALL with long text that will wrap at some point soon
+      </Button>
+
+      <div>-</div>
+      {/* MEDIUM */}
+      <Button renderIcon={Search} size="md" {...args}>
+        MEDIUM with long text that will wrap
+      </Button>
+      <div style={{ height: '5px' }}></div>
+      <Button renderIcon={Search} size="md" kind="secondary" {...args}>
+        MEDIUM with long text that will wrap at some point soon
+      </Button>
+
+      <div>-</div>
+      {/* LARGE */}
+      <Button renderIcon={Search} size="lg" {...args}>
+        LARGE with long text that will wrap
+      </Button>
+      <div style={{ height: '5px' }}></div>
+      <Button renderIcon={Search} size="lg" kind="secondary" {...args}>
+        LARGE with long text that will wrap at some point soon
+      </Button>
+
+      <div>-</div>
+      {/* XL and 2XL */}
+      <Button renderIcon={ArrowRight} size="xl" kind="tertiary" {...args}>
+        X-LARGE has align-items: baseline, so it wraps nicely
+      </Button>
+      <div style={{ height: '5px' }}></div>
+      <Button renderIcon={ArrowRight} size="2xl" kind="tertiary" {...args}>
+        2X-LARGE has align-items: baseline, so it wraps nicely
+      </Button>
+    </>
+  );
+  // END TEST ZONE
 };
 
 export const Secondary = (args) => {

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -419,4 +419,27 @@
   .#{$prefix}--btn--ghost.#{$prefix}--btn--icon-only .#{$prefix}--btn__icon {
     @include high-contrast-mode('icon-fill');
   }
+
+  // TEST for #9478
+  // align icons manually to account for line wrap (see: #9478)
+  .#{$prefix}--btn.#{$prefix}--btn--sm .#{$prefix}--btn__icon {
+    top: 7px;
+    background: rgb(32, 182, 174);
+  }
+
+  .#{$prefix}--btn.#{$prefix}--btn--md .#{$prefix}--btn__icon {
+    top: 10px;
+    background: rgb(32, 182, 174);
+  }
+
+  .#{$prefix}--btn .#{$prefix}--btn__icon {
+    top: 14px;
+    background: rgb(32, 182, 174);
+  }
+
+  .#{$prefix}--btn.#{$prefix}--btn--xl .#{$prefix}--btn__icon,
+  .#{$prefix}--btn.#{$prefix}--btn--2xl .#{$prefix}--btn__icon {
+    top: auto;
+  }
+  // end align icons manually
 }


### PR DESCRIPTION
#9478
NOT COMPLETE , currently seeking feedback.

During Carbon Dev Office Hours, it was suggested to submit a format to compare all sizes so others can test/tinker 🧪.

Thank you for your insight!

___

**USE CASE** (from Design Team office hours): user changes language on the page, which can have unintended changes in length/wrapping
- ![image](https://user-images.githubusercontent.com/9935383/225923774-1e4cec2a-ed25-4015-a02a-fbec6faa5310.png)


**Findings**
- ONLY need to test sizes `sm`, `md`, `lg`
  - does NOT apply to `xl` or `2xl` who meet design requirements (already set to align `baseline`)
- `btn` is set to `align-items: center`, which is why icons stay centered.
- manipulating `line-height` had various results for me. It seems the core issue exists: text and icon have different alignment needs, so even if we alter line-height, icons require a new value
- icon background temporarily highlighted to display spacing since icons vary in size 
- Idea 1 (ugly): align all button icons with `baseline`, which looks great on wrap, but bad on single line (yanks text up)
- Idea 2 (dynamic): use JS to monitor the `max-width` of the button via `offsetWidth` sometime around page load (i.e. after language updated)
    - if `width >= 320px`, set alignment from center => baseline.
- Idea 3 (static): find a static distance for `top` since icons have `absolute` positioning
    - I tried matching `top` spacing of icon with button `padding`, but that did not align properly.
    - using `pixel` values for now because padding had calculations (below)
      - SIZE = `padding-top` = CLASS
      - sm = calc(0.375rem - 3px) = .cds—btn—sm
      - md = calc(0.675rem - 3px) = .cds—btn—md
      - lg =  calc(0.875rem - 3px) = .cds—btn
      - xl = 1rem = .cds--btn--xl:not(.cds--btn--icon-only)
      - 2xl = 1rem = .cds--btn--2xl:not(.cds--btn--icon-only)
___

**The following solution attempts Idea 3**, though alignment isn’t pixel perfect.

Are there more considerations beyond language selection that could alter button state/wrapping? Would that change the correct solution? Is it desired for all CSS to stay within the SCSS  file and not rely on JS? What’s the typical way to handle that?

#### Changelog

**New**

- add static `top` distance for the button icons

**Changed**

- n/a

**Removed**

- n/a

#### Testing / Reviewing

Open Storybook > Button > Default
- Visit `Button.stories.js` to alter `Default` example. Currently all 5 sizes are displayed
![image](https://user-images.githubusercontent.com/9935383/225920582-6ac968cc-fd11-4553-be12-4dfd9fc6bc52.png)

- Visit bottom of `/styles/scss/components/button/_button.scss` 
![image](https://user-images.githubusercontent.com/9935383/225920795-6d0f5217-5f37-48e2-b562-9793eea1f925.png)

    - test area setup with pixel amounts to demonstrate how single line and wrap do not easily share a value
- Test various CSS values per button `size` and see what kind of alignment you can get
