### PR TITLE
fix(modal): ensure combobox has correct color when placed in modal

### DIFF
--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -63,7 +63,8 @@
     .#{$prefix}--date-picker__input,
     .#{$prefix}--multi-select,
     .#{$prefix}--number__control-btn::before,
-    .#{$prefix}--number__control-btn::after {
+    .#{$prefix}--number__control-btn::after,
+    .#{$prefix}--list-box input[role='combobox'] {
       background-color: $field-02;
     }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14486

Adjusts background color for `ComboBox` when placed inside a `Modal`

#### Changelog

**Changed**

- Override for `ComboBox` styles in `Modal`

#### Testing / Reviewing

Place a `ComboBox` inside a `Modal` and ensure it has the correct background
