### PR TITLE
fix(Accordion): resolve overflow issue

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.stories.js
+++ b/packages/react/src/components/Accordion/Accordion.stories.js
@@ -15,6 +15,13 @@ import {
 } from '../Accordion';
 import Button from '../Button';
 import mdx from './Accordion.mdx';
+import { Information } from '@carbon/icons-react';
+import {
+  ToggletipLabel,
+  Toggletip,
+  ToggletipButton,
+  ToggletipContent,
+} from '../Toggletip';
 
 import { WithLayer } from '../../../.storybook/templates/WithLayer';
 
@@ -65,6 +72,398 @@ export const Default = () => (
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
         commodo consequat.
       </p>
+    </AccordionItem>
+  </Accordion>
+);
+
+export const Test = () => (
+  <Accordion>
+    <AccordionItem title="Item 1">
+      <ToggletipLabel>Toggletip label</ToggletipLabel>
+      <Toggletip align="top">
+        <ToggletipButton label="Show information">
+          <Information />
+        </ToggletipButton>
+        <ToggletipContent>
+          <p>
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+        </ToggletipContent>
+      </Toggletip>
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>{' '}
+      <div>content is still rendered when accordion is collapsed</div>
+    </AccordionItem>
+    <AccordionItem title="Item 2" open>
+      <p>HELLO</p>
     </AccordionItem>
   </Accordion>
 );

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -152,7 +152,8 @@ function AccordionItem({
     } else {
       // accordion opens
       content.current.style.maxBlockSize =
-        content.current.scrollHeight + 15 + 'px';
+        // Scroll height plus top/bottom padding
+        content.current.scrollHeight + 32 + 'px';
     }
 
     const nextValue = !isOpen;

--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -154,7 +154,6 @@ $content-padding: 0 0 0 $spacing-05 !default;
   }
 
   .#{$prefix}--accordion__content {
-    overflow: hidden;
     padding-inline: layout.density('padding-inline');
 
     // Custom breakpoints based on issue #4993
@@ -201,6 +200,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
 
     .#{$prefix}--accordion__wrapper {
       // Properties for when the accordion is open
+      overflow: visible;
       max-block-size: fit-content;
       opacity: 1;
       padding-block: $spacing-03;

--- a/packages/styles/scss/components/accordion/_accordion.scss
+++ b/packages/styles/scss/components/accordion/_accordion.scss
@@ -144,7 +144,8 @@ $content-padding: 0 0 0 $spacing-05 !default;
   }
 
   .#{$prefix}--accordion__wrapper {
-    // Properties for when the accordion closes
+    // Properties for when the accordion is closed
+    overflow: hidden;
     padding: 0;
     max-block-size: 0;
     opacity: 0;
@@ -199,7 +200,7 @@ $content-padding: 0 0 0 $spacing-05 !default;
     overflow: visible;
 
     .#{$prefix}--accordion__wrapper {
-      // Properties for when the accordion opens
+      // Properties for when the accordion is open
       max-block-size: fit-content;
       opacity: 1;
       padding-block: $spacing-03;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15417
Closes https://github.com/carbon-design-system/carbon/issues/15357

Fixes an issue where collapsed `Accordion` content was pushing content down even when hidden.

#### Changelog

**New**

- Added `overflow: hidden` to `.cds--accordion__wrapper`

**Changed**

- Adjusted the calculated `max-block-size` to properly account for top/bottom padding

**Removed**

- Unnecessary `overflow: hidden` on `.cds--accordion__content`. Moved to the wrapper class `.cds--accordion__wrapper`

#### Testing / Reviewing

Go to `Accordion --> Test` and ensure the content does not cause the page to scroll when collapsed. Ensure the content is animated properly when opening and that the `Toggletip` overflows the `Accordion.` Also, ensure the padding for the default open `AccordionItem` remains the same after being closed and reopened. 

Test story will be removed before merging 
