### PR TITLE
fix(icon-helpers): fix TypeScript type issues

### DIFF
--- a/packages/icon-helpers/src/getAttributes.ts
+++ b/packages/icon-helpers/src/getAttributes.ts
@@ -1,19 +1,11 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
 
-interface IconAttributes
-  extends Omit<React.SVGProps<React.ReactSVGElement>, 'tabIndex'> {
-  tabindex?: string | number | undefined;
-
-  title?: string | undefined;
-}
-
-export const defaultAttributes: IconAttributes = {
+export const defaultAttributes = {
   // Reference:
   // https://github.com/IBM/carbon-components-react/issues/1392
   // https://github.com/PolymerElements/iron-iconset-svg/pull/47
@@ -31,9 +23,9 @@ export default function getAttributes({
   height,
   viewBox = `0 0 ${width} ${height}`,
   ...attributes
-}: IconAttributes = {}): IconAttributes {
+}: Record<string, unknown> = {}): Record<string, unknown> {
   const { tabindex, ...rest } = attributes;
-  const iconAttributes: IconAttributes = {
+  const iconAttributes: Record<string, unknown> = {
     ...defaultAttributes,
     ...rest,
     width,

--- a/packages/icon-helpers/src/toSVG.ts
+++ b/packages/icon-helpers/src/toSVG.ts
@@ -1,16 +1,17 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import getAttributes from './getAttributes';
+import IconDescriptor from './types';
 
 /**
  * Convert an icon descriptor to a DOM node.
  */
-export default function toSVG(descriptor) {
+export default function toSVG(descriptor: IconDescriptor): SVGElement {
   const { elem = 'svg', attrs = {}, content = [] } = descriptor;
   const node = document.createElementNS('http://www.w3.org/2000/svg', elem);
   const attributes = elem !== 'svg' ? attrs : getAttributes(attrs);

--- a/packages/icon-helpers/src/toString.ts
+++ b/packages/icon-helpers/src/toString.ts
@@ -1,16 +1,17 @@
 /**
- * Copyright IBM Corp. 2018, 2023
+ * Copyright IBM Corp. 2018, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import getAttributes from './getAttributes';
+import IconDescriptor from './types';
 
 /**
  * Convert an icon descriptor to a String
  */
-export default function toString(descriptor) {
+export default function toString(descriptor: IconDescriptor): string {
   const { elem = 'svg', attrs = {}, content = [] } = descriptor;
   const children = content.map(toString).join('');
   if (elem !== 'svg') {
@@ -21,7 +22,7 @@ export default function toString(descriptor) {
   )}>${children}</${elem}>`;
 }
 
-export function formatAttributes(attrs) {
+export function formatAttributes(attrs: Record<string, unknown>): string {
   return Object.keys(attrs).reduce((acc, key, index) => {
     const attribute = `${key}="${attrs[key]}"`;
     if (index === 0) {

--- a/packages/icon-helpers/src/types.ts
+++ b/packages/icon-helpers/src/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default interface IconDescriptor {
+  elem?: string;
+
+  attrs?: Record<string, string>;
+
+  content?: Array<IconDescriptor>;
+}


### PR DESCRIPTION
Closes #15114

Fixes TypeScript issues introduced when migrating getAttributes() function to TypeScript.

#### Changelog

**Changed**

- Migrated remaining functions to TypeScript
- Removed dependency on React types

#### Testing / Reviewing

Standard build/test runs must be passing. There should be no functional/behavioral changes introduced by this change. Using @carbon/icon-helpers in non-React projects should not cause any errors.