### PR TITLE
Add types to file uploader

### DIFF
--- a/packages/react/src/components/Button/Button.Skeleton.js
+++ b/packages/react/src/components/Button/Button.Skeleton.js
@@ -11,6 +11,7 @@ import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import * as FeatureFlags from '@carbon/feature-flags';
 
+/** @type any */
 const ButtonSkeleton = ({
   className,
   small = false,

--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.tsx
@@ -12,7 +12,15 @@ import SkeletonText from '../SkeletonText';
 import ButtonSkeleton from '../Button/Button.Skeleton';
 import { usePrefix } from '../../internal/usePrefix';
 
-function FileUploaderSkeleton({ className, ...rest }) {
+export interface FileUploaderSkeletonProps {
+  /**
+   * Specify an optional className to add.
+   */
+  className?: string;
+}
+
+function FileUploaderSkeleton(props: FileUploaderSkeletonProps) {
+  const { className, ...rest } = props;
   const prefix = usePrefix();
   return (
     <div className={cx(`${prefix}--form-item`, className)} {...rest}>

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -8,14 +8,102 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import * as FeatureFlags from '@carbon/feature-flags';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import Filename from './Filename';
 import FileUploaderButton from './FileUploaderButton';
 import { ButtonKinds } from '../../prop-types/types';
 import { keys, matches } from '../../internal/keyboard';
 import { PrefixContext } from '../../internal/usePrefix';
 
-export default class FileUploader extends React.Component {
+let sizes = FeatureFlags.enabled('enable-v11-release')
+  ? ['sm', 'md', 'lg']
+  : ['default', 'field', 'small', 'sm', 'md', 'lg'];
+export interface FileUploaderProps {
+  /**
+   * Specify the types of files that this input should be able to receive
+   */
+  accept?: string[];
+
+  /**
+   * Specify the type of the `<FileUploaderButton>`
+   */
+  buttonKind: typeof ButtonKinds[number]; //todo PropTypes.oneOf(ButtonKinds),
+
+  /**
+   * Provide the label text to be read by screen readers when interacting with
+   * the `<FileUploaderButton>`
+   */
+  buttonLabel?: string;
+
+  /**
+   * Provide a custom className to be applied to the container node
+   */
+  className?: string;
+
+  /**
+   * Specify whether file input is disabled
+   */
+  disabled?: boolean;
+
+  /**
+   * Specify the status of the File Upload
+   */
+  filenameStatus: 'edit' | 'complete' | 'uploading';
+
+  /**
+   * Provide a description for the complete/close icon that can be read by screen readers
+   */
+  iconDescription: any; //todo
+  // FeatureFlags.enabled('enable-v11-release')
+  //   ? PropTypes.string.isRequired
+  //   : PropTypes.string,
+
+  /**
+   * Specify the description text of this `<FileUploader>`
+   */
+  labelDescription?: string;
+
+  /**
+   * Specify the title text of this `<FileUploader>`
+   */
+  labelTitle?: string;
+
+  /**
+   * Specify if the component should accept multiple files to upload
+   */
+  multiple?: boolean;
+
+  /**
+   * Provide a name for the underlying `<input>` node
+   */
+  name?: string;
+
+  /**
+   * Provide an optional `onChange` hook that is called each time the input is
+   * changed
+   */
+  onChange?: (evt: any) => void; //todoPropTypes.func,
+
+  /**
+   * Provide an optional `onClick` hook that is called each time the
+   * FileUploader is clicked
+   */
+  onClick?: (evt: any) => void; //todo PropTypes.func,
+
+  /**
+   * Provide an optional `onDelete` hook that is called when an uploaded item
+   * is removed
+   */
+  onDelete?: (evt: unknown) => void; //todo PropTypes.func,
+
+  /**
+   * Specify the size of the FileUploaderButton, from a list of available
+   * sizes.
+   */
+  size: typeof sizes[number]; //todo: better way?
+}
+
+export default class FileUploader extends PureComponent<FileUploaderProps> {
   static propTypes = {
     /**
      * Specify the types of files that this input should be able to receive
@@ -138,7 +226,7 @@ export default class FileUploader extends React.Component {
 
   handleChange = (evt) => {
     evt.stopPropagation();
-    const filenames = Array.prototype.map.call(
+    const filenames: any = Array.prototype.map.call(
       evt.target.files,
       (file) => file.name
     );
@@ -156,14 +244,18 @@ export default class FileUploader extends React.Component {
     if (filenameStatus === 'edit') {
       evt.stopPropagation();
       const filteredArray = this.state.filenames.filter(
+        // @ts-ignore
         (filename) => filename !== this.nodes[index].innerText.trim()
       );
       this.setState({ filenames: filteredArray });
       if (this.props.onDelete) {
         this.props.onDelete(evt);
+        // @ts-ignore
         this.uploaderButton.current.focus();
       }
-      this.props.onClick(evt);
+      if (this.props.onClick) {
+        this.props.onClick(evt);
+      }
     }
   };
 
@@ -194,7 +286,7 @@ export default class FileUploader extends React.Component {
 
     const classes = classNames({
       [`${prefix}--form-item`]: true,
-      [className]: className,
+      [className ?? '']: className,
     });
 
     const getHelperLabelClasses = (baseClass) =>
@@ -236,12 +328,14 @@ export default class FileUploader extends React.Component {
                 <span
                   key={index}
                   className={selectedFileClasses}
-                  ref={(node) => (this.nodes[index] = node)} // eslint-disable-line
+                  // @ts-ignore
+                  ref={(node) => (this.nodes[index] = node)}
                   {...other}>
                   <p className={`${prefix}--file-filename`} id={name}>
                     {name}
                   </p>
                   <span className={`${prefix}--file__state-container`}>
+                    {/* @ts-ignore */}
                     <Filename
                       iconDescription={iconDescription}
                       aria-describedby={name}

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -315,6 +315,7 @@ export default class FileUploader extends PureComponent<FileUploaderProps> {
           labelText={buttonLabel}
           multiple={multiple}
           buttonKind={buttonKind}
+          // @ts-ignore
           onChange={this.handleChange}
           disableLabelChanges
           accept={accept}
@@ -340,6 +341,7 @@ export default class FileUploader extends PureComponent<FileUploaderProps> {
                       iconDescription={iconDescription}
                       aria-describedby={name}
                       status={filenameStatus}
+                      // @ts-ignore todo: check why this isn't on filename
                       onKeyDown={(evt) => {
                         if (matches(evt, [keys.Enter, keys.Space])) {
                           this.handleClick(evt, { index, filenameStatus });

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -15,348 +15,367 @@ import { ButtonKinds } from '../../prop-types/types';
 import { keys, matches } from '../../internal/keyboard';
 import { PrefixContext } from '../../internal/usePrefix';
 
-let sizes = FeatureFlags.enabled('enable-v11-release')
-  ? ['sm', 'md', 'lg']
-  : ['default', 'field', 'small', 'sm', 'md', 'lg'];
-export interface FileUploaderProps {
-  /**
-   * Specify the types of files that this input should be able to receive
-   */
-  accept?: string[];
+  let fflag: boolean = FeatureFlags.enabled('enable-v11-release');
 
-  /**
-   * Specify the type of the `<FileUploaderButton>`
-   */
-  buttonKind: typeof ButtonKinds[number]; //todo PropTypes.oneOf(ButtonKinds),
-
-  /**
-   * Provide the label text to be read by screen readers when interacting with
-   * the `<FileUploaderButton>`
-   */
-  buttonLabel?: string;
-
-  /**
-   * Provide a custom className to be applied to the container node
-   */
-  className?: string;
-
-  /**
-   * Specify whether file input is disabled
-   */
-  disabled?: boolean;
-
-  /**
-   * Specify the status of the File Upload
-   */
-  filenameStatus: 'edit' | 'complete' | 'uploading';
-
-  /**
-   * Provide a description for the complete/close icon that can be read by screen readers
-   */
-  iconDescription: any; //todo
-  // FeatureFlags.enabled('enable-v11-release')
-  //   ? PropTypes.string.isRequired
-  //   : PropTypes.string,
-
-  /**
-   * Specify the description text of this `<FileUploader>`
-   */
-  labelDescription?: string;
-
-  /**
-   * Specify the title text of this `<FileUploader>`
-   */
-  labelTitle?: string;
-
-  /**
-   * Specify if the component should accept multiple files to upload
-   */
-  multiple?: boolean;
-
-  /**
-   * Provide a name for the underlying `<input>` node
-   */
-  name?: string;
-
-  /**
-   * Provide an optional `onChange` hook that is called each time the input is
-   * changed
-   */
-  onChange?: (evt: any) => void; //todoPropTypes.func,
-
-  /**
-   * Provide an optional `onClick` hook that is called each time the
-   * FileUploader is clicked
-   */
-  onClick?: (evt: any) => void; //todo PropTypes.func,
-
-  /**
-   * Provide an optional `onDelete` hook that is called when an uploaded item
-   * is removed
-   */
-  onDelete?: (evt: unknown) => void; //todo PropTypes.func,
-
-  /**
-   * Specify the size of the FileUploaderButton, from a list of available
-   * sizes.
-   */
-  size: typeof sizes[number]; //todo: better way?
-}
-
-export default class FileUploader extends PureComponent<FileUploaderProps> {
-  static propTypes = {
-    /**
-     * Specify the types of files that this input should be able to receive
-     */
-    accept: PropTypes.arrayOf(PropTypes.string),
-
-    /**
-     * Specify the type of the `<FileUploaderButton>`
-     */
-    buttonKind: PropTypes.oneOf(ButtonKinds),
-
-    /**
-     * Provide the label text to be read by screen readers when interacting with
-     * the `<FileUploaderButton>`
-     */
-    buttonLabel: PropTypes.string,
-
-    /**
-     * Provide a custom className to be applied to the container node
-     */
-    className: PropTypes.string,
-
-    /**
-     * Specify whether file input is disabled
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * Specify the status of the File Upload
-     */
-    filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading'])
-      .isRequired,
-
+  type enabled = {
     /**
      * Provide a description for the complete/close icon that can be read by screen readers
      */
-    iconDescription: FeatureFlags.enabled('enable-v11-release')
-      ? PropTypes.string.isRequired
-      : PropTypes.string,
-
-    /**
-     * Specify the description text of this `<FileUploader>`
-     */
-    labelDescription: PropTypes.string,
-
-    /**
-     * Specify the title text of this `<FileUploader>`
-     */
-    labelTitle: PropTypes.string,
-
-    /**
-     * Specify if the component should accept multiple files to upload
-     */
-    multiple: PropTypes.bool,
-
-    /**
-     * Provide a name for the underlying `<input>` node
-     */
-    name: PropTypes.string,
-
-    /**
-     * Provide an optional `onChange` hook that is called each time the input is
-     * changed
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * Provide an optional `onClick` hook that is called each time the
-     * FileUploader is clicked
-     */
-    onClick: PropTypes.func,
-
-    /**
-     * Provide an optional `onDelete` hook that is called when an uploaded item
-     * is removed
-     */
-    onDelete: PropTypes.func,
+    iconDescription: string;
 
     /**
      * Specify the size of the FileUploaderButton, from a list of available
      * sizes.
      */
-    size: FeatureFlags.enabled('enable-v11-release')
-      ? PropTypes.oneOf(['sm', 'md', 'lg'])
-      : PropTypes.oneOf(['default', 'field', 'small', 'sm', 'md', 'lg']),
+    size: 'sm' | 'md' | 'lg';
   };
 
-  static contextType = PrefixContext;
+  type disabled = {
+    /**
+     * Provide a description for the complete/close icon that can be read by screen readers
+     */
+    iconDescription?: string;
 
-  static defaultProps = {
-    disabled: false,
-    iconDescription: FeatureFlags.enabled('enable-v11-release')
-      ? undefined
-      : 'Provide icon description',
-    filenameStatus: 'uploading',
-    buttonLabel: '',
-    buttonKind: 'primary',
-    multiple: false,
-    onClick: () => {},
-    accept: [],
+    /**
+     * Specify the size of the FileUploaderButton, from a list of available
+     * sizes.
+     */
+    size: 'default' | 'field' | 'small' | 'sm' | 'md' | 'lg';
   };
 
-  state = {
-    filenames: [],
-  };
+  type FFlagDependentTypes<FFlag extends boolean = boolean> = FFlag extends true
+    ? enabled
+    : disabled;
 
-  nodes = [];
+  export type FileUploaderProps = {
+    /**
+     * Specify the types of files that this input should be able to receive
+     */
+    accept?: string[];
 
-  uploaderButton = React.createRef();
+    /**
+     * Specify the type of the `<FileUploaderButton>`
+     */
+    buttonKind: typeof ButtonKinds[number];
 
-  static getDerivedStateFromProps({ filenameStatus }, state) {
-    const { prevFilenameStatus } = state;
-    return prevFilenameStatus === filenameStatus
-      ? null
-      : {
-          filenameStatus,
-          prevFilenameStatus: filenameStatus,
-        };
-  }
+    /**
+     * Provide the label text to be read by screen readers when interacting with
+     * the `<FileUploaderButton>`
+     */
+    buttonLabel?: string;
 
-  handleChange = (evt) => {
-    evt.stopPropagation();
-    const filenames: any = Array.prototype.map.call(
-      evt.target.files,
-      (file) => file.name
-    );
-    this.setState({
-      filenames: this.props.multiple
-        ? this.state.filenames.concat(filenames)
-        : filenames,
-    });
-    if (this.props.onChange) {
-      this.props.onChange(evt);
+    /**
+     * Provide a custom className to be applied to the container node
+     */
+    className?: string;
+
+    /**
+     * Specify whether file input is disabled
+     */
+    disabled?: boolean;
+
+    /**
+     * Specify the status of the File Upload
+     */
+    filenameStatus: 'edit' | 'complete' | 'uploading';
+
+    /**
+     * Specify the description text of this `<FileUploader>`
+     */
+    labelDescription?: string;
+
+    /**
+     * Specify the title text of this `<FileUploader>`
+     */
+    labelTitle?: string;
+
+    /**
+     * Specify if the component should accept multiple files to upload
+     */
+    multiple?: boolean;
+
+    /**
+     * Provide a name for the underlying `<input>` node
+     */
+    name?: string;
+
+    /**
+     * Provide an optional `onChange` hook that is called each time the input is
+     * changed
+     */
+    onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void;
+
+    /**
+     * Provide an optional `onClick` hook that is called each time the
+     * FileUploader is clicked
+     */
+    onClick?: (evt: React.MouseEvent<HTMLDivElement>) => void;
+
+    /**
+     * Provide an optional `onDelete` hook that is called when an uploaded item
+     * is removed
+     */
+    onDelete?: (evt: React.MouseEvent<HTMLDivElement>) => void;
+
+    /**
+     * Specify the size of the FileUploaderButton, from a list of available
+     * sizes.
+     */
+    // size: typeof sizes[number];
+  } & FFlagDependentTypes<typeof fflag>;
+
+  export default class FileUploader extends PureComponent<FileUploaderProps> {
+    static propTypes = {
+      /**
+       * Specify the types of files that this input should be able to receive
+       */
+      accept: PropTypes.arrayOf(PropTypes.string),
+
+      /**
+       * Specify the type of the `<FileUploaderButton>`
+       */
+      buttonKind: PropTypes.oneOf(ButtonKinds),
+
+      /**
+       * Provide the label text to be read by screen readers when interacting with
+       * the `<FileUploaderButton>`
+       */
+      buttonLabel: PropTypes.string,
+
+      /**
+       * Provide a custom className to be applied to the container node
+       */
+      className: PropTypes.string,
+
+      /**
+       * Specify whether file input is disabled
+       */
+      disabled: PropTypes.bool,
+
+      /**
+       * Specify the status of the File Upload
+       */
+      filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading'])
+        .isRequired,
+
+      /**
+       * Provide a description for the complete/close icon that can be read by screen readers
+       */
+      iconDescription: FeatureFlags.enabled('enable-v11-release')
+        ? PropTypes.string.isRequired
+        : PropTypes.string,
+
+      /**
+       * Specify the description text of this `<FileUploader>`
+       */
+      labelDescription: PropTypes.string,
+
+      /**
+       * Specify the title text of this `<FileUploader>`
+       */
+      labelTitle: PropTypes.string,
+
+      /**
+       * Specify if the component should accept multiple files to upload
+       */
+      multiple: PropTypes.bool,
+
+      /**
+       * Provide a name for the underlying `<input>` node
+       */
+      name: PropTypes.string,
+
+      /**
+       * Provide an optional `onChange` hook that is called each time the input is
+       * changed
+       */
+      onChange: PropTypes.func,
+
+      /**
+       * Provide an optional `onClick` hook that is called each time the
+       * FileUploader is clicked
+       */
+      onClick: PropTypes.func,
+
+      /**
+       * Provide an optional `onDelete` hook that is called when an uploaded item
+       * is removed
+       */
+      onDelete: PropTypes.func,
+
+      /**
+       * Specify the size of the FileUploaderButton, from a list of available
+       * sizes.
+       */
+      size: FeatureFlags.enabled('enable-v11-release')
+        ? PropTypes.oneOf(['sm', 'md', 'lg'])
+        : PropTypes.oneOf(['default', 'field', 'small', 'sm', 'md', 'lg']),
+    };
+
+    static contextType = PrefixContext;
+
+    static defaultProps = {
+      disabled: false,
+      iconDescription: FeatureFlags.enabled('enable-v11-release')
+        ? undefined
+        : 'Provide icon description',
+      filenameStatus: 'uploading',
+      buttonLabel: '',
+      buttonKind: 'primary',
+      multiple: false,
+      onClick: () => {},
+      accept: [],
+    };
+
+    state = {
+      filenames: [] as string[],
+    };
+
+    nodes: HTMLSpanElement | null[] = [];
+
+    uploaderButton = React.createRef<HTMLLabelElement>();
+
+    static getDerivedStateFromProps({ filenameStatus }, state) {
+      const { prevFilenameStatus } = state;
+      return prevFilenameStatus === filenameStatus
+        ? null
+        : {
+            filenameStatus,
+            prevFilenameStatus: filenameStatus,
+          };
     }
-  };
 
-  handleClick = (evt, { index, filenameStatus }) => {
-    if (filenameStatus === 'edit') {
+    handleChange = (evt) => {
       evt.stopPropagation();
-      const filteredArray = this.state.filenames.filter(
-        // @ts-ignore
-        (filename) => filename !== this.nodes[index].innerText.trim()
-      );
-      this.setState({ filenames: filteredArray });
-      if (this.props.onDelete) {
-        this.props.onDelete(evt);
-        // @ts-ignore
-        this.uploaderButton.current.focus();
+      const filenames = Array.prototype.map.call(
+        evt.target.files,
+        (file: File) => file.name
+      ) as string[];
+
+      this.setState({
+        filenames: this.props.multiple
+          ? this.state.filenames.concat(filenames)
+          : filenames,
+      });
+      if (this.props.onChange) {
+        this.props.onChange(evt);
       }
-      if (this.props.onClick) {
-        this.props.onClick(evt);
+    };
+
+    handleClick = (evt, { index, filenameStatus }) => {
+      if (filenameStatus === 'edit') {
+        evt.stopPropagation();
+        const filteredArray = this.state.filenames.filter(
+          (filename) => filename !== this.nodes[index].innerText.trim()
+        );
+        this.setState({ filenames: filteredArray });
+        if (this.props.onDelete) {
+          this.props.onDelete(evt);
+          this.uploaderButton.current?.focus();
+        }
+        if (this.props.onClick) {
+          this.props.onClick(evt);
+        }
       }
-    }
-  };
+    };
 
-  clearFiles = () => {
-    // A clearFiles function that resets filenames and can be referenced using a ref by the parent.
-    this.setState({ filenames: [] });
-  };
+    clearFiles = () => {
+      // A clearFiles function that resets filenames and can be referenced using a ref by the parent.
+      this.setState({ filenames: [] });
+    };
 
-  render() {
-    const {
-      iconDescription,
-      buttonLabel,
-      buttonKind,
-      disabled,
-      filenameStatus,
-      labelDescription,
-      labelTitle,
-      className,
-      multiple,
-      accept,
-      name,
-      size = 'md',
-      onDelete, // eslint-disable-line no-unused-vars
-      ...other
-    } = this.props;
+    render() {
+      const {
+        iconDescription,
+        buttonLabel,
+        buttonKind,
+        disabled,
+        filenameStatus,
+        labelDescription,
+        labelTitle,
+        className,
+        multiple,
+        accept,
+        name,
+        size = 'md',
+        onDelete, // eslint-disable-line no-unused-vars
+        ...other
+      } = this.props;
 
-    const prefix = this.context;
+      const prefix = this.context;
 
-    const classes = classNames({
-      [`${prefix}--form-item`]: true,
-      [className ?? '']: className,
-    });
-
-    const getHelperLabelClasses = (baseClass) =>
-      classNames(baseClass, {
-        [`${prefix}--label-description--disabled`]: disabled,
+      const classes = classNames({
+        [`${prefix}--form-item`]: true,
+        [className ?? '']: className,
       });
 
-    const selectedFileClasses = classNames(`${prefix}--file__selected-file`, {
-      [`${prefix}--file__selected-file--md`]: size === 'field' || size === 'md',
-      [`${prefix}--file__selected-file--sm`]: size === 'small' || size === 'sm',
-    });
+      const getHelperLabelClasses = (baseClass) =>
+        classNames(baseClass, {
+          [`${prefix}--label-description--disabled`]: disabled,
+        });
 
-    return (
-      <div className={classes} {...other}>
-        {FeatureFlags.enabled('enable-v11-release') && !labelTitle ? null : (
-          <p className={getHelperLabelClasses(`${prefix}--file--label`)}>
-            {labelTitle}
+      const selectedFileClasses = classNames(`${prefix}--file__selected-file`, {
+        [`${prefix}--file__selected-file--md`]:
+          size === 'field' || size === 'md',
+        [`${prefix}--file__selected-file--sm`]:
+          size === 'small' || size === 'sm',
+      });
+
+      return (
+        <div className={classes} {...other}>
+          {FeatureFlags.enabled('enable-v11-release') && !labelTitle ? null : (
+            <p className={getHelperLabelClasses(`${prefix}--file--label`)}>
+              {labelTitle}
+            </p>
+          )}
+          <p className={getHelperLabelClasses(`${prefix}--label-description`)}>
+            {labelDescription}
           </p>
-        )}
-        <p className={getHelperLabelClasses(`${prefix}--label-description`)}>
-          {labelDescription}
-        </p>
-        <FileUploaderButton
-          //@ts-ignore
-          innerRef={this.uploaderButton}
-          disabled={disabled}
-          labelText={buttonLabel}
-          multiple={multiple}
-          buttonKind={buttonKind}
-          // @ts-ignore
-          onChange={this.handleChange}
-          disableLabelChanges
-          accept={accept}
-          name={name}
-          size={size}
-        />
-        <div className={`${prefix}--file-container`}>
-          {this.state.filenames.length === 0
-            ? null
-            : this.state.filenames.map((name, index) => (
-                <span
-                  key={index}
-                  className={selectedFileClasses}
-                  // @ts-ignore
-                  ref={(node) => (this.nodes[index] = node)}
-                  {...other}>
-                  <p className={`${prefix}--file-filename`} id={name}>
-                    {name}
-                  </p>
-                  <span className={`${prefix}--file__state-container`}>
-                    {/* @ts-ignore */}
-                    <Filename
-                      iconDescription={iconDescription}
-                      aria-describedby={name}
-                      status={filenameStatus}
-                      // @ts-ignore todo: check why this isn't on filename
-                      onKeyDown={(evt) => {
-                        if (matches(evt, [keys.Enter, keys.Space])) {
-                          this.handleClick(evt, { index, filenameStatus });
+          <FileUploaderButton
+            // @ts-ignore innerRef isn't a defined property on FileUploaderButton
+            innerRef={this.uploaderButton}
+            disabled={disabled}
+            labelText={buttonLabel}
+            multiple={multiple}
+            buttonKind={buttonKind}
+            onChange={this.handleChange}
+            disableLabelChanges
+            accept={accept}
+            name={name}
+            size={size}
+          />
+          <div className={`${prefix}--file-container`}>
+            {this.state.filenames.length === 0
+              ? null
+              : this.state.filenames.map((name, index) => (
+                  <span
+                    key={index}
+                    className={selectedFileClasses}
+                    ref={(node) => (this.nodes[index] = node)}
+                    {...other}>
+                    <p className={`${prefix}--file-filename`} id={name}>
+                      {name}
+                    </p>
+                    <span className={`${prefix}--file__state-container`}>
+                      <Filename
+                        iconDescription={iconDescription}
+                        aria-describedby={name}
+                        status={filenameStatus}
+                        // @ts-ignore onKeyDown isn't a defined property on Filename
+                        onKeyDown={(evt) => {
+                          if (matches(evt, [keys.Enter, keys.Space])) {
+                            this.handleClick(evt, { index, filenameStatus });
+                          }
+                        }}
+                        onClick={(evt) =>
+                          this.handleClick(evt, { index, filenameStatus })
                         }
-                      }}
-                      onClick={(evt) =>
-                        this.handleClick(evt, { index, filenameStatus })
-                      }
-                    />
+                      />
+                    </span>
                   </span>
-                </span>
-              ))}
+                ))}
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
   }
-}

--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -310,6 +310,7 @@ export default class FileUploader extends PureComponent<FileUploaderProps> {
           {labelDescription}
         </p>
         <FileUploaderButton
+          //@ts-ignore
           innerRef={this.uploaderButton}
           disabled={disabled}
           labelText={buttonLabel}

--- a/packages/react/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.tsx
@@ -111,7 +111,6 @@ function FileUploaderButton(props: FileUploaderButtonProps) {
     onChange = noop,
     name,
     size = 'md',
-    // eslint-disable-next-line react/prop-types
     // @ts-ignore
     innerRef,
     ...other

--- a/packages/react/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.tsx
@@ -6,7 +6,7 @@
  */
 
 import cx from 'classnames';
-import PropTypes from 'prop-types';
+import PropTypes, { ReactNodeLike } from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { matches, keys } from '../../internal/keyboard';
 import { ButtonKinds } from '../../prop-types/types';
@@ -17,22 +17,105 @@ import deprecate from '../../prop-types/deprecate';
 
 function noop() {}
 
-function FileUploaderButton({
-  accept,
-  buttonKind = 'primary',
-  className,
-  disabled = false,
-  disableLabelChanges = false,
-  id,
-  labelText: ownerLabelText = 'Add file',
-  multiple = false,
-  onChange = noop,
-  name,
-  size = 'md',
-  // eslint-disable-next-line react/prop-types
-  innerRef,
-  ...other
-}) {
+let sizes = FeatureFlags.enabled('enable-v11-release')
+  ? ['sm', 'md', 'lg']
+  : ['default', 'field', 'small', 'sm', 'md', 'lg'];
+export interface FileUploaderButtonProps {
+  /**
+   * Specify the types of files that this input should be able to receive
+   */
+  accept?: string[];
+
+  /**
+   * Specify the type of underlying button
+   */
+  buttonKind?: typeof ButtonKinds[number];
+
+  /**
+   * Provide a custom className to be applied to the container node
+   */
+  className?: string;
+
+  /**
+   * Specify whether you want to disable any updates to the FileUploaderButton
+   * label
+   */
+  disableLabelChanges?: boolean;
+
+  /**
+   * Specify whether file input is disabled
+   */
+  disabled?: boolean;
+
+  /**
+   * Provide a unique id for the underlying `<input>` node
+   */
+  id?: string;
+
+  /**
+   * Provide the label text to be read by screen readers when interacting with
+   * this control
+   */
+  labelText?: ReactNodeLike;
+
+  /**
+   * Specify if the component should accept multiple files to upload
+   */
+  multiple?: boolean;
+
+  /**
+   * Provide a name for the underlying `<input>` node
+   */
+  name?: string;
+
+  /**
+   * Provide an optional `onChange` hook that is called each time the `<input>`
+   * value changes
+   */
+  onChange?: any; //todo PropTypes.func,
+
+  /**
+   * Provide an optional `onClick` hook that is called each time the button is
+   * clicked
+   */
+  onClick?: any; //todo PropTypes.func,
+
+  /**
+   * Provide an accessibility role for the `<FileUploaderButton>`
+   */
+  role?: string;
+
+  /**
+   * Specify the size of the FileUploaderButton, from a list of available
+   * sizes.
+   */
+  size: typeof sizes[number];
+
+  /**
+   * Provide a custom tabIndex value for the `<FileUploaderButton>`
+   * @deprecated The `tabIndex` prop for `FileUploaderButton` has been deprecated since it now renders a button element by default.
+   */
+  tabIndex: number;
+}
+
+function FileUploaderButton(props: FileUploaderButtonProps) {
+  const {
+    accept,
+    buttonKind = 'primary',
+    className,
+    disabled = false,
+    disableLabelChanges = false,
+    id,
+    labelText: ownerLabelText = 'Add file',
+    multiple = false,
+    onChange = noop,
+    name,
+    size = 'md',
+    // eslint-disable-next-line react/prop-types
+    // @ts-ignore
+    innerRef,
+    ...other
+  } = props;
   const prefix = usePrefix();
   const [labelText, setLabelText] = useState(ownerLabelText);
   const [prevOwnerLabelText, setPrevOwnerLabelText] = useState(ownerLabelText);
@@ -54,11 +137,13 @@ function FileUploaderButton({
 
   function onClick(event) {
     event.target.value = null;
+    //@ts-ignore
     inputNode.current.click();
   }
 
   function onKeyDown(event) {
     if (matches(event, [keys.Enter, keys.Space])) {
+      //@ts-ignore
       inputNode.current.click();
     }
   }
@@ -99,8 +184,9 @@ function FileUploaderButton({
         id={inputId}
         disabled={disabled}
         type="file"
-        tabIndex="-1"
+        tabIndex={-1}
         multiple={multiple}
+        //@ts-ignore
         accept={accept}
         name={name}
         onChange={handleOnChange}

--- a/packages/react/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.tsx
@@ -72,13 +72,13 @@ export interface FileUploaderButtonProps {
    * Provide an optional `onChange` hook that is called each time the `<input>`
    * value changes
    */
-  onChange?: any; //todo PropTypes.func,
+  onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void;
 
   /**
    * Provide an optional `onClick` hook that is called each time the button is
    * clicked
    */
-  onClick?: any; //todo PropTypes.func,
+  onClick?: (evt: React.MouseEvent<HTMLButtonElement>) => void;
 
   /**
    * Provide an accessibility role for the `<FileUploaderButton>`
@@ -111,7 +111,7 @@ function FileUploaderButton(props: FileUploaderButtonProps) {
     onChange = noop,
     name,
     size = 'md',
-    // @ts-ignore
+    // @ts-ignore property not defined on FileUploaderButton
     innerRef,
     ...other
   } = props;
@@ -119,7 +119,7 @@ function FileUploaderButton(props: FileUploaderButtonProps) {
   const [labelText, setLabelText] = useState(ownerLabelText);
   const [prevOwnerLabelText, setPrevOwnerLabelText] = useState(ownerLabelText);
   const { current: inputId } = useRef(id || uid());
-  const inputNode = useRef(null);
+  const inputNode = useRef<HTMLInputElement>(null);
   const classes = cx(`${prefix}--btn`, className, {
     [`${prefix}--btn--${buttonKind}`]: buttonKind,
     [`${prefix}--btn--disabled`]: disabled,
@@ -136,14 +136,12 @@ function FileUploaderButton(props: FileUploaderButtonProps) {
 
   function onClick(event) {
     event.target.value = null;
-    //@ts-ignore
-    inputNode.current.click();
+    inputNode.current?.click();
   }
 
   function onKeyDown(event) {
     if (matches(event, [keys.Enter, keys.Space])) {
-      //@ts-ignore
-      inputNode.current.click();
+      inputNode.current?.click();
     }
   }
 
@@ -185,7 +183,7 @@ function FileUploaderButton(props: FileUploaderButtonProps) {
         type="file"
         tabIndex={-1}
         multiple={multiple}
-        //@ts-ignore
+        // @ts-ignore accept property type mismatch
         accept={accept}
         name={name}
         onChange={handleOnChange}

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
@@ -53,7 +53,12 @@ export interface FileUploaderDropContainerProps {
    * Event handler that is called after files are added to the uploader
    * The event handler signature looks like `onAddFiles(evt, { addedFiles })`
    */
-  onAddFiles?: any; //todo PropTypes.func,
+  onAddFiles?: (
+    evt: React.ChangeEvent<HTMLDivElement>,
+    {
+      addedFiles: [],
+    }
+  ) => void;
 
   /**
    * Provide a custom regex pattern for the acceptedTypes
@@ -90,7 +95,7 @@ function FileUploaderDropContainer(props: FileUploaderDropContainerProps) {
     ...rest
   } = props;
   const prefix = usePrefix();
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { current: uid } = useRef(id || uniqueId());
   const [isActive, setActive] = useState(false);
   const labelClasses = classNames(`${prefix}--file-browse-btn`, {
@@ -116,7 +121,6 @@ function FileUploaderDropContainer(props: FileUploaderDropContainerProps) {
     const acceptedTypes = new Set(accept);
     return transferredFiles.reduce((acc, curr) => {
       const { name, type: mimeType = '' } = curr;
-      //todo check this
       const fileExtensionRegExp = new RegExp(pattern ?? '', 'i');
       const hasFileExtension = fileExtensionRegExp.test(name);
       if (!hasFileExtension) {
@@ -138,7 +142,7 @@ function FileUploaderDropContainer(props: FileUploaderDropContainerProps) {
 
   function handleChange(event) {
     const addedFiles = validateFiles(event);
-    return onAddFiles(event, { addedFiles });
+    if (onAddFiles) return onAddFiles(event, { addedFiles }); 
   }
 
   return (
@@ -180,7 +184,6 @@ function FileUploaderDropContainer(props: FileUploaderDropContainerProps) {
         onKeyDown={(evt) => {
           // @ts-ignore
           if (matches(evt, [keys.Enter, keys.Space])) {
-            // @ts-ignore
             inputRef.current?.click();
           }
         }}
@@ -196,13 +199,13 @@ function FileUploaderDropContainer(props: FileUploaderDropContainerProps) {
         ref={inputRef}
         tabIndex={-1}
         disabled={disabled}
-        // @ts-ignore
+        // @ts-ignore property type mismatch
         accept={accept}
         name={name}
         multiple={multiple}
         onChange={handleChange}
         onClick={(evt) => {
-          // @ts-ignore
+          // @ts-ignore property shouldn't exist on type
           evt.target.value = null;
         }}
       />

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
@@ -12,22 +12,83 @@ import { keys, matches } from '../../internal/keyboard';
 import uniqueId from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 
-function FileUploaderDropContainer({
-  accept,
-  className,
-  id,
-  disabled,
-  labelText,
-  multiple,
-  name,
-  onAddFiles,
-  pattern,
-  role,
-  tabIndex,
-  // eslint-disable-next-line react/prop-types
-  innerRef,
-  ...rest
-}) {
+export interface FileUploaderDropContainerProps {
+  /**
+   * Specify the types of files that this input should be able to receive
+   */
+  accept?: string[];
+
+  /**
+   * Provide a custom className to be applied to the container node
+   */
+  className?: string;
+
+  /**
+   * Specify whether file input is disabled
+   */
+  disabled?: boolean;
+
+  /**
+   * Provide a unique id for the underlying `<input>` node
+   */
+  id?: string;
+
+  /**
+   * Provide the label text to be read by screen readers when interacting with
+   * this control
+   */
+  labelText: string;
+
+  /**
+   * Specify if the component should accept multiple files to upload
+   */
+  multiple?: boolean;
+
+  /**
+   * Provide a name for the underlying `<input>` node
+   */
+  name?: string;
+
+  /**
+   * Event handler that is called after files are added to the uploader
+   * The event handler signature looks like `onAddFiles(evt, { addedFiles })`
+   */
+  onAddFiles?: any; //todo PropTypes.func,
+
+  /**
+   * Provide a custom regex pattern for the acceptedTypes
+   */
+  pattern?: string;
+
+  /**
+   * Provide an accessibility role for the `<FileUploaderButton>`
+   */
+  role?: string;
+
+  /**
+   * Provide a custom tabIndex value for the `<FileUploaderButton>`
+   */
+  tabIndex?: number;
+}
+
+function FileUploaderDropContainer(props: FileUploaderDropContainerProps) {
+  const {
+    accept,
+    className,
+    id,
+    disabled,
+    labelText,
+    multiple,
+    name,
+    onAddFiles,
+    pattern,
+    role,
+    tabIndex,
+    // @ts-ignore
+    // eslint-disable-next-line react/prop-types
+    innerRef,
+    ...rest
+  } = props;
   const prefix = usePrefix();
   const inputRef = useRef(null);
   const { current: uid } = useRef(id || uniqueId());
@@ -37,7 +98,7 @@ function FileUploaderDropContainer({
   });
   const dropareaClasses = classNames(`${prefix}--file__drop-container`, {
     [`${prefix}--file__drop-container--drag-over`]: isActive,
-    [className]: className,
+    [className ? className : '']: className,
   });
 
   /**
@@ -49,13 +110,14 @@ function FileUploaderDropContainer({
       event.type === 'drop'
         ? [...event.dataTransfer.files]
         : [...event.target.files];
-    if (!accept.length) {
+    if (!accept?.length) {
       return transferredFiles;
     }
     const acceptedTypes = new Set(accept);
     return transferredFiles.reduce((acc, curr) => {
       const { name, type: mimeType = '' } = curr;
-      const fileExtensionRegExp = new RegExp(pattern, 'i');
+      //todo check this
+      const fileExtensionRegExp = new RegExp(pattern ?? '', 'i');
       const hasFileExtension = fileExtensionRegExp.test(name);
       if (!hasFileExtension) {
         return acc;
@@ -116,8 +178,10 @@ function FileUploaderDropContainer({
         htmlFor={uid}
         tabIndex={tabIndex || 0}
         onKeyDown={(evt) => {
+          // @ts-ignore
           if (matches(evt, [keys.Enter, keys.Space])) {
-            inputRef.current.click();
+            // @ts-ignore
+            inputRef.current?.click();
           }
         }}
         {...rest}>
@@ -130,13 +194,15 @@ function FileUploaderDropContainer({
         id={uid}
         className={`${prefix}--file-input`}
         ref={inputRef}
-        tabIndex="-1"
+        tabIndex={-1}
         disabled={disabled}
+        // @ts-ignore
         accept={accept}
         name={name}
         multiple={multiple}
         onChange={handleChange}
         onClick={(evt) => {
+          // @ts-ignore
           evt.target.value = null;
         }}
       />

--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -14,18 +14,71 @@ import uid from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 import * as FeatureFlags from '@carbon/feature-flags';
 
-function FileUploaderItem({
-  uuid,
-  name,
-  status,
-  iconDescription,
-  onDelete,
-  invalid,
-  errorSubject,
-  errorBody,
-  size,
-  ...other
-}) {
+let sizes = FeatureFlags.enabled('enable-v11-release')
+  ? ['sm', 'md', 'lg']
+  : ['default', 'field', 'small', 'sm', 'md', 'lg'];
+export interface FileUploaderItemProps {
+  /**
+   * Error message body for an invalid file upload
+   */
+  errorBody?: string;
+
+  /**
+   * Error message subject for an invalid file upload
+   */
+  errorSubject?: string;
+
+  /**
+   * Description of status icon (displayed in native tooltip)
+   */
+  iconDescription?: string;
+
+  /**
+   * Specify if the currently uploaded file is invalid
+   */
+  invalid?: boolean;
+
+  /**
+   * Name of the uploaded file
+   */
+  name?: string;
+
+  /**
+   * Event handler that is called after removing a file from the file uploader
+   * The event handler signature looks like `onDelete(evt, { uuid })`
+   */
+  onDelete?: any; // todoPropTypes.func,
+
+  /**
+   * Specify the size of the FileUploaderButton, from a list of available
+   * sizes.
+   */
+  size?: typeof sizes[number];
+
+  /**
+   * Status of the file upload
+   */
+  status?: 'uploading' | 'edit' | 'complete';
+
+  /**
+   * Unique identifier for the file object
+   */
+  uuid?: string;
+}
+
+function FileUploaderItem(props: FileUploaderItemProps) {
+  const {
+    uuid,
+    name,
+    status,
+    iconDescription,
+    onDelete,
+    invalid,
+    errorSubject,
+    errorBody,
+    size,
+    ...other
+  } = props;
   const prefix = usePrefix();
   const { current: id } = useRef(uuid || uid());
   const classes = cx(`${prefix}--file__selected-file`, {
@@ -44,6 +97,7 @@ function FileUploaderItem({
           aria-describedby={name}
           status={status}
           invalid={invalid}
+          // @ts-ignore
           onKeyDown={(evt) => {
             if (matches(evt, [keys.Enter, keys.Space])) {
               if (status === 'edit') {

--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -47,7 +47,7 @@ export interface FileUploaderItemProps {
    * Event handler that is called after removing a file from the file uploader
    * The event handler signature looks like `onDelete(evt, { uuid })`
    */
-  onDelete?: any; // todoPropTypes.func,
+  onDelete?: (evt: React.KeyboardEvent, { uuid: string }) => void;
 
   /**
    * Specify the size of the FileUploaderButton, from a list of available
@@ -97,16 +97,16 @@ function FileUploaderItem(props: FileUploaderItemProps) {
           aria-describedby={name}
           status={status}
           invalid={invalid}
-          // @ts-ignore
+          // @ts-ignore property not defined on Filename
           onKeyDown={(evt) => {
             if (matches(evt, [keys.Enter, keys.Space])) {
-              if (status === 'edit') {
+              if (status === 'edit' && onDelete) {
                 onDelete(evt, { uuid: id });
               }
             }
           }}
           onClick={(evt) => {
-            if (status === 'edit') {
+            if (status === 'edit' && onDelete) {
               onDelete(evt, { uuid: id });
             }
           }}

--- a/packages/react/src/components/FileUploader/Filename.tsx
+++ b/packages/react/src/components/FileUploader/Filename.tsx
@@ -11,11 +11,34 @@ import React from 'react';
 import Loading from '../Loading';
 import { usePrefix } from '../../internal/usePrefix';
 
-function Filename({ iconDescription, status, invalid, ...rest }) {
+export interface FilenameProps {
+  /**
+   * Provide a description of the SVG icon to denote file upload status
+   */
+  iconDescription?: string;
+
+  /**
+   * Specify if the file is invalid
+   */
+  invalid?: boolean;
+
+  /**
+   * Status of the file upload
+   */
+  status?: 'edit' | 'complete' | 'uploading';
+
+  /**
+   * Provide a custom tabIndex value for the `<Filename>`
+   */
+  tabIndex?: string;
+}
+function Filename(props: FilenameProps) {
+  const { iconDescription, status, invalid, tabIndex, ...rest } = props;
   const prefix = usePrefix();
   switch (status) {
     case 'uploading':
       return (
+        // @ts-ignore: todo fix once Loading component is converted to TS
         <Loading description={iconDescription} small withOverlay={false} />
       );
     case 'edit':
@@ -26,6 +49,7 @@ function Filename({ iconDescription, status, invalid, ...rest }) {
             aria-label={iconDescription}
             className={`${prefix}--file-close`}
             type="button"
+            tabIndex={tabIndex ? parseInt(tabIndex) : undefined}
             {...rest}>
             <Close />
           </button>

--- a/packages/react/src/components/SkeletonText/SkeletonText.js
+++ b/packages/react/src/components/SkeletonText/SkeletonText.js
@@ -18,6 +18,7 @@ function getRandomInt(min, max, n) {
   return Math.floor(randoms[n % 3] * (max - min + 1)) + min;
 }
 
+/** @type any */
 const SkeletonText = ({
   paragraph,
   lineCount,


### PR DESCRIPTION
Closes #

This PR converts FileUploader.js, FileUploaderButton.js, FileUploaderDropContainer.js, FileUploaderItem.js, FileUploaderSkeleton.js, and Filename.js to typescript.

#### Changelog



**Changed**

- FileUploader.js has been converted to TS
- FileUploaderButton.js has been converted to TS
-  FileUploaderDropContainer.js has been converted to TS
- FileUploaderItem.js has been converted to TS
- FileUploaderSkeleton.js has been converted to TS
- Filename.js has been converted to TS



#### Testing / Reviewing

These changes can be tested and verified by running a fresh yarn, yarn build and yarn storybook. Verify that the behavior in the FileUploader story remains unchanged
