### PR TITLE
fix(Modal): render correct backgrounds for NumberInput on Modal (#12230)

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -234,10 +234,12 @@ describe('ContentSwitcher', () => {
 
     it('should have no AC violations', async () => {
       const { container } = render(
-        <ContentSwitcher>
-          <Switch kind="anchor" text="one" />
-          <Switch kind="anchor" text="two" />
-        </ContentSwitcher>
+        <main>
+          <ContentSwitcher>
+            <Switch kind="anchor" text="one" />
+            <Switch kind="anchor" text="two" />
+          </ContentSwitcher>
+        </main>
       );
       await expect(container).toHaveNoACViolations('ContentSwitcher');
     });

--- a/packages/react/src/components/Loading/Loading-test.js
+++ b/packages/react/src/components/Loading/Loading-test.js
@@ -37,13 +37,6 @@ describe('Loading', () => {
       const { container } = render(<Loading />);
       const liveRegion = container.querySelector('[aria-live]');
       expect(liveRegion).toBeInstanceOf(HTMLElement);
-
-      const id = liveRegion.getAttribute('aria-labelledby');
-      expect(id).toBeDefined();
-
-      const label = document.getElementById(id);
-      expect(label).toBeDefined();
-      expect(typeof label.textContent).toBe('string');
     });
 
     // https://www.w3.org/TR/WCAG21/#status-messages

--- a/packages/react/src/components/Loading/Loading.js
+++ b/packages/react/src/components/Loading/Loading.js
@@ -39,7 +39,6 @@ function Loading({
     <div
       {...rest}
       aria-atomic="true"
-      aria-labelledby={loadingId}
       aria-live={active ? 'assertive' : 'off'}
       className={loadingClassName}>
       <label id={loadingId} className={`${prefix}--visually-hidden`}>

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -62,8 +62,14 @@
     .#{$prefix}--dropdown-list,
     .#{$prefix}--number input[type='number'],
     .#{$prefix}--date-picker__input,
-    .#{$prefix}--multi-select {
+    .#{$prefix}--multi-select,
+    .#{$prefix}--number__control-btn::before,
+    .#{$prefix}--number__control-btn::after {
       background-color: $field-02;
+    }
+
+    .#{$prefix}--number__rule-divider {
+      background-color: $border-subtle-02;
     }
   }
 


### PR DESCRIPTION
* fix(Modal): render correct backgrounds for NumberInput on Modal

* chore(modal): remove numberinput example

Closes https://github.com/carbon-design-system/carbon/issues/12229

#### Changelog

**Changed**

- Added more overrides to Modal to properly style form elements, in this case the NumberInput controls

#### Testing / Reviewing

This is a cherry pick to v10, refer to the #12230