### PR TITLE
fix(DataTable): don't set unique name for each radio input

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -632,7 +632,7 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
           onClick,
         ]),
         id: `${this.getTablePrefix()}__select-row-${row.id}`,
-        name: `select-row-${row.id}`,
+        name: `select-row`,
         ariaLabel: t(translationKey),
         disabled: row.disabled,
         radio: this.props.radio || null,

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -61,7 +61,7 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
                 <input
                   class="cds--radio-button"
                   id="data-table-17__select-row-b"
-                  name="select-row-b"
+                  name="select-row"
                   type="radio"
                   value=""
                 />
@@ -97,7 +97,7 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
                 <input
                   class="cds--radio-button"
                   id="data-table-17__select-row-a"
-                  name="select-row-a"
+                  name="select-row"
                   type="radio"
                   value=""
                 />
@@ -133,7 +133,7 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
                 <input
                   class="cds--radio-button"
                   id="data-table-17__select-row-c"
-                  name="select-row-c"
+                  name="select-row"
                   type="radio"
                   value=""
                 />
@@ -227,7 +227,7 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
                 <input
                   class="cds--radio-button"
                   id="data-table-16__select-row-b"
-                  name="select-row-b"
+                  name="select-row"
                   type="radio"
                   value=""
                 />
@@ -263,7 +263,7 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
                 <input
                   class="cds--radio-button"
                   id="data-table-16__select-row-a"
-                  name="select-row-a"
+                  name="select-row"
                   type="radio"
                   value=""
                 />
@@ -299,7 +299,7 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
                 <input
                   class="cds--radio-button"
                   id="data-table-16__select-row-c"
-                  name="select-row-c"
+                  name="select-row"
                   type="radio"
                   value=""
                 />
@@ -540,7 +540,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
               />
             </svg>
           </button>
@@ -675,7 +675,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
                 <input
                   class="cds--checkbox"
                   id="data-table-7__select-row-b"
-                  name="select-row-b"
+                  name="select-row"
                   type="checkbox"
                 />
                 <label
@@ -707,7 +707,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
                 <input
                   class="cds--checkbox"
                   id="data-table-7__select-row-a"
-                  name="select-row-a"
+                  name="select-row"
                   type="checkbox"
                 />
                 <label
@@ -739,7 +739,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
                 <input
                   class="cds--checkbox"
                   id="data-table-7__select-row-c"
-                  name="select-row-c"
+                  name="select-row"
                   type="checkbox"
                 />
                 <label
@@ -965,7 +965,7 @@ exports[`DataTable renders as expected - Component API should render and match s
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
               />
             </svg>
           </button>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -540,7 +540,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"
               />
             </svg>
           </button>
@@ -965,7 +965,7 @@ exports[`DataTable renders as expected - Component API should render and match s
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"
               />
             </svg>
           </button>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -61,7 +61,7 @@ exports[`TableToolbarSearch renders as expected - Component API should render 1`
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+          d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"
         />
       </svg>
     </button>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -61,7 +61,7 @@ exports[`TableToolbarSearch renders as expected - Component API should render 1`
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"
+          d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
         />
       </svg>
     </button>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14268

Fixes an issue that was preventing a user from navigating a Radio selection `DataTable` with the arrow keys. Since each radio button had a `name` appended with the row id, it assumed they were all in their own groups. Now, they all get the same name for each table. If a user has multiple radio tables, they would just need to pass in their own `name` prop to `TableSelectRow` after the `getSelectionProps`

#### Changelog

**Changed**

- Removed unique id per row that was being appended to the `name`


#### Testing / Reviewing

Go to `DataTable --> Selection --> With Radio` and ensure you can navigate the `DataTable` with the arrow keys
