### PR TITLE
fix(UIShell): add bg color to selected states

### DIFF
--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -254,12 +254,11 @@
   a.#{$prefix}--header__menu-item[aria-current='page']::after,
   .#{$prefix}--header__menu-item--current::after {
     position: absolute;
-    top: 0;
-    right: 0;
     bottom: -2px;
-    left: 0;
-    width: 100%;
-    border-bottom: 3px solid $border-interactive;
+    left: -2px;
+    width: calc(100% + 4px);
+    height: 3px;
+    background-color: $border-interactive;
     content: '';
   }
 
@@ -271,16 +270,21 @@
   .#{$prefix}--header__submenu .#{$prefix}--header__menu {
     a.#{$prefix}--header__menu-item[aria-current='page']::after,
     .#{$prefix}--header__menu-item--current::after {
-      bottom: 0;
+      top: -2px;
       left: -2px;
-      border-bottom: none;
-      border-left: 3px solid $border-interactive;
+      width: 3px;
+      height: calc(100% + 4px);
+      background-color: $border-interactive;
     }
 
     a.#{$prefix}--header__menu-item[aria-current='page']:focus::after,
     .#{$prefix}--header__menu-item--current:focus::after {
-      left: 0;
-      border-left: 3px solid $border-interactive;
+      top: -2px;
+      left: -2px;
+      // extra, hidden width prevents flickering on focus change
+      width: 5px;
+      height: calc(100% + 4px);
+      background-color: $border-interactive;
     }
   }
 

--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -351,6 +351,17 @@
     color: $text-primary;
   }
 
+  .#{$prefix}--header__menu-title[aria-expanded='true']
+    + .#{$prefix}--header__menu
+    .#{$prefix}--header__menu-item.#{$prefix}--header__menu-item--current {
+    // used for both desktop and mobile
+    background-color: $layer-selected;
+
+    &:hover {
+      background-color: $layer-selected-hover;
+    }
+  }
+
   .#{$prefix}--header__menu .#{$prefix}--header__menu-item {
     height: mini-units(6);
   }

--- a/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
+++ b/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
@@ -490,6 +490,11 @@
       background-color: $background-hover;
       color: $text-primary;
     }
+
+    // non-hover, selected state inherited from `_header.scss`
+    a.#{$prefix}--header__menu-item--current:hover {
+      background-color: $layer-selected-hover;
+    }
   }
 
   .#{$prefix}--side-nav


### PR DESCRIPTION
Closes #10132 

Add desired background colors for **selected** menu-items

@aagonzales helped confirm the story above just needs proper background color to bring it up to spec. Let me know if there are any other design requirements!

#### Changelog

**New**

- add background colors for both selected states ("selected" and "selected + hover")

**Changed**

- n/a

**Removed**

- n/a

#### Testing / Reviewing
1. open `UIShell.stories.js` and find `HeaderBaseWNavigation`
2. add `isCurrentPage` to a `HeaderMenuItem` under both `HeaderNavigation`(desktop) and `SideNav`(mobile) 
![image](https://user-images.githubusercontent.com/9935383/226699660-4f40e9e4-28a5-4b56-b805-66a6cd4eaa78.png)
3. visit Storybook > UI Shell > Header Base w/Navigation to confirm updates for desktop and mobile now display as designed

Please reference the issue for design details.