### PR TITLE
style(Notification): fix issue with alignment when inline

### DIFF
--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -1036,7 +1036,9 @@ export function ActionableNotification({
           </div>
         </div>
       </div>
-      <div ref={innerModal}>
+      <div
+        className={`${prefix}--actionable-notification__button-wrapper`}
+        ref={innerModal}>
         {actionButtonLabel && (
           <NotificationActionButton
             onClick={onActionButtonClick}

--- a/packages/styles/scss/components/notification/_actionable-notification.scss
+++ b/packages/styles/scss/components/notification/_actionable-notification.scss
@@ -223,6 +223,10 @@
     padding: convert.to-rem(15px) 0;
   }
 
+  .#{$prefix}--actionable-notification__button-wrapper {
+    display: flex;
+  }
+
   .#{$prefix}--actionable-notification--toast
     .#{$prefix}--actionable-notification__text-wrapper {
     padding: convert.to-rem(15px) 0 convert.to-rem(23px) 0;


### PR DESCRIPTION
Reported on Slack: 

![Screenshot 2023-12-04 at 10 16 44 AM](https://github.com/carbon-design-system/carbon/assets/11928039/d957db40-14c8-4f37-a1b3-319d07b6f6ca)

#### Changelog

**Changed**

- A [div](https://github.com/carbon-design-system/carbon/pull/14877/files#diff-463089737f576a8b2bc258f3180fd32a1f7cf211fe6e3e3c1aca36d41cc998f5R1039) was added in #14877 which caused some issues when the `ActionableNotification` was in `inline` mode. I added the flex property to its new container so it behaves as expected. 


#### Testing / Reviewing

Go to `Notifications --> ActionableNotification --> Playground` and turn on the `inline` option. Ensure the notification close button does not wrap to a new line
