### PR TITLE
fix: modal body className

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -33,6 +33,16 @@ describe('ComposedModal', () => {
       );
     });
 
+    it('supports a custom class on the modal body', () => {
+      render(
+        <ComposedModal>
+          <ModalBody className="custom-class" data-testid="modal-body" />
+        </ComposedModal>
+      );
+
+      expect(screen.getByTestId('modal-body')).toHaveClass('custom-class');
+    });
+
     it('should spread props onto the outermost div', () => {
       render(<ComposedModal data-testid="modal" />);
 

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -53,12 +53,15 @@ export const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
     const prefix = usePrefix();
     const contentRef = useRef<HTMLDivElement>(null);
     const [isScrollable, setIsScrollable] = useState(false);
-    const contentClass = cx({
-      [`${prefix}--modal-content`]: true,
-      [`${prefix}--modal-content--with-form`]: hasForm,
-      [`${prefix}--modal-scroll-content`]: hasScrollingContent || isScrollable,
-      customClassName,
-    });
+    const contentClass = cx(
+      {
+        [`${prefix}--modal-content`]: true,
+        [`${prefix}--modal-content--with-form`]: hasForm,
+        [`${prefix}--modal-scroll-content`]:
+          hasScrollingContent || isScrollable,
+      },
+      customClassName
+    );
 
     useIsomorphicEffect(() => {
       if (contentRef.current) {


### PR DESCRIPTION
Closes #15515

Fix custom className on ModalBody introduced in latest version 1.51.0

#### Changelog

**Changed**

- ModalBody className assignment 

#### Testing / Reviewing

Added test for passing a class to ModalBody
