### PR TITLE
docs(storybook): add text direction auto/ltr/rtl switcher

### DIFF
--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -29,7 +29,7 @@ const devTools = {
     description: "Set the layout context's size",
     defaultValue: false,
     toolbar: {
-      title: 'unstable__Layout size',
+      title: 'dev :: unstable__Layout size',
       items: [
         {
           value: false,
@@ -48,7 +48,7 @@ const devTools = {
     description: "Set the layout context's density",
     defaultValue: false,
     toolbar: {
-      title: 'unstable__Layout density',
+      title: 'dev :: unstable__Layout density',
       items: [
         {
           value: false,
@@ -68,6 +68,7 @@ const globalTypes = {
     defaultValue: 'en',
     toolbar: {
       icon: 'globe',
+      title: 'Locale',
       items: [
         {
           right: '🇺🇸',
@@ -82,12 +83,39 @@ const globalTypes = {
       ],
     },
   },
+  dir: {
+    name: 'Text direction',
+    description: 'Set the text direction for the story',
+    defaultValue: 'ltr',
+    toolbar: {
+      icon: 'transfer',
+      title: 'Text direction',
+      items: [
+        {
+          right: '🔄',
+          title: 'auto',
+          value: 'auto',
+        },
+        {
+          right: '➡️',
+          title: 'left-to-right (ltr)',
+          value: 'ltr',
+        },
+        {
+          right: '⬅️',
+          title: 'right-to-left (rtl)',
+          value: 'rtl',
+        },
+      ],
+    },
+  },
   theme: {
     name: 'Theme',
     description: 'Set the global theme for displaying components',
     defaultValue: 'white',
     toolbar: {
       icon: 'paintbrush',
+      title: 'Theme',
       items: ['white', 'g10', 'g90', 'g100'],
     },
   },
@@ -277,7 +305,7 @@ const parameters = {
 
 const decorators = [
   (Story, context) => {
-    const { layoutDensity, layoutSize, locale, theme } = context.globals;
+    const { layoutDensity, layoutSize, locale, dir, theme } = context.globals;
 
     React.useEffect(() => {
       document.documentElement.setAttribute('data-carbon-theme', theme);
@@ -285,7 +313,8 @@ const decorators = [
 
     React.useEffect(() => {
       document.documentElement.lang = locale;
-    }, [locale]);
+      document.documentElement.dir = dir;
+    }, [locale, dir]);
 
     return (
       <GlobalTheme theme={theme}>


### PR DESCRIPTION
Closes #13620 

This PR improves our storybook toolbar to have a `Text direction` toolbar item that influences the `dir` attribute on the `html` element that wraps the story.

![image](https://github.com/carbon-design-system/carbon/assets/3360588/f156d05e-e331-4b8e-a6db-ab1ef5df1c83)

#### Changelog

**New**

- Add a `Text direction` toolbar item to storybook

**Changed**

- Provide a `title` for our custom toolbar items in storybook to prevent confusion and improve discoverability
- add `dev ::` prefix for toolbar items that are only visible in dev

#### Testing / Reviewing

- Go to a tile story, select `rtl` or `ltr`. 
- The component should reflow to display properly when rtl vs ltr is selected thanks to recent work in https://github.com/carbon-design-system/carbon/pull/14441
- Other components that have been updated to use logical properties should also render appropriately as it switches. 




