### PR TITLE
fix(textarea): persist onChange for React 16

### DIFF
--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -175,6 +175,7 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
     id,
     onChange: (evt) => {
       if (!other.disabled && onChange) {
+        evt.persist();
         // delay textCount assignation to give the textarea element value time to catch up if is a controlled input
         setTimeout(() => {
           setTextCount(evt.target?.value?.length);


### PR DESCRIPTION
[Reported in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1689560271450069)

#### Changelog

**Changed**

- call evt.persist() in the onchange to ensure it is not removed prematurely in react 16