### PR TITLE
15257 deleted options bug

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -138,6 +138,11 @@ export interface MultiSelectProps<ItemType>
   className?: string;
 
   /**
+   * Specify the text that should be read for screen readers that describes that all items are deleted
+   */
+  clearAnnouncement?: string;
+
+  /**
    * Specify the text that should be read for screen readers that describes total items selected
    */
   clearSelectionDescription?: string;
@@ -324,6 +329,7 @@ const MultiSelect = React.forwardRef(
       sortItems = defaultSortItems as MultiSelectProps<ItemType>['sortItems'],
       compareItems = defaultCompareItems,
       clearSelectionText = 'To clear selection, press Delete or Backspace',
+      clearAnnouncement = 'all items have been cleared',
       clearSelectionDescription = 'Total items selected: ',
       light,
       invalid,
@@ -353,6 +359,7 @@ const MultiSelect = React.forwardRef(
     const [isOpen, setIsOpen] = useState(open || false);
     const [prevOpenProp, setPrevOpenProp] = useState(open);
     const [topItems, setTopItems] = useState([]);
+    const [itemsCleared, setItemsCleared] = useState(false);
     const {
       selectedItems: controlledSelectedItems,
       onItemChange,
@@ -409,12 +416,17 @@ const MultiSelect = React.forwardRef(
             e.stopPropagation();
           }
 
+          if (!isOpen && match(e, keys.Delete) && selectedItems.length > 0) {
+            setItemsCleared(true);
+          }
+
           if (
             (match(e, keys.Space) ||
               match(e, keys.ArrowDown) ||
               match(e, keys.Enter)) &&
             !isOpen
           ) {
+            setItemsCleared(false);
             setIsOpenWrapper(true);
           }
         }
@@ -709,6 +721,9 @@ const MultiSelect = React.forwardRef(
                 }
               )}
           </ListBox.Menu>
+          {itemsCleared && (
+            <span aria-live="assertive" aria-label={clearAnnouncement} />
+          )}
         </ListBox>
         {!inline && !invalid && !warn && helperText && (
           <div id={helperId} className={helperClasses}>

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -587,6 +587,8 @@ const MultiSelect = React.forwardRef(
         size: 'mini',
       });
     }
+    const itemsSelectedText =
+      selectedItems.length > 0 && selectedItems.map((item) => item.text);
 
     return (
       <div className={wrapperClasses}>
@@ -594,8 +596,8 @@ const MultiSelect = React.forwardRef(
           {titleText && titleText}
           {selectedItems.length > 0 && (
             <span className={`${prefix}--visually-hidden`}>
-              {clearSelectionDescription} {selectedItems.length},
-              {clearSelectionText}
+              {clearSelectionDescription} {selectedItems.length}{' '}
+              {itemsSelectedText},{clearSelectionText}
             </span>
           )}
         </label>

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -89,6 +89,10 @@ interface SortItemsOptions<ItemType>
   selectedItems: ItemType[];
 }
 
+interface selectedItemType {
+  text: string;
+}
+
 interface MultiSelectSortingProps<ItemType> {
   /**
    * Provide a compare function that is used to determine the ordering of
@@ -587,8 +591,10 @@ const MultiSelect = React.forwardRef(
         size: 'mini',
       });
     }
+
     const itemsSelectedText =
-      selectedItems.length > 0 && selectedItems.map((item) => item.text);
+      selectedItems.length > 0 &&
+      selectedItems.map((item) => (item as selectedItemType).text);
 
     return (
       <div className={wrapperClasses}>


### PR DESCRIPTION
Closes #15257 

## Testing
Select an item in the `Multiselect` component and run VO. 
Hit `Escape` to close the menu and a then `delete` to remove the selected items. 
The screen reader should read the following `all items have been cleared`


