### PR TITLE
fix: storybook footer styles

### DIFF
--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -89,7 +89,6 @@
     bottom: 0;
     width: 100%;
     z-index: 99999;
-    opacity: 0.5;
   }
 
   #root > div {

--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -89,6 +89,11 @@
     bottom: 0;
     width: 100%;
     z-index: 99999;
+    opacity: 0.5;
+  }
+
+  #root > div {
+    height: calc(100vh - 48px);
   }
 
   .os-content form span {


### PR DESCRIPTION
Styling bug was introduced in this [PR](https://github.com/carbon-design-system/carbon/pull/15680) - footer was covering up the storybook controls.

#### Changelog
- update content height for storybook to allow for footer

#### Testing / Reviewing

Make sure storybook and footer renders correctly without overlap