### PR TITLE
ci(cache): cleanup caches after PRs merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |
@@ -88,6 +89,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |
@@ -127,6 +129,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |
@@ -186,6 +189,7 @@ jobs:
         with:
           node-version: '20.x'
       - uses: actions/cache@v3
+        if: github.event_name != 'merge_group'
         id: cache
         with:
           path: |

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+name: Cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
Follow up to #15077 

Caches created for PR workflow runs [can't be reused](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) outside the pull request:

> When a cache is created by a workflow run triggered on a pull request, the cache is created for the merge ref (`refs/pull/.../merge`). Because of this, the cache will have a limited scope and can only be restored by re-runs of the pull request. It cannot be restored by the base branch or other pull requests targeting that base branch.

Instead of waiting on the caches to be deleted by GitHub's cache eviction policy, we can delete these caches immediately once the PR has been merged:

> ### Force deleting cache entries
> 
> Caches have branch scope restrictions in place, which means some caches have limited usage options. For more information on cache scope restrictions, see "[Caching dependencies to speed up workflows](/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)." If caches limited to a specific branch are using a lot of storage quota, it may cause caches from the `default` branch to be created and deleted at a high frequency.
> 
> For example, a repository could have many new pull requests opened, each with their own caches that are restricted to that branch. These caches could take up the majority of the cache storage for that repository. Once a repository has reached its maximum cache storage, the cache eviction policy will create space by deleting the oldest caches in the repository. In order to prevent cache thrashing when this happens, you can set up workflows to delete caches on a faster cadence than the cache eviction policy will. You can use the [`gh-actions-cache`](https://github.com/actions/gh-actions-cache/) CLI extension to delete caches for specific branches.
> 
> This example workflow uses `gh-actions-cache` to delete up to 100 caches created by a branch once a pull request is closed.

#### Changelog

**New**

- add workflow to delete PR github action caches after PRs merge