### PR TITLE
fix: we can't upload the same file twice in the FileUploader component

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/react/src/components/FileUploader/FileUploader.tsx
@@ -230,7 +230,7 @@ export default class FileUploader extends React.Component<
     ) as string[];
     this.setState({
       filenames: this.props.multiple
-        ? this.state.filenames.concat(filenames)
+        ? [...new Set([...this.state.filenames, ...filenames])]
         : filenames,
     });
     if (this.props.onChange) {


### PR DESCRIPTION
Closes #13341
Now we can't upload the same file twice in the FileUploader when "multiple" property is set to true.