### PR TITLE
Added coverage report for `.tsx` files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   preset: 'jest-config-carbon',
   collectCoverageFrom: [
     'packages/**/src/**/*.js',
+    'packages/**/src/**/*.tsx',
     '!packages/{cli,components}/**',
     '!packages/**/{examples,stories}/**',
     '!**/*-story.js',


### PR DESCRIPTION
This issue adds the coverage for files with `.tsx`.

If you reproduce the steps below on "Testing / Reviewing" you will no see `.tsx` files in the coverage report.

**New**

- Collecting coverage for `.tsx` files

#### Testing / Reviewing

- Run `yarn test --coverage`
- Open the `index.html` in the coverage folder that was created
- There are `.tsx` files there on the coverage report