### PR TITLE
chore: update release docs

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -161,12 +161,32 @@ git push upstream v11.2.0
 
 - [ ] Verify that this triggers a run of the
       [Release Workflow](https://github.com/carbon-design-system/carbon/actions/workflows/release.yml)
-- [ ] Review and approve the Pull Request generated from this action on the
-      [gatsby-theme-carbon](https://github.com/carbon-design-system/gatsby-theme-carbon)
+- [ ] Review and approve the Pull Request generated from this action in
+      [gatsby-theme-carbon](https://github.com/carbon-design-system/gatsby-theme-carbon/pulls)
       to verify no breaking changes have occurred in this release. If the PR
       from the previous release was not merged, the existing PR will be updated.
 
 **Friday**
+
+After the PR to the Carbon Gatsby theme is merged it will trigger an automated
+release of the theme. To then update the Carbon website to the latest version of
+Carbon and gatsby-theme-carbon you will need to:
+
+- [ ] Check that the
+      [chore(release): update carbon deps](https://github.com/carbon-design-system/gatsby-theme-carbon/pulls)
+      PR has been merged in the gatsby-theme-carbon repo.
+- [ ] Check that
+      [gatsby-theme-carbon](https://github.com/carbon-design-system/gatsby-theme-carbon)
+      has been released and is on the
+      [latest version](https://github.com/carbon-design-system/gatsby-theme-carbon/blob/main/packages/gatsby-theme-carbon/package.json)
+      of Carbon
+- [ ] Run the
+      [Update Carbon and gatsby-theme-carbon deps workflow](https://github.com/carbon-design-system/carbon-website/actions/workflows/update-carbon-gatsby-deps.yml)
+      to automatically open a PR in the Carbon website to update to latest
+      Carbon and gatsby-theme-carbon versions.
+- [ ] Review and approve the
+      [pull request](https://github.com/carbon-design-system/carbon-website/pulls)
+      generate by the workflow.
 
 The packages that have been published will be switched to latest on the first
 Friday of a sprint. To make the switch, you will need to:
@@ -185,6 +205,7 @@ Friday of a sprint. To make the switch, you will need to:
 - [ ] Uncheck "this is a prerelease" on the Release
 
 - [ ] Post the release announcement in slack
+
   - [ ] #carbon-announcements
   - [ ] #carbon-components
   - [ ] #carbon-design-system

--- a/docs/release.md
+++ b/docs/release.md
@@ -205,7 +205,6 @@ Friday of a sprint. To make the switch, you will need to:
 - [ ] Uncheck "this is a prerelease" on the Release
 
 - [ ] Post the release announcement in slack
-
   - [ ] #carbon-announcements
   - [ ] #carbon-components
   - [ ] #carbon-design-system


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/3688
Closes https://github.com/carbon-design-system/carbon-website/issues/3675

The release of the gatsby theme has been automated, the PR updates release docs to include steps to update the Carbon website using the new [workflow](https://github.com/carbon-design-system/carbon-website/actions/workflows/update-carbon-gatsby-deps.yml) created in the website repo. 



