### PR TITLE
fix: incorrect aria-labelledby value in the Toggle component

### DIFF
--- a/packages/react/src/components/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Toggle/Toggle.tsx
@@ -158,6 +158,8 @@ export function Toggle({
     [`${prefix}--toggle__switch--checked`]: checked,
   });
 
+  const labelId = `${id}_label`;
+
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
@@ -189,11 +191,12 @@ export function Toggle({
         role="switch"
         type="button"
         aria-checked={checked}
-        aria-labelledby={id}
+        aria-labelledby={ariaLabelledby ?? labelId}
         disabled={disabled}
         onClick={handleClick}
       />
       <LabelComponent
+        id={labelId}
         htmlFor={ariaLabelledby ? undefined : id}
         className={`${prefix}--toggle__label`}>
         {labelText && <Text className={labelTextClasses}>{labelText}</Text>}


### PR DESCRIPTION
aria-labelledby value of the button points to itself.
It should be the ID of the label, or the provided value passed via props.
This PR fixes this issue by assigning an id to the label, and setting the aria-labelledby attribute of the button to this value.

Before:
<img width="815" alt="image" src="https://github.com/carbon-design-system/carbon/assets/2729020/8d23badf-5b2e-4b67-b732-a5755fdff116">
After:
<img width="851" alt="image" src="https://github.com/carbon-design-system/carbon/assets/2729020/7608c201-035c-4110-ade9-2c647b41c8d4">


#### Changelog

**New**

- added ID to the label in the Toggle component

**Changed**

- aria-labelledby value is set to the ID of the label, if no explicit aria-labelledby value is provided