### PR TITLE
fix: fixed TypeError of undefined issue triage action

### DIFF
--- a/actions/issues/src/plugins/add-triage-label.js
+++ b/actions/issues/src/plugins/add-triage-label.js
@@ -29,7 +29,7 @@ const plugin = {
     });
 
     if (!hasTriageLabel) {
-      await octokit.issues.addLabels({
+      await octokit.issues?.addLabels({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: issue.number,


### PR DESCRIPTION
This issue attempts to fix the triage action to add a label when new issues are created

The job that it is failing: https://github.com/carbon-design-system/carbon/actions/runs/7060031440

![Screenshot 2023-12-04 at 11 54 27](https://github.com/carbon-design-system/carbon/assets/52183462/d0d7ce0f-d051-4f7a-9542-a6cdb24656d7)

#### Testing / Reviewing

I'll re-run the job that is failing to verify if it will fix it