### PR TITLE
ci(cache): turn off caching in the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |
@@ -88,6 +89,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |
@@ -127,6 +129,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |
@@ -186,6 +189,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |


### PR DESCRIPTION
We're seeing a ton of cache misses in the merge queue. Based on the [restrictions for accessing a cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), caches created in the merge queue can't be reused.

This pull request makes it so that all `ci` jobs skip caching when in the merge queue.

#### Changelog

**Changed**

- Update CI workflow to only cache if the event does not match `merge_group` (the trigger used for the merge queue)


#### Testing / Reviewing

- The cache steps in workflows ran on this PR should still create a cache