### PR TITLE
fix(progressindicator): correct padding on secondaryLabel in firefox

### DIFF
--- a/packages/styles/scss/components/progress-indicator/_progress-indicator.scss
+++ b/packages/styles/scss/components/progress-indicator/_progress-indicator.scss
@@ -329,7 +329,7 @@ $progress-indicator-bar-width: 1px inset transparent !default;
 
   .#{$prefix}--progress--vertical .#{$prefix}--progress-optional {
     position: static;
-    margin: auto 0;
+    margin: 0 0 auto;
     inline-size: 100%;
   }
 


### PR DESCRIPTION
Closes #15383 

#### Changelog

**Changed**

- specify top margin of 0 on secondary labels

#### Testing / Reviewing

- For some reason, chrome was resolving the top margin of `auto` to `0px`, potentially because it's `position: static`? I'm not totally sure. So in effect, Firefox was rendering correctly based on the styles written and chrome was wrong. but what we _want_ is how chrome was rendering it. So this should be correct now. 
- View the ProgressIndicator Playground story in Firefox and Chrome. Select the vertical toggle. Observe there is no top margin in either browser.
