### PR TITLE
feat(component): replaced `SideNavItems.js` ->  `SideNavItems.tsx` component

### DIFF
--- a/packages/react/src/components/UIShell/SideNavItems.tsx
+++ b/packages/react/src/components/UIShell/SideNavItems.tsx
@@ -11,7 +11,26 @@ import React from 'react';
 import { CARBON_SIDENAV_ITEMS } from './_utils';
 import { usePrefix } from '../../internal/usePrefix';
 
-const SideNavItems = ({
+interface SideNavItemsProps {
+  /**
+   * Provide a single icon as the child to `SideNavIcon` to render in the
+   * container
+   */
+  children: React.ReactNode;
+
+  /**
+   * Provide an optional class to be applied to the containing node
+   */
+  className?: string;
+
+  /**
+   * Property to indicate if the side nav container is open (or not). Use to
+   * keep local state and styling in step with the SideNav expansion state.
+   */
+  isSideNavExpanded?: boolean;
+}
+
+const SideNavItems: React.FC<SideNavItemsProps> = ({
   className: customClassName,
   children,
   isSideNavExpanded,
@@ -21,13 +40,16 @@ const SideNavItems = ({
   const childrenWithExpandedState = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       // avoid spreading `isSideNavExpanded` to non-Carbon UI Shell children
-      return React.cloneElement(child, {
-        ...(CARBON_SIDENAV_ITEMS.includes(child.type?.displayName)
-          ? {
-              isSideNavExpanded,
-            }
-          : {}),
-      });
+      const childType = child.type as React.ComponentType;
+      if (childType && childType.displayName) {
+        return React.cloneElement(child, {
+          ...(CARBON_SIDENAV_ITEMS.includes(childType.displayName)
+            ? {
+                isSideNavExpanded,
+              }
+            : {}),
+        });
+      }
     }
   });
   return <ul className={className}>{childrenWithExpandedState}</ul>;


### PR DESCRIPTION
Closes #13603

Detailed Description

- In this pull request, I have introduced a new component file, SideNavItems.tsx, along with corresponding TypeScript types to enhance type safety. During the development of this component, I encountered an issue. the issue was related to TypeScript's ability to correctly infer types, particularly with regards to (child.type?.displayName).

To resolve the issue with TypeScript's type inference, I implemented a solution by explicitly defining the child's type as React.ComponentType. I then checked whether the displayName property existed within childType. This approach ensured that TypeScript correctly recognised and inferred the types, effectively resolving the issue.


In previous PRs, I unintentionally omitted running the tests before making the commits. I acknowledge and apologise for this oversight. All test suites were successful.

New

- Added a new file SideNavItems.tsx along with its corresponding TypeScript types. Issue Resolution

Changed
- SideNavItems.js to SideNavItems.tsx

Removed
- None



It's important to note that all other aspects of the SideNavItems.tsx file are functioning as expected, and there are no other issues in the codebase.

Testing / Review
Reviewers can verify the changes in this PR by:

- Examining the new SideNavItems.tsx file and its associated TypeScript types for correctness and completeness.
- Confirming that the issue related to the isSideNavExpanded prop has been successfully resolved.
