### PR TITLE
fix(react): headerMenu requiring isActive prop #15351

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.js
+++ b/packages/react/src/components/UIShell/HeaderMenu.js
@@ -215,10 +215,11 @@ class HeaderMenu extends React.Component {
     const hasActiveDescendant = (childrenArg) =>
       React.Children.toArray(childrenArg).some(
         (child) =>
-          child.props.isActive ||
-          child.props.isCurrentPage ||
-          (child.props.children instanceof Array &&
-            hasActiveDescendant(child.props.children))
+          child.props &&
+          (child.props.isActive ||
+            child.props.isCurrentPage ||
+            (child.props.children instanceof Array &&
+              hasActiveDescendant(child.props.children)))
       );
 
     const accessibilityLabel = {


### PR DESCRIPTION
Closes #15351

HeaderMenu component throws an error when there is some nested plain text element inside.

#### Changelog

**Changed**
- Put a null check for `child.props` for the `hasActiveDescendant` function.

#### Testing / Reviewing

(Cause of the issue)
This happens because the `hasActiveDescendant` function does not consider the case when the HeaderMenu component has plain text as a child. The example that @dbryan17 provides us is using plain text as a child of the HeaderMenu component, so plain texts don't have any `child.props`, the function will throw an error.
https://github.com/carbon-design-system/carbon/blob/3f70e1deab402402dfb18dcc3ae4c7057818ab82/packages/react/src/components/UIShell/HeaderMenu.js#L215-L222

![Screenshot 2023-12-29 at 11 01 55 AM](https://github.com/carbon-design-system/carbon/assets/62743644/821f3208-ae83-483d-8e10-2bad7a86011f)
For example, If you put plain text inside the HeaderMenu component, you will see the error.

(Solution)
The solution for this issue is to make this component accept plain text elements and have the `hasActiveDescendant` function throw `false` when it is the case. So that I make sure that put a null check for `child.props`.
