### PR TITLE
fix(sass): remove colons from classnames

### DIFF
--- a/packages/react/src/components/Layout/index.tsx
+++ b/packages/react/src/components/Layout/index.tsx
@@ -156,11 +156,11 @@ const LayoutConstraint = React.forwardRef<ReactNode, LayoutConstraintProps>(
         size,
         density,
       }).map(([group, constraints]) => ({
-        [`${prefix}--layout-constraint--${group}:default-${constraints?.default}`]:
+        [`${prefix}--layout-constraint--${group}---default-${constraints?.default}`]:
           constraints?.default,
-        [`${prefix}--layout-constraint--${group}:min-${constraints?.min}`]:
+        [`${prefix}--layout-constraint--${group}---min-${constraints?.min}`]:
           constraints?.min,
-        [`${prefix}--layout-constraint--${group}:max-${constraints?.max}`]:
+        [`${prefix}--layout-constraint--${group}---max-${constraints?.max}`]:
           constraints?.max,
       }))
     );

--- a/packages/react/src/components/Layout/index.tsx
+++ b/packages/react/src/components/Layout/index.tsx
@@ -156,11 +156,11 @@ const LayoutConstraint = React.forwardRef<ReactNode, LayoutConstraintProps>(
         size,
         density,
       }).map(([group, constraints]) => ({
-        [`${prefix}--layout-constraint--${group}---default-${constraints?.default}`]:
+        [`${prefix}--layout-constraint--${group}__default-${constraints?.default}`]:
           constraints?.default,
-        [`${prefix}--layout-constraint--${group}---min-${constraints?.min}`]:
+        [`${prefix}--layout-constraint--${group}__min-${constraints?.min}`]:
           constraints?.min,
-        [`${prefix}--layout-constraint--${group}---max-${constraints?.max}`]:
+        [`${prefix}--layout-constraint--${group}__max-${constraints?.max}`]:
           constraints?.max,
       }))
     );

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -634,7 +634,7 @@ Let's assume `my-component` supports sizes from `sm` to `lg` with a default of
 <div class="my-component">
   ...
   <div
-    class="cds--layout-constraint--size---default-md cds--layout-constraint--size---min-sm cds--layout-constraint--size---max-lg">
+    class="cds--layout-constraint--size__default-md cds--layout-constraint--size__min-sm cds--layout-constraint--size__max-lg">
     <!-- The button component will now be constrainted to the minimum size of 'sm', the maximum of 'lg' and default to 'md' -->
     <div class="button">...</div>
   </div>
@@ -649,13 +649,13 @@ All layout groups offer the following utility classes:
 <tr><td>
 
 ```
-cds--layout-constraint--group---default-step
+cds--layout-constraint--group__default-step
 ```
 
 </td><td>
 
 ```scss
-.cds--layout-constraint--group---default-step {
+.cds--layout-constraint--group__default-step {
   // for each property in this group:
   --cds-layout-group-property: var(
     --cds-layout-group-property-context,
@@ -667,13 +667,13 @@ cds--layout-constraint--group---default-step
 </td></tr><tr><td>
 
 ```
-cds--layout-constraint--group---min-step
+cds--layout-constraint--group__min-step
 ```
 
 </td><td>
 
 ```scss
