### PR TITLE
feat(Pictograms): watson logo pictogram removed

### DIFF
--- a/packages/pictograms/deprecated.yml
+++ b/packages/pictograms/deprecated.yml
@@ -8,4 +8,6 @@ deprecated:
   - name: ibm--z--partition
     reason: This icon should no longer be used
   - name: watson--logo
-    reason: This pictogram should no longer be usedd  
+    reason:
+      This pictogram should no longer be used, as it represents the old avatar
+      for the Watson brand, which is retired since the watsonx brand launch.

--- a/packages/pictograms/deprecated.yml
+++ b/packages/pictograms/deprecated.yml
@@ -7,3 +7,5 @@ deprecated:
     reason: This icon should no longer be used
   - name: ibm--z--partition
     reason: This icon should no longer be used
+  - name: watson--logo
+    reason: This pictogram should no longer be usedd  


### PR DESCRIPTION
**Removed**

- the watson--logo pictogram needs to be deprecated, but most importantly it needs to be hidden from the library on both carbon and IDL so that nobody uses it going forward. Thank you!
