### PR TITLE
fix(numberinput): v10 update styles for modal

### DIFF
--- a/.github/workflows/v10-release.yml
+++ b/.github/workflows/v10-release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.repos.createRelease({
+            const response = await github.rest.repos.createRelease({
               tag_name: context.ref,
               name: context.ref,
               draft: false,
@@ -53,6 +53,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
+            core.setOutput('upload_url', response.data.upload_url);
 
       - name: Upload Release Asset
         id: upload-release-asset

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -67,7 +67,7 @@
     }
 
     .#{$prefix}--number__rule-divider {
-      background-color: $border-subtle-02;
+      background-color: $decorative-01;
     }
   }
 

--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -60,8 +60,14 @@
     .#{$prefix}--dropdown-list,
     .#{$prefix}--number input[type='number'],
     .#{$prefix}--date-picker__input,
-    .#{$prefix}--multi-select {
+    .#{$prefix}--multi-select,
+    .#{$prefix}--number__control-btn::before,
+    .#{$prefix}--number__control-btn::after {
       background-color: $field-02;
+    }
+
+    .#{$prefix}--number__rule-divider {
+      background-color: $border-subtle-02;
     }
   }
 


### PR DESCRIPTION
Fix/continuation of https://github.com/carbon-design-system/carbon/pull/13806

Style changes were not ported over to `packages/components`

This also should fix the upload of the sketch asset to the github release that failed during the previous release https://github.com/carbon-design-system/carbon/actions/runs/4996104133/jobs/8948853885

#### Changelog

**Changed**

- port style changes from https://github.com/carbon-design-system/carbon/pull/13806 into `packages/components`

#### Testing / Reviewing

- Ensure styles for modal.scss match between `packages/styles` and `packages/components` except that the usage of the v11 token `$border-subtle-02` should instead be the v10 token `@decorative-01` as specified [here](https://github.com/carbon-design-system/carbon/blob/main/docs/migration/v11.md#design-tokens)
