### PR TITLE
fix(light-dark-mode): add default value to createContext

### DIFF
--- a/examples/light-dark-mode/src/components/ThemePreference.js
+++ b/examples/light-dark-mode/src/components/ThemePreference.js
@@ -1,7 +1,10 @@
 import { GlobalTheme } from '@carbon/react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-const ThemePreferenceContext = createContext();
+const ThemePreferenceContext = createContext({
+  theme: 'g10',
+  setTheme: () => null,
+});
 
 function useThemePreference() {
   return useContext(ThemePreferenceContext);


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14408

Adds a default value to the `createContext` in `light-dark-mode` example

#### Changelog

**Changed**

- Adds a default value to the `createContext` 

#### Testing / Reviewing

Ensure the `light-dark-mode` example still works as expected
