### PR TITLE
SSR in NextJS fix by using useWindowEvent 

### DIFF
--- a/packages/react/src/components/UIShell/HeaderContainer.js
+++ b/packages/react/src/components/UIShell/HeaderContainer.js
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import React, { useState, useCallback } from 'react';
 import { keys, match } from '../../internal/keyboard';
-import { useEvent } from '../../internal/useEvent';
+import { useWindowEvent } from '../../internal/useEvent';
 
 // eslint-disable-next-line react/prop-types
 const HeaderContainer = ({ isSideNavExpanded, render: Children }) => {
@@ -16,7 +16,7 @@ const HeaderContainer = ({ isSideNavExpanded, render: Children }) => {
   const [isSideNavExpandedState, setIsSideNavExpandedState] =
     useState(isSideNavExpanded);
 
-  useEvent(window, 'keydown', (event) => {
+  useWindowEvent('keydown', (event) => {
     if (match(event, keys.Escape)) {
       setIsSideNavExpandedState(false);
     }


### PR DESCRIPTION
Fix the problem in this [PR](https://github.com/carbon-design-system/carbon/pull/13614)

Window was not defined in server-side rendering when using NextJS

```
info  - Creating an optimized production build .ReferenceError: window is not defined
    at HeaderContainer (<redacted>)
```

#### Testing / Reviewing

To test the issue I did a [StackBlitz](https://stackblitz.com/edit/nextjs-cqbapt?file=pages%2Findex.js,pages%2FuseEvent.js) sample