### PR TITLE
fix(Tag): fixed a11y test by removing arialabel

### DIFF
--- a/packages/react/src/components/Tag/Tag-test.js
+++ b/packages/react/src/components/Tag/Tag-test.js
@@ -28,16 +28,14 @@ describe('Tag', () => {
   });
 
   it('should have an appropriate aria-label when (filterable)', () => {
-    const children = 'tag content';
+    const children = 'tag-3';
     const { container } = render(
       <Tag type="red" filter>
         {children}
       </Tag>
     );
-    const button = container.querySelector('[aria-label], [aria-labelledby]');
-    const accessibilityLabel =
-      button.getAttribute('aria-label') ||
-      button.getAttribute('aria-labelledby');
+    const button = container.querySelector('[aria-labelledby]');
+    const accessibilityLabel = button.getAttribute('aria-labelledby');
     // This check would mirror our "Accessibility label must contain at least all of visible label"
     // requirement
     expect(accessibilityLabel).toEqual(expect.stringContaining(children));

--- a/packages/react/src/components/Tag/Tag.js
+++ b/packages/react/src/components/Tag/Tag.js
@@ -59,15 +59,7 @@ const Tag = ({
 
   if (filter) {
     return (
-      <div
-        className={tagClasses}
-        aria-label={
-          title !== undefined
-            ? `${title} ${children}`
-            : `Clear filter ${children}`
-        }
-        id={tagId}
-        {...other}>
+      <div className={tagClasses} id={tagId} {...other}>
         <span
           className={`${prefix}--tag__label`}
           title={typeof children === 'string' ? children : null}>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/13706

`carbon-v10 update`

By removing the aria-label from the div tag the violation goes away.
I tested with the voice over from MacOS and the readability still works as expected.

### Testing / Reviewing

To reproduce the error or check the fix, you can follow these steps:

- Open the Tag storybook;
- In Controls section set the filter prop to true;
- Open the component itself in a new tab;
- Then run the IBM Equal Access Accessibility Checker;
- The violation should be gone.