### PR TITLE
feat(link): adds external prop

### DIFF
--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -20,7 +20,7 @@ const Link = React.forwardRef(function Link(
     visited = false,
     renderIcon: Icon,
     size,
-    external = false,
+    openInNewWindow = false,
     ...rest
   },
   ref
@@ -36,7 +36,7 @@ const Link = React.forwardRef(function Link(
   let rel = null;
   let target = null;
 
-  if (external) {
+  if (openInNewWindow) {
     rel = 'noopener';
     target = '_blank';
   } else {
@@ -89,11 +89,6 @@ Link.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Specify if the link should open in a new tab
-   */
-  external: PropTypes.bool,
-
-  /**
    * Provide the `href` attribute for the `<a>` node
    */
   href: PropTypes.string,
@@ -102,6 +97,11 @@ Link.propTypes = {
    * Specify whether you want the inline version of this control
    */
   inline: PropTypes.bool,
+
+  /**
+   * Specify if the link should open in a new tab
+   */
+  openInNewWindow: PropTypes.bool,
 
   /**
    * Optional prop to render an icon next to the link.

--- a/packages/react/src/components/Link/Link.js
+++ b/packages/react/src/components/Link/Link.js
@@ -20,6 +20,7 @@ const Link = React.forwardRef(function Link(
     visited = false,
     renderIcon: Icon,
     size,
+    external = false,
     ...rest
   },
   ref
@@ -31,9 +32,20 @@ const Link = React.forwardRef(function Link(
     [`${prefix}--link--visited`]: visited,
     [`${prefix}--link--${size}`]: size,
   });
-  const rel = rest.target === '_blank' ? 'noopener' : null;
+
+  let rel = null;
+  let target = null;
+
+  if (external) {
+    rel = 'noopener';
+    target = '_blank';
+  } else {
+    rel = rest.target === '_blank' && 'noopener';
+  }
+
   const linkProps = {
     className,
+    target,
     rel,
   };
 
@@ -75,6 +87,11 @@ Link.propTypes = {
    * Specify if the control should be disabled, or not
    */
   disabled: PropTypes.bool,
+
+  /**
+   * Specify if the link should open in a new tab
+   */
+  external: PropTypes.bool,
 
   /**
    * Provide the `href` attribute for the `<a>` node


### PR DESCRIPTION
Closes #13633 

This PR adds an external prop to allow the link component to open in a new tab

#### Changelog

**Changed**

- `packages/react/src/components/Link/Link.js`


#### Testing / Reviewing

1. Change `external` control in storybook to true
2. When you click on the link it should open in a new tab 
