### PR TITLE
fix(#15332) use toArray or checks for mapping children

### DIFF
--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -228,12 +228,12 @@ export default class ContentSwitcher extends React.Component<
         role="tablist"
         onChange={undefined}>
         {children &&
-          React.Children.toArray(children).map((child: ReactElement, index) =>
-            React.cloneElement(child, {
+          React.Children.toArray(children).map((child, index) =>
+            React.cloneElement(child as ReactElement, {
               index,
               onClick: composeEventHandlers([
                 this.handleChildChange,
-                child.props.onClick,
+                (child as ReactElement).props.onClick,
               ]),
               onKeyDown: this.handleChildChange,
               selected: index === this.state.selectedIndex,

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -228,7 +228,7 @@ export default class ContentSwitcher extends React.Component<
         role="tablist"
         onChange={undefined}>
         {children &&
-          React.Children.map(children, (child: ReactElement, index) =>
+          React.Children.toArray(children).map((child: ReactElement, index) =>
             React.cloneElement(child, {
               index,
               onClick: composeEventHandlers([

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.js
@@ -56,6 +56,10 @@ function ProgressIndicator({
   return (
     <ul className={className} {...rest}>
       {React.Children.map(children, (child, index) => {
+        if (!React.isValidElement(child)) {
+          return null;
+        }
+
         // only setup click handlers if onChange event is passed
         const onClick = onChange ? () => onChange(index) : undefined;
         if (index === currentIndex) {

--- a/packages/react/src/components/UIShell/Switcher.tsx
+++ b/packages/react/src/components/UIShell/Switcher.tsx
@@ -109,7 +109,7 @@ const Switcher = forwardRef<HTMLUListElement, SwitcherProps>(function Switcher(
     }
   };
 
-  const childrenWithProps = React.Children.map(children, (child, index) => {
+  const childrenWithProps = React.Children.toArray(children).map((child, index) => {
     // only setup click handlers if onChange event is passed
     if (
       React.isValidElement(child) &&

--- a/packages/react/src/components/UIShell/Switcher.tsx
+++ b/packages/react/src/components/UIShell/Switcher.tsx
@@ -109,27 +109,29 @@ const Switcher = forwardRef<HTMLUListElement, SwitcherProps>(function Switcher(
     }
   };
 
-  const childrenWithProps = React.Children.toArray(children).map((child, index) => {
-    // only setup click handlers if onChange event is passed
-    if (
-      React.isValidElement(child) &&
-      child.type &&
-      getDisplayName(child.type) === 'Switcher'
-    ) {
+  const childrenWithProps = React.Children.toArray(children).map(
+    (child, index) => {
+      // only setup click handlers if onChange event is passed
+      if (
+        React.isValidElement(child) &&
+        child.type &&
+        getDisplayName(child.type) === 'Switcher'
+      ) {
+        return React.cloneElement(child as React.ReactElement<any>, {
+          handleSwitcherItemFocus,
+          index,
+          key: index,
+          expanded,
+        });
+      }
+
       return React.cloneElement(child as React.ReactElement<any>, {
-        handleSwitcherItemFocus,
         index,
         key: index,
         expanded,
       });
     }
-
-    return React.cloneElement(child as React.ReactElement<any>, {
-      index,
-      key: index,
-      expanded,
-    });
-  });
+  );
 
   return (
     <ul


### PR DESCRIPTION
Closes #15332 

Using toArray to get rid of null or other non element children.  See ticket for more info on how this was changed recently and the benefit of toArray over direct map.
