### PR TITLE
style(link): don't use visited color by default

### DIFF
--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -65,11 +65,11 @@ $link-focus-text-color: custom-property.get-var(
     }
 
     &:visited {
-      color: $link-visited-text-color;
+      color: $link-text-color;
     }
 
     &:visited:hover {
-      color: $link-visited-text-color;
+      color: $link-hover-text-color;
     }
   }
 


### PR DESCRIPTION
Ref #15790

Visited links should not render with the `$link-visited-text-color` token by default but only if opted in via the `visited` prop on the component (#5239). The v1.53.0 release included a regression.

#### Changelog

**Changed**

- Use normal, non-visited, link color on `:visited` selector
  - Keep visited color on `.cds--link--visited:visited` selector

#### Testing / Reviewing

Storybook
