### PR TITLE
Add LTS notification - v10 storybook

### DIFF
--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -35,19 +35,21 @@ function Container({ story, id }) {
         <div
           style={{
             backgroundColor: 'black',
+            fontSize: '1rem',
             width: 'auto',
             padding: '1rem',
             margin: '-1rem -1rem 0px -1rem',
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            fontSize: '1rem',
+            g1p: '2rem',
           }}>
           <p style={{ color: 'white' }}>
             carbon-components-react@7.x is in maintenance mode, support is
             scheduled to end on September 30, 2024.
           </p>
           <a
+            style={{ textDecoration: 'none' }}
             href="https://github.com/carbon-design-system/carbon/blob/main/docs/release-schedule.md"
             target="_blank">
             Release schedule

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -44,8 +44,8 @@ function Container({ story, id }) {
             fontSize: '1rem',
           }}>
           <p style={{ color: 'white' }}>
-            carbon-components-react {`v${PackageInfo.version}`} is in
-            maintenance mode, support is scheduled to end on September 30, 2024.
+            carbon-components-react@7.x is in maintenance mode, support is
+            scheduled to end on September 30, 2024.
           </p>
           <a
             href="https://github.com/carbon-design-system/carbon/blob/main/docs/release-schedule.md"

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -7,6 +7,7 @@
 
 import './styles.scss';
 import './polyfills';
+import PackageInfo from './../package.json';
 
 import React, { useEffect } from 'react';
 
@@ -37,11 +38,20 @@ function Container({ story, id }) {
             width: 'auto',
             padding: '1rem',
             margin: '-1rem -1rem 0px -1rem',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: '1rem',
           }}>
           <p style={{ color: 'white' }}>
-            Carbon v10 is currently in maintenance mode, support is scheduled to
-            end on September 30, 2024.
+            carbon-components-react {`v${PackageInfo.version}`} is in
+            maintenance mode, support is scheduled to end on September 30, 2024.
           </p>
+          <a
+            href="https://github.com/carbon-design-system/carbon/blob/main/docs/release-schedule.md"
+            target="_blank">
+            Release schedule
+          </a>
         </div>
       )}
 

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -7,7 +7,7 @@
 
 import './styles.scss';
 import './polyfills';
-import PackageInfo from './../package.json';
+// import ArrowRight from '../../icons/src/svg/32/arrow--down-right.svg';
 
 import React, { useEffect } from 'react';
 
@@ -34,8 +34,7 @@ function Container({ story, id }) {
       {!url && (
         <div
           style={{
-            backgroundColor: 'black',
-            fontSize: '1rem',
+            backgroundColor: '#0043CE',
             width: 'auto',
             padding: '1rem',
             margin: '-1rem -1rem 0px -1rem',
@@ -44,12 +43,14 @@ function Container({ story, id }) {
             alignItems: 'center',
             gap: '2rem',
           }}>
-          <p style={{ color: 'white' }}>
+          <p
+            style={{ color: 'white', fontWeight: 'bold', fontSize: '.875rem' }}>
             carbon-components-react@7.x is in maintenance mode, support is
             scheduled to end on September 30, 2024.
+            <span style={{ fontWeight: '400' }}> Start using v11 now!</span>
           </p>
           <a
-            style={{ textDecoration: 'none' }}
+            style={{ textDecoration: 'none', color: 'white' }}
             href="https://github.com/carbon-design-system/carbon/blob/main/docs/release-schedule.md"
             target="_blank">
             Release schedule

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -25,8 +25,26 @@ function Container({ story, id }) {
     };
   }, []);
 
+  // Does not include LTS message in UIShell elements to avoid overlaying
+  const url = window.location.href.includes('ui-shell');
+
   return (
     <React.StrictMode>
+      {!url && (
+        <div
+          style={{
+            backgroundColor: 'black',
+            width: 'auto',
+            padding: '1rem',
+            margin: '-1rem -1rem 0px -1rem',
+          }}>
+          <p style={{ color: 'white' }}>
+            Carbon v10 is currently in maintenance mode, support is scheduled to
+            end on September 30, 2024.
+          </p>
+        </div>
+      )}
+
       <div
         className={id.toLowerCase()}
         data-floating-menu-container

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -42,7 +42,7 @@ function Container({ story, id }) {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            g1p: '2rem',
+            gap: '2rem',
           }}>
           <p style={{ color: 'white' }}>
             carbon-components-react@7.x is in maintenance mode, support is

--- a/packages/react/.storybook/Container.js
+++ b/packages/react/.storybook/Container.js
@@ -7,7 +7,6 @@
 
 import './styles.scss';
 import './polyfills';
-// import ArrowRight from '../../icons/src/svg/32/arrow--down-right.svg';
 
 import React, { useEffect } from 'react';
 


### PR DESCRIPTION
Closes #14765 

I've tested each default story, and they all appear to be working well. However, when it comes to the UIShell, there's an issue with the sticky/fixed header. I'm considering the best course of action, which might involve excluding the UIShell from the LTS notification, to prevent any additional problems when working with that particular story.

#### Changelog

**New**

- Added LTS notification

#### Testing / Reviewing

- Check if the design looks good
- Check if the components looks good

**_OBS: The message it is just an example, we are still selecting the best one._**