### PR TITLE
fix: fixed tooltip when multiple files are uploaded

### DIFF
--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -102,7 +102,7 @@ function FileUploaderItem({
   };
 
   useLayoutEffect(() => {
-    const element = document.querySelector(`.${prefix}--file-filename`);
+    const element = document.querySelector(`[title="${name}"]`);
     isEllipsisActive(element);
   }, [prefix, name]);
 


### PR DESCRIPTION
Closes #14792

Fixed the selector when multiple file are uploaded. Tooltip now works as expected

#### Changelog

#### Testing / Reviewing

Go to the drag and drop for multiple files and test if you can upload multiple files with long and short names.