### PR TITLE
fix: tab-tip-expanded-closed-a11y

### DIFF
--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -98,6 +98,7 @@ export const TabTip = () => {
         <button
           aria-label="Settings"
           type="button"
+          aria-expanded={open}
           onClick={() => {
             setOpen(!open);
           }}>
@@ -134,6 +135,7 @@ export const TabTip = () => {
         <button
           aria-label="Settings"
           type="button"
+          aria-expanded={open}
           onClick={() => {
             setOpenTwo(!openTwo);
           }}>
@@ -150,7 +152,7 @@ export const TabTip = () => {
           </RadioButtonGroup>
           <hr />
           <fieldset className={`${prefix}--fieldset`}>
-            <legend className={`${prefix}--label`}>Edit columns</legend>
+            <legend className={`${prefix}--label`}>Testing</legend>
             <Checkbox defaultChecked labelText="Name" id="checkbox-label-8" />
             <Checkbox defaultChecked labelText="Type" id="checkbox-label-9" />
             <Checkbox


### PR DESCRIPTION
Closes #14824 

Added `aria-expanded` to `Tabtip`

#### Testing / Reviewing

- Navigate to `Tabtip` storybook and make sure using a screen reader that the expanded / collapsed is being announced as seen below

<img width="900" alt="Screenshot 2024-04-03 at 15 55 17" src="https://github.com/carbon-design-system/carbon/assets/32720851/02a1497c-f26e-4151-b16f-13fec4d10aff">

