### PR TITLE
fix(modal): update hasScrollingContent styles

### DIFF
--- a/e2e/components/ComposedModal/ComposedModal-test.e2e.js
+++ b/e2e/components/ComposedModal/ComposedModal-test.e2e.js
@@ -37,10 +37,19 @@ test.describe('ComposedModal', () => {
           theme,
         });
       });
+
       test('full width modal @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'ComposedModal',
           id: 'components-composedmodal--full-width',
+          theme,
+        });
+      });
+
+      test('with scrolling content @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'ComposedModal',
+          id: 'components-composedmodal--with-scrolling-content',
           theme,
         });
       });

--- a/e2e/components/Modal/Modal-test.e2e.js
+++ b/e2e/components/Modal/Modal-test.e2e.js
@@ -37,6 +37,14 @@ test.describe('Modal', () => {
           theme,
         });
       });
+
+      test('with scrolling content modal @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'Modal',
+          id: 'components-modal--with-scrolling-content',
+          theme,
+        });
+      });
     });
   });
 });

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -10,6 +10,8 @@ import ReactDOM from 'react-dom';
 import ComposedModal, { ModalBody } from './ComposedModal';
 import { ModalHeader } from './ModalHeader';
 import { ModalFooter } from './ModalFooter';
+import MultiSelect from '../MultiSelect';
+import Dropdown from '../Dropdown';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
 import TextInput from '../TextInput';
