### PR TITLE
style(Checkbox): fix invalid, warning icon size when text wraps

### DIFF
--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -223,12 +223,13 @@
   .#{$prefix}--checkbox-group__validation-msg,
   .#{$prefix}--checkbox__validation-msg {
     display: none;
-    align-items: flex-end;
+    align-items: flex-start;
     margin-top: $spacing-02;
   }
 
   .#{$prefix}--checkbox__invalid-icon {
-    margin: 0 convert.to-rem(1px) 0 convert.to-rem(3px);
+    min-width: convert.to-rem(16px);
+    margin: convert.to-rem(1px) convert.to-rem(1px) 0 convert.to-rem(3px);
     fill: $support-error;
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14514

Adds a `min-width` so invalid, warn icons do not shrink. Also aligns them to the top of the warning message when text wraps

#### Changelog

**Changed**

- Adjusted `min-width` of the icon so that icon does not shrink
- Align icon to the top of the error/warning text
- Pushed icon down 1px to better align with text

#### Testing / Reviewing

Go to the `Checkbox` playground story and add in a bunch of text for the error message so that the text wraps. Ensure the icon stays the same size and aligns to the top
