### PR TITLE
`Tabs` - Fixed arrow navigation

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -93,14 +93,6 @@ export const Dismissable = () => {
       panel: <TabPanel>Monitoring</TabPanel>,
     },
     {
-      label: 'fdsfdsfsd',
-      panel: <TabPanel>fdsfdsfsd</TabPanel>,
-    },
-    {
-      label: 'kjhjhjhkjh',
-      panel: <TabPanel>kjhjhjhkjh</TabPanel>,
-    },
-    {
       label: 'Activity',
       panel: <TabPanel>Activity</TabPanel>,
     },
@@ -128,7 +120,6 @@ export const Dismissable = () => {
     if (tabIndex === selectedIndex) {
       const defaultTabIndex = filteredTabs.findIndex((tab) => !tab.disabled);
       setSelectedIndex(defaultTabIndex);
-      document.dispatchEvent(new KeyboardEvent('keypress', { key: 'Tab' }));
     } else {
       setSelectedIndex(filteredTabs.indexOf(selectedTab));
     }

--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -93,6 +93,14 @@ export const Dismissable = () => {
       panel: <TabPanel>Monitoring</TabPanel>,
     },
     {
+      label: 'fdsfdsfsd',
+      panel: <TabPanel>fdsfdsfsd</TabPanel>,
+    },
+    {
+      label: 'kjhjhjhkjh',
+      panel: <TabPanel>kjhjhjhkjh</TabPanel>,
+    },
+    {
       label: 'Activity',
       panel: <TabPanel>Activity</TabPanel>,
     },
@@ -120,6 +128,7 @@ export const Dismissable = () => {
     if (tabIndex === selectedIndex) {
       const defaultTabIndex = filteredTabs.findIndex((tab) => !tab.disabled);
       setSelectedIndex(defaultTabIndex);
+      document.dispatchEvent(new KeyboardEvent('keypress', { key: 'Tab' }));
     } else {
       setSelectedIndex(filteredTabs.indexOf(selectedTab));
     }

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -404,7 +404,9 @@ function TabList({
     ) {
       event.preventDefault();
 
-      const activeTabs: TabElement[] = tabs.current.filter(
+      const filtredTabs = tabs.current.filter((tab) => tab !== null);
+
+      const activeTabs: TabElement[] = filtredTabs.filter(
         (tab) => !tab.disabled
       );
 
@@ -420,7 +422,6 @@ function TabList({
       } else if (activation === 'manual') {
         setActiveIndex(nextIndex);
       }
-
       tabs.current[nextIndex]?.focus();
     }
   }


### PR DESCRIPTION
Closes #14819

Now we are filtering null values in the array. The arrow navigation was not working due to the null values.

#### Testing / Reviewing

- Go to dismissable tabs variant;
- Delete a Tab;
- Use the arrow navigation.