### PR TITLE
feat(SkeletonIcon): Add types for `SkeletonIcon`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1268,6 +1268,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "amanlajpal",
+      "name": "Aman Lajpal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/42869088?v=4",
+      "profile": "https://github.com/amanlajpal",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/cordesmj"><img src="https://avatars.githubusercontent.com/u/7409239?v=4?s=100" width="100px;" alt=""/><br /><sub><b>cordesmj</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=cordesmj" title="Code">💻</a></td>
     <td align="center"><a href="https://med-aziz-chebbi.web.app/"><img src="https://avatars.githubusercontent.com/u/60013060?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aziz Chebbi</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=azizChebbi" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/misiekhardcore"><img src="https://avatars.githubusercontent.com/u/58469680?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michał Konopski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=misiekhardcore" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/amanlajpal"><img src="https://avatars.githubusercontent.com/u/42869088?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aman Lajpal</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=amanlajpal" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=amanlajpal" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
+++ b/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
@@ -25,8 +25,8 @@ const SkeletonIcon: React.FC<SkeletonIconProps> = ({ className, ...other }) => {
   const prefix = usePrefix();
 
   const skeletonIconClasses = classNames({
+    className,
     [`${prefix}--icon--skeleton`]: true,
-    [className!]: className,
   });
 
   return <div className={skeletonIconClasses} {...other} />;

--- a/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
+++ b/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
@@ -5,32 +5,31 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 
-const SkeletonIcon = ({ className, ...other }) => {
-  const prefix = usePrefix();
-
-  const skeletonIconClasses = classNames({
-    [`${prefix}--icon--skeleton`]: true,
-    [className]: className,
-  });
-
-  return <div className={skeletonIconClasses} {...other} />;
-};
-
-SkeletonIcon.propTypes = {
+interface SkeletonIconProps {
   /**
    * Specify an optional className to add.
    */
-  className: PropTypes.string,
+  className?: string;
 
   /**
    * The CSS styles.
    */
-  style: PropTypes.object,
+  style?: React.CSSProperties;
+}
+
+const SkeletonIcon: React.FC<SkeletonIconProps> = ({ className, ...other }) => {
+  const prefix = usePrefix();
+
+  const skeletonIconClasses = classNames({
+    [`${prefix}--icon--skeleton`]: true,
+    [className!]: className,
+  });
+
+  return <div className={skeletonIconClasses} {...other} />;
 };
 
 export default SkeletonIcon;

--- a/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
+++ b/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
@@ -30,6 +30,18 @@ const SkeletonIcon: React.FC<SkeletonIconProps> = ({ className, ...other }) => {
   });
 
   return <div className={skeletonIconClasses} {...other} />;
+};
+
+SkeletonIcon.propTypes = {
+  /**
+   * Specify an optional className to add.
+   */
+  className: PropTypes.string,
+
+  /**
+   * The CSS styles.
+   */
+  style: PropTypes.object,
 };
 
 export default SkeletonIcon;

--- a/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
+++ b/packages/react/src/components/SkeletonIcon/SkeletonIcon.tsx
@@ -24,8 +24,7 @@ interface SkeletonIconProps {
 const SkeletonIcon: React.FC<SkeletonIconProps> = ({ className, ...other }) => {
   const prefix = usePrefix();
 
-  const skeletonIconClasses = classNames({
-    className,
+  const skeletonIconClasses = classNames(className, {
     [`${prefix}--icon--skeleton`]: true,
   });
 


### PR DESCRIPTION
Closes: #13574

Added Typescript types to SkeletonIcon Component

Changelog

New

Added types for the component props

Changed

Renamed file extension to .tsx
Added non-null assertion on className as it was absent

Removed

PropTypes and its import statement

Testing / Reviewing

You can check this by confirming that there are no errors when:

building
creating a component that uses the SkeletonIcon and testing which props are valid/invalid

![image](https://github.com/carbon-design-system/carbon/assets/42869088/75015ab5-40d7-46dc-be4e-158b83bb84bf)
