### PR TITLE
fix(RadioButton): remove aria-readonly from fieldset

### DIFF
--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -213,7 +213,6 @@ const RadioButtonGroup = React.forwardRef(
           className={fieldsetClasses}
           disabled={disabled}
           data-invalid={invalid ? true : undefined}
-          aria-readonly={readOnly}
           aria-describedby={showHelper && helperText ? helperId : undefined}
           {...rest}>
           {legendText && (


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/13665

Removes `aria-readonly` from the underlying `fieldset` in `RadioButtonGroup`

#### Changelog

**Removed**

- Removed `aria-readonly` from `fieldset`

#### Testing / Reviewing

Ensure no a11y violations appear when `readOnly` is set to true in `Radio Button` story. 
