### PR TITLE
fix(ci): update add-to-merge-queue workflow triggers and conditionals

### DIFF
--- a/.github/workflows/add-to-merge-queue.yml
+++ b/.github/workflows/add-to-merge-queue.yml
@@ -1,23 +1,15 @@
 name: Add To Merge Queue
 on:
   pull_request:
-    types: [labeled]
-
-env:
-  LABEL_READY_TO_MERGE: 'status: ready to merge 🎉'
-  LABEL_ENABLE_AUTOMERGE: 'status: enable automerge 🟠'
+    types: [labeled, opened, reopened]
 
 jobs:
   add-to-merge-queue:
-    name: Add the PR to the merge queue
+    name: Add to Merge Queue if the PR is labelled with any of the automerge labels
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.issue.labels.*.name, 'status: ready to merge 🎉') || contains(github.event.issue.labels.*.name, 'status: enable automerge 🟠')}}
     steps:
-      - name: 'Add to merge queue if either of the automerge labels are added'
-        if:
-          ${{ contains(github.event.issue.labels.*.name,
-          env.LABEL_READY_TO_MERGE) ||
-          contains(github.event.issue.labels.*.name, env.LABEL_ENABLE_AUTOMERGE)
-          }}
+      - name: 'Add the PR to the merge queue via the GitHub CLI'
         run: gh pr merge
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/v10-ci.yml
+++ b/.github/workflows/v10-ci.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - v10
-  merge_group:
-    types: [checks_requested]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Follow up to https://github.com/carbon-design-system/carbon/pull/14222

#### Changelog

**Changed**

- trigger `add-to-merge-queue.yml` workflow on PR open and reopen (since labels can be applied before/at open and reopen)
- move labels out of env variables to hardcoded strings in the conditional