### PR TITLE
fix(DataTableSkeleton): fix TypeScript interface and proptypes

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2444,14 +2444,6 @@ Map {
     ],
   },
   "DataTableSkeleton" => Object {
-    "defaultProps": Object {
-      "columnCount": 5,
-      "compact": false,
-      "rowCount": 5,
-      "showHeader": true,
-      "showToolbar": true,
-      "zebra": false,
-    },
     "propTypes": Object {
       "className": Object {
         "type": "string",
@@ -2464,23 +2456,20 @@ Map {
       },
       "headers": Object {
         "args": Array [
-          Array [
-            Object {
-              "type": "array",
-            },
-            Object {
-              "args": Array [
-                Object {
-                  "key": Object {
-                    "type": "string",
-                  },
+          Object {
+            "args": Array [
+              Object {
+                "header": Object {
+                  "isRequired": true,
+                  "type": "node",
                 },
-              ],
-              "type": "shape",
-            },
-          ],
+              },
+            ],
+            "isRequired": true,
+            "type": "shape",
+          },
         ],
-        "type": "oneOfType",
+        "type": "arrayOf",
       },
       "rowCount": Object {
         "type": "number",

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.tsx
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.tsx
@@ -6,15 +6,15 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { TableHTMLAttributes } from 'react';
+import React, { type FunctionComponent, TableHTMLAttributes } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 
 export interface DataTableSkeletonHeader {
   /**
-   * Optionally specify header label
+   * Specify header label
    */
-  header?: string;
+  header: React.ReactNode;
 
   /**
    * Optionally specify header key
@@ -61,15 +61,15 @@ export interface DataTableSkeletonProps
   zebra?: boolean;
 }
 
-const DataTableSkeleton = ({
+const DataTableSkeleton: FunctionComponent<DataTableSkeletonProps> = ({
   headers,
-  rowCount,
-  columnCount,
-  zebra,
-  compact,
+  rowCount = 5,
+  columnCount = 5,
+  zebra = false,
+  compact = false,
   className,
-  showHeader,
-  showToolbar,
+  showHeader = true,
+  showToolbar = true,
   ...rest
 }) => {
   const prefix = usePrefix();
@@ -156,12 +156,11 @@ DataTableSkeleton.propTypes = {
   /**
    * Optionally specify the displayed headers
    */
-  headers: PropTypes.oneOfType([
-    PropTypes.array,
+  headers: PropTypes.arrayOf(
     PropTypes.shape({
-      key: PropTypes.string,
-    }),
-  ]),
+      header: PropTypes.node.isRequired,
+    }).isRequired
+  ),
 
   /**
    * Specify the number of rows that you want to render in the skeleton state
@@ -182,15 +181,6 @@ DataTableSkeleton.propTypes = {
    * Optionally specify whether you want the DataTable to be zebra striped
    */
   zebra: PropTypes.bool,
-};
-
-DataTableSkeleton.defaultProps = {
-  rowCount: 5,
-  columnCount: 5,
-  zebra: false,
-  compact: false,
-  showHeader: true,
-  showToolbar: true,
 };
 
 export default DataTableSkeleton;


### PR DESCRIPTION
`DataTableSkeleton` is not usable in TypeScript. I think the `headers` PropType was also wrong.

#### Changelog

**Changed**

- Use props in the component
- Use values from default prop type as default values for parameters
- If headers are specified, require the `header` value which is displayed

**Removed**

- default prop types

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
