### PR TITLE
fix(ChatButton): adjust padding when icon is not present

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -9716,6 +9716,19 @@ Map {
         ],
         "type": "oneOf",
       },
+      "renderIcon": Object {
+        "args": Array [
+          Array [
+            Object {
+              "type": "func",
+            },
+            Object {
+              "type": "object",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
       "size": Object {
         "args": Array [
           Array [

--- a/packages/react/src/components/ChatButton/ChatButton.js
+++ b/packages/react/src/components/ChatButton/ChatButton.js
@@ -19,6 +19,7 @@ const ChatButton = React.forwardRef(function ChatButton(
     isQuickAction,
     isSelected,
     kind,
+    renderIcon,
     size,
     ...other
   },
@@ -27,6 +28,7 @@ const ChatButton = React.forwardRef(function ChatButton(
   const prefix = usePrefix();
   const classNames = classnames(className, {
     [`${prefix}--chat-btn`]: true,
+    [`${prefix}--chat-btn--with-icon`]: renderIcon,
     [`${prefix}--chat-btn--quick-action`]: isQuickAction,
     [`${prefix}--chat-btn--quick-action--selected`]: isSelected,
   });
@@ -48,6 +50,7 @@ const ChatButton = React.forwardRef(function ChatButton(
       kind={kind}
       ref={ref}
       size={size}
+      renderIcon={renderIcon}
       {...other}>
       {children}
     </Button>
@@ -90,6 +93,12 @@ ChatButton.propTypes = {
     'ghost',
     'tertiary',
   ]),
+
+  /**
+   * Optional prop to specify an icon to be rendered.
+   * Can be a React component class
+   */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
    * Specify the size of the `ChatButton`, from the following list of sizes:

--- a/packages/react/src/components/ChatButton/ChatButton.stories.js
+++ b/packages/react/src/components/ChatButton/ChatButton.stories.js
@@ -63,6 +63,11 @@ export const Default = () => (
       <ChatButton size="lg" renderIcon={Add}>
         Primary
       </ChatButton>
+      <br />
+      <br />
+      <ChatButton size="sm">Primary</ChatButton>
+      <ChatButton size="md">Primary</ChatButton>
+      <ChatButton size="lg">Primary</ChatButton>
     </div>
     <div className="test-button-kinds">
       <h3>Kinds</h3>
@@ -82,6 +87,13 @@ export const Default = () => (
       <ChatButton kind="danger" renderIcon={Add}>
         Danger
       </ChatButton>
+      <br />
+      <br />
+      <ChatButton kind="primary">Primary</ChatButton>
+      <ChatButton kind="secondary">Secondary</ChatButton>
+      <ChatButton kind="tertiary">Tertiary</ChatButton>
+      <ChatButton kind="ghost">Ghost</ChatButton>
+      <ChatButton kind="danger">Danger</ChatButton>
     </div>
     <div className="test-button-quick-action">
       <h3>Quick action</h3>
@@ -96,6 +108,18 @@ export const Default = () => (
         Selected and Disabled
       </ChatButton>
       <ChatButton disabled isQuickAction renderIcon={Add}>
+        Disabled
+      </ChatButton>
+      <br />
+      <br />
+      <ChatButton isQuickAction>Quick action</ChatButton>
+      <ChatButton isSelected isQuickAction>
+        Selected and Enabled
+      </ChatButton>
+      <ChatButton disabled isSelected isQuickAction>
+        Selected and Disabled
+      </ChatButton>
+      <ChatButton disabled isQuickAction>
         Disabled
       </ChatButton>
     </div>

--- a/packages/styles/scss/components/chat-button/_chat-button.scss
+++ b/packages/styles/scss/components/chat-button/_chat-button.scss
@@ -16,6 +16,10 @@
     border-radius: convert.to-rem(24px);
   }
 
+  .#{$prefix}--chat-btn:not(.#{$prefix}--chat-btn--with-icon) {
+    padding-inline-end: convert.to-rem(15px);
+  }
+
   .#{$prefix}--chat-btn.#{$prefix}--btn--md {
     border-radius: convert.to-rem(20px);
   }


### PR DESCRIPTION
Adjusts padding to be `16px` when an icon is not present in `Button`

#### Changelog

**New**

-Added non-icon variants to the `ChatButton` stories

**Changed**

- Reduced padding when the `Button` is not rendering an icon. 

#### Testing / Reviewing

Go to `Experimental --> ChatButton` and ensure the non-icon button padding is correct. Ensure there are no regressions to the icon variant. 
