### PR TITLE
fix(v10): backport a11y fixes for UIShell, FileUploaderButton

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3398,8 +3398,9 @@ Map {
   "HeaderPanel" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
+      "children": Object {
+        "type": "node",
+      },
       "className": Object {
         "type": "string",
       },

--- a/packages/react/src/components/FileUploader/FileUploader.js
+++ b/packages/react/src/components/FileUploader/FileUploader.js
@@ -232,7 +232,7 @@ export default class FileUploader extends React.Component {
                 <span
                   key={index}
                   className={selectedFileClasses}
-                  ref={(node) => (this.nodes[index] = node)} // eslint-disable-line
+                  ref={(node) => (this.nodes[index] = node)}
                   {...other}>
                   <p className={`${prefix}--file-filename`}>{name}</p>
                   <span className={`${prefix}--file__state-container`}>

--- a/packages/react/src/components/FileUploader/FileUploaderButton.js
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.js
@@ -26,7 +26,6 @@ function FileUploaderButton({
   labelText: ownerLabelText = 'Add file',
   multiple = false,
   onChange = noop,
-  role = 'button',
   name,
   size = 'md',
   tabIndex = 0,
@@ -53,10 +52,16 @@ function FileUploaderButton({
 
   function onClick(event) {
     event.target.value = null;
+    if (inputNode.current) {
+      inputNode.current.value = '';
+      inputNode.current.click();
+    }
   }
 
   function onKeyDown(event) {
-    if (matches(event, [keys.Enter, keys.Space])) {
+    event.preventDefault();
+    if (matches(event, [keys.Enter, keys.Space]) && inputNode.current) {
+      inputNode.current.value = '';
       inputNode.current.click();
     }
   }
@@ -76,16 +81,18 @@ function FileUploaderButton({
 
   return (
     <>
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <label
-        tabIndex={disabled ? -1 : tabIndex || 0}
+      <button
+        type="button"
+        disabled={disabled}
         className={classes}
+        onClick={onClick}
         onKeyDown={onKeyDown}
-        htmlFor={inputId}
+        tabIndex={tabIndex ? tabIndex : undefined}
         {...other}>
-        <span role={role} aria-disabled={disabled}>
-          {labelText}
-        </span>
+        {labelText}
+      </button>
+      <label className={`${prefix}--visually-hidden`} htmlFor={inputId}>
+        <span>{labelText}</span>
       </label>
       <input
         className={`${prefix}--visually-hidden`}
@@ -93,12 +100,11 @@ function FileUploaderButton({
         id={inputId}
         disabled={disabled}
         type="file"
-        tabIndex="-1"
+        tabIndex={-1}
         multiple={multiple}
         accept={accept}
         name={name}
         onChange={handleOnChange}
-        onClick={onClick}
       />
     </>
   );

--- a/packages/react/src/components/FileUploader/__tests__/FileUploaderButton-test.js
+++ b/packages/react/src/components/FileUploader/__tests__/FileUploaderButton-test.js
@@ -69,7 +69,7 @@ describe('FileUploaderButton', () => {
     const { container } = render(
       <FileUploaderButton accept={['.png']} labelText="test" />
     );
-    const input = container.querySelector('input');
+    const input = container.querySelector('button');
 
     const filename = 'test.png';
     const file = new File(['test'], filename, { type: 'image/png' });

--- a/packages/react/src/components/UIShell/HeaderPanel.js
+++ b/packages/react/src/components/UIShell/HeaderPanel.js
@@ -8,25 +8,13 @@
 import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import { usePrefix } from '../../internal/usePrefix';
 
 const HeaderPanel = React.forwardRef(function HeaderPanel(
-  {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-    children,
-    className: customClassName,
-    expanded,
-    ...other
-  },
+  { children, className: customClassName, expanded, ...other },
   ref
 ) {
   const prefix = usePrefix();
-  const accessibilityLabel = {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-  };
 
   const className = cx(`${prefix}--header-panel`, {
     [`${prefix}--header-panel--expanded`]: expanded,
@@ -34,7 +22,7 @@ const HeaderPanel = React.forwardRef(function HeaderPanel(
   });
 
   return (
-    <div {...other} className={className} {...accessibilityLabel} ref={ref}>
+    <div {...other} className={className} ref={ref}>
       {children}
     </div>
   );
@@ -42,9 +30,9 @@ const HeaderPanel = React.forwardRef(function HeaderPanel(
 
 HeaderPanel.propTypes = {
   /**
-   * Required props for accessibility label on the underlying menu
+   * The content that will render inside of the `HeaderPanel`
    */
-  ...AriaLabelPropType,
+  children: PropTypes.node,
 
   /**
    * Optionally provide a custom class to apply to the underlying `<li>` node

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -560,7 +560,7 @@ export const HeaderBaseWActionsAndRightPanel = withReadme(readme, () => {
           <Notification20 />
         </HeaderGlobalAction>
       </HeaderGlobalBar>
-      <HeaderPanel aria-label="Header Panel" expanded={expanded} />
+      <HeaderPanel expanded={expanded} />
     </Header>
   );
 });
@@ -590,7 +590,7 @@ export const HeaderBaseWActionsAndSwitcher = withReadme(readme, () => (
         <AppSwitcher20 />
       </HeaderGlobalAction>
     </HeaderGlobalBar>
-    <HeaderPanel aria-label="Header Panel" expanded>
+    <HeaderPanel expanded>
       <Switcher aria-label="Switcher Container">
         <SwitcherItem isSelected aria-label="Link 1" href="#">
           Link 1

--- a/packages/react/src/components/UIShell/next/UIShell.stories.js
+++ b/packages/react/src/components/UIShell/next/UIShell.stories.js
@@ -547,7 +547,7 @@ export const HeaderBaseWActionsAndRightPanel = () => (
         <AppSwitcher20 />
       </HeaderGlobalAction>
     </HeaderGlobalBar>
-    <HeaderPanel aria-label="Header Panel" expanded />
+    <HeaderPanel expanded />
   </Header>
 );
 
@@ -576,7 +576,7 @@ export const HeaderBaseWActionsAndSwitcher = () => (
         <AppSwitcher20 />
       </HeaderGlobalAction>
     </HeaderGlobalBar>
-    <HeaderPanel aria-label="Header Panel" expanded>
+    <HeaderPanel expanded>
       <Switcher aria-label="Switcher Container">
         <SwitcherItem isSelected aria-label="Link 1" href="#">
           Link 1


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12498
Closes https://github.com/carbon-design-system/carbon/issues/13728

Backports a few more a11y fixes to V10. See linked issues for more information

#### Changelog

**Changed**

- Updated `FileUploaderButton` and `HeaderPanel` based on v11 fixes

**Removed**

- unnecessary code 

#### Testing / Reviewing

Ensure the `FileUploader` story as well as the `HeaderBaseWActionsAndRightPanel` stories have no a11y violations
