### PR TITLE
fix(DataTable-BatchAction): resolve batch action button alignment

### DIFF
--- a/packages/styles/scss/components/data-table/action/_data-table-action.scss
+++ b/packages/styles/scss/components/data-table/action/_data-table-action.scss
@@ -633,8 +633,8 @@
   .#{$prefix}--table-toolbar--sm .#{$prefix}--btn--primary {
     height: rem(32px);
     min-height: auto;
-    padding-top: calc(0.375rem - 3px);
-    padding-bottom: calc(0.375rem - 3px);
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
   }
 
   .#{$prefix}--table-toolbar--sm


### PR DESCRIPTION
Closes #14312 

The TableBatchActions inside TableToolbar are misaligned for size variant 'sm'.

#### Changelog

**Changed**

- updated the buttons styles (`padding-top `and `padding-bottom`) for 'sm' variant.

#### Testing / Reviewing

checked manually through storybook.

https://deploy-preview-14384--carbon-components-react.netlify.app/?path=/story/components-datatable-batch-actions--playground&args=size:sm
