### PR TITLE
fix: 14418-form-file-uploader-bug

### DIFF
--- a/packages/react/src/components/Form/Form.stories.js
+++ b/packages/react/src/components/Form/Form.stories.js
@@ -130,9 +130,17 @@ export const Default = () => (
         <FileUploader
           {...fileUploaderEvents}
           id="file-1"
-          labelDescription="Choose Files..."
-          iconDescription="Dismiss file"
           role="button"
+          labelDescription="Max file size is 500mb. Only .jpg files are supported."
+          buttonLabel="Add file"
+          buttonKind="primary"
+          size="md"
+          filenameStatus="edit"
+          accept={['.jpg', '.png']}
+          multiple={true}
+          disabled={false}
+          iconDescription="Dismiss file"
+          name=""
         />
       </FormGroup>
 


### PR DESCRIPTION
Closes #14418 

Form storybook should now have a dismissible file in the storybook example instead of an infinite loading file

### Testing: 

- upload a file and make sure you can remove the file via keyboard navigation as seen below

<img width="1098" alt="Screenshot 2023-08-16 at 14 27 04" src="https://github.com/carbon-design-system/carbon/assets/32720851/e25a0e3c-f43a-46d3-b438-219bea7ea6b4">

