### PR TITLE
fix(Dropdown): backport dropdown a11y fix to v10

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -178,6 +178,9 @@ const Dropdown = React.forwardRef(function Dropdown(
         )}
         <button
           type="button"
+          // aria-expanded is already being passed through {...toggleButtonProps}
+          role="combobox" // eslint-disable-line jsx-a11y/role-has-required-aria-props
+          aria-controls={getMenuProps().id}
           className={`${prefix}--list-box__field`}
           disabled={disabled}
           aria-disabled={disabled}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -63,6 +63,7 @@ exports[`Dropdown should render 1`] = `
         onKeyDown={[Function]}
       >
         <button
+          aria-controls="downshift-0-menu"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -72,6 +73,7 @@ exports[`Dropdown should render 1`] = `
           id="downshift-0-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          role="combobox"
           title="input"
           type="button"
         >
@@ -214,6 +216,7 @@ exports[`Dropdown should render custom item components 1`] = `
         onKeyDown={[Function]}
       >
         <button
+          aria-controls="downshift-6-menu"
           aria-disabled={false}
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -223,6 +226,7 @@ exports[`Dropdown should render custom item components 1`] = `
           id="downshift-6-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          role="combobox"
           title="input"
           type="button"
         >
@@ -528,6 +532,7 @@ exports[`Dropdown should render with strings as items 1`] = `
         onKeyDown={[Function]}
       >
         <button
+          aria-controls="downshift-4-menu"
           aria-disabled={false}
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -537,6 +542,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           id="downshift-4-toggle-button"
           onClick={[Function]}
           onKeyDown={[Function]}
+          role="combobox"
           title="input"
           type="button"
         >

--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -514,10 +514,12 @@ $list-box-menu-width: to-rem(300px);
   .#{$prefix}--list-box
     .#{$prefix}--list-box__field[aria-expanded='false']
     + .#{$prefix}--list-box__menu {
+    display: none;
     max-height: 0;
   }
 
   .#{$prefix}--list-box--expanded .#{$prefix}--list-box__menu {
+    display: block;
     // 40px item height * 5.5 items shown
     max-height: to-rem(220px);
   }


### PR DESCRIPTION
Closes #13110 (Adding the v10 fix)
Refs #13391 

Backports a11y fix for the `Dropdown` component to v10

This fixes the AVT violation `None of the descendent elements with "option" role is tabbable` seen on the Dropdown when the dropdown list is open in Carbon v10.

![carbon-v10-dropdown-avt](https://github.com/carbon-design-system/carbon/assets/114688923/59aeb93c-2660-4d2c-a9c7-491896961541)


#### Changelog

**Changed**

- Copied changes over from v11 regarding the referenced issue
- Updated snapshot tests for unit tests to pass with new DOM structure changes

#### Testing / Reviewing

- No new violations introduced, no style or functional regressions
- Verify that the reported violation does not occur on v10 storybook using the IBM a11y checker scan (version 3.1.63)

Local development storybook testing
![localhost-v10-dropdown-avt-fix](https://github.com/carbon-design-system/carbon/assets/114688923/40b2aeab-150b-4d42-9b4e-696e15c4dcd3)