### PR TITLE
docs(data-table): hide toolbar content from screenreader when hidden

### DIFF
--- a/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content.stories.js
+++ b/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content.stories.js
@@ -154,7 +154,8 @@ export const Default = () => {
                       Download
                     </TableBatchAction>
                   </TableBatchActions>
-                  <TableToolbarContent>
+                  <TableToolbarContent
+                    aria-hidden={batchActionProps.shouldShowBatchActions}>
                     <TableToolbarSearch
                       tabIndex={
                         batchActionProps.shouldShowBatchActions ? -1 : 0


### PR DESCRIPTION
Closes #14264 



#### Changelog


- update dynamic DataTable story to correctly set aria-hidden on toolbar when visually hidden





#### Testing / Reviewing


