### PR TITLE
chore(config): fix browserslist-config-carbon targets

### DIFF
--- a/config/browserslist-config-carbon/index.js
+++ b/config/browserslist-config-carbon/index.js
@@ -7,4 +7,4 @@
 
 'use strict';
 
-module.exports = ['> 0.5%', 'last 2 versions', 'not ie <= 11', 'Firefox ESR'];
+module.exports = ['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead'];

--- a/packages/react/src/components/DatePicker/DatePicker.js
+++ b/packages/react/src/components/DatePicker/DatePicker.js
@@ -362,7 +362,7 @@ const DatePicker = React.forwardRef(function DatePicker(
       maxDate: maxDate,
       plugins: [
         datePickerType === 'range'
-          ? new carbonFlatpickrRangePlugin({
+          ? carbonFlatpickrRangePlugin({
               input: endInputField.current,
             })
           : () => {},

--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -142,23 +142,6 @@ const Modal = React.forwardRef(function Modal(
       Array.isArray(secondaryButtons) && secondaryButtons.length === 2,
   });
 
-  const modalButton = (
-    <button
-      className={modalCloseButtonClass}
-      type="button"
-      onClick={onRequestClose}
-      title={ariaLabel}
-      aria-label={closeButtonLabel ? closeButtonLabel : 'close'}
-      ref={button}>
-      <Close
-        size={20}
-        aria-hidden="true"
-        tabIndex="-1"
-        className={`${modalCloseButtonClass}__icon`}
-      />
-    </button>
-  );
-
   const ariaLabel =
     modalLabel || ariaLabelProp || modalAriaLabel || modalHeading;
   const getAriaLabelledBy = modalLabel ? modalLabelId : modalHeadingId;
@@ -218,6 +201,23 @@ const Modal = React.forwardRef(function Modal(
       focusButton(innerModal.current);
     }
   }, [open, selectorPrimaryFocus, danger, prefix]);
+
+  const modalButton = (
+    <button
+      className={modalCloseButtonClass}
+      type="button"
+      onClick={onRequestClose}
+      title={ariaLabel}
+      aria-label={closeButtonLabel ? closeButtonLabel : 'close'}
+      ref={button}>
+      <Close
+        size={20}
+        aria-hidden="true"
+        tabIndex="-1"
+        className={`${modalCloseButtonClass}__icon`}
+      />
+    </button>
+  );
 
   const modalBody = (
     <div


### PR DESCRIPTION
Closes #13523

exclude dead browsers

#### Changelog

**New**

- exclude dead browsers from browserslist-config-carbon

**Changed**

- added `not dead` query
- fix: make ariaLabel accessible for modalButton
- fix: remove unused new constructor for datepicker

#### Testing / Reviewing

[browserlist with this config](https://browsersl.ist/#q=%3E+0.5%25%2C+last+2+versions%2C+Firefox+ESR%2C+not+dead)