### PR TITLE
feat: tearsheet as modal kind (proposal / talking point)

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1443,6 +1443,15 @@ Map {
       "isFullWidth": Object {
         "type": "bool",
       },
+      "kind": Object {
+        "args": Array [
+          Array [
+            "",
+            "tearsheet",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "launcherButtonRef": Object {
         "args": Array [
           Array [

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -24,6 +24,8 @@ import {
   StructuredListCell,
 } from '../StructuredList';
 import mdx from './ComposedModal.mdx';
+import './ComposedModal.stories.scss';
+import { ModalInfluencer } from './ModalInfluencer';
 
 export default {
   title: 'Components/ComposedModal',
@@ -36,6 +38,13 @@ export default {
   parameters: {
     docs: {
       page: mdx,
+    },
+  },
+  argTypes: {
+    kind: {
+      table: {
+        disable: true,
+      },
     },
   },
 };
@@ -346,6 +355,150 @@ export const WithInlineLoading = () => {
       </ComposedModal>
     </>
   );
+};
+
+const ModalTearsheet = (_args) => {
+  const { 'kind ': kind, 'influencer ': influencer, ...args } = _args;
+  const [open, setOpen] = useState(true);
+  const [open2, setOpen2] = useState(false);
+  const localRef = useRef();
+
+  return (
+    <>
+      <div className="sb-blank-header">Global Header Placeholder</div>
+      <div className="sb-page-content">
+        <Button onClick={() => setOpen(true)}>Launch composed modal</Button>
+      </div>
+      <ComposedModal
+        ref={localRef}
+        id="ts1"
+        open={open}
+        onClose={() => setOpen(false)}
+        kind={kind}
+        size={args.size}>
+        <ModalHeader label="Account resources" title="Add a custom domain" />
+        {influencer === 'start' ? (
+          <ModalInfluencer location="start">
+            This is often used for dividing content. Typically, but not limited
+            to, placement on the left side of the tearsheet, this space is
+            usually reserved for a menu, vertical progress indicator, or
+            filters. We advise not to use 2 influencers at the same time due to
+            the lack of available screen space.
+          </ModalInfluencer>
+        ) : (
+          ''
+        )}
+        <ModalBody>
+          <p style={{ marginBottom: '1rem' }}>
+            Custom domains direct requests for your apps in this Cloud Foundry
+            organization to a URL that you own. A custom domain can be a shared
+            domain, a shared subdomain, or a shared domain and host.
+          </p>
+          <TextInput
+            data-modal-primary-focus
+            id="text-input-1"
+            labelText="Domain name"
+            placeholder="e.g. github.com"
+            style={{ marginBottom: '1rem' }}
+          />
+          <Select id="select-1" defaultValue="us-south" labelText="Region">
+            <SelectItem value="us-south" text="US South" />
+            <SelectItem value="us-east" text="US East" />
+          </Select>
+
+          <Button onClick={() => setOpen2(true)}>Open 2</Button>
+        </ModalBody>
+        {influencer === 'end' ? (
+          <ModalInfluencer location="end">
+            This is often used for dividing content. Typically, but not limited
+            to, placement on the left side of the tearsheet, this space is
+            usually reserved for a menu, vertical progress indicator, or
+            filters. We advise not to use 2 influencers at the same time due to
+            the lack of available screen space.
+          </ModalInfluencer>
+        ) : (
+          ''
+        )}
+        <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
+      </ComposedModal>
+
+      <ComposedModal
+        id="ts2"
+        open={open2}
+        onClose={() => setOpen2(false)}
+        kind={kind}
+        size={args.size}>
+        <ModalHeader label="Account resources" title="Add a custom domain" />
+        <ModalBody>
+          <p style={{ marginBottom: '1rem' }}>
+            Custom domains direct requests for your apps in this Cloud Foundry
+            organization to a URL that you own. A custom domain can be a shared
+            domain, a shared subdomain, or a shared domain and host.
+          </p>
+          <TextInput
+            data-modal-primary-focus
+            id="text-input-1"
+            labelText="Domain name"
+            placeholder="e.g. github.com"
+            style={{ marginBottom: '1rem' }}
+          />
+          <Select id="select-1" defaultValue="us-south" labelText="Region">
+            <SelectItem value="us-south" text="US South" />
+            <SelectItem value="us-east" text="US East" />
+          </Select>
+        </ModalBody>
+        <ModalFooter primaryButtonText="Add" secondaryButtonText="Cancel" />
+      </ComposedModal>
+    </>
+  );
+};
+
+export const ModalTearsheetKind = {
+  parameters: {
+    controls: {
+      include: ['influencer ', 'kind ', 'size'],
+    },
+  },
+  argTypes: {
+    'influencer ': {
+      description: `Optional: influencer`,
+      control: {
+        type: 'select',
+        labels: {
+          0: 'start: influencer before content',
+          1: 'end: influencer after content',
+          2: 'No influencer.',
+        },
+      },
+      options: [0, 1, 2],
+      mapping: {
+        0: 'start',
+        1: 'end',
+        2: null,
+      },
+    },
+    'kind ': {
+      description: `Optional: kind property ('tearsheet')`,
+      control: {
+        type: 'select',
+        labels: {
+          0: 'tearsheet',
+          1: 'null - default modal kind',
+        },
+      },
+      options: [0, 1],
+      mapping: {
+        0: 'tearsheet',
+        1: null,
+      },
+    },
+  },
+  args: {
+    'kind ': 0,
+  },
+  render: (args) => {
+    return <ModalTearsheet {...args} />;
+  },
 };
 
 export const Playground = (args) => {

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.scss
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.scss
@@ -1,3 +1,34 @@
+@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+
+#storybook-root {
+  &:not(:has(.sb-blank-header)) {
+    --#{$prefix}-modal-kind-side-inset-start: 0rem;
+  }
+}
+
 .sb-notification p {
   line-height: 1;
+}
+
+.sb-blank-header {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  padding-inline-start: $spacing-05;
+  top: 0;
+  left: 0;
+  background-color: $background-inverse;
+  color: $text-inverse;
+  width: 100%;
+  height: $spacing-09;
+}
+
+.sb-page-content {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  height: 50vh;
+  width: 100%;
 }

--- a/packages/react/src/components/ComposedModal/ModalInfluencer.tsx
+++ b/packages/react/src/components/ComposedModal/ModalInfluencer.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright IBM Corp. 2016, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { type ReactNode, type HTMLAttributes } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { usePrefix } from '../../internal/usePrefix';
+
+type DivProps = HTMLAttributes<HTMLDivElement>;
+export interface ModalInfluencerProps extends DivProps {
+  /**
+   * Specify the content to be placed in the ModalInfluencer
+   */
+  children?: ReactNode;
+
+  /**
+   * Specify an optional className to be applied to the modal influencer
+   */
+  className?: string;
+
+  /**
+   * Specify an optional location for the influencer
+   */
+  location: 'start' | 'end';
+}
+
+export const ModalInfluencer = React.forwardRef<
+  HTMLDivElement,
+  ModalInfluencerProps
+>(function ModalInfluencer(
+  { children, className: customClassName, location, ...rest },
+  ref
+) {
+  const prefix = usePrefix();
+
+  const influencerClass = cx(
+    `${prefix}--modal-influencer ${prefix}--modal-influencer--${location}`,
+    customClassName
+  );
+
+  return (
+    <div className={influencerClass} {...rest} ref={ref}>
+      {children}
+    </div>
+  );
+});
+
+ModalInfluencer.propTypes = {
+  /**
+   * Specify the content to be placed in the ModalInfluencer
+   */
+  children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to the modal influencer
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify an optional location for the influencer
+   */
+  location: PropTypes.oneOf(['start', 'end']),
+};

--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:list';
 @use '../button';
 @use '../../config' as *;
 @use '../../breakpoint' as *;
@@ -18,6 +19,32 @@
 @use '../../utilities/focus-outline' as *;
 @use '../../utilities/high-contrast-mode' as *;
 @use '../../utilities/z-index' as *;
+
+@mixin modal-kind-tearsheet {
+  align-items: flex-end;
+
+  .#{$prefix}--modal-container {
+    block-size: 100%;
+    max-block-size: calc(100% - #{$spacing-11});
+    transform: translate3d(0, calc(min(95vh, 500px)), 0);
+  }
+
+  &.#{$prefix}--modal__influencer--start .#{$prefix}--modal-container {
+    grid-template-areas: 'header header' 'influencer content' 'influencer footer';
+    grid-template-columns: minmax(25%, 200px) 1fr;
+  }
+
+  &.#{$prefix}--modal__influencer--end .#{$prefix}--modal-container {
+    grid-template-areas: 'header header' 'content influencer' 'footer footer';
+    grid-template-columns: 1fr minmax(25%, 200px);
+  }
+
+  .#{$prefix}--modal-influencer {
+    padding: $spacing-05;
+    background-color: $background;
+    grid-area: influencer;
+  }
+}
 
 /// Modal styles
 /// @access public
@@ -158,7 +185,7 @@
     display: grid;
     background-color: $layer;
     block-size: 100%;
-    grid-template-columns: 100%;
+    grid-template-areas: 'header' 'content' 'footer';
     grid-template-rows: auto 1fr auto;
     inline-size: 100%;
     inset-block-start: 0;
@@ -200,8 +227,7 @@
     position: relative;
     color: $text-primary;
     font-weight: 400;
-    grid-column: 1/-1;
-    grid-row: 2/-2;
+    grid-area: content;
     overflow-y: auto;
     padding-block-end: $spacing-09;
     // Required to accommodate focus outline's negative offset:
@@ -240,8 +266,7 @@
   // Modal header
   // -----------------------------
   .#{$prefix}--modal-header {
-    grid-column: 1/-1;
-    grid-row: 1/1;
+    grid-area: header;
     margin-block-end: $spacing-03;
     padding-block-start: $spacing-05;
     padding-inline-end: $spacing-09;
@@ -373,8 +398,7 @@
     display: flex;
     justify-content: flex-end;
     block-size: convert.to-rem(64px);
-    grid-column: 1/-1;
-    grid-row: -1/-1;
+    grid-area: footer;
     margin-block-start: auto;
   }
 
@@ -517,4 +541,8 @@
     @include high-contrast-mode('focus');
   }
   /* stylelint-enable no-duplicate-selectors */
+
+  .#{$prefix}--modal--kind-tearsheet {
+    @include modal-kind-tearsheet();
+  }
 }


### PR DESCRIPTION
An experiment to see what a SidePanel Modal might look like as a stylised version of the ComposedModal.

Following on from the AI work to create Web Component versions of @carbon/ibm-products/SidePanel and Tearsheet it appeared that SidePanel is similar to a ComposedModal in many ways.

This PR adds a single property kind to the Composed modal and uses styling SCSS to achieve most of the implementation. It is intended to spark a discussion about where the base Tearsheet component should live and what it should look like. This implementation does not consider usage of the stacking Tearsheet use case.

Guidance on usage of SidePanel https://pages.github.ibm.com/cdai-design/pal/components/tearsheet/usage

Changelog
Changed

ComposedModal properties and additional styling