### PR TITLE
chore: onboard remaining packages to IBM Telemetry 🚀

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,3 +55,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,9 +23,13 @@
     "access": "public",
     "provenance": true
   },
+  "scripts": {
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
+  },
   "dependencies": {
     "@babel/core": "^7.18.2",
     "@carbon/cli-reporter": "^10.7.0",
+    "@ibm/telemetry-js": "^1.2.1",
     "@octokit/plugin-retry": "^3.0.7",
     "@octokit/plugin-throttling": "^4.0.0",
     "@octokit/rest": "^19.0.0",

--- a/packages/cli/telemetry.yml
+++ b/packages/cli/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 9495f863-d218-4262-acd0-fbf6076ff244
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/colors/README.md
+++ b/packages/colors/README.md
@@ -153,3 +153,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -16,7 +16,8 @@
     "lib",
     "scss",
     "umd",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "keywords": [
     "eyeglass-module",
@@ -34,7 +35,8 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonColors && node tasks/build.js && carbon-cli check \"scss/*.scss\"",
-    "clean": "rimraf css es lib umd scss index.scss"
+    "clean": "rimraf css es lib umd scss index.scss",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",
@@ -51,5 +53,8 @@
     "name": "@carbon/colors",
     "sassDir": "scss",
     "needs": "^1.3.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
   }
 }

