### PR TITLE
style(RadioButton): left align radio button when width is increased

### DIFF
--- a/e2e/components/RadioButton/RadioButton-test.avt.e2e.js
+++ b/e2e/components/RadioButton/RadioButton-test.avt.e2e.js
@@ -22,6 +22,17 @@ test.describe('RadioButton @avt', () => {
     await expect(page).toHaveNoACViolations('RadioButton');
   });
 
+  test('@avt-advanced-states - vertical', async ({ page }) => {
+    await visitStory(page, {
+      component: 'RadioButton',
+      id: 'components-radiobutton--vertical',
+      globals: {
+        theme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('RadioButton-vertical');
+  });
+
   test('@avt-advanced-states - skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'RadioButton',

--- a/e2e/components/RadioButton/RadioButton-test.e2e.js
+++ b/e2e/components/RadioButton/RadioButton-test.e2e.js
@@ -21,6 +21,14 @@ test.describe('RadioButton', () => {
           theme,
         });
       });
+
+      test('vertical @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'RadioButton',
+          id: 'components-radiobutton--vertical',
+          theme,
+        });
+      });
     });
   });
 });

--- a/packages/react/src/components/RadioButton/RadioButton.stories.js
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.js
@@ -51,6 +51,33 @@ export const Default = () => {
   );
 };
 
+export const Vertical = () => {
+  return (
+    <RadioButtonGroup
+      legendText="Group label"
+      name="radio-button-group"
+      defaultSelected="radio-1"
+      orientation="vertical">
+      <RadioButton
+        labelText="Radio button label"
+        value="radio-1"
+        id="radio-1"
+      />
+      <RadioButton
+        labelText="Radio button label"
+        value="radio-2"
+        id="radio-2"
+      />
+      <RadioButton
+        labelText="Radio button label"
+        value="radio-3"
+        id="radio-3"
+        disabled
+      />
+    </RadioButtonGroup>
+  );
+};
+
 export const Skeleton = () => {};
 
 export const Playground = (args) => {

--- a/packages/styles/scss/components/radio-button/_radio-button.scss
+++ b/packages/styles/scss/components/radio-button/_radio-button.scss
@@ -77,6 +77,8 @@ $radio-border-width: 1px !default;
 
   .#{$prefix}--radio-button__label-text {
     @include type.type-style('body-compact-01');
+
+    flex: 1;
   }
 
   .#{$prefix}--radio-button__appearance {
@@ -237,10 +239,6 @@ $radio-border-width: 1px !default;
   .#{$prefix}--radio-button__label.#{$prefix}--skeleton
     .#{$prefix}--radio-button__appearance {
     display: none;
-  }
-
-  .#{$prefix}--radio-button-wrapper {
-    display: flex;
   }
 
   .#{$prefix}--radio-button-wrapper .#{$prefix}--radio-button__label {

--- a/packages/styles/scss/components/radio-button/_radio-button.scss
+++ b/packages/styles/scss/components/radio-button/_radio-button.scss
@@ -239,8 +239,12 @@ $radio-border-width: 1px !default;
     display: none;
   }
 
+  .#{$prefix}--radio-button-wrapper {
+    display: flex;
+  }
+
   .#{$prefix}--radio-button-wrapper .#{$prefix}--radio-button__label {
-    display: inline-flex;
+    display: flex;
     align-items: flex-start;
     justify-content: center;
     margin: 0;

--- a/packages/styles/scss/components/radio-button/_radio-button.scss
+++ b/packages/styles/scss/components/radio-button/_radio-button.scss
@@ -240,7 +240,7 @@ $radio-border-width: 1px !default;
   }
 
   .#{$prefix}--radio-button-wrapper .#{$prefix}--radio-button__label {
-    display: flex;
+    display: inline-flex;
     align-items: flex-start;
     justify-content: center;
     margin: 0;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15436

Sets the radio button to be `inline-flex` so it does not span the entire containing box when the width is increased

#### Changelog

**New**

- Added a story and tests for a new `Vertical` radio button

**Changed**

- `display: flex` to the radio button wrapper

#### Testing / Reviewing

Ensure there are no regressions. See bug [repro](https://stackblitz.com/edit/github-81xkqc-kqlub8?file=src%2FApp.jsx) for a stacked implementation, and verify that the change to `flex` solves the issue
