### PR TITLE
Datatable: fixed typeError when sorting arrays

### DIFF
--- a/packages/react/src/components/DataTable/tools/sorting.js
+++ b/packages/react/src/components/DataTable/tools/sorting.js
@@ -35,8 +35,8 @@ export const compare = (a, b, locale = 'en') => {
   // if column has React elements, this should sort by the child string if there is one
   if (typeof a === 'object' && typeof b === 'object') {
     if (
-      typeof a.props.children === 'string' &&
-      typeof b.props.children === 'string'
+      typeof a.props?.children === 'string' &&
+      typeof b.props?.children === 'string'
     ) {
       return compareStrings(a.props.children, b.props.children, locale);
     }


### PR DESCRIPTION
Closes #15287

Prevent Type Error by using the `?` 

Uncaught TypeError: Cannot read properties of undefined (reading 'children')

#### Testing / Reviewing

The storybook DataTable sorting functionality should be working with an array of strings/numbers