### PR TITLE
fix(Tile): backport SelectableTile a11y fix to v10

### DIFF
--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -15,6 +15,7 @@ import {
   TileBelowTheFoldContent,
 } from '../Tile';
 import { shallow, mount } from 'enzyme';
+import { render } from '@carbon/test-utils/react';
 
 const prefix = 'bx';
 
@@ -229,8 +230,15 @@ describe('Tile', () => {
       expect(wrapper.find('div').at(0).props().disabled).toEqual(true);
     });
 
-    it('should have no Accessibility Checker violations', () => {
-      expect(wrapper).toHaveNoACViolations('SelectableTile');
+    it('should have no AC violations', async () => {
+      const { container } = render(
+        <main>
+          <SelectableTile id="tile-1" name="tiles" value="selectable">
+            Selectable
+          </SelectableTile>
+        </main>
+      );
+      await expect(container).toHaveNoACViolations('SelectableTile');
     });
   });
 

--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -167,7 +167,7 @@ describe('Tile', () => {
 
     it('the input should be checked when state is selected', () => {
       label.simulate('click');
-      expect(wrapper.find('input').props().checked).toEqual(true);
+      expect(wrapper.find('div').at(0).prop('aria-checked')).toEqual(true);
     });
 
     it('supports setting initial selected state from props', () => {
@@ -195,10 +195,14 @@ describe('Tile', () => {
     it('supports light version', () => {
       const wrapper = mount(<SelectableTile>Test</SelectableTile>);
       expect(wrapper.props().light).toEqual(false);
-      expect(wrapper.childAt(1).hasClass('bx--tile--light')).toEqual(false);
+      expect(wrapper.find('div').at(0).hasClass('bx--tile--light')).toEqual(
+        false
+      );
       wrapper.setProps({ light: true });
       expect(wrapper.props().light).toEqual(true);
-      expect(wrapper.childAt(1).hasClass('bx--tile--light')).toEqual(true);
+      expect(wrapper.find('div').at(0).hasClass('bx--tile--light')).toEqual(
+        true
+      );
     });
 
     it('should call onChange when the checkbox value changes', () => {
@@ -222,7 +226,11 @@ describe('Tile', () => {
 
     it('supports disabled state', () => {
       wrapper.setProps({ disabled: true });
-      expect(wrapper.find('input').props().disabled).toEqual(true);
+      expect(wrapper.find('div').at(0).props().disabled).toEqual(true);
+    });
+
+    it('should have no Accessibility Checker violations', () => {
+      expect(wrapper).toHaveNoACViolations('SelectableTile');
     });
   });
 

--- a/packages/react/src/components/Tile/Tile.js
+++ b/packages/react/src/components/Tile/Tile.js
@@ -250,9 +250,6 @@ export function SelectableTile(props) {
     },
     className
   );
-  const inputClasses = cx(`${prefix}--tile-input`, {
-    [`${prefix}--tile-input--checked`]: isSelected,
-  });
 
   // TODO: rename to handleClick when handleClick prop is deprecated
   function handleOnClick(evt) {
@@ -284,36 +281,30 @@ export function SelectableTile(props) {
   }, [selected]);
 
   return (
-    <>
-      <input
-        ref={input}
-        tabIndex={-1}
-        id={id}
-        className={inputClasses}
-        value={value}
-        onChange={!disabled ? handleChange : null}
-        type="checkbox"
-        disabled={disabled}
-        name={name}
-        title={title}
-        checked={isSelected}
-      />
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <label
-        htmlFor={id}
-        className={classes}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-        tabIndex={!disabled ? tabIndex : null}
-        {...rest}
-        onClick={!disabled ? handleOnClick : null}
-        onKeyDown={!disabled ? handleOnKeyDown : null}>
-        <span
-          className={`${prefix}--tile__checkmark ${prefix}--tile__checkmark--persistent`}>
-          {isSelected ? <CheckboxCheckedFilled16 /> : <Checkbox16 />}
-        </span>
-        <span className={`${prefix}--tile-content`}>{children}</span>
+    <div
+      className={classes}
+      onClick={!disabled ? handleOnClick : null}
+      role="checkbox"
+      aria-checked={isSelected}
+      disabled={disabled}
+      onKeyDown={!disabled ? handleOnKeyDown : null}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={!disabled ? tabIndex : null}
+      value={value}
+      name={name}
+      ref={input}
+      id={id}
+      onChange={!disabled ? handleChange : null}
+      title={title}
+      {...rest}>
+      <span
+        className={`${prefix}--tile__checkmark ${prefix}--tile__checkmark--persistent`}>
+        {isSelected ? <CheckboxCheckedFilled16 /> : <Checkbox16 />}
+      </span>
+      <label htmlFor={id} className={`${prefix}--tile-content`}>
+        {children}
       </label>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #14321 
Refs #12301 

Backports a11y fix for the `SelectableTile` component to v10

#### Changelog

**Changed**

- Copied changes over from v11 regarding the referenced issue
- Refactored some v10 `SelectableTile` unit tests to pass with the new DOM structure changes

#### Testing / Reviewing
Verify that the reported violation in #14321 does not occur for SelectableTile, no new violations introduced, no style or functional regressions, and VO now announces the checked/unchecked state of the tile when focused.
