### PR TITLE
fix(ListBox): backport listbox a11y fixes to v10

### DIFF
--- a/packages/components/src/components/form/_form.scss
+++ b/packages/components/src/components/form/_form.scss
@@ -85,7 +85,7 @@
     > .#{$prefix}--text-area--invalid:not(:focus),
   .#{$prefix}--select-input__wrapper[data-invalid]
     .#{$prefix}--select-input:not(:focus),
-  .#{$prefix}--list-box[data-invalid]:not(:focus),
+  .#{$prefix}--list-box[data-invalid]:not(.#{$prefix}--multi-select--invalid--focused),
   .#{$prefix}--combo-box[data-invalid] .#{$prefix}--text-input:not(:focus) {
     @include focus-outline('invalid');
   }

--- a/packages/components/src/components/multi-select/_multi-select.scss
+++ b/packages/components/src/components/multi-select/_multi-select.scss
@@ -10,6 +10,7 @@
 //-----------------------------
 
 @import '../../globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
+@import '../../globals/scss/helper-mixins';
 @import '../../globals/scss/vars';
 @import '../checkbox/checkbox';
 @import '../list-box/list-box';
@@ -18,9 +19,20 @@
 /// @access private
 /// @group multi-select
 @mixin multiselect {
+  .#{$prefix}--multi-select .#{$prefix}--list-box__field--wrapper {
+    display: inline-flex;
+    width: 100%;
+    height: calc(100% + 1px);
+    align-items: center;
+  }
+
+  .#{$prefix}--multi-select .#{$prefix}--list-box__field:focus {
+    @include focus-outline('reset');
+  }
+
   .#{$prefix}--multi-select .#{$prefix}--tag {
     min-width: auto;
-    margin: 0 $carbon--spacing-03 0 0;
+    margin: 0 $spacing-03 0 $spacing-05;
   }
 
   .#{$prefix}--multi-select--filterable .#{$prefix}--tag {
@@ -76,12 +88,16 @@
     outline: none;
   }
 
-  .#{$prefix}--multi-select--filterable--input-focused {
+  .#{$prefix}--multi-select--filterable--input-focused,
+  .#{$prefix}--multi-select
+    .#{$prefix}--list-box__field--wrapper--input-focused {
     @include focus-outline('outline');
   }
 
   .#{$prefix}--multi-select--filterable.#{$prefix}--multi-select--selected
-    .#{$prefix}--text-input {
+    .#{$prefix}--text-input,
+  .#{$prefix}--multi-select.#{$prefix}--multi-select--selected
+    .#{$prefix}--list-box__field {
     padding-left: 0;
   }
 

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -291,6 +291,14 @@ const ComboBox = React.forwardRef((props, ref) => {
             if (match(event, keys.Enter) && !inputValue) {
               toggleMenu();
             }
+
+            if (match(event, keys.Escape) && inputValue) {
+              if (event.target === textInput.current && isOpen) {
+                toggleMenu();
+                event.preventDownshiftDefault = true;
+                event.persist();
+              }
+            }
           },
         });
 

