### PR TITLE
fix(Accordion): correctly set height when open prop is set

### DIFF
--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -200,6 +200,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
 
     .#{$prefix}--accordion__wrapper {
       // Properties for when the accordion opens
+      max-block-size: fit-content;
       opacity: 1;
       padding-block: $spacing-03;
       padding-block-end: $spacing-06;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15340

Properly sets a `max-block-size` at initialization so that when an `open` prop is provided, the correct height is calculated 

#### Changelog

**New**

- Added a `max-block-size` to the initial open state selector

#### Testing / Reviewing

Set one of the Accordion items to `open`, refresh the page, and ensure the height is correct and not content overflows
