### PR TITLE
fix(Multiselect): prevent console error when typing and open

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -339,7 +339,15 @@ const MultiSelect = React.forwardRef(function MultiSelect<ItemType>(
     highlightedIndex,
     isOpen,
     itemToString: (items) => {
-      return (items as ItemType[]).map((item) => itemToString(item)).join(', ');
+      return (
+        (Array.isArray(items) &&
+          items
+            .map(function (item) {
+              return itemToString(item);
+            })
+            .join(', ')) ||
+        ''
+      );
     },
     onStateChange,
     selectedItem: controlledSelectedItems,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/9938

Fixes an issue that would cause a console warning if the menu was open and a user started typing

#### Changelog

**Changed**

- Checks if `items` is an Array before trying to map over it

#### Testing / Reviewing

Go to `MultiSelect`, open the menu, and try typing. Verify no console errors appear when typing. 
