### PR TITLE
docs: remove onStateChange property from ComboBox

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1277,9 +1277,6 @@ Map {
       "onInputChange": Object {
         "type": "func",
       },
-      "onStateChange": Object {
-        "type": "func",
-      },
       "onToggleClick": Object {
         "type": "func",
       },

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -174,11 +174,6 @@ Playground.argTypes = {
       disable: true,
     },
   },
-  onStateChange: {
-    table: {
-      disable: true,
-    },
-  },
   onToggleClick: {
     table: {
       disable: true,

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -194,13 +194,6 @@ export interface ComboBoxProps
   onInputChange?: (inputText: string) => void;
 
   /**
-   * Helper function passed to Downshift that allows the user to observe internal
-   * state changes
-   * `(changes, stateAndHelpers) => void`
-   */
-  onStateChange?: (changes: object, stateAndHelpers: object) => void;
-
-  /**
    * Callback function that fires when the combobox menu toggle is clicked
    * `(evt) => void`
    * @param {MouseEvent} event
@@ -293,7 +286,6 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
     type: _type,
     warn,
     warnText,
-    onStateChange: _onStateChange,
     ...rest
   } = props;
   const prefix = usePrefix();
@@ -792,13 +784,6 @@ ComboBox.propTypes = {
    * @param {string} inputText
    */
   onInputChange: PropTypes.func,
-
-  /**
-   * Helper function passed to Downshift that allows the user to observe internal
-   * state changes
-   * `(changes, stateAndHelpers) => void`
-   */
-  onStateChange: PropTypes.func,
 
   /**
    * Callback function that fires when the combobox menu toggle is clicked


### PR DESCRIPTION
Closes #13767

The onStateChange is a property of the downshiftProps, not a property of the ComboBox itself.

#### Changelog

**New**

- the onStateChange property is removed from the ComboBox and the docs are updated accordingly. 