### PR TITLE
fix(Combobox): fix issue with numpad keys acting as home, end

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -590,11 +590,11 @@ const ComboBox = forwardRef(
                 }
               }
 
-              if (match(event, keys.Home)) {
+              if (match(event, keys.Home) && event.code !== 'Numpad7') {
                 event.target.setSelectionRange(0, 0);
               }
 
-              if (match(event, keys.End)) {
+              if (match(event, keys.End) && event.code !== 'Numpad1') {
                 event.target.setSelectionRange(
                   event.target.value.length,
                   event.target.value.length

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -329,11 +329,11 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect(
                   handleOnMenuChange(false);
                 }
 
-                if (match(event, keys.Home)) {
+                if (match(event, keys.Home) && event.code !== 'Numpad7') {
                   event.target.setSelectionRange(0, 0);
                 }
 
-                if (match(event, keys.End)) {
+                if (match(event, keys.End) && event.code !== 'Numpad1') {
                   event.target.setSelectionRange(
                     event.target.value.length,
                     event.target.value.length


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/14887

Fixes an issue where the numpad `7` and `1` keys were being interpreted as `home` and `end`, causing unexpected input issues

#### Changelog


**Changed**

- Only change cursor position if the `Home` and `End` keys are explicitly pressed

#### Testing / Reviewing

Go to `Combobox` or `FilterableMultiselect` and try using your numpad to enter some numbers. Pressing `7` or `1` should not adjust the cursor position. Using `Home` and `End` should 
