### PR TITLE
docs(datatable): add a disabled button to the batch action example story

### DIFF
--- a/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
@@ -85,7 +85,8 @@ export const Default = () => (
               <TableBatchAction
                 tabIndex={batchActionProps.shouldShowBatchActions ? 0 : -1}
                 renderIcon={TrashCan}
-                onClick={batchActionClick(selectedRows)}>
+                onClick={batchActionClick(selectedRows)}
+                disabled>
                 Delete
               </TableBatchAction>
               <TableBatchAction


### PR DESCRIPTION
@thyhmdo noticed we no longer had an example of a disabled button in the batch action bar in the storybook

#### Changelog

**Changed**

- disabled the 'delete' button in the default batch action story

#### Testing / Reviewing

- Ensure the button is disabled and has the appropriate styling, isn't interactable, etc.
