### PR TITLE
feat: side panel as modal kind (proposal / talking point) 

### DIFF
--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -24,6 +24,7 @@ import {
   StructuredListCell,
 } from '../StructuredList';
 import mdx from './ComposedModal.mdx';
+import './ComposedModal.stories.scss';
 
 export default {
   title: 'Components/ComposedModal',
@@ -36,6 +37,13 @@ export default {
   parameters: {
     docs: {
       page: mdx,
+    },
+  },
+  argTypes: {
+    kind: {
+      table: {
+        disable: true,
+      },
     },
   },
 };
@@ -346,6 +354,75 @@ export const WithInlineLoading = () => {
       </ComposedModal>
     </>
   );
+};
+
+const ModalSide = (args) => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <>
+      <div className="sb-blank-header">Global Header Placeholder</div>
+      <div className="sb-page-content">
+        <Button onClick={() => setOpen(true)}>Launch composed modal</Button>
+      </div>
+      <ComposedModal
+        open={open}
+        onClose={() => setOpen(false)}
+        kind={args['Kind']}
+        size={args.size}>
+        <ModalHeader label="Account resources" title="Add a custom domain" />
+        <ModalBody>
+          <p style={{ marginBottom: '1rem' }}>
+            Custom domains direct requests for your apps in this Cloud Foundry
+            organization to a URL that you own. A custom domain can be a shared
+            domain, a shared subdomain, or a shared domain and host.
+          </p>
+          <TextInput
+            data-modal-primary-focus
+            id="text-input-1"
+            labelText="Domain name"
+            placeholder="e.g. github.com"
+            style={{ marginBottom: '1rem' }}
+          />
+          <Select id="select-1" defaultValue="us-south" labelText="Region">
+            <SelectItem value="us-south" text="US South" />
+            <SelectItem value="us-east" text="US East" />
+          </Select>
+        </ModalBody>
+        <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
+      </ComposedModal>
+    </>
+  );
+};
+
+export const ModalSideKind = {
+  parameters: {
+    controls: {
+      include: ['Kind', 'size'],
+    },
+  },
+  argTypes: {
+    Kind: {
+      description: `Optional: kind property ('start' or 'end')`,
+      control: {
+        type: 'select',
+        labels: {
+          0: 'side-end - after content',
+          1: 'side-start - before content',
+          2: 'null - default modal kind',
+        },
+      },
+      options: [0, 1, 2],
+      mapping: {
+        0: 'side-end',
+        1: 'side-start',
+        2: null,
+      },
+    },
+  },
+  render: (args) => {
+    return <ModalSide {...args} />;
+  },
 };
 
 export const Playground = (args) => {

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -356,7 +356,8 @@ export const WithInlineLoading = () => {
   );
 };
 
