### PR TITLE
fix(DataTable): fix stacking issues with table toolbar + batch actions

### DIFF
--- a/packages/styles/scss/components/data-table/action/_data-table-action.scss
+++ b/packages/styles/scss/components/data-table/action/_data-table-action.scss
@@ -27,6 +27,7 @@
   .#{$prefix}--table-toolbar {
     // Need for batch actions
     position: relative;
+    z-index: 1;
     display: flex;
     width: 100%;
     min-height: $spacing-09;
@@ -388,6 +389,7 @@
     justify-content: space-between;
     background-color: $background-brand;
     clip-path: polygon(0 0, 100% 0, 100% 0, 0 0);
+    opacity: 0;
     pointer-events: none;
     transform: translate3d(0, 48px, 0);
     transition: transform $duration-fast-02 motion(standard, productive),
@@ -401,7 +403,9 @@
   }
   // 200% to allow tooltips
   .#{$prefix}--batch-actions--active {
-    clip-path: polygon(0 0, 200% 0, 200% 200%, 0 200%);
+    z-index: 1;
+    clip-path: polygon(0 0, 300% 0, 300% 300%, 0 300%);
+    opacity: 1;
     pointer-events: all;
     transform: translate3d(0, 0, 0);
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14137

Adds some `z-index` values so that the batch actions and toolbars render over table content. Also tweaked the `clip-path` a bit so that longer tooltips can be rendered. This very slightly adjusts how much the toolbar slides down when fading in/out, but seems like a good compromise. Also added `opacity` transition to make this less noticeable.

#### Changelog

**New**

- `z-index` added to batch action bar, table toolbar

**Changed**

- tweaked `clip-path` to allow longer tooltips in batch action bar

#### Testing / Reviewing

Go to the batch actions story, and add a much longer string for the tooltips that appear. Ensure the animations look correct and there are no regressions
