### PR TITLE
fix(password-input): apply layout size class

### DIFF
--- a/packages/react/src/components/TextInput/PasswordInput.tsx
+++ b/packages/react/src/components/TextInput/PasswordInput.tsx
@@ -220,7 +220,8 @@ const PasswordInput = React.forwardRef(function PasswordInput(
       [`${prefix}--text-input--light`]: light,
       [`${prefix}--text-input--invalid`]: normalizedProps.invalid,
       [`${prefix}--text-input--warning`]: normalizedProps.warn,
-      [`${prefix}--text-input--${size}`]: size,
+      [`${prefix}--text-input--${size}`]: size, // TODO: V12 - Remove this class
+      [`${prefix}--layout--size-${size}`]: size,
     }
   );
   const sharedTextInputProps = {


### PR DESCRIPTION
Reported via slack in #carbon-react: https://stackblitz.com/edit/github-4r9kha?file=src%2FApp.jsx

The PasswordInput currently isn't responding to the size prop since it doesn't apply the appropriate layout class.

#### Changelog

**Changed**

- Added appropriate layout class to password input

#### Testing / Reviewing

Pull this PR, locally run storybook, apply a valid size to the `TogglePasswordVisibility` story. The size should adapt accordingly.
