### PR TITLE
test(Multiselect): add AVT for multiselect

### DIFF
--- a/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
+++ b/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
@@ -1,0 +1,231 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('MultiSelect @avt', () => {
+  test('accessibility-checker', async ({ page }) => {
+    await visitStory(page, {
+      component: 'MultiSelect',
+      id: 'components-multiselect--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('MultiSelect');
+  });
+
+  // Skipping now due to AVT violation, possible false positive
+  test.skip('accessibility-checker open multiselect', async ({ page }) => {
+    await visitStory(page, {
+      component: 'MultiSelect',
+      id: 'components-multiselect--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('button');
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    // Tab and open the MultiSelect
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible;
+    await expect(menu).toBeFocused();
+
+    await expect(page).toHaveNoACViolations('MultiSelect-open');
+  });
+
+  test('multiselect - keyboard nav', async ({ page }) => {
+    await visitStory(page, {
+      component: 'MultiSelect',
+      id: 'components-multiselect--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('button', {
+      expanded: false,
+      name: 'Multiselect Label',
+    });
+    const selection = page.getByRole('button', {
+      name: 'Clear all selected items',
+    });
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    await expect(selection).not.toBeVisible();
+    // Tab and open the MultiSelect with Arrow Down
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Enter
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Spacebar
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Space');
+    await expect(menu).toBeVisible();
+    // Navigation inside the menu
+    // move to first option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'An example option that is really long to show what should be done to handle long text',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select first option (should only select with space bar)
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'An example option that is really long to show what should be done to handle long text',
+        selected: false,
+      })
+    ).toBeVisible();
+    await page.keyboard.press('Space');
+    await expect(
+      page.getByRole('option', {
+        name: 'An example option that is really long to show what should be done to handle long text',
+        selected: true,
+      })
+    ).toBeVisible();
+    // move to second option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select second option
+    await page.keyboard.press('Space');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+        selected: true,
+      })
+    ).toBeVisible();
+    // focus comes back to the toggle button after closing
+    await page.keyboard.press('Escape');
+    await expect(toggleButton).toBeFocused();
+    // should show count of selected items when closed
+    await expect(menu).not.toBeVisible();
+    await expect(selection).toBeVisible();
+    // should only clear selection when escape is pressed when the menu is closed
+    await page.keyboard.press('Escape');
+    await expect(selection).not.toBeVisible();
+  });
+
+  test('filterable multiselect - keyboard nav', async ({ page }) => {
+    await visitStory(page, {
+      component: 'MultiSelect',
+      id: 'components-multiselect--filterable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('combobox');
+    const selection = page.getByRole('button', {
+      name: 'Clear all selected items',
+    });
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    await expect(selection).not.toBeVisible();
+    // Tab and open the MultiSelect with Arrow Down
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Enter
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Spacebar
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Space');
+    await expect(menu).toBeVisible();
+    // Navigation inside the menu
+    // move to first option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'An example option that is really long to show what should be done to handle long text',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select first option (should only select with enter)
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'An example option that is really long to show what should be done to handle long text',
+        selected: true,
+      })
+    ).toBeVisible();
+    // move to second option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select second option
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+        selected: true,
+      })
+    ).toBeVisible();
+    // focus comes back to the toggle button after closing
+    await page.keyboard.press('Escape');
+    await expect(toggleButton).toBeFocused();
+    // should show count of selected items when closed
+    await expect(menu).not.toBeVisible();
+    await expect(selection).toBeVisible();
+    // should only clear selection when escape is pressed when the menu is closed
+    await page.keyboard.press('Escape');
+    await expect(selection).not.toBeVisible();
+
+    // should filter menu items based on text input
+    await page.keyboard.press('2');
+    await expect(menu).toBeVisible();
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 2',
+        selected: false,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+        selected: false,
+      })
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
+++ b/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
@@ -11,7 +11,7 @@ const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
 test.describe('MultiSelect @avt', () => {
-  test('accessibility-checker', async ({ page }) => {
+  test('accessibility-checker multiselect', async ({ page }) => {
     await visitStory(page, {
       component: 'MultiSelect',
       id: 'components-multiselect--default',
@@ -20,6 +20,42 @@ test.describe('MultiSelect @avt', () => {
       },
     });
     await expect(page).toHaveNoACViolations('MultiSelect');
+  });
+
+  test('accessibility-checker filterable multiselect', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FilterableMultiSelect',
+      id: 'components-multiselect--filterable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FilterableMultiSelect');
+  });
+
+  // Skipping now due to AVT violation, possible false positive
+  test.skip('accessibility-checker open filterable multiselect', async ({
+    page,
+  }) => {
+    await visitStory(page, {
+      component: 'FilterableMultiSelect',
+      id: 'components-multiselect--filterable',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('button');
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    // Tab and open the MultiSelect
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible;
+    await expect(menu).toBeFocused();
+
+    await expect(page).toHaveNoACViolations('MultiSelect-open');
   });
 
   // Skipping now due to AVT violation, possible false positive
@@ -136,7 +172,7 @@ test.describe('MultiSelect @avt', () => {
 
   test('filterable multiselect - keyboard nav', async ({ page }) => {
     await visitStory(page, {
-      component: 'MultiSelect',
+      component: 'FilterableMultiSelect',
       id: 'components-multiselect--filterable',
       globals: {
         theme: 'white',

--- a/e2e/components/MultiSelect/MultiSelect-test.e2e.js
+++ b/e2e/components/MultiSelect/MultiSelect-test.e2e.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-const { expect, test } = require('@playwright/test');
+const { test } = require('@playwright/test');
 const { themes } = require('../../test-utils/env');
-const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+const { snapshotStory } = require('../../test-utils/storybook');
 
 test.describe('MultiSelect', () => {
   themes.forEach((theme) => {
@@ -54,16 +54,5 @@ test.describe('MultiSelect', () => {
         });
       });
     });
-  });
-
-  test('accessibility-checker @avt', async ({ page }) => {
-    await visitStory(page, {
-      component: 'MultiSelect',
-      id: 'components-multiselect--default',
-      globals: {
-        theme: 'white',
-      },
-    });
-    await expect(page).toHaveNoACViolations('MultiSelect');
   });
 });

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3457,7 +3457,6 @@ Map {
   "FilterableMultiSelect" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "defaultProps": Object {
-      "aria-label": "Choose an item",
       "compareItems": [Function],
       "direction": "bottom",
       "disabled": false,
@@ -3470,9 +3469,7 @@ Map {
       "sortItems": [Function],
     },
     "propTypes": Object {
-      "aria-label": Object {
-        "type": "string",
-      },
+      "aria-label": [Function],
       "ariaLabel": [Function],
       "compareItems": Object {
         "isRequired": true,
@@ -5029,7 +5026,6 @@ Map {
     "Filterable": Object {
       "$$typeof": Symbol(react.forward_ref),
       "defaultProps": Object {
-        "aria-label": "Choose an item",
         "compareItems": [Function],
         "direction": "bottom",
         "disabled": false,
@@ -5042,9 +5038,7 @@ Map {
         "sortItems": [Function],
       },
       "propTypes": Object {
-        "aria-label": Object {
-          "type": "string",
-        },
+        "aria-label": [Function],
         "ariaLabel": [Function],
         "compareItems": Object {
           "isRequired": true,

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -27,7 +27,6 @@ import { FormContext } from '../FluidForm';
 
 const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
   {
-    ['aria-label']: ariaLabel,
     className: containerClassName,
     compareItems,
     direction,
@@ -347,14 +346,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
               },
             });
 
-            const menuProps = getMenuProps(
-              {
-                'aria-label': ariaLabel,
-              },
-              {
-                suppressRefError: true,
-              }
-            );
+            const menuProps = getMenuProps({}, { suppressRefError: true });
 
             const handleFocus = (evt) => {
               if (

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -28,7 +28,6 @@ import { FormContext } from '../FluidForm';
 const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
   {
     ['aria-label']: ariaLabel,
-    ariaLabel: deprecatedAriaLabel,
     className: containerClassName,
     compareItems,
     direction,
@@ -376,7 +375,6 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
                   </label>
                 ) : null}
                 <ListBox
-                  aria-label={deprecatedAriaLabel || ariaLabel}
                   onFocus={isFluid ? handleFocus : null}
                   onBlur={isFluid ? handleFocus : null}
                   className={className}
@@ -503,9 +501,13 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
 
 FilterableMultiSelect.propTypes = {
   /**
+   * Deprecated, aria-label is no longer needed
    * Specify a label to be read by screen readers on the container node
    */
-  ['aria-label']: PropTypes.string,
+  ['aria-label']: deprecate(
+    PropTypes.string,
+    'ariaLabel / aria-label props are no longer required for FilterableMultiSelect'
+  ),
 
   /**
    * Deprecated, please use `aria-label` instead.
@@ -513,7 +515,7 @@ FilterableMultiSelect.propTypes = {
    */
   ariaLabel: deprecate(
     PropTypes.string,
-    'This prop syntax has been deprecated. Please use the new `aria-label`.'
+    'ariaLabel / aria-label props are no longer required for FilterableMultiSelect'
   ),
 
   /**

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -659,7 +659,6 @@ FilterableMultiSelect.propTypes = {
 };
 
 FilterableMultiSelect.defaultProps = {
-  ['aria-label']: 'Choose an item',
   compareItems: defaultCompareItems,
   direction: 'bottom',
   disabled: false,

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -254,7 +254,6 @@ export const _Filterable = () => {
   return (
     <div style={{ width: 300 }}>
       <FilterableMultiSelect
-        aria-label="test"
         id="carbon-multiselect-example-3"
         titleText="Multiselect title"
         helperText="This is helper text"

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -16,7 +16,7 @@ export default {
   title: 'Components/MultiSelect',
   component: MultiSelect,
   subcomponents: {
-    'MultiSelect.Filterable': MultiSelect.Filterable,
+    FilterableMultiSelect,
   },
   argTypes: {
     size: {
@@ -254,6 +254,7 @@ export const _Filterable = () => {
   return (
     <div style={{ width: 300 }}>
       <FilterableMultiSelect
+        aria-label="test"
         id="carbon-multiselect-example-3"
         titleText="Multiselect title"
         helperText="This is helper text"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14210
Closes https://github.com/carbon-design-system/carbon/issues/14215
Refs https://github.com/carbon-design-system/carbon/pull/14276

Adds in AVT for `Multiselect` and `FilterableMultiselect`. This would be nice to get in to ensure functionality remains the same during the Downshift upgrade (#14276). These tests add a11y checks when the menu is closed; open currently has errors, so under a `skip` flag for now. It also tests all keyboard navigation such as opening/closing, making a selection, and clearing a selection. 

#### Changelog

**New**

- a11y checks for `Multiselect`, `FilterableMultiselect`
- keyboard tests for `Multiselect`, `FilterableMultiselect`

**Changed**

- marked `ariaLabel` and `aria-label` as deprecated in `FilterableMultiselect`. These were causing a11y violations. 

**Removed**

- `avt` tests from `vrt` file
- `aria-label` from `ListBox` inside `FilterableMultiselect`. This was causing an a11y violation.
- removed default prop value for `aria-label`

#### Testing / Reviewing

Ensure the `avt` test file covers all intended usage
