### PR TITLE
fix(SideNav): don't change expanded state when it's controlled

### DIFF
--- a/packages/react/src/components/UIShell/SideNav.tsx
+++ b/packages/react/src/components/UIShell/SideNav.tsx
@@ -91,7 +91,7 @@ function SideNavRenderFunction(
   const navRef = useMergedRefs([sideNavRef, ref]);
 
   const handleToggle: typeof onToggle = (event, value = !expanded) => {
-    if (!controlled) {
+    if (controlled === undefined) {
       setExpandedState(value, enterDelayMs);
     }
     if (onToggle) {


### PR DESCRIPTION
#### Related issues

- https://github.com/carbon-design-system/carbon/issues/3666
- https://github.com/carbon-design-system/carbon/issues/13911#issuecomment-1588798106

The issue is closed but the problem still happened.

#### Changelog

**New**

- Don't change the `expanded` state if the `expanded` prop is `true` or `false`.

**Removed**

- Change the `expanded` state when the `expanded` prop is falsy value (`undefined`, `false`, `null` or `0`). Make the `SideNave` close even if the `expanded` prop that passed is `true`.

#### Before

`expanded` prop already `false`. But the `SideNav` set its internal state to `true`. Make the `SideNav` open again. 

https://github.com/carbon-design-system/carbon/assets/39755201/0de6f0f8-75ef-45a0-9696-edc5e9034ba0


