### PR TITLE
chore: add sha to github action

### DIFF
--- a/.github/workflows/contribution-buddy.yml
+++ b/.github/workflows/contribution-buddy.yml
@@ -8,7 +8,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v3
+      - uses: dessant/label-actions@ade7bcd4c1b30de6ba8e556cc31301fd4f79ca65 #v3.1.0
         with:
           github-token: ${{ github.token }}
           config-path: '.github/label-actions.yml'


### PR DESCRIPTION
part of https://github.com/carbon-design-system/carbon/issues/14294

adding an SHA to lock in versioning to the github action while we are testing / researching different approaches 