### PR TITLE
Fixed `Toggle` aria-labelledby

### DIFF
--- a/packages/react/src/components/Toggle/Toggle.stories.js
+++ b/packages/react/src/components/Toggle/Toggle.stories.js
@@ -17,8 +17,7 @@ export default {
 
 export const Default = () => (
   <Toggle
-    // labelText="Toggle element label"
-    aria-label="aaa"
+    labelText="Toggle element label"
     labelA="Off"
     labelB="On"
     defaultToggled

--- a/packages/react/src/components/Toggle/Toggle.stories.js
+++ b/packages/react/src/components/Toggle/Toggle.stories.js
@@ -92,9 +92,9 @@ export const WithAccessibleLabels = () => (
 
     <div>
       <div id="toggle-6-label" style={{ marginBlockEnd: '0.5rem' }}>
-        External toggle label
+        Internal aria-label toggle
       </div>
-      <Toggle aria-label="aria-label toggle label" id="toggle-6" hideLabel />
+      <Toggle aria-label="Internal aria-label toggle" id="toggle-6" hideLabel />
     </div>
 
     <div>

--- a/packages/react/src/components/Toggle/Toggle.stories.js
+++ b/packages/react/src/components/Toggle/Toggle.stories.js
@@ -17,7 +17,8 @@ export default {
 
 export const Default = () => (
   <Toggle
-    labelText="Toggle element label"
+    // labelText="Toggle element label"
+    aria-label="aaa"
     labelA="Off"
     labelB="On"
     defaultToggled
@@ -93,7 +94,7 @@ export const WithAccessibleLabels = () => (
       <div id="toggle-6-label" style={{ marginBlockEnd: '0.5rem' }}>
         External toggle label
       </div>
-      <Toggle id="toggle-6" hideLabel />
+      <Toggle aria-label="aria-label toggle label" id="toggle-6" hideLabel />
     </div>
 
     <div>

--- a/packages/react/src/components/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Toggle/Toggle.tsx
@@ -191,7 +191,7 @@ export function Toggle({
         role="switch"
         type="button"
         aria-checked={checked}
-        aria-labelledby={ariaLabelledby ?? (labelText ? labelId : '')}
+        aria-labelledby={ariaLabelledby ?? (labelText ? labelId : undefined)}
         disabled={disabled}
         onClick={handleClick}
       />

--- a/packages/react/src/components/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Toggle/Toggle.tsx
@@ -191,7 +191,7 @@ export function Toggle({
         role="switch"
         type="button"
         aria-checked={checked}
-        aria-labelledby={ariaLabelledby ?? labelId}
+        aria-labelledby={ariaLabelledby ?? (labelText ? labelId : '')}
         disabled={disabled}
         onClick={handleClick}
       />


### PR DESCRIPTION
Closes #16055

`aria-labelledby` is being set empty when there is no label for reference.

#### Changelog

#### Testing / Reviewing

- Test with VO or inspect the `Toggle` button to check the attributes.