### PR TITLE
fix: allow aria-controls optional in TableExpand(Header|Row) types

### DIFF
--- a/packages/react/src/components/DataTable/TableExpandHeader.tsx
+++ b/packages/react/src/components/DataTable/TableExpandHeader.tsx
@@ -18,7 +18,7 @@ type TableExpandHeaderPropsBase = {
   /**
    * Space separated list of one or more ID values referencing the TableExpandedRow(s) being controlled by the TableExpandHeader
    */
-  ['aria-controls']: string;
+  ['aria-controls']?: string;
 
   /**
    * @deprecated This prop has been deprecated and will be

--- a/packages/react/src/components/DataTable/TableExpandRow.tsx
+++ b/packages/react/src/components/DataTable/TableExpandRow.tsx
@@ -17,7 +17,7 @@ interface TableExpandRowProps extends PropsWithChildren<TableRowProps> {
   /**
    * Space separated list of one or more ID values referencing the TableExpandedRow(s) being controlled by the TableExpandRow
    */
-  ['aria-controls']: string;
+  ['aria-controls']?: string;
 
   /**
    * @deprecated This prop has been deprecated and will be
@@ -136,7 +136,6 @@ TableExpandRow.propTypes = {
    * Space separated list of one or more ID values referencing the TableExpandedRow(s) being controlled by the TableExpandRow
    * TODO: make this required in v12
    */
-  /**@ts-ignore*/
   ['aria-controls']: PropTypes.string,
 
   /**


### PR DESCRIPTION
`aria-controls` is expected to be optional in TableExpandHeader and TableExpandRow. Reference https://ibm-security.slack.com/archives/C03C8VASVED/p1704886339356979?thread_ts=1704880429.593959&cid=C03C8VASVED

#### Changelog

Changed

- Make `aria-controls` option in TableExpandHeader and TableExpandRow types

Removed

- Unnecessary `ts-ignore` clean-up

#### Testing / Reviewing

This is aligned with prop-type requirements