### PR TITLE
fix: 15752 invalid tooltip on hovering the select component

### DIFF
--- a/packages/react/src/components/Select/Select.stories.js
+++ b/packages/react/src/components/Select/Select.stories.js
@@ -84,9 +84,9 @@ export const Default = () => {
           value="An example option that is really long to show what should be done to handle long text"
           text="An example option that is really long to show what should be done to handle long text"
         />
-        <SelectItem value="Option 2" text="Option 2" />
-        <SelectItem value="Option 3" text="Option 3" />
-        <SelectItem value="Option 4" text="Option 4" />
+        <SelectItem value="option-2" text="Option 2" />
+        <SelectItem value="option-3" text="Option 3" />
+        <SelectItem value="option-4" text="Option 4" />
       </Select>
     </div>
   );
@@ -101,10 +101,10 @@ export const Inline = () => {
         labelText="Select"
         helperText="Optional helper text">
         <SelectItem value="" text="" />
-        <SelectItem value="Option 1" text="Option 1" />
-        <SelectItem value="Option 2" text="Option 2" />
-        <SelectItem value="Option 3" text="Option 3" />
-        <SelectItem value="Option 4" text="Option 4" />
+        <SelectItem value="option-1" text="Option 1" />
+        <SelectItem value="option-2" text="Option 2" />
+        <SelectItem value="option-3" text="Option 3" />
+        <SelectItem value="option-4" text="Option 4" />
       </Select>
     </div>
   );
@@ -124,7 +124,7 @@ export const _WithLayer = () => (
           value="An example option that is really long to show what should be done to handle long text"
           text="An example option that is really long to show what should be done to handle long text"
         />
-        <SelectItem value="Option 2" text="Option 2" />
+        <SelectItem value="option-2" text="Option 2" />
       </Select>
     )}
   </WithLayer>
