### PR TITLE
Add Keyboard Nav AVT test for `FluidTextArea`

### DIFF
--- a/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
+++ b/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
@@ -76,7 +76,7 @@ test.describe('FluidTextArea @avt', () => {
 
     // Writting a word to check functionality
     await textArea.fill('test');
-    await expect(page.getByText('test')).toBeVisible();
+    await expect(textArea).toHaveValue('test');
     await expect(page).toHaveNoACViolations('FluidTextArea default');
   });
 
@@ -105,7 +105,7 @@ test.describe('FluidTextArea @avt', () => {
 
     // Writting a word to check functionality
     await textArea.fill('test');
-    await expect(page.getByText('test')).toBeVisible();
+    await expect(textArea).toHaveValue('test');
     await expect(page).toHaveNoACViolations('FluidTextArea with tooltip');
   });
 });

--- a/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
+++ b/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
@@ -21,4 +21,91 @@ test.describe('FluidTextArea @avt', () => {
     });
     await expect(page).toHaveNoACViolations('FluidTextArea @avt-default-state');
   });
+
+  test('@avt-advanced-states default-with-layers', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidTextArea',
+      id: 'experimental-unstable-fluidtextarea--default-with-layers',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'FluidTextArea-default-with-layers'
+    );
+  });
+
+  test('@avt-advanced-states default-with-tooltip', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidTextArea',
+      id: 'experimental-unstable-fluidtextarea--default-with-tooltip',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'FluidTextArea-default-with-tooltip'
+    );
+  });
+
+  test('@avt-advanced-states skeleton', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FluidTextArea',
+      id: 'experimental-unstable-fluidtextarea--skeleton',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FluidTextArea-skeleton');
+  });
+
+  test('@avt-keyboard-nav FluidTextArea default', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TextArea',
+      id: 'experimental-unstable-fluidtextarea--default',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const textArea = page.getByRole('textbox');
+    await expect(page.getByText('Text Area label')).toBeVisible();
+
+    // Checking focus on textarea
+    await page.keyboard.press('Tab');
+    await expect(textArea).toBeFocused();
+
+    // Writting a word to check functionality
+    await textArea.fill('Peter');
+    await expect(page.getByText('Peter')).toBeVisible();
+    await expect(page).toHaveNoACViolations('FluidTextArea keyboard counter');
+  });
+
+  test('@avt-keyboard-nav FluidTextArea default', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TextArea',
+      id: 'experimental-unstable-fluidtextarea--default-with-tooltip',
+      globals: {
+        theme: 'white',
+      },
+    });
+    const textArea = page.getByRole('textbox');
+    await expect(page.getByText('Text Area label')).toBeVisible();
+
+    // Checking tooltip
+    await page.keyboard.press('Tab');
+    await expect(page.getByLabel('Show information')).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(
+      page.getByText('Additional field information here.')
+    ).toBeVisible();
+
+    // Checking focus on textarea
+    await page.keyboard.press('Tab');
+    await expect(textArea).toBeFocused();
+
+    // Writting a word to check functionality
+    await textArea.fill('Peter');
+    await expect(page.getByText('Peter')).toBeVisible();
+    await expect(page).toHaveNoACViolations('FluidTextArea keyboard counter');
+  });
 });

--- a/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
+++ b/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
@@ -75,12 +75,12 @@ test.describe('FluidTextArea @avt', () => {
     await expect(textArea).toBeFocused();
 
     // Writting a word to check functionality
-    await textArea.fill('Peter');
-    await expect(page.getByText('Peter')).toBeVisible();
-    await expect(page).toHaveNoACViolations('FluidTextArea keyboard counter');
+    await textArea.fill('test');
+    await expect(page.getByText('test')).toBeVisible();
+    await expect(page).toHaveNoACViolations('FluidTextArea default');
   });
 
-  test('@avt-keyboard-nav FluidTextArea default', async ({ page }) => {
+  test('@avt-keyboard-nav FluidTextArea with tooltip', async ({ page }) => {
     await visitStory(page, {
       component: 'TextArea',
       id: 'experimental-unstable-fluidtextarea--default-with-tooltip',
@@ -88,7 +88,6 @@ test.describe('FluidTextArea @avt', () => {
         theme: 'white',
       },
     });
-    const textArea = page.getByRole('textbox');
     await expect(page.getByText('Text Area label')).toBeVisible();
 
     // Checking tooltip
@@ -100,12 +99,13 @@ test.describe('FluidTextArea @avt', () => {
     ).toBeVisible();
 
     // Checking focus on textarea
+    const textArea = page.getByRole('textbox');
     await page.keyboard.press('Tab');
     await expect(textArea).toBeFocused();
 
     // Writting a word to check functionality
-    await textArea.fill('Peter');
-    await expect(page.getByText('Peter')).toBeVisible();
-    await expect(page).toHaveNoACViolations('FluidTextArea keyboard counter');
+    await textArea.fill('test');
+    await expect(page.getByText('test')).toBeVisible();
+    await expect(page).toHaveNoACViolations('FluidTextArea with tooltip');
   });
 });


### PR DESCRIPTION
Closes #15159

Added keyboard navigation to `FluidTextArea` component.

#### Changelog

**New**

- Added new file `e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js`

#### Testing / Reviewing

- Ensure the test pass.
- Ensure that the expected navigation is covered.