### PR TITLE
fix(DataTable): make DataTableHeader.slug optional

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1415,6 +1415,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ggdawson",
+      "name": "Garrett Dawson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37080130?v=4",
+      "profile": "https://github.com/ggdawson",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/amercury"><img src="https://avatars.githubusercontent.com/u/17834588?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexandr Ovchinnikov</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=amercury" title="Code">💻</a></td>
     <td align="center"><a href="https://jt-helsinki.github.io/blog/"><img src="https://avatars.githubusercontent.com/u/20871336?v=4?s=100" width="100px;" alt=""/><br /><sub><b>J Thomas</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=jt-helsinki" title="Code">💻</a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/ggdawson"><img src="https://avatars.githubusercontent.com/u/37080130?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Garrett Dawson</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ggdawson" title="Code">💻</a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-restore -->

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -91,7 +91,7 @@ export interface DataTableRow<ColTypes extends any[]> {
 export interface DataTableHeader {
   key: string;
   header: React.ReactNode;
-  slug: React.ReactElement;
+  slug?: React.ReactElement;
 }
 
 export interface DataTableRenderProps<RowType, ColTypes extends any[]> {


### PR DESCRIPTION
Closes #15737 

Makes the `slug` property of `DataTableHeader` optional.

#### Changelog

**New**

- n/a

**Changed**

- DataTableHeader type 

**Removed**

- n/a

#### Testing / Reviewing

[repro](https://stackblitz.com/edit/stackblitz-starters-267fuz?file=src%2FApp.tsx)

To test, use the updated type.
