### PR TITLE
docs(migration): fix typos

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -978,12 +978,12 @@ spacing.
 
 - This component has been updated from a class component to a functional
   component
-- The `className` prop is now applied to the outermost element of `NumberInput`
+- The `className` prop is now applied to the outermost element of `RadioButtonGroup`
 
 ### RadioTile
 
 - The deprecated prop `iconDescription` is no longer needed and has been removed
-- The `className` prop is now applied to the outermost element of `NumberInput`
+- The `className` prop is now applied to the outermost element of `RadioTile`
 
 ### Search
 

--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -978,7 +978,8 @@ spacing.
 
 - This component has been updated from a class component to a functional
   component
-- The `className` prop is now applied to the outermost element of `RadioButtonGroup`
+- The `className` prop is now applied to the outermost element of
+  `RadioButtonGroup`
 
 ### RadioTile
 


### PR DESCRIPTION
Reported in [slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1709069737694319) 

#### Changelog



**Changed**

- fix typos in migration guide docs


#### Testing / Reviewing
