### PR TITLE
fix(ContentSwitcher): selectionMode optional type

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -56,7 +56,7 @@ export interface ContentSwitcherProps
   /**
    * Choose whether or not to automatically change selection on focus
    */
-  selectionMode: 'automatic' | 'manual';
+  selectionMode?: 'automatic' | 'manual';
 
   /**
    * Specify the size of the Content Switcher. Currently supports either `sm`, 'md' (default) or 'lg` as an option.


### PR DESCRIPTION
Closes #

Update to @carbon/react to v1.41.1  doesn't work because selectionMode is a required prop there.

#### Changelog

**Changed**

- changed `selectionMode` to optional property. It is already defaulted to 'automatic'.

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
