### PR TITLE
fix(DataTable): fix ai gradient issue in safari

### DIFF
--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -1002,6 +1002,8 @@
   tr.#{$prefix}--expandable-row--hover.#{$prefix}--data-table--slug-row,
   tr.#{$prefix}--data-table--selected.#{$prefix}--parent-row.#{$prefix}--expandable-row--hover.#{$prefix}--data-table--slug-row {
     @include ai-table-gradient('hover');
+
+    background-attachment: fixed;
   }
 
   tr.#{$prefix}--parent-row.cds--data-table--selected.#{$prefix}--data-table--slug-row,
@@ -1009,6 +1011,8 @@
   tr.#{$prefix}--data-table--selected.#{$prefix}--data-table--slug-row
     + .#{$prefix}--expandable-row {
     @include ai-table-gradient('selected');
+
+    background-attachment: fixed;
   }
 
   tr.#{$prefix}--data-table--slug-row.#{$prefix}--data-table--selected td,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15841

Fixes an issue with the gradient background in `DataTable`

#### Changelog

**New**

- Added `background-attachment: fixed;` to hover, selected styles

#### Testing / Reviewing

View `unstable__Slug --> DataTable` with a slug row in Safari and ensure gradients look correct.
