### PR TITLE
fix(components): guard event.persist() calls

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -411,7 +411,7 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
 
     if (event.target === textInput.current && isOpen) {
       event.preventDownshiftDefault = true;
-      event.persist();
+      event?.persist?.();
     }
   };
 
@@ -521,7 +521,7 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
               if (event.target === textInput.current && isOpen) {
                 toggleMenu();
                 event.preventDownshiftDefault = true;
-                event.persist();
+                event?.persist?.();
               }
             }
 

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -175,7 +175,7 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
     id,
     onChange: (evt) => {
       if (!other.disabled && onChange) {
-        evt.persist();
+        evt?.persist?.();
         // delay textCount assignation to give the textarea element value time to catch up if is a controlled input
         setTimeout(() => {
           setTextCount(evt.target?.value?.length);

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -154,13 +154,13 @@ export const ClickableTile = React.forwardRef<
   const [isSelected, setIsSelected] = useState(clicked);
 
   function handleOnClick(evt: MouseEvent) {
-    evt.persist();
+    evt?.persist?.();
     setIsSelected(!isSelected);
     onClick(evt);
   }
 
   function handleOnKeyDown(evt: KeyboardEvent) {
-    evt.persist();
+    evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
       evt.preventDefault();
       setIsSelected(!isSelected);
@@ -360,7 +360,7 @@ export const SelectableTile = React.forwardRef<
   // TODO: rename to handleClick when handleClick prop is deprecated
   function handleOnClick(evt) {
     evt.preventDefault();
-    evt.persist();
+    evt?.persist?.();
     setIsSelected(!isSelected);
     clickHandler(evt);
     onChange(evt);
@@ -368,7 +368,7 @@ export const SelectableTile = React.forwardRef<
 
   // TODO: rename to handleKeyDown when handleKeyDown prop is deprecated
   function handleOnKeyDown(evt) {
-    evt.persist();
+    evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
       evt.preventDefault();
       setIsSelected(!isSelected);
@@ -601,7 +601,7 @@ export const ExpandableTile = React.forwardRef<
   }
 
   function handleClick(evt: MouseEvent) {
-    evt.persist();
+    evt?.persist?.();
     setIsExpanded(!isExpanded);
     setMaxHeight();
   }


### PR DESCRIPTION
[Raised in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1692626599191779?thread_ts=1689560271.450069&cid=C2K6RFJ1G)

Even though `persist()` is available and just a noop in later versions of react that don't have event pooling anymore, we still need to guard calls to these. It was pointed out that if we begin to call `persist()`, it can break tests where event handlers are mocked. Example:

> On our app we mock onChange function passed to the textArea like:
> ```js
> let onChange = jest.fn();
>     let component = getComponent('hello', onChange);
>     component
>       .find('textarea')
>       .props()
>       .onChange({ target: { value: '   test123' }, persist: jest.fn() });
> ```
> I had to add persist: jest.fn() into this bcs of that change
> 

#### Changelog

**Changed**

- modify all `event.persist()` calls to be guarded via `event?.persist?.();`

#### References

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#optional_chaining_with_function_calls