### PR TITLE
chore: remove node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "jest-junit": "^16.0.0",
     "lerna": "^8.0.0",
     "lint-staged": "^15.0.0",
-    "node-gyp": "^7.1.2",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9205,7 +9205,6 @@ __metadata:
     jest-junit: "npm:^16.0.0"
     lerna: "npm:^8.0.0"
     lint-staged: "npm:^15.0.0"
-    node-gyp: "npm:^7.1.2"
     prettier: "npm:^2.8.8"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -19939,26 +19938,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^7.1.2, node-gyp@npm:latest":
-  version: 7.1.2
-  resolution: "node-gyp@npm:7.1.2"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    glob: "npm:^7.1.4"
-    graceful-fs: "npm:^4.2.3"
-    nopt: "npm:^5.0.0"
-    npmlog: "npm:^4.1.2"
-    request: "npm:^2.88.2"
-    rimraf: "npm:^3.0.2"
-    semver: "npm:^7.3.2"
-    tar: "npm:^6.0.2"
-    which: "npm:^2.0.2"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: b29061c73753551df1d74ec2195c664909d2c5aa02f413009368f144b152e80aa88d6967b24545caa3a589c59e86dbd1b2f4cc93088cb31de7d88b5b8984cafd
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:^9.0.0":
   version: 9.3.1
   resolution: "node-gyp@npm:9.3.1"
@@ -19976,6 +19955,26 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: e9345b22be0a3256af87a16ba9604362cd8e4db304e67e71dd83bb8e573f3fdbaf69e359b5af572a14a98730cc3e1813679444ee029093d2a2f38ba3cac4ed7e
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:latest":
+  version: 7.1.2
+  resolution: "node-gyp@npm:7.1.2"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    glob: "npm:^7.1.4"
+    graceful-fs: "npm:^4.2.3"
+    nopt: "npm:^5.0.0"
+    npmlog: "npm:^4.1.2"
+    request: "npm:^2.88.2"
+    rimraf: "npm:^3.0.2"
+    semver: "npm:^7.3.2"
+    tar: "npm:^6.0.2"
+    which: "npm:^2.0.2"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: b29061c73753551df1d74ec2195c664909d2c5aa02f413009368f144b152e80aa88d6967b24545caa3a589c59e86dbd1b2f4cc93088cb31de7d88b5b8984cafd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This removes node-gyp as a dependency in the root workspace.

It appears there used to be and still are quite a few packages that implicitly rely on node-gyp without actually listing it as a dependency. I assume when this was added in https://github.com/carbon-design-system/carbon/pull/7405 this was the case. 

* https://github.com/yarnpkg/berry/issues/1016
* https://github.com/yarnpkg/berry/issues/5974
* https://github.com/yarnpkg/berry/issues/1252
* https://github.com/yarnpkg/berry/issues/5804

I can't reproduce any issues after removing this dependency. I ran the following without issues:

```
yarn && yarn build && yarn format && yarn lint && yarn test
```

#### Changelog

**Removed**

- remove node-gyp as a devDependency

#### Testing / Reviewing

- If ci begins to fail, local builds stop working, or there are errors in the release, we can revert this change
