### PR TITLE
chore(ci): update office hours links in slack notifications

### DIFF
--- a/.github/workflows/slack-office-hours-design.yml
+++ b/.github/workflows/slack-office-hours-design.yml
@@ -70,7 +70,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/event/10323408",
+                    "url": "https://ec.yourlearning.ibm.com/w3/event/10408782",
                     "action_id": "button-action"
                   }
                 },

--- a/.github/workflows/slack-office-hours-dev.yml
+++ b/.github/workflows/slack-office-hours-dev.yml
@@ -68,7 +68,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/enrollment/event/10322733",
+                    "url": "https://ec.yourlearning.ibm.com/w3/enrollment/event/10408799",
                     "action_id": "button-action"
                   }
                 },


### PR DESCRIPTION
This just updates the event central urls in the office hours reminder slack blasts.

To review, check that the links go to the correct events.