### PR TITLE
docs(Fluid): group fluid stories in storybook

### DIFF
--- a/e2e/components/FluidComboBox/FluidComboBox-test.avt.e2e.js
+++ b/e2e/components/FluidComboBox/FluidComboBox-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidComboBox @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidComboBox',
-      id: 'experimental-unstable-fluidcombobox--default',
+      id: 'experimental-fluid-components-unstable-fluidcombobox--default',
       globals: {
         theme: 'white',
       },
@@ -26,7 +26,7 @@ test.describe('FluidComboBox @avt', () => {
   test.skip('@avt-advanced-states open', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidComboBox',
-      id: 'experimental-unstable-fluidcombobox--default',
+      id: 'experimental-fluid-components-unstable-fluidcombobox--default',
       globals: {
         theme: 'white',
       },
@@ -47,7 +47,7 @@ test.describe('FluidComboBox @avt', () => {
   test('@avt-keyboard-nav', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidComboBox',
-      id: 'experimental-unstable-fluidcombobox--default',
+      id: 'experimental-fluid-components-unstable-fluidcombobox--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidComboBox/FluidComboBox-test.e2e.js
+++ b/e2e/components/FluidComboBox/FluidComboBox-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidComboBox', () => {
       test('fluid dropdown @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidComboBox',
-          id: 'experimental-unstable-fluidcombobox--default',
+          id: 'experimental-fluid-components-unstable-fluidcombobox--default',
           theme,
         });
       });

--- a/e2e/components/FluidDatePicker/FluidDatePicker-test.avt.e2e.js
+++ b/e2e/components/FluidDatePicker/FluidDatePicker-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidDatePicker @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',
-      id: 'experimental-unstable-fluiddatepicker--range-with-calendar',
+      id: 'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
       globals: {
         theme: 'white',
       },
@@ -25,7 +25,7 @@ test.describe('FluidDatePicker @avt', () => {
   test('@avt-advanced-states single', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',
-      id: 'experimental-unstable-fluiddatepicker--single',
+      id: 'experimental-fluid-components-unstable-fluiddatepicker--single',
       globals: {
         theme: 'white',
       },
@@ -36,7 +36,7 @@ test.describe('FluidDatePicker @avt', () => {
   test('@avt-advanced-states simple', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',
-      id: 'experimental-unstable-fluiddatepicker--simple',
+      id: 'experimental-fluid-components-unstable-fluiddatepicker--simple',
       globals: {
         theme: 'white',
       },
@@ -47,7 +47,7 @@ test.describe('FluidDatePicker @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',
-      id: 'experimental-unstable-fluiddatepicker--skeleton',
+      id: 'experimental-fluid-components-unstable-fluiddatepicker--skeleton',
       globals: {
         theme: 'white',
       },
@@ -58,7 +58,7 @@ test.describe('FluidDatePicker @avt', () => {
   test('@avt-keyboard-nav single', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',
-      id: 'experimental-unstable-fluiddatepicker--single',
+      id: 'experimental-fluid-components-unstable-fluiddatepicker--single',
       globals: {
         theme: 'white',
       },
@@ -79,7 +79,7 @@ test.describe('FluidDatePicker @avt', () => {
   test('@avt-keyboard-nav range', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',
-      id: 'experimental-unstable-fluiddatepicker--range-with-calendar',
+      id: 'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidDatePicker/FluidDatePicker-test.e2e.js
+++ b/e2e/components/FluidDatePicker/FluidDatePicker-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidDatePicker', () => {
       test('fluid date picker (range) @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidDatePicker',
-          id: 'experimental-unstable-fluiddatepicker--range-with-calendar',
+          id: 'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
           theme,
         });
       });
@@ -25,7 +25,7 @@ test.describe('FluidDatePicker', () => {
       test('fluid date picker (single) @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidDatePicker',
-          id: 'experimental-unstable-fluiddatepicker--single',
+          id: 'experimental-fluid-components-unstable-fluiddatepicker--single',
           theme,
         });
       });
@@ -33,7 +33,7 @@ test.describe('FluidDatePicker', () => {
       test('fluid date picker (simple) @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidDatePicker',
-          id: 'experimental-unstable-fluiddatepicker--simple',
+          id: 'experimental-fluid-components-unstable-fluiddatepicker--simple',
           theme,
         });
       });

--- a/e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js
+++ b/e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidDropdown @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDropdown',
-      id: 'experimental-unstable-fluiddropdown--default',
+      id: 'experimental-fluid-components-unstable-fluiddropdown--default',
       globals: {
         theme: 'white',
       },
@@ -25,7 +25,7 @@ test.describe('FluidDropdown @avt', () => {
   test('@avt-advanced-states condensed', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDropdown',
-      id: 'experimental-unstable-fluiddropdown--condensed',
+      id: 'experimental-fluid-components-unstable-fluiddropdown--condensed',
       globals: {
         theme: 'white',
       },
@@ -36,7 +36,7 @@ test.describe('FluidDropdown @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDropdown',
-      id: 'experimental-unstable-fluiddropdown--skeleton',
+      id: 'experimental-fluid-components-unstable-fluiddropdown--skeleton',
       globals: {
         theme: 'white',
       },
@@ -47,7 +47,7 @@ test.describe('FluidDropdown @avt', () => {
   test('@avt-keyboard-nav', async ({ page }) => {
     await visitStory(page, {
       component: 'Dropdown',
-      id: 'experimental-unstable-fluiddropdown--default',
+      id: 'experimental-fluid-components-unstable-fluiddropdown--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidDropdown/FluidDropdown-test.e2e.js
+++ b/e2e/components/FluidDropdown/FluidDropdown-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidDropdown', () => {
       test('fluid dropdown @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidDropdown',
-          id: 'experimental-unstable-fluiddropdown--default',
+          id: 'experimental-fluid-components-unstable-fluiddropdown--default',
           theme,
         });
       });

--- a/e2e/components/FluidForm/FluidForm-test.avt.e2e.js
+++ b/e2e/components/FluidForm/FluidForm-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidForm @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidForm',
-      id: 'experimental-fluidform--default',
+      id: 'experimental-fluid-components-fluidform--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidForm/FluidForm-test.e2e.js
+++ b/e2e/components/FluidForm/FluidForm-test.e2e.js
@@ -16,7 +16,7 @@ test.describe('FluidForm', () => {
       test('fluid form @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidForm',
-          id: 'experimental-fluidform--default',
+          id: 'experimental-fluid-components-fluidform--default',
           theme,
         });
       });

--- a/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
+++ b/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidMultiSelect @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
-      id: 'experimental-unstable-fluidmultiselect--default',
+      id: 'experimental-fluid-components-unstable-fluidmultiselect--default',
       globals: {
         theme: 'white',
       },
@@ -27,7 +27,7 @@ test.describe('FluidMultiSelect @avt', () => {
   test('@avt-advanced-states condensed', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
-      id: 'experimental-unstable-fluidmultiselect--condensed',
+      id: 'experimental-fluid-components-unstable-fluidmultiselect--condensed',
       globals: {
         theme: 'white',
       },
@@ -38,7 +38,7 @@ test.describe('FluidMultiSelect @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
-      id: 'experimental-unstable-fluidmultiselect--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidmultiselect--skeleton',
       globals: {
         theme: 'white',
       },
@@ -49,7 +49,7 @@ test.describe('FluidMultiSelect @avt', () => {
   test('@avt-keyboard-nav FluidMultiSelect', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
-      id: 'experimental-unstable-fluidmultiselect--default',
+      id: 'experimental-fluid-components-unstable-fluidmultiselect--default',
       globals: {
         theme: 'white',
       },
@@ -144,7 +144,7 @@ test.describe('FluidMultiSelect @avt', () => {
   test('@avt-keyboard-nav FluidMultiSelect condensed', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',
-      id: 'experimental-unstable-fluidmultiselect--condensed',
+      id: 'experimental-fluid-components-unstable-fluidmultiselect--condensed',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidMultiSelect/FluidMultiSelect-test.e2e.js
+++ b/e2e/components/FluidMultiSelect/FluidMultiSelect-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidMultiSelect', () => {
       test('fluid dropdown @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidMultiSelect',
-          id: 'experimental-unstable-fluidmultiselect--default',
+          id: 'experimental-fluid-components-unstable-fluidmultiselect--default',
           theme,
         });
       });

--- a/e2e/components/FluidNumberInput/FluidNumberInput-test.avt.e2e.js
+++ b/e2e/components/FluidNumberInput/FluidNumberInput-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidNumberInput @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidNumberInput',
-      id: 'experimental-unstable-fluidnumberinput--default',
+      id: 'experimental-fluid-components-unstable-fluidnumberinput--default',
       globals: {
         theme: 'white',
       },
@@ -27,7 +27,7 @@ test.describe('FluidNumberInput @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidNumberInput',
-      id: 'experimental-unstable-fluidnumberinput--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidnumberinput--skeleton',
       globals: {
         theme: 'white',
       },
@@ -38,7 +38,7 @@ test.describe('FluidNumberInput @avt', () => {
   test('@avt-keyboard-nav NumberInput', async ({ page }) => {
     await visitStory(page, {
       component: 'NumberInput',
-      id: 'experimental-unstable-fluidnumberinput--default',
+      id: 'experimental-fluid-components-unstable-fluidnumberinput--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidNumberInput/FluidNumberInput-test.e2e.js
+++ b/e2e/components/FluidNumberInput/FluidNumberInput-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidNumberInput', () => {
       test('fluid text input @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidNumberInput',
-          id: 'experimental-unstable-fluidnumberinput--default',
+          id: 'experimental-fluid-components-unstable-fluidnumberinput--default',
           theme,
         });
       });

--- a/e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js
+++ b/e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidSearch @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSearch',
-      id: 'experimental-unstable-fluidsearch--default',
+      id: 'experimental-fluid-components-unstable-fluidsearch--default',
       globals: {
         theme: 'white',
       },
@@ -25,7 +25,7 @@ test.describe('FluidSearch @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSearch',
-      id: 'experimental-unstable-fluidsearch--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidsearch--skeleton',
       globals: {
         theme: 'white',
       },
@@ -36,7 +36,7 @@ test.describe('FluidSearch @avt', () => {
   test('@avt-keyboard-nav', async ({ page }) => {
     await visitStory(page, {
       component: 'Search',
-      id: 'experimental-unstable-fluidsearch--default',
+      id: 'experimental-fluid-components-unstable-fluidsearch--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidSearch/FluidSearch-test.e2e.js
+++ b/e2e/components/FluidSearch/FluidSearch-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidSearch', () => {
       test('fluid select @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidSearch',
-          id: 'experimental-unstable-fluidsearch--default',
+          id: 'experimental-fluid-components-unstable-fluidsearch--default',
           theme,
         });
       });

--- a/e2e/components/FluidSelect/FluidSelect-test.avt.e2e.js
+++ b/e2e/components/FluidSelect/FluidSelect-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidSelect @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSelect',
-      id: 'experimental-unstable-fluidselect--default',
+      id: 'experimental-fluid-components-unstable-fluidselect--default',
       globals: {
         theme: 'white',
       },
@@ -25,7 +25,7 @@ test.describe('FluidSelect @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSelect',
-      id: 'experimental-unstable-fluidselect--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidselect--skeleton',
       globals: {
         theme: 'white',
       },
@@ -36,7 +36,7 @@ test.describe('FluidSelect @avt', () => {
   test('@avt-keyboard-nav FluidSelect', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSelect',
-      id: 'experimental-unstable-fluidselect--default',
+      id: 'experimental-fluid-components-unstable-fluidselect--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidSelect/FluidSelect-test.e2e.js
+++ b/e2e/components/FluidSelect/FluidSelect-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidSelect', () => {
       test('fluid select @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidSelect',
-          id: 'experimental-unstable-fluidselect--default',
+          id: 'experimental-fluid-components-unstable-fluidselect--default',
           theme,
         });
       });

--- a/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
+++ b/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidTextArea @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextArea',
-      id: 'experimental-unstable-fluidtextarea--default',
+      id: 'experimental-fluid-components-unstable-fluidtextarea--default',
       globals: {
         theme: 'white',
       },
@@ -25,7 +25,7 @@ test.describe('FluidTextArea @avt', () => {
   test('@avt-advanced-states default-with-layers', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextArea',
-      id: 'experimental-unstable-fluidtextarea--default-with-layers',
+      id: 'experimental-fluid-components-unstable-fluidtextarea--default-with-layers',
       globals: {
         theme: 'white',
       },
@@ -38,7 +38,7 @@ test.describe('FluidTextArea @avt', () => {
   test('@avt-advanced-states default-with-tooltip', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextArea',
-      id: 'experimental-unstable-fluidtextarea--default-with-tooltip',
+      id: 'experimental-fluid-components-unstable-fluidtextarea--default-with-tooltip',
       globals: {
         theme: 'white',
       },
@@ -51,7 +51,7 @@ test.describe('FluidTextArea @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextArea',
-      id: 'experimental-unstable-fluidtextarea--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidtextarea--skeleton',
       globals: {
         theme: 'white',
       },
@@ -62,7 +62,7 @@ test.describe('FluidTextArea @avt', () => {
   test('@avt-keyboard-nav FluidTextArea default', async ({ page }) => {
     await visitStory(page, {
       component: 'TextArea',
-      id: 'experimental-unstable-fluidtextarea--default',
+      id: 'experimental-fluid-components-unstable-fluidtextarea--default',
       globals: {
         theme: 'white',
       },
@@ -83,7 +83,7 @@ test.describe('FluidTextArea @avt', () => {
   test('@avt-keyboard-nav FluidTextArea with tooltip', async ({ page }) => {
     await visitStory(page, {
       component: 'TextArea',
-      id: 'experimental-unstable-fluidtextarea--default-with-tooltip',
+      id: 'experimental-fluid-components-unstable-fluidtextarea--default-with-tooltip',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidTextArea/FluidTextArea-test.e2e.js
+++ b/e2e/components/FluidTextArea/FluidTextArea-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidTextArea', () => {
       test('fluid textarea @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidTextArea',
-          id: 'experimental-unstable-fluidtextarea--default',
+          id: 'experimental-fluid-components-unstable-fluidtextarea--default',
           theme,
         });
       });

--- a/e2e/components/FluidTextInput/FluidTextInput-test.avt.e2e.js
+++ b/e2e/components/FluidTextInput/FluidTextInput-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextInput',
-      id: 'experimental-unstable-fluidtextinput--default',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--default',
       globals: {
         theme: 'white',
       },
@@ -25,7 +25,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-advanced-states password input', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextInput',
-      id: 'experimental-unstable-fluidtextinput--password-input',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--password-input',
       globals: {
         theme: 'white',
       },
@@ -36,7 +36,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-advanced-states with tooltip', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextInput',
-      id: 'experimental-unstable-fluidtextinput--default-with-tooltip',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--default-with-tooltip',
       globals: {
         theme: 'white',
       },
@@ -47,7 +47,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextInput',
-      id: 'experimental-unstable-fluidtextinput--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--skeleton',
       globals: {
         theme: 'white',
       },
@@ -58,7 +58,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-keyboard-nav default', async ({ page }) => {
     await visitStory(page, {
       component: 'TextInput',
-      id: 'experimental-unstable-fluidtextinput--default',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--default',
       globals: {
         theme: 'white',
       },
@@ -80,7 +80,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-keyboard-nav with tooltip', async ({ page }) => {
     await visitStory(page, {
       component: 'TextInput',
-      id: 'experimental-unstable-fluidtextinput--default-with-tooltip',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--default-with-tooltip',
       globals: {
         theme: 'white',
       },
@@ -110,7 +110,7 @@ test.describe('FluidTextInput @avt', () => {
   test('@avt-keyboard-nav for password', async ({ page }) => {
     await visitStory(page, {
       component: 'TextInput',
-      id: 'experimental-unstable-fluidtextinput--password-input',
+      id: 'experimental-fluid-components-unstable-fluidtextinput--password-input',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidTextInput/FluidTextInput-test.e2e.js
+++ b/e2e/components/FluidTextInput/FluidTextInput-test.e2e.js
@@ -17,13 +17,13 @@ test.describe('FluidTextInput', () => {
       test('fluid text input @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidTextInput',
-          id: 'experimental-unstable-fluidtextinput--default',
+          id: 'experimental-fluid-components-unstable-fluidtextinput--default',
           theme,
         });
 
         await snapshotStory(page, {
           component: 'FluidTextInput',
-          id: 'experimental-unstable-fluidtextinput--password-input',
+          id: 'experimental-fluid-components-unstable-fluidtextinput--password-input',
           theme,
         });
       });

--- a/e2e/components/FluidTimePicker/FluidTimePicker-test.avt.e2e.js
+++ b/e2e/components/FluidTimePicker/FluidTimePicker-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('FluidTimePicker @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTimePicker',
-      id: 'experimental-unstable-fluidtimepicker--default',
+      id: 'experimental-fluid-components-unstable-fluidtimepicker--default',
       globals: {
         theme: 'white',
       },
@@ -27,7 +27,7 @@ test.describe('FluidTimePicker @avt', () => {
   test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTimePicker',
-      id: 'experimental-unstable-fluidtimepicker--skeleton',
+      id: 'experimental-fluid-components-unstable-fluidtimepicker--skeleton',
       globals: {
         theme: 'white',
       },
@@ -38,7 +38,7 @@ test.describe('FluidTimePicker @avt', () => {
   test('@avt-keyboard-nav TimePicker', async ({ page }) => {
     await visitStory(page, {
       component: 'TimePicker',
-      id: 'experimental-unstable-fluidtimepicker--default',
+      id: 'experimental-fluid-components-unstable-fluidtimepicker--default',
       globals: {
         theme: 'white',
       },

--- a/e2e/components/FluidTimePicker/FluidTimePicker-test.e2e.js
+++ b/e2e/components/FluidTimePicker/FluidTimePicker-test.e2e.js
@@ -17,7 +17,7 @@ test.describe('FluidTimePicker', () => {
       test('fluid text input @vrt', async ({ page }) => {
         await snapshotStory(page, {
           component: 'FluidTimePicker',
-          id: 'experimental-unstable-fluidtimepicker--default',
+          id: 'experimental-fluid-components-unstable-fluidtimepicker--default',
           theme,
         });
       });

--- a/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
+++ b/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
@@ -16,7 +16,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidComboBox',
+  title: 'Experimental/Fluid Components/unstable__FluidComboBox',
   component: FluidComboBox,
   subcomponents: {
     FluidComboBoxSkeleton,

--- a/packages/react/src/components/FluidDatePicker/FluidDatePicker.stories.js
+++ b/packages/react/src/components/FluidDatePicker/FluidDatePicker.stories.js
@@ -18,7 +18,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidDatePicker',
+  title: 'Experimental/Fluid Components/unstable__FluidDatePicker',
   component: FluidDatePicker,
   subcomponents: {
     FluidDatePickerSkeleton,

--- a/packages/react/src/components/FluidDropdown/FluidDropdown.stories.js
+++ b/packages/react/src/components/FluidDropdown/FluidDropdown.stories.js
@@ -16,7 +16,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidDropdown',
+  title: 'Experimental/Fluid Components/unstable__FluidDropdown',
   component: FluidDropdown,
   subcomponents: {
     FluidDropdownSkeleton,

--- a/packages/react/src/components/FluidForm/FluidForm.stories.js
+++ b/packages/react/src/components/FluidForm/FluidForm.stories.js
@@ -47,7 +47,7 @@ const InvalidPasswordProps = {
 };
 
 export default {
-  title: 'Experimental/FluidForm',
+  title: 'Experimental/Fluid Components/FluidForm',
   component: FluidForm,
   parameters: {
     docs: {

--- a/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.stories.js
+++ b/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.stories.js
@@ -19,7 +19,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidMultiSelect',
+  title: 'Experimental/Fluid Components/unstable__FluidMultiSelect',
   component: FluidMultiSelect,
   subcomponents: {
     FluidMultiSelectSkeleton,

--- a/packages/react/src/components/FluidNumberInput/FluidNumberInput.stories.js
+++ b/packages/react/src/components/FluidNumberInput/FluidNumberInput.stories.js
@@ -16,7 +16,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidNumberInput',
+  title: 'Experimental/Fluid Components/unstable__FluidNumberInput',
   component: FluidNumberInput,
   subcomponents: {
     FluidNumberInputSkeleton,

--- a/packages/react/src/components/FluidSearch/FluidSearch.stories.js
+++ b/packages/react/src/components/FluidSearch/FluidSearch.stories.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { FluidSearch, FluidSearchSkeleton } from '.';
 
 export default {
-  title: 'Experimental/unstable__FluidSearch',
+  title: 'Experimental/Fluid Components/unstable__FluidSearch',
   component: FluidSearch,
   subcomponents: {
     FluidSearchSkeleton,

--- a/packages/react/src/components/FluidSelect/FluidSelect.stories.js
+++ b/packages/react/src/components/FluidSelect/FluidSelect.stories.js
@@ -18,7 +18,7 @@ import { Information } from '@carbon/icons-react';
 import mdx from './FluidSelect.mdx';
 
 export default {
-  title: 'Experimental/unstable__FluidSelect',
+  title: 'Experimental/Fluid Components/unstable__FluidSelect',
   component: FluidSelect,
   subcomponents: {
     FluidSelectSkeleton,

--- a/packages/react/src/components/FluidTextArea/FluidTextArea.stories.js
+++ b/packages/react/src/components/FluidTextArea/FluidTextArea.stories.js
@@ -20,7 +20,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidTextArea',
+  title: 'Experimental/Fluid Components/unstable__FluidTextArea',
   component: FluidTextArea,
   subcomponents: {
     FluidTextAreaSkeleton,

--- a/packages/react/src/components/FluidTextInput/FluidTextInput.stories.js
+++ b/packages/react/src/components/FluidTextInput/FluidTextInput.stories.js
@@ -18,7 +18,7 @@ import { Information } from '@carbon/icons-react';
 import './test.scss';
 
 export default {
-  title: 'Experimental/unstable__FluidTextInput',
+  title: 'Experimental/Fluid Components/unstable__FluidTextInput',
   component: FluidTextInput,
   subcomponents: {
     FluidTextInputSkeleton,

--- a/packages/react/src/components/FluidTimePicker/FluidTimePicker.stories.js
+++ b/packages/react/src/components/FluidTimePicker/FluidTimePicker.stories.js
@@ -19,7 +19,7 @@ import {
 import { Information } from '@carbon/icons-react';
 
 export default {
-  title: 'Experimental/unstable__FluidTimePicker',
+  title: 'Experimental/Fluid Components/unstable__FluidTimePicker',
   component: FluidTimePicker,
   subcomponents: {
     FluidTimePickerSelect,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15315

Groups all `Fluid` component stories under a new `Fluid components` folder in the `unstable` section

#### Changelog


**Changed**

- Grouped `Fluid*` stories together
- Updated test paths

#### Testing / Reviewing

Ensure all fluid components are visible inside the new folder and tests run properly with the updated paths 
