### PR TITLE
fix(styles): add display property to contained liste item class

### DIFF
--- a/packages/styles/scss/components/contained-list/_contained-list.scss
+++ b/packages/styles/scss/components/contained-list/_contained-list.scss
@@ -134,6 +134,7 @@
 
   .#{$prefix}--contained-list-item {
     position: relative;
+    display: list-item;
     list-style: none;
   }
 


### PR DESCRIPTION
Closes #14341

Similar to PR #12050

Specify display CSS property for specific wrapper classes.

This is to apply the style upstream instead of in Carbon Angular. List item elements already have a display property of `list-item` by default, but since we have to use custom HTML elements in angular, we have to explicitly specify the display property on the host. So this change aims to bring the style changes upstream.

#### Changelog

**New**

- Specified display property for wrapper classes of accordion item, table, & context menu components.


#### Testing / Reviewing

- [ ] Build the styles package
- [ ] Comment out or remove ALL styles in React package storybook styles.scss (packages/react/.storybook/styles.scss)
- [ ] Import the built styles in React package storybook styles file:
```scss
@import '../../styles/css/styles.css';
```
- [ ] Run storybook & verify if there are any visual changes to Accordion, Data Table, & Context Menu components.

I have reviewed React package code & verified via storybook to ensure these changes do not impact the package, but VRT can be performed against multiple browsers.
