### PR TITLE
Add Keyboard Nav AVT test for `IconButton`

### DIFF
--- a/e2e/components/IconButton/IconButton-test.avt.e2e.js
+++ b/e2e/components/IconButton/IconButton-test.avt.e2e.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('IconButton @avt', () => {
+  test('@avt-default-state IconButton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'IconButton',
+      id: 'components-iconbutton--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('IconButton');
+  });
+
+  test('@avt-keyboard-state IconButton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'IconButton',
+      id: 'components-iconbutton--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page.getByRole('button')).toBeVisible();
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button')).toBeFocused();
+    await expect(page.getByLabel('label')).toBeVisible();
+  });
+});

--- a/e2e/components/IconButton/IconButton-test.avt.e2e.js
+++ b/e2e/components/IconButton/IconButton-test.avt.e2e.js
@@ -21,7 +21,7 @@ test.describe('IconButton @avt', () => {
     await expect(page).toHaveNoACViolations('IconButton');
   });
 
-  test('@avt-keyboard-state IconButton', async ({ page }) => {
+  test('@avt-keyboard-nav IconButton', async ({ page }) => {
     await visitStory(page, {
       component: 'IconButton',
       id: 'components-iconbutton--default',

--- a/e2e/components/IconButton/IconButton-test.e2e.js
+++ b/e2e/components/IconButton/IconButton-test.e2e.js
@@ -6,9 +6,9 @@
  */
 
 'use strict';
-const { expect, test } = require('@playwright/test');
+const { test } = require('@playwright/test');
 const { themes } = require('../../test-utils/env');
-const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+const { snapshotStory } = require('../../test-utils/storybook');
 
 test.describe('IconButton', () => {
   themes.forEach((theme) => {
@@ -21,16 +21,5 @@ test.describe('IconButton', () => {
         });
       });
     });
-  });
-
-  test('accessibility-checker @avt', async ({ page }) => {
-    await visitStory(page, {
-      component: 'IconButton',
-      id: 'components-iconbutton--default',
-      globals: {
-        theme: 'white',
-      },
-    });
-    await expect(page).toHaveNoACViolations('IconButton');
   });
 });


### PR DESCRIPTION
Closes #14798 

Added keyboard navigation to `IconButton` component.

#### Changelog

**New**

- Added new file `e2e/components/IconButton/IconButton-test.avt.e2e.js`

#### Testing / Reviewing

- Ensure the test pass.
- Ensure that the expected navigation is covered.
