### PR TITLE
chore(workflows): update workflows to be compatible with GH merge queue

### DIFF
--- a/.github/workflows/add-to-merge-queue.yml
+++ b/.github/workflows/add-to-merge-queue.yml
@@ -1,0 +1,23 @@
+name: Add To Merge Queue
+on:
+  pull_request:
+    types: [labeled]
+
+env:
+  LABEL_READY_TO_MERGE: 'status: ready to merge 🎉'
+  LABEL_ENABLE_AUTOMERGE: 'status: enable automerge 🟠'
+
+jobs:
+  add-to-merge-queue:
+    name: Add the PR to the merge queue
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Add to merge queue if either of the automerge labels are added'
+        if:
+          ${{ contains(github.event.issue.labels.*.name,
+          env.LABEL_READY_TO_MERGE) ||
+          contains(github.event.issue.labels.*.name, env.LABEL_ENABLE_AUTOMERGE)
+          }}
+        run: gh pr merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -138,7 +140,8 @@ jobs:
       - name: Build project
         run: yarn build
       - name: Build storybook
-        run: STORYBOOK_STORE_7=false yarn workspace @carbon/react storybook:build
+        run:
+          STORYBOOK_STORE_7=false yarn workspace @carbon/react storybook:build
       - name: Run storybook
         id: storybook
         run: |
@@ -196,7 +199,8 @@ jobs:
       - name: Build project
         run: yarn build
       - name: Build storybook
-        run: STORYBOOK_STORE_7=false yarn workspace @carbon/react storybook:build
+        run:
+          STORYBOOK_STORE_7=false yarn workspace @carbon/react storybook:build
       - name: Run storybook
         id: storybook
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, v10]
   pull_request:
     branches: [main, v10]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '0 12 * * 1'
 

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,31 +1,44 @@
-name: "DCO Assistant"
+name: 'DCO Assistant'
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   DCO:
     runs-on: ubuntu-latest
     steps:
-      - name: "DCO Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO document and I hereby sign the DCO.') || github.event_name == 'pull_request_target'
+      - name: 'DCO Assistant'
+        if:
+          (github.event.comment.body == 'recheck' || github.event.comment.body
+          == 'I have read the DCO document and I hereby sign the DCO.') ||
+          github.event_name == 'pull_request_target'
         uses: cla-assistant/github-action@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-signatures: "dco-signatures.json"
-          path-to-document: "https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md"
-          branch: "main"
+          path-to-signatures: 'dco-signatures.json'
+          path-to-document: 'https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md'
+          branch: 'main'
           allowlist: bot*
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-dco
-          create-file-commit-message: "chore: create file to store dco signatures"
-          signed-commit-message: "chore: $contributorName has signed the dco in #$pullRequestNo"
-          custom-notsigned-prcomment: "Thanks for your submission! We ask that $you sign our [Developer Certificate of Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md) before we can accept your contribution. You can sign the DCO by adding a comment below using this text:"
-          custom-pr-sign-comment: "I have read the DCO document and I hereby sign the DCO."
-          custom-allsigned-prcomment: "All contributors have signed the DCO."
+          create-file-commit-message:
+            'chore: create file to store dco signatures'
+          signed-commit-message:
+            'chore: $contributorName has signed the dco in #$pullRequestNo'
+          custom-notsigned-prcomment:
+            'Thanks for your submission! We ask that $you sign our [Developer
+            Certificate of
+            Origin](https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md)
+            before we can accept your contribution. You can sign the DCO by
+            adding a comment below using this text:'
+          custom-pr-sign-comment:
+            'I have read the DCO document and I hereby sign the DCO.'
+          custom-allsigned-prcomment: 'All contributors have signed the DCO.'
           lock-pullrequest-aftermerge: false
           use-dco-flag: true

--- a/.github/workflows/v10-ci.yml
+++ b/.github/workflows/v10-ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - v10
+  merge_group:
+    types: [checks_requested]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,7 +1,0 @@
-# .kodiak.toml
-version = 1
-
-[merge]
-automerge_label = ["status: ready to merge 🎉", "status: enable automerge 🟠"]
-notify_on_conflict = "false"
-method = "squash"


### PR DESCRIPTION
This updates our CI workflows to be compatible with the [GitHub merge queue](https://github.blog/2023-07-12-github-merge-queue-is-generally-available/)

#### Changelog

**New**

- add new workflow to add PRs to the merge queue if the `ready to merge` or `automerge` labels are applied to a PR

**Changed**

- update workflows to trigger on `merge_group`
