### PR TITLE
style(DataTable): scope ai gradient styles to slug rows

### DIFF
--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -1003,7 +1003,7 @@
   .#{$prefix}--data-table tbody tr.#{$prefix}--data-table--slug-row:hover,
   tr.#{$prefix}--data-table--slug-row:hover
     + .#{$prefix}--expandable-row[data-child-row],
-  tr.#{$prefix}--expandable-row--hover
+  tr.#{$prefix}--data-table--slug-row.#{$prefix}--expandable-row--hover
     + .#{$prefix}--expandable-row[data-child-row]:hover,
   tr.#{$prefix}--expandable-row--hover.#{$prefix}--data-table--slug-row,
   tr.#{$prefix}--data-table--selected.#{$prefix}--parent-row.#{$prefix}--expandable-row--hover.#{$prefix}--data-table--slug-row {


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon/issues/16023

Fixes an issue where AI styles were being displayed when the `slug` was not provided

#### Changelog

**Changed**

- Scopes selector to only rows with `slug`


#### Testing / Reviewing

Ensure AI `DataTable` still renders as expected 
