### PR TITLE
style(Slug): increase touch target to 24px for mini, 2xs variants

### DIFF
--- a/packages/styles/scss/components/slug/_slug.scss
+++ b/packages/styles/scss/components/slug/_slug.scss
@@ -108,6 +108,15 @@ $sizes: (
     transition: opacity $duration-fast-01 motion(entrance, productive);
   }
 
+  .#{$prefix}--slug__button.#{$prefix}--slug__button--mini::after,
+  .#{$prefix}--slug__button.#{$prefix}--slug__button--2xs::after {
+    position: absolute;
+    block-size: convert.to-rem(24px);
+    content: '';
+    inline-size: convert.to-rem(24px);
+    opacity: 0;
+  }
+
   .#{$prefix}--slug__button:hover::before {
     opacity: 1;
   }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15098

Increases the touch target of all `mini` and `2xs` variants to be `24px`

#### Changelog

**New**

- Added a pseudo-element to mimic a larger touch target for these small variants


#### Testing / Reviewing

Go to `unstable__Slug` and ensure the touch target is `24px`. Ensure all hover/focus interactions remain the same. 
