### PR TITLE
fix(Button): Align Ghost Button Kind hover & active styles with Design Guidance

### DIFF
--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -108,9 +108,9 @@
       transparent,
       transparent,
       $link-primary,
-      $layer-hover,
+      $background-hover,
       currentColor,
-      $layer-active
+      $background-active
     );
 
     padding-inline-end: calc(layout.density('padding-inline') - rem(1px));


### PR DESCRIPTION
As per Design guidance specifications for [Ghost Button](https://carbondesignsystem.com/components/button/style#ghost-button):

#### Changelog

**Changed**

- Ghost Button theme inputs
  - `$layer-hover` -> `$background-hover`
  - `$layer-active` -> `$background-active`

#### Testing / Reviewing
* View source in production Storybook for Ghost Button and notice that hover/active use `layer` tokens
* View source in branch Storybook for Ghost Button and notice that hover/active use `background` tokens
👍 
