### PR TITLE
ci: add jsx,tsx,tsx to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     }
   },
   "lint-staged": {
-    "**/*.js": [
+    "**/*.{js,jsx,ts,tsx}": [
       "prettier --cache --write",
       "eslint"
     ],


### PR DESCRIPTION
It's probably a mistake that only *.js is handled in the recommit.

#### Changelog

**New**

- add jsx,ts,tsx extensions to lint-staged

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
