### PR TITLE
docs(button): specify danger is not supported for icon only buttons

### DIFF
--- a/packages/cli/src/component/templates/mdx.template.mdx
+++ b/packages/cli/src/component/templates/mdx.template.mdx
@@ -10,8 +10,7 @@ guidelines](https://www.carbondesignsystem.com/components/<%= name %>/usage)
 &nbsp;|&nbsp; [Accessibility](https://www.carbondesignsystem.com/components/<%=
 url %>/accessibility)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/AspectRatio/AspectRatio.mdx
+++ b/packages/react/src/components/AspectRatio/AspectRatio.mdx
@@ -9,8 +9,7 @@ import { AspectRatio } from '.';
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview#aspect-ratio)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -15,8 +15,7 @@ import * as ButtonStories from './Button.stories';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Danger Buttons](#danger-buttons)
@@ -72,9 +71,9 @@ danger button or the ghost danger button may be more appropriate.
 ## Icon-only Buttons
 
 Icon buttons allow users to take actions, and make choices, with a single tap.
-Icon buttons can take the form of any of the seven types (Primary, Secondary,
-Tertiary, Danger, Danger tertiary, Danger ghost and Ghost) but most commonly
-will be styled as primary or ghost buttons.
+Icon buttons can take the form of Primary, Secondary, Tertiary, and Ghost but
+most commonly will be styled as primary or ghost buttons. Icon only buttons do
+not support Danger, Danger tertiary, or Danger ghost.
 
 <Canvas>
   <Story of={ButtonStories.IconButton} />
@@ -182,10 +181,11 @@ button is interacted with.
 Carbon has seven types of buttons, `primary`, `secondary`, `tertiary`, `ghost`,
 `danger`, `danger--tertiary`, and `danger--ghost`. If no `kind` is specified, a
 `primary` button will be rendered. For more information on when to use each
-variant, check out the [design documentation](https://www.carbondesignsystem.com/components/button/usage#overview)
+variant, check out the
+[design documentation](https://www.carbondesignsystem.com/components/button/usage#overview)
 
 <Unstyled>
-  <div style={{display: 'flex', justifyContent: 'space-between'}}>
+  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
     <Button>Primary</Button>
     <Button kind="secondary">Secondary</Button>
     <Button kind="tertiary">Tertiary </Button>
@@ -223,11 +223,12 @@ to render icon-only buttons, please refer to the section on the
 [hasIconOnly](#button-hasicononly) prop
 
 <Unstyled>
-  <Button renderIcon={Add} iconDescription="Add" style={{marginRight: '3px'}}>Add</Button>
-  <Button
-    renderIcon={TrashCan}
-    kind="danger"
-    iconDescription="TrashCan">Delete</Button>
+  <Button renderIcon={Add} iconDescription="Add" style={{ marginRight: '3px' }}>
+    Add
+  </Button>
+  <Button renderIcon={TrashCan} kind="danger" iconDescription="TrashCan">
+    Delete
+  </Button>
 </Unstyled>
 
 ```jsx
@@ -241,11 +242,16 @@ the Icon to ensure the proper classes are applied:
 <Unstyled>
   <Button
     renderIcon={(props) => <Add size={24} {...props} />}
-    iconDescription="Add" style={{marginRight: '3px'}}>Add</Button>
+    iconDescription="Add"
+    style={{ marginRight: '3px' }}>
+    Add
+  </Button>
   <Button
     renderIcon={(props) => <TrashCan size={24} {...props} />}
     kind="danger"
-    iconDescription="TrashCan">Delete</Button>
+    iconDescription="TrashCan">
+    Delete
+  </Button>
 </Unstyled>
 
 ```jsx
@@ -261,7 +267,9 @@ an element appear as a button control to a screen reader. Check out the
 [References](#references) section for more information.
 
 <Unstyled>
-  <Button as="div" role="button">a11y Button</Button>
+  <Button as="div" role="button">
+    a11y Button
+  </Button>
 </Unstyled>
 
 ```jsx

--- a/packages/react/src/components/ClassPrefix/ClassPrefix.mdx
+++ b/packages/react/src/components/ClassPrefix/ClassPrefix.mdx
@@ -6,8 +6,7 @@ import * as ClassPrefixStories from './ClassPrefix.stories';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ClassPrefix)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/ComboButton/ComboButton.mdx
+++ b/packages/react/src/components/ComboButton/ComboButton.mdx
@@ -4,8 +4,7 @@ import { ArgsTable } from '@storybook/blocks';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ComboButton)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)
@@ -15,7 +14,10 @@ import { ArgsTable } from '@storybook/blocks';
 
 ## Overview
 
-A `ComboButton` can be used to offer additional, secondary actions in a disclosed list next to the primary action. These additional actions must be `MenuItem`s passed as `children`. The primary action's label is passed as `props.label`.
+A `ComboButton` can be used to offer additional, secondary actions in a
+disclosed list next to the primary action. These additional actions must be
+`MenuItem`s passed as `children`. The primary action's label is passed as
+`props.label`.
 
 ```jsx
 <ComboButton label="Primary action">

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -96,21 +96,21 @@ const ModalStateManager = ({
 };
 ```
 
+{/* <!-- prettier-ignore-start --> */}
+
 <Unstyled>
   <InlineNotification
     kind="warning"
     title="Warning"
     className="sb-notification">
-    <CodeSnippet type="inline" hideCopyButton>
-      {'Modal'}
-    </CodeSnippet>
-    and <CodeSnippet type="inline" hideCopyButton>
-      {'ComposedModal'}
-    </CodeSnippet>
+    <CodeSnippet type="inline" hideCopyButton>Modal</CodeSnippet>
+    and
+    <CodeSnippet type="inline" hideCopyButton>ComposedModal</CodeSnippet>
     have to be put at the top level in a React tree. The easiest way to ensure
     that is using React portal as shown in above example.
   </InlineNotification>
 </Unstyled>
+{/* <!-- prettier-ignore-end --> */}
 
 ## Modal sizes
 
@@ -211,24 +211,23 @@ With `<ComposedModal>`, you can control the buttons with the following code.
 </ComposedModal>
 ```
 
+{/* <!-- prettier-ignore-start --> */}
+
 <Unstyled>
   <InlineNotification
     kind="warning"
     title="Warning"
     className="sb-notification">
     As the instruction for the three buttons implies,{' '}
-    <CodeSnippet type="inline" hideCopyButton>
-      {'ModalFooter'}
-    </CodeSnippet>
-    is flexible on the buttons as you render <CodeSnippet
-      type="inline"
-      hideCopyButton>
-      {'Button'}
-    </CodeSnippet>'s by yourself, as shown below. In this case, the application code
+    <CodeSnippet type="inline" hideCopyButton>ModalFooter</CodeSnippet>
+    is flexible on the buttons as you render 
+    <CodeSnippet type="inline" hideCopyButton>Button</CodeSnippet>
+    's by yourself, as shown below. In this case, the application code
     needs to take care of running actions upon clicking those buttons, e.g. closing
     the modal
   </InlineNotification>
 </Unstyled>
+{/* <!-- prettier-ignore-end --> */}
 
 ```jsx
 <ComposedModal>

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -3,7 +3,7 @@ import ComposedModal from '../ComposedModal';
 import { InlineNotification } from '../Notification';
 import CodeSnippet from '../CodeSnippet';
 import * as ComposedModalStories from './ComposedModal.stories.js';
-import './ComposedModal.stories.scss'
+import './ComposedModal.stories.scss';
 
 # ComposedModal
 
@@ -15,8 +15,7 @@ import './ComposedModal.stories.scss'
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)
@@ -98,11 +97,18 @@ const ModalStateManager = ({
 ```
 
 <Unstyled>
-  <InlineNotification kind="warning" title="Warning" className="sb-notification">
-    <CodeSnippet type="inline" hideCopyButton>{'Modal'}</CodeSnippet>
-  and <CodeSnippet type="inline" hideCopyButton>{'ComposedModal'}</CodeSnippet>
-    have to be put at the top level in a React tree. The easiest way to ensure that is using React
-    portal as shown in above example.
+  <InlineNotification
+    kind="warning"
+    title="Warning"
+    className="sb-notification">
+    <CodeSnippet type="inline" hideCopyButton>
+      {'Modal'}
+    </CodeSnippet>
+    and <CodeSnippet type="inline" hideCopyButton>
+      {'ComposedModal'}
+    </CodeSnippet>
+    have to be put at the top level in a React tree. The easiest way to ensure
+    that is using React portal as shown in above example.
   </InlineNotification>
 </Unstyled>
 
@@ -206,11 +212,21 @@ With `<ComposedModal>`, you can control the buttons with the following code.
 ```
 
 <Unstyled>
-  <InlineNotification kind="warning" title="Warning" className="sb-notification">
-    As the instruction for the three buttons implies, <CodeSnippet type="inline" hideCopyButton>{'ModalFooter'}</CodeSnippet>
-    is flexible on the buttons as you render <CodeSnippet type="inline" hideCopyButton>{'Button'}</CodeSnippet>'s by yourself,
-    as shown below. In this case, the application code needs to take care of running
-    actions upon clicking those buttons, e.g. closing the modal
+  <InlineNotification
+    kind="warning"
+    title="Warning"
+    className="sb-notification">
+    As the instruction for the three buttons implies,{' '}
+    <CodeSnippet type="inline" hideCopyButton>
+      {'ModalFooter'}
+    </CodeSnippet>
+    is flexible on the buttons as you render <CodeSnippet
+      type="inline"
+      hideCopyButton>
+      {'Button'}
+    </CodeSnippet>'s by yourself, as shown below. In this case, the application code
+    needs to take care of running actions upon clicking those buttons, e.g. closing
+    the modal
   </InlineNotification>
 </Unstyled>
 

--- a/packages/react/src/components/ContainedList/ContainedList.mdx
+++ b/packages/react/src/components/ContainedList/ContainedList.mdx
@@ -9,8 +9,8 @@ import * as ContainedListStories from './ContainedList.stories.js';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -31,68 +31,76 @@ import * as ContainedListStories from './ContainedList.stories.js';
 ### Search
 
 #### Expandable Search:
-Within the Contained List you can pass in an `ExpandableSearch` component within the `action` prop as seen below.
-The `ExpandableSearch` will give you the capability to expand and collapse the search bar within the title.
-However, we do not support passing in the `ExpandableSearch` within the title action prop while passing in the `Search` component
-as a child at the same time. If this happens, the `ExpandableSearch` in the title will override any other `Search` passed in as a child.
-To prevent this potential conflict, we have added funtionality to support both designs and both use cases. Please see [Persistent Search](#persistent-search) docs below.
+
+Within the Contained List you can pass in an `ExpandableSearch` component within
+the `action` prop as seen below. The `ExpandableSearch` will give you the
+capability to expand and collapse the search bar within the title. However, we
+do not support passing in the `ExpandableSearch` within the title action prop
+while passing in the `Search` component as a child at the same time. If this
+happens, the `ExpandableSearch` in the title will override any other `Search`
+passed in as a child. To prevent this potential conflict, we have added
+funtionality to support both designs and both use cases. Please see
+[Persistent Search](#persistent-search) docs below.
 
 ```js
-  export const WithExpandableSearch = () => {
-    const [searchTerm, setSearchTerm] = useState('');
-    const [searchResults, setSearchResults] = useState([]);
-    const handleChange = (event) => {
-      setSearchTerm(event.target.value);
-    };
-
-    useEffect(() => {
-      const listItems = [
-        'List item 1',
-        'List item 2',
-        'List item 3',
-        'List item 4'
-      ];
-
-      const results = listItems.filter((listItem) =>
-        listItem.toLowerCase().includes(searchTerm.toLowerCase())
-      );
-      setSearchResults(results);
-    }, [searchTerm]);
-
-    return (
-      <ContainedList
-        label="List title"
-        kind="on-page"
-        action={
-          <ExpandableSearch
-            placeholder="Filterable search"
-            value={searchTerm}
-            onChange={handleChange}
-            closeButtonLabelText="Clear search input"
-            size="lg"
-          />
-        }>
-        {searchResults.map((listItem, key) => (
-          <ContainedListItem key={key}>
-            {listItem}
-          </ContainedListItem>
-        ))}
-      </ContainedList>
-    );
+export const WithExpandableSearch = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  const handleChange = (event) => {
+    setSearchTerm(event.target.value);
   };
+
+  useEffect(() => {
+    const listItems = [
+      'List item 1',
+      'List item 2',
+      'List item 3',
+      'List item 4',
+    ];
+
+    const results = listItems.filter((listItem) =>
+      listItem.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+    setSearchResults(results);
+  }, [searchTerm]);
+
+  return (
+    <ContainedList
+      label="List title"
+      kind="on-page"
+      action={
+        <ExpandableSearch
+          placeholder="Filterable search"
+          value={searchTerm}
+          onChange={handleChange}
+          closeButtonLabelText="Clear search input"
+          size="lg"
+        />
+      }>
+      {searchResults.map((listItem, key) => (
+        <ContainedListItem key={key}>{listItem}</ContainedListItem>
+      ))}
+    </ContainedList>
+  );
+};
 ```
+
 <Canvas>
   <Story of={ContainedListStories.WithExpandableSearch} />
 </Canvas>
 
 #### Persistent Search:
-We have added in the capability to pass down the `Search` component as a child of `ContainedList`.
-The `Search` component itself is not a prop but does render with specific styling such that the `Search` bar appears below the Contained List title as opposed to rendering inline.
-If you would like the Search to render inline to the Contained List title, please see the [Expandable Search](#expandable-search) docs above
-The `Search` component will also remain persistent under the title, so that it remains visible on scroll, when there are many list items passed in.
+
+We have added in the capability to pass down the `Search` component as a child
+of `ContainedList`. The `Search` component itself is not a prop but does render
+with specific styling such that the `Search` bar appears below the Contained
+List title as opposed to rendering inline. If you would like the Search to
+render inline to the Contained List title, please see the
+[Expandable Search](#expandable-search) docs above The `Search` component will
+also remain persistent under the title, so that it remains visible on scroll,
+when there are many list items passed in.
 
 ```js
-
 export const WithPersistentSearch = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -105,7 +113,7 @@ export const WithPersistentSearch = () => {
       'List item 1',
       'List item 2',
       'List item 3',
-      'List item 4'
+      'List item 4',
     ];
 
     const results = listItems.filter((listItem) =>
@@ -124,14 +132,11 @@ export const WithPersistentSearch = () => {
         size="lg"
       />
       {searchResults.map((listItem, key) => (
-        <ContainedListItem key={key}>
-          {listItem}
-        </ContainedListItem>
+        <ContainedListItem key={key}>{listItem}</ContainedListItem>
       ))}
     </ContainedList>
   );
 };
-
 ```
 
 <Canvas>

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.mdx
@@ -13,8 +13,7 @@ import * as ContentSwitcherStories from './ContentSwitcher.stories.js';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)

--- a/packages/react/src/components/ContextMenu/useContextMenu.mdx
+++ b/packages/react/src/components/ContextMenu/useContextMenu.mdx
@@ -2,8 +2,7 @@
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ContextMenu)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)
@@ -13,9 +12,13 @@
 
 ## Overview
 
-The `useContextMenu` hook is meant to be used in conjunction with `Menu` (see this [component's documentation](/docs/components-menu--playground) for more details). It provides an easy way to generate the necessary props for `Menu`.
+The `useContextMenu` hook is meant to be used in conjunction with `Menu` (see
+this [component's documentation](/docs/components-menu--playground) for more
+details). It provides an easy way to generate the necessary props for `Menu`.
 
-By default, it will listen to the `contextmenu` event on `document`. In most cases you'll want to restrict a context menu to a certain element or group of elements only. You can pass that element as the argument for `useContextMenu`.
+By default, it will listen to the `contextmenu` event on `document`. In most
+cases you'll want to restrict a context menu to a certain element or group of
+elements only. You can pass that element as the argument for `useContextMenu`.
 
 ```jsx
 function SomeComponent() {
@@ -24,9 +27,7 @@ function SomeComponent() {
 
   return (
     <>
-      <div ref={el}>
-        …
-      </div>
+      <div ref={el}>…</div>
 
       <Menu {...menuProps}>
         <MenuItem label="Cut" />
@@ -38,7 +39,9 @@ function SomeComponent() {
 }
 ```
 
-Be aware that the following props are not set by `useContextMenu` and can therefore be configured by the user:
+Be aware that the following props are not set by `useContextMenu` and can
+therefore be configured by the user:
+
 - className
 - label
 - size
@@ -52,7 +55,7 @@ Be aware that the following props are not set by `useContextMenu` and can theref
 const menuProps = useContextMenu(
   // the DOM element or react ref the "contextmenu" event should be attached to.
   // defaults to document.
-  trigger,
+  trigger
 );
 ```
 

--- a/packages/react/src/components/CopyButton/CopyButton.mdx
+++ b/packages/react/src/components/CopyButton/CopyButton.mdx
@@ -9,8 +9,7 @@ import * as CopyButtonStories from './CopyButton.stories.js';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)

--- a/packages/react/src/components/DataTable/DataTable.mdx
+++ b/packages/react/src/components/DataTable/DataTable.mdx
@@ -1,5 +1,12 @@
 import { Story, ArgsTable, Canvas, Meta } from '@storybook/blocks';
-import { Table, TableHead, TableHeader, TableRow, TableCell, TableBody } from '../DataTable'
+import {
+  Table,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '../DataTable';
 
 # DataTable
 
@@ -13,8 +20,8 @@ import { Table, TableHead, TableHeader, TableRow, TableCell, TableBody } from '.
   <Story id="components-datatable-basic--playground" />
 </Canvas>
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Getting started](#getting-started)
@@ -24,7 +31,7 @@ import { Table, TableHead, TableHeader, TableRow, TableCell, TableBody } from '.
 - [Expansion](#expansion)
   - [Programmatic expansion](#programmatic-expansion)
 - [Selection](#selection)
-    - [Programmatic selection](#programmatic-selection)
+  - [Programmatic selection](#programmatic-selection)
 - [Filtering](#filtering)
 - [Batch actions](#batch-actions)
 - [Toolbar](#toolbar)
@@ -292,7 +299,7 @@ _Note: press "Show code" above to view a code snippet of this example_
 ## Toolbar
 
 <Canvas>
-  <Story id="components-datatable-toolbar--playground"/>
+  <Story id="components-datatable-toolbar--playground" />
 </Canvas>
 
 ### Overflow Menu
@@ -323,60 +330,48 @@ cell.
 
 ## Text Wrapping Alignment
 
-DataTable provides an experimental `experimentalAutoAlign` prop that you may
-opt into to have the table automatically align contents to the top when at least
-one table cell content is being wrapped on the table. Keep in mind this feature
-is experimental and might not be performant in tables with large datasets.
+DataTable provides an experimental `experimentalAutoAlign` prop that you may opt
+into to have the table automatically align contents to the top when at least one
+table cell content is being wrapped on the table. Keep in mind this feature is
+experimental and might not be performant in tables with large datasets.
 
 ### Table with `experimentalAutoAlign = true`
 
-<div style={{width: '300px'}}>
+<div style={{ width: '300px' }}>
   <Table experimentalAutoAlign>
     <TableHead>
       <TableRow>
-          <TableHeader>
-            Header1
-          </TableHeader>
-          <TableHeader>
-            Header2
-          </TableHeader>
-          <TableHeader>
-            Header3
-          </TableHeader>
+        <TableHeader>Header1</TableHeader>
+        <TableHeader>Header2</TableHeader>
+        <TableHeader>Header3</TableHeader>
       </TableRow>
     </TableHead>
     <TableBody>
-        <TableRow>
-          <TableCell>Wrapping content</TableCell>
-          <TableCell>content</TableCell>
-          <TableCell>content</TableCell>
-        </TableRow>
+      <TableRow>
+        <TableCell>Wrapping content</TableCell>
+        <TableCell>content</TableCell>
+        <TableCell>content</TableCell>
+      </TableRow>
     </TableBody>
   </Table>
 </div>
 
 ```jsx
-<div style={{width: '300px'}}>
+<div style={{ width: '300px' }}>
   <Table experimentalAutoAlign>
     <TableHead>
       <TableRow>
-          <TableHeader>
-            Header1
-          </TableHeader>
-          <TableHeader>
-            Header2
-          </TableHeader>
-          <TableHeader>
-            Header3
-          </TableHeader>
+        <TableHeader>Header1</TableHeader>
+        <TableHeader>Header2</TableHeader>
+        <TableHeader>Header3</TableHeader>
       </TableRow>
     </TableHead>
     <TableBody>
-        <TableRow>
-          <TableCell>Wrapping content</TableCell>
-          <TableCell>content</TableCell>
-          <TableCell>content</TableCell>
-        </TableRow>
+      <TableRow>
+        <TableCell>Wrapping content</TableCell>
+        <TableCell>content</TableCell>
+        <TableCell>content</TableCell>
+      </TableRow>
     </TableBody>
   </Table>
 </div>
@@ -384,53 +379,41 @@ is experimental and might not be performant in tables with large datasets.
 
 ### Table with `experimentalAutoAlign = false`
 
-<div style={{width: '300px'}}>
+<div style={{ width: '300px' }}>
   <Table>
     <TableHead>
       <TableRow>
-          <TableHeader>
-            Header1
-          </TableHeader>
-          <TableHeader>
-            Header2
-          </TableHeader>
-          <TableHeader>
-            Header3
-          </TableHeader>
+        <TableHeader>Header1</TableHeader>
+        <TableHeader>Header2</TableHeader>
+        <TableHeader>Header3</TableHeader>
       </TableRow>
     </TableHead>
     <TableBody>
-        <TableRow>
-          <TableCell>Wrapping content</TableCell>
-          <TableCell>content</TableCell>
-          <TableCell>content</TableCell>
-        </TableRow>
+      <TableRow>
+        <TableCell>Wrapping content</TableCell>
+        <TableCell>content</TableCell>
+        <TableCell>content</TableCell>
+      </TableRow>
     </TableBody>
   </Table>
 </div>
 
 ```jsx
-<div style={{width: '300px'}}>
+<div style={{ width: '300px' }}>
   <Table>
     <TableHead>
       <TableRow>
-          <TableHeader>
-            Header1
-          </TableHeader>
-          <TableHeader>
-            Header2
-          </TableHeader>
-          <TableHeader>
-            Header3
-          </TableHeader>
+        <TableHeader>Header1</TableHeader>
+        <TableHeader>Header2</TableHeader>
+        <TableHeader>Header3</TableHeader>
       </TableRow>
     </TableHead>
     <TableBody>
-        <TableRow>
-          <TableCell>Wrapping content</TableCell>
-          <TableCell>content</TableCell>
-          <TableCell>content</TableCell>
-        </TableRow>
+      <TableRow>
+        <TableCell>Wrapping content</TableCell>
+        <TableCell>content</TableCell>
+        <TableCell>content</TableCell>
+      </TableRow>
     </TableBody>
   </Table>
 </div>
@@ -440,8 +423,10 @@ is experimental and might not be performant in tables with large datasets.
 
 ### Accessible Name
 
-To comply with accessibility requirements, make sure to supply the component with an accessible name by providing eiher the `aria-label`, `aria-labelledby` or
-`title` attribute to the `Table` component. Read more on the accessible naming rule
+To comply with accessibility requirements, make sure to supply the component
+with an accessible name by providing eiher the `aria-label`, `aria-labelledby`
+or `title` attribute to the `Table` component. Read more on the accessible
+naming rule
 [here](https://able.ibm.com/rules/archives/latest/doc/en-US/aria_accessiblename_exists.html).
 
 ## Props

--- a/packages/react/src/components/DatePicker/DatePicker.mdx
+++ b/packages/react/src/components/DatePicker/DatePicker.mdx
@@ -13,8 +13,7 @@ import * as DatePickerStories from './DatePicker.stories';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
   - [Simple DatePicker](#simple-datepicker)

--- a/packages/react/src/components/Dropdown/Dropdown.mdx
+++ b/packages/react/src/components/Dropdown/Dropdown.mdx
@@ -13,8 +13,7 @@ import * as DropdownStories from './Dropdown.stories';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
   - [Inline dropdown](#inline-dropdown)

--- a/packages/react/src/components/FluidForm/FluidForm.mdx
+++ b/packages/react/src/components/FluidForm/FluidForm.mdx
@@ -1,8 +1,8 @@
 import { ArgsTable, Canvas, Story } from '@storybook/blocks';
 import * as FluidFormStories from './FluidForm.stories';
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Form](#form)
@@ -35,8 +35,9 @@ import * as FluidFormStories from './FluidForm.stories';
 
 ### Accessible Name
 
-To comply with accessibility requirements, make sure to supply the component with an accessible name by providing eiher the `aria-label`, `aria-labelledby` or
-`title` attribute. Read more on the accessible naming rule
+To comply with accessibility requirements, make sure to supply the component
+with an accessible name by providing eiher the `aria-label`, `aria-labelledby`
+or `title` attribute. Read more on the accessible naming rule
 [here](https://able.ibm.com/rules/archives/latest/doc/en-US/aria_accessiblename_exists.html).
 
 ## Component API

--- a/packages/react/src/components/FluidSelect/FluidSelect.mdx
+++ b/packages/react/src/components/FluidSelect/FluidSelect.mdx
@@ -8,8 +8,8 @@ import SelectItem from '../SelectItem';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/FluidSelect)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Default state](#default-state)

--- a/packages/react/src/components/Form/Form.mdx
+++ b/packages/react/src/components/Form/Form.mdx
@@ -1,8 +1,8 @@
 import { ArgsTable, Canvas, Story } from '@storybook/blocks';
 import * as FormStories from './Form.stories';
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Form](#form)
@@ -39,8 +39,9 @@ suit their needs.
 
 ### Accessible Name
 
-To comply with accessibility requirements, make sure to supply the component with an accessible name by providing eiher the `aria-label`, `aria-labelledby` or
-`title` attribute. Read more on the accessible naming rule
+To comply with accessibility requirements, make sure to supply the component
+with an accessible name by providing eiher the `aria-label`, `aria-labelledby`
+or `title` attribute. Read more on the accessible naming rule
 [here](https://able.ibm.com/rules/archives/latest/doc/en-US/aria_accessiblename_exists.html).
 
 ## Component API

--- a/packages/react/src/components/FormGroup/FormGroup.mdx
+++ b/packages/react/src/components/FormGroup/FormGroup.mdx
@@ -10,8 +10,7 @@ import * as FormGroupStories from './FormGroup.stories';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)

--- a/packages/react/src/components/FormLabel/FormLabel.mdx
+++ b/packages/react/src/components/FormLabel/FormLabel.mdx
@@ -11,8 +11,7 @@ import * as FormLabelStories from './FormLabel.stories';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)

--- a/packages/react/src/components/Heading/Heading.mdx
+++ b/packages/react/src/components/Heading/Heading.mdx
@@ -5,8 +5,7 @@ import * as HeadingStories from './Heading.stories';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/Heading)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/IconButton/IconButton.mdx
+++ b/packages/react/src/components/IconButton/IconButton.mdx
@@ -2,13 +2,11 @@ import { ArgsTable } from '@storybook/blocks';
 
 # IconButton
 
-[Source
-code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/IconButton)
+[Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/IconButton)
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/button/usage)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 
@@ -20,10 +18,10 @@ code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/sr
 
 ## Overview
 
-The `IconButton` component is useful when you have a button where the
-content is an icon. In this situation, it's important that the button itself is
-labeled in a way that can be understandable by mouse, keyboard, and screen
-readers. As a result, this component makes it easy to create accessible icon buttons
+The `IconButton` component is useful when you have a button where the content is
+an icon. In this situation, it's important that the button itself is labeled in
+a way that can be understandable by mouse, keyboard, and screen readers. As a
+result, this component makes it easy to create accessible icon buttons
 
 ```jsx
 import { IconButton } from '@carbon/react';
@@ -37,6 +35,12 @@ function ExampleComponent() {
   );
 }
 ```
+
+## Kind
+
+Icon buttons can take the form of Primary, Secondary, Tertiary, and Ghost but
+most commonly will be styled as primary or ghost buttons. Icon only buttons do
+not support Danger, Danger tertiary, or Danger ghost.
 
 ## Alignment
 

--- a/packages/react/src/components/IdPrefix/IdPrefix.mdx
+++ b/packages/react/src/components/IdPrefix/IdPrefix.mdx
@@ -6,8 +6,7 @@ import * as IdPrefixStories from './IdPrefix.stories';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/ClassPrefix)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 
@@ -26,8 +25,8 @@ automatically generated `id` attributes placed on certain DOM elements.
   <Story of={IdPrefixStories.Default} />
 </Canvas>
 
-This component is intended to be used in limited cases, primarily only if
-you have id conflicts when using v10 and v11 packages at the same time during
+This component is intended to be used in limited cases, primarily only if you
+have id conflicts when using v10 and v11 packages at the same time during
 migration.
 
 In React, you can use `IdPrefix` anywhere in your component tree and specify the

--- a/packages/react/src/components/Layout/Layout.mdx
+++ b/packages/react/src/components/Layout/Layout.mdx
@@ -4,8 +4,8 @@ import { ArgsTable } from '@storybook/blocks';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Layout)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -17,13 +17,22 @@ import { ArgsTable } from '@storybook/blocks';
 
 ## Overview
 
-The `Layout` component provides a way to set layout contexts for specific parts of a web application. It uses Carbon's experimental `layout` sass module (exported from `@carbon/styles`) to control layout-related settings like size and density of all components within a layout context.
+The `Layout` component provides a way to set layout contexts for specific parts
+of a web application. It uses Carbon's experimental `layout` sass module
+(exported from `@carbon/styles`) to control layout-related settings like size
+and density of all components within a layout context.
 
-All children components that support it will react to the `size` and `density` you pass in the `Layout` props. Note that not all components support the entire spectrum of options available. In these cases, a component will typically cap out at the maximum or minimum size it supports in order to still best suit the layout context's intent.
+All children components that support it will react to the `size` and `density`
+you pass in the `Layout` props. Note that not all components support the entire
+spectrum of options available. In these cases, a component will typically cap
+out at the maximum or minimum size it supports in order to still best suit the
+layout context's intent.
 
-If a component is outside a layout context or `props.size` / `props.density` isn't set, it will fall back to its default rendering.
+If a component is outside a layout context or `props.size` / `props.density`
+isn't set, it will fall back to its default rendering.
 
-Components that are explicitely passed a `size` to are unaffected by the layout context. Example:
+Components that are explicitely passed a `size` to are unaffected by the layout
+context. Example:
 
 ```jsx
 <div>
@@ -45,9 +54,13 @@ Components that are explicitely passed a `size` to are unaffected by the layout 
 
 ### LayoutConstraint
 
-In order to apply specific constraints to children components that might differ from their own preference, the `<LayoutConstraint>` utility component can be used.
+In order to apply specific constraints to children components that might differ
+from their own preference, the `<LayoutConstraint>` utility component can be
+used.
 
-An example of this use case is the icon-only content switcher. It uses `IconButton` under the hood which supports all sizes and defaults to `lg`. The `ContentSwitcher` though only supports `sm`->`lg` and defaults to `md`.
+An example of this use case is the icon-only content switcher. It uses
+`IconButton` under the hood which supports all sizes and defaults to `lg`. The
+`ContentSwitcher` though only supports `sm`->`lg` and defaults to `md`.
 
 ```jsx
 <div>
@@ -58,13 +71,15 @@ An example of this use case is the icon-only content switcher. It uses `IconButt
 </div>
 ```
 
-The constraints for a group (`size` and `density`) must be passed as an object with any of these keys:
+The constraints for a group (`size` and `density`) must be passed as an object
+with any of these keys:
+
 - `min`
 - `default`
 - `max`
 
-Example: `size={{ min: 'sm', max: 'lg }}`<br />
-Example: `density={{ default: 'condensed' }}`
+Example: `size={{ min: 'sm', max: 'lg }}`<br /> Example:
+`density={{ default: 'condensed' }}`
 
 ## Component API
 

--- a/packages/react/src/components/Menu/Menu.mdx
+++ b/packages/react/src/components/Menu/Menu.mdx
@@ -4,8 +4,7 @@ import { ArgsTable } from '@storybook/blocks';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Menu)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Positioning](#positioning)
@@ -23,9 +22,14 @@ import { ArgsTable } from '@storybook/blocks';
 
 ## Overview
 
-`Menu` is a versatile component that can be used in a variety of situations. It implements the [menu design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) defined in the ARIA Authoring Practices Guide (APG).
+`Menu` is a versatile component that can be used in a variety of situations. It
+implements the
+[menu design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) defined
+in the ARIA Authoring Practices Guide (APG).
 
-The `Menu` component's `children` must be a collection of any of these subcomponents:
+The `Menu` component's `children` must be a collection of any of these
+subcomponents:
+
 - [MenuItem](#menuitem)
 - [MenuItemDivider](#menuitemdivider)
 - [MenuItemGroup](#menuitemgroup)
@@ -34,16 +38,28 @@ The `Menu` component's `children` must be a collection of any of these subcompon
 
 ## Positioning
 
-You must provide a reference point for the `Menu` to position itself at. The props `x` and `y` either accept a single number each or an array of two numbers.
+You must provide a reference point for the `Menu` to position itself at. The
+props `x` and `y` either accept a single number each or an array of two numbers.
 
-The latter option is used to specify the trigger boundaries. For example, Carbon uses this for the [next version of OverflowMenu](/story/experimental-feature-flags-overflowmenu--overflow-menu) where we pass `[x, x + width]` and `[y, y + height]` of the trigger button. This way, the `Menu` is able to automatically determine its ideal position on the screen (which side to open at and in which direction) while always staying visually attached to the trigger.
-Each `MenuItem` that has `children` and therfore a submenu uses the same approach under the hood to correctly position the submenu.
+The latter option is used to specify the trigger boundaries. For example, Carbon
+uses this for the
+[next version of OverflowMenu](/story/experimental-feature-flags-overflowmenu--overflow-menu)
+where we pass `[x, x + width]` and `[y, y + height]` of the trigger button. This
+way, the `Menu` is able to automatically determine its ideal position on the
+screen (which side to open at and in which direction) while always staying
+visually attached to the trigger. Each `MenuItem` that has `children` and
+therfore a submenu uses the same approach under the hood to correctly position
+the submenu.
 
 ## Subcomponents
 
 ### MenuItem
 
-A `MenuItem` renders a basic menu item with a label an optionally a shortcut hint (_note: the component only renders this hint and doesn't actually register the shortcut in the browser_). Each `MenuItem` can be clicked unless it's marked as `disabled`. If it triggers a destructive action, you can pass it `kind="danger"` to highlight it specially on hover and focus.
+A `MenuItem` renders a basic menu item with a label an optionally a shortcut
+hint (_note: the component only renders this hint and doesn't actually register
+the shortcut in the browser_). Each `MenuItem` can be clicked unless it's marked
+as `disabled`. If it triggers a destructive action, you can pass it
+`kind="danger"` to highlight it specially on hover and focus.
 
 ```jsx
 <Menu>
@@ -53,7 +69,8 @@ A `MenuItem` renders a basic menu item with a label an optionally a shortcut hin
 </Menu>
 ```
 
-In order to render a submenu, you can pass any of the above mentioned subcomponents as `children` of a `MenuItem`.
+In order to render a submenu, you can pass any of the above mentioned
+subcomponents as `children` of a `MenuItem`.
 
 ```jsx
 <Menu>
@@ -69,7 +86,8 @@ In order to render a submenu, you can pass any of the above mentioned subcompone
 
 ### MenuItemDivider
 
-The `MenuItemDivider` renders a thin dividing line, visually separating menu items. Use this to enhance grouping of related items.
+The `MenuItemDivider` renders a thin dividing line, visually separating menu
+items. Use this to enhance grouping of related items.
 
 ```jsx
 <Menu>
@@ -83,11 +101,18 @@ The `MenuItemDivider` renders a thin dividing line, visually separating menu ite
 
 ### MenuItemGroup
 
-You can logically group multiple menu items by wrapping them inside a `MenuItemGroup`. This doesn't affect the visual rendering but can tremendously improve the experience for assistive technology users. You'll always want to use a `MenuItemGroup` if you have multiple [`MenuItemSelectable`](#menuitemselectable) that are relatd to each other.
+You can logically group multiple menu items by wrapping them inside a
+`MenuItemGroup`. This doesn't affect the visual rendering but can tremendously
+improve the experience for assistive technology users. You'll always want to use
+a `MenuItemGroup` if you have multiple
+[`MenuItemSelectable`](#menuitemselectable) that are relatd to each other.
 
 ### MenuItemSelectable
 
-`MenuItemSelectable` is a checkbox in a menu context. Each `MenuItemSelectable` can be checked and unchecked unrelated to other items. If multiple items are related to each other, you'll want to wrap them in a `MenuItemGroup` for improved accessibility.
+`MenuItemSelectable` is a checkbox in a menu context. Each `MenuItemSelectable`
+can be checked and unchecked unrelated to other items. If multiple items are
+related to each other, you'll want to wrap them in a `MenuItemGroup` for
+improved accessibility.
 
 ```jsx
 <Menu>
@@ -99,34 +124,31 @@ You can logically group multiple menu items by wrapping them inside a `MenuItemG
 ```
 
 ### MenuItemRadioGroup
-`MenuItemRadioGroup` is a radio button group in a menu context. Only one item can be selected at a time. The component automatically wraps itself in a `MenuItemGroup`, so you won't have to nest it manually.
+
+`MenuItemRadioGroup` is a radio button group in a menu context. Only one item
+can be selected at a time. The component automatically wraps itself in a
+`MenuItemGroup`, so you won't have to nest it manually.
 
 ```jsx
 <Menu>
   <MenuItemRadioGroup
     label="Font family"
-    items={[
-      'Sans',
-      'Serif',
-      'Mono',
-    ]}
+    items={['Sans', 'Serif', 'Mono']}
     selectedItem="Sans"
   />
   <MenuItemDivider />
   <MenuItemRadioGroup
     label="Text decoration"
-    items={[
-      'None',
-      'Overline',
-      'Line-through',
-      'Underline',
-    ]}
+    items={['None', 'Overline', 'Line-through', 'Underline']}
     selectedItem="None"
   />
 </Menu>
 ```
 
-The `items` prop is designed to accept arbitrary items to best match your data structure. If you pass your items as anything that doesn't support `.toString()` out of the box, you'll need to pass a custom `itemToString` function that will be used for rendering the labels.
+The `items` prop is designed to accept arbitrary items to best match your data
+structure. If you pass your items as anything that doesn't support `.toString()`
+out of the box, you'll need to pass a custom `itemToString` function that will
+be used for rendering the labels.
 
 ```jsx
 const items = [
@@ -144,12 +166,17 @@ const items = [
   items={items}
   selectedItem={items[3]}
   itemToString={(item) => item.label}
-/>
+/>;
 ```
 
 ## Context menu (right-click menu)
 
-The `Menu` component is suited to be used as a context menu for complex web applications. To make this easy, Carbon provides a [`useContextMenu`](/story/hooks-usecontextmenu--use-context-menu) react hook. Please refer to the [hook's documentation](/docs/hooks-usecontextmenu--use-context-menu) for more details.
+The `Menu` component is suited to be used as a context menu for complex web
+applications. To make this easy, Carbon provides a
+[`useContextMenu`](/story/hooks-usecontextmenu--use-context-menu) react hook.
+Please refer to the
+[hook's documentation](/docs/hooks-usecontextmenu--use-context-menu) for more
+details.
 
 ## Component API
 

--- a/packages/react/src/components/MenuButton/MenuButton.mdx
+++ b/packages/react/src/components/MenuButton/MenuButton.mdx
@@ -4,8 +4,7 @@ import { ArgsTable } from '@storybook/blocks';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/MenuButton)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)
@@ -15,7 +14,9 @@ import { ArgsTable } from '@storybook/blocks';
 
 ## Overview
 
-A `MenuButton` can be used to group a set of actions that are related. These actions must be `MenuItem`s passed as `children`. The trigger buttons's label is passed as `props.label`.
+A `MenuButton` can be used to group a set of actions that are related. These
+actions must be `MenuItem`s passed as `children`. The trigger buttons's label is
+passed as `props.label`.
 
 ```jsx
 <MenuButton label="Actions">

--- a/packages/react/src/components/Modal/Modal.mdx
+++ b/packages/react/src/components/Modal/Modal.mdx
@@ -97,19 +97,20 @@ const ModalStateManager = ({
 };
 ```
 
+{/* <!-- prettier-ignore-start --> */}
+
 <Unstyled>
   <InlineNotification
     title="Warning"
     kind="warning"
     className="sb-notification">
-    <CodeSnippet type="inline" hideCopyButton>
-      {'<Modal>'}
-    </CodeSnippet>
-    /<CodeSnippet type="inline" hideCopyButton>{`<ComposedModal>`}</CodeSnippet>{' '}
+    <CodeSnippet type="inline" hideCopyButton>{'<Modal>'}</CodeSnippet>
+    <CodeSnippet type="inline" hideCopyButton>{`<ComposedModal>`}</CodeSnippet>{' '}
     has to be put at the top level in a React tree. The easiest way to ensure
     that is using React portal as shown in above example.
   </InlineNotification>
 </Unstyled>
+{/* <!-- prettier-ignore-end --> */}
 
 ## Modal sizes
 
@@ -210,24 +211,23 @@ With `<ComposedModal>`, you can control the buttons with the following code.
 </ComposedModal>
 ```
 
+{/* <!-- prettier-ignore-start --> */}
+
 <Unstyled>
   <InlineNotification
     title="Warning"
     kind="warning"
     className="sb-notification">
     As the instruction for the three buttons implies,{' '}
-    <CodeSnippet type="inline" hideCopyButton>
-      {'<ModalFooter>'}
-    </CodeSnippet>
-    is flexible on the buttons as you render <CodeSnippet
-      type="inline"
-      hideCopyButton>
-      {'<Button>'}
-    </CodeSnippet>s by yourself, as shown below. In this case, the application code
+    <CodeSnippet type="inline" hideCopyButton>{'<ModalFooter>'}</CodeSnippet>
+    is flexible on the buttons as you render 
+    <CodeSnippet type="inline" hideCopyButton>{'<Button>'}</CodeSnippet>
+    s by yourself, as shown below. In this case, the application code
     needs to take care of running actions upon clicking those buttons, e.g. closing
     the modal:
   </InlineNotification>
 </Unstyled>
+{/* <!-- prettier-ignore-end --> */}
 
 ```jsx
 <ComposedModal>

--- a/packages/react/src/components/Modal/Modal.mdx
+++ b/packages/react/src/components/Modal/Modal.mdx
@@ -13,8 +13,8 @@ import './Modal.stories.scss';
 &nbsp;|&nbsp;
 [Accessibility](https://www.carbondesignsystem.com/components/modal/accessibility)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -96,11 +96,18 @@ const ModalStateManager = ({
   );
 };
 ```
+
 <Unstyled>
-  <InlineNotification title="Warning" kind="warning" className="sb-notification">
-    <CodeSnippet type="inline" hideCopyButton>{'<Modal>'}</CodeSnippet>/<CodeSnippet type="inline" hideCopyButton>{`<ComposedModal>`}</CodeSnippet> has to be put at the
-    top level in a React tree. The easiest way to ensure that is using React
-    portal as shown in above example.
+  <InlineNotification
+    title="Warning"
+    kind="warning"
+    className="sb-notification">
+    <CodeSnippet type="inline" hideCopyButton>
+      {'<Modal>'}
+    </CodeSnippet>
+    /<CodeSnippet type="inline" hideCopyButton>{`<ComposedModal>`}</CodeSnippet>{' '}
+    has to be put at the top level in a React tree. The easiest way to ensure
+    that is using React portal as shown in above example.
   </InlineNotification>
 </Unstyled>
 
@@ -204,11 +211,21 @@ With `<ComposedModal>`, you can control the buttons with the following code.
 ```
 
 <Unstyled>
-  <InlineNotification title="Warning" kind="warning" className="sb-notification">
-    As the instruction for the three buttons implies, <CodeSnippet type="inline" hideCopyButton>{'<ModalFooter>'}</CodeSnippet>
-    is flexible on the buttons as you render <CodeSnippet type="inline" hideCopyButton>{'<Button>'}</CodeSnippet>s by yourself,
-    as shown below. In this case, the application code needs to take care of running
-    actions upon clicking those buttons, e.g. closing the modal:
+  <InlineNotification
+    title="Warning"
+    kind="warning"
+    className="sb-notification">
+    As the instruction for the three buttons implies,{' '}
+    <CodeSnippet type="inline" hideCopyButton>
+      {'<ModalFooter>'}
+    </CodeSnippet>
+    is flexible on the buttons as you render <CodeSnippet
+      type="inline"
+      hideCopyButton>
+      {'<Button>'}
+    </CodeSnippet>s by yourself, as shown below. In this case, the application code
+    needs to take care of running actions upon clicking those buttons, e.g. closing
+    the modal:
   </InlineNotification>
 </Unstyled>
 

--- a/packages/react/src/components/OverflowMenu/next/OverflowMenu.mdx
+++ b/packages/react/src/components/OverflowMenu/next/OverflowMenu.mdx
@@ -4,8 +4,7 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/OverflowMenu/next)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 - [Overview](#overview)
 - [Component API](#component-api)
@@ -15,7 +14,9 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs';
 
 ## Overview
 
-This version of the `OverflowMenu` can be enabled by using the `enable-v12-overflowmenu` feature flag and supports all [subcomponents of `Menu`](/docs/components-menu--playground#subcomponents).
+This version of the `OverflowMenu` can be enabled by using the
+`enable-v12-overflowmenu` feature flag and supports all
+[subcomponents of `Menu`](/docs/components-menu--playground#subcomponents).
 
 ```jsx
 <OverflowMenu label="Primary action">

--- a/packages/react/src/components/Popover/Popover.mdx
+++ b/packages/react/src/components/Popover/Popover.mdx
@@ -8,8 +8,7 @@ import * as PopoverStories from './Popover.stories';
 [Usage guidelines](https://www.carbondesignsystem.com/components/popover/usage)
 &nbsp;|&nbsp;
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -11,8 +11,7 @@ import * as ProgressIndicatorStories from './ProgressIndicator.stories';
 
 ## Table of Contents
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/Select/Select.mdx
+++ b/packages/react/src/components/Select/Select.mdx
@@ -12,8 +12,8 @@ import SelectItem from '../SelectItem';
 &nbsp;|&nbsp;
 [Accessibility](https://www.carbondesignsystem.com/components/select/accessibility)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Default state](#default-state)

--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Story } from '@storybook/blocks';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from './Tabs';
 import * as TabsStories from './Tabs.stories';
-import { Grid, Column } from '../Grid'
+import { Grid, Column } from '../Grid';
 
 # Tabs
 
@@ -11,8 +11,8 @@ import { Grid, Column } from '../Grid'
 &nbsp;|&nbsp;
 [Accessibility](https://www.carbondesignsystem.com/components/tabs/accessibility)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -210,12 +210,15 @@ loaded when the Tab is clicked. In v11, to do this, you can this by setting
 
 ### Tabs and the Grid - fullWidth prop
 
-By default, a `Tab` component is only as wide as it's content. This posses difficulties when trying to align tabs to the grid.
-Alternatively, you may choose to use the `fullWidth` prop to allow `Tab` elements to grow as  wide as their container allows.
+By default, a `Tab` component is only as wide as it's content. This posses
+difficulties when trying to align tabs to the grid. Alternatively, you may
+choose to use the `fullWidth` prop to allow `Tab` elements to grow as wide as
+their container allows.
 
-Note that this feature is *only available* for `contained` tabs in large and extra large screen sizes.
-The prop is a no-op for smaller screens and will also be ignored for `TabList`s with more than 8 tabs.
-`fullWidth` paired up with a wrapping `Grid` component will allow for "grid-aware" tabs:
+Note that this feature is _only available_ for `contained` tabs in large and
+extra large screen sizes. The prop is a no-op for smaller screens and will also
+be ignored for `TabList`s with more than 8 tabs. `fullWidth` paired up with a
+wrapping `Grid` component will allow for "grid-aware" tabs:
 
 <Canvas>
   <Grid condensed>
@@ -237,26 +240,29 @@ The prop is a no-op for smaller screens and will also be ignored for `TabList`s 
 </Canvas>
 
 ```jsx
-    <Grid condensed>
-      <Column lg={16} md={8} sm={4}>
-        <Tabs>
-          <TabList aria-label="List of tabs" contained fullWidth>
-            <Tab>Tab Label 1</Tab>
-            <Tab>Tab Label 2</Tab>
-            <Tab disabled>Tab Label 3</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel>Tab Panel 1</TabPanel>
-            <TabPanel>Tab Panel 2</TabPanel>
-            <TabPanel>Tab Panel 3</TabPanel>
-          </TabPanels>
-        </Tabs>
-      </Column>
-    </Grid>
+<Grid condensed>
+  <Column lg={16} md={8} sm={4}>
+    <Tabs>
+      <TabList aria-label="List of tabs" contained fullWidth>
+        <Tab>Tab Label 1</Tab>
+        <Tab>Tab Label 2</Tab>
+        <Tab disabled>Tab Label 3</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>Tab Panel 2</TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </Column>
+</Grid>
 ```
 
-Using the `fullWidth` prop alone within a `Grid` makes it so that the `Tabs` container aligns to the `Grid`, but not the individual `Tab` items;
-to have each individual `Tab` take up exactly one or many columns within the `Grid`, you must specify the number of columns as a multiple of the number of `Tab` items within the `TabList`.
+Using the `fullWidth` prop alone within a `Grid` makes it so that the `Tabs`
+container aligns to the `Grid`, but not the individual `Tab` items; to have each
+individual `Tab` take up exactly one or many columns within the `Grid`, you must
+specify the number of columns as a multiple of the number of `Tab` items within
+the `TabList`.
 
 For example, to have 5 tabs and each tab span exactly two columns:
 
@@ -284,26 +290,26 @@ For example, to have 5 tabs and each tab span exactly two columns:
 </Canvas>
 
 ```jsx
-  <Grid condensed>
-    <Column lg={10}>
-      <Tabs>
-        <TabList aria-label="List of tabs" contained fullWidth>
-          <Tab>Tab Label 1</Tab>
-          <Tab>Tab Label 2</Tab>
-          <Tab disabled>Tab Label 3</Tab>
-          <Tab>Tab Label 4</Tab>
-          <Tab>Tab Label 5</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>Tab Panel 1</TabPanel>
-          <TabPanel>Tab Panel 2</TabPanel>
-          <TabPanel>Tab Panel 3</TabPanel>
-          <TabPanel>Tab Panel 4</TabPanel>
-          <TabPanel>Tab Panel 5</TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Column>
-  </Grid>
+<Grid condensed>
+  <Column lg={10}>
+    <Tabs>
+      <TabList aria-label="List of tabs" contained fullWidth>
+        <Tab>Tab Label 1</Tab>
+        <Tab>Tab Label 2</Tab>
+        <Tab disabled>Tab Label 3</Tab>
+        <Tab>Tab Label 4</Tab>
+        <Tab>Tab Label 5</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>Tab Panel 2</TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+        <TabPanel>Tab Panel 4</TabPanel>
+        <TabPanel>Tab Panel 5</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </Column>
+</Grid>
 ```
 
 Or, to have 5 tabs and each tab span exactly three columns:
@@ -332,33 +338,27 @@ Or, to have 5 tabs and each tab span exactly three columns:
 </Canvas>
 
 ```jsx
-  <Grid condensed>
-    <Column lg={15}>
-      <Tabs>
-        <TabList aria-label="List of tabs" contained fullWidth>
-          <Tab>Tab Label 1</Tab>
-          <Tab>Tab Label 2</Tab>
-          <Tab disabled>Tab Label 3</Tab>
-          <Tab>Tab Label 4</Tab>
-          <Tab>Tab Label 5</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>Tab Panel 1</TabPanel>
-          <TabPanel>Tab Panel 2</TabPanel>
-          <TabPanel>Tab Panel 3</TabPanel>
-          <TabPanel>Tab Panel 4</TabPanel>
-          <TabPanel>Tab Panel 5</TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Column>
-  </Grid>
+<Grid condensed>
+  <Column lg={15}>
+    <Tabs>
+      <TabList aria-label="List of tabs" contained fullWidth>
+        <Tab>Tab Label 1</Tab>
+        <Tab>Tab Label 2</Tab>
+        <Tab disabled>Tab Label 3</Tab>
+        <Tab>Tab Label 4</Tab>
+        <Tab>Tab Label 5</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>Tab Panel 2</TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+        <TabPanel>Tab Panel 4</TabPanel>
+        <TabPanel>Tab Panel 5</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </Column>
+</Grid>
 ```
-
-
-
-
-
-
 
 ## V11
 

--- a/packages/react/src/components/Toggletip/Toggletip.mdx
+++ b/packages/react/src/components/Toggletip/Toggletip.mdx
@@ -6,8 +6,7 @@ import { ArgsTable } from '@storybook/blocks';
 &nbsp;|&nbsp;
 [Usage guidelines](https://www.carbondesignsystem.com/components/toggletip/usage)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.mdx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.mdx
@@ -9,8 +9,7 @@ import * as DefinitionTooltipStories from './DefinitionTooltip.stories';
 &nbsp;|&nbsp;
 [Accessibility](https://www.carbondesignsystem.com/components/tooltip/accessibility)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 

--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -9,8 +9,7 @@ import * as TooltipStories from './Tooltip.stories';
 &nbsp;|&nbsp;
 [Accessibility](https://www.carbondesignsystem.com/components/tooltip/accessibility)
 
-{/* <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
+{/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 
 ## Table of Contents
 


### PR DESCRIPTION
Part of https://github.com/carbon-design-system/carbon/issues/14300

#### Changelog

**Changed**

- Clarify in Button and IconButton `.mdx` docs that danger is not a supported option for icon only buttons
- Reformat doctoc comments to be compatible with MDX2

#### Testing / Reviewing

- Proofread the docs changes
