### PR TITLE
fix(peerDependencies): make sass optional for styles - Solves @carbon/charts example issue

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -35,7 +35,7 @@
     "sass": {
       "optional": true
     }
-	},
+  },
   "dependencies": {
     "@carbon/colors": "^11.16.0",
     "@carbon/feature-flags": "^0.15.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -31,10 +31,10 @@
   "peerDependencies": {
     "sass": "^1.33.0"
   },
-  	"peerDependenciesMeta": {
-		"sass": {
-			"optional": true
-		}
+  "peerDependenciesMeta": {
+    "sass": {
+      "optional": true
+    }
 	},
   "dependencies": {
     "@carbon/colors": "^11.16.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -31,6 +31,11 @@
   "peerDependencies": {
     "sass": "^1.33.0"
   },
+  	"peerDependenciesMeta": {
+		"sass": {
+			"optional": true
+		}
+	},
   "dependencies": {
     "@carbon/colors": "^11.16.0",
     "@carbon/feature-flags": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,6 +2502,9 @@ __metadata:
     sass: ^1.51.0
   peerDependencies:
     sass: ^1.33.0
+  peerDependenciesMeta:
+    sass:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I am a contributor to `@carbon/charts`. This PR solves a problem with the Carbon Charts StackBlitz examples forcing users to install sass. This is because each example calls `import '@carbon/styles/css/styles.css` and `sass` is a non-optional peerDependency for `@carbon/styles`.

As `@carbon/styles` can be used without `sass` (as is the case shown above importing just the CSS file), `sass` should not be a mandatory peerDependency. This PR solves that.

#### Changelog

**Changed**

- Added peerDependenciesMeta property to packages/styles/package.json indicating `sass` is an optional peer dependency

#### Testing / Reviewing

Setup any kind of project and add `@carbon/styles` as a dependency and leave out `sass`. You will get a warning from npm or yarn.
