### PR TITLE
docs(treeview): clarify state props documentation

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -9114,6 +9114,9 @@ Map {
       "disabled": Object {
         "type": "bool",
       },
+      "id": Object {
+        "type": "string",
+      },
       "isExpanded": Object {
         "type": "bool",
       },
@@ -9197,6 +9200,9 @@ Map {
         },
         "disabled": Object {
           "type": "bool",
+        },
+        "id": Object {
+          "type": "string",
         },
         "isExpanded": Object {
           "type": "bool",

--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -234,7 +234,8 @@ const TreeNode = React.forwardRef(
 
 TreeNode.propTypes = {
   /**
-   * The value of the active node in the tree
+   * **Note:** this is controlled by the parent TreeView component, do not set manually.
+   * The ID of the active node in the tree
    */
   active: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -249,7 +250,8 @@ TreeNode.propTypes = {
   className: PropTypes.string,
 
   /**
-   * TreeNode depth to determine spacing, automatically calculated by default
+   * * **Note:** this is controlled by the parent TreeView component, do not set manually.
+   * TreeNode depth to determine spacing
    */
   depth: PropTypes.number,
 
@@ -295,6 +297,7 @@ TreeNode.propTypes = {
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
+   * **Note:** this is controlled by the parent TreeView component, do not set manually.
    * Array containing all selected node IDs in the tree
    */
   selected: PropTypes.arrayOf(

--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -21,6 +21,7 @@ const TreeNode = React.forwardRef(
       className,
       depth,
       disabled,
+      id: nodeId,
       isExpanded,
       label,
       onNodeFocusEvent,
@@ -34,7 +35,7 @@ const TreeNode = React.forwardRef(
     },
     ref
   ) => {
-    const { current: id } = useRef(rest.id || uniqueId());
+    const { current: id } = useRef(nodeId || uniqueId());
     const [expanded, setExpanded] = useState(isExpanded);
     const currentNode = useRef(null);
     const currentNodeLabel = useRef(null);
@@ -259,6 +260,11 @@ TreeNode.propTypes = {
    * Specify if the TreeNode is disabled
    */
   disabled: PropTypes.bool,
+
+  /**
+   * Specify the TreeNode's ID. Must be unique in the DOM and is used for props.active and props.selected
+   */
+  id: PropTypes.string,
 
   /**
    * Specify if the TreeNode is expanded (only applicable to parent nodes)

--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -223,7 +223,7 @@ export default function TreeView({
 
 TreeView.propTypes = {
   /**
-   * Mark the active node in the tree, represented by its value
+   * Mark the active node in the tree, represented by its ID
    */
   active: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 


### PR DESCRIPTION
Ref #14451 

Addresses points 2, 3, and 4 of the linked discussion.

#### Changelog

**New**

- Officially document `props.id` on `TreeNode`

**Changed**

- Clarify that `props.active`, `props.selected`, and `props.depth` are controlled by `TreeView` and shouldn't be set manually
- Clarify that `props.active` and `props.selected` are referencing `props.id` instead of `props.value`

#### Testing / Reviewing

Automated tests for minor code change, rest is documentation only
