### PR TITLE
fix(OverflowMenu): backport a11y fix to v10

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2442,6 +2442,7 @@ exports[`DataTable should render 1`] = `
                     onClickOutside={[Function]}
                   >
                     <button
+                      aria-controls={null}
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Settings"
@@ -3430,6 +3431,7 @@ exports[`DataTable sticky header should render 1`] = `
                     onClickOutside={[Function]}
                   >
                     <button
+                      aria-controls={null}
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Settings"

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
@@ -39,6 +39,7 @@ exports[`DataTable.TableToolbarMenu should render 1`] = `
       onClickOutside={[Function]}
     >
       <button
+        aria-controls={null}
         aria-expanded={false}
         aria-haspopup={true}
         aria-label="Add"

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -20,6 +20,9 @@ import mergeRefs from '../../tools/mergeRefs';
 import { PrefixContext } from '../../internal/usePrefix';
 import * as FeatureFlags from '@carbon/feature-flags';
 import deprecate from '../../prop-types/deprecate';
+import setupGetInstanceId from '../../tools/setupGetInstanceId';
+
+const getInstanceId = setupGetInstanceId();
 
 const on = (element, ...args) => {
   element.addEventListener(...args);
@@ -94,6 +97,7 @@ export const getMenuOffset = (menuBody, direction, trigger, flip) => {
 
 class OverflowMenu extends Component {
   state = {};
+  instanceId = getInstanceId();
 
   static propTypes = {
     /**
@@ -524,12 +528,15 @@ class OverflowMenu extends Component {
         })
     );
 
+    const menuBodyId = `overflow-menu-${this.instanceId}__menu-body`;
+
     const menuBody = (
       <ul
         className={overflowMenuOptionsClasses}
         tabIndex="-1"
         role="menu"
-        aria-label={ariaLabel}>
+        aria-label={ariaLabel}
+        id={menuBodyId}>
         {childrenWithProps}
       </ul>
     );
@@ -568,7 +575,8 @@ class OverflowMenu extends Component {
           onClick={this.handleClick}
           aria-label={ariaLabel}
           id={id}
-          ref={mergeRefs(this._triggerRef, ref)}>
+          ref={mergeRefs(this._triggerRef, ref)}
+          aria-controls={this.state.open ? menuBodyId : null}>
           <IconElement {...iconProps}>
             {iconDescription && <title>{iconDescription}</title>}
           </IconElement>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14602
Refs https://github.com/carbon-design-system/carbon/pull/13823

Ports an a11y fix back to v10

#### Changelog

**Changed**

- `menuBodyId` in `OverflowMenu` mapped to `aria-controls` of button

#### Testing / Reviewing

Open the `OverflowMenu`, then run the a11y checker. There should be no `None of the descendent elements with "menuitem" role is tabbable` violations
