### PR TITLE
fix(Modal): secondaryButtons prop type mismatch

### DIFF
--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -32,7 +32,7 @@ export const ModalSizes = ['xs', 'sm', 'md', 'lg'] as const;
 export type ModalSize = (typeof ModalSizes)[number];
 
 export interface ModalSecondaryButton {
-  buttonText?: string;
+  buttonText?: string | React.ReactNode;
 
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15392

The issue has a type mismatch. The `Modal` component has a `secondaryButtons` that accepts the `string` type but also differs from the existing implementation.

#### Changelog

**Changed**

- Fixed type mismatch

#### Testing / Reviewing

Check whether it accepts not only strings.
