### PR TITLE
fix(react): publish type definitions for @carbon/react/icons

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,6 +18,7 @@
     "index.scss",
     "icons/index.js",
     "icons/index.esm.js",
+    "icons/index.d.ts",
     "icons/package.json",
     ".playwright/INTERNAL_AVT_REPORT_DO_NOT_USE.json"
   ],


### PR DESCRIPTION
TypeScript types were added to `@carbon/react/icons` in #14714, but are not consumable, cause... `index.d.ts` is not being published... Oops.

#### Changelog

**New**

- Added `icons/index.d.ts` to the list of files published by `@carbon/react`.

#### Testing / Reviewing

Can only test after this change is released. After it's released, should be able to use TypeScript types for icons.