### PR TITLE
fix(DataTable): correct padding with expandable content

### DIFF
--- a/packages/styles/scss/components/data-table/expandable/_data-table-expandable.scss
+++ b/packages/styles/scss/components/data-table/expandable/_data-table-expandable.scss
@@ -69,7 +69,7 @@
   }
 
   tr.#{$prefix}--parent-row.#{$prefix}--expandable-row + tr[data-child-row] td {
-    padding-left: 4rem;
+    padding-left: 3.5rem;
     border-bottom: 1px solid $border-subtle;
     transition: padding-bottom $duration-fast-02 motion(standard, productive),
       transform $duration-fast-02 motion(standard, productive),


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14240

Reduces padding for expandable content so that it aligns with the table cell text

#### Changelog


**Changed**

- Reduced padding by `8px` to align text with the cell content


#### Testing / Reviewing

Ensure expanded text aligns properly
