### PR TITLE
`Tooltip` & `DefinitionTooltip` changed storybook and functionality

### DIFF
--- a/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
+++ b/e2e/components/DefinitionTooltip/DefinitionTooltip-test.avt.e2e.js
@@ -10,7 +10,7 @@
 const { expect, test } = require('@playwright/test');
 const { visitStory } = require('../../test-utils/storybook');
 
-test.describe('DefinitionTooltip @avt', () => {
+test.describe('@avt DefinitionTooltip', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'DefinitionTooltip',
@@ -24,7 +24,7 @@ test.describe('DefinitionTooltip @avt', () => {
     );
   });
 
-  test('@avt-keyboard-state default', async ({ page }) => {
+  test('@avt-keyboard-nav default', async ({ page }) => {
     await visitStory(page, {
       component: 'DefinitionTooltip',
       id: 'components-definitiontooltip--default',
@@ -38,10 +38,10 @@ test.describe('DefinitionTooltip @avt', () => {
     const primaryButton = page.getByRole('button', { name: 'URL' });
 
     // Testing DefinitionTooltip
-    await page.keyboard.press('Tab');
     await expect(primaryButton).toBeVisible();
-    await expect(primaryButton).toHaveAttribute('aria-expanded', 'false');
-    await primaryButton.click();
+    await page.keyboard.press('Tab');
     await expect(primaryButton).toHaveAttribute('aria-expanded', 'true');
+    await primaryButton.click();
+    await expect(primaryButton).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
@@ -105,7 +105,7 @@ const DefinitionTooltip: React.FC<DefinitionTooltipProps> = ({
         openOnHover ? setOpen(true) : null;
       }}
       onFocus={() => {
-        openOnHover ? setOpen(true) : null;
+        setOpen(true);
       }}
       open={isOpen}>
       <button

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
@@ -104,6 +104,9 @@ const DefinitionTooltip: React.FC<DefinitionTooltipProps> = ({
       onMouseEnter={() => {
         openOnHover ? setOpen(true) : null;
       }}
+      onFocus={() => {
+        openOnHover ? setOpen(true) : null;
+      }}
       open={isOpen}>
       <button
         {...rest}
@@ -112,9 +115,6 @@ const DefinitionTooltip: React.FC<DefinitionTooltipProps> = ({
         aria-expanded={isOpen}
         onBlur={() => {
           setOpen(false);
-        }}
-        onClick={() => {
-          setOpen(!isOpen);
         }}
         onKeyDown={onKeyDown}
         type="button">

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
@@ -116,6 +116,9 @@ const DefinitionTooltip: React.FC<DefinitionTooltipProps> = ({
         onBlur={() => {
           setOpen(false);
         }}
+        onClick={() => {
+          setOpen(!isOpen);
+        }}
         onKeyDown={onKeyDown}
         type="button">
         {children}

--- a/packages/react/src/components/Tooltip/Tooltip.stories.js
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.js
@@ -108,7 +108,7 @@ export const Playground = PlaygroundStory.bind({});
 Playground.args = {
   align: 'bottom',
   closeOnActivation: false,
-  defaultOpen: true,
+  defaultOpen: false,
   label: 'Custom label',
 };
 


### PR DESCRIPTION
Closes #12921

There is a couple changes made in storybook and also in the functionality. Now the `Tooltip` and `DefinitionTooltip` have similar behaviour, except for the onClick on `DefinitionTooltip`.

#### Changelog

- Changed defaultOpen to false on `Tolltip` Playground
- Add onFocus to `DefinitionTooltip`

#### Testing / Reviewing

- Test the `Tooltip` and `DefinitionTolltip`