### PR TITLE
fix: Datepicker closeOnSelect prop

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -315,6 +315,46 @@ describe('Single date picker', () => {
     await userEvent.click(screen.getByText('clear'));
     expect(screen.getByLabelText('Date Picker label')).toHaveValue('');
   });
+
+  it('should respect closeOnSelect prop', async () => {
+    const DatePickerExample = () => {
+      const [date, setDate] = useState();
+      return (
+        <DatePicker
+          datePickerType="single"
+          value={date}
+          closeOnSelect={false}
+          minDate="11/25/2023"
+          maxDate="11/28/2023"
+          onChange={(value) => {
+            setDate(value);
+          }}>
+          <DatePickerInput
+            placeholder="mm/dd/yyyy"
+            labelText="Date Picker label"
+            id="date-picker-simple"
+          />
+        </DatePicker>
+      );
+    };
+    render(<DatePickerExample />);
+    const input = screen.getByLabelText('Date Picker label');
+    expect(screen.getByRole('application')).not.toHaveClass('open');
+
+    await userEvent.click(input);
+    expect(screen.getByRole('application')).toHaveClass('open');
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const belowMinDate = document.querySelector(
+      '[aria-label="November 26, 2023"]'
+    );
+    await userEvent.click(belowMinDate);
+
+    expect(screen.getByLabelText('Date Picker label')).toHaveValue(
+      '11/26/2023'
+    );
+    expect(screen.getByRole('application')).toHaveClass('open');
+  });
 });
 
 describe('Date picker with locale', () => {

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -644,7 +644,7 @@ const DatePicker = React.forwardRef(function DatePicker(
     }
 
     function handleOnChange(event) {
-      if (datePickerType == 'single') {
+      if (datePickerType == 'single' && closeOnSelect) {
         calendar.calendarContainer.classList.remove('open');
       }
 
@@ -720,7 +720,15 @@ const DatePicker = React.forwardRef(function DatePicker(
         end.removeEventListener('change', handleOnChange);
       }
     };
-  }, [savedOnChange, savedOnClose, savedOnOpen, readOnly, hasInput]); //eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    savedOnChange,
+    savedOnClose,
+    savedOnOpen,
+    readOnly,
+    closeOnSelect,
+    hasInput,
+  ]);
 
   // this hook allows consumers to access the flatpickr calendar
   // instance for cases where functions like open() or close()


### PR DESCRIPTION
Closes #15215

Datepicker should avoid the close action when the user select a date in the calendar if the `closeOnSelect` prop is set as `false`.

#### Changelog

**New**

- Test case to check the intended behaviour when the prop is set to the desired condition

**Changed**

_None_

**Removed**

_None_