@@ -209,49 +211,18 @@ export const WithScrollingContent = () => {
           domain, a shared subdomain, or a shared domain and host.
         </p>
         <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
-        </p>
-        <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
-          organization to a URL that you own. A custom domain can be a shared
-          domain, a shared subdomain, or a shared domain and host.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus eu
+          nibh odio. Nunc a consequat est, id porttitor sapien. Proin vitae leo
+          vitae orci tincidunt auctor eget eget libero. Ut tincidunt ultricies
+          fringilla. Aliquam erat volutpat. Aenean arcu odio, elementum vel
+          vehicula vitae, porttitor ac lorem. Sed viverra elit ac risus
+          tincidunt fermentum. Ut sollicitudin nibh id risus ornare ornare.
+          Etiam gravida orci ut lectus dictum, quis ultricies felis mollis.
+          Mauris nec commodo est, nec faucibus nibh. Nunc commodo ante quis
+          pretium consectetur. Ut ac nisl vitae mi mattis vulputate a at elit.
+          Nullam porttitor ex eget mi feugiat mattis. Nunc non sodales magna.
+          Proin ornare tellus quis hendrerit egestas. Donec pharetra leo nec
+          molestie sollicitudin.{' '}
         </p>
         <TextInput
           data-modal-primary-focus
@@ -260,10 +231,40 @@ export const WithScrollingContent = () => {
           placeholder="e.g. github.com"
           style={{ marginBottom: '1rem' }}
         />
-        <Select id="select-1" defaultValue="us-south" labelText="Region">
+        <Select
+          id="select-1"
+          defaultValue="us-south"
+          labelText="Region"
+          style={{ marginBottom: '1rem' }}>
           <SelectItem value="us-south" text="US South" />
           <SelectItem value="us-east" text="US East" />
         </Select>
+        <Dropdown
+          id="drop"
+          label="Dropdown"
+          titleText="Dropdown"
+          items={[
+            { id: 'one', label: 'one', name: 'one' },
+            { id: 'two', label: 'two', name: 'two' },
+          ]}
+          style={{ marginBottom: '1rem' }}
+        />
+        <MultiSelect
+          id="test"
+          label="Multiselect"
+          titleText="Multiselect"
+          items={[
+            {
+              id: 'downshift-1-item-0',
+              text: 'Option 1',
+            },
+            {
+              id: 'downshift-1-item-1',
+              text: 'Option 2',
+            },
+          ]}
+          itemToString={(item) => (item ? item.text : '')}
+        />
       </ModalBody>
       <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
     </ComposedModal>

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -231,14 +231,12 @@ export const WithScrollingContent = () => {
           placeholder="e.g. github.com"
           style={{ marginBottom: '1rem' }}
         />
-        <Select
-          id="select-1"
-          defaultValue="us-south"
-          labelText="Region"
-          style={{ marginBottom: '1rem' }}>
-          <SelectItem value="us-south" text="US South" />
-          <SelectItem value="us-east" text="US East" />
-        </Select>
+        <div style={{ marginBottom: '1rem' }}>
+          <Select id="select-1" defaultValue="us-south" labelText="Region">
+            <SelectItem value="us-south" text="US South" />
+            <SelectItem value="us-east" text="US East" />
+          </Select>
+        </div>
         <Dropdown
           id="drop"
           label="Dropdown"

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -198,6 +198,78 @@ export const WithStateManager = () => {
   );
 };
 
+export const WithScrollingContent = () => {
+  return (
+    <ComposedModal open>
+      <ModalHeader label="Account resources" title="Add a custom domain" />
+      <ModalBody hasScrollingContent>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+        <TextInput
+          data-modal-primary-focus
+          id="text-input-1"
+          labelText="Domain name"
+          placeholder="e.g. github.com"
+          style={{ marginBottom: '1rem' }}
+        />
+        <Select id="select-1" defaultValue="us-south" labelText="Region">
+          <SelectItem value="us-south" text="US South" />
+          <SelectItem value="us-east" text="US East" />
+        </Select>
+      </ModalBody>
+      <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
+    </ComposedModal>
+  );
+};
+
 export const Playground = (args) => {
   return (
     <ComposedModal open {...args}>

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -232,14 +232,12 @@ export const WithScrollingContent = () => {
         placeholder="e.g. github.com"
         style={{ marginBottom: '1rem' }}
       />
-      <Select
-        id="select-1"
-        defaultValue="us-south"
-        labelText="Region"
-        style={{ marginBottom: '1rem' }}>
-        <SelectItem value="us-south" text="US South" />
-        <SelectItem value="us-east" text="US East" />
-      </Select>
+      <div style={{ marginBottom: '1rem' }}>
+        <Select id="select-1" defaultValue="us-south" labelText="Region">
+          <SelectItem value="us-south" text="US South" />
+          <SelectItem value="us-east" text="US East" />
+        </Select>
+      </div>
       <Dropdown
         id="drop"
         label="Dropdown"

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -198,6 +198,105 @@ const modalFooter = (numberOfButtons) => {
   };
 };
 
+export const WithScrollingContent = () => {
+  return (
+    <Modal
+      open
+      hasScrollingContent
+      modalHeading="Add a custom domain"
+      modalLabel="Account resources"
+      primaryButtonText="Add"
+      secondaryButtonText="Cancel">
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <p style={{ marginBottom: '1rem' }}>
+        Custom domains direct requests for your apps in this Cloud Foundry
+        organization to a URL that you own. A custom domain can be a shared
+        domain, a shared subdomain, or a shared domain and host.
+      </p>
+      <TextInput
+        data-modal-primary-focus
+        id="text-input-1"
+        labelText="Domain name"
+        placeholder="e.g. github.com"
+        style={{ marginBottom: '1rem' }}
+      />
+      <Select id="select-1" defaultValue="us-south" labelText="Region">
+        <SelectItem value="us-south" text="US South" />
+        <SelectItem value="us-east" text="US East" />
+      </Select>
+      <Dropdown
+        id="drop"
+        label="Dropdown"
+        titleText="Dropdown"
+        items={[
+          { id: 'one', label: 'one', name: 'one' },
+          { id: 'two', label: 'two', name: 'two' },
+        ]}
+      />
+      <MultiSelect
+        id="test"
+        label="Multiselect"
+        titleText="Multiselect"
+        items={[
+          {
+            id: 'downshift-1-item-0',
+            text: 'Option 1',
+          },
+          {
+            id: 'downshift-1-item-1',
+            text: 'Option 2',
+          },
+        ]}
+        itemToString={(item) => (item ? item.text : '')}
+      />
+    </Modal>
+  );
+};
+
 export const Playground = ({ numberOfButtons, ...args }) => {
   return (
     <Modal

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -213,49 +213,17 @@ export const WithScrollingContent = () => {
         domain, a shared subdomain, or a shared domain and host.
       </p>
       <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
-      </p>
-      <p style={{ marginBottom: '1rem' }}>
-        Custom domains direct requests for your apps in this Cloud Foundry
-        organization to a URL that you own. A custom domain can be a shared
-        domain, a shared subdomain, or a shared domain and host.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus eu
+        nibh odio. Nunc a consequat est, id porttitor sapien. Proin vitae leo
+        vitae orci tincidunt auctor eget eget libero. Ut tincidunt ultricies
+        fringilla. Aliquam erat volutpat. Aenean arcu odio, elementum vel
+        vehicula vitae, porttitor ac lorem. Sed viverra elit ac risus tincidunt
+        fermentum. Ut sollicitudin nibh id risus ornare ornare. Etiam gravida
+        orci ut lectus dictum, quis ultricies felis mollis. Mauris nec commodo
+        est, nec faucibus nibh. Nunc commodo ante quis pretium consectetur. Ut
+        ac nisl vitae mi mattis vulputate a at elit. Nullam porttitor ex eget mi
+        feugiat mattis. Nunc non sodales magna. Proin ornare tellus quis
+        hendrerit egestas. Donec pharetra leo nec molestie sollicitudin.{' '}
       </p>
       <TextInput
         data-modal-primary-focus
@@ -264,7 +232,11 @@ export const WithScrollingContent = () => {
         placeholder="e.g. github.com"
         style={{ marginBottom: '1rem' }}
       />
-      <Select id="select-1" defaultValue="us-south" labelText="Region">
+      <Select
+        id="select-1"
+        defaultValue="us-south"
+        labelText="Region"
+        style={{ marginBottom: '1rem' }}>
         <SelectItem value="us-south" text="US South" />
         <SelectItem value="us-east" text="US East" />
       </Select>
@@ -276,6 +248,7 @@ export const WithScrollingContent = () => {
           { id: 'one', label: 'one', name: 'one' },
           { id: 'two', label: 'two', name: 'two' },
         ]}
+        style={{ marginBottom: '1rem' }}
       />
       <MultiSelect
         id="test"

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -349,6 +349,10 @@
   // -----------------------------
   // Modal overflow
   // -----------------------------
+  .#{$prefix}--modal-scroll-content {
+    // Required to accommodate focus outline's negative offset when scrolling in Chrome
+    border-block-end: 2px solid transparent;
+  }
   // Required so overflow-indicator disappears at end of content
   .#{$prefix}--modal-scroll-content > *:last-child {
     padding-block-end: $spacing-06;

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -198,12 +198,14 @@
     @include type-style('body-01');
 
     position: relative;
+    // Required to accommodate focus outline's negative offset when scrolling in Chrome
+    border-block-end: 2px solid transparent;
     color: $text-primary;
     font-weight: 400;
     grid-column: 1/-1;
     grid-row: 2/-2;
-    margin-block-end: $spacing-09;
     overflow-y: auto;
+    padding-block-end: $spacing-09;
     // Required to accommodate focus outline's negative offset:
     padding-block-start: $spacing-03;
     // anything besides text/p spans full width, with just 16px padding
@@ -349,20 +351,29 @@
   // -----------------------------
   // Required so overflow-indicator disappears at end of content
   .#{$prefix}--modal-scroll-content > *:last-child {
-    padding-block-end: $spacing-07;
+    padding-block-end: $spacing-06;
   }
 
   .#{$prefix}--modal-content--overflow-indicator {
     position: absolute;
-    background-image: linear-gradient(to bottom, transparent, $layer);
-    block-size: convert.to-rem(32px);
-    content: '';
+    background: $layer;
+    block-size: convert.to-rem(48px);
     grid-column: 1/-1;
     grid-row: 2/-2;
-    inline-size: 100%;
-    inset-block-end: $spacing-09;
+    inline-size: calc(100% - $spacing-04);
+    inset-block-end: 0;
     inset-inline-start: 0;
     pointer-events: none;
+
+    &::before {
+      position: absolute;
+      background-image: linear-gradient(to bottom, transparent, $layer);
+      block-size: convert.to-rem(32px);
+      content: '';
+      inline-size: 100%;
+      inset-block-start: -32px;
+      pointer-events: none;
+    }
   }
 
   // Safari-only media query

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -198,8 +198,6 @@
     @include type-style('body-01');
 
     position: relative;
-    // Required to accommodate focus outline's negative offset when scrolling in Chrome
-    border-block-end: 2px solid transparent;
     color: $text-primary;
     font-weight: 400;
     grid-column: 1/-1;

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -362,7 +362,7 @@
     block-size: convert.to-rem(48px);
     grid-column: 1/-1;
     grid-row: 2/-2;
-    inline-size: calc(100% - $spacing-04);
+    inline-size: calc(100% - $spacing-05);
     inset-block-end: 0;
     inset-inline-start: 0;
     pointer-events: none;
@@ -392,7 +392,6 @@
   .#{$prefix}--modal-content:focus
     ~ .#{$prefix}--modal-content--overflow-indicator {
     margin: 0 2px 2px;
-    inline-size: calc(100% - 4px);
   }
 
   @media screen and (-ms-high-contrast: active) {


### PR DESCRIPTION
Closes #13714 

Update the styling for the scroll fade so that it appears inside the modal-content and there isn't an odd space below. This also fixes the issue where if you click in the space below the content it closes the modal. 

#### Changelog

**New**
- Add **WithScrollingContent** stories to `Modal` and `ComposedModal`

**Changed**

- swap margin for padding on `modal-content ` so the fade will appear inside the modal 
- update styles for `modal-scroll-content` to accommodate the margin/padding swap


#### Testing / Reviewing

Check styles for Modal and ComposedModal, focus should wrap entire content area above button. 