-.cds--layout-constraint--group---min-step {
+.cds--layout-constraint--group__min-step {
   // for each property in this group:
   --cds-layout-group-property-min: var(
     --cds-layout-group-property-step,
@@ -685,13 +685,13 @@ cds--layout-constraint--group---min-step
 </td></tr><tr><td>
 
 ```
-cds--layout-constraint--group---max-step
+cds--layout-constraint--group__max-step
 ```
 
 </td><td>
 
 ```scss
-.cds--layout-constraint--group---max-step {
+.cds--layout-constraint--group__max-step {
   // for each property in this group:
   --cds-layout-group-property-max: var(
     --cds-layout-group-property-step,

--- a/packages/styles/docs/sass.md
+++ b/packages/styles/docs/sass.md
@@ -634,7 +634,7 @@ Let's assume `my-component` supports sizes from `sm` to `lg` with a default of
 <div class="my-component">
   ...
   <div
-    class="cds--layout-constraint--size:default-md cds--layout-constraint--size:min-sm cds--layout-constraint--size:max-lg">
+    class="cds--layout-constraint--size---default-md cds--layout-constraint--size---min-sm cds--layout-constraint--size---max-lg">
     <!-- The button component will now be constrainted to the minimum size of 'sm', the maximum of 'lg' and default to 'md' -->
     <div class="button">...</div>
   </div>
@@ -649,13 +649,13 @@ All layout groups offer the following utility classes:
 <tr><td>
 
 ```
-cds--layout-constraint--group:default-step
+cds--layout-constraint--group---default-step
 ```
 
 </td><td>
 
 ```scss
-.cds--layout-constraint--group\:default-step {
+.cds--layout-constraint--group---default-step {
   // for each property in this group:
   --cds-layout-group-property: var(
     --cds-layout-group-property-context,
@@ -667,13 +667,13 @@ cds--layout-constraint--group:default-step
 </td></tr><tr><td>
 
 ```
-cds--layout-constraint--group:min-step
+cds--layout-constraint--group---min-step
 ```
 
 </td><td>
 
 ```scss
-.cds--layout-constraint--group\:min-step {
+.cds--layout-constraint--group---min-step {
   // for each property in this group:
   --cds-layout-group-property-min: var(
     --cds-layout-group-property-step,
@@ -685,13 +685,13 @@ cds--layout-constraint--group:min-step
 </td></tr><tr><td>
 
 ```
-cds--layout-constraint--group:max-step
+cds--layout-constraint--group---max-step
 ```
 
 </td><td>
 
 ```scss
-.cds--layout-constraint--group\:max-step {
+.cds--layout-constraint--group---max-step {
   // for each property in this group:
   --cds-layout-group-property-max: var(
     --cds-layout-group-property-step,

--- a/packages/styles/scss/_layout.scss
+++ b/packages/styles/scss/_layout.scss
@@ -89,7 +89,7 @@ $layout-tokens: (
       }
 
       @each $constraint in ('min', 'max') {
-        .#{$prefix}--layout-constraint--#{$group}---#{$constraint}-#{$step} {
+        .#{$prefix}--layout-constraint--#{$group}__#{$constraint}-#{$step} {
           @include custom-property.declaration(
             'layout-#{$group}-#{$property}-#{$constraint}',
             custom-property.get-var(

--- a/packages/styles/scss/_layout.scss
+++ b/packages/styles/scss/_layout.scss
@@ -75,7 +75,7 @@ $layout-tokens: (
         );
       }
 
-      .#{$prefix}--layout-constraint--#{$group}\:default-#{$step} {
+      .#{$prefix}--layout-constraint--#{$group}---default-#{$step} {
         @include custom-property.declaration(
           'layout-#{$group}-#{$property}',
           custom-property.get-var(
@@ -89,7 +89,7 @@ $layout-tokens: (
       }
 
       @each $constraint in ('min', 'max') {
-        .#{$prefix}--layout-constraint--#{$group}\:#{$constraint}-#{$step} {
+        .#{$prefix}--layout-constraint--#{$group}---#{$constraint}-#{$step} {
           @include custom-property.declaration(
             'layout-#{$group}-#{$property}-#{$constraint}',
             custom-property.get-var(

--- a/packages/styles/scss/_layout.scss
+++ b/packages/styles/scss/_layout.scss
@@ -75,7 +75,7 @@ $layout-tokens: (
         );
       }
 
-      .#{$prefix}--layout-constraint--#{$group}---default-#{$step} {
+      .#{$prefix}--layout-constraint--#{$group}__default-#{$step} {
         @include custom-property.declaration(
           'layout-#{$group}-#{$property}',
           custom-property.get-var(


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/3599

`css-loader` is a dependency of `gatsby`, and when it converts classnames to js exports, `css-loader` does not convert reserved and control filesystem characters (`<>:"/\|?*`) contained within the className. [link to docs](https://github.com/webpack-contrib/css-loader#localidentname:~:text=The%20%5Blocal%5D,to%20%2D.)

Since the layout constraint classes contained colons, this resulted in css-loader outputting invalid js variable names that also contained colons (as shown in the original issue), causing gatsby site compilation to fail. This would likely fail in any webpack-based app as well.

#### Changelog

**Changed**

- modify usage of `:` within classnames to be `__` instead
- update related documentation

