### PR TITLE
fix(react): warnings from SideNav in console log from inert prop

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1306,6 +1306,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "kuri-sun",
+      "name": "Ruki",
+      "avatar_url": "https://avatars.githubusercontent.com/u/62743644?v=4",
+      "profile": "https://haruki-kuriwada.netlify.app/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   <tr>
     <td align="center"><a href="https://github.com/allisonishida"><img src="https://avatars.githubusercontent.com/u/22247062?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Allison Ishida</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=allisonishida" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/alewitt2"><img src="https://avatars.githubusercontent.com/u/48691328?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alex Lewitt</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=alewitt2" title="Code">💻</a></td>
+    <td align="center"><a href="https://haruki-kuriwada.netlify.app/"><img src="https://avatars.githubusercontent.com/u/62743644?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ruki</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=kuri-sun" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/UIShell/SideNav.tsx
+++ b/packages/react/src/components/UIShell/SideNav.tsx
@@ -239,7 +239,7 @@ function SideNavRenderFunction(
         tabIndex={-1}
         ref={navRef}
         className={`${prefix}--side-nav__navigation ${className}`}
-        inert={!isRail && (expanded || isLg ? undefined : -1)}
+        inert={!isRail ? (expanded || isLg ? undefined : -1) : undefined}
         {...accessibilityLabel}
         {...eventHandlers}
         {...other}>


### PR DESCRIPTION
Closes #

In storybook, "Rail" type of SideNav will produce this console warning.
`Warning: Received `false` for a non-boolean attribute `inert`.

If you want to write it to the DOM, pass a string instead: inert="false" or inert={value.toString()}.

If you used to conditionally omit it with inert={condition && value}, pass inert={condition ? value : undefined} instead.
    at nav
    at SideNavRenderFunction (c:\GitClones\CDD-Hub\node_modules\@carbon\react\lib\components\UIShell\SideNav.js:38:15)`

#### Changelog

**Changed**

- Make sure that it does not pass boolean value to `inert` property for `nav` HTML.

#### Testing / Reviewing

** Checklist **
(Cause)
the `inert` property throwing the error was passed boolean value. (line.242 in Sidebar.tsx)
If a Sidebar component is "Rail" type, this condition returns `false` which `inert` property does not accept.
It resulted as a console error, only for "Rail" type.
(Solution)
When "isRail" property gets passed to this component, `inert` property should be `undefined`.

** Test **
Rail Sidebar component in storybook, there is no this console warning anymore.
