### PR TITLE
chore: remove website automated dep update

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -12,49 +12,6 @@ on:
       - completed
 
 jobs:
-  carbon-website:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: carbon-design-system/carbon-website
-          ref: main
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Update dependencies
-        run: |
-          yarn upgrade \
-            @carbon/elements@next \
-            @carbon/pictograms@next \
-            @carbon/pictograms-react@next \
-            @carbon/icons-react@next \
-            @carbon/react@next
-      - name: Generate token
-        uses: tibdex/github-app-token@v1
-        id: generate_token
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          branch: 'release/update-carbon-deps'
-          commit-message: 'chore(release): update carbon deps'
-          delete-branch: true
-          title: 'chore(release): update carbon deps'
-          token: ${{ steps.generate_token.outputs.token }}
-          body: |
-            Automated pull request to update Carbon on the website
-
-            **Checklist**
-
-            - [ ] Verify package version bumps are accurate
-            - [ ] Verify CI passes as expected
-            - [ ] Verify no regressions on the website in the deploy preview
   design-language-website:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/release.md
+++ b/docs/release.md
@@ -110,9 +110,6 @@ git push upstream v11.2.0-rc.0
 
 - [ ] Verify that this triggers a run of the
       [Release Workflow](https://github.com/carbon-design-system/carbon/actions/workflows/release.yml)
-- [ ] Review and approve the Pull Request generated from this action on the
-      [Carbon Website](https://github.com/carbon-design-system/carbon-website)
-      to verify no breaking changes have occurred in this release
 
 #### Releasing another prerelease
 
@@ -165,7 +162,7 @@ git push upstream v11.2.0
 - [ ] Verify that this triggers a run of the
       [Release Workflow](https://github.com/carbon-design-system/carbon/actions/workflows/release.yml)
 - [ ] Review and approve the Pull Request generated from this action on the
-      [Carbon Website](https://github.com/carbon-design-system/carbon-website)
+      [gatsby-theme-carbon](https://github.com/carbon-design-system/gatsby-theme-carbon)
       to verify no breaking changes have occurred in this release. If the PR
       from the previous release was not merged, the existing PR will be updated.
 


### PR DESCRIPTION
Ref [#3688](https://github.com/carbon-design-system/carbon-website/issues/3688)


#### Changelog


**Removed**

- remove automated website dep update PR (need to be in sync with gatsby theme carbon version)
- update release.md
