### PR TITLE
chore(Popover): use header tag for "Available storage" header

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1278,6 +1278,15 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "allisonishida",
+      "name": "Allison Ishida",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22247062?v=4",
+      "profile": "https://github.com/allisonishida",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://med-aziz-chebbi.web.app/"><img src="https://avatars.githubusercontent.com/u/60013060?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aziz Chebbi</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=azizChebbi" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/misiekhardcore"><img src="https://avatars.githubusercontent.com/u/58469680?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michał Konopski</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=misiekhardcore" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/amanlajpal"><img src="https://avatars.githubusercontent.com/u/42869088?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aman Lajpal</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=amanlajpal" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=amanlajpal" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/allisonishida"><img src="https://avatars.githubusercontent.com/u/22247062?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Allison Ishida</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=allisonishida" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -69,7 +69,7 @@ const PlaygroundStory = (props) => {
         <CheckboxIcon />
       </div>
       <PopoverContent className="p-3">
-        <p className="popover-title">Available storage</p>
+        <h2 className="popover-title">Available storage</h2>
         <p className="popover-details">
           This server has 150 GB of block storage remaining.
         </p>
@@ -246,7 +246,7 @@ export const AutoAlign = () => {
             />
           </div>
           <PopoverContent className="p-3">
-            <p className="popover-title">Available storage</p>
+            <h2 className="popover-title">Available storage</h2>
             <p className="popover-details">
               This server has 150 GB of block storage remaining.
             </p>
@@ -258,7 +258,7 @@ export const AutoAlign = () => {
           <CheckboxIcon />
         </div>
         <PopoverContent className="p-3">
-          <p className="popover-title">Available storage</p>
+          <h2 className="popover-title">Available storage</h2>
           <p className="popover-details">
             This server has 150 GB of block storage remaining.
           </p>
@@ -277,7 +277,7 @@ export const AutoAlign = () => {
             <CheckboxIcon />
           </div>
           <PopoverContent className="p-3">
-            <p className="popover-title">Available storage</p>
+            <h2 className="popover-title">Available storage</h2>
             <p className="popover-details">
               This server has 350 GB of block storage remaining.
             </p>
@@ -297,7 +297,7 @@ export const AutoAlign = () => {
             <CheckboxIcon />
           </div>
           <PopoverContent className="p-3">
-            <p className="popover-title">Available storage</p>
+            <h2 className="popover-title">Available storage</h2>
             <p className="popover-details">
               This server has 150 GB of block storage remaining.
             </p>
@@ -317,7 +317,7 @@ export const AutoAlign = () => {
             <CheckboxIcon />
           </div>
           <PopoverContent className="p-3">
-            <p className="popover-title">Available storage</p>
+            <h2 className="popover-title">Available storage</h2>
             <p className="popover-details">
               This server has 150 GB of block storage remaining.
             </p>


### PR DESCRIPTION
Closes #14823

use `<h2>` tag in the 'Available storage' headers in the Popover component

#### Changelog

**Changed**
- replace the `<p>` tag with the `<h2>` tag for the "Available storage" text in the Popover component

#### Testing / Reviewing
Turn on screen reader and confirm that "Available storage" is announced as a header
