### PR TITLE
fix(DataTable): check for undefined document obj

### DIFF
--- a/packages/react/src/components/DataTable/Table.tsx
+++ b/packages/react/src/components/DataTable/Table.tsx
@@ -186,7 +186,11 @@ export const Table = ({
   useWindowEvent('resize', debouncedSetTableAlignment);
 
   // recalculate table alignment once fonts have loaded
-  if (typeof document !== 'undefined' && document?.fonts?.status && document.fonts.status !== 'loaded') {
+  if (
+    typeof document !== 'undefined' &&
+    document?.fonts?.status &&
+    document.fonts.status !== 'loaded'
+  ) {
     document.fonts.ready.then(() => {
       setTableAlignment();
     });

--- a/packages/react/src/components/DataTable/Table.tsx
+++ b/packages/react/src/components/DataTable/Table.tsx
@@ -186,7 +186,7 @@ export const Table = ({
   useWindowEvent('resize', debouncedSetTableAlignment);
 
   // recalculate table alignment once fonts have loaded
-  if (document?.fonts?.status && document.fonts.status !== 'loaded') {
+  if (typeof document !== 'undefined' && document?.fonts?.status && document.fonts.status !== 'loaded') {
     document.fonts.ready.then(() => {
       setTableAlignment();
     });


### PR DESCRIPTION
Closes #14107 

Adds check for `undefined` document type before accessing variable

#### Changelog

**Changed**

- Add edcheck for `undefined` document type before accessing variable

#### Testing / Reviewing

There's really no way to test this. I tested by running a nextJs app and manually overwriting the node_modules with these changes and verifying the error is no longer present.

Note: I opted for the `typeof document !== 'undefined' &&` instead of the suggested `document &&` approach because the latter didn't seem to work when I was testing in `node_modules`