### PR TITLE
docs(grid): remove columns prop from story

### DIFF
--- a/packages/react/src/components/Grid/Grid.stories.js
+++ b/packages/react/src/components/Grid/Grid.stories.js
@@ -316,7 +316,4 @@ Playground.argTypes = {
       type: 'boolean',
     },
   },
-  columns: {
-    control: { type: 'number' },
-  },
 };


### PR DESCRIPTION
Reported in [slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1693340585706519)

#### Changelog




**Removed**

- Remove columns prop from Grid story, it doesn't exist

