### PR TITLE
fix(react): wrong alignment with button icon only and danger--ghost kind

### DIFF
--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -277,10 +277,6 @@
         $button-danger-active
       );
 
-      padding-inline-end: calc(
-        layout.density('padding-inline') - convert.to-rem(1px)
-      );
-
       .#{$prefix}--btn__icon {
         position: static;
         margin-inline-start: $spacing-03;


### PR DESCRIPTION
Closes #15452

The icon is misplaced for buttons with icon only and danger--ghost kind. The alignment should be the same as for the other kinds.
Here is the difference.

#### Changelog

**Removed**
- Removed additional padding-inline-end from ghost-danger icon button class.

#### Testing / Reviewing

This CSS code makes padding on the left side of the `danger-ghost` icon button.
https://github.com/carbon-design-system/carbon/blob/3f70e1deab402402dfb18dcc3ae4c7057818ab82/packages/styles/scss/components/button/_button.scss#L280-L282

![Screenshot 2023-12-31 at 12 50 01 PM](https://github.com/carbon-design-system/carbon/assets/62743644/cc2abfc0-66e1-4b2b-91e7-d30a97589b05)
^ This is the `danger-ghost` button's CSS.
![Screenshot 2023-12-31 at 12 40 08 PM](https://github.com/carbon-design-system/carbon/assets/62743644/e71d0990-b916-4109-b2ec-b67900183ac1)
^ This is any other button's CSS.
