### PR TITLE
fix(TextInput): restrict onChange event TypeScript type

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -99,9 +99,7 @@ export interface TextInputProps
    * Optionally provide an `onChange` handler that is called whenever `<input>`
    * is updated
    */
-  onChange?: (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
   /**
    * Optionally provide an `onClick` handler that is called whenever the


### PR DESCRIPTION
Closes #13777

Changes the TypeScript type on `TextInput`'s `onChange` function `event` parameter to match the internal representation of the component and legacy DefinitelyTyped types. 

#### Changelog

**Changed**

- Removed `HTMLTextAreaElement` reference from `TextInput`'s `onChange` function `event` parameter type

#### Testing / Reviewing

Unit tests should pass. In a TypeScript environment, the accepted onChange function event argument type should include `ChangeEvent<HTMLInputElement>` only. The change has no visual side effects.