--- a/packages/colors/telemetry.yml
+++ b/packages/colors/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 8c6b584f-72b3-499f-9341-bb0afeda0aa8
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -80,3 +80,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -16,7 +16,8 @@
     "lib",
     "src",
     "umd",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "keywords": [
     "ibm",
@@ -33,7 +34,8 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonElements",
-    "clean": "rimraf es lib umd"
+    "clean": "rimraf es lib umd",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@carbon/colors": "^11.20.0",
@@ -42,7 +44,8 @@
     "@carbon/layout": "^11.20.0",
     "@carbon/motion": "^11.16.0",
     "@carbon/themes": "^11.32.0",
-    "@carbon/type": "^11.25.0"
+    "@carbon/type": "^11.25.0",
+    "@ibm/telemetry-js": "^1.2.1"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",

--- a/packages/elements/telemetry.yml
+++ b/packages/elements/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: ab59403a-7d2b-4f03-b4c8-5372dc9e2156
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -105,3 +105,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -15,7 +15,8 @@
     "es",
     "lib",
     "scss",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "keywords": [
     "ibm",
@@ -31,7 +32,8 @@
   "scripts": {
     "build": "yarn clean && node tasks/build.js && rollup -c",
     "clean": "rimraf es lib scss/generated src/generated",
-    "watch": "yarn clean && node tasks/build.js && rollup -c -w"
+    "watch": "yarn clean && node tasks/build.js && rollup -c -w",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",
@@ -54,5 +56,8 @@
     "presets": [
       "@babel/env"
     ]
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
   }
 }

--- a/packages/feature-flags/telemetry.yml
+++ b/packages/feature-flags/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: e1c4a88e-d5e0-4f47-a500-f162ee84d209
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -95,3 +95,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -12,7 +12,8 @@
   "files": [
     "css",
     "scss",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "keywords": [
     "eyeglass-module",
@@ -30,10 +31,12 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli inline && carbon-cli check \"scss/*.scss\"",
-    "clean": "rimraf scss/_inlined scss/vendor"
+    "clean": "rimraf scss/_inlined scss/vendor",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
-    "@carbon/layout": "^11.20.0"
+    "@carbon/layout": "^11.20.0",
+    "@ibm/telemetry-js": "^1.2.1"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",

--- a/packages/grid/telemetry.yml
+++ b/packages/grid/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: b5e1ce58-4ab2-4643-9282-fd1d6a0cecfe
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/icon-helpers/README.md
+++ b/packages/icon-helpers/README.md
@@ -106,3 +106,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/icon-helpers/package.json
+++ b/packages/icon-helpers/package.json
@@ -14,7 +14,8 @@
   "files": [
     "es",
     "lib",
-    "umd"
+    "umd",
+    "telemetry.yml"
   ],
   "keywords": [
     "ibm",
@@ -31,12 +32,16 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli bundle src/index.ts --name CarbonIconHelpers",
-    "clean": "rimraf es lib umd"
+    "clean": "rimraf es lib umd",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",
     "rimraf": "^5.0.0",
     "typescript-config-carbon": "^0.2.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
+  }
 }

--- a/packages/icon-helpers/telemetry.yml
+++ b/packages/icon-helpers/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 123fb465-aaf3-4fce-a54e-ea4944b61678
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -152,3 +152,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -13,7 +13,8 @@
   "bugs": "https://github.com/carbon-design-system/carbon/issues",
   "files": [
     "es",
-    "lib"
+    "lib",
+    "telemetry.yml"
   ],
   "keywords": [
     "ibm",
@@ -31,14 +32,14 @@
   "scripts": {
     "build": "yarn clean && node tasks/build.js",
     "clean": "rimraf es lib",
-    "postinstall": "carbon-telemetry collect --install"
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "peerDependencies": {
     "react": ">=16"
   },
   "dependencies": {
     "@carbon/icon-helpers": "^10.46.0",
-    "@carbon/telemetry": "0.1.0",
+    "@ibm/telemetry-js": "^1.2.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/icons-react/telemetry.yml
+++ b/packages/icons-react/telemetry.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: e31e2f56-3767-407b-a854-ad7b9cd27677
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # Icon
+        - aria-hidden
+        - aria-label
+        - aria-labelledby
+        - children
+        - className
+        - height
+        - preserveAspectRatio
+        - tabIndex
+        - title
+        - viewBox
+        - width
+        - xmlns
+      allowedAttributeStringValues:
+        # Icon - aria-hidden
+        - 'false'
+        - 'true'

--- a/packages/icons-vue/README.md
+++ b/packages/icons-vue/README.md
@@ -95,3 +95,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -26,10 +26,12 @@
   },
   "scripts": {
     "build": "yarn clean && node tasks/build.js",
-    "clean": "rimraf es lib"
+    "clean": "rimraf es lib",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
-    "@carbon/icon-helpers": "^10.46.0"
+    "@carbon/icon-helpers": "^10.46.0",
+    "@ibm/telemetry-js": "^1.2.1"
   },
   "devDependencies": {
     "@carbon/cli-reporter": "^10.7.0",

--- a/packages/icons-vue/telemetry.yml
+++ b/packages/icons-vue/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 39aef2ca-e3d9-4afc-9617-c2495f61865d
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -110,3 +110,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -17,7 +17,8 @@
     "scss",
     "svg",
     "build-info.json",
-    "metadata.json"
+    "metadata.json",
+    "telemetry.yml"
   ],
   "keywords": [
     "ibm",
@@ -36,11 +37,15 @@
     "build": "yarn clean && node tasks/build.js",
     "ci-check": "node tasks/ci-check.js",
     "clean": "rimraf es lib metadata.json svg",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",
     "@carbon/icon-build-helpers": "^1.22.0",
     "rimraf": "^5.0.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
   }
 }

--- a/packages/icons/telemetry.yml
+++ b/packages/icons/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: b75a5380-3b55-4854-ad79-7bf340315aeb
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -50,3 +50,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonLayout && node tasks/build.js",
-    "clean": "rimraf es lib umd scss/generated"
+    "clean": "rimraf es lib umd scss/generated",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",
@@ -35,5 +36,8 @@
     "@carbon/test-utils": "^10.30.0",
     "core-js": "^3.16.0",
     "rimraf": "^5.0.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
   }
 }

--- a/packages/layout/telemetry.yml
+++ b/packages/layout/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: bf462a00-a4ac-4660-8554-c59ce1f088e8
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -78,3 +78,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -26,10 +26,14 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonMotion",
-    "clean": "rimraf es lib umd"
+    "clean": "rimraf es lib umd",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",
     "rimraf": "^5.0.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
   }
 }

