### PR TITLE
feat: add keyboard nav DefinitionTooltip

### DIFF
--- a/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
+++ b/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('DefinitionTooltip', () => {
+test.describe('DefinitionTooltip @avt', () => {
   test('@avt-default-state DefinitionTooltip', async ({ page }) => {
     await visitStory(page, {
       component: 'DefinitionTooltip',

--- a/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
+++ b/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('DefinitionTooltip', () => {
+  test('@avt-default-state DefinitionTooltip', async ({ page }) => {
+    await visitStory(page, {
+      component: 'DefinitionTooltip',
+      id: 'components-definitiontooltip--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('DefinitionTooltip');
+  });
+
+  test('@avt-keyboard-state default', async ({ page }) => {
+    await visitStory(page, {
+      component: 'DefinitionTooltip',
+      id: 'components-definitiontooltip--default',
+      globals: {
+        theme: 'white',
+      },
+      args: {
+        disabled: true,
+      },
+    });
+    const primaryButton = page.getByRole('button', { name: 'URL' });
+
+    // Testing DefinitionTooltip
+    await page.keyboard.press('Tab');
+    await expect(primaryButton).toBeVisible();
+    await expect(primaryButton).toHaveAttribute('aria-expanded', 'false');
+    await primaryButton.click();
+    await expect(primaryButton).toHaveAttribute('aria-expanded', 'true');
+  });
+});


### PR DESCRIPTION
Closes #14751 

Added keyboard navigation to DefinitionTooltip component.

Added new file e2e/components/DefinitionTooltip /DefinitionTooltip -test.avt.e2e.js

Testing / Reviewing: `yarn playwright test components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js`

Ensure the test pass.
Ensure that the expected navigation is covered.