### PR TITLE
feat(sidenavmenu): support optional collapse with sideNav

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1470,6 +1470,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "navargas",
+      "name": "Nicholas Vargas",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8397737?v=4",
+      "profile": "https://github.com/navargas",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/mranjana"><img src="https://avatars.githubusercontent.com/u/91003483?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anjana M R</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mranjana" title="Code">💻</a></td>
     <td align="center"><a href="https://cuppajoey.com/"><img src="https://avatars.githubusercontent.com/u/14837881?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joseph Schultz</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=cuppajoey" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/anjaly0606"><img src="https://avatars.githubusercontent.com/u/99959496?v=4?s=100" width="100px;" alt=""/><br /><sub><b>anjaly0606</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=anjaly0606" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/navargas"><img src="https://avatars.githubusercontent.com/u/8397737?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nicholas Vargas</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=navargas" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=navargas" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/UIShell/SideNavMenu.tsx
+++ b/packages/react/src/components/UIShell/SideNavMenu.tsx
@@ -12,6 +12,7 @@ import React, {
   ForwardedRef,
   ReactNode,
   Ref,
+  useEffect,
   useContext,
   useState,
 } from 'react';
@@ -57,6 +58,11 @@ interface SideNavMenuProps {
   isSideNavExpanded?: boolean;
 
   /**
+   * Specifies if the SideNavMenu should collapse when the SideNav does
+   */
+  collapseWithSideNav?: boolean;
+
+  /**
    * The tabIndex for the button element.
    * If not specified, the default validation will be applied.
    */
@@ -75,6 +81,7 @@ const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
       defaultExpanded = false,
       isActive = false,
       large = false,
+      collapseWithSideNav = false,
       renderIcon: IconElement,
       isSideNavExpanded,
       tabIndex,
@@ -93,6 +100,13 @@ const SideNavMenu = React.forwardRef<HTMLElement, SideNavMenuProps>(
       [`${prefix}--side-nav__item--large`]: large,
       [customClassName as string]: !!customClassName,
     });
+
+    // When collapseWithSideNav is enabled, set isExpanded to false with isSideNavExpanded
+    useEffect(() => {
+      if (collapseWithSideNav && !isSideNavExpanded && isExpanded) {
+        setIsExpanded(false);
+      }
+    }, [isSideNavExpanded, collapseWithSideNav, isExpanded]);
 
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions

--- a/packages/react/src/components/UIShell/UIShell.SideNav.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.SideNav.stories.js
@@ -431,7 +431,10 @@ export const SideNavRailWHeader = (args) => (
                   </HeaderMenu>
                 </HeaderSideNavItems>
               )}
-              <SideNavMenu renderIcon={Fade} title="Category title">
+              <SideNavMenu
+                collapseWithSideNav={args.collapseWithSideNav}
+                renderIcon={Fade}
+                title="Category title">
                 <SideNavMenuItem href="https://www.carbondesignsystem.com/">
                   Link
                 </SideNavMenuItem>
@@ -442,7 +445,10 @@ export const SideNavRailWHeader = (args) => (
                   Link
                 </SideNavMenuItem>
               </SideNavMenu>
-              <SideNavMenu renderIcon={Fade} title="Category title">
+              <SideNavMenu
+                collapseWithSideNav={args.collapseWithSideNav}
+                renderIcon={Fade}
+                title="Category title">
                 <SideNavMenuItem href="https://www.carbondesignsystem.com/">
                   Link
                 </SideNavMenuItem>
@@ -455,7 +461,10 @@ export const SideNavRailWHeader = (args) => (
                   Link
                 </SideNavMenuItem>
               </SideNavMenu>
-              <SideNavMenu renderIcon={Fade} title="Category title">
+              <SideNavMenu
+                collapseWithSideNav={args.collapseWithSideNav}
+                renderIcon={Fade}
+                title="Category title">
                 <SideNavMenuItem href="https://www.carbondesignsystem.com/">
                   Link
                 </SideNavMenuItem>
@@ -496,6 +505,16 @@ SideNavRailWHeader.argTypes = {
     },
     description:
       "Optional prop to display the side nav rail. It doesn't work along side with `isFixedNav` prop.",
+  },
+  collapseWithSideNav: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
+    description: 'Optional prop to collapse menus when the side nav closes.',
   },
   isFixedNav: {
     control: {


### PR DESCRIPTION
Closes #15900 

SideNav currently shows an empty space when a menu item without an icon is active, and the side nav is collapsed in rail mode.

<img width="304" alt="316735853-bfeb332f-315b-426f-af68-a593d441e9f7" src="https://github.com/carbon-design-system/carbon/assets/8397737/a250e351-3a04-4ceb-a124-a86967e40a2f">

This PR adds an optional SideNavMenu prop `collapseWithSideNav`. When true, the menus collapse when the side nav does.

#### Changelog

**New**

- Optional SideNavMenu prop `collapseWithSideNav`

**Changed**

- Added option to SideNav rail mode storybook

**Removed**

- n/a

#### Testing / Reviewing

Navigate to the side nav rail page:

http://localhost:3000/?path=/story/components-ui-shell-sidenav--side-nav-rail-w-header&args=collapseWithSideNav:!true

<img width="1235" alt="Screenshot" src="https://github.com/carbon-design-system/carbon/assets/8397737/8597626c-e74a-476b-98d6-258c5ce651f7">

After toggling to `true`, you can open a menu, or multiple menus. When the side nav closes, you can verify that the menus close as well.

<img width="283" alt="Screenshot" src="https://github.com/carbon-design-system/carbon/assets/8397737/d3d66000-7669-4c02-9a2c-cfabb11e71f5">

<img width="284" alt="Screenshot 1" src="https://github.com/carbon-design-system/carbon/assets/8397737/920fa9f7-844a-4e7d-99a0-46bed60dc71e">


