### PR TITLE
fix(headermenu): headermenu typing corrected

### DIFF
--- a/packages/react/src/components/UIShell/HeaderMenu.tsx
+++ b/packages/react/src/components/UIShell/HeaderMenu.tsx
@@ -375,8 +375,8 @@ class HeaderMenu extends React.Component<HeaderMenuProps, HeaderMenuState> {
   };
 }
 
-const HeaderMenuForwardRef = React.forwardRef((props, ref) => {
-  return <HeaderMenu menuLinkName="link" {...props} focusRef={ref} />;
+const HeaderMenuForwardRef = React.forwardRef((props: HeaderMenuProps, ref) => {
+  return <HeaderMenu {...props} focusRef={ref} />;
 });
 
 HeaderMenuForwardRef.displayName = 'HeaderMenu';


### PR DESCRIPTION
Closes #16181 

HeaderMenu typing has been inferred to the forwardRef props

#### Changelog

**New**

- No new code added

**Changed**

- Added HeaderMenuProps typing to the fowardRef props

**Removed**

- removed menuLinkName prop from the forwardRef HeaderMenu component

#### Testing / Reviewing

Test with tsx preferred.