--- a/packages/motion/telemetry.yml
+++ b/packages/motion/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 4d3a6099-2f13-49f6-81e5-5b91593567ab
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/pictograms-react/README.md
+++ b/packages/pictograms-react/README.md
@@ -112,3 +112,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/pictograms-react/package.json
+++ b/packages/pictograms-react/package.json
@@ -14,7 +14,8 @@
   "files": [
     "es",
     "lib",
-    "umd"
+    "umd",
+    "telemetry.yml"
   ],
   "keywords": [
     "ibm",
@@ -32,14 +33,14 @@
   "scripts": {
     "build": "yarn clean && node tasks/build.js",
     "clean": "rimraf es lib umd",
-    "postinstall": "carbon-telemetry collect --install"
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "peerDependencies": {
     "react": ">=16"
   },
   "dependencies": {
     "@carbon/icon-helpers": "^10.46.0",
-    "@carbon/telemetry": "0.1.0",
+    "@ibm/telemetry-js": "^1.2.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/pictograms-react/telemetry.yml
+++ b/packages/pictograms-react/telemetry.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 6ec11acd-6750-42fe-8f88-aa8725537be2
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null
+  jsx:
+    elements:
+      allowedAttributeNames:
+        # Icon
+        - aria-hidden
+        - aria-label
+        - aria-labelledby
+        - children
+        - className
+        - height
+        - preserveAspectRatio
+        - tabIndex
+        - title
+        - viewBox
+        - width
+        - xmlns
+      allowedAttributeStringValues:
+        # Icon - aria-hidden
+        - 'false'
+        - 'true'

--- a/packages/pictograms/README.md
+++ b/packages/pictograms/README.md
@@ -33,3 +33,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/pictograms/package.json
+++ b/packages/pictograms/package.json
@@ -29,10 +29,14 @@
     "build": "yarn clean && node tasks/build.js",
     "ci-check": "node tasks/ci-check.js",
     "clean": "rimraf es lib build-info.json metadata.json",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "@carbon/icon-build-helpers": "^1.22.0",
     "rimraf": "^5.0.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1"
   }
 }

--- a/packages/pictograms/telemetry.yml
+++ b/packages/pictograms/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: d16cedf8-a425-4a90-8943-8135c88a9799
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -143,3 +143,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -19,7 +19,8 @@
   "files": [
     "css",
     "scss",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "publishConfig": {
     "access": "public",
@@ -27,7 +28,8 @@
   },
   "scripts": {
     "build": "yarn clean && node tasks/build-css.js",
-    "clean": "rimraf css"
+    "clean": "rimraf css",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "peerDependencies": {
     "sass": "^1.33.0"
@@ -45,7 +47,8 @@
     "@carbon/motion": "^11.16.0",
     "@carbon/themes": "^11.32.0",
     "@carbon/type": "^11.25.0",
-    "@ibm/plex": "6.0.0-next.6"
+    "@ibm/plex": "6.0.0-next.6",
+    "@ibm/telemetry-js": "^1.2.1"
   },
   "devDependencies": {
     "@carbon/test-utils": "^10.30.0",

--- a/packages/styles/telemetry.yml
+++ b/packages/styles/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: d2574dfc-6ec7-4d1a-9c7a-b22cc16dc747
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -111,3 +111,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -27,12 +27,14 @@
   "scripts": {
     "ci-check": "carbon-cli check \"scss/**/*.scss\" -i \"**/generated/**\" -i \"**/compat/**\"",
     "clean": "rimraf es lib umd scss/generated scss/compat/generated",
-    "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonThemes && babel-node --presets '@babel/preset-env' tasks/build.js && carbon-cli check \"scss/*.scss\""
+    "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonThemes && babel-node --presets '@babel/preset-env' tasks/build.js && carbon-cli check \"scss/*.scss\"",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@carbon/colors": "^11.20.0",
     "@carbon/layout": "^11.20.0",
     "@carbon/type": "^11.25.0",
+    "@ibm/telemetry-js": "^1.2.1",
     "color": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/themes/telemetry.yml
+++ b/packages/themes/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: a56e8642-350a-4ee1-8e04-711cf16f3508
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -262,3 +262,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -17,7 +17,8 @@
     "scss",
     "src",
     "umd",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "keywords": [
     "eyeglass-module",
@@ -35,11 +36,13 @@
   },
   "scripts": {
     "build": "yarn clean && carbon-cli bundle src/index.js --name CarbonType && carbon-cli check \"scss/*.scss\"",
-    "clean": "rimraf css es lib umd"
+    "clean": "rimraf css es lib umd",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "dependencies": {
     "@carbon/grid": "^11.21.0",
-    "@carbon/layout": "^11.20.0"
+    "@carbon/layout": "^11.20.0",
+    "@ibm/telemetry-js": "^1.2.1"
   },
   "devDependencies": {
     "@carbon/cli": "^11.15.0",

--- a/packages/type/telemetry.yml
+++ b/packages/type/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 43a17f29-6354-4c01-b4ec-920a1248f0f7
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/packages/upgrade/README.md
+++ b/packages/upgrade/README.md
@@ -80,3 +80,12 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
 ## 📝 License
 
 Licensed under the [Apache 2.0 License](/LICENSE).
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -15,7 +15,8 @@
   "files": [
     "bin",
     "cli.js",
-    "transforms"
+    "transforms",
+    "telemetry.yml"
   ],
   "keywords": [
     "carbon",
@@ -34,7 +35,8 @@
   "scripts": {
     "build": "esbuild src/cli.js --bundle --platform=node --outfile=cli.js --target=node14 --external:jscodeshift",
     "clean": "rimraf cli.js",
-    "watch": "yarn build --watch"
+    "watch": "yarn build --watch",
+    "postinstall": "ibmtelemetry --config=telemetry.yml"
   },
   "devDependencies": {
     "chalk": "^4.1.1",
@@ -56,6 +58,7 @@
     "yargs": "^17.0.1"
   },
   "dependencies": {
+    "@ibm/telemetry-js": "^1.2.1",
     "jscodeshift": "^0.13.1"
   }
 }

--- a/packages/upgrade/telemetry.yml
+++ b/packages/upgrade/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 9e4d8d64-c172-4f68-ac67-3e4c3ecae2d0
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.18.2"
     "@carbon/cli-reporter": "npm:^10.7.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     "@octokit/plugin-retry": "npm:^3.0.7"
     "@octokit/plugin-throttling": "npm:^4.0.0"
     "@octokit/rest": "npm:^19.0.0"
@@ -1834,6 +1835,7 @@ __metadata:
     "@carbon/motion": "npm:^11.16.0"
     "@carbon/themes": "npm:^11.32.0"
     "@carbon/type": "npm:^11.25.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     fs-extra: "npm:^11.0.0"
     klaw-sync: "npm:^6.0.0"
     replace-in-file: "npm:^7.0.0"
@@ -1851,6 +1853,7 @@ __metadata:
     "@babel/template": "npm:^7.16.7"
     "@babel/types": "npm:^7.18.4"
     "@carbon/scss-generator": "npm:^10.18.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     "@rollup/plugin-babel": "npm:^6.0.0"
     "@rollup/plugin-node-resolve": "npm:^15.0.0"
     change-case: "npm:^4.1.2"
@@ -1875,6 +1878,7 @@ __metadata:
   dependencies:
     "@carbon/cli": "npm:^11.15.0"
     "@carbon/layout": "npm:^11.20.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     rimraf: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
@@ -1920,6 +1924,7 @@ __metadata:
   resolution: "@carbon/icon-helpers@workspace:packages/icon-helpers"
   dependencies:
     "@carbon/cli": "npm:^11.15.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     rimraf: "npm:^5.0.0"
     typescript-config-carbon: "npm:^0.2.0"
   languageName: unknown
@@ -1945,7 +1950,7 @@ __metadata:
     "@carbon/icon-build-helpers": "npm:^1.22.0"
     "@carbon/icon-helpers": "npm:^10.46.0"
     "@carbon/icons": "npm:^11.37.0-rc.0"
-    "@carbon/telemetry": "npm:0.1.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     prop-types: "npm:^15.7.2"
     rimraf: "npm:^5.0.0"
   peerDependencies:
@@ -1960,6 +1965,7 @@ __metadata:
     "@carbon/cli-reporter": "npm:^10.7.0"
     "@carbon/icon-helpers": "npm:^10.46.0"
     "@carbon/icons": "npm:^11.37.0-rc.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     fs-extra: "npm:^11.0.0"
     prettier: "npm:^2.8.8"
     rimraf: "npm:^5.0.0"
@@ -1974,6 +1980,7 @@ __metadata:
   dependencies:
     "@carbon/cli": "npm:^11.15.0"
     "@carbon/icon-build-helpers": "npm:^1.22.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     rimraf: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
@@ -1993,6 +2000,7 @@ __metadata:
     "@carbon/cli-reporter": "npm:^10.7.0"
     "@carbon/scss-generator": "npm:^10.18.0"
     "@carbon/test-utils": "npm:^10.30.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     core-js: "npm:^3.16.0"
     rimraf: "npm:^5.0.0"
   languageName: unknown
@@ -2003,6 +2011,7 @@ __metadata:
   resolution: "@carbon/motion@workspace:packages/motion"
   dependencies:
     "@carbon/cli": "npm:^11.15.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     rimraf: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
@@ -2014,7 +2023,7 @@ __metadata:
     "@carbon/icon-build-helpers": "npm:^1.22.0"
     "@carbon/icon-helpers": "npm:^10.46.0"
     "@carbon/pictograms": "npm:^12.31.0"
-    "@carbon/telemetry": "npm:0.1.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     prop-types: "npm:^15.7.2"
     rimraf: "npm:^5.0.0"
   peerDependencies:
@@ -2027,6 +2036,7 @@ __metadata:
   resolution: "@carbon/pictograms@workspace:packages/pictograms"
   dependencies:
     "@carbon/icon-build-helpers": "npm:^1.22.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     rimraf: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
@@ -2140,6 +2150,7 @@ __metadata:
     "@carbon/themes": "npm:^11.32.0"
     "@carbon/type": "npm:^11.25.0"
     "@ibm/plex": "npm:6.0.0-next.6"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     autoprefixer: "npm:^10.4.7"
     browserslist-config-carbon: "npm:^11.2.0"
     css: "npm:^3.0.0"
@@ -2193,6 +2204,7 @@ __metadata:
     "@carbon/scss-generator": "npm:^10.18.0"
     "@carbon/test-utils": "npm:^10.30.0"
     "@carbon/type": "npm:^11.25.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     change-case: "npm:^4.1.1"
     color: "npm:^4.0.0"
     core-js: "npm:^3.16.0"
@@ -2210,6 +2222,7 @@ __metadata:
     "@carbon/grid": "npm:^11.21.0"
     "@carbon/layout": "npm:^11.20.0"
     "@carbon/test-utils": "npm:^10.30.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     change-case: "npm:^4.1.1"
     css: "npm:^3.0.0"
     rimraf: "npm:^5.0.0"
@@ -2220,6 +2233,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/upgrade@workspace:packages/upgrade"
   dependencies:
+    "@ibm/telemetry-js": "npm:^1.2.1"
     chalk: "npm:^4.1.1"
     change-case: "npm:^4.1.2"
     esbuild: "npm:^0.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,6 +1815,7 @@ __metadata:
     "@carbon/cli-reporter": "npm:^10.7.0"
     "@carbon/scss-generator": "npm:^10.18.0"
     "@carbon/test-utils": "npm:^10.30.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     change-case: "npm:^4.1.1"
     fs-extra: "npm:^11.0.0"
     rimraf: "npm:^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,7 +1964,8 @@ __metadata:
   dependencies:
     "@carbon/cli-reporter": "npm:^10.7.0"
     "@carbon/icon-helpers": "npm:^10.46.0"
-    "@carbon/icons": "npm:^11.37.0-rc.0"
+    "@carbon/icons": "npm:^11.37.0"
+    "@ibm/telemetry-js": "npm:^1.2.1"
     fs-extra: "npm:^11.0.0"
     prettier: "npm:^2.8.8"
     rimraf: "npm:^5.0.0"


### PR DESCRIPTION
## Description

Adds the config file and dependency necessary to start tracking telemetry data via [IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js) for the packages:

- `@carbon/cli`
- `@carbon/colors`
- `@carbon/elements`
- `@carbon/feature-flags`
- `@carbon/grid`
- `@carbon/icon-helpers`
- `@carbon/icons`
- `@carbon/icons-react`
- `@carbon/icons-vue`
- `@carbon/layout`
- `@carbon/motion`
- `@carbon/pictograms`
- `@carbon/pictograms-react`
- `@carbon/styles`
- `@carbon/themes`
- `@carbon/type`
- `@carbon/upgrade`

The `jsx` config for the two `-react` packages were generated by running the [JS config generator](https://www.npmjs.com/package/@ibm/telemetry-js-config-generator) in the icon build helper package.

**NOTE:** This separate PR needs reviewed on the v10 branch with a new release after the PR is merged: https://github.com/carbon-design-system/carbon/pull/15852

#### Changelog

For each package listed above:

**New**

- Adds @ibm/telemetry-js dependency
- Adds telemetry.yml config file
- Adds readme telemetry notice
- Adds postinstall script to use the telemetry command
- Adds telemetry.yml as an exported file if the package specifies `files`

**Changed**

- N/A

**Removed**

- `@carbon/telemetry` in `@carbon/icons-react` and `@carbon/pictograms-react`

#### Testing / Reviewing

Please look through package.json config files and ensure all necessary modifications have been made so that the "telemetry.yml" config file is included in the release version of each package.

**PLEASE NOTE:** In order for IBM Telemetry to start collecting data for this project, a new build must be published including these changes.
