### PR TITLE
fix(postinstall): include scripts dir in build output

### DIFF
--- a/packages/carbon-components-react/package.json
+++ b/packages/carbon-components-react/package.json
@@ -15,7 +15,8 @@
     "es",
     "lib",
     "scss",
-    "index.scss"
+    "index.scss",
+    "scripts/postinstall.js"
   ],
   "keywords": [
     "react",

--- a/packages/carbon-components/package.json
+++ b/packages/carbon-components/package.json
@@ -12,7 +12,8 @@
   "homepage": "https://www.carbondesignsystem.com/",
   "files": [
     "scss/**/*",
-    "index.scss"
+    "index.scss",
+    "scripts/postinstall.js"
   ],
   "keywords": [
     "carbon",


### PR DESCRIPTION
[Reported on slack](https://ibm-studios.slack.com/archives/C046Y0YUD/p1680793031815889), as part of https://github.com/carbon-design-system/carbon/pull/13304 the scripts directory wasn't being included in the build causing failures on install.

#### Changelog

**Changed**

- include scripts directory in `files` array in package.json of packages that need it