-const ModalSide = (args) => {
+const ModalSide = (_args) => {
+  const { 'kind ': kind, ...args } = _args;
   const [open, setOpen] = useState(true);
 
   return (
@@ -368,7 +369,7 @@ const ModalSide = (args) => {
       <ComposedModal
         open={open}
         onClose={() => setOpen(false)}
-        kind={args['Kind']}
+        kind={kind}
         size={args.size}>
         <ModalHeader label="Account resources" title="Add a custom domain" />
         <ModalBody>
@@ -398,12 +399,12 @@ const ModalSide = (args) => {
 export const ModalSideKind = {
   parameters: {
     controls: {
-      include: ['Kind', 'size'],
+      include: ['kind ', 'size'],
     },
   },
   argTypes: {
-    Kind: {
-      description: `Optional: kind property ('start' or 'end')`,
+    'kind ': {
+      description: `Optional: kind property ('side-start' or 'side-end')`,
       control: {
         type: 'select',
         labels: {
@@ -419,6 +420,9 @@ export const ModalSideKind = {
         2: null,
       },
     },
+  },
+  args: {
+    'kind ': 0,
   },
   render: (args) => {
     return <ModalSide {...args} />;

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.scss
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.scss
@@ -1,3 +1,34 @@
+@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+
+#storybook-root {
+  &:not(:has(.sb-blank-header)) {
+    --#{$prefix}-modal-kind-side-inset-start: 0rem;
+  }
+}
+
 .sb-notification p {
   line-height: 1;
+}
+
+.sb-blank-header {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  padding-inline-start: $spacing-05;
+  top: 0;
+  left: 0;
+  background-color: $background-inverse;
+  color: $text-inverse;
+  width: 100%;
+  height: $spacing-09;
+}
+
+.sb-page-content {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  height: 50vh;
+  width: 100%;
 }

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -203,6 +203,8 @@ export interface ComposedModalProps extends HTMLAttributes<HTMLDivElement> {
   /** Specify the CSS selectors that match the floating menus. */
   selectorsFloatingMenus?: Array<string | null | undefined>;
 
+  kind?: '' | 'side-start' | 'side-end';
+
   size?: 'xs' | 'sm' | 'md' | 'lg';
 
   /**
@@ -221,6 +223,7 @@ const ComposedModal = React.forwardRef<HTMLDivElement, ComposedModalProps>(
       containerClassName,
       danger,
       isFullWidth,
+      kind,
       onClose,
       onKeyDown,
       open,
@@ -306,6 +309,7 @@ const ComposedModal = React.forwardRef<HTMLDivElement, ComposedModalProps>(
         'is-visible': isOpen,
         [`${prefix}--modal--danger`]: danger,
         [`${prefix}--modal--slug`]: slug,
+        [`${prefix}--modal--kind-${kind}`]: kind,
       },
       customClassName
     );
@@ -464,6 +468,11 @@ ComposedModal.propTypes = {
    * Specify whether the Modal content should have any inner padding.
    */
   isFullWidth: PropTypes.bool,
+
+  /**
+   * Specify an optional location for the side kind
+   */
+  kind: PropTypes.oneOf(['', 'side-start', 'side-end']),
 
   /**
    * Provide a ref to return focus to once the modal is closed.

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:list';
 @use '../button';
 @use '../../config' as *;
 @use '../../breakpoint' as *;
@@ -18,6 +19,69 @@
 @use '../../utilities/focus-outline' as *;
 @use '../../utilities/high-contrast-mode' as *;
 @use '../../utilities/z-index' as *;
+
+:root {
+  --#{$prefix}-modal-kind-side-inset-start: #{$spacing-09};
+}
+
+$kind-side-sizes: (
+  xs: 16rem,
+  sm: 20rem,
+  md: 30rem,
+  lg: 40rem 50%,
+);
+
+@mixin set-kind-side-inline-size($size: map-get($kind-side-sizes, md)) {
+  /* any value is single value list */
+  inline-size: list.nth($size, 1);
+  @if list.length($size) > 1 {
+    min-inline-size: list.nth($size, 2);
+  }
+
+  max-inline-size: 100%;
+}
+
+@mixin modal-kind-side {
+  $kind-side-inset-start: var(
+    --#{$prefix}-modal-kind-side-inset-start,
+    $spacing-09
+  );
+
+  @each $size, $size_value in $kind-side-sizes {
+    .#{$prefix}--modal-container--#{$size} {
+      @include set-kind-side-inline-size($size_value);
+    }
+  }
+
+  align-items: flex-start;
+  inset-block-start: $kind-side-inset-start;
+
+  &.#{$prefix}--modal--kind-side-start {
+    justify-content: flex-start;
+  }
+
+  &.#{$prefix}--modal--kind-side-end {
+    justify-content: flex-end;
+  }
+
+  .#{$prefix}--modal-container {
+    block-size: calc(100% - #{$kind-side-inset-start});
+    max-block-size: calc(100% - #{$kind-side-inset-start});
+  }
+
+  &.#{$prefix}--modal--kind-side-start .#{$prefix}--modal-container {
+    transform: translate3d(-100%, 0, 0);
+  }
+
+  &.#{$prefix}--modal--kind-side-end .#{$prefix}--modal-container {
+    transform: translate3d(100%, 0, 0);
+  }
+
+  &.#{$prefix}--modal--kind-side-end.is-visible .#{$prefix}--modal-container,
+  &.#{$prefix}--modal--kind-side-start.is-visible .#{$prefix}--modal-container {
+    transform: translate3d(0, 0, 0);
+  }
+}
 
 /// Modal styles
 /// @access public
@@ -517,4 +581,9 @@
     @include high-contrast-mode('focus');
   }
   /* stylelint-enable no-duplicate-selectors */
+
+  .#{$prefix}--modal--kind-side-start,
+  .#{$prefix}--modal--kind-side-end {
+    @include modal-kind-side();
+  }
 }


### PR DESCRIPTION
An experiment to see what a SidePanel Modal might look like as a stylised version of the ComposedModal.

Following on from the AI work to create Web Component versions of @carbon/ibm-products/SidePanel and Tearsheet it appeared that SidePanel is similar to a ComposedModal in many ways. 

This PR adds a single property `kind` to the Composed modal and uses styling SCSS to achieve most of the implementation. It is intended to spark a discussion about where the base SidePanel component should live and what it should look like.

Guidance on usage of SidePanel https://pages.github.ibm.com/cdai-design/pal/components/side-panel/usage

#### Changelog

**Changed**

- ComposedModal properties and additional styling