### PR TITLE
fix(icons): correct type export for CarbonIcon

### DIFF
--- a/packages/icon-build-helpers/src/builders/react/next/typescript.js
+++ b/packages/icon-build-helpers/src/builders/react/next/typescript.js
@@ -78,7 +78,7 @@ async function writeIndex(buckets, outDir) {
     templates.banner +
     '\n' +
     "export { default as Icon } from './Icon';\n" +
-    "export { CarbonIconProps, CarbonIconType } from './CarbonIcon';\n" +
+    "export type { CarbonIconProps, CarbonIconType } from './CarbonIcon';\n" +
     bucketModules.map((path) => "export * from './" + path + "';").join('\n') +
     '\n';
   await fs.writeFile(path.resolve(outDir, 'index.d.ts'), indexContent);


### PR DESCRIPTION
Followup to https://github.com/carbon-design-system/carbon/pull/15979/files

This should fix an error we're seeing on the website where

```
Can't resolve './CarbonIcon' in '/vercel/path0/node_modules/@carbon/icons-react/lib'
```

#### Changelog

**Changed**

- update icon builder to properly export CarbonIcon types

#### Testing / Reviewing

- I think the only way to reliably test this fix is to merge this and push it out in a prerelease to test it against the website updates @alisonjoseph is making
