### PR TITLE
Add Keyboard Nav AVT test for `FluidDropdown`

### DIFF
--- a/e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js
+++ b/e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022
+ * Copyright IBM Corp. 2016, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,5 +20,76 @@ test.describe('FluidDropdown @avt', () => {
       },
     });
     await expect(page).toHaveNoACViolations('FluidDropdown');
+  });
+
+  test('@avt-advanced-states condensed', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidDropdown',
+      id: 'experimental-unstable-fluiddropdown--condensed',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FluidDropdown-condensed');
+  });
+
+  test('@avt-advanced-states skeleton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidDropdown',
+      id: 'experimental-unstable-fluiddropdown--skeleton',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FluidDropdown-skeleton');
+  });
+
+  test('@avt-keyboard-nav', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Dropdown',
+      id: 'experimental-unstable-fluiddropdown--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('combobox');
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    // Tab and open the Dropdown with Arrow Down
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Space
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('Space');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Enter
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    // Should focus on selected item by default
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 2',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--active cds--list-box__menu-item--highlighted'
+    );
+    // Navigation inside the menu
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 4',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select second option
+    await page.keyboard.press('Enter');
+    // focus comes back to the toggle button
+    await expect(toggleButton).toBeFocused();
   });
 });


### PR DESCRIPTION
Closes #15142

Added keyboard navigation to `FluidDropdown` component.

#### Changelog

**New**

- Added new file `e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js`

#### Testing / Reviewing

- Ensure the test pass.
- Ensure that the expected navigation is covered.
