### PR TITLE
fix(tooltip): toggle aria-hidden so iphone voiceover works correctly

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -195,7 +195,7 @@ function Tooltip<T extends React.ElementType>({
           : null}
       </div>
       <PopoverContent
-        aria-hidden={open ? 'true' : 'false'}
+        aria-hidden={open ? 'false' : 'true'}
         className={`${prefix}--tooltip-content`}
         id={id}
         ref={tooltipRef}

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -195,7 +195,7 @@ function Tooltip<T extends React.ElementType>({
           : null}
       </div>
       <PopoverContent
-        aria-hidden="true"
+        aria-hidden={open ? 'true' : 'false'}
         className={`${prefix}--tooltip-content`}
         id={id}
         ref={tooltipRef}


### PR DESCRIPTION
Closes #13939

Set aria-hidden to false when tooltip is open so that it is read on iphone



#### Testing / Reviewing

Make sure nothing has changed with tooltip, and if you want to test on iphone 

1. Open link in safari on iphone
3. Go to Setting > Accessibility > VoiceOver on OR ask Siri to turn on voiceover
5. Take 2 fingers and swipe down to hear VO navigate through the page

