### PR TITLE
fix(CodeSnippet): fix horizontal scrolling with keyboard

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.js
@@ -303,14 +303,14 @@ CodeSnippet.propTypes = {
   ]),
 
   /**
-   * Specify a label to be read by screen readers on the containing <textbox>
+   * Specify a label to be read by screen readers on the containing textbox
    * node
    */
   ['aria-label']: PropTypes.string,
 
   /**
    * Deprecated, please use `aria-label` instead.
-   * Specify a label to be read by screen readers on the containing <textbox>
+   * Specify a label to be read by screen readers on the containing textbox
    * node
    */
   ariaLabel: deprecate(

--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -225,7 +225,6 @@ $copy-btn-feedback: $background-inverse !default;
 
   // collapsed pre
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre {
-    overflow-x: auto;
     padding-block-end: convert.to-rem(24px);
     padding-inline-end: $spacing-08;
   }
@@ -236,29 +235,18 @@ $copy-btn-feedback: $background-inverse !default;
     padding-inline-end: 0;
   }
 
-  // expanded pre
-  .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
-    .#{$prefix}--snippet-container
-    pre {
-    overflow-x: auto;
-  }
-
-  .#{$prefix}--snippet--multi.#{$prefix}--snippet--has-right-overflow
-    .#{$prefix}--snippet-container
-    pre::after {
+  .#{$prefix}--snippet--multi.#{$prefix}--snippet--has-right-overflow::after {
     position: absolute;
     background-image: linear-gradient(to right, transparent, $layer);
     block-size: 100%;
     content: '';
     inline-size: convert.to-rem(16px);
     inset-block-start: 0;
-    inset-inline-end: 0;
+    inset-inline-end: $spacing-05;
   }
 
   [dir='rtl']
-    .#{$prefix}--snippet--multi.#{$prefix}--snippet--has-right-overflow
-    .#{$prefix}--snippet-container
-    pre::after {
+    .#{$prefix}--snippet--multi.#{$prefix}--snippet--has-right-overflow::after {
     background-image: linear-gradient(to left, transparent, $layer);
   }
 
@@ -414,9 +402,7 @@ $copy-btn-feedback: $background-inverse !default;
   }
 
   .#{$prefix}--snippet--light.#{$prefix}--snippet--single::after,
-  .#{$prefix}--snippet--light.#{$prefix}--snippet--multi
-    .#{$prefix}--snippet-container
-    pre::after {
+  .#{$prefix}--snippet--light.#{$prefix}--snippet--multi::after {
     // Safari interprets `transparent` differently, so make color token value transparent instead:
     background-image: linear-gradient(to right, rgba($layer, 0), $layer);
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14693

Fixes an issue that prevented horizontal scrolling when focused on the multi-line code snippet and text overflowed to the right. 

#### Changelog

**Changed**

- Moved the `::after` to the snippet container. Otherwise, the `::after` scrolled with the `pre` when it was scrolling

**Removed**

- Removed `overflow-x` on the `pre` so that content can properly be scrolled via the container element

#### Testing / Reviewing

Go to `CodeSnippet` --> `Multi` and ensure you can scroll vertically and horizontally with the keyboard when focused. Also ensure there are no regressions with the single-line variant. 
