### PR TITLE
fix(react): tooltip doesn't work when trigger has tabindex=-1

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -12,10 +12,7 @@ import { Popover, PopoverAlignment, PopoverContent } from '../Popover';
 import { keys, match } from '../../internal/keyboard';
 import { useDelayedState } from '../../internal/useDelayedState';
 import { useId } from '../../internal/useId';
-import {
-  useNoInteractiveChildren,
-  getInteractiveContent,
-} from '../../internal/useNoInteractiveChildren';
+import { useNoInteractiveChildren } from '../../internal/useNoInteractiveChildren';
 import { usePrefix } from '../../internal/usePrefix';
 import { type PolymorphicProps } from '../../types/common';
 
@@ -200,17 +197,6 @@ function Tooltip<T extends React.ElementType>({
     'The Tooltip component must have no interactive content rendered by the' +
       '`label` or `description` prop'
   );
-
-  useEffect(() => {
-    if (containerRef !== null && containerRef.current) {
-      const interactiveContent = getInteractiveContent(
-        containerRef.current as HTMLElement
-      );
-      if (!interactiveContent) {
-        setOpen(false);
-      }
-    }
-  });
 
   useEffect(() => {
     if (isDragging) {


### PR DESCRIPTION
Closes #15214

When the trigger button of a Tooltip has tabindex set to -1 the tooltip doesn't appear at all on hover and only for a flicker on click.

#### Changelog

**Removed**

-  the `useEffect` (line 203 in Tooltip.tsx).
https://github.com/carbon-design-system/carbon/blob/8c0130499a08892c6e89e7f6d198d10462b1e017/packages/react/src/components/Tooltip/Tooltip.tsx#L204-L213

#### Testing / Reviewing

(Cause of this issue)
I concluded that this happens because of the `useEffect` (line 203 in Tooltip.tsx).
https://github.com/carbon-design-system/carbon/blob/8c0130499a08892c6e89e7f6d198d10462b1e017/packages/react/src/components/Tooltip/Tooltip.tsx#L204-L213

When the user has a `tabIndex=-1` element, `interactiveContent` is always `null` since `getInteractiveContent` checks whether the elements are focusable or not by `if (element.tabIndex === undefined || element.tabIndex < 0` condition in the `isFocusable` function.
https://github.com/carbon-design-system/carbon/blob/8c0130499a08892c6e89e7f6d198d10462b1e017/packages/react/src/internal/useNoInteractiveChildren.js#L87-L90

We can just remove this `useEffect` since we don't need the focusable state detection that makes TooltipContent always hidden.
