### PR TITLE
fix(storybook): fix issue with text rendering in storybook props table

### DIFF
--- a/packages/react/.storybook/styles.scss
+++ b/packages/react/.storybook/styles.scss
@@ -28,3 +28,20 @@ body {
   background: styles.$background;
   color: styles.$text-primary;
 }
+
+// Docs overrides
+.docblock-argstable-head ~ .docblock-argstable-body,
+.docblock-argstable-head ~ .docblock-argstable-body p {
+  @include styles.type-style('body-01');
+}
+
+.docblock-argstable-head ~ .docblock-argstable-body table tbody {
+  filter: none;
+}
+
+/* stylelint-disable */
+.docblock-argstable-head ~ .docblock-argstable-body table tbody > tr > td {
+  border: none !important;
+  box-shadow: none;
+}
+/* stylelint-enable */


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14040

Fixes an issue with some weird visual bugs / text rendering in different sizes in the props table in storybook

#### Changelog

**New**

- Added some storybook-specific styles to target these incorrect styles. 


#### Testing / Reviewing

Open up the storybook and navigate to a props table, ensure all the text is the same size and that the props marked `deprecated` don't have a weird border around them 
