### PR TITLE
fix(zone): update styles to use the prefix

### DIFF
--- a/packages/styles/scss/_zone.scss
+++ b/packages/styles/scss/_zone.scss
@@ -36,8 +36,8 @@ $-components: (
 
 @each $name, $theme in $zones {
   .#{config.$prefix}--#{'' + $name} {
-    background: var(--cds-background);
-    color: var(--cds-text-primary);
+    background-color: custom-property.get-var('background');
+    color: custom-property.get-var('text-primary');
 
     @each $key, $value in $theme {
       @if type-of($value) == color {


### PR DESCRIPTION
Closes #14827

#### Changelog

**Changed**

- update tokens to use the configurable prefix instead of a hardcoded `cds`
  - These style declarations were first introduced in https://github.com/carbon-design-system/carbon/pull/11895

#### Testing / Reviewing

- zone styles should now respect any configured prefix
