### PR TITLE
fix(FileUploader): add missing typings to props variables

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploader.Skeleton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.Skeleton.tsx
@@ -20,7 +20,10 @@ export interface FileUploaderSkeletonProps extends ReactAttr<HTMLDivElement> {
   className?: string;
 }
 
-function FileUploaderSkeleton({ className, ...rest }) {
+function FileUploaderSkeleton({
+  className,
+  ...rest
+}: FileUploaderSkeletonProps) {
   const prefix = usePrefix();
   return (
     <div className={cx(`${prefix}--form-item`, className)} {...rest}>

--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -44,7 +44,10 @@ export interface FileUploaderItemProps extends ReactAttr<HTMLSpanElement> {
    * Event handler that is called after removing a file from the file uploader
    * The event handler signature looks like `onDelete(evt, { uuid })`
    */
-  onDelete?: (event: any, opts: { uuid: string }) => void;
+  onDelete?: (
+    event: React.SyntheticEvent<HTMLElement>,
+    opts: { uuid: string }
+  ) => void;
 
   /**
    * Specify the size of the FileUploaderButton, from a list of available
@@ -66,21 +69,21 @@ export interface FileUploaderItemProps extends ReactAttr<HTMLSpanElement> {
 function FileUploaderItem({
   uuid,
   name,
-  status,
+  status = 'uploading',
   iconDescription,
-  onDelete,
+  onDelete = () => {},
   invalid,
   errorSubject,
   errorBody,
   size,
   ...other
-}) {
+}: FileUploaderItemProps) {
   const prefix = usePrefix();
   const { current: id } = useRef(uuid || uid());
   const classes = cx(`${prefix}--file__selected-file`, {
     [`${prefix}--file__selected-file--invalid`]: invalid,
-    [`${prefix}--file__selected-file--md`]: size === 'field' || size === 'md',
-    [`${prefix}--file__selected-file--sm`]: size === 'small' || size === 'sm',
+    [`${prefix}--file__selected-file--md`]: size === 'md',
+    [`${prefix}--file__selected-file--sm`]: size === 'sm',
   });
   return (
     <span className={classes} {...other}>


### PR DESCRIPTION
The FileUploaderDropContainer, FileUploaderItem and FileUploaderSkeleton components props arguments were missing type, which effectively made them untyped when consumed. This change enforces props arg type, and also fixes downstream typing issues within the implementation itself.

#### Changelog

**Changed**

- Set proper TypeScript type for FileUploaderDropContainer, FileUploaderItem and FileUploaderSkeleton props.

#### Testing / Reviewing

Using mentioned components in a TypeScript project should show no errors and give proper type hints for component props.