### PR TITLE
fix(menuButton): fix RTL issues with MenuButton

### DIFF
--- a/packages/react/src/components/Menu/Menu.js
+++ b/packages/react/src/components/Menu/Menu.js
@@ -82,8 +82,15 @@ const Menu = React.forwardRef(function Menu(
       focusReturn.current = document.activeElement;
 
       const pos = calculatePosition();
-      menu.current.style.left = `${pos[0]}px`;
-      menu.current.style.top = `${pos[1]}px`;
+      if (document?.dir === 'rtl' && !rest?.id?.includes('MenuButton')) {
+        menu.current.style.insetInlineStart = `initial`;
+        menu.current.style.insetInlineEnd = `${pos[0]}px`;
+      } else {
+        menu.current.style.insetInlineStart = `${pos[0]}px`;
+        menu.current.style.insetInlineEnd = `initial`;
+      }
+
+      menu.current.style.insetBlockStart = `${pos[1]}px`;
       setPosition(pos);
 
       menu.current.focus();

--- a/packages/react/src/components/Menu/Menu.js
+++ b/packages/react/src/components/Menu/Menu.js
@@ -22,6 +22,7 @@ import { useMergedRefs } from '../../internal/useMergedRefs';
 import { usePrefix } from '../../internal/usePrefix';
 
 import { MenuContext, menuReducer } from './MenuContext';
+import { useLayoutDirection } from '../LayoutDirection';
 
 const spacing = 8; // distance to keep to window edges, in px
 
@@ -71,6 +72,9 @@ const Menu = React.forwardRef(function Menu(
     (item) => !item.disabled && item.ref.current
   );
 
+  // Set RTL based on document direction or `LayoutDirection`
+  const { direction } = useLayoutDirection();
+
   function returnFocus() {
     if (focusReturn.current) {
       focusReturn.current.focus();
@@ -82,7 +86,10 @@ const Menu = React.forwardRef(function Menu(
       focusReturn.current = document.activeElement;
 
       const pos = calculatePosition();
-      if (document?.dir === 'rtl' && !rest?.id?.includes('MenuButton')) {
+      if (
+        (document?.dir === 'rtl' || direction === 'rtl') &&
+        !rest?.id?.includes('MenuButton')
+      ) {
         menu.current.style.insetInlineStart = `initial`;
         menu.current.style.insetInlineEnd = `${pos[0]}px`;
       } else {

--- a/packages/react/src/components/Menu/Menu.stories.js
+++ b/packages/react/src/components/Menu/Menu.stories.js
@@ -43,7 +43,7 @@ export const Playground = (args) => {
   const target = document.getElementById('storybook-root');
 
   return (
-    <Menu {...args} target={target} x={document?.dir === 'rtl' ? '250' : 0}>
+    <Menu {...args} target={target} x={document?.dir === 'rtl' ? 250 : 0}>
       <MenuItem label="Share with">
         <MenuItemRadioGroup
           label="Share with"

--- a/packages/react/src/components/Menu/Menu.stories.js
+++ b/packages/react/src/components/Menu/Menu.stories.js
@@ -43,7 +43,7 @@ export const Playground = (args) => {
   const target = document.getElementById('storybook-root');
 
   return (
-    <Menu {...args} target={target}>
+    <Menu {...args} target={target} x={document?.dir === 'rtl' ? '250' : 0}>
       <MenuItem label="Share with">
         <MenuItemRadioGroup
           label="Share with"

--- a/packages/react/src/components/Menu/MenuItem.js
+++ b/packages/react/src/components/Menu/MenuItem.js
@@ -9,7 +9,7 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 
-import { CaretRight, Checkmark } from '@carbon/react/icons';
+import { CaretRight, CaretLeft, Checkmark } from '@carbon/react/icons';
 import { keys, match } from '../../internal/keyboard';
 import { useControllableState } from '../../internal/useControllableState';
 import { useMergedRefs } from '../../internal/useMergedRefs';
@@ -40,6 +40,7 @@ const MenuItem = React.forwardRef(function MenuItem(
   const menuItem = useRef();
   const ref = useMergedRefs([forwardRef, menuItem]);
   const [boundaries, setBoundaries] = useState({ x: -1, y: -1 });
+  const [isRtl, setRtl] = useState(false);
 
   const hasChildren = Boolean(children);
   const [submenuOpen, setSubmenuOpen] = useState(false);
@@ -60,10 +61,17 @@ const MenuItem = React.forwardRef(function MenuItem(
 
   function openSubmenu() {
     const { x, y, width, height } = menuItem.current.getBoundingClientRect();
-    setBoundaries({
-      x: [x, x + width],
-      y: [y, y + height],
-    });
+    if (isRtl) {
+      setBoundaries({
+        x: [-x, x - width],
+        y: [y, y + height],
+      });
+    } else {
+      setBoundaries({
+        x: [x, x + width],
+        y: [y, y + height],
+      });
+    }
 
     setSubmenuOpen(true);
   }
@@ -126,6 +134,14 @@ const MenuItem = React.forwardRef(function MenuItem(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (document?.dir === 'rtl') {
+      setRtl(true);
+    } else {
+      setRtl(false);
+    }
+  }, []);
+
   return (
     <li
       role="menuitem"
@@ -150,7 +166,7 @@ const MenuItem = React.forwardRef(function MenuItem(
       {hasChildren && (
         <>
           <div className={`${prefix}--menu-item__shortcut`}>
-            <CaretRight />
+            {isRtl ? <CaretLeft /> : <CaretRight />}
           </div>
           <Menu
             label={label}

--- a/packages/react/src/components/Menu/MenuItem.js
+++ b/packages/react/src/components/Menu/MenuItem.js
@@ -149,7 +149,8 @@ const MenuItem = React.forwardRef(function MenuItem(
       )}
       {hasChildren && (
         <>
-          <div className={`${prefix}--menu-item__shortcut`}>
+          <div
+            className={`${prefix}--menu-item__shortcut ${prefix}--menu-item__caret`}>
             <CaretRight />
           </div>
           <Menu

--- a/packages/react/src/components/Menu/MenuItem.js
+++ b/packages/react/src/components/Menu/MenuItem.js
@@ -17,6 +17,7 @@ import { usePrefix } from '../../internal/usePrefix';
 
 import { Menu } from './Menu';
 import { MenuContext } from './MenuContext';
+import { useLayoutDirection } from '../LayoutDirection';
 
 const hoverIntentDelay = 150; // in ms
 
@@ -134,13 +135,15 @@ const MenuItem = React.forwardRef(function MenuItem(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Set RTL based on document direction or `LayoutDirection`
+  const { direction } = useLayoutDirection();
   useEffect(() => {
-    if (document?.dir === 'rtl') {
+    if (document?.dir === 'rtl' || direction === 'rtl') {
       setRtl(true);
     } else {
       setRtl(false);
     }
-  }, []);
+  }, [direction]);
 
   return (
     <li

--- a/packages/react/src/components/Menu/MenuItem.js
+++ b/packages/react/src/components/Menu/MenuItem.js
@@ -149,8 +149,7 @@ const MenuItem = React.forwardRef(function MenuItem(
       )}
       {hasChildren && (
         <>
-          <div
-            className={`${prefix}--menu-item__shortcut ${prefix}--menu-item__caret`}>
+          <div className={`${prefix}--menu-item__shortcut`}>
             <CaretRight />
           </div>
           <Menu

--- a/packages/react/src/components/MenuButton/index.js
+++ b/packages/react/src/components/MenuButton/index.js
@@ -59,7 +59,7 @@ const MenuButton = React.forwardRef(function MenuButton(
   }
 
   function handleOpen() {
-    menuRef.current.style.width = `${width}px`;
+    menuRef.current.style.inlineSize = `${width}px`;
   }
 
   const triggerClasses = classNames(`${prefix}--menu-button__trigger`, {

--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -113,6 +113,10 @@
     display: flex;
   }
 
+  [dir='rtl'] .#{$prefix}--menu-item__caret {
+    transform: rotate(0.5turn);
+  }
+
   .#{$prefix}--menu-item-group > ul,
   .#{$prefix}--menu-item-radio-group > ul {
     @include component-reset.reset;

--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -113,10 +113,6 @@
     display: flex;
   }
 
-  [dir='rtl'] .#{$prefix}--menu-item__caret {
-    transform: rotate(0.5turn);
-  }
-
   .#{$prefix}--menu-item-group > ul,
   .#{$prefix}--menu-item-radio-group > ul {
     @include component-reset.reset;


### PR DESCRIPTION
Fixes some positioning logic inside `Menu` and `MenuButton`. 

#### Changelog

**Changed**

- Adjusted positioning logic based on `RTL` 


#### Testing / Reviewing

Check `Menu` and `MenuButton` stories in both LTR and RTL modes. Should render as expected.

One note: I'm seeing an issue where the state seems to be stale if you go from `MenuButton` to `Menu` with RTL enabled. It appears on the wrong side. However, once you refresh it is fixed. Any ideas? Can probably be fixed later
