### PR TITLE
feat(OverflowMenu): add `tooltipAlignment` prop as part of OverflowMenu API

### DIFF
--- a/packages/react/src/components/ComboButton/index.js
+++ b/packages/react/src/components/ComboButton/index.js
@@ -36,7 +36,7 @@ const ComboButton = React.forwardRef(function ComboButton(
     label,
     onClick,
     size = 'lg',
-    tooltipAlign,
+    tooltipAlignment,
     translateWithId: t = defaultTranslateWithId,
     ...rest
   },
@@ -105,7 +105,7 @@ const ComboButton = React.forwardRef(function ComboButton(
         label={t('carbon.combo-button.additional-actions')}
         size={size}
         disabled={disabled}
-        align={tooltipAlign}
+        align={tooltipAlignment}
         aria-haspopup
         aria-expanded={open}
         onClick={handleTriggerClick}
@@ -163,7 +163,7 @@ ComboButton.propTypes = {
   /**
    * Specify how the trigger tooltip should be aligned.
    */
-  tooltipAlign: PropTypes.oneOf([
+  tooltipAlignment: PropTypes.oneOf([
     'top',
     'top-left',
     'top-right',

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -97,6 +97,20 @@ class OverflowMenu extends Component {
 
   static propTypes = {
     /**
+     * Specify how the tooltip should align with the OverflowMenu
+     */
+    align: PropTypes.oneOf([
+      'top',
+      'top-left',
+      'top-right',
+      'bottom',
+      'bottom-left',
+      'bottom-right',
+      'left',
+      'right',
+    ]),
+
+    /**
      * Specify a label to be read by screen readers on the container node
      */
     ['aria-label']: PropTypes.string,
@@ -467,6 +481,7 @@ class OverflowMenu extends Component {
     const prefix = this.context;
     const {
       id,
+      align,
       ['aria-label']: ariaLabel,
       ariaLabel: deprecatedAriaLabel,
       children,
@@ -567,6 +582,7 @@ class OverflowMenu extends Component {
         <span className={`${prefix}--overflow-menu__wrapper`}>
           <IconButton
             {...other}
+            align={align}
             type="button"
             aria-haspopup
             aria-expanded={this.state.open}

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -97,20 +97,6 @@ class OverflowMenu extends Component {
 
   static propTypes = {
     /**
-     * Specify how the tooltip should align with the OverflowMenu
-     */
-    align: PropTypes.oneOf([
-      'top',
-      'top-left',
-      'top-right',
-      'bottom',
-      'bottom-left',
-      'bottom-right',
-      'left',
-      'right',
-    ]),
-
-    /**
      * Specify a label to be read by screen readers on the container node
      */
     ['aria-label']: PropTypes.string,
@@ -245,6 +231,20 @@ class OverflowMenu extends Component {
      * Specify the size of the OverflowMenu. Currently supports either `sm`, 'md' (default) or 'lg` as an option.
      */
     size: PropTypes.oneOf(['sm', 'md', 'lg']),
+
+    /**
+     * Specify how the tooltip should align with the OverflowMenu
+     */
+    tooltipAlignment: PropTypes.oneOf([
+      'top',
+      'top-left',
+      'top-right',
+      'bottom',
+      'bottom-left',
+      'bottom-right',
+      'left',
+      'right',
+    ]),
   };
 
   static contextType = PrefixContext;
@@ -481,7 +481,6 @@ class OverflowMenu extends Component {
     const prefix = this.context;
     const {
       id,
-      align,
       ['aria-label']: ariaLabel,
       ariaLabel: deprecatedAriaLabel,
       children,
@@ -501,6 +500,7 @@ class OverflowMenu extends Component {
       menuOptionsClass,
       light,
       size = 'md',
+      tooltipAlignment,
       ...other
     } = this.props;
 
@@ -582,7 +582,7 @@ class OverflowMenu extends Component {
         <span className={`${prefix}--overflow-menu__wrapper`}>
           <IconButton
             {...other}
-            align={align}
+            align={tooltipAlignment}
             type="button"
             aria-haspopup
             aria-expanded={this.state.open}

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.mdx
@@ -32,22 +32,6 @@ this attribute is found, the menu will be placed on `document.body`.
   <Story id="components-overflowmenu--render-custom-icon" />
 </Preview>
 
-## Customizing the tooltip
-
-The `OverflowMenu` uses an `IconButton` under the hood, which means it can accept any props that an `IconButton` can receive and will succesfully pass those forward.
-To modify the tooltip's alignment, you may make use of the `align` property as described in the `IconButton` props:
-
-```jsx
-  <OverflowMenu aria-label="overflow-menu" align="bottom">
-    <OverflowMenuItem itemText="Stop app" />
-    <OverflowMenuItem itemText="Restart app" />
-    <OverflowMenuItem itemText="Rename app" />
-    <OverflowMenuItem itemText="Clone and move app" disabled requireTitle />
-    <OverflowMenuItem itemText="Edit routes and access" requireTitle />
-    <OverflowMenuItem hasDivider isDelete itemText="Delete app" />
-  </OverflowMenu>
-```
-
 ## Component API
 
 <Props />

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -54,6 +54,19 @@ export const Playground = (args) => (
 );
 
 Playground.argTypes = {
+  align: {
+    options: [
+      'top',
+      'top-left',
+      'top-right',
+      'bottom',
+      'bottom-left',
+      'bottom-right',
+      'left',
+      'right',
+    ],
+    control: { type: 'select' },
+  },
   ariaLabel: {
     table: {
       disable: true,

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -54,7 +54,7 @@ export const Playground = (args) => (
 );
 
 Playground.argTypes = {
-  align: {
+  tooltipAlignment: {
     options: [
       'top',
       'top-left',


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/13446

`align` could already be passed to `IconButton` inside `OverflowMenu` via the `other` prop. This change will surface as `tooltipAlignment` on the `OverflowMenu` API so users will know it is available to use in this component.

#### Changelog

**New**

- `tooltipAlignment ` prop is added in `OverflowMenu`

#### Testing / Reviewing

Go to the playground story inside `OverflowMenu` and change the `tooltipAlignment ` prop
