### PR TITLE
fix(Tabs): adjust contained tabs background value

### DIFF
--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -566,6 +566,10 @@
     }
   }
 
+  .#{$prefix}--tabs--contained ~ .#{$prefix}--tab-content {
+    background: $layer;
+  }
+
   .#{$prefix}--tab-content--interactive {
     &:focus {
       outline: none;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15787

Adds in `$layer` as the background for contained `Tabs`

#### Changelog

**New**

- Sets `$layer` as the background for `Tabs` in the contained variant. 

#### Testing / Reviewing

View the `Tabs` stories that show the contained variant and ensure the background for the `Tab` content is correct. 
