### PR TITLE
Add Keyboard Nav AVT test for `FluidSearch`

### DIFF
--- a/e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js
+++ b/e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js
@@ -21,4 +21,49 @@ test.describe('FluidSearch @avt', () => {
     });
     await expect(page).toHaveNoACViolations('FluidSearch @avt-default-state');
   });
+
+  test('@avt-advanced-states skeleton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidSearch',
+      id: 'experimental-unstable-fluidsearch--skeleton',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FluidSearch-skeleton');
+  });
+
+  test('@avt-keyboard-nav', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Search',
+      id: 'experimental-unstable-fluidsearch--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const search = page.getByRole('searchbox');
+    const clearButton = page.getByRole('button');
+    await expect(search).toBeVisible();
+    await expect(clearButton).not.toBeVisible();
+
+    // Tab to the Search
+    await page.keyboard.press('Tab');
+    await expect(search).toBeFocused();
+    // Enter search value
+    await search.fill('test');
+    await expect(search).toHaveValue('test');
+    await expect(clearButton).toBeVisible();
+    // Clear the search value with Clear button
+    await page.keyboard.press('Tab');
+    await expect(clearButton).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(search).toHaveValue('');
+    await expect(search).toBeFocused();
+    // Clear the search value with ESC key
+    await search.fill('test');
+    await expect(search).toHaveValue('test');
+    await page.keyboard.press('Escape');
+    await expect(search).toHaveValue('');
+    await expect(search).toBeFocused();
+  });
 });


### PR DESCRIPTION
Closes #15150 

Added keyboard navigation to `FluidSearch` component.

#### Changelog

**New**

- Added new file `e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js`

#### Testing / Reviewing

- Ensure the test pass.
- Ensure that the expected navigation is covered.
