### PR TITLE
fix(RadioButton): fix issue with print preview with Radio + Checkbox

### DIFF
--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -76,6 +76,10 @@
   .#{$prefix}--checkbox-label::before,
   .#{$prefix}--checkbox-label::after {
     box-sizing: border-box;
+
+    @media print {
+      print-color-adjust: exact;
+    }
   }
 
   // Spacing for presentational checkbox

--- a/packages/styles/scss/components/radio-button/_radio-button.scss
+++ b/packages/styles/scss/components/radio-button/_radio-button.scss
@@ -123,6 +123,10 @@ $radio-border-width: 1px !default;
       @include high-contrast-mode('icon-fill') {
         background-color: ButtonText;
       }
+
+      @media print {
+        print-color-adjust: exact;
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/15894

Fixes an issue with `RadioButton` and `Checkbox` pseudo-elements not appearing when print preview is shown

#### Changelog

**New**

- Added a print-specific media query to ensure these elements appear


#### Testing / Reviewing

Go to Checkbox (and select one) and RadioButton and ensure they show up when you open print preview (<kbd>⌘</kbd>+<kbd>P</kbd>)
