### PR TITLE
feat(containedlist): spread rest props

### DIFF
--- a/packages/react/src/components/ContainedList/ContainedList.js
+++ b/packages/react/src/components/ContainedList/ContainedList.js
@@ -58,6 +58,7 @@ function ContainedList({
   kind = variants[0],
   label,
   size,
+  ...rest
 }) {
   const labelId = `${useId('contained-list')}-header`;
   const prefix = usePrefix();
@@ -82,7 +83,7 @@ function ContainedList({
   const renderedChildren = renderChildren(children);
 
   return (
-    <div className={classes}>
+    <div className={classes} {...rest}>
       <div className={`${prefix}--contained-list__header`}>
         <div id={labelId} className={`${prefix}--contained-list__label`}>
           {label}

--- a/packages/react/src/components/ContainedList/ContainedListItem/ContainedListItem.js
+++ b/packages/react/src/components/ContainedList/ContainedListItem/ContainedListItem.js
@@ -18,6 +18,7 @@ function ContainedListItem({
   disabled = false,
   onClick,
   renderIcon: IconElement,
+  ...rest
 }) {
   const prefix = usePrefix();
 
@@ -41,7 +42,7 @@ function ContainedListItem({
   );
 
   return (
-    <li className={classes}>
+    <li className={classes} {...rest}>
       {isClickable ? (
         <button
           className={`${prefix}--contained-list-item__content`}


### PR DESCRIPTION
Highlighted in office hours today by @sjbeatle - rest props were not being spread onto `ContainedList` and `ContainedListItem`.

#### Changelog

**Changed**

- spread rest props onto `ContainedList` and `ContainedListItem`

#### Testing / Reviewing

- Ensure any additional props passed to these components are properly applied to the containing element
