### PR TITLE
fix: fixed open state with auto size

### DIFF
--- a/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
+++ b/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
@@ -180,7 +180,7 @@
   }
 
   .#{$prefix}--side-nav__item--large {
-    block-size: mini-units(6);
+    block-size: auto;
   }
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #14888

`SideNav` with large items was not showing the sub menu items when clicking to open. The `block-size` css was changed to auto, so now the menu is able to open.

#### Changelog

#### Testing / Reviewing

- Check if the story is working as expected.