### PR TITLE
ci: include dedupe, format in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,30 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dedupe:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-      - name: Run yarn dedupe
-        run: yarn dedupe --check
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-      - name: Install dependencies
-        run: yarn install --immutable --immutable-cache
-      - name: Check formatting of project files
-        run: yarn format:diff
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -46,8 +22,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Run yarn dedupe
+        run: yarn dedupe --check
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
+      - name: Check formatting of project files
+        run: yarn format:diff
       - name: Lint JavaScript files
         run: yarn lint
       - name: Lint Sass files


### PR DESCRIPTION
dedupe, format and lint run as independent and parallel jobs. This seems inefficient.

#### Changelog

**Changed**

- Moved dedupe and format job steps into the lint one
- Add node_modules cache to lint job

#### Testing / Reviewing

The entire lint job including dedupe and format now takes 2m 54s, compared to 2m 57 for format alone before, saving the other 42s + 2m 25s completely. This saves 50% resources for this part of the CI, without compromising the feedback loop imo.

We could even consider adding e2e as well, as it's quick too. But then the naming of the new job would be more difficult :)