### PR TITLE
fix(DataTable): backport #13236 to v10

### DIFF
--- a/packages/react/src/components/DataTable/tools/sorting.js
+++ b/packages/react/src/components/DataTable/tools/sorting.js
@@ -86,6 +86,7 @@ export const sortRows = ({
       locale,
       sortStates,
       compare,
+      rowIds: [a, b],
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16158

Backports `DataTable` fix to `v10`

#### Testing / Reviewing

Ensure there are no regressions
