### PR TITLE
fix(treeview): don't overwrite disabled=true state for children

### DIFF
--- a/packages/react/src/components/TreeView/TreeNode.js
+++ b/packages/react/src/components/TreeView/TreeNode.js
@@ -62,7 +62,7 @@ const TreeNode = React.forwardRef(
         return React.cloneElement(node, {
           active,
           depth: depth + 1,
-          disabled,
+          disabled: disabled || node.props.disabled,
           onTreeSelect,
           selected,
           tabIndex: (!node.props.disabled && -1) || null,

--- a/packages/react/src/components/TreeView/Treeview.stories.js
+++ b/packages/react/src/components/TreeView/Treeview.stories.js
@@ -262,3 +262,12 @@ Playground.argTypes = {
     control: { type: 'select' },
   },
 };
+
+export const Temp = () => (
+  <TreeView label="Tree View">
+    <TreeNode label="Enabled">
+      <TreeNode label="Disabled" disabled />
+    </TreeNode>
+    <TreeNode label="Disabled" disabled></TreeNode>
+  </TreeView>
+);


### PR DESCRIPTION
Currently, when a `TreeNode` is a child of another `TreeNode`, its disabled state is overwritten by the parent node.
This means you cannot disable a node when the parent is enabled.

Reproduction: https://stackblitz.com/edit/github-3sknv6?file=src%2FApp.jsx

This PR implements a fix that creates the following behavior:
 - A child node can be disabled if the parent node is enabled
 - A child node is always disabled if the parent node is disabled

Please let me know if you don't agree with this!

#### Changelog

**Changed**

- Don't overwrite `props.disabled` of the child node unless the parent node is disabled itself

#### Testing / Reviewing

- Storybook (story: "Temp")  **←   ⚠️This needs to be removed before merging**⚠️ 
- Automated testing
