### PR TITLE
fix: fixed datatable hover with Toggletip

### DIFF
--- a/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
@@ -29,8 +29,11 @@ import DataTable, {
   TableToolbarMenu,
 } from '..';
 
+import { Toggletip, ToggletipButton, ToggletipContent } from '../../Toggletip';
+
 import { batchActionClick, rows, headers } from './shared';
 import mdx from '../DataTable.mdx';
+import Link from '../../Link';
 
 export default {
   title: 'Components/DataTable/Batch Actions',
@@ -282,6 +285,62 @@ export const Playground = (args) => (
         </TableContainer>
       );
     }}
+  </DataTable>
+);
+
+export const Test = () => (
+  <DataTable
+    headers={[
+      {
+        key: 'demo',
+        header: 'Demo',
+      },
+    ]}
+    rows={[{ demo: 'Trigger' }]}>
+    {({
+      rows,
+      headers,
+      getHeaderProps,
+      getRowProps,
+      getTableProps,
+      getTableContainerProps,
+    }) => (
+      <TableContainer {...getTableContainerProps()}>
+        <Table {...getTableProps()}>
+          <TableHead>
+            <TableRow>
+              {headers.map((header) => (
+                <TableHeader key={1} {...getHeaderProps({ header })}>
+                  {header.header}
+                </TableHeader>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row} {...getRowProps({ row })}>
+                {row.cells.map((cell) => (
+                  <TableCell key={row}>
+                    <Toggletip defaultOpen align="right">
+                      <ToggletipButton>{cell.value}</ToggletipButton>
+                      <ToggletipContent>
+                        <p>
+                          Lorem ipsum dolor{' '}
+                          <Link href="www.google.com" inline>
+                            sit amet
+                          </Link>
+                          .
+                        </p>
+                      </ToggletipContent>
+                    </Toggletip>
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    )}
   </DataTable>
 );
 

--- a/packages/react/src/components/Toggletip/Toggletip.stories.js
+++ b/packages/react/src/components/Toggletip/Toggletip.stories.js
@@ -17,6 +17,15 @@ import {
   ToggletipActions,
 } from '../Toggletip';
 import mdx from './Toggletip.mdx';
+import DataTable, {
+  TableContainer,
+  Table,
+  TableHeader,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '../DataTable';
 
 export default {
   title: 'Components/Toggletip',
@@ -127,6 +136,62 @@ const PlaygroundStory = (controls) => {
     </>
   );
 };
+
+export const Test = () => (
+  <DataTable
+    headers={[
+      {
+        key: 'demo',
+        header: 'Demo',
+      },
+    ]}
+    rows={[{ demo: 'Trigger' }]}>
+    {({
+      rows,
+      headers,
+      getHeaderProps,
+      getRowProps,
+      getTableProps,
+      getTableContainerProps,
+    }) => (
+      <TableContainer {...getTableContainerProps()}>
+        <Table {...getTableProps()}>
+          <TableHead>
+            <TableRow>
+              {headers.map((header) => (
+                <TableHeader key={1} {...getHeaderProps({ header })}>
+                  {header.header}
+                </TableHeader>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row} {...getRowProps({ row })}>
+                {row.cells.map((cell) => (
+                  <TableCell key={row}>
+                    <Toggletip defaultOpen align="right">
+                      <ToggletipButton>{cell.value}</ToggletipButton>
+                      <ToggletipContent>
+                        <p>
+                          Lorem ipsum dolor{' '}
+                          <Link href="www.google.com" inline>
+                            sit amet
+                          </Link>
+                          .
+                        </p>
+                      </ToggletipContent>
+                    </Toggletip>
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    )}
+  </DataTable>
+);
 
 export const Playground = PlaygroundStory.bind({});
 

--- a/packages/react/src/components/Toggletip/Toggletip.stories.js
+++ b/packages/react/src/components/Toggletip/Toggletip.stories.js
@@ -17,15 +17,6 @@ import {
   ToggletipActions,
 } from '../Toggletip';
 import mdx from './Toggletip.mdx';
-import DataTable, {
-  TableContainer,
-  Table,
-  TableHeader,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
-} from '../DataTable';
 
 export default {
   title: 'Components/Toggletip',
@@ -136,62 +127,6 @@ const PlaygroundStory = (controls) => {
     </>
   );
 };
-
-export const Test = () => (
-  <DataTable
-    headers={[
-      {
-        key: 'demo',
-        header: 'Demo',
-      },
-    ]}
-    rows={[{ demo: 'Trigger' }]}>
-    {({
-      rows,
-      headers,
-      getHeaderProps,
-      getRowProps,
-      getTableProps,
-      getTableContainerProps,
-    }) => (
-      <TableContainer {...getTableContainerProps()}>
-        <Table {...getTableProps()}>
-          <TableHead>
-            <TableRow>
-              {headers.map((header) => (
-                <TableHeader key={1} {...getHeaderProps({ header })}>
-                  {header.header}
-                </TableHeader>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map((row) => (
-              <TableRow key={row} {...getRowProps({ row })}>
-                {row.cells.map((cell) => (
-                  <TableCell key={row}>
-                    <Toggletip defaultOpen align="right">
-                      <ToggletipButton>{cell.value}</ToggletipButton>
-                      <ToggletipContent>
-                        <p>
-                          Lorem ipsum dolor{' '}
-                          <Link href="www.google.com" inline>
-                            sit amet
-                          </Link>
-                          .
-                        </p>
-                      </ToggletipContent>
-                    </Toggletip>
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    )}
-  </DataTable>
-);
 
 export const Playground = PlaygroundStory.bind({});
 

--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -121,13 +121,16 @@
   }
 
   .#{$prefix}--data-table
-    + :not(.#{$prefix}--popover-container)
-    tr:hover
+    tr
+    + :not(.#{$prefix}--popover-container):hover
     .#{$prefix}--link {
     color: $link-secondary;
   }
 
-  .#{$prefix}--data-table tr:hover .#{$prefix}--link--disabled {
+  .#{$prefix}--data-table
+    tr
+    + :not(.#{$prefix}--popover-container):hover
+    .#{$prefix}--link--disabled {
     color: $text-disabled;
   }
 

--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -121,7 +121,7 @@
   }
 
   .#{$prefix}--data-table
-    + :not(.#{$prefix}--toggletip-content)
+    + :not(.#{$prefix}--popover-container)
     tr:hover
     .#{$prefix}--link {
     color: $link-secondary;

--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -120,7 +120,10 @@
     color: $text-primary;
   }
 
-  .#{$prefix}--data-table tr:hover .#{$prefix}--link {
+  .#{$prefix}--data-table
+    + :not(.#{$prefix}--toggletip-content)
+    tr:hover
+    .#{$prefix}--link {
     color: $link-secondary;
   }
 


### PR DESCRIPTION
Closes #15720

Added a CSS selector to avoid that the `Link` inside any popover family gets the hover change when hovering the `tr`. 
The Link hover still works on data tables where it uses the `Link` in a `tr`

#### Testing / Reviewing

- Go to `Datatable Batch Actions` stories and test the variant Test.

- [ ] Removed Test story