### PR TITLE
fix: 10663 , Removes border flickering on disabled button

### DIFF
--- a/packages/styles/scss/components/file-uploader/_file-uploader.scss
+++ b/packages/styles/scss/components/file-uploader/_file-uploader.scss
@@ -93,6 +93,7 @@
     color: $text-disabled;
     cursor: no-drop;
     text-decoration: none;
+    transition: none;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Closes #10663

Removes border flickering on disabled button when focus changes

#### Testing / Reviewing
1.Open storybook
2.Go to the FIleUploader - drag and drop upload container example application 
3.Disable the button from props 
4.Hover and verify if borders flickers 
