### PR TITLE
Fixed test titles to match rules in playwright

### DIFF
--- a/e2e/components/AspectRatio/AspectRatio-test.avt.e2e.js
+++ b/e2e/components/AspectRatio/AspectRatio-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('AspectRatio @avt', () => {
+test.describe('@avt AspectRatio', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'AspectRatio',

--- a/e2e/components/Breadcrumb/Breadcrumb-test.avt.e2e.js
+++ b/e2e/components/Breadcrumb/Breadcrumb-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('breadcrumb @avt', () => {
+test.describe('@avt Breadcrumb', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Breadcrumb',

--- a/e2e/components/Button/Button-test.avt.e2e.js
+++ b/e2e/components/Button/Button-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Button @avt', () => {
+test.describe('@avt Button', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Button',

--- a/e2e/components/ChatButton/ChatButton-test.avt.e2e.js
+++ b/e2e/components/ChatButton/ChatButton-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ChatButton @avt', () => {
+test.describe('@avt ChatButton', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Button',

--- a/e2e/components/Checkbox/Checkbox-test.avt.e2e.js
+++ b/e2e/components/Checkbox/Checkbox-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('Checkbox @avt', () => {
+test.describe('@avt Checkbox', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Checkbox',

--- a/e2e/components/ClassPrefix/ClassPrefix-test.avt.e2e.js
+++ b/e2e/components/ClassPrefix/ClassPrefix-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ClassPrefix @avt', () => {
+test.describe('@avt ClassPrefix', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ClassPrefix',

--- a/e2e/components/CodeSnippet/CodeSnippet-test.avt.e2e.js
+++ b/e2e/components/CodeSnippet/CodeSnippet-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('CodeSnippet @avt', () => {
+test.describe('@avt CodeSnippet', () => {
   test('@avt-default-state inline', async ({ page }) => {
     await visitStory(page, {
       component: 'CodeSnippet',
@@ -84,7 +84,7 @@ test.describe('CodeSnippet @avt', () => {
     await expect(page).toHaveNoACViolations('CodeSnippet skeleton');
   });
 
-  test('inline @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav inline', async ({ page }) => {
     await visitStory(page, {
       component: 'CodeSnippet',
       id: 'components-codesnippet--inline',
@@ -103,7 +103,7 @@ test.describe('CodeSnippet @avt', () => {
     await expect(page.getByRole('tooltip')).toHaveText('Copied to clipboard');
   });
 
-  test('multiline @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav multiline', async ({ page }) => {
     await visitStory(page, {
       component: 'CodeSnippet',
       id: 'components-codesnippet--multiline',
@@ -130,7 +130,7 @@ test.describe('CodeSnippet @avt', () => {
     await expect(page.getByText('Show more')).not.toBeVisible();
   });
 
-  test('singleline @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav singleline', async ({ page }) => {
     await visitStory(page, {
       component: 'CodeSnippet',
       id: 'components-codesnippet--singleline',

--- a/e2e/components/ComboBox/ComboBox-test.avt.e2e.js
+++ b/e2e/components/ComboBox/ComboBox-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ComboBox @avt', () => {
+test.describe('@avt ComboBox', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ComboBox',
@@ -38,7 +38,7 @@ test.describe('ComboBox @avt', () => {
     await page.keyboard.press('Tab');
     await expect(combobox).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible;
+    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible();
     await expect(combobox).toBeFocused();
 
     await expect(page).toHaveNoACViolations('ComboBox-open');

--- a/e2e/components/ComboButton/ComboButton-test.avt.e2e.js
+++ b/e2e/components/ComboButton/ComboButton-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('ComboButton @avt', () => {
+test.describe('@avt ComboButton', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ComboButton',

--- a/e2e/components/ComposedModal/ComposedModal-test.avt.e2e.js
+++ b/e2e/components/ComposedModal/ComposedModal-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ComposedModal @avt', () => {
+test.describe('@avt ComposedModal', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ComposedModal',

--- a/e2e/components/ContainedList/ContainedList-test.avt.e2e.js
+++ b/e2e/components/ContainedList/ContainedList-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('ContainedList @avt', () => {
+test.describe('@avt ContainedList', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ContainedList',

--- a/e2e/components/ContentSwitcher/ContentSwitcher-test.avt.e2e.js
+++ b/e2e/components/ContentSwitcher/ContentSwitcher-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('ContentSwitcher @avt', () => {
+test.describe('@avt ContentSwitcher', () => {
   test('@avt-default-state ContentSwitcher', async ({ page }) => {
     await visitStory(page, {
       component: 'ContentSwitcher',

--- a/e2e/components/CopyButton/CopyButton-test.avt.e2e.js
+++ b/e2e/components/CopyButton/CopyButton-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('CopyButton @avt', () => {
+test.describe('@avt CopyButton', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'CopyButton',

--- a/e2e/components/DataTable/DataTable-test.avt.e2e.js
+++ b/e2e/components/DataTable/DataTable-test.avt.e2e.js
@@ -10,8 +10,8 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('DataTable @avt', () => {
-  test.describe('basic', () => {
+test.describe('@avt DataTable', () => {
+  test.describe('@avt @avt basic', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -38,7 +38,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('batch actions', () => {
+  test.describe('@avt batch actions', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -53,7 +53,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('dynamic', () => {
+  test.describe('@avt dynamic', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -175,7 +175,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('expansion', () => {
+  test.describe('@avt expansion', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -202,7 +202,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('filtering', () => {
+  test.describe('@avt filtering', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -217,7 +217,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('selection', () => {
+  test.describe('@avt selection', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -258,7 +258,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('skeleton', () => {
+  test.describe('@avt skeleton', () => {
     test('@avt-default-state skeleton', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -273,7 +273,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('sorting', () => {
+  test.describe('@avt sorting', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',
@@ -288,7 +288,7 @@ test.describe('DataTable @avt', () => {
     });
   });
 
-  test.describe('toolbar', () => {
+  test.describe('@avt toolbar', () => {
     test('@avt-default-state', async ({ page }) => {
       await visitStory(page, {
         component: 'DataTable',

--- a/e2e/components/DatePicker/DatePicker-test.avt.e2e.js
+++ b/e2e/components/DatePicker/DatePicker-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('DatePicker @avt', () => {
+test.describe('@avt DatePicker', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
@@ -22,7 +22,7 @@ test.describe('DatePicker @avt', () => {
     await expect(page).toHaveNoACViolations('DatePicker');
   });
 
-  test('range @avt-advanced-states', async ({ page }) => {
+  test('@avt-advanced-states range', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
       id: 'components-datepicker--range',
@@ -33,7 +33,7 @@ test.describe('DatePicker @avt', () => {
     await expect(page).toHaveNoACViolations('DatePicker-Range');
   });
 
-  test('disabled @avt-advanced-states', async ({ page }) => {
+  test('@avt-advanced-states disabled', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
       id: 'components-datepicker--playground',
@@ -50,7 +50,7 @@ test.describe('DatePicker @avt', () => {
   });
 
   // skipping for now due to accessibility violation
-  test('skeleton @avt-advanced-states', async ({ page }) => {
+  test('@avt-advanced-states skeleton', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
       id: 'components-datepicker--skeleton',
@@ -63,7 +63,7 @@ test.describe('DatePicker @avt', () => {
   });
 
   // skipping for now due to accessibility violation
-  test('open @avt-advanced-states', async ({ page }) => {
+  test('@avt-advanced-states open', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
       id: 'components-datepicker--playground',
@@ -78,7 +78,7 @@ test.describe('DatePicker @avt', () => {
     await expect(page).toHaveNoACViolations('DatePicker-Open');
   });
 
-  test('simple state @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav simple state', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
       id: 'components-datepicker--single-with-calendar',
@@ -104,7 +104,7 @@ test.describe('DatePicker @avt', () => {
     );
   });
 
-  test('range state @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav range state', async ({ page }) => {
     await visitStory(page, {
       component: 'DatePicker',
       id: 'components-datepicker--range-with-calendar',

--- a/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
+++ b/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('DefinitionTooltip @avt', () => {
+test.describe('@avt DefinitionTooltip', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'DefinitionTooltip',
@@ -24,7 +24,7 @@ test.describe('DefinitionTooltip @avt', () => {
     );
   });
 
-  test('@avt-keyboard-state default', async ({ page }) => {
+  test('@avt-keyboard-nav default', async ({ page }) => {
     await visitStory(page, {
       component: 'DefinitionTooltip',
       id: 'components-definitiontooltip--default',

--- a/e2e/components/Dropdown/Dropdown-test.avt.e2e.js
+++ b/e2e/components/Dropdown/Dropdown-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Dropdown @avt', () => {
+test.describe('@avt Dropdown', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Dropdown',
@@ -39,7 +39,7 @@ test.describe('Dropdown @avt', () => {
     const menu = page.getByRole('listbox');
     await expect(toggleButton).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible;
+    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible();
     await expect(menu).toBeFocused();
 
     await expect(page).toHaveNoACViolations('Dropdown-open');

--- a/e2e/components/ErrorBoundary/ErrorBoundary-test.avt.e2e.js
+++ b/e2e/components/ErrorBoundary/ErrorBoundary-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ErrorBoundary @avt', () => {
+test.describe('@avt ErrorBoundary', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ErrorBoundary',
@@ -35,7 +35,7 @@ test.describe('ErrorBoundary @avt', () => {
     );
   });
 
-  test('@avt-keyboard-state', async ({ page }) => {
+  test('@avt-keyboard-nav', async ({ page }) => {
     await visitStory(page, {
       component: 'ErrorBoundary',
       id: 'components-errorboundary--default',

--- a/e2e/components/FileUploader/FileUploader-test.avt.e2e.js
+++ b/e2e/components/FileUploader/FileUploader-test.avt.e2e.js
@@ -11,7 +11,7 @@ const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 const path = require('path');
 
-test.describe('FileUploader @avt', () => {
+test.describe('@avt FileUploader', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FileUploader',

--- a/e2e/components/FlexGrid/FlexGrid-test.avt.e2e.js
+++ b/e2e/components/FlexGrid/FlexGrid-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FlexGrid @avt', () => {
+test.describe('@avt FlexGrid', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FlexGrid',

--- a/e2e/components/FluidComboBox/FluidComboBox-test.avt.e2e.js
+++ b/e2e/components/FluidComboBox/FluidComboBox-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidComboBox @avt', () => {
+test.describe('@avt FluidComboBox', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidComboBox',
@@ -38,7 +38,7 @@ test.describe('FluidComboBox @avt', () => {
     await page.keyboard.press('Tab');
     await expect(combobox).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible;
+    await expect(page.getByRole('combobox', { expanded: true })).toBeVisible();
     await expect(combobox).toBeFocused();
 
     await expect(page).toHaveNoACViolations('FluidComboBox-open');

--- a/e2e/components/FluidDatePicker/FluidDatePicker-test.avt.e2e.js
+++ b/e2e/components/FluidDatePicker/FluidDatePicker-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidDatePicker @avt', () => {
+test.describe('@avt FluidDatePicker', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDatePicker',

--- a/e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js
+++ b/e2e/components/FluidDropdown/FluidDropdown-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidDropdown @avt', () => {
+test.describe('@avt FluidDropdown', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidDropdown',

--- a/e2e/components/FluidForm/FluidForm-test.avt.e2e.js
+++ b/e2e/components/FluidForm/FluidForm-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidForm @avt', () => {
+test.describe('@avt FluidForm', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidForm',

--- a/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
+++ b/e2e/components/FluidMultiSelect/FluidMultiSelect-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidMultiSelect @avt', () => {
+test.describe('@avt FluidMultiSelect', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidMultiSelect',

--- a/e2e/components/FluidNumberInput/FluidNumberInput-test.avt.e2e.js
+++ b/e2e/components/FluidNumberInput/FluidNumberInput-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidNumberInput @avt', () => {
+test.describe('@avt FluidNumberInput', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidNumberInput',

--- a/e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js
+++ b/e2e/components/FluidSearch/FluidSearch-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidSearch @avt', () => {
+test.describe('@avt FluidSearch', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSearch',

--- a/e2e/components/FluidSelect/FluidSelect-test.avt.e2e.js
+++ b/e2e/components/FluidSelect/FluidSelect-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidSelect @avt', () => {
+test.describe('@avt FluidSelect', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidSelect',

--- a/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
+++ b/e2e/components/FluidTextArea/FluidTextArea-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidTextArea @avt', () => {
+test.describe('@avt FluidTextArea', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextArea',

--- a/e2e/components/FluidTextInput/FluidTextInput-test.avt.e2e.js
+++ b/e2e/components/FluidTextInput/FluidTextInput-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidTextInput @avt', () => {
+test.describe('@avt FluidTextInput', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTextInput',

--- a/e2e/components/FluidTimePicker/FluidTimePicker-test.avt.e2e.js
+++ b/e2e/components/FluidTimePicker/FluidTimePicker-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FluidTimePicker @avt', () => {
+test.describe('@avt FluidTimePicker', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FluidTimePicker',

--- a/e2e/components/Form/Form-test.avt.e2e.js
+++ b/e2e/components/Form/Form-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Form @avt', () => {
+test.describe('@avt Form', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Form',

--- a/e2e/components/FormGroup/FormGroup-test.avt.e2e.js
+++ b/e2e/components/FormGroup/FormGroup-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FormGroup @avt', () => {
+test.describe('@avt FormGroup', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FormGroup',

--- a/e2e/components/FormLabel/FormLabel-test.avt.e2e.js
+++ b/e2e/components/FormLabel/FormLabel-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('FormLabel @avt', () => {
+test.describe('@avt FormLabel', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'FormLabel',

--- a/e2e/components/Grid/Grid-test.avt.e2e.js
+++ b/e2e/components/Grid/Grid-test.avt.e2e.js
@@ -9,7 +9,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Grid @avt', () => {
+test.describe('@avt Grid', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Grid',

--- a/e2e/components/Heading/Heading-test.avt.e2e.js
+++ b/e2e/components/Heading/Heading-test.avt.e2e.js
@@ -9,7 +9,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Heading @avt', () => {
+test.describe('@avt Heading', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Heading',

--- a/e2e/components/IconButton/IconButton-test.avt.e2e.js
+++ b/e2e/components/IconButton/IconButton-test.avt.e2e.js
@@ -9,7 +9,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('IconButton @avt', () => {
+test.describe('@avt IconButton', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'IconButton',

--- a/e2e/components/IdPrefix/IdPrefix-test.avt.e2e.js
+++ b/e2e/components/IdPrefix/IdPrefix-test.avt.e2e.js
@@ -9,7 +9,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('IdPrefix @avt', () => {
+test.describe('@avt IdPrefix', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'IdPrefix',

--- a/e2e/components/InlineLoading/InlineLoading-test.avt.e2e.js
+++ b/e2e/components/InlineLoading/InlineLoading-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('InlineLoading @avt', () => {
+test.describe('@avt InlineLoading', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'InlineLoading',

--- a/e2e/components/Layer/Layer-test.avt.e2e.js
+++ b/e2e/components/Layer/Layer-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Layer @avt', () => {
+test.describe('@avt Layer', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Layer',

--- a/e2e/components/Link/Link-test.avt.e2e.js
+++ b/e2e/components/Link/Link-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Link @avt', () => {
+test.describe('@avt Link', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Link',

--- a/e2e/components/Loading/Loading-test.avt.e2e.js
+++ b/e2e/components/Loading/Loading-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Loading @avt', () => {
+test.describe('@avt Loading', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Loading',

--- a/e2e/components/Menu/Menu-test.avt.e2e.js
+++ b/e2e/components/Menu/Menu-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Menu @avt', () => {
+test.describe('@avt Menu', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Menu',

--- a/e2e/components/MenuButton/MenuButton-test.avt.e2e.js
+++ b/e2e/components/MenuButton/MenuButton-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('MenuButton @avt', () => {
+test.describe('@avt MenuButton', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'MenuButton',

--- a/e2e/components/Modal/Modal-test.avt.e2e.js
+++ b/e2e/components/Modal/Modal-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Modal @avt', () => {
+test.describe('@avt Modal', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Modal',

--- a/e2e/components/Notifications/Notifications-test.avt.e2e.js
+++ b/e2e/components/Notifications/Notifications-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Notifications @avt', () => {
+test.describe('@avt Notifications', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Notifications',
@@ -23,9 +23,7 @@ test.describe('Notifications @avt', () => {
     await expect(page).toHaveNoACViolations('Notifications actionable');
   });
 
-  test('accessibility-checker Notifications actionable keyboard', async ({
-    page,
-  }) => {
+  test('@avt-keyboard-nav', async ({ page }) => {
     await visitStory(page, {
       component: 'Notifications',
       id: 'components-notifications-actionable--default',

--- a/e2e/components/NumberInput/NumberInput-test.avt.e2e.js
+++ b/e2e/components/NumberInput/NumberInput-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('NumberInput @avt', () => {
+test.describe('@avt NumberInput', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'NumberInput',

--- a/e2e/components/OrderedList/OrderedList-test.avt.e2e.js
+++ b/e2e/components/OrderedList/OrderedList-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('OrderedList @avt', () => {
+test.describe('@avt OrderedList', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'OrderedList',

--- a/e2e/components/OverflowMenu/OverflowMenu-test.avt.e2e.js
+++ b/e2e/components/OverflowMenu/OverflowMenu-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('OverflowMenu @avt', () => {
+test.describe('@avt OverflowMenu', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'OverflowMenu',

--- a/e2e/components/Pagination/Pagination-test.avt.e2e.js
+++ b/e2e/components/Pagination/Pagination-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Pagination @avt', () => {
+test.describe('@avt Pagination', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Pagination',

--- a/e2e/components/PaginationNav/PaginationNav-test.avt.e2e.js
+++ b/e2e/components/PaginationNav/PaginationNav-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('PaginationNav @avt', () => {
+test.describe('@avt PaginationNav', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'PaginationNav',

--- a/e2e/components/Popover/Popover-test.avt.e2e.js
+++ b/e2e/components/Popover/Popover-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('Popover @avt', () => {
+test.describe('@avt Popover', () => {
   test('@avt-advanced-states auto align', async ({ page }) => {
     await visitStory(page, {
       component: 'Popover',

--- a/e2e/components/ProgressBar/ProgressBar-test.avt.e2e.js
+++ b/e2e/components/ProgressBar/ProgressBar-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ProgressBar @avt', () => {
+test.describe('@avt ProgressBar', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ProgressBar',

--- a/e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js
+++ b/e2e/components/ProgressIndicator/ProgressIndicator-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('ProgressIndicator', () => {
+test.describe('@avt ProgressIndicator', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ProgressIndicator',

--- a/e2e/components/RadioButton/RadioButton-test.avt.e2e.js
+++ b/e2e/components/RadioButton/RadioButton-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('RadioButton @avt', () => {
+test.describe('@avt RadioButton', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'RadioButton',

--- a/e2e/components/Search/Search-test.avt.e2e.js
+++ b/e2e/components/Search/Search-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Search @avt', () => {
+test.describe('@avt Search', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Search',

--- a/e2e/components/Select/Select-test.avt.e2e.js
+++ b/e2e/components/Select/Select-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Select @avt', () => {
+test.describe('@avt Select', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Select',

--- a/e2e/components/Slider/Slider-test.avt.e2e.js
+++ b/e2e/components/Slider/Slider-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Slider @avt', () => {
+test.describe('@avt Slider', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Slider',

--- a/e2e/components/StructuredList/StructuredList-test.avt.e2e.js
+++ b/e2e/components/StructuredList/StructuredList-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('StructuredList @avt', () => {
+test.describe('@avt StructuredList', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'StructuredList',

--- a/e2e/components/Tabs/Tabs-test.avt.e2e.js
+++ b/e2e/components/Tabs/Tabs-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Tabs @avt', () => {
+test.describe('@avt Tabs', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Tabs',

--- a/e2e/components/Tag/Tag-test.avt.e2e.js
+++ b/e2e/components/Tag/Tag-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('Tag @avt', () => {
+test.describe('@avt Tag', () => {
   test('@avt-default-state Tag', async ({ page }) => {
     await visitStory(page, {
       component: 'Tag',

--- a/e2e/components/TextArea/TextArea-test.avt.e2e.js
+++ b/e2e/components/TextArea/TextArea-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('TextArea @avt', () => {
+test.describe('@avt TextArea', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'TextArea',

--- a/e2e/components/TextInput/TextInput-test.avt.e2e.js
+++ b/e2e/components/TextInput/TextInput-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('TextInput @avt', () => {
+test.describe('@avt TextInput', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'TextInput',

--- a/e2e/components/Tile/Tile-test.avt.e2e.js
+++ b/e2e/components/Tile/Tile-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Tile @avt', () => {
+test.describe('@avt Tile', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Tile',
@@ -22,7 +22,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('Tile');
   });
 
-  test('ClickableTile @avt-default-state', async ({ page }) => {
+  test('@avt-default-state ClickableTile', async ({ page }) => {
     await visitStory(page, {
       component: 'ClickableTile',
       id: 'components-tile--clickable',
@@ -33,7 +33,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('ClickableTile');
   });
 
-  test('ExpandableTile @avt-default-state', async ({ page }) => {
+  test('@avt-default-state ExpandableTile', async ({ page }) => {
     await visitStory(page, {
       component: 'ExpandableTile',
       id: 'components-tile--expandable',
@@ -44,7 +44,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('ExpandableTile');
   });
 
-  test('SelectableTile @avt-default-state', async ({ page }) => {
+  test('@avt-default-state SelectableTile', async ({ page }) => {
     await visitStory(page, {
       component: 'SelectableTile',
       id: 'components-tile--selectable',
@@ -55,7 +55,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('SelectableTile');
   });
 
-  test('SelectableTile multi-select @avt-default-state', async ({ page }) => {
+  test('@avt-default-state SelectableTile multi-select', async ({ page }) => {
     await visitStory(page, {
       component: 'SelectableTile',
       id: 'components-tile--multi-select',
@@ -66,7 +66,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('SelectableTile multi-select');
   });
 
-  test('RadioTile @avt-default-state', async ({ page }) => {
+  test('@avt-default-state RadioTile', async ({ page }) => {
     await visitStory(page, {
       component: 'RadioTile',
       id: 'components-tile--radio',
@@ -77,7 +77,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('RadioTile');
   });
 
-  test('ClickableTile - @avt-advanced-states', async ({ page }) => {
+  test('@avt-advanced-states ClickableTile', async ({ page }) => {
     await visitStory(page, {
       component: 'Tile',
       id: 'components-tile--clickable',
@@ -92,7 +92,7 @@ test.describe('Tile @avt', () => {
     await expect(page).toHaveNoACViolations('ClickableTile-Disabled');
   });
 
-  test('ExpandableTile - @avt-advanced-states', async ({ page }) => {
+  test('@avt-advanced-states ExpandableTile', async ({ page }) => {
     await visitStory(page, {
       component: 'ExpandableTile',
       id: 'components-tile--expandable',
@@ -109,7 +109,7 @@ test.describe('Tile @avt', () => {
     );
   });
 
-  test('SelectableTile @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav SelectableTile', async ({ page }) => {
     await visitStory(page, {
       component: 'SelectableTile',
       id: 'components-tile--selectable',
@@ -126,7 +126,7 @@ test.describe('Tile @avt', () => {
     );
   });
 
-  test('RadioTile @avt-keyboard-nav', async ({ page }) => {
+  test('@avt-keyboard-nav RadioTile', async ({ page }) => {
     await visitStory(page, {
       component: 'RadioTile',
       id: 'components-tile--radio',

--- a/e2e/components/TimePicker/TimePicker-test.avt.e2e.js
+++ b/e2e/components/TimePicker/TimePicker-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('TimePicker @avt', () => {
+test.describe('@avt TimePicker', () => {
   test('@avt-default-state TimePicker', async ({ page }) => {
     await visitStory(page, {
       component: 'TimePicker',

--- a/e2e/components/Toggle/Toggle-test.avt.e2e.js
+++ b/e2e/components/Toggle/Toggle-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Toggle @avt', () => {
+test.describe('@avt Toggle', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Toggle',

--- a/e2e/components/Toggletip/Toggletip-test.avt.e2e.js
+++ b/e2e/components/Toggletip/Toggletip-test.avt.e2e.js
@@ -10,7 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 
-test.describe('Toggletip @avt', () => {
+test.describe('@avt Toggletip', () => {
   test('@avt-default-state Toggletip', async ({ page }) => {
     await visitStory(page, {
       component: 'Toggletip',

--- a/e2e/components/Tooltip/Tooltip-test.avt.e2e.js
+++ b/e2e/components/Tooltip/Tooltip-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('Tooltip @avt', () => {
+test.describe('@avt Tooltip', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Tooltip',
@@ -45,7 +45,7 @@ test.describe('Tooltip @avt', () => {
   });
 
   // Prevent timeout
-  test.slow('tooltip default - @avt-keyboard-nav', async ({ page }) => {
+  test.slow('@avt-keyboard-nav tooltip default', async ({ page }) => {
     await visitStory(page, {
       component: 'Tooltip',
       id: 'components-tooltip--default',

--- a/e2e/components/TreeView/TreeView-test.avt.e2e.js
+++ b/e2e/components/TreeView/TreeView-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('TreeView @avt', () => {
+test.describe('@avt TreeView', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'TreeView',

--- a/e2e/components/UIShell/UIShell-test.avt.e2e.js
+++ b/e2e/components/UIShell/UIShell-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('UIShell @avt', () => {
+test.describe('@avt UIShell', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'UIShell',

--- a/e2e/components/UnorderedList/UnorderedList-test.avt.e2e.js
+++ b/e2e/components/UnorderedList/UnorderedList-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('UnorderedList @avt', () => {
+test.describe('@avt UnorderedList', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'UnorderedList',


### PR DESCRIPTION
Closes #[15726](https://github.com/carbon-design-system/carbon/issues/15726)

Changed `describe` titles to match playwright rules wrriten in this [PR](https://github.com/carbon-design-system/carbon/pull/15692)

#### Testing / Reviewing

- Check if CI is pasisng

### Question
Datatable has a bunch of `describe` titles with @avt. Would it be a problem in the Carbon Website .json that shows the coverage? @alisonjoseph 