@@ -143,9 +143,9 @@ export const Playground = (args) => {
           value="An example option that is really long to show what should be done to handle long text"
           text="An example option that is really long to show what should be done to handle long text"
         />
-        <SelectItem value="Option 2" text="Option 2" />
-        <SelectItem value="Option 3" text="Option 3" />
-        <SelectItem value="Option 4" text="Option 4" />
+        <SelectItem value="option-2" text="Option 2" />
+        <SelectItem value="option-3" text="Option 3" />
+        <SelectItem value="option-4" text="Option 4" />
       </Select>
     </div>
   );

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -12,6 +12,7 @@ import React, {
   ForwardedRef,
   ReactNode,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -157,6 +158,7 @@ const Select = React.forwardRef(function Select(
     warnText,
     onChange,
     slug,
+    defaultValue,
     ...other
   }: SelectProps,
   ref: ForwardedRef<HTMLSelectElement>
@@ -222,12 +224,20 @@ const Select = React.forwardRef(function Select(
     ariaProps['aria-describedby'] = helper ? helperId : undefined;
   }
 
+  const selectDefaultTitle = (defaultValue) => {
+    const selectElement = document.getElementById(id);
+    const title = defaultValue
+      ? selectElement?.querySelector(`option[value=${defaultValue}]`)?.text
+      : selectElement?.options[selectElement?.selectedIndex]?.text;
+    setTitle(title);
+  };
   const handleFocus = (evt) => {
     setIsFocused(evt.type === 'focus' ? true : false);
   };
 
   const handleChange = (evt) => {
-    setTitle(evt?.target?.value);
+    const selectedIndex = evt?.target?.selectedIndex;
+    setTitle(evt?.target?.options[selectedIndex]?.text);
   };
 
   const readOnlyEventHandlers = {
@@ -255,6 +265,10 @@ const Select = React.forwardRef(function Select(
       size: 'mini',
     });
   }
+  useEffect(() => {
+    selectDefaultTitle(defaultValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const input = (() => {
     return (
@@ -263,6 +277,7 @@ const Select = React.forwardRef(function Select(
           {...other}
           {...ariaProps}
           id={id}
+          defaultValue={defaultValue}
           className={inputClasses}
           disabled={disabled || undefined}
           aria-invalid={invalid || undefined}

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -224,20 +224,6 @@ const Select = React.forwardRef(function Select(
     ariaProps['aria-describedby'] = helper ? helperId : undefined;
   }
 
-  const selectDefaultTitle = (defaultValue) => {
-    const selectElement = document.getElementById(
-      id
-    ) as HTMLSelectElement | null;
-    if (defaultValue) {
-      const defaultOption: HTMLOptionElement | null | undefined =
-        selectElement?.querySelector(`option[value=${defaultValue}]`);
-      setTitle(defaultOption?.text || '');
-    } else {
-      setTitle(
-        selectElement?.options[selectElement?.selectedIndex]?.text || ''
-      );
-    }
-  };
   const handleFocus = (evt) => {
     setIsFocused(evt.type === 'focus' ? true : false);
   };
@@ -273,7 +259,10 @@ const Select = React.forwardRef(function Select(
     });
   }
   useEffect(() => {
-    selectDefaultTitle(defaultValue);
+    const selectElement = document.getElementById(
+      id
+    ) as HTMLSelectElement | null;
+    setTitle(selectElement?.options[selectElement?.selectedIndex]?.text || '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -225,11 +225,18 @@ const Select = React.forwardRef(function Select(
   }
 
   const selectDefaultTitle = (defaultValue) => {
-    const selectElement = document.getElementById(id);
-    const title = defaultValue
-      ? selectElement?.querySelector(`option[value=${defaultValue}]`)?.text
-      : selectElement?.options[selectElement?.selectedIndex]?.text;
-    setTitle(title);
+    const selectElement = document.getElementById(
+      id
+    ) as HTMLSelectElement | null;
+    if (defaultValue) {
+      const defaultOption: HTMLOptionElement | null | undefined =
+        selectElement?.querySelector(`option[value=${defaultValue}]`);
+      setTitle(defaultOption?.text || '');
+    } else {
+      setTitle(
+        selectElement?.options[selectElement?.selectedIndex]?.text || ''
+      );
+    }
   };
   const handleFocus = (evt) => {
     setIsFocused(evt.type === 'focus' ? true : false);

--- a/packages/react/src/components/Select/__tests__/Select-test.js
+++ b/packages/react/src/components/Select/__tests__/Select-test.js
@@ -250,6 +250,16 @@ describe('Select', () => {
         `${prefix}--select--slug`
       );
     });
+    
+    it('should show SelectItem text as title', () => {
+      render(
+        <Select id="select" labelText="Select" defaultValue="option-2">
+          <SelectItem text="Option 1" value="option-1" />
+          <SelectItem text="Option 2" value="option-2" />
+        </Select>
+      );
+      expect(screen.getByLabelText('Select').title).toEqual('Option 2');
+    });
   });
 
   describe('behaves as expected', () => {

--- a/packages/react/src/components/Select/__tests__/Select-test.js
+++ b/packages/react/src/components/Select/__tests__/Select-test.js
@@ -250,7 +250,7 @@ describe('Select', () => {
         `${prefix}--select--slug`
       );
     });
-    
+
     it('should show SelectItem text as title', () => {
       render(
         <Select id="select" labelText="Select" defaultValue="option-2">


### PR DESCRIPTION
Closes #15752

Fixed the invalid title/no title in Select component on hovering

**New**

- `selectDefaultTitle` which gets select element by it's id. if `defaultValue` is passed, it gets the option with `defaultValue` from select, otherwise get option by using the `selectedIndex`

**Changed**
- To show the valid tooltip replaced select value with option's text by using `selectedIndex` in `select.options`
- To show default option's text in title executed the `selectDefaultTitle` in `useEffect`
- Added a new test case which is '_should show SelectItem text as title_' which renders `Select` with `defaultValue` 'Option 2', expected result should be the title 'Option 2'


#### Testing / Reviewing

- Hover on Select component, it should show the selected Option as tooltip
- If there's no option selected, tooltip should not show