### PR TITLE
chore(ci): pin actions to a SHA

### DIFF
--- a/.github/workflows/add-review-labels.yml
+++ b/.github/workflows/add-review-labels.yml
@@ -4,7 +4,7 @@ jobs:
   reviewer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - uses: ./actions/add-review-labels
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,7 +19,7 @@ jobs:
     name: Add issue with enhancement label to the Proposals project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c #v0.5.0
         with:
           labeled: ${{ env.LABEL_ENHANCEMENT }}
           project-url: ${{ env.PROPOSALS_PROJECT_URL }}
@@ -29,7 +29,7 @@ jobs:
     name: Add issue with typescript label to the TypeScript Adoption project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c #v0.5.0
         with:
           labeled: ${{ env.LABEL_TYPESCRIPT }}
           project-url: ${{ env.TYPESCRIPT_PROJECT_URL }}
@@ -39,7 +39,7 @@ jobs:
     name: Add issue to the Design System project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c #v0.5.0
         with:
           labeled: ${{ env.LABEL_ENHANCEMENT }}, ${{ env.LABEL_TYPESCRIPT }}
           label-operator: NOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
-      - uses: dorny/paths-filter@v2.11.1
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 #v2.11.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,9 +24,9 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@0b21cf2492b6b02c465a3e5d7c473717ad7721ba #v3.23.1
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@0b21cf2492b6b02c465a3e5d7c473717ad7721ba #v3.23.1

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -39,7 +39,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 #v5.0.2
         with:
           branch: 'release/update-carbon-deps'
           commit-message: 'chore(release): update carbon deps'
@@ -82,7 +82,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 #v5.0.2
         with:
           branch: 'release/update-carbon-deps'
           commit-message: 'chore(release): update carbon deps'

--- a/.github/workflows/deploy-react-storybook.yml
+++ b/.github/workflows/deploy-react-storybook.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #4.1.1
       - name: Use Node.js 20.x
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 #v4.0.1
         with:
@@ -42,14 +42,14 @@ jobs:
           cd packages/react
           yarn storybook:build
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d #v4.0.0
       - name: Fix permissions
         run: |
           chmod -v -R +rX "_site/" | while read line; do
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 #v3.0.0
         with:
           path: 'packages/react/storybook-static'
 
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@87c3283f01cd6fe19a0ab93a23b2f6fcba5a8e42 #v4.0.3

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - name: run-ghrs
         # Use latest release.
-        uses: jgehrcke/github-repo-stats@RELEASE
+        uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa #1.4.2
         with:
           ghtoken: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/issue-triage-strategic-adopter.yml
+++ b/.github/workflows/issue-triage-strategic-adopter.yml
@@ -10,8 +10,8 @@ jobs:
     if: |
       !github.event.issue.pull_request
     steps:
-      - uses: actions/checkout@main
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b #v2.0.2
         id: regex-match
         with:
           text: ${{ github.event.issue.body }}
