### PR TITLE
fix(OverflowMenu): fix issue with small variant

### DIFF
--- a/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
+++ b/packages/styles/scss/components/overflow-menu/_overflow-menu.scss
@@ -58,6 +58,7 @@
   .#{$prefix}--overflow-menu--sm {
     block-size: convert.to-rem(32px);
     inline-size: convert.to-rem(32px);
+    min-block-size: convert.to-rem(32px);
   }
 
   .#{$prefix}--overflow-menu--lg {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14718

Override default `min-block-height` when `sm` is passed down

#### Changelog

**Changed**

- Unset the default 40px `min-block-height`


#### Testing / Reviewing

Go to `OverflowMenu` playground story, choose size `sm` and ensure it renders correctly 