### PR TITLE
Add Keyboard Nav AVT test for `FluidMultiSelect`

### DIFF
--- a/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
+++ b/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
@@ -23,4 +23,121 @@ test.describe('FluidMultiSelect @avt', () => {
       'FluidMultiSelect @avt-default-state'
     );
   });
+
+  test('@avt-advanced-states condensed', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidMultiSelect',
+      id: 'experimental-unstable-fluidmultiselect--condensed',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FluidMultiSelect-condensed');
+  });
+
+  test('@avt-advanced-states skeleton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidMultiSelect',
+      id: 'experimental-unstable-fluidmultiselect--skeleton',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FluidMultiSelect-skeleton');
+  });
+
+  test('@avt-keyboard-nav', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidMultiSelect',
+      id: 'experimental-unstable-fluidmultiselect--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('combobox', {
+      expanded: false,
+    });
+    const selection = page.getByRole('button', {
+      name: 'Clear all selected items',
+    });
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    await expect(selection).not.toBeVisible();
+    // Tab and open the MultiSelect with Arrow Down
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Enter
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Spacebar
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Space');
+    await expect(menu).toBeVisible();
+    // Navigation inside the menu
+    // move to first option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select first option (should select with enter and space)
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+        selected: true,
+      })
+    ).toBeVisible();
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+        selected: false,
+      })
+    ).toBeVisible();
+    await page.keyboard.press('Space');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+        selected: true,
+      })
+    ).toBeVisible();
+    // move to second option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select second option
+    await page.keyboard.press('Space');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+        selected: true,
+      })
+    ).toBeVisible();
+    // focus comes back to the toggle button after closing
+    await page.keyboard.press('Escape');
+    await expect(toggleButton).toBeFocused();
+    // should show count of selected items when closed
+    await expect(menu).not.toBeVisible();
+    await expect(selection).toBeVisible();
+    // should only clear selection when escape is pressed when the menu is closed
+    await page.keyboard.press('Escape');
+    await expect(selection).not.toBeVisible();
+  });
 });

--- a/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
+++ b/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
@@ -46,7 +46,7 @@ test.describe('FluidMultiSelect @avt', () => {
     await expect(page).toHaveNoACViolations('FluidMultiSelect-skeleton');
   });
 
-  test('@avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav FluidMultiSelect', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
       id: 'experimental-unstable-fluidmultiselect--default',
@@ -141,7 +141,7 @@ test.describe('FluidMultiSelect @avt', () => {
     await expect(selection).not.toBeVisible();
   });
 
-  test('@avt-keyboard-nav condensed', async ({ page }) => {
+  test('@avt-keyboard-nav FluidMultiSelect condensed', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
       id: 'experimental-unstable-fluidmultiselect--condensed',

--- a/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
+++ b/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
@@ -140,4 +140,99 @@ test.describe('FluidMultiSelect @avt', () => {
     await page.keyboard.press('Escape');
     await expect(selection).not.toBeVisible();
   });
+
+  test('@avt-keyboard-nav condensed', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidMultiSelect',
+      id: 'experimental-unstable-fluidmultiselect--condensed',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const toggleButton = page.getByRole('combobox', {
+      expanded: false,
+    });
+    const selection = page.getByRole('button', {
+      name: 'Clear all selected items',
+    });
+    const menu = page.getByRole('listbox');
+
+    await expect(toggleButton).toBeVisible();
+    await expect(selection).not.toBeVisible();
+    // Tab and open the MultiSelect with Arrow Down
+    await page.keyboard.press('Tab');
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Enter
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(menu).toBeVisible();
+    // Close with Escape, retain focus, and open with Spacebar
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible();
+    await expect(toggleButton).toBeFocused();
+    await page.keyboard.press('Space');
+    await expect(menu).toBeVisible();
+    // Navigation inside the menu
+    // move to first option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select first option (should select with enter and space)
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+        selected: true,
+      })
+    ).toBeVisible();
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+        selected: false,
+      })
+    ).toBeVisible();
+    await page.keyboard.press('Space');
+    await expect(
+      page.getByRole('option', {
+        name: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+        selected: true,
+      })
+    ).toBeVisible();
+    // move to second option
+    await page.keyboard.press('ArrowDown');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+      })
+    ).toHaveClass(
+      'cds--list-box__menu-item cds--list-box__menu-item--highlighted'
+    );
+    // select second option
+    await page.keyboard.press('Space');
+    await expect(
+      page.getByRole('option', {
+        name: 'Option 1',
+        selected: true,
+      })
+    ).toBeVisible();
+    // focus comes back to the toggle button after closing
+    await page.keyboard.press('Escape');
+    await expect(toggleButton).toBeFocused();
+    // should show count of selected items when closed
+    await expect(menu).not.toBeVisible();
+    await expect(selection).toBeVisible();
+    // should only clear selection when escape is pressed when the menu is closed
+    await page.keyboard.press('Escape');
+    await expect(selection).not.toBeVisible();
+  });
 });

--- a/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
+++ b/e2e/components/MultiSelect/MultiSelect-test.avt.e2e.js
@@ -22,7 +22,7 @@ test.describe('MultiSelect @avt', () => {
     await expect(page).toHaveNoACViolations('MultiSelect');
   });
 
-  test('@avt-default-state filterable multiselect', async ({ page }) => {
+  test('@avt-advanced-states filterable multiselect', async ({ page }) => {
     await visitStory(page, {
       component: 'FilterableMultiSelect',
       id: 'components-multiselect--filterable',


### PR DESCRIPTION
Closes #15145

Added keyboard navigation to `FluidMultiSelect` component.

#### Changelog

**New**

- Added new file `e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js`

#### Testing / Reviewing

- Ensure the test pass.
- Ensure that the expected navigation is covered.
