### PR TITLE
🛠️ fix(OverflowMenu): Pass `size` Prop Along To `IconButton`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1136,6 +1136,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "sjbeatle",
+      "name": "Steven Black",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7853451?v=4",
+      "profile": "http://www.steveblackonline.com/",
+      "contributions": [
+        "code",
+        "a11y"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/pratikkarad"><img src="https://avatars.githubusercontent.com/u/32093370?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Pratik Karad</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=pratikkarad" title="Code">💻</a> <a href="#a11y-pratikkarad" title="Accessibility">️️️️♿️</a></td>
     <td align="center"><a href="https://github.com/gerzonc"><img src="https://avatars.githubusercontent.com/u/36211892?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gerzon</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=gerzonc" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/kubijo"><img src="https://avatars.githubusercontent.com/u/11244314?v=4?s=100" width="100px;" alt=""/><br /><sub><b>kubijo</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=kubijo" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.steveblackonline.com/"><img src="https://avatars.githubusercontent.com/u/7853451?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Steven Black</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=sjbeatle" title="Code">💻</a> <a href="#a11y-sjbeatle" title="Accessibility">️️️️♿️</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -574,6 +574,7 @@ class OverflowMenu extends Component {
             onClick={this.handleClick}
             id={id}
             ref={mergeRefs(this._triggerRef, ref)}
+            size={size}
             label={iconDescription}>
             <IconElement {...iconProps} />
           </IconButton>


### PR DESCRIPTION
## Details
There was a recent change to `OverflowMenu` that triggered Visual Regression Test errors in our application...

The commit in particular is b70ac6dcad0ec6e86c80dc4fa0a2ad1b892f02fb
That commit changed the trigger element from `button` to the `IconButton` component for some accessibility updates, but it didn't properly set the `size` property for the `IconButton`, causing the value to always be "md" for the button, regardless of what was set for the `OverflowMenu` parent element.

### OverflowMenu Size Small: BEFORE
<img width="103" alt="image" src="https://user-images.githubusercontent.com/7853451/234437822-c2aa7e05-d3c2-44c4-9a44-43eeca2c80ed.png">

### OverflowMenu Size Small: AFTER
<img width="104" alt="image" src="https://user-images.githubusercontent.com/7853451/234438054-a5ac29ec-dc10-45c3-9db7-7ec495860207.png">

## Resolution
The fix comes from very simply passing the `size` property value down to the `IconButton` sub-component. 🎉 

Please let me know if you have any questions. Thank you!