### PR TITLE
fix(UIShell): various fixes to avoid null pointer assertions

### DIFF
--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -177,7 +177,7 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
       if (!other.disabled && onChange) {
         // delay textCount assignation to give the textarea element value time to catch up if is a controlled input
         setTimeout(() => {
-          setTextCount(evt.target.value?.length);
+          setTextCount(evt.target?.value?.length);
         }, 0);
         onChange(evt);
       }

--- a/packages/react/src/components/UIShell/HeaderPanel.js
+++ b/packages/react/src/components/UIShell/HeaderPanel.js
@@ -46,7 +46,7 @@ const HeaderPanel = React.forwardRef(function HeaderPanel(
     eventHandlers.onBlur = (event) => {
       if (
         !event.currentTarget.contains(event.relatedTarget) &&
-        !lastClickedElement.classList.contains('cds--switcher__item-link')
+        !lastClickedElement?.classList?.contains('cds--switcher__item-link')
       ) {
         setExpandedState(false);
         setLastClickedElement(null);

--- a/packages/react/src/components/UIShell/Switcher.js
+++ b/packages/react/src/components/UIShell/Switcher.js
@@ -66,13 +66,24 @@ const Switcher = React.forwardRef(function Switcher(props, forwardRef) {
   };
 
   const childrenWithProps = React.Children.toArray(children).map(
-    (child, index) =>
+    (child, index) => {
+      // handleSwitcherItemFocus should only be passed down if the child is a SwitcherItem
+      // SwitcherDivider, for example, does not accept a handleSwitcherItemFocus prop
+      if (child.type?.displayName === 'SwitcherItem') {
+        React.cloneElement(child, {
+          handleSwitcherItemFocus,
+          index,
+          key: index,
+          expanded,
+        });
+      }
+
       React.cloneElement(child, {
-        handleSwitcherItemFocus,
         index,
         key: index,
         expanded,
-      })
+      });
+    }
   );
 
   return (

--- a/packages/react/src/components/UIShell/Switcher.js
+++ b/packages/react/src/components/UIShell/Switcher.js
@@ -70,7 +70,7 @@ const Switcher = React.forwardRef(function Switcher(props, forwardRef) {
       // handleSwitcherItemFocus should only be passed down if the child is a SwitcherItem
       // SwitcherDivider, for example, does not accept a handleSwitcherItemFocus prop
       if (child.type?.displayName === 'SwitcherItem') {
-        React.cloneElement(child, {
+        return React.cloneElement(child, {
           handleSwitcherItemFocus,
           index,
           key: index,
@@ -78,7 +78,7 @@ const Switcher = React.forwardRef(function Switcher(props, forwardRef) {
         });
       }
 
-      React.cloneElement(child, {
+      return React.cloneElement(child, {
         index,
         key: index,
         expanded,


### PR DESCRIPTION
Surfaced in office hours this morning, a few bugs relating to UIShell and TextArea

#### Changelog

**Changed**

- protect against null pointer exceptions with optional chaining
- only pass handleSwitcherItemFocus to components that accept that prop