### PR TITLE
fix(incremental-example): limit hoisting of dependencies

### DIFF
--- a/examples/incremental-migration-vite/package.json
+++ b/examples/incremental-migration-vite/package.json
@@ -2,11 +2,13 @@
   "name": "incremental-migration-vite",
   "private": true,
   "version": "0.1.0",
-  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
   },
   "dependencies": {
     "@carbon/icons-react": "^10.49.0",


### PR DESCRIPTION
This should fix all the intermittent test failures we've been seeing on the `@carbon/icons-react` e2e public api snapshots.

The incremental example was recently duplicated and reconfigured to run on Vite. This example specifies a purposefully outdated `@carbon/icons-react@10.x` dependency. This version was being hoisted throughout the monorepo, causing the icons-react dep to be misconfigured in the e2e snapshots. This caused it to fail to generate the proper snapshot resulting in the overall failure of the CI check.

#### Changelog

**New**

- add `"installConfig": { "hoistingLimits": "workspaces" }` to incremental-adoption-vite example

#### Testing / Reviewing

- All CI checks should pass

#### References

* We ran into this previously on commit https://github.com/carbon-design-system/carbon/pull/12091/commits/a3456cd13b36e00bc0f8f732d7773cb5709b7819 on https://github.com/carbon-design-system/carbon/pull/12091
