### PR TITLE
fix(carbon-components): remove "warning" dependency (unused)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,8 +65,7 @@
   "dependencies": {
     "@carbon/telemetry": "0.1.0",
     "flatpickr": "4.6.1",
-    "lodash.debounce": "^4.0.8",
-    "warning": "^3.0.0"
+    "lodash.debounce": "^4.0.8"
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",

--- a/packages/components/src/components/modal/modal.js
+++ b/packages/components/src/components/modal/modal.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import warning from 'warning';
 import settings from '../../globals/js/settings';
 import mixin from '../../globals/js/misc/mixin';
 import createComponent from '../../globals/js/mixins/create-component';
@@ -110,7 +109,7 @@ class Modal extends mixin(
           this.element.querySelector(settings.selectorTabbable);
         focusableItem.focus();
         if (__DEV__) {
-          warning(
+          console.warn(
             focusableItem,
             `Modals need to contain a focusable element by either using ` +
               `\`${this.options.selectorPrimaryFocus}\` or settings.selectorTabbable.`

--- a/yarn.lock
+++ b/yarn.lock
@@ -11737,7 +11737,6 @@ __metadata:
     terser-webpack-plugin: ^2.3.2
     through2: ^3.0.0
     vinyl-named: ^1.1.0
-    warning: ^3.0.0
     webpack: ^4.41.5
     webpack-dev-middleware: ^3.7.2
     webpack-hot-middleware: ^2.21.0


### PR DESCRIPTION
Closes #14422 

`carbon-components@10.58.8` has a dependency named "warning" that is interfering with the UMD bundle creation for `@carbon/charts`. The "warning" module appears to be unused. It makes the assumption that process.env.NODE_ENV exists which is not the case in a bundle designed to be used in a browser.

#### Changelog

**Removed**

- Remove "warning" dependency from package.json for `carbon-components@v10`

#### Testing / Reviewing

Run `yarn build-dev` from packages/components directory.