--- a/packages/react/src/components/ListBox/ListBoxSelection.js
+++ b/packages/react/src/components/ListBox/ListBoxSelection.js
@@ -9,7 +9,6 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Close16 } from '@carbon/icons-react';
-import { match, keys } from '../../internal/keyboard';
 import { usePrefix } from '../../internal/usePrefix';
 
 /**
@@ -39,20 +38,7 @@ const ListBoxSelection = ({
       onClearSelection(event);
     }
   };
-  const handleOnKeyDown = (event) => {
-    event.stopPropagation();
-    if (disabled) {
-      return;
-    }
 
-    // When a user hits ENTER, we'll clear the selection
-    if (match(event, keys.Enter)) {
-      clearSelection(event);
-      if (onClearSelection) {
-        onClearSelection(event);
-      }
-    }
-  };
   const description = selectionCount ? t('clear.all') : t('clear.selection');
   const tagClasses = cx(
     `${prefix}--tag`,
@@ -62,6 +48,8 @@ const ListBoxSelection = ({
       [`${prefix}--tag--disabled`]: disabled,
     }
   );
+
+  /* eslint-disable jsx-a11y/click-events-have-key-events */
   return selectionCount ? (
     <div className={tagClasses}>
       <span className={`${prefix}--tag__label`} title={selectionCount}>
@@ -69,10 +57,9 @@ const ListBoxSelection = ({
       </span>
       <div
         role="button"
-        tabIndex={disabled ? -1 : 0}
+        tabIndex={-1}
         className={`${prefix}--tag__close-icon`}
         onClick={handleOnClick}
-        onKeyDown={handleOnKeyDown}
         disabled={disabled}
         aria-label={t('clear.all')}
         title={description}>
@@ -83,9 +70,8 @@ const ListBoxSelection = ({
     <div
       role="button"
       className={className}
-      tabIndex={disabled ? -1 : 0}
+      tabIndex={-1}
       onClick={handleOnClick}
-      onKeyDown={handleOnKeyDown}
       aria-label={description}
       title={description}>
       {selectionCount}

--- a/packages/react/src/components/ListBox/__tests__/ListBoxSelection-test.js
+++ b/packages/react/src/components/ListBox/__tests__/ListBoxSelection-test.js
@@ -44,16 +44,6 @@ describe('ListBoxSelection', () => {
     expect(mockProps.clearSelection).toHaveBeenCalled();
   });
 
-  it('should call clearSelection on Enter keydown', () => {
-    const wrapper = mount(<ListBox.Selection {...mockProps} />);
-    wrapper.simulate('keydown', {
-      key: 'Enter',
-      keyCode: 13,
-      which: 13,
-    });
-    expect(mockProps.clearSelection).toHaveBeenCalled();
-  });
-
   it('should not clearSelection on click when disabled', () => {
     const wrapper = mount(<ListBox.Selection {...mockProps} disabled={true} />);
     wrapper.simulate('click');

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -17,9 +17,8 @@ exports[`ListBoxField should render 1`] = `
         aria-label="Clear selected item"
         className="bx--list-box__selection"
         onClick={[Function]}
-        onKeyDown={[Function]}
         role="button"
-        tabIndex={0}
+        tabIndex={-1}
         title="Clear selected item"
       >
         <ForwardRef(Close16)>

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -37,9 +37,8 @@ exports[`ListBoxSelection should render 1`] = `
     aria-label="translation"
     className="bx--list-box__selection"
     onClick={[Function]}
-    onKeyDown={[Function]}
     role="button"
-    tabIndex={0}
+    tabIndex={-1}
     title="translation"
   >
     <ForwardRef(Close16)>
@@ -118,9 +117,8 @@ exports[`ListBoxSelection should render 2`] = `
       aria-label="translation"
       className="bx--tag__close-icon"
       onClick={[Function]}
-      onKeyDown={[Function]}
       role="button"
-      tabIndex={0}
+      tabIndex={-1}
       title="translation"
     >
       <ForwardRef(Close16)>

--- a/packages/react/src/components/ListBox/next/ListBoxSelection.js
+++ b/packages/react/src/components/ListBox/next/ListBoxSelection.js
@@ -9,7 +9,6 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Close16 } from '@carbon/icons-react';
-import { match, keys } from '../../../internal/keyboard';
 import { usePrefix } from '../../../internal/usePrefix';
 
 /**
@@ -51,21 +50,6 @@ function ListBoxSelection({
     }
   }
 
-  function onKeyDown(event) {
-    event.stopPropagation();
-    if (disabled) {
-      return;
-    }
-
-    // When a user hits ENTER, we'll clear the selection
-    if (match(event, keys.Enter)) {
-      clearSelection(event);
-      if (onClearSelection) {
-        onClearSelection(event);
-      }
-    }
-  }
-
   if (selectionCount) {
     return (
       <div className={tagClasses}>
@@ -77,8 +61,7 @@ function ListBoxSelection({
           className={`${prefix}--tag__close-icon`}
           disabled={disabled}
           onClick={onClick}
-          onKeyDown={onKeyDown}
-          tabIndex={disabled ? -1 : 0}
+          tabIndex={-1}
           title={description}
           type="button">
           <Close16 />
@@ -93,8 +76,7 @@ function ListBoxSelection({
       aria-label={description}
       className={className}
       onClick={onClick}
-      onKeyDown={onKeyDown}
-      tabIndex={disabled ? -1 : 0}
+      tabIndex={-1}
       title={description}
       type="button">
       <Close16 />

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -349,6 +349,7 @@ export default class FilterableMultiSelect extends React.Component {
         {(prefix) => {
           const wrapperClasses = cx(
             `${prefix}--multi-select__wrapper`,
+            `${prefix}--multi-select--filterable__wrapper`,
             `${prefix}--list-box__wrapper`,
             [enabled ? containerClassName : null],
             {
@@ -423,6 +424,7 @@ export default class FilterableMultiSelect extends React.Component {
                     inputValue,
                     selectedItem,
                   }) => {
+                    console.log(this.state.inputFocused);
                     const className = cx(
                       `${prefix}--multi-select`,
                       `${prefix}--combo-box`,
@@ -430,6 +432,8 @@ export default class FilterableMultiSelect extends React.Component {
                       [enabled ? null : containerClassName],
                       {
                         [`${prefix}--multi-select--invalid`]: invalid,
+                        [`${prefix}--multi-select--invalid--focused`]:
+                          invalid && this.state.inputFocused,
                         [`${prefix}--multi-select--open`]: isOpen,
                         [`${prefix}--multi-select--inline`]: inline,
                         [`${prefix}--multi-select--selected`]:
@@ -483,12 +487,30 @@ export default class FilterableMultiSelect extends React.Component {
                         if (match(event, keys.Space)) {
                           event.stopPropagation();
                         }
+
+                        if (!disabled) {
+                          if (
+                            match(event, keys.Delete) ||
+                            match(event, keys.Escape)
+                          ) {
+                            if (isOpen) {
+                              this.handleOnMenuChange(true);
+                              this.clearInputValue();
+                              event.stopPropagation();
+                            } else if (!isOpen) {
+                              this.clearInputValue();
+                              clearSelection();
+                              event.stopPropagation();
+                            }
+                          }
+                        }
                       },
                       onFocus: () => {
                         this.setState({ inputFocused: true });
                       },
                       onBlur: () => {
-                        this.setState({ inputFocused: false });
+                        this.setState({ inputFocused: false, inputValue: '' });
+                        this.handleOnMenuChange(false);
                       },
                     });
                     const menuProps = getMenuProps(

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -424,7 +424,6 @@ export default class FilterableMultiSelect extends React.Component {
                     inputValue,
                     selectedItem,
                   }) => {
-                    console.log(this.state.inputFocused);
                     const className = cx(
                       `${prefix}--multi-select`,
                       `${prefix}--combo-box`,

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -80,7 +80,7 @@ exports[`FilterableMultiSelect should render 1`] = `
       suppressRefError={false}
     >
       <div
-        className="bx--multi-select__wrapper bx--list-box__wrapper"
+        className="bx--multi-select__wrapper bx--multi-select--filterable__wrapper bx--list-box__wrapper"
       >
         <ListBox
           className="bx--multi-select bx--combo-box bx--multi-select--filterable"

--- a/packages/react/src/components/MultiSelect/next/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/next/FilterableMultiSelect.js
@@ -84,6 +84,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
 
   const wrapperClasses = cx(
     `${prefix}--multi-select__wrapper`,
+    `${prefix}--multi-select--filterable__wrapper`,
     `${prefix}--list-box__wrapper`,
     [enabled ? containerClassName : null],
     {
@@ -238,6 +239,8 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
               [enabled ? null : containerClassName],
               {
                 [`${prefix}--multi-select--invalid`]: invalid,
+                [`${prefix}--multi-select--invalid--focused`]:
+                  invalid && inputFocused,
                 [`${prefix}--multi-select--open`]: isOpen,
                 [`${prefix}--multi-select--inline`]: inline,
                 [`${prefix}--multi-select--selected`]: selectedItem.length > 0,
@@ -290,12 +293,27 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
                 if (match(event, keys.Space)) {
                   event.stopPropagation();
                 }
+
+                if (!disabled) {
+                  if (match(event, keys.Delete) || match(event, keys.Escape)) {
+                    if (isOpen) {
+                      handleOnMenuChange(true);
+                      clearInputValue();
+                      event.stopPropagation();
+                    } else if (!isOpen) {
+                      clearInputValue();
+                      clearSelection();
+                      event.stopPropagation();
+                    }
+                  }
+                }
               },
               onFocus: () => {
                 setInputFocused(true);
               },
               onBlur: () => {
                 setInputFocused(false);
+                setInputValue('');
               },
             });
 

--- a/packages/react/src/components/MultiSelect/next/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/next/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -80,7 +80,7 @@ exports[`FilterableMultiSelect should render 1`] = `
       suppressRefError={false}
     >
       <div
-        className="bx--multi-select__wrapper bx--list-box__wrapper"
+        className="bx--multi-select__wrapper bx--multi-select--filterable__wrapper bx--list-box__wrapper"
       >
         <ListBox
           className="bx--multi-select bx--combo-box bx--multi-select--filterable"

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -77,7 +77,7 @@ $input-label-weight: 400 !default;
     > .#{$prefix}--text-area--invalid:not(:focus),
   .#{$prefix}--select-input__wrapper[data-invalid]
     .#{$prefix}--select-input:not(:focus),
-  .#{$prefix}--list-box[data-invalid]:not(:focus),
+  .#{$prefix}--list-box[data-invalid]:not(.#{$prefix}--multi-select--invalid--focused),
   .#{$prefix}--combo-box[data-invalid] .#{$prefix}--text-input:not(:focus) {
     @include focus-outline('invalid');
   }

--- a/packages/styles/scss/components/multiselect/_multiselect.scss
+++ b/packages/styles/scss/components/multiselect/_multiselect.scss
@@ -17,9 +17,20 @@
 /// @access public
 /// @group multi-select
 @mixin multiselect {
+  .#{$prefix}--multi-select .#{$prefix}--list-box__field--wrapper {
+    display: inline-flex;
+    width: 100%;
+    height: calc(100% + 1px);
+    align-items: center;
+  }
+
+  .#{$prefix}--multi-select .#{$prefix}--list-box__field:focus {
+    @include focus-outline('reset');
+  }
+
   .#{$prefix}--multi-select .#{$prefix}--tag {
     min-width: auto;
-    margin: 0 $spacing-03 0 0;
+    margin: 0 $spacing-03 0 $spacing-05;
   }
 
   .#{$prefix}--multi-select--filterable .#{$prefix}--tag {
@@ -75,12 +86,16 @@
     outline: none;
   }
 
-  .#{$prefix}--multi-select--filterable--input-focused {
+  .#{$prefix}--multi-select--filterable--input-focused,
+  .#{$prefix}--multi-select
+    .#{$prefix}--list-box__field--wrapper--input-focused {
     @include focus-outline('outline');
   }
 
   .#{$prefix}--multi-select--filterable.#{$prefix}--multi-select--selected
-    .#{$prefix}--text-input {
+    .#{$prefix}--text-input,
+  .#{$prefix}--multi-select.#{$prefix}--multi-select--selected
+    .#{$prefix}--list-box__field {
     padding-left: 0;
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14069
Refs #13173

Backports a11y fixes to v10

#### Changelog

**Changed**

- `x` no longer receives focus (`Multiselect` selection, clear text from `ComboBox` + `FilterableMultiselect`, items can be cleared via `esc` key. Can still click to activate.
- Rearranged `Multiselect` so that the selection tag/button is not a descendant of another button
- CSS fixes also ported over

#### Testing / Reviewing

Check `ComboBox`, `Multiselect`, and `FilterableMultiselect` and ensure all functionality matches v11, and there are not a11y violations