### PR TITLE
Triage Bot: update octokit code to v20

### DIFF
--- a/actions/add-review-labels/index.js
+++ b/actions/add-review-labels/index.js
@@ -96,7 +96,7 @@ async function run() {
       return label.name === readyForReviewLabel;
     });
     if (hasReadyLabel) {
-      await octokit.issues.removeLabel({
+      await octokit.rest.issues.removeLabel({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: pullRequest.number,
@@ -110,7 +110,7 @@ async function run() {
       return label.name === additionalReviewLabel;
     });
     if (!hasAdditionalReviewLabel) {
-      await octokit.issues.addLabels({
+      await octokit.rest.issues.addLabels({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: pullRequest.number,
@@ -125,7 +125,7 @@ async function run() {
       return label.name === additionalReviewLabel;
     });
     if (hasAdditionalReviewLabel) {
-      await octokit.issues.removeLabel({
+      await octokit.rest.issues.removeLabel({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: pullRequest.number,
@@ -144,7 +144,7 @@ async function run() {
       return user === pullRequest.user.login;
     });
     if (shouldAutoLabel) {
-      await octokit.issues.addLabels({
+      await octokit.rest.issues.addLabels({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: pullRequest.number,

--- a/actions/issues/src/plugins/add-issue-response.js
+++ b/actions/issues/src/plugins/add-issue-response.js
@@ -62,7 +62,7 @@ const plugin = {
       });
 
       if (hasMaintainerLabel && doesNotMentionAnotherMember) {
-        await octokit.issues.removeLabel({
+        await octokit.rest.issues.removeLabel({
           owner: repository.owner.login,
           repo: repository.name,
           issue_number: issue.number,
@@ -78,7 +78,7 @@ const plugin = {
         return;
       }
 
-      await octokit.issues.addLabels({
+      await octokit.rest.issues.addLabels({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: issue.number,
@@ -89,7 +89,7 @@ const plugin = {
         return label.name === waitingForAuthor;
       });
       if (hasAuthorLabel) {
-        await octokit.issues.removeLabel({
+        await octokit.rest.issues.removeLabel({
           owner: repository.owner.login,
           repo: repository.name,
           issue_number: issue.number,
@@ -104,7 +104,7 @@ const plugin = {
         return;
       }
 
-      await octokit.issues.addLabels({
+      await octokit.rest.issues.addLabels({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: issue.number,

--- a/actions/issues/src/plugins/add-triage-label.js
+++ b/actions/issues/src/plugins/add-triage-label.js
@@ -29,7 +29,7 @@ const plugin = {
     });
 
     if (!hasTriageLabel) {
-      await octokit.issues?.addLabels({
+      await octokit.rest.issues.addLabels({
         owner: repository.owner.login,
         repo: repository.name,
         issue_number: issue.number,


### PR DESCRIPTION
The docs updated and might be because of this update that the `addLabels` was getting undefined in this [PR](https://github.com/carbon-design-system/carbon/pull/15313)

Old doc: https://octokit.github.io/rest.js/v16#:~:text=.issues.-,addLabels,-(%7B%0A%20%20owner
New doc: https://octokit.github.io/rest.js/v20#:~:text=.issues.-,addLabels,-(%7B%0A%20%20%20%20%20%20%20%20owner

If this change works it will not only fix the triage bot, but also the triage response and review label actions.

#### Testing / Reviewing

The test will be made after the PR is merged