### PR TITLE
feat(component): replaced SideNavIcon.js -> SideNavIcon.tsx component

### DIFF
--- a/packages/react/src/components/UIShell/SideNavIcon.tsx
+++ b/packages/react/src/components/UIShell/SideNavIcon.tsx
@@ -10,15 +10,38 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 
-function SideNavIcon({ children, className: customClassName, small }) {
+interface SideNavIconProps {
+  /**
+   * Provide a single icon as the child to `SideNavIcon` to render in the
+   * container
+   */
+  children: React.ReactNode;
+
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className?: string;
+
+  /**
+   * Specify whether the icon should be placed in a smaller bounding box
+   * Since the 'small' prop is not provided, we make it optional and set a default value to `false`.
+   */
+  small?: boolean;
+}
+
+const SideNavIcon: React.FC<SideNavIconProps> = ({
+  children,
+  className: customClassName,
+  small,
+}) => {
   const prefix = usePrefix();
   const className = cx({
     [`${prefix}--side-nav__icon`]: true,
     [`${prefix}--side-nav__icon--small`]: small,
-    [customClassName]: !!customClassName,
+    [customClassName as string]: !!customClassName,
   });
   return <div className={className}>{children}</div>;
-}
+};
 
 SideNavIcon.propTypes = {
   /**


### PR DESCRIPTION
Closes #13601

I successfully replaced the `SideNavIcon.js` component with `SideNavIcon.tsx` along with the corresponding type definitions. I have also executed tests, and they ran without any issues. Although there was an issue resulting in a "build failed" status, I addressed the situation by making the `small` prop optional in the `SideNavIcon` component. To ensure its functionality even when not provided, a default value of `false` is assigned.

#### Changelog

**New**

- None

**Changed**

- `SideNavIcon.js` to `SideNavIcon.tsx`
- `small` prop as optional in SideNavIconProps.

**Removed**

- None

#### Testing / Reviewing

- Examining the new `SideNavIcon.tsx` file and its associated TypeScript types for correctness and completeness.

Please provide feedback and verify the changes. My last PR failed because of the issue i mentioned above, it's resolved now.