### PR TITLE
fix(UIShell): refactor displayName check

### DIFF
--- a/packages/react/src/components/UIShell/HeaderPanel.js
+++ b/packages/react/src/components/UIShell/HeaderPanel.js
@@ -71,7 +71,7 @@ const HeaderPanel = React.forwardRef(function HeaderPanel(
     setLastClickedElement(focusedElement);
 
     if (
-      children.type.__docgenInfo.displayName === 'Switcher' &&
+      children.type?.displayName === 'Switcher' &&
       !focusedElement?.closest(`.${prefix}--header-panel--expanded`) &&
       !focusedElement?.closest(`.${prefix}--header__action`) &&
       !headerPanelRef?.current?.classList.contains(`${prefix}--switcher`) &&


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14096

Uses consistent displayName checking that is found in other components. The previous usage was causing errors in tests and in the console. 

#### Changelog


**Changed**

- `children.type?.displayName === 'Switcher'` instead of `children.type.__docgenInfo.displayName === 'Switcher'`


#### Testing / Reviewing

Ensure the Header Base w/ Actions and Switcher story still closes the switcher when clicking outside the switcher