### PR TITLE
fix(example): update class-prefix to use proper font path for vite

### DIFF
--- a/examples/class-prefix/src/index.scss
+++ b/examples/class-prefix/src/index.scss
@@ -1,3 +1,4 @@
 @use '@carbon/react' with (
+  $font-path: '@ibm/plex',
   $prefix: 'custom'
 );


### PR DESCRIPTION
When I ran a `yarn build` I saw output in the console about this that should be fixed by properly setting the font path. Vite doesn't need the tilde `~`