### PR TITLE
fix(datepicker): reduced opacity to set disabled state for calendar icon

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1452,6 +1452,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "anjaly0606",
+      "name": "anjaly0606",
+      "avatar_url": "https://avatars.githubusercontent.com/u/99959496?v=4",
+      "profile": "https://github.com/anjaly0606",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/ggdawson"><img src="https://avatars.githubusercontent.com/u/37080130?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Garrett Dawson</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ggdawson" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=ggdawson" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/dedanade"><img src="https://avatars.githubusercontent.com/u/66811981?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Adebonojo</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=dedanade" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/mranjana"><img src="https://avatars.githubusercontent.com/u/91003483?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anjana M R</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mranjana" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/anjaly0606"><img src="https://avatars.githubusercontent.com/u/99959496?v=4?s=100" width="100px;" alt=""/><br /><sub><b>anjaly0606</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=anjaly0606" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -177,7 +177,7 @@
 
   .#{$prefix}--date-picker__input:disabled ~ .#{$prefix}--date-picker__icon {
     cursor: not-allowed;
-    opacity: 0.3;
+    fill: $icon-disabled;
   }
 
   .#{$prefix}--date-picker--range

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -177,6 +177,7 @@
 
   .#{$prefix}--date-picker__input:disabled ~ .#{$prefix}--date-picker__icon {
     cursor: not-allowed;
+    opacity: 0.3;
   }
 
   .#{$prefix}--date-picker--range


### PR DESCRIPTION
Closes   
#15983 

Added disabled state for datepicker and datepicker range calendar icon by icon disabled fill 

#### Changelog


**Changed**

- _date-picker.scss 
fill icon disabled



#### Testing / Reviewing

{{ Datepicker component }}
