### PR TITLE
fix(DatePicker): ensure icon is correct if label extends past input

### DIFF
--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -216,13 +216,15 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
         </label>
       )}
       <div className={wrapperClasses}>
-        {input}
-        {isFluid && <DatePickerIcon datePickerType={datePickerType} />}
-        <DatePickerIcon
-          datePickerType={datePickerType}
-          invalid={invalid}
-          warn={warn}
-        />
+        <span>
+          {input}
+          {isFluid && <DatePickerIcon datePickerType={datePickerType} />}
+          <DatePickerIcon
+            datePickerType={datePickerType}
+            invalid={invalid}
+            warn={warn}
+          />
+        </span>
       </div>
       {invalid && (
         <>

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -51,9 +51,12 @@
   }
 
   .#{$prefix}--date-picker-input__wrapper {
-    position: relative;
     display: flex;
     align-items: center;
+  }
+
+  .#{$prefix}--date-picker-input__wrapper span {
+    position: relative;
   }
 
   .#{$prefix}--date-picker.#{$prefix}--date-picker--simple

--- a/packages/styles/scss/components/fluid-date-picker/_fluid-date-picker.scss
+++ b/packages/styles/scss/components/fluid-date-picker/_fluid-date-picker.scss
@@ -62,6 +62,12 @@
 
   .#{$prefix}--date-picker--fluid
     .#{$prefix}--date-picker-input__wrapper
+    > span {
+    inline-size: 100%;
+  }
+
+  .#{$prefix}--date-picker--fluid
+    .#{$prefix}--date-picker-input__wrapper
     .#{$prefix}--date-picker__input {
     padding: convert.to-rem(32px) $spacing-05 convert.to-rem(13px);
     background: transparent;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14907

Adds a wrapper around the input and SVG so that the position of the icon is always computed based on the input rather than the container

#### Changelog

**New**

- `span` around `input` and `svg`

**Changed**

- moved `position: relative` to the outer wrapper to the new `span`

#### Testing / Reviewing

Add a really long label to `Single DatePicker` and ensure the icon stays in the correct spot 