### PR TITLE
fix(ComboButton): import IconButton before Button

### DIFF
--- a/packages/react/src/components/ComboButton/index.js
+++ b/packages/react/src/components/ComboButton/index.js
@@ -10,8 +10,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { ChevronDown } from '@carbon/icons-react';
-import { Button } from '../Button';
 import { IconButton } from '../IconButton';
+import { Button } from '../Button';
 import { Menu } from '../Menu';
 
 import { useAttachedMenu } from '../../internal/useAttachedMenu';


### PR DESCRIPTION
Fixes for broken ComboButton story.

#### Changelog

**Changed**

- Put Button import under IconButton import in ComboButton's index file

#### Testing / Reviewing

Make sure ComboButton stories are able to render in preview