### PR TITLE
fix(icons-react): use declare keyword in bucket TypeScript types

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next/typescript.js
+++ b/packages/icon-build-helpers/src/builders/react/next/typescript.js
@@ -57,7 +57,7 @@ async function writeBucketTypes(buckets, outDir) {
   for (const bucket of buckets) {
     const iconLines = [];
     for (const m of bucket.modules) {
-      iconLines.push('export const ' + m.name + ': CarbonIconType;');
+      iconLines.push('declare const ' + m.name + ': CarbonIconType;');
     }
     const bucketModule = `generated/${bucket.id}`;
     const filepath = path.resolve(outDir, `${bucketModule}.d.ts`);
@@ -66,7 +66,7 @@ async function writeBucketTypes(buckets, outDir) {
       '\n' +
       "import type { CarbonIconType } from '../CarbonIcon';\n" +
       iconLines.join('\n') +
-      '\n';
+      `\nexport { ${bucket.modules.map((m) => m.name).join(', ')} };\n`;
     await fs.writeFile(filepath, content);
   }
 }


### PR DESCRIPTION
An attempt to fix TypeScript compilation problem reported in https://github.com/carbon-design-system/carbon-website/pull/3787#issuecomment-1789480156.

#### Changelog

**Changed**

- Use declare keyword in icons-react TypeScript definition files for icon buckets.

#### Testing / Reviewing

The TypeScript typed code using icons-react should compile without issues.