### PR TITLE
Add Keyboard Nav AVT test for `Tag`

### DIFF
--- a/e2e/components/Tag/Tag-test.avt.e2e.js
+++ b/e2e/components/Tag/Tag-test.avt.e2e.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('Tag @avt', () => {
+  test('@avt-default-state Tag', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Tag',
+      id: 'components-tag--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Tag');
+  });
+
+  test('@avt-advanced-states Tag skeleton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Tag',
+      id: 'components-tag--skeleton',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Tag-skeleton');
+  });
+
+  test('@avt-keyboard-nav Tag', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Tag',
+      id: 'components-tag--playground',
+      globals: {
+        theme: 'white',
+      },
+      args: {
+        filter: true,
+      },
+    });
+
+    await expect(page.getByText('Tag content')).toBeVisible();
+    await page.keyboard.press('Tab');
+    await expect(
+      page.getByRole('button', { name: 'Clear filter' })
+    ).toBeFocused();
+  });
+});

--- a/e2e/components/Tag/Tag-test.e2e.js
+++ b/e2e/components/Tag/Tag-test.e2e.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-const { expect, test } = require('@playwright/test');
-const { themes } = require('../../test-utils/env');
-const { snapshotStory, visitStory } = require('../../test-utils/storybook');
+import { test } from '@playwright/test';
+import { themes } from '../../test-utils/env';
+import { snapshotStory } from '../../test-utils/storybook';
 
 test.describe('Tag', () => {
   themes.forEach((theme) => {
@@ -22,16 +22,5 @@ test.describe('Tag', () => {
         });
       });
     });
-  });
-
-  test('accessibility-checker @avt', async ({ page }) => {
-    await visitStory(page, {
-      component: 'Tag',
-      id: 'components-tag--default',
-      globals: {
-        theme: 'white',
-      },
-    });
-    await expect(page).toHaveNoACViolations('Tag');
   });
 });


### PR DESCRIPTION
Closes #14917

Added keyboard navigation to `Tag` component.

#### Changelog

**New**

- Added new file `e2e/components/Tag/Tag-test.avt.e2e.js`

#### Testing / Reviewing

- Ensure the test pass.
- Ensure that the expected navigation is covered.

