### PR TITLE
fix(CodeSnippet): v10 - fix horizontal scrolling with keyboard

### DIFF
--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -212,20 +212,12 @@
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre {
     padding-right: $carbon--spacing-08;
     padding-bottom: to-rem(24px);
-    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--no-copy
     .#{$prefix}--snippet-container
     pre {
     padding-right: 0;
-  }
-
-  // expanded pre
-  .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
-    .#{$prefix}--snippet-container
-    pre {
-    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {

--- a/packages/components/src/components/code-snippet/_code-snippet.scss
+++ b/packages/components/src/components/code-snippet/_code-snippet.scss
@@ -220,17 +220,6 @@
     padding-right: 0;
   }
 
-  .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: to-rem(16px);
-    height: 100%;
-    // Safari interprets `transparent` differently, so make color token value transparent instead:
-    background-image: linear-gradient(to right, rgba($field-01, 0), $field-01);
-    content: '';
-  }
-
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre code {
     overflow: hidden;
   }

--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -224,20 +224,12 @@ $copy-btn-feedback: $background-inverse !default;
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre {
     padding-right: $spacing-08;
     padding-bottom: to-rem(24px);
-    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi.#{$prefix}--snippet--no-copy
     .#{$prefix}--snippet-container
     pre {
     padding-right: 0;
-  }
-
-  // expanded pre
-  .#{$prefix}--snippet--multi.#{$prefix}--snippet--expand
-    .#{$prefix}--snippet-container
-    pre {
-    overflow-x: auto;
   }
 
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {

--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -232,17 +232,6 @@ $copy-btn-feedback: $background-inverse !default;
     padding-right: 0;
   }
 
-  .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre::after {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: to-rem(16px);
-    height: 100%;
-    // Safari interprets `transparent` differently, so make color token value transparent instead:
-    background-image: linear-gradient(to right, rgba($layer, 0), $layer);
-    content: '';
-  }
-
   .#{$prefix}--snippet--multi .#{$prefix}--snippet-container pre code {
     overflow: hidden;
   }


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/pull/14717
Closes https://github.com/carbon-design-system/carbon/issues/14693

Backport fix from `main` to allow keyboard arrows to scroll the multi-line `CodeSnippet` if text is overflowing to the right

#### Changelog

**Removed**

- Removed unnecessary styles that were preventing keyboard scrolling 

#### Testing / Reviewing

Tab to Multi line code snippet and ensure you can navigate with arrow keys 
