### PR TITLE
feat(component): replaced `SideNavDivider.js` -> `SideNavDivider.tsx` component

### DIFF
--- a/packages/react/src/components/UIShell/SideNavDivider.tsx
+++ b/packages/react/src/components/UIShell/SideNavDivider.tsx
@@ -10,7 +10,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 
-function SideNavDivider({ className }) {
+interface SideNavDividerProps {
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className?: string;
+}
+const SideNavDivider: React.FC<SideNavDividerProps> = ({ className }) => {
   const prefix = usePrefix();
   const classNames = cx(`${prefix}--side-nav__divider`, className);
   return (
@@ -18,7 +24,7 @@ function SideNavDivider({ className }) {
       <hr />
     </li>
   );
-}
+};
 
 SideNavDivider.propTypes = {
   /**


### PR DESCRIPTION
Closes #13598

I successfully replaced the `SideNavDivider.js` component with `SideNavDivider.tsx` along with the corresponding type definitions. I have also executed tests, and they ran without any issues. 

#### Changelog

**New**

- `SideNavDivider.tsx`

**Changed**

- None

**Removed**

- None

#### Testing / Reviewing

- Examining the new `SideNavDivider.tsx` file and its associated TypeScript types for correctness and completeness.

Please provide feedback and verify the changes. My last PR failed because of the issue i mentioned above, it's resolved now.
