### PR TITLE
fix(search): screen reader announces search region twice

### DIFF
--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -99,7 +99,7 @@ export interface SearchProps extends InputPropsBase {
   renderIcon?: ComponentType | FunctionComponent;
 
   /**
-   * Specify the role for the underlying `<input>`, defaults to `searchbox`
+   * Optional prop to specify the role for the underlying `<input>`
    */
   role?: string;
 
@@ -137,7 +137,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
     onExpand,
     placeholder = 'Search',
     renderIcon,
-    role = 'searchbox',
+    role,
     size = 'md',
     type = 'text',
     value,
@@ -204,7 +204,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
   }
 
   return (
-    <div role="search" aria-label={placeholder} className={searchClasses}>
+    <div role="search"className={searchClasses}>
       {/* the magnifier is used in ExpandableSearch as a click target to expand,
       however, it does not need a keyboard event bc the input element gets focus on keyboard nav and expands that way*/}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
@@ -333,7 +333,7 @@ Search.propTypes = {
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
-   * Specify the role for the underlying `<input>`, defaults to `searchbox`
+   * Optional prop to specify the role for the underlying `<input>`
    */
   role: PropTypes.string,
 


### PR DESCRIPTION
Closes #13945

This PR removes redundant aria-lable and role=searchbox from the Search component

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role

> Including role="searchbox" when the form is a search and the label indicates the element is a search may result in assistive technology announcing something along the lines of "search search this site search box", which is redundant. The inclusion of role="searchbox" is not necessary:

>Screen readers will announce the type of role the landmark is. Because of this, you do not need to describe what the landmark is in its label. For example, a declaration of role="search" with an [aria-label="Sitewide search"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) may be announced redundantly as, "sitewide search search".

#### Changelog

**Changed**
- Updated tests 

**Removed**

- remove aria-label from containing div
- remove role=searchbox

#### Testing / Reviewing

Check using voiceover (and jaws if possible) that search is no longer read twice on any of the search stories / container list with search. Should be no a11y violations. Nothing should change functionally. 
