### PR TITLE
fix: fixed style in inline notification

### DIFF
--- a/packages/styles/scss/components/notification/_actionable-notification.scss
+++ b/packages/styles/scss/components/notification/_actionable-notification.scss
@@ -190,6 +190,16 @@
     opacity: 1;
   }
 
+  .#{$prefix}--actionable-notification--warning
+    .#{$prefix}--inline-notification__icon
+    path[opacity='0'],
+  .#{$prefix}--actionable-notification--warning-alt
+    .#{$prefix}--inline-notification__icon
+    path:first-of-type {
+    fill: $black-100;
+    opacity: 1;
+  }
+
   .#{$prefix}--actionable-notification__details {
     display: flex;
     flex-grow: 1;


### PR DESCRIPTION
Closes #15958

Changed the "!" to the dark color when lowContrast is true.

#### Testing / Reviewing

- Check for Percy changes
- Go to `Actionable Notification` Playground and change these props:
  - Inline = true
  - kind = warning
  - lowContrast = true