### PR TITLE
fix: correct imports for custom data table state manager example

### DIFF
--- a/packages/react/examples/custom-data-table-state-manager-vite/src/components/CustomDataTable.jsx
+++ b/packages/react/examples/custom-data-table-state-manager-vite/src/components/CustomDataTable.jsx
@@ -18,7 +18,7 @@ import {
   TableToolbarMenu,
   TableBatchActions,
   TableBatchAction,
-} from 'carbon-components-react';
+} from '@carbon/react';
 import {
   useFilteredRows,
   usePageInfo,

--- a/packages/react/examples/custom-data-table-state-manager-vite/src/components/Pagination.jsx
+++ b/packages/react/examples/custom-data-table-state-manager-vite/src/components/Pagination.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
-import { Pagination as CarbonPagination } from 'carbon-components-react';
+import { Pagination as CarbonPagination } from '@carbon/react';
 
 /**
  * Wrapped version of Carbon `<Pagination>`, that uses zero-based starting row


### PR DESCRIPTION
Follow up to https://github.com/carbon-design-system/carbon/pull/15275 - these invalid imports prevent the example from running within Stackblitz.

#### Changelog

**Changed**

- changed imports from `carbon-components-react` to `@carbon/react`