### PR TITLE
fix(StaticNotification): set describedby on action button

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7239,7 +7239,7 @@ Map {
         "type": "string",
       },
       "subtitle": Object {
-        "type": "string",
+        "type": "node",
       },
       "title": Object {
         "type": "string",

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -1226,7 +1226,7 @@ export interface StaticNotificationProps
   /**
    * Specify the subtitle
    */
-  subtitle?: string;
+  subtitle?: ReactNode;
 
   /**
    * Specify the title
@@ -1295,7 +1295,10 @@ export function StaticNotification({
       </div>
       <div className={`${prefix}--actionable-notification__button-wrapper`}>
         {actionButtonLabel && (
-          <NotificationActionButton onClick={onActionButtonClick} inline>
+          <NotificationActionButton
+            onClick={onActionButtonClick}
+            aria-describedby={titleId}
+            inline>
             {actionButtonLabel}
           </NotificationActionButton>
         )}
@@ -1350,7 +1353,7 @@ StaticNotification.propTypes = {
   /**
    * Specify the subtitle
    */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
 
   /**
    * Specify the title


### PR DESCRIPTION
Follow-on to [a previous PR](https://github.com/carbon-design-system/carbon/pull/15804) that added the actionButton capability to StaticNotification. I didn't realize that the aria-describedby was being enforced on the button in addition to the body. My storybook example didn't catch that, b/c the current`useInteractiveChildrenNeedDescription` is only checking the **first** interactive child.  So when i went to use it with just the button, kaboom.

Fully tested it out locally in our microservice, recreating the issue and fixing it. 
I also changed the proptype of `subtitle` to Node to match actionableNotification, making the swap easier.

#### Changelog

**New**

- pass titleId to the NotificationButton as `aria-describedby`. No new prop for this.
- additional storybook story for the action button only

**Changed**

- updated `subtitle` to be PropTypes.Node to match ActionableNotification. 


#### Testing / Reviewing

render a StaticNotification within live code with action button and embedded links.

