### PR TITLE
docs: Add tsconfig note to @carbon/react README.md

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1422,7 +1422,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/37080130?v=4",
       "profile": "https://github.com/ggdawson",
       "contributions": [
-        "code"
+        "code",
+        "doc"
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://jt-helsinki.github.io/blog/"><img src="https://avatars.githubusercontent.com/u/20871336?v=4?s=100" width="100px;" alt=""/><br /><sub><b>J Thomas</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=jt-helsinki" title="Code">💻</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://github.com/ggdawson"><img src="https://avatars.githubusercontent.com/u/37080130?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Garrett Dawson</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ggdawson" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ggdawson"><img src="https://avatars.githubusercontent.com/u/37080130?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Garrett Dawson</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ggdawson" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=ggdawson" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -51,6 +51,25 @@ to include `node_modules` in its `includePaths` option. For more information,
 checkout the [configuration](../styles/docs/sass.md#configuration) section in
 our Sass docs.
 
+### TypeScript
+
+There is an ongoing project to add `*.d.ts` files to `@carbon/react`. Though not
+all components have yet been typed, you can still use the project successfully
+in a TypeScript setting, provided you amend to your `tsconfig.json` or
+equivalent configuration file. Include the `skipLibCheck: true` compiler option:
+
+```json
+{
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}
+```
+
+To track the progress of TypeScript adoption, check out:
+
+- [TypeScript Adoption](https://github.com/orgs/carbon-design-system/projects/53)
+
 ## Usage
 
 The `@carbon/react` package provides components and icons for the Carbon Design


### PR DESCRIPTION
Closes #15678 

Adds a note to the `@carbon/react` README.md about how to get the TS compiler working.

#### Changelog

**New**

- n/a

**Changed**

- `@carbon/react/README.md`

**Removed**

- n/a

#### Testing / Reviewing

Have tested the suggestion in my own projects, and it appears to be working.
