### PR TITLE
[AVT] - Added keyboard nav test `TextInput`

### DIFF
--- a/e2e/components/TextInput/TextInput-test.avt.e2e.js
+++ b/e2e/components/TextInput/TextInput-test.avt.e2e.js
@@ -37,4 +37,26 @@ test.describe('TextInput @avt', () => {
     await expect(page.getByRole('textbox')).toBeDisabled();
     await expect(page).toHaveNoACViolations('TextInput-Disabled');
   });
+
+  test('accessibility-checker keyboard nav', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TextInput',
+      id: 'components-textinput--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const input = page.getByRole('textbox');
+
+    // Check the focus
+    await expect(input).toBeVisible();
+    await page.keyboard.press('Tab');
+    await expect(input).toBeFocused();
+
+    // Check input interaction
+    await input.fill('Text');
+    await expect(input).toHaveValue('Text');
+    await page.keyboard.press('Backspace');
+    await expect(input).toHaveValue('Tex');
+  });
 });

--- a/e2e/components/TextInput/TextInput-test.avt.e2e.js
+++ b/e2e/components/TextInput/TextInput-test.avt.e2e.js
@@ -59,4 +59,25 @@ test.describe('TextInput @avt', () => {
     await page.keyboard.press('Backspace');
     await expect(input).toHaveValue('Tex');
   });
+
+  test('accessibility-checker keyboard nav for password', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TextInput',
+      id: 'components-textinput--toggle-password-visibility',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const input = page.getByRole('textbox');
+    const span = page.locator('span.cds--assistive-text');
+
+    await page.keyboard.press('Tab');
+    await input.fill('Text');
+
+    // Checking toggle interaction
+    await page.keyboard.press('Tab');
+    await expect(span).toHaveText('Show password');
+    await page.keyboard.press('Enter');
+    await expect(span).toHaveText('Hide password');
+  });
 });


### PR DESCRIPTION
Closes #14579

Added keyboard navigation to `TextInput` component.

#### Testing / Reviewing

- Ensure the test pass
- Ensure that all the necessary navigation is covered.
