### PR TITLE
fix(Type): update style to use prefix

### DIFF
--- a/packages/type/scss/_default-type.scss
+++ b/packages/type/scss/_default-type.scss
@@ -6,6 +6,7 @@
 //
 @use 'sass:meta';
 @use 'styles' as *;
+@use 'prefix' as *;
 
 /// Include default type styles
 /// @access public
@@ -40,7 +41,7 @@
   }
 
   a {
-    color: var(--cds-link-primary, #0062fe);
+    color: var(--#{$prefix}-link-primary, #0062fe);
   }
 
   em {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14835

Updates the type token for the default anchor link color to use the prefix

#### Changelog

**Changed**

- Now uses the prefix instead of hardcoded `cds`


#### Testing / Reviewing

Ensure the correct token is set
