### PR TITLE
fix(DataTable): backport checkbox selection a11y fix to v10

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -988,11 +988,16 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                               type="checkbox"
                             />
                             <label
-                              aria-label="Select all rows"
                               className="bx--checkbox-label"
                               htmlFor="data-table-7__select-all"
                               onClick={[Function]}
-                            />
+                            >
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select all rows
+                              </span>
+                            </label>
                           </div>
                         </ForwardRef(InlineCheckbox)>
                       </th>
@@ -1388,11 +1393,16 @@ exports[`DataTable selection should render 1`] = `
                               type="checkbox"
                             />
                             <label
-                              aria-label="Select all rows"
                               className="bx--checkbox-label"
                               htmlFor="data-table-6__select-all"
                               onClick={[Function]}
-                            />
+                            >
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select all rows
+                              </span>
+                            </label>
                           </div>
                         </ForwardRef(InlineCheckbox)>
                       </th>
@@ -1483,11 +1493,16 @@ exports[`DataTable selection should render 1`] = `
                               type="checkbox"
                             />
                             <label
-                              aria-label="Select row"
                               className="bx--checkbox-label"
                               htmlFor="data-table-6__select-row-b"
                               onClick={[Function]}
-                            />
+                            >
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select row
+                              </span>
+                            </label>
                           </div>
                         </ForwardRef(InlineCheckbox)>
                       </td>
@@ -1546,11 +1561,16 @@ exports[`DataTable selection should render 1`] = `
                               type="checkbox"
                             />
                             <label
-                              aria-label="Select row"
                               className="bx--checkbox-label"
                               htmlFor="data-table-6__select-row-a"
                               onClick={[Function]}
-                            />
+                            >
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select row
+                              </span>
+                            </label>
                           </div>
                         </ForwardRef(InlineCheckbox)>
                       </td>
@@ -1609,11 +1629,16 @@ exports[`DataTable selection should render 1`] = `
                               type="checkbox"
                             />
                             <label
-                              aria-label="Select row"
                               className="bx--checkbox-label"
                               htmlFor="data-table-6__select-row-c"
                               onClick={[Function]}
-                            />
+                            >
+                              <span
+                                className="bx--visually-hidden"
+                              >
+                                Select row
+                              </span>
+                            </label>
                           </div>
                         </ForwardRef(InlineCheckbox)>
                       </td>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectAll-test.js.snap
@@ -47,11 +47,16 @@ exports[`DataTable.TableSelectAll should render 1`] = `
                         type="checkbox"
                       />
                       <label
-                        aria-label="Select all rows in the table"
                         className="bx--checkbox-label"
                         htmlFor="id"
                         onClick={[Function]}
-                      />
+                      >
+                        <span
+                          className="bx--visually-hidden"
+                        >
+                          Select all rows in the table
+                        </span>
+                      </label>
                     </div>
                   </ForwardRef(InlineCheckbox)>
                 </th>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableSelectRow-test.js.snap
@@ -46,11 +46,16 @@ exports[`DataTable.TableSelectRow should render 1`] = `
                         type="checkbox"
                       />
                       <label
-                        aria-label="Aria label"
                         className="bx--checkbox-label"
                         htmlFor="id"
                         onClick={[Function]}
-                      />
+                      >
+                        <span
+                          className="bx--visually-hidden"
+                        >
+                          Aria label
+                        </span>
+                      </label>
                     </div>
                   </ForwardRef(InlineCheckbox)>
                 </td>

--- a/packages/react/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/packages/react/src/components/InlineCheckbox/InlineCheckbox.js
@@ -60,12 +60,12 @@ const InlineCheckbox = React.forwardRef(function InlineCheckbox(
         <label
           htmlFor={id}
           className={`${prefix}--checkbox-label`}
-          aria-label={ariaLabel}
           title={title}
           onClick={(evt) => {
             evt.stopPropagation();
-          }}
-        />
+          }}>
+          <span className={`${prefix}--visually-hidden`}>{ariaLabel}</span>
+        </label>
       }
     </div>
   );


### PR DESCRIPTION
Closes #14002 
Refs #14206 

Backports a11y fix for the `InlineCheckbox` component to v10

This fixes the AVT violation `The ARIA attributes "aria-label" are not valid for the element <label> with ARIA role "none"` seen on the DataTable Selection variant in Carbon v10.

#### Changelog

**Changed**

* Copied changes over from v11 regarding the referenced issue
* Updated snapshot tests for unit tests to pass with new DOM structure changes

#### Testing / Reviewing

- Verify that the reported violation in #14002 does not occur for the DataTable Selection variant through the v10 storybook using the IBM a11y checker scan (09 August 2023 latest version deployment).
- No new violations introduced, no style or functional regressions
- VO now announces the action of the checkbox (Select row, Unselect row, Select all rows, Unselect all rows)
