### PR TITLE
chore(test): add avt for tile

### DIFF
--- a/e2e/components/Tile/Tile-test.avt.e2e.js
+++ b/e2e/components/Tile/Tile-test.avt.e2e.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('Tile @avt', () => {
+  test('Tile default state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Tile',
+      id: 'components-tile--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Tile');
+  });
+
+  test('ClickableTile default state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ClickableTile',
+      id: 'components-tile--clickable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('ClickableTile');
+  });
+
+  test('ExpandableTile default state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ExpandableTile',
+      id: 'components-tile--expandable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('ExpandableTile');
+  });
+
+  test('SelectableTile default state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'SelectableTile',
+      id: 'components-tile--selectable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('SelectableTile');
+  });
+
+  test('SelectableTile multi-select default state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'SelectableTile',
+      id: 'components-tile--multi-select',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('SelectableTile multi-select');
+  });
+
+  test('RadioTile default state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'RadioTile',
+      id: 'components-tile--radio',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('RadioTile');
+  });
+
+  test('ClickableTile disabled state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Tile',
+      id: 'components-tile--clickable',
+      globals: {
+        theme: 'white',
+      },
+      args: {
+        disabled: 'true',
+      },
+    });
+    await expect(page.locator('a#clickable-tile-1')).toBeDisabled();
+    await expect(page).toHaveNoACViolations('ClickableTile-Disabled');
+  });
+
+  test('ExpandableTile expanded state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ExpandableTile',
+      id: 'components-tile--expandable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    // Expand Tile by keyboard
+    // todo
+
+    // The tile should expand
+    // todo
+  });
+});

--- a/e2e/components/Tile/Tile-test.avt.e2e.js
+++ b/e2e/components/Tile/Tile-test.avt.e2e.js
@@ -92,7 +92,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('ClickableTile-Disabled');
   });
 
-  test('ExpandableTile expanded state', async ({ page }) => {
+  test('ExpandableTile keyboard expanded state', async ({ page }) => {
     await visitStory(page, {
       component: 'ExpandableTile',
       id: 'components-tile--expandable',
@@ -100,10 +100,12 @@ test.describe('Tile @avt', () => {
         theme: 'white',
       },
     });
-    // Expand Tile by keyboard
-    // todo
-
-    // The tile should expand
-    // todo
+    await expect(page.locator('body')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#expandable-tile-1')).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#expandable-tile-1')).toHaveClass(
+      'cds--tile--is-expanded'
+    );
   });
 });

--- a/e2e/components/Tile/Tile-test.avt.e2e.js
+++ b/e2e/components/Tile/Tile-test.avt.e2e.js
@@ -105,7 +105,7 @@ test.describe('Tile @avt', () => {
     await expect(page.locator('#expandable-tile-1')).toBeFocused();
     await page.keyboard.press('Enter');
     await expect(page.locator('#expandable-tile-1')).toHaveClass(
-      'cds--tile--is-expanded'
+      'cds--tile cds--tile--expandable cds--tile--is-expanded'
     );
   });
 });

--- a/e2e/components/Tile/Tile-test.avt.e2e.js
+++ b/e2e/components/Tile/Tile-test.avt.e2e.js
@@ -109,10 +109,10 @@ test.describe('Tile @avt', () => {
     );
   });
 
-  test('SelectableTile multi-select keyboard', async ({ page }) => {
+  test('SelectableTile keyboard', async ({ page }) => {
     await visitStory(page, {
       component: 'SelectableTile',
-      id: 'components-tile--multi-select',
+      id: 'components-tile--selectable',
       globals: {
         theme: 'white',
       },
@@ -121,7 +121,9 @@ test.describe('Tile @avt', () => {
     await page.keyboard.press('Tab');
     await expect(page.locator('#selectable-tile-1')).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page.locator('#expandable-tile-1')).toBeChecked();
+    await expect(page.locator('#selectable-tile-1')).toHaveClass(
+      'cds--tile cds--tile--selectable cds--tile--is-selected'
+    );
   });
 
   test('RadioTile keyboard', async ({ page }) => {

--- a/e2e/components/Tile/Tile-test.avt.e2e.js
+++ b/e2e/components/Tile/Tile-test.avt.e2e.js
@@ -108,4 +108,34 @@ test.describe('Tile @avt', () => {
       'cds--tile cds--tile--expandable cds--tile--is-expanded'
     );
   });
+
+  test('SelectableTile multi-select keyboard', async ({ page }) => {
+    await visitStory(page, {
+      component: 'SelectableTile',
+      id: 'components-tile--multi-select',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page.locator('body')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#selectable-tile-1')).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#expandable-tile-1')).toBeChecked();
+  });
+
+  test('RadioTile keyboard', async ({ page }) => {
+    await visitStory(page, {
+      component: 'RadioTile',
+      id: 'components-tile--radio',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page.locator('body')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('#radio-tile-2')).toBeFocused();
+    await page.keyboard.press('ArrowUp');
+    await expect(page.locator('#radio-tile-1')).toBeChecked();
+  });
 });

--- a/e2e/components/Tile/Tile-test.e2e.js
+++ b/e2e/components/Tile/Tile-test.e2e.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-const { expect, test } = require('@playwright/test');
+const { test } = require('@playwright/test');
 const { themes } = require('../../test-utils/env');
-const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+const { snapshotStory } = require('../../test-utils/storybook');
 
 test.describe('Tile', () => {
   themes.forEach((theme) => {
@@ -176,27 +176,5 @@ test.describe('Tile', () => {
         });
       });
     });
-  });
-
-  test('accessibility-checker @avt', async ({ page }) => {
-    await visitStory(page, {
-      component: 'Tile',
-      id: 'components-tile--default',
-      globals: {
-        theme: 'white',
-      },
-    });
-    await expect(page).toHaveNoACViolations('Tile');
-  });
-
-  test('accessibility-checker selectable tile @avt', async ({ page }) => {
-    await visitStory(page, {
-      component: 'SelectableTile',
-      id: 'components-tile--selectable',
-      globals: {
-        theme: 'white',
-      },
-    });
-    await expect(page).toHaveNoACViolations('SelectableTile');
   });
 });


### PR DESCRIPTION
Closes #14186 

Add AVT testing for Tile components

#### Changelog

**New**

- Add tests for all tile variants, disabled state and keyboard nav for expandable tile

**Changed**

- Moved default Tile AVT test to dedicated e2e/components/Tile/Tile-test.avt.e2e.js file


#### Testing / Reviewing

- CI should pass
- Review tests to make sure they look ok, and didn't miss anything for Tile
