### PR TITLE
fix(sidenavitems): remove conditional so children are always cloned

### DIFF
--- a/packages/react/src/components/UIShell/SideNavItems.tsx
+++ b/packages/react/src/components/UIShell/SideNavItems.tsx
@@ -30,9 +30,6 @@ interface SideNavItemsProps {
   isSideNavExpanded?: boolean;
 }
 
-const dogName = (adventurer as any)?.dog;
-console.log(dogName);
-
 const SideNavItems: React.FC<SideNavItemsProps> = ({
   className: customClassName,
   children,

--- a/packages/react/src/components/UIShell/SideNavItems.tsx
+++ b/packages/react/src/components/UIShell/SideNavItems.tsx
@@ -30,6 +30,9 @@ interface SideNavItemsProps {
   isSideNavExpanded?: boolean;
 }
 
+const dogName = (adventurer as any)?.dog;
+console.log(dogName);
+
 const SideNavItems: React.FC<SideNavItemsProps> = ({
   className: customClassName,
   children,
@@ -40,16 +43,14 @@ const SideNavItems: React.FC<SideNavItemsProps> = ({
   const childrenWithExpandedState = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       // avoid spreading `isSideNavExpanded` to non-Carbon UI Shell children
-      const childType = child.type as React.ComponentType;
-      if (childType && childType.displayName) {
-        return React.cloneElement(child, {
-          ...(CARBON_SIDENAV_ITEMS.includes(childType.displayName)
-            ? {
-                isSideNavExpanded,
-              }
-            : {}),
-        });
-      }
+      const childDisplayName = (child.type as any)?.displayName;
+      return React.cloneElement(child, {
+        ...(CARBON_SIDENAV_ITEMS.includes(childDisplayName)
+          ? {
+              isSideNavExpanded,
+            }
+          : {}),
+      });
     }
   });
   return <ul className={className}>{childrenWithExpandedState}</ul>;


### PR DESCRIPTION
Reported on slack [here](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1699985423900869) and [here](https://ibm-studios.slack.com/archives/CJP4DAY72/p1699919638999779)

This issue was introduced in https://github.com/carbon-design-system/carbon/pull/15084

#### Changelog

**Changed**

- Fixes the conditional so it's once again placed on the isSideNavExpanded prop on cloned children, instead of the entire `cloneElement` call

#### Testing / Reviewing

* SideNavItems should now render an array of elements passed as children
