### PR TITLE
style(Button): set min, max layout sizes

### DIFF
--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -23,7 +23,7 @@
 
 @mixin button {
   .#{$prefix}--btn {
-    @include layout.use('size', $default: 'lg');
+    @include layout.use('size', $min: 'sm', $default: 'lg', $max: '2xl');
     @include layout.use('density', $default: 'normal');
 
     @include button-base;


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/discussions/14659

Prevents `size="xs"` from being applied when using the layout styles

#### Changelog

**Changed**

- Set a `min` and `max` based on https://carbondesignsystem.com/components/button/usage/#button-sizes

#### Testing / Reviewing

Use the layout size dropdown to set to `sm`. Then set to `xs`. There should be no size change 