### PR TITLE
fix(Textarea): ensure onKeyDown is called

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -8245,6 +8245,9 @@ Map {
       "onClick": Object {
         "type": "func",
       },
+      "onKeyDown": Object {
+        "type": "func",
+      },
       "placeholder": Object {
         "type": "string",
       },

--- a/packages/react/src/components/TextArea/TextArea-test.js
+++ b/packages/react/src/components/TextArea/TextArea-test.js
@@ -341,6 +341,20 @@ describe('events', () => {
         await userEvent.keyboard('big blue');
         expect(onChange).toHaveBeenCalled();
       });
+
+      it('should invoke onKeyDown when textarea is keyed', async () => {
+        const onKeyDown = jest.fn();
+        render(
+          <TextArea
+            disabled={false}
+            id="testing"
+            labelText="testLabel"
+            onKeyDown={onKeyDown}
+          />
+        );
+        await userEvent.type(screen.getByLabelText('testLabel'), 'test');
+        expect(onKeyDown).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -105,6 +105,12 @@ export interface TextAreaProps
   onClick?: (evt: React.MouseEvent<HTMLTextAreaElement>) => void;
 
   /**
+   * Optionally provide an `onKeyDown` handler that is called whenever `<textarea>`
+   * is keyed
+   */
+  onKeyDown?: (evt: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+
+  /**
    * Specify the placeholder attribute for the `<textarea>`
    */
   placeholder?: string;
@@ -154,6 +160,7 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
     hideLabel,
     onChange = noopFn,
     onClick = noopFn,
+    onKeyDown = noopFn,
     invalid = false,
     invalidText = '',
     helperText = '',
@@ -209,7 +216,7 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
 
   const textareaProps: {
     id: TextAreaProps['id'];
-    onKeyDown: (evt: React.KeyboardEvent) => void;
+    onKeyDown: TextAreaProps['onKeyDown'];
     onChange: TextAreaProps['onChange'];
     onClick: TextAreaProps['onClick'];
     maxLength?: number;
@@ -223,6 +230,10 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
         if (maxCount && textCount >= maxCount && key === 32) {
           evt.preventDefault();
         }
+      }
+
+      if (!disabled && onKeyDown) {
+        onKeyDown(evt);
       }
     },
     onPaste: (evt) => {
@@ -545,6 +556,12 @@ TextArea.propTypes = {
    * `<textarea>` is clicked
    */
   onClick: PropTypes.func,
+
+  /**
+   * Optionally provide an `onKeyDown` handler that is called whenever `<textarea>`
+   * is keyed
+   */
+  onKeyDown: PropTypes.func,
 
   /**
    * Specify the placeholder attribute for the `<textarea>`


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15416

Calls `onKeyDown` if it is provided

#### Changelog

**Changed**

- Calls `onKeyDown` if the element is not disabled and `onKeyDown` is passed down.
- Added test to ensure it is called

#### Testing / Reviewing

Add a `onKeyDown` to a `TextArea` and ensure it is called when a user types in the `TextArea`
