### PR TITLE
fix: active states and focus states of inline and standalone links

### DIFF
--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -46,7 +46,10 @@ $link-focus-text-color: custom-property.get-var(
     &:active,
     &:active:visited,
     &:active:visited:hover {
+      @include focus-outline;
+
       color: $text-primary;
+      outline-color: $link-focus-text-color;
       text-decoration: underline;
     }
 

--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -54,6 +54,7 @@ $link-focus-text-color: custom-property.get-var(
       @include focus-outline;
 
       outline-color: $link-focus-text-color;
+      text-decoration: underline;
     }
 
     &:visited {
@@ -87,11 +88,6 @@ $link-focus-text-color: custom-property.get-var(
   .#{$prefix}--link.#{$prefix}--link--inline {
     display: inline;
     text-decoration: underline;
-
-    &:focus,
-    &:visited {
-      text-decoration: none;
-    }
   }
 
   .#{$prefix}--link--disabled.#{$prefix}--link--inline {


### PR DESCRIPTION
Closes #15613 

Added an underline on the focus state and active state

**Changed**

- Changed some styles to incorporate underline at different states

#### Testing / Reviewing
- Test the default and inline link component in active and focus states it should have underline.
