### PR TITLE
fix(ListBox): align `ListBox` keyboard implementations, focus on open

### DIFF
--- a/e2e/components/Dropdown/Dropdown-test.avt.e2e.js
+++ b/e2e/components/Dropdown/Dropdown-test.avt.e2e.js
@@ -71,20 +71,19 @@ test.describe('Dropdown @avt', () => {
     await expect(menu).not.toBeVisible();
     await expect(toggleButton).toBeFocused();
     await page.keyboard.press('Enter');
+    // Should focus on selected item by default
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--active cds--list-box__menu-item--highlighted'
+    );
     // Navigation inside the menu
     await page.keyboard.press('ArrowDown');
     await expect(
       page.getByRole('option', {
-        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
-      })
-    ).toHaveClass(
-      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
-    );
-    // move to second option
-    await page.keyboard.press('ArrowDown');
-    await expect(
-      page.getByRole('option', {
-        name: 'Option 1',
+        name: 'Option 2',
       })
     ).toHaveClass(
       'cds--list-box__menu-item cds--list-box__menu-item--highlighted'

--- a/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
+++ b/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
@@ -172,7 +172,7 @@ test.describe('MultiSelect @avt', () => {
     await expect(selection).not.toBeVisible();
   });
 
-  test('filterable multiselect - keyboard nav', async ({ page }) => {
+  test.slow('filterable multiselect - keyboard nav', async ({ page }) => {
     await visitStory(page, {
       component: 'FilterableMultiSelect',
       id: 'components-multiselect--filterable',

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -81,7 +81,8 @@ export const Playground = (args) => (
       id="default"
       titleText="Dropdown label"
       helperText="This is some helper text"
-      label="Dropdown menu options"
+      initialSelectedItem={items[1]}
+      label="Option 1"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
       {...args}
@@ -163,7 +164,8 @@ export const Default = () => (
       id="default"
       titleText="Dropdown label"
       helperText="This is some helper text"
-      label="Dropdown menu options"
+      initialSelectedItem={items[1]}
+      label="Option 1"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
     />
@@ -175,7 +177,8 @@ export const Inline = () => (
     <Dropdown
       id="inline"
       titleText="Inline dropdown label"
-      label="Dropdown menu options"
+      initialSelectedItem={items[1]}
+      label="Option 1"
       type="inline"
       items={items}
       itemToString={(item) => (item ? item.text : '')}
@@ -191,7 +194,8 @@ export const _WithLayer = () => (
           id={`default-${layer}`}
           titleText="Dropdown label"
           helperText="This is some helper text"
-          label="Dropdown menu options"
+          initialSelectedItem={items[1]}
+          label="Option 1"
           items={items}
           itemToString={(item) => (item ? item.text : '')}
         />
@@ -207,7 +211,8 @@ export const InlineWithLayer = () => (
         <Dropdown
           id={`inline-${layer}`}
           titleText="Inline dropdown label"
-          label="Dropdown menu options"
+          initialSelectedItem={items[1]}
+          label="Option 1"
           type="inline"
           items={items}
           itemToString={(item) => (item ? item.text : '')}

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -163,9 +163,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
       case stateChangeTypes.keyDownHome:
       case stateChangeTypes.keyDownEnd:
         setHighlightedIndex(
-          changes.highlightedIndex !== undefined
-            ? changes.highlightedIndex
-            : null
+          changes.highlightedIndex !== undefined ? changes.highlightedIndex : 0
         );
         if (stateChangeTypes.keyDownArrowDown === type && !isOpen) {
           handleOnMenuChange(true);

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -499,6 +499,12 @@ const MultiSelect = React.forwardRef(
             );
             props.scrollIntoView(itemArray[highlightedIndex]);
           }
+          if (highlightedIndex === -1) {
+            return {
+              ...changes,
+              highlightedIndex: 0,
+            };
+          }
           return changes;
         case ItemMouseMove:
           return { ...changes, highlightedIndex: state.highlightedIndex };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12721

Fixes some outstanding divergences between `ComboBox`, `Dropdown`, `Multiselect`, and `FilterableMultiselect`.

#### Changelog

**New**

- If no item is selected, `Dropdown` should focus on the first item by default when opened with `ArrowDown`. If an item is selected, the focus should go to the selected item. This should be the same behavior for `Listbox` components listed above

**Changed**

- Set an `initialSelectedItem` for all `Dropdown` stories to get rid of the "fake placeholder" option that doesn't exist in the menu. Focus should go to the initially selected item when opened.
- Updated tests to account for the new behavior

#### Testing / Reviewing

Ensure the `Listbox` components above all behave the same on `Enter`, `ArrowDown` and `Space` when opening. Ensure all stories make sense regarding placeholder values.
