### PR TITLE
fix(Slug): adjust callout width, fix revert story

### DIFF
--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -453,7 +453,10 @@
     padding-inline-end: convert.to-rem(112px);
   }
 
-  .#{$prefix}--number__input-wrapper--slug .#{$prefix}--number__control-btn {
+  .#{$prefix}--number__input-wrapper--slug
+    input[type='number']:not(:has(~ .#{$prefix}--slug--revert))
+    ~ .#{$prefix}--number__controls
+    .#{$prefix}--number__control-btn {
     border-block-end-color: $ai-border-strong;
   }
 

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -454,7 +454,9 @@
   }
 
   .#{$prefix}--number__input-wrapper--slug
-    input[type='number']:not(:has(~ .#{$prefix}--slug--revert))
+    input[type='number']:not([data-invalid]):not(
+      :has(~ .#{$prefix}--slug--revert)
+    )
     ~ .#{$prefix}--number__controls
     .#{$prefix}--number__control-btn {
     border-block-end-color: $ai-border-strong;

--- a/packages/styles/scss/components/slug/_slug.scss
+++ b/packages/styles/scss/components/slug/_slug.scss
@@ -572,13 +572,7 @@ $sizes: (
   }
 
   .#{$prefix}--slug.#{$prefix}--slug--enabled
-    .#{$prefix}--slug-content--with-actions
-    .#{$prefix}--toggletip-content {
-    max-inline-size: convert.to-rem(334px);
-  }
-
-  .#{$prefix}--slug.#{$prefix}--slug--enabled
-    .#{$prefix}--slug-content:not(.#{$prefix}--slug-content--with-actions)
+    .#{$prefix}--slug-content
     .#{$prefix}--toggletip-content {
     max-inline-size: convert.to-rem(320px);
   }


### PR DESCRIPTION
Fixes some issues that @aagonzales pointed out with the latest `AI` updates

![Screenshot 2024-01-23 at 12 21 11 PM](https://github.com/carbon-design-system/carbon/assets/11928039/77fd7211-d0a3-4fbb-9b67-8a40ad0a9b55)

#### Changelog

**Changed**

- Set the same `max-width` for all callouts (action vs without action)
- Ensure the ai border on `NumberInput` is removed when the ai styles are not active (revert test story)


#### Testing / Reviewing

Ensure padding is correct for the action bar variant of the callout. Ensure the `NumberInput` border is removed when a user changes the ai value (`Slug --> Form --> Revert Test`)
