### PR TITLE
feat(component): add SideNavItems.tsx component

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1268,6 +1268,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Nirajsah",
+      "name": "Niraj Sah",
+      "avatar_url": "https://avatars.githubusercontent.com/u/51414373?v=4",
+      "profile": "https://github.com/Nirajsah",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/cordesmj"><img src="https://avatars.githubusercontent.com/u/7409239?v=4?s=100" width="100px;" alt=""/><br /><sub><b>cordesmj</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=cordesmj" title="Code">💻</a></td>
     <td align="center"><a href="https://med-aziz-chebbi.web.app/"><img src="https://avatars.githubusercontent.com/u/60013060?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aziz Chebbi</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=azizChebbi" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/misiekhardcore"><img src="https://avatars.githubusercontent.com/u/58469680?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michał Konopski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=misiekhardcore" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Nirajsah"><img src="https://avatars.githubusercontent.com/u/51414373?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Niraj Sah</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Nirajsah" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/UIShell/SideNavItems.tsx
+++ b/packages/react/src/components/UIShell/SideNavItems.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import cx from 'classnames';
+// import PropTypes, { bool } from "prop-types";
+import React from 'react';
+import { CARBON_SIDENAV_ITEMS } from './_utils';
+import { usePrefix } from '../../internal/usePrefix';
+
+interface SideNavItemsProps {
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className?: string;
+  /**
+   * Provide a single icon as the child to `SideNavIcon` to render in the
+   * container, and it is required
+   */
+  children: React.ReactNode;
+  /**
+   * Property to indicate if the side nav container is open (or not). Use to
+   * keep local state and styling in step with the SideNav expansion state.
+   */
+  isSideNavExpanded?: boolean;
+}
+
+const SideNavItems: React.FC<SideNavItemsProps> = ({
+  className: customClassName,
+  children,
+  isSideNavExpanded,
+}): React.ReactElement => {
+  const prefix = usePrefix();
+  const className = cx([`${prefix}--side-nav__items`], customClassName);
+  const childrenWithExpandedState = React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      const childType = child.type as React.ComponentType<any>;
+
+      // avoid spreading `isSideNavExpanded` to non-Carbon UI Shell children
+
+      // Check if the child's type's displayName is in CARBON_SIDENAV_ITEMS
+      if (childType && childType.displayName) {
+        // If it's in CARBON_SIDENAV_ITEMS, pass isSideNavExpanded as a prop
+        if (CARBON_SIDENAV_ITEMS.includes(childType.displayName)) {
+          return React.cloneElement(child, {
+            isSideNavExpanded,
+          } as React.HTMLProps<HTMLUListElement>); // We're adding the isSideNavExpanded prop to ensure that this cloned element has the expected props of an HTML unordered list (<ul>) element.
+        } else {
+          // If it's not in CARBON_SIDENAV_ITEMS, don't pass isSideNavExpanded
+          return child;
+        }
+      }
+    }
+  });
+  return <ul className={className}>{childrenWithExpandedState}</ul>;
+};
+
+SideNavItems.displayName = 'SideNavItems';
+
+// Commenting the SideNavItem.propTypes, it is not required as typescript will
+// provide type checking
+
+// SideNavItems.propTypes = {
+//   /**
+//    * Provide a single icon as the child to `SideNavIcon` to render in the
+//    * container
+//    */
+//   children: PropTypes.node.isRequired,
+//
+//   /**
+//    * Provide an optional class to be applied to the containing node
+//    */
+//   className: PropTypes.string,
+//
+//   /**
+//    * Property to indicate if the side nav container is open (or not). Use to
+//    * keep local state and styling in step with the SideNav expansion state.
+//    */
+//   isSideNavExpanded: PropTypes.bool,
+// };
+
+export default SideNavItems;


### PR DESCRIPTION
Closes #13603

Detailed Description

- In this pull request, I've introduced a new component file SideNavItems.tsx along with the necessary TypeScript types to ensure type safety. While working on this component, I encountered an issue related to the isSideNavExpanded prop, where TypeScript was throwing an error: "Object literal may only specify known properties, and 'isSideNavExpanded' does not exist in type 'Partial<unknown> & Attributes." To resolve the issue, I explicitly instructed TypeScript to infer the type as HTMLUListElement, ensuring proper handling of the prop.

New

- Added a new file SideNavItems.tsx along with its corresponding TypeScript types.
Issue Resolution
- Addressed an issue where TypeScript was complaining about the isSideNavExpanded prop by explicitly instructing TS to infer the type.

Changed
- None

Removed
- Removed the SideNavItems.propTypes block as it is no longer required with TypeScript providing type checking.



It's important to note that all other aspects of the SideNavItems.tsx file are functioning as expected, and there are no other issues in the codebase.

Testing / Review
Reviewers can verify the changes in this PR by:

- Examining the new SideNavItems.tsx file and its associated TypeScript types for correctness and completeness.
- Confirming that the issue related to the isSideNavExpanded prop has been successfully resolved.
- Ensuring that the removal of the SideNavItems.propTypes block does not introduce any new issues, as TypeScript now handles type checking.
