### PR TITLE
fix(release-notifications): use app token for authentication

### DIFF
--- a/.github/workflows/release-notifications.yml
+++ b/.github/workflows/release-notifications.yml
@@ -11,12 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Add release information on pull requests
         uses: ./actions/release-notifications
         with:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           OWNER: 'carbon-design-system'
           REPO_NAME: 'carbon'
           enabled: true
-        env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
This workflow [has been failing](https://github.com/carbon-design-system/carbon/actions/runs/5486593631/jobs/9996889645) due to [rate limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting) on the API calls used to post comments on the related issues. This should bump the allowed rate up to 15000 calls/hr

#### Changelog

**Changed**

- swap out the token for one generated via the Carbon GitHub App

**Removed**

- remove unused ACCESS_TOKEN secret (I couldn't find anything this was being used for 🤔)
