### PR TITLE
fix(UIShell): use hr instead of li with role

### DIFF
--- a/packages/react/src/components/UIShell/SideNavDivider.js
+++ b/packages/react/src/components/UIShell/SideNavDivider.js
@@ -13,7 +13,7 @@ import { usePrefix } from '../../internal/usePrefix';
 function SideNavDivider({ className }) {
   const prefix = usePrefix();
   const classNames = cx(`${prefix}--side-nav__divider`, className);
-  return <li role="separator" className={classNames} />;
+  return <hr className={classNames} />;
 }
 
 SideNavDivider.propTypes = {

--- a/packages/react/src/components/UIShell/SideNavDivider.js
+++ b/packages/react/src/components/UIShell/SideNavDivider.js
@@ -13,7 +13,11 @@ import { usePrefix } from '../../internal/usePrefix';
 function SideNavDivider({ className }) {
   const prefix = usePrefix();
   const classNames = cx(`${prefix}--side-nav__divider`, className);
-  return <hr className={classNames} />;
+  return (
+    <li className={classNames}>
+      <hr />
+    </li>
+  );
 }
 
 SideNavDivider.propTypes = {

--- a/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
+++ b/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
@@ -187,10 +187,10 @@
   // Side-nav > Navigation > Divider
   //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__divider {
+    border: none;
     margin: $spacing-03 $spacing-05;
     background-color: $border-subtle;
     block-size: 1px;
-    list-style-type: none;
   }
 
   //----------------------------------------------------------------------------

--- a/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
+++ b/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
@@ -187,10 +187,14 @@
   // Side-nav > Navigation > Divider
   //----------------------------------------------------------------------------
   .#{$prefix}--side-nav__divider {
-    border: none;
     margin: $spacing-03 $spacing-05;
     background-color: $border-subtle;
     block-size: 1px;
+    list-style-type: none;
+  }
+
+  .#{$prefix}--side-nav__divider hr {
+    border: none;
   }
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14479

Refactors UI Shell Side Nav Separator to use an `hr` instead of a `li` with `role="separator" to fix an a11y issue

#### Changelog

**Changed**

- changed `li` to `hr`, added styles to match current

**Removed**

- unnecessary role 

#### Testing / Reviewing

Run a11y checker on a UI Shell story with a side nav separator and ensure there are no violations
