### PR TITLE
fix: modified _number-input.scss:91

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -211,6 +211,7 @@ describe('Simple date picker', () => {
           default: module.DatePickerInput,
         }))
       );
+
       render(
         <React.Suspense fallback="Loading">
           <LazyDatePicker datePickerType="single">
@@ -222,6 +223,7 @@ describe('Simple date picker', () => {
           </LazyDatePicker>
         </React.Suspense>
       );
+
       const labeledElement = await screen.findByLabelText('Date Picker label');
       expect(labeledElement).toBeInTheDocument();
 

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -88,7 +88,7 @@
     }
 
     &[data-invalid] {
-      padding-inline-end: convert.to-rem(112px);
+      padding-inline-end: convert.to-rem(128px);
     }
   }
 

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -88,7 +88,7 @@
     }
 
     &[data-invalid] {
-      padding-inline-end: convert.to-rem(128px);
+      padding-inline-end: convert.to-rem(112px);
     }
   }
 

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -88,7 +88,7 @@
     }
 
     &[data-invalid] {
-      padding-inline-end: convert.to-rem(128px);
+      padding-inline-end: convert.to-rem(112px);
     }
   }
 
@@ -377,6 +377,13 @@
 
   // No steppers
   .#{$prefix}--number--nosteppers input[type='number'] {
+    padding-inline-end: 0;
+  }
+
+  .#{$prefix}--number--nosteppers input[type='number'][data-invalid],
+  .#{$prefix}--number--nosteppers
+    .#{$prefix}--number__input-wrapper--warning
+    input[type='number'] {
     padding-inline-end: convert.to-rem(48px);
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15414

Fixes an issue with padding when `hideSteppers` is set to true

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}

Full report : 

The input was like this before
![image_2023-12-18_183825308](https://github.com/carbon-design-system/carbon/assets/82550120/9eeceea6-6f43-4f15-a07b-e8848fdaab17)

Right now it will be like this :
![image_2023-12-18_183903376](https://github.com/carbon-design-system/carbon/assets/82550120/8bb666e0-4dea-44ee-8e62-2ea71d009061)

Changes did on styles/scss/components/number-input/_number-input.scss:91

Please note that it seems that the bug appeared only with invalid property and container under 150px and that the natural min-width of the NumberInput is 150px, which mean that you will have bug under that container size.

Edit : Problem, I actually modified no JS code, but 2 failed tests are blocking me
