### PR TITLE
fix(accordion): update focus styles to fix VO

### DIFF
--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -82,26 +82,16 @@ $content-padding: 0 0 0 $spacing-05 !default;
     padding-inline-end: layout.density('padding-inline');
     transition: background-color motion(standard, productive) $duration-fast-02;
 
-    &:hover::before,
-    &:focus::before {
-      position: absolute;
-      block-size: calc(100% + 2px);
-      content: '';
-      inline-size: 100%;
-      inset-block-start: -1px;
-      inset-inline-start: 0;
-    }
-
-    &:hover::before {
+    &:hover {
       background-color: $layer-hover;
     }
 
     &:focus {
+      box-shadow: /* Border top */ 0 -1px 0 0 $focus, inset 0 1px 0 0 $focus,
+        /* Border right */ inset 2px 0 0 0 $focus,
+        /* Border bottom */ 0 1px 0 0 $focus, inset 0 -1px 0 0 $focus,
+        /* Border left */ inset -2px 0 0 0 $focus;
       outline: none;
-    }
-
-    &:focus::before {
-      @include focus-outline('outline-compat');
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/8645

Remove styles being set:
```
&:focus::before {
    content: '';
  }
```
to fix bug where content wasn't being read on VO 

#### Changelog



**Changed**

- update how focus styles are being rendered, use box-shadow instead 

#### Testing / Reviewing

check that focus styles visually look the same for Accordion and that VO works