### PR TITLE
fix(Loading): wobbling of small Loader

### DIFF
--- a/packages/styles/scss/components/loading/_loading.scss
+++ b/packages/styles/scss/components/loading/_loading.scss
@@ -57,10 +57,10 @@
   .#{$prefix}--loading--small {
     block-size: convert.to-rem(16px);
     inline-size: convert.to-rem(16px);
-    
+
     //See https://github.com/carbon-design-system/carbon/issues/13121
     line-height: 1rem;
-    
+
     circle {
       stroke-width: 16;
     }

--- a/packages/styles/scss/components/loading/_loading.scss
+++ b/packages/styles/scss/components/loading/_loading.scss
@@ -57,7 +57,10 @@
   .#{$prefix}--loading--small {
     block-size: convert.to-rem(16px);
     inline-size: convert.to-rem(16px);
-
+    
+    //See https://github.com/carbon-design-system/carbon/issues/13121
+    line-height: 1rem;
+    
     circle {
       stroke-width: 16;
     }


### PR DESCRIPTION
Closes #13121 

small `Loading` spinner wobbles when  line-height greater than 1 rem added to it

#### Changelog

**New**

- added `line-height:1rem;` property so that it overrides any external line-height property if added


#### Testing / Reviewing

https://stackblitz.com/edit/github-9cxysl?file=src%2FApp.jsx
