### PR TITLE
fix(icons-react): avoid special tokens in bucket .d.ts exports

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next/typescript.js
+++ b/packages/icon-build-helpers/src/builders/react/next/typescript.js
@@ -57,16 +57,17 @@ async function writeBucketTypes(buckets, outDir) {
   for (const bucket of buckets) {
     const iconLines = [];
     for (const m of bucket.modules) {
-      iconLines.push('declare const ' + m.name + ': CarbonIconType;');
+      iconLines.push('declare const _' + m.name + ': CarbonIconType;');
     }
     const bucketModule = `generated/${bucket.id}`;
     const filepath = path.resolve(outDir, `${bucketModule}.d.ts`);
+    const exports = bucket.modules.map((m) => `_${m.name} as ${m.name}`);
     const content =
       templates.banner +
       '\n' +
       "import type { CarbonIconType } from '../CarbonIcon';\n" +
       iconLines.join('\n') +
-      `\nexport { ${bucket.modules.map((m) => m.name).join(', ')} };\n`;
+      `\nexport { ${exports.join(', ')} };\n`;
     await fs.writeFile(filepath, content);
   }
 }


### PR DESCRIPTION
Addresses carbon-website build problem reported in https://github.com/carbon-design-system/carbon-website/pull/3787#issuecomment-1799329706.

#### Changelog

**Changed**

- Generated bucket TypeScript type definition files in icons-react use a safer way to export definitions to avoid conflicts with reserved token names, such as Boolean, Error or Function.

#### Testing / Reviewing

Fragile icon types should import and compile without problems. There should be no changes to icons usage in both TS and non-TS projects.