### PR TITLE
fix(slider): update rem() usage to to-rem()

### DIFF
--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -43,7 +43,7 @@
     min-inline-size: convert.to-rem(200px);
 
     .#{$prefix}--slider-container--two-handles & {
-      margin-inline: rem(4px);
+      margin-inline: convert.to-rem(4px);
     }
   }
 


### PR DESCRIPTION
Testing the v11.41.0 release in the gatsby theme surfaced this error: rhttps://github.com/carbon-design-system/gatsby-theme-carbon/actions/runs/6660435827/job/18101533330?pr=1359