### PR TITLE
fix(tag): increase disabled selector specificity

### DIFF
--- a/packages/styles/scss/components/tag/_tag.scss
+++ b/packages/styles/scss/components/tag/_tag.scss
@@ -258,12 +258,13 @@
     outline-offset: -1px;
   }
 
-  .#{$prefix}--tag--disabled,
+  .#{$prefix}--tag--disabled:not(.#{$prefix}--tag--operational),
   .#{$prefix}--tag--filter.#{$prefix}--tag--disabled,
   .#{$prefix}--tag--interactive.#{$prefix}--tag--disabled {
     @include tag-theme($layer, $text-disabled);
 
     box-shadow: none;
+    outline: none;
 
     &:hover {
       cursor: not-allowed;


### PR DESCRIPTION
Because of selector specificity, the `high-contrast` and `outline` variant of the `<Tag>` currently don't support a disabled state.

#### Changelog

**Changed**

- Increased selector specificity
- Reset `outline` property in addition to `box-shadow`

#### Testing / Reviewing

- Storybook → Tag → Playground → disabled: true; type: high-contrast
- Storybook → Tag → Playground → disabled: true; type: outline
