### PR TITLE
fix(layout): create mixin

### DIFF
--- a/packages/styles/scss/_layout.scss
+++ b/packages/styles/scss/_layout.scss
@@ -32,7 +32,7 @@ $layout-tokens: (
   ),
 );
 
-:root {
+@mixin emit-layout-tokens {
   @each $group, $properties in $layout-tokens {
     @each $property, $steps in $properties {
       @each $step, $value in $steps {
@@ -101,4 +101,8 @@ $layout-tokens: (
       }
     }
   }
+}
+
+:root {
+  @include emit-layout-tokens();
 }


### PR DESCRIPTION
Closes #

In order for `@carbon/web-components` to use the `layout-tokens` we need a separate `mixin`, so that we can apply the tokens inside the encapsulated web component and not the `root`

#### Changelog

**Changed**

- created a `emit-layout-tokens` mixins and then added the mixin to the `root`


#### Testing / Reviewing

confirmed via storybook that layout tokens are still working
