### PR TITLE
feature/HeaderNavigation types

### DIFF
--- a/packages/react/src/components/UIShell/HeaderNavigation.tsx
+++ b/packages/react/src/components/UIShell/HeaderNavigation.tsx
@@ -6,30 +6,28 @@
  */
 
 import cx from 'classnames';
-import React from 'react';
+import React, { type ComponentProps } from 'react';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import { usePrefix } from '../../internal/usePrefix';
 
-function HeaderNavigation(props) {
-  const {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-    children,
-    className: customClassName,
-    ...rest
-  } = props;
+type HeaderNavigationProps = ComponentProps<'nav'>;
+
+export default function HeaderNavigation({
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  children,
+  className: customClassName,
+  ...rest
+}: HeaderNavigationProps) {
   const prefix = usePrefix();
   const className = cx(`${prefix}--header__nav`, customClassName);
-  // Assign both label strategies in this option, only one should be defined
-  // so when we spread that should be the one that is applied to the node
-  const accessibilityLabel = {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-  };
-
   return (
-    <nav {...rest} {...accessibilityLabel} className={className}>
+    <nav
+      {...rest}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className={className}>
       <ul className={`${prefix}--header__menu-bar`}>{children}</ul>
     </nav>
   );
@@ -52,6 +50,3 @@ HeaderNavigation.propTypes = {
    */
   className: PropTypes.string,
 };
-
-export default HeaderNavigation;
-export { HeaderNavigation };

--- a/packages/react/src/components/UIShell/__tests__/HeaderNavigation-test.js
+++ b/packages/react/src/components/UIShell/__tests__/HeaderNavigation-test.js
@@ -7,7 +7,7 @@
 
 import { cleanup, render, screen } from '@testing-library/react';
 import React from 'react';
-import { HeaderNavigation } from '../HeaderNavigation';
+import HeaderNavigation from '../HeaderNavigation';
 
 describe('HeaderNavigation', () => {
   it('should render children that are passed to the component', () => {


### PR DESCRIPTION
Closes #13593 

Converted UIShell/HeaderNavigation.js to tsx and added appropriate prop types.

#### Changelog

**New**

- Added type for HeaderNavigation props

**Changed**

- Renamed UIShell/HeaderNavigation.js to UIShell/HeaderNavigation.tsx
- Removed a duplicate export of HeaderNavigation that was only used in one place

#### Testing / Reviewing

You can check this by confirming that there are no errors when:

- building
- viewing the UIShell stories that have a HeaderNavigation
- creating a component that uses the HeaderNavigation and testing which props are valid/invalid
