### PR TITLE
fix(tile): `ClickableTile` should navigate on keypress

### DIFF
--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -163,7 +163,6 @@ export const ClickableTile = React.forwardRef<
   function handleOnKeyDown(evt: KeyboardEvent) {
     evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
-      evt.preventDefault();
       setIsSelected(!isSelected);
       onKeyDown(evt);
     }


### PR DESCRIPTION
[Reported on slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1697719961531719)

I can't find a good reason as to why the keydown handler would need to call `preventDefault()`. I _think_ it was added by accident during the functional refactor, https://github.com/carbon-design-system/carbon/pull/9721

#### Changelog

**Changed**

- No longer call `evt.preventDefault()` in the keydown handler

#### Testing / Reviewing

- In the ClickableTile story: focus the tile, press enter or space, the clickabletile should navigate. It previously would not navigate.
- This behavior should match what happens on click of the clickabletile.
