### PR TITLE
test(Link): add @avt tests

### DIFF
--- a/e2e/components/Link/Link-test.avt.e2e.js
+++ b/e2e/components/Link/Link-test.avt.e2e.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('Link @avt', () => {
+  test('accessibility-checker default', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Link',
+      id: 'components-link--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('components-link--default');
+  });
+
+  test('accessibility-checker inline', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Link',
+      id: 'components-link--inline',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('components-link--inline');
+  });
+
+  test('accessibility-checker paired with icon', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Link',
+      id: 'components-link--paired-with-icon',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'components-link--paired-with-icon'
+    );
+  });
+});

--- a/e2e/components/Link/Link-test.e2e.js
+++ b/e2e/components/Link/Link-test.e2e.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-const { expect, test } = require('@playwright/test');
+const { test } = require('@playwright/test');
 const { themes } = require('../../test-utils/env');
-const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+const { snapshotStory } = require('../../test-utils/storybook');
 
 test.describe('Link', () => {
   themes.forEach((theme) => {
@@ -30,16 +30,5 @@ test.describe('Link', () => {
         });
       });
     });
-  });
-
-  test('accessibility-checker @avt', async ({ page }) => {
-    await visitStory(page, {
-      component: 'Link',
-      id: 'components-link--default',
-      globals: {
-        theme: 'white',
-      },
-    });
-    await expect(page).toHaveNoACViolations('Link');
   });
 });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14333

Adds in AVT tests to check each `Link` story for a11y violations. Doesn't seem like there are any other states to test here 

#### Changelog

**New**

-`Link-test.avt.e2e.js` 

**Changed**

- Moved accessibility checker tests to `avt` file 


#### Testing / Reviewing

Ensure all `Link` tests pass and have proper coverage 
