### PR TITLE
fix(datatable): remove toolbar search and menu from tab order

### DIFF
--- a/e2e/components/DataTable/DataTable-test.avt.e2e.js
+++ b/e2e/components/DataTable/DataTable-test.avt.e2e.js
@@ -154,8 +154,6 @@ test.describe('DataTable @avt', () => {
       await page.keyboard.press('Shift+Tab');
       await page.keyboard.press('Shift+Tab');
       await page.keyboard.press('Shift+Tab');
-      await page.keyboard.press('Shift+Tab');
-      await page.keyboard.press('Shift+Tab');
 
       await page
         .getByRole('heading', { name: 'Expandable row content' })

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -515,6 +515,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
             id="custom-id"
             placeholder="Filter table"
             role="searchbox"
+            tabindex="0"
             type="text"
             value=""
           />
@@ -941,6 +942,7 @@ exports[`DataTable renders as expected - Component API should render and match s
             id="custom-id"
             placeholder="Filter table"
             role="searchbox"
+            tabindex="0"
             type="text"
             value=""
           />

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -40,6 +40,7 @@ exports[`TableToolbarSearch renders as expected - Component API should render 1`
       id="custom-id"
       placeholder="Filter table"
       role="searchbox"
+      tabindex="0"
       type="text"
       value=""
     />

--- a/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content.stories.js
+++ b/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content.stories.js
@@ -154,8 +154,16 @@ export const Default = () => {
                     </TableBatchAction>
                   </TableBatchActions>
                   <TableToolbarContent>
-                    <TableToolbarSearch onChange={onInputChange} />
-                    <TableToolbarMenu>
+                    <TableToolbarSearch
+                      tabIndex={
+                        batchActionProps.shouldShowBatchActions ? -1 : 0
+                      }
+                      onChange={onInputChange}
+                    />
+                    <TableToolbarMenu
+                      tabIndex={
+                        batchActionProps.shouldShowBatchActions ? -1 : 0
+                      }>
                       <TableToolbarAction onClick={this.handleOnRowAdd}>
                         Add row
                       </TableToolbarAction>
@@ -328,8 +336,14 @@ export const Playground = (args) => {
                         action('TableToolbarSearch - onChange')(evt);
                         onInputChange(evt);
                       }}
+                      tabIndex={
+                        batchActionProps.shouldShowBatchActions ? -1 : 0
+                      }
                     />
-                    <TableToolbarMenu>
+                    <TableToolbarMenu
+                      tabIndex={
+                        batchActionProps.shouldShowBatchActions ? -1 : 0
+                      }>
                       <TableToolbarAction
                         onClick={(evt) => {
                           action('handleOnRowAdd')(evt);

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -243,7 +243,6 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
         {labelText}
       </label>
       <input
-        {...rest}
         autoComplete={autoComplete}
         className={`${prefix}--search-input`}
         defaultValue={defaultValue}
@@ -257,6 +256,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
         type={type}
         value={value}
         tabIndex={onExpand && !isExpanded ? -1 : undefined}
+        {...rest}
       />
       <button
         aria-label={closeButtonLabelText}


### PR DESCRIPTION
This removes the table toolbar search and menu actions from the tab order when batch actions are open, as discussed in https://github.com/carbon-design-system/carbon/pull/14357#discussion_r1281907787

#### Changelog

**Changed**

- update Search to put `...rest` after other props
- update stories to remove TableToolbarSearch and TableToolbarMenu actions from tab order when batch action bar is open/visible

#### Testing / Reviewing

* focus should move through the actions when the batch action bar is closed
* focus should not move through the actions when the batch action bar is open


https://github.com/carbon-design-system/carbon/assets/3360588/b7593fe3-5e58-4628-8dba-6fd184dda7b6


