### PR TITLE
chore(storybook): add default value to warnText prop

### DIFF
--- a/packages/react/src/components/NumberInput/NumberInput.stories.js
+++ b/packages/react/src/components/NumberInput/NumberInput.stories.js
@@ -97,7 +97,11 @@ Playground.argTypes = {
     control: { type: 'text' },
   },
   warnText: {
-    control: { type: 'text' },
+    control: {
+      type: 'text',
+    },
+    defaultValue:
+      'Warning message that is really long can wrap to more lines but should not be excessively long.',
   },
 };
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/13499

Adds in a default value to the `warnText` prop in the playground story for `NumberInput`

#### Changelog

**Changed**

- Added default text to `warnText` in the playground story for `NumberInput`

#### Testing / Reviewing

Ensure that when `warn` is set to true, `warnText` appears