@@ -27,7 +27,7 @@ jobs:
             Cloud|Sterling Data Exchange SaaS|TRIRIGA|Sterling Order and
             Inventory Management|Supply Chain Intelligence Suite\b'
           flags: g
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         if: ${{ steps.regex-match.outputs.match != '' }}
         with:
           script: |

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,7 +15,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Generate token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
         id: generate_token

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Use Node.js 20.x
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 #v4.0.1
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -18,7 +18,7 @@ jobs:
   packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - uses: ./actions/promote
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-notifications.yml
+++ b/.github/workflows/release-notifications.yml
@@ -10,7 +10,7 @@ jobs:
     name: Post notification comments on PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Generate token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
         id: generate_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             github.rest.repos.createRelease({

--- a/.github/workflows/slack-announcement.yml
+++ b/.github/workflows/slack-announcement.yml
@@ -3,7 +3,7 @@ name: Send slack announcement
 on:
   workflow_dispatch:
     inputs:
-      text: 
+      text:
         required: true
         description: 'Announcement title'
         type: string
@@ -18,35 +18,35 @@ on:
 
 jobs:
   setup:
-      runs-on: ubuntu-latest
-      outputs:
-        matrix: ${{steps.matrix.outputs.channel}}
-      steps:
-        - id: matrix
-          run: |
-            channels="${{ github.event.inputs.channel }}"
-            echo "channel=[\"${channels//', '/\",\"}\"]" >> $GITHUB_OUTPUT
-            
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{steps.matrix.outputs.channel}}
+    steps:
+      - id: matrix
+        run: |
+          channels="${{ github.event.inputs.channel }}"
+          echo "channel=[\"${channels//', '/\",\"}\"]" >> $GITHUB_OUTPUT
+
   slack-announcement:
-    needs: [ setup ]
+    needs: [setup]
     name: Send slack announcement
     runs-on: ubuntu-latest
     strategy:
       matrix:
         value: ${{fromJSON(needs.setup.outputs.matrix)}}
     steps:
-        - name: Send slack announcement
-          id: slack
-          uses: slackapi/slack-github-action@v1.24.0
-          with:
-            payload: |
-              {
-                "username": "Carbon Design System",
-                "icon_url": "https://user-images.githubusercontent.com/3360588/192045905-5d9705af-92e2-4432-805e-15db98571e8b.png",
-                "channel": "${{ matrix.value }}",
-                "text": "${{ github.event.inputs.text }}",
-                "blocks": ${{ toJSON(fromJSON(github.event.inputs.block-kit).blocks) }}
-              }
-          env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-            SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send slack announcement
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
+        with:
+          payload: |
+            {
+              "username": "Carbon Design System",
+              "icon_url": "https://user-images.githubusercontent.com/3360588/192045905-5d9705af-92e2-4432-805e-15db98571e8b.png",
+              "channel": "${{ matrix.value }}",
+              "text": "${{ github.event.inputs.text }}",
+              "blocks": ${{ toJSON(fromJSON(github.event.inputs.block-kit).blocks) }}
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/slack-build-notifications.yml
+++ b/.github/workflows/slack-build-notifications.yml
@@ -19,11 +19,12 @@ jobs:
     # We only want notifications for successful runs for certain workflows
     if:
       ${{ github.event.workflow_run.conclusion == 'success' &&
-      contains(fromJson('["Version", "Release", "Deploy React storybook to GitHub Pages", "promote"]'), github.event.workflow.name) }}
+      contains(fromJson('["Version", "Release", "Deploy React storybook to
+      GitHub Pages", "promote"]'), github.event.workflow.name) }}
     steps:
       - name: Send custom JSON data to Slack
         id: slack-success
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
         with:
           payload: |
             {
@@ -41,7 +42,7 @@ jobs:
     steps:
       - name: Send custom JSON data to Slack
         id: slack-failure
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
         with:
           payload: |
             {

--- a/.github/workflows/slack-office-hours-design.yml
+++ b/.github/workflows/slack-office-hours-design.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
         with:
           payload: |
             {

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e #v9.0.0
         with:
           any-of-issue-labels:
             "status: waiting for author's response 💬,status: needs more info 🤷‍♀️"

--- a/.github/workflows/v10-ci.yml
+++ b/.github/workflows/v10-ci.yml
@@ -101,7 +101,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
-      - uses: dorny/paths-filter@v2.11.1
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 #v2.11.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/v10-deploy-react-storybook.yml
+++ b/.github/workflows/v10-deploy-react-storybook.yml
@@ -35,7 +35,7 @@ jobs:
           touch packages/react/storybook-static/CNAME
           echo "v7-react.carbondesignsystem.com" > packages/react/storybook-static/CNAME
       - name: Push to v7 repo
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@07c4d7b3def0a8ebe788a8f2c843a4e1de4f6900 #v1.7.2
         env:
           API_TOKEN_GITHUB: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/v10-release.yml
+++ b/.github/workflows/v10-release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             github.rest.repos.createRelease({
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -64,7 +64,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 #v5.0.2
         with:
           branch: 'release/${{ github.event.inputs.tag }}'
           commit-message: 'chore(release): ${{ github.event.inputs.tag }}'


### PR DESCRIPTION
Closes #14052

This PR, along with https://github.com/carbon-design-system/carbon/pull/15565 and https://github.com/carbon-design-system/carbon/pull/15408 should cover all actions to be pinned to a SHA.

#### Changelog

**Changed**

- Update all actions to a SHA

#### Testing / Reviewing

1. Pull down the PR and open the changed files in VSCode
2. <kbd>cmd</kbd> + `click` on the `actions/*` string - this should navigate you to the repo of that action
3. Click "Releases" in the sidebar
4. View the tagged commit, it should match the commit SHA specified in our action file
5. The listed tag should match the `#v.#.#.#` comment in our action file

<img width="981" alt="image" src="https://github.com/carbon-design-system/carbon/assets/3360588/5c443bc8-c526-48df-b248-a8b40aabf0b0">
