### PR TITLE
fix: added hasFocus as deprecated prop

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -109,9 +109,7 @@ Map {
       "closeOnEscape": Object {
         "type": "bool",
       },
-      "hasFocus": Object {
-        "type": "bool",
-      },
+      "hasFocus": [Function],
       "hideCloseButton": Object {
         "type": "bool",
       },

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -1103,6 +1103,7 @@ ActionableNotification.propTypes = {
   closeOnEscape: PropTypes.bool,
 
   /**
+   * Deprecated, please use StaticNotification once it's available. Issue #15532
    * Specify if focus should be moved to the component when the notification contains actions
    */
   hasFocus: deprecate(PropTypes.bool),

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -843,6 +843,7 @@ export interface ActionableNotificationProps
   closeOnEscape?: boolean;
 
   /**
+   * @deprecated use StaticNotification once it's available. Issue #15532
    * Specify if focus should be moved to the component when the notification contains actions
    */
   hasFocus?: boolean;
@@ -1104,7 +1105,7 @@ ActionableNotification.propTypes = {
   /**
    * Specify if focus should be moved to the component when the notification contains actions
    */
-  hasFocus: PropTypes.bool,
+  hasFocus: deprecate(PropTypes.bool),
 
   /**
    * Specify the close button should be disabled, or not

--- a/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
+++ b/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
@@ -40,6 +40,14 @@ export const Default = () => (
   />
 );
 
+Default.argTypes = {
+  hasFocus: {
+    table: {
+      disable: true,
+    },
+  },
+};
+
 export const Playground = (args) => <ActionableNotification {...args} />;
 
 Playground.argTypes = {

--- a/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
+++ b/packages/react/src/components/Notification/stories/ActionableNotification.stories.js
@@ -72,6 +72,11 @@ Playground.argTypes = {
       disable: true,
     },
   },
+  hasFocus: {
+    table: {
+      disable: true,
+    },
+  },
 };
 Playground.args = {
   actionButtonLabel: 'Action',

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -407,6 +407,7 @@ function TabList({
       const activeTabs: TabElement[] = tabs.current.filter(
         (tab) => !tab.disabled
       );
+
       const currentIndex = activeTabs.indexOf(
         tabs.current[activation === 'automatic' ? selectedIndex : activeIndex]
       );

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -327,7 +327,6 @@ function TabList({
   const nextButton = useRef<HTMLButtonElement>(null);
   const [isScrollable, setIsScrollable] = useState(false);
   const [scrollLeft, setScrollLeft] = useState<number>(0);
-  const [activeTabs, setActiveTabs] = useState<TabElement[]>([]);
 
   let hasSecondaryLabelTabs = false;
   if (contained) {
@@ -399,26 +398,15 @@ function TabList({
     }, scrollDebounceWait);
   }, [scrollDebounceWait]);
 
-  useEffect(() => {
-    setActiveTabs([]);
-    console.log('tabs', tabs);
-    const filteredTabs: TabElement[] = tabs.current.filter(
-      (tab) => !tab.disabled
-    );
-
-    setActiveTabs(filteredTabs);
-    // console.log('activeTabs UseEffect', activeTabs);
-  }, [tabs]);
-
   function onKeyDown(event: KeyboardEvent) {
     if (
       matches(event, [keys.ArrowRight, keys.ArrowLeft, keys.Home, keys.End])
     ) {
       event.preventDefault();
-      // filterTabs();
-      console.log('onKeyDown');
 
-      console.log('activeTabs', activeTabs);
+      const activeTabs: TabElement[] = tabs.current.filter(
+        (tab) => !tab.disabled
+      );
       const currentIndex = activeTabs.indexOf(
         tabs.current[activation === 'automatic' ? selectedIndex : activeIndex]
       );

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -327,6 +327,7 @@ function TabList({
   const nextButton = useRef<HTMLButtonElement>(null);
   const [isScrollable, setIsScrollable] = useState(false);
   const [scrollLeft, setScrollLeft] = useState<number>(0);
+  const [activeTabs, setActiveTabs] = useState<TabElement[]>([]);
 
   let hasSecondaryLabelTabs = false;
   if (contained) {
@@ -398,16 +399,26 @@ function TabList({
     }, scrollDebounceWait);
   }, [scrollDebounceWait]);
 
+  useEffect(() => {
+    setActiveTabs([]);
+    console.log('tabs', tabs);
+    const filteredTabs: TabElement[] = tabs.current.filter(
+      (tab) => !tab.disabled
+    );
+
+    setActiveTabs(filteredTabs);
+    // console.log('activeTabs UseEffect', activeTabs);
+  }, [tabs]);
+
   function onKeyDown(event: KeyboardEvent) {
     if (
       matches(event, [keys.ArrowRight, keys.ArrowLeft, keys.Home, keys.End])
     ) {
       event.preventDefault();
+      // filterTabs();
+      console.log('onKeyDown');
 
-      const activeTabs: TabElement[] = tabs.current.filter(
-        (tab) => !tab.disabled
-      );
-
+      console.log('activeTabs', activeTabs);
       const currentIndex = activeTabs.indexOf(
         tabs.current[activation === 'automatic' ? selectedIndex : activeIndex]
       );


### PR DESCRIPTION
Closes #15534

Deprecating `hasFocus` because we are gonna have a new variant in the future called `StaticNotification` to avoid confusion around the usage of the `ActionableNotification`.

**Changed**

- `hasFocus` prop is deprecated
- Removed `hasFocus` prop from Default and Playground stories

#### Testing / Reviewing

- Ensure focus always moves to the `ActionableNotification`