### PR TITLE
fix(bug): slider.scss uses deprecated `/`

### DIFF
--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -146,7 +146,7 @@
       block-size: convert.to-rem(2px);
       content: '';
       inline-size: convert.to-rem(6px);
-      inset-block-start: calc(50% - #{calc(convert.to-rem(2px) / 2)});
+      inset-block-start: calc(50% - #{convert.to-rem(2px) * .5});
       inset-inline-end: 0;
     }
 

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -146,7 +146,7 @@
       block-size: convert.to-rem(2px);
       content: '';
       inline-size: convert.to-rem(6px);
-      inset-block-start: calc(50% - #{convert.to-rem(2px) * .5});
+      inset-block-start: calc(50% - #{convert.to-rem(2px) * 0.5});
       inset-inline-end: 0;
     }
 

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -146,7 +146,7 @@
       block-size: convert.to-rem(2px);
       content: '';
       inline-size: convert.to-rem(6px);
-      inset-block-start: calc(50% - #{convert.to-rem(2px) / 2});
+      inset-block-start: calc(50% - #{calc(convert.to-rem(2px) / 2)});
       inset-inline-end: 0;
     }
 


### PR DESCRIPTION
an accidental deprecated division `/` snuck in and is causing sass loader errors downstream.

Closes # https://github.com/carbon-design-system/carbon/issues/15062

cant load `@use carbon/react` in scss

#### Changelog

**Changed**

- Fixes usage of deprecated division `/`

#### Testing / Reviewing

make sure slider still works as expected, and no sass warnings
