### PR TITLE
fix(react): downshift replacing id prop in dropdown (#15241)

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -516,6 +516,13 @@ const Dropdown = React.forwardRef(
                   item,
                   index,
                 });
+                if (
+                  item !== null &&
+                  typeof item === 'object' &&
+                  Object.prototype.hasOwnProperty.call(item, 'id')
+                ) {
+                  itemProps.id = item['id'];
+                }
                 const title =
                   isObject && 'text' in item && itemToElement
                     ? item.text


### PR DESCRIPTION
Closes #15241

The id from the Dropdown component is not being set as expected. In the storybook example, we set an array of items with ids, but when you check in the DOM what's being rendered it's actually the ids from Downshift.

#### Changelog

**New**

- Added the process to convert the `id` coming from the `getItemProps` function([Downshift library](https://www.downshift-js.com/downshift/)) into `id` coming from `item` prop.  only if the `item` object has an `id` property.


#### Testing / Reviewing

(Cause of the bug)
It passed the `id` prop from the Downshift library into the Dropdown component, even if a user declares the `id` property inside of each Dropdown item object.

(Solution)
If each Dropdown item object has an `id` property, we are going to use the `id` as the id of each `<li>` element, instead of using the id from the Downshift library.
But if each Dropdown item does not include an `id` property, we are just going to use the id from the Downshift library.
 