### PR TITLE
fix(ExpandableSearch): allow isExpanded state to be controlled

### DIFF
--- a/packages/react/src/components/ExpandableSearch/ExpandableSearch.tsx
+++ b/packages/react/src/components/ExpandableSearch/ExpandableSearch.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import classnames from 'classnames';
 import Search, { type SearchProps } from '../Search';
 import { usePrefix } from '../../internal/usePrefix';
@@ -31,10 +31,14 @@ function ExpandableSearch({
       evt.relatedTarget &&
       evt.relatedTarget.classList.contains(`${prefix}--search-close`);
 
-    if (expanded && !relatedTargetIsAllowed && !hasContent) {
+    if (expanded && !relatedTargetIsAllowed && !hasContent && !isExpanded) {
       setExpanded(false);
     }
   }
+
+  useEffect(() => {
+    setExpanded(!!isExpanded);
+  }, [isExpanded]);
 
   function handleChange(evt) {
     setHasContent(evt.target.value !== '');
@@ -50,7 +54,7 @@ function ExpandableSearch({
       evt.stopPropagation();
 
       // escape key only clears if the input is empty, otherwise it clears the input
-      if (!evt.target?.value) {
+      if (!evt.target?.value && !isExpanded) {
         setExpanded(false);
       }
     }

--- a/packages/react/src/components/Search/Search.stories.js
+++ b/packages/react/src/components/Search/Search.stories.js
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { WithLayer } from '../../../.storybook/templates/WithLayer';
 
 import ExpandableSearch from '../ExpandableSearch';
 import Search from '.';
+import Button from '../Button';
 
 export default {
   title: 'Components/Search',
@@ -25,6 +26,22 @@ export default {
   subcomponents: {
     ExpandableSearch,
   },
+};
+
+export const Test = () => {
+  const [isExpanded, setExpanded] = useState(false);
+
+  const handleToggleExpandClick = useCallback(() => {
+    setExpanded(!isExpanded);
+  }, [isExpanded]);
+
+  return (
+    <>
+      <div>isExpanded = {isExpanded.toString()}</div>
+      <ExpandableSearch isExpanded={isExpanded} />
+      <Button onClick={handleToggleExpandClick}>Toggle Expand</Button>
+    </>
+  );
 };
 
 export const Default = () => (


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15147

Fixes an issue that was causing the `ExpandableSearch` not to update when the `isExpanded` prop was changed. 

#### Changelog

**New**

- Added a `useEffect` so that the `Search` is updated if the `isExpanded` prop is changed. 
- A test story to verify it works


#### Testing / Reviewing

Ensure the test story works as expected, and that the existing `Search` and `ExpandableSearch` stories function the same
