### PR TITLE
style(Type): fix old variable usage

### DIFF
--- a/packages/styles/scss/__tests__/__snapshots__/type-test.js.snap
+++ b/packages/styles/scss/__tests__/__snapshots__/type-test.js.snap
@@ -933,7 +933,7 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 72,
+              "column": 59,
               "line": 96,
             },
             "source": undefined,
@@ -944,12 +944,12 @@ Object {
           },
           "property": "font-size",
           "type": "declaration",
-          "value": "var(--cds-helper-text-02-font-size, carbon--type-scale(2))",
+          "value": "var(--cds-helper-text-02-font-size, 0.875rem)",
         },
         Object {
           "position": Position {
             "end": Object {
-              "column": 85,
+              "column": 58,
               "line": 97,
             },
             "source": undefined,
@@ -960,7 +960,7 @@ Object {
           },
           "property": "font-weight",
           "type": "declaration",
-          "value": "var(--cds-helper-text-02-font-weight, carbon--font-weight(\\"regular\\"))",
+          "value": "var(--cds-helper-text-02-font-weight, 400)",
         },
         Object {
           "position": Position {

--- a/packages/type/scss/_styles.scss
+++ b/packages/type/scss/_styles.scss
@@ -92,8 +92,8 @@ $helper-text-01: (
 /// @deprecated
 /// @group @carbon/type
 $helper-text-02: (
-  font-size: carbon--type-scale(2),
-  font-weight: carbon--font-weight('regular'),
+  font-size: scale.type-scale(2),
+  font-weight: font-family.font-weight('regular'),
   line-height: 1.28572,
   letter-spacing: 0.16px,
 ) !default;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14364

Fixes a reference to the old carbon type scale

#### Changelog

**Removed**

- Removes usage of `carbon--`

#### Testing / Reviewing

Ensure Type styles compile and do not throw any errors 
