### PR TITLE
feat(Slug): add Tooltip to Slug

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -10372,6 +10372,28 @@ Map {
       "slugLabel": Object {
         "type": "string",
       },
+      "tooltipAlignment": Object {
+        "args": Array [
+          Array [
+            "top",
+            "top-left",
+            "top-right",
+            "bottom",
+            "bottom-left",
+            "bottom-right",
+            "left",
+            "left-bottom",
+            "left-top",
+            "right",
+            "right-bottom",
+            "right-top",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "tooltipDescription": Object {
+        "type": "string",
+      },
     },
     "render": [Function],
   },

--- a/packages/react/src/components/Slug/Slug.stories.js
+++ b/packages/react/src/components/Slug/Slug.stories.js
@@ -46,13 +46,13 @@ const content = <span>AI was used to generate this content</span>;
 export const Default = () => (
   <>
     <div className="slug-container slug-container-example">
-      <Slug autoAlign size="mini">
+      <Slug tooltipDescription="Explain AI" autoAlign size="mini">
         <SlugContent>{aiContent}</SlugContent>
       </Slug>
-      <Slug autoAlign size="2xs">
+      <Slug tooltipDescription="Explain AI" autoAlign size="2xs">
         <SlugContent>{aiContent}</SlugContent>
       </Slug>
-      <Slug autoAlign size="xs">
+      <Slug tooltipDescription="Explain AI" autoAlign size="xs">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -69,7 +69,7 @@ export const Default = () => (
           </SlugActions>
         </SlugContent>
       </Slug>
-      <Slug autoAlign size="sm">
+      <Slug tooltipDescription="Explain AI" autoAlign size="sm">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -86,7 +86,7 @@ export const Default = () => (
           </SlugActions>
         </SlugContent>
       </Slug>
-      <Slug autoAlign size="md">
+      <Slug tooltipDescription="Explain AI" autoAlign size="md">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -103,7 +103,7 @@ export const Default = () => (
           </SlugActions>
         </SlugContent>
       </Slug>
-      <Slug autoAlign size="lg">
+      <Slug tooltipDescription="Explain AI" autoAlign size="lg">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -120,71 +120,7 @@ export const Default = () => (
           </SlugActions>
         </SlugContent>
       </Slug>
-      <Slug autoAlign size="xl">
-        <SlugContent>
-          {aiContent}
-          <SlugActions>
-            <IconButton kind="ghost" label="View">
-              <View />
-            </IconButton>
-            <IconButton kind="ghost" label="Open Folder">
-              <FolderOpen />
-            </IconButton>
-            <IconButton kind="ghost" label="Folders">
-              <Folders />
-            </IconButton>
-            <Button>View details</Button>
-          </SlugActions>
-        </SlugContent>
-      </Slug>
-    </div>
-    <div className="slug-container-example slug-container">
-      <Slug kind="hollow" autoAlign size="mini">
-        <SlugContent>{content}</SlugContent>
-      </Slug>
-      <Slug kind="hollow" autoAlign size="2xs">
-        <SlugContent>{content}</SlugContent>
-      </Slug>
-      <Slug kind="hollow" autoAlign size="xs">
-        <SlugContent>{content}</SlugContent>
-      </Slug>
-    </div>
-    <div className="slug-container-example slug-container">
-      <Slug autoAlign kind="inline" size="sm">
-        <SlugContent>
-          {aiContent}
-          <SlugActions>
-            <IconButton kind="ghost" label="View">
-              <View />
-            </IconButton>
-            <IconButton kind="ghost" label="Open Folder">
-              <FolderOpen />
-            </IconButton>
-            <IconButton kind="ghost" label="Folders">
-              <Folders />
-            </IconButton>
-            <Button>View details</Button>
-          </SlugActions>
-        </SlugContent>
-      </Slug>
-      <Slug autoAlign kind="inline" size="md">
-        <SlugContent>
-          {aiContent}
-          <SlugActions>
-            <IconButton kind="ghost" label="View">
-              <View />
-            </IconButton>
-            <IconButton kind="ghost" label="Open Folder">
-              <FolderOpen />
-            </IconButton>
-            <IconButton kind="ghost" label="Folders">
-              <Folders />
-            </IconButton>
-            <Button>View details</Button>
-          </SlugActions>
-        </SlugContent>
-      </Slug>
-      <Slug autoAlign kind="inline" size="lg">
+      <Slug tooltipDescription="Explain AI" autoAlign size="xl">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -203,7 +139,18 @@ export const Default = () => (
       </Slug>
     </div>
     <div className="slug-container-example slug-container">
-      <Slug autoAlign kind="inline" size="sm" aiTextLabel="Text goes here">
+      <Slug tooltipDescription="Explain AI" kind="hollow" autoAlign size="mini">
+        <SlugContent>{content}</SlugContent>
+      </Slug>
+      <Slug tooltipDescription="Explain AI" kind="hollow" autoAlign size="2xs">
+        <SlugContent>{content}</SlugContent>
+      </Slug>
+      <Slug tooltipDescription="Explain AI" kind="hollow" autoAlign size="xs">
+        <SlugContent>{content}</SlugContent>
+      </Slug>
+    </div>
+    <div className="slug-container-example slug-container">
+      <Slug tooltipDescription="Explain AI" autoAlign kind="inline" size="sm">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -220,7 +167,7 @@ export const Default = () => (
           </SlugActions>
         </SlugContent>
       </Slug>
-      <Slug autoAlign kind="inline" size="md" aiTextLabel="Text goes here">
+      <Slug tooltipDescription="Explain AI" autoAlign kind="inline" size="md">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -237,7 +184,7 @@ export const Default = () => (
           </SlugActions>
         </SlugContent>
       </Slug>
-      <Slug autoAlign kind="inline" size="lg" aiTextLabel="Text goes here">
+      <Slug tooltipDescription="Explain AI" autoAlign kind="inline" size="lg">
         <SlugContent>
           {aiContent}
           <SlugActions>
@@ -256,13 +203,96 @@ export const Default = () => (
       </Slug>
     </div>
     <div className="slug-container-example slug-container">
-      <Slug autoAlign kind="inline" dotType="hollow" size="sm">
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign
+        kind="inline"
+        size="sm"
+        aiTextLabel="Text goes here">
+        <SlugContent>
+          {aiContent}
+          <SlugActions>
+            <IconButton kind="ghost" label="View">
+              <View />
+            </IconButton>
+            <IconButton kind="ghost" label="Open Folder">
+              <FolderOpen />
+            </IconButton>
+            <IconButton kind="ghost" label="Folders">
+              <Folders />
+            </IconButton>
+            <Button>View details</Button>
+          </SlugActions>
+        </SlugContent>
+      </Slug>
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign
+        kind="inline"
+        size="md"
+        aiTextLabel="Text goes here">
+        <SlugContent>
+          {aiContent}
+          <SlugActions>
+            <IconButton kind="ghost" label="View">
+              <View />
+            </IconButton>
+            <IconButton kind="ghost" label="Open Folder">
+              <FolderOpen />
+            </IconButton>
+            <IconButton kind="ghost" label="Folders">
+              <Folders />
+            </IconButton>
+            <Button>View details</Button>
+          </SlugActions>
+        </SlugContent>
+      </Slug>
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign
+        kind="inline"
+        size="lg"
+        aiTextLabel="Text goes here">
+        <SlugContent>
+          {aiContent}
+          <SlugActions>
+            <IconButton kind="ghost" label="View">
+              <View />
+            </IconButton>
+            <IconButton kind="ghost" label="Open Folder">
+              <FolderOpen />
+            </IconButton>
+            <IconButton kind="ghost" label="Folders">
+              <Folders />
+            </IconButton>
+            <Button>View details</Button>
+          </SlugActions>
+        </SlugContent>
+      </Slug>
+    </div>
+    <div className="slug-container-example slug-container">
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign
+        kind="inline"
+        dotType="hollow"
+        size="sm">
         <SlugContent>{content}</SlugContent>
       </Slug>
-      <Slug autoAlign kind="inline" dotType="hollow" size="md">
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign
+        kind="inline"
+        dotType="hollow"
+        size="md">
         <SlugContent>{content}</SlugContent>
       </Slug>
-      <Slug autoAlign kind="inline" dotType="hollow" size="lg">
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign
+        kind="inline"
+        dotType="hollow"
+        size="lg">
         <SlugContent>{content}</SlugContent>
       </Slug>
     </div>
@@ -300,7 +330,11 @@ export const Test = (args) => {
 
   return (
     <div className="slug-container-example slug-container centered">
-      <Slug autoAlign={false} defaultOpen {...args}>
+      <Slug
+        tooltipDescription="Explain AI"
+        autoAlign={false}
+        defaultOpen
+        {...args}>
         <SlugContent>
           {' '}
           <div>
@@ -452,7 +486,7 @@ export const Playground = (args) => {
   return (
     <>
       <div className="slug-container-example">
-        <Slug autoAlign {...args}>
+        <Slug tooltipDescription="Explain AI" autoAlign {...args}>
           <SlugContent>{renderedContent}</SlugContent>
         </Slug>
       </div>

--- a/packages/react/src/components/Slug/index.js
+++ b/packages/react/src/components/Slug/index.js
@@ -16,6 +16,7 @@ import {
   ToggletipContent,
   ToggletipActions,
 } from '../Toggletip';
+import { Tooltip } from '../Tooltip';
 import { IconButton } from '../IconButton';
 import { Undo } from '@carbon/icons-react';
 import { useId } from '../../internal/useId';
@@ -100,6 +101,8 @@ export const Slug = React.forwardRef(function Slug(
     revertLabel = 'Revert to AI input',
     slugLabel = 'Show information',
     size = 'xs',
+    tooltipDescription,
+    tooltipAlignment,
     ...rest
   },
   ref
@@ -136,31 +139,50 @@ export const Slug = React.forwardRef(function Slug(
     ? `${aiText} - ${slugLabel}`
     : `${aiText} - ${aiTextLabel}`;
 
-  return (
-    <div className={slugClasses} ref={ref} id={id}>
-      {revertActive ? (
-        <IconButton
-          onClick={handleOnRevertClick}
-          kind="ghost"
-          size="sm"
-          label={revertLabel}
-          {...rest}>
-          <Undo />
-        </IconButton>
-      ) : (
-        <Toggletip align={align} autoAlign={autoAlign} {...rest}>
-          <ToggletipButton className={slugButtonClasses} label={ariaLabel}>
-            <span className={`${prefix}--slug__text`}>{aiText}</span>
-            {aiTextLabel && (
-              <span className={`${prefix}--slug__additional-text`}>
-                {aiTextLabel}
-              </span>
-            )}
-          </ToggletipButton>
+  const ConditionalWrapper = ({ children }) => {
+    if (tooltipDescription && kind !== 'hollow' && dotType !== 'hollow') {
+      console.log(tooltipAlignment);
+      return (
+        <Tooltip
+          className={`${prefix}--icon-tooltip`}
+          description={tooltipDescription}
+          align={tooltipAlignment}
+          closeOnActivation>
           {children}
-        </Toggletip>
-      )}
-    </div>
+        </Tooltip>
+      );
+    } else {
+      return children;
+    }
+  };
+
+  return (
+    <ConditionalWrapper>
+      <div className={slugClasses} ref={ref} id={id}>
+        {revertActive ? (
+          <IconButton
+            onClick={handleOnRevertClick}
+            kind="ghost"
+            size="sm"
+            label={revertLabel}
+            {...rest}>
+            <Undo />
+          </IconButton>
+        ) : (
+          <Toggletip align={align} autoAlign={autoAlign} {...rest}>
+            <ToggletipButton className={slugButtonClasses} label={ariaLabel}>
+              <span className={`${prefix}--slug__text`}>{aiText}</span>
+              {aiTextLabel && (
+                <span className={`${prefix}--slug__additional-text`}>
+                  {aiTextLabel}
+                </span>
+              )}
+            </ToggletipButton>
+            {children}
+          </Toggletip>
+        )}
+      </div>
+    </ConditionalWrapper>
   );
 });
 
@@ -203,12 +225,12 @@ Slug.propTypes = {
   autoAlign: PropTypes.bool,
 
   /**
-   * Specify the content you want rendered inside the slug ToggleTip
+   * Specify the content you want rendered inside the `Slug` popover.
    */
   children: PropTypes.node,
 
   /**
-   * Specify an optional className to be added to the AI slug
+   * Specify an optional className to be added to the `Slug`
    */
   className: PropTypes.string,
 
@@ -218,7 +240,7 @@ Slug.propTypes = {
   dotType: PropTypes.oneOf(['default', 'hollow']),
 
   /**
-   * Specify the type of Slug, from the following list of types:
+   * Specify the type of `Slug`, either `default`, `hollow`, or `inline`:
    */
   kind: PropTypes.oneOf(['default', 'hollow', 'inline']),
 
@@ -238,12 +260,12 @@ Slug.propTypes = {
   revertLabel: PropTypes.string,
 
   /**
-   * Specify the size of the button, from the following list of sizes:
+   * Specify the size of the `Slug`, can be `mini`, `2xs`, `xs`, `sm`, `md`, `lg`, or `xl`
    */
   size: PropTypes.oneOf(['mini', '2xs', 'xs', 'sm', 'md', 'lg', 'xl']),
 
   /**
-   * Specify the content you want rendered inside the slug ToggleTip
+   * Specify the content you want rendered inside the `Slug` ToggleTip
    */
   slugContent: PropTypes.node,
 
@@ -251,4 +273,30 @@ Slug.propTypes = {
    * Specify the text that will be provided to the aria-label of the `Slug` button
    */
   slugLabel: PropTypes.string,
+
+  /**
+   * Specify the alignment of the tooltip when the `Slug` is hovered or focused
+   */
+  tooltipAlignment: PropTypes.oneOf([
+    'top',
+    'top-left',
+    'top-right',
+
+    'bottom',
+    'bottom-left',
+    'bottom-right',
+
+    'left',
+    'left-bottom',
+    'left-top',
+
+    'right',
+    'right-bottom',
+    'right-top',
+  ]),
+
+  /**
+   * Specify the text that will be shown in the tooltip when the `Slug` is hovered or focused
+   */
+  tooltipDescription: PropTypes.string,
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15616

Adds a conditional `Tooltip` around `Slug` if a `TooltipDescription` is provided. 

#### Changelog

**New**

- `TooltipDescription` provides the text that will be rendered inside the `Tooltip` for `Slug` that is activated on hover/focus of the `Slug` itself
- `TooltipAlignment` specifies the alignment of the `Tooltip` for `Slug`

**Changed**

- Added a `ConditionalWrapper` that wraps the `Slug` contents and is only rendered if `TooltipDescription` is provided. This avoids us having to set a `TooltipDescription` by default, which would be needed since a small popover appears even if there is no `description` provided for the `Tooltip`
- Updated the stories to use this new prop


#### Testing / Reviewing

Go to the default `Slug` story, ensure the `Tooltip` appears on hover/focus, and close when the `Slug` is clicked. 

@aagonzales do we want to add this `Tooltip` to all `Slug` examples? Is this label mandatory? If so, I can always render the `Tooltip`, but not sure what we want to have as the default fallback text
