### PR TITLE
fix: combobx ref bug

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -24,7 +24,7 @@ import React, {
   type ReactElement,
   type RefAttributes,
   type PropsWithChildren,
-  type PropsWithoutRef,
+  type PropsWithRef,
   type InputHTMLAttributes,
   type MouseEvent,
   type KeyboardEvent,
@@ -999,7 +999,7 @@ ComboBox.propTypes = {
   warnText: PropTypes.node,
 };
 
-type ComboboxComponentProps<ItemType> = PropsWithoutRef<
+type ComboboxComponentProps<ItemType> = PropsWithRef<
   PropsWithChildren<ComboBoxProps<ItemType>> & RefAttributes<HTMLInputElement>
 >;
 


### PR DESCRIPTION
Closes #14756

worked on this with @riddhybansal 🎉 
 
 - Update the ability to pass in `ref` in `ComboBox`
 
 ### Testing 
- Import `ComboBox` into a `.tsx` file and pass in the `ref` attribute - should no longer show an error as seen below
<img width="1080" alt="Screenshot 2024-04-04 at 09 20 03" src="https://github.com/carbon-design-system/carbon/assets/32720851/443c1a0e-7838-4139-a396-154e7906953b">
