### PR TITLE
fix(modal-v10): remove aria-labelledby from modal body

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -490,8 +490,7 @@ export default class Modal extends Component {
         <div
           id={this.modalBodyId}
           className={contentClasses}
-          {...hasScrollingContentProps}
-          aria-labelledby={getAriaLabelledBy}>
+          {...hasScrollingContentProps}>
           {this.props.children}
         </div>
         {hasScrollingContent && (

--- a/packages/react/src/components/Modal/next/Modal.js
+++ b/packages/react/src/components/Modal/next/Modal.js
@@ -240,8 +240,7 @@ const Modal = React.forwardRef(function Modal(
       <div
         id={modalBodyId}
         className={contentClasses}
-        {...hasScrollingContentProps}
-        aria-labelledby={getAriaLabelledBy}>
+        {...hasScrollingContentProps}>
         {children}
       </div>
       {hasScrollingContent && (

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -143,7 +143,6 @@ exports[`ModalWrapper should render 1`] = `
             </button>
           </div>
           <div
-            aria-labelledby="bx--modal-header__label--modal-1"
             className="bx--modal-content"
             id="bx--modal-body--modal-1"
           >


### PR DESCRIPTION
Closes #14161

Backporting https://github.com/carbon-design-system/carbon/pull/13840/files#diff-22f235c4784785309ea4abec2fa146f38d2be0d56b42466af68a247a0fe898b3R246 to v10

#### Changelog

**Removed**

- remove aria-labelledby from modal body

#### Testing / Reviewing

- the accessibility-checker violation described in the original issue should no longer be present
