### PR TITLE
fix: 15256-multiselect-selected-options-bug

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -587,6 +587,8 @@ const MultiSelect = React.forwardRef(
         size: 'mini',
       });
     }
+    const itemsSelectedText =
+      selectedItems.length > 0 && selectedItems.map((item) => item.text);
 
     return (
       <div className={wrapperClasses}>
@@ -594,8 +596,8 @@ const MultiSelect = React.forwardRef(
           {titleText && titleText}
           {selectedItems.length > 0 && (
             <span className={`${prefix}--visually-hidden`}>
-              {clearSelectionDescription} {selectedItems.length},
-              {clearSelectionText}
+              {clearSelectionDescription} {selectedItems.length}{' '}
+              {itemsSelectedText},{clearSelectionText}
             </span>
           )}
         </label>

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -89,6 +89,10 @@ interface SortItemsOptions<ItemType>
   selectedItems: ItemType[];
 }
 
+interface selectedItemType {
+  text: string;
+}
+
 interface MultiSelectSortingProps<ItemType> {
   /**
    * Provide a compare function that is used to determine the ordering of
@@ -587,8 +591,10 @@ const MultiSelect = React.forwardRef(
         size: 'mini',
       });
     }
+
     const itemsSelectedText =
-      selectedItems.length > 0 && selectedItems.map((item) => item.text);
+      selectedItems.length > 0 &&
+      selectedItems.map((item) => (item as selectedItemType).text);
 
     return (
       <div className={wrapperClasses}>


### PR DESCRIPTION
Closes #15256 

Added `itemsSelectedText` to be read by screen readers. This allow screen reader users to know which items have been selected with the menu is closed. 

## Testing: 
Select a few items, close the menu 
Run closed menu through screen reader. It should read `Total items selected: ...` and then the description of the items selected 