### PR TITLE
Added hideLabel to Dropdown family

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2990,6 +2990,9 @@ Map {
       "className": Object {
         "type": "string",
       },
+      "hideLabel": Object {
+        "type": "bool",
+      },
       "size": Object {
         "args": Array [
           Array [

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
@@ -13,12 +13,26 @@ import { usePrefix } from '../../internal/usePrefix';
 import { ReactAttr } from '../../types/common';
 
 export interface DropdownSkeletonProps extends ReactAttr<HTMLDivElement> {
+  /**
+   * Specify an optional className to add.
+   */
+  className?: string;
+
+  /**
+   * Specify whether the label should be hidden, or not
+   */
+  hideLabel?: boolean;
+
+  /**
+   * Specify the size of the ListBox.
+   */
   size?: ListBoxSize;
 }
 
 const DropdownSkeleton: React.FC<DropdownSkeletonProps> = ({
   className,
   size,
+  hideLabel,
   ...rest
 }: DropdownSkeletonProps) => {
   const prefix = usePrefix();
@@ -36,7 +50,9 @@ const DropdownSkeleton: React.FC<DropdownSkeletonProps> = ({
   return (
     <div className={wrapperClasses} {...rest}>
       <div className={`${prefix}--list-box__field`}>
-        <span className={`${prefix}--list-box__label`} />
+        {!hideLabel && (
+          <span className={`${prefix}--list-box__label ${prefix}--skeleton`} />
+        )}
       </div>
     </div>
   );
@@ -47,6 +63,11 @@ DropdownSkeleton.propTypes = {
    * Specify an optional className to add.
    */
   className: PropTypes.string,
+
+  /**
+   * Specify whether the label should be hidden, or not
+   */
+  hideLabel: PropTypes.bool,
 
   /**
    * Specify the size of the ListBox.

--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
@@ -39,8 +39,6 @@ const DropdownSkeleton: React.FC<DropdownSkeletonProps> = ({
   const wrapperClasses = cx(
     className,
     `${prefix}--skeleton`,
-    `${prefix}--dropdown-v2`,
-    `${prefix}--list-box`,
     `${prefix}--form-item`,
     {
       [`${prefix}--list-box--${size}`]: size,
@@ -49,11 +47,10 @@ const DropdownSkeleton: React.FC<DropdownSkeletonProps> = ({
 
   return (
     <div className={wrapperClasses} {...rest}>
-      <div className={`${prefix}--list-box__field`}>
-        {!hideLabel && (
-          <span className={`${prefix}--list-box__label ${prefix}--skeleton`} />
-        )}
-      </div>
+      {!hideLabel && (
+        <span className={`${prefix}--label ${prefix}--skeleton`} />
+      )}
+      <div className={`${prefix}--skeleton ${prefix}--dropdown`} />
     </div>
   );
 };


### PR DESCRIPTION
Closes #15853

Added `hideLabel` prop to Dropdown Skeleton. This will avoid the page to jump when loading if the user does not have a label added to the Dropdown or any of it's variants.

#### Testing / Reviewing

- Check if the Dropdown Skeleton is working as expected.