### PR TITLE
fix(ClickableTile): duplicate onKeyDown calls

### DIFF
--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -137,7 +137,7 @@ export const ClickableTile = React.forwardRef<
     href,
     light,
     onClick = () => {},
-    onKeyDown = () => {},
+    onKeyDown,
     renderIcon: Icon,
     ...rest
   },
@@ -164,9 +164,13 @@ export const ClickableTile = React.forwardRef<
     evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
       setIsSelected(!isSelected);
+      if (onKeyDown) {
+        evt.preventDefault();
+        onKeyDown(evt);
+      }
+    } else if (onKeyDown) {
       onKeyDown(evt);
     }
-    onKeyDown(evt);
   }
 
   const v12DefaultIcons = useFeatureFlag('enable-v12-tile-default-icons');


### PR DESCRIPTION
Shouldnt call onKeyDown callback twice when enter or space is pressed.

If a user defines their own callback for onKeyDown, then there is a good chance they want to control what happens when any key is pressed (including enter and space). So preventDefault should be called for that use case.

reference: https://github.com/carbon-design-system/carbon/pull/14945#issuecomment-1780034376

Closes: #15028

ClickableTile double onKeyDown event

#### Changelog

**Changed**

- Fixes bug around ClickableTile onKeyDown

#### Testing / Reviewing

- create a ClickableTile like the following 
```
<ClickableTile onKeyDown={()=>console.log('my-event')} href="www.ibm.com">
some text
</ClickableTile>
```
- tab to the tile and press enter. the tile should log "my-event" 1 time and not link to the href. previously it would link to the href and log "my-event" 2 times.
