### PR TITLE
fix: removed placeholder from dropdown/downshift storybook examples

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -73,7 +73,6 @@ export const Default = () => (
         },
       }}
       itemToString={(item) => (item ? item.text : '')}
-      placeholder="Filter..."
       titleText="ComboBox title"
       helperText="Combobox helper text"
     />
@@ -89,7 +88,6 @@ export const _WithLayer = () => (
           id={`carbon-combobox-${layer}`}
           items={items}
           itemToString={(item) => (item ? item.text : '')}
-          placeholder="Filter..."
           titleText="ComboBox title"
           helperText="Combobox helper text"
         />
@@ -109,7 +107,6 @@ export const Playground = (args) => (
         },
       }}
       itemToString={(item) => (item ? item.text : '')}
-      placeholder="Filter..."
       titleText="ComboBox title"
       helperText="Combobox helper text"
       {...args}

--- a/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
+++ b/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
@@ -68,7 +68,6 @@ const ToggleTip = (
 export const Default = () => (
   <div style={{ width: '400px' }}>
     <FluidComboBox
-      placeholder="Filter..."
       onChange={() => {}}
       id="default"
       titleText="Label"
@@ -82,7 +81,6 @@ export const Default = () => (
 export const Condensed = () => (
   <div style={{ width: '400px' }}>
     <FluidComboBox
-      placeholder="Filter..."
       onChange={() => {}}
       id="default"
       isCondensed
@@ -97,7 +95,6 @@ export const Condensed = () => (
 export const Playground = (args) => (
   <div style={{ width: args.playgroundWidth }}>
     <FluidComboBox
-      placeholder="Filter..."
       onChange={() => {}}
       id="default"
       titleText="Label"
@@ -108,7 +105,6 @@ export const Playground = (args) => (
     />
     <br />
     <FluidComboBox
-      placeholder="Filter..."
       {...args}
       onChange={() => {}}
       id="default-3"


### PR DESCRIPTION
Closes #13122 

#### Changelog

**Changed**

- Placeholder in either the ComboBox and FluidComboBox removed

#### Testing / Reviewing

Verify that there are no placeholder values present in either the ComboBox or FluidComboBox