### PR TITLE
feat: proposal for system color preferences

### DIFF
--- a/packages/react/src/components/Theme/Theme-story.scss
+++ b/packages/react/src/components/Theme/Theme-story.scss
@@ -9,6 +9,8 @@
 @use '@carbon/styles/scss/theme';
 
 .theme-section {
+  display: flex;
+  gap: 1rem;
   padding: 1rem;
   background: theme.$background;
   color: theme.$text-primary;

--- a/packages/react/src/components/Theme/Theme.stories.js
+++ b/packages/react/src/components/Theme/Theme.stories.js
@@ -68,6 +68,38 @@ export const Default = () => {
           <p>white theme</p>
         </section>
       </Theme>
+      <Theme theme="system-white-g90">
+        <section className="theme-section">
+          <p>System preferences white/g90 themes</p>
+          <Theme theme="system-white-g90" compliment>
+            <p>&nbsp;Compliment of system theme&nbsp;</p>
+          </Theme>
+        </section>
+      </Theme>
+      <Theme theme="system-white-g100">
+        <section className="theme-section">
+          <p>System preferences white/g100 themes</p>
+          <Theme theme="system-white-g100" compliment>
+            <p>&nbsp;Compliment of system theme&nbsp;</p>
+          </Theme>
+        </section>
+      </Theme>
+      <Theme theme="system-g10-g90">
+        <section className="theme-section">
+          <p>System preferences g10/g90 themes</p>
+          <Theme theme="system-g10-g90" compliment>
+            <p>&nbsp;Compliment of system theme&nbsp;</p>
+          </Theme>
+        </section>
+      </Theme>
+      <Theme theme="system-g10-g100">
+        <section className="theme-section">
+          <p>System preferences g10/g100 themes</p>
+          <Theme theme="system-g10-g100" compliment>
+            <p>&nbsp;Compliment of system theme&nbsp;</p>
+          </Theme>
+        </section>
+      </Theme>
     </>
   );
 };
@@ -114,6 +146,11 @@ const PlaygroundStory = (args) => {
     <Theme {...args}>
       <section className="theme-section">
         <p>{args.theme} theme</p>
+        {args.theme.startsWith('system') ? (
+          <Theme {...args} compliment>
+            <p>&nbsp;Compliment of system theme&nbsp;</p>
+          </Theme>
+        ) : null}
       </section>
     </Theme>
   );

--- a/packages/react/src/components/Theme/index.tsx
+++ b/packages/react/src/components/Theme/index.tsx
@@ -13,8 +13,17 @@ import { PolymorphicProps } from '../../types/common';
 import { LayerContext } from '../Layer/LayerContext';
 
 interface GlobalThemeProps {
-  theme?: 'white' | 'g10' | 'g90' | 'g100';
+  theme?:
+    | 'white'
+    | 'g10'
+    | 'g90'
+    | 'g100'
+    | 'system-white-g90'
+    | 'system-white-g100'
+    | 'system-g10-g90'
+    | 'system-g10-g100';
   children?: React.ReactNode;
+  compliment?: boolean;
 }
 
 export const ThemeContext = React.createContext<GlobalThemeProps>({
@@ -50,10 +59,22 @@ GlobalTheme.propTypes = {
    */
   children: PropTypes.node,
 
+  /** select the compliment of a system theme */
+  compliment: PropTypes.bool,
+
   /**
    * Specify the global theme for your app
    */
-  theme: PropTypes.oneOf(['white', 'g10', 'g90', 'g100']),
+  theme: PropTypes.oneOf([
+    'white',
+    'g10',
+    'g90',
+    'g100',
+    'system-white-g90',
+    'system-white-g100',
+    'system-g10-g90',
+    'system-g10-g100',
+  ]),
 };
 
 type ThemeBaseProps = GlobalThemeProps & {
@@ -68,6 +89,7 @@ type ThemeProps<E extends ElementType> = PolymorphicProps<E, ThemeBaseProps>;
 export function Theme<E extends ElementType = 'div'>({
   as: BaseComponent = 'div' as E,
   className: customClassName,
+  compliment,
   theme,
   ...rest
 }: ThemeProps<E>) {
@@ -77,6 +99,18 @@ export function Theme<E extends ElementType = 'div'>({
     [`${prefix}--g10`]: theme === 'g10',
     [`${prefix}--g90`]: theme === 'g90',
     [`${prefix}--g100`]: theme === 'g100',
+    [`${prefix}--system-white-g90`]: theme === 'system-white-g90',
+    [`${prefix}--system-white-g100`]: theme === 'system-white-g100',
+    [`${prefix}--system-g10-g90`]: theme === 'system-g10-g90',
+    [`${prefix}--system-g10-g100`]: theme === 'system-g10-g100',
+    [`${prefix}--system-white-g90--compliment`]:
+      theme === 'system-white-g90' && compliment,
+    [`${prefix}--system-white-g100--compliment`]:
+      theme === 'system-white-g100' && compliment,
+    [`${prefix}--system-g10-g90--compliment`]:
+      theme === 'system-g10-g90' && compliment,
+    [`${prefix}--system-g10-g100--compliment`]:
+      theme === 'system-g10-g100' && compliment,
     [`${prefix}--layer-one`]: true,
   });
   const value = React.useMemo(() => {
@@ -120,7 +154,16 @@ Theme.propTypes = {
   /**
    * Specify the theme
    */
-  theme: PropTypes.oneOf(['white', 'g10', 'g90', 'g100']),
+  theme: PropTypes.oneOf([
+    'white',
+    'g10',
+    'g90',
+    'g100',
+    'system-white-g90',
+    'system-white-g100',
+    'system-g10-g90',
+    'system-g10-g100',
+  ]),
 };
 
 /**

--- a/packages/styles/scss/_zone.scss
+++ b/packages/styles/scss/_zone.scss
@@ -26,6 +26,24 @@ $zones: (
   g10: themes.$g10,
   g90: themes.$g90,
   g100: themes.$g100,
+  system: (
+    white-g90: (
+      light: themes.$white,
+      dark: themes.$g90,
+    ),
+    white-g100: (
+      light: themes.$white,
+      dark: themes.$g100,
+    ),
+    g10-g90: (
+      light: themes.$g10,
+      dark: themes.$g90,
+    ),
+    g10-g100: (
+      light: themes.$g10,
+      dark: themes.$g100,
+    ),
+  ),
 ) !default;
 
 $-components: (
@@ -34,66 +52,93 @@ $-components: (
   tag.$tag-tokens
 );
 
-@each $name, $theme in $zones {
-  .#{config.$prefix}--#{'' + $name} {
-    background-color: custom-property.get-var('background');
-    color: custom-property.get-var('text-primary');
+@mixin apply-theme-map($theme) {
+  background-color: custom-property.get-var('background');
+  color: custom-property.get-var('text-primary');
+  @each $key, $value in $theme {
+    @if type-of($value) == color {
+      @include custom-property.declaration($key, $value);
+    }
+  }
 
-    @each $key, $value in $theme {
-      @if type-of($value) == color {
+  // Note: we need to re-emit the contextual layer tokens as part of the theme
+  // mixin. Otherwise, the layer tokens are defined at the :root level and will
+  // not pick up the theme-specific, or zone-specific, value from the first
+  // layer.
+  //
+  // For example, in this situation:
+  //
+  // ```
+  // :root {
+  //   --layer-one: #000000;
+  //   --layer: var(--layer-one);
+  // }
+  // ```
+  //
+  // This will always evaluate to the value of `--layer-one` at the `:root`
+  // selector, even if `--layer-one` is redefined layer on in the cascade.
+  //
+  // ```
+  // .zone {
+  //   --layer-one: #ffffff;
+  // }
+  // ```
+  //
+  // Even though you would expect `--layer` to be redefined, it will keep the
+  // value defined at the `:root` level.
+  //
+  // @see https://github.com/carbon-design-system/carbon/issues/11138
+  @include layer-tokens.emit-layer-tokens(1);
+
+  @each $group in $-components {
+    @each $key, $value in $group {
+      @if meta.type-of($value) == map {
+        $fallback: map.get($value, fallback);
+        $theme-values: map.get($value, values);
+
+        @each $theme-value in $theme-values {
+          $value: map.get($theme-value, value);
+
+          @if theme.matches(map.get($theme-value, theme), $theme) and
+            meta.type-of($value) ==
+            color
+          {
+            @include custom-property.declaration($key, $value);
+          }
+        }
+      } @else if meta.type-of($value) == color {
         @include custom-property.declaration($key, $value);
       }
     }
+  }
+}
 
-    // Note: we need to re-emit the contextual layer tokens as part of the theme
-    // mixin. Otherwise, the layer tokens are defined at the :root level and will
-    // not pick up the theme-specific, or zone-specific, value from the first
-    // layer.
-    //
-    // For example, in this situation:
-    //
-    // ```
-    // :root {
-    //   --layer-one: #000000;
-    //   --layer: var(--layer-one);
-    // }
-    // ```
-    //
-    // This will always evaluate to the value of `--layer-one` at the `:root`
-    // selector, even if `--layer-one` is redefined layer on in the cascade.
-    //
-    // ```
-    // .zone {
-    //   --layer-one: #ffffff;
-    // }
-    // ```
-    //
-    // Even though you would expect `--layer` to be redefined, it will keep the
-    // value defined at the `:root` level.
-    //
-    // @see https://github.com/carbon-design-system/carbon/issues/11138
-    @include layer-tokens.emit-layer-tokens(1);
+@each $name, $theme in $zones {
+  @if $name == 'system' {
+    @each $inner-name, $inner-theme in $theme {
+      $light: map.get($inner-theme, 'light');
+      $dark: map.get($inner-theme, 'dark');
 
-    @each $group in $-components {
-      @each $key, $value in $group {
-        @if meta.type-of($value) == map {
-          $fallback: map.get($value, fallback);
-          $theme-values: map.get($value, values);
-
-          @each $theme-value in $theme-values {
-            $value: map.get($theme-value, value);
-
-            @if theme.matches(map.get($theme-value, theme), $theme) and
-              meta.type-of($value) ==
-              color
-            {
-              @include custom-property.declaration($key, $value);
-            }
-          }
-        } @else if meta.type-of($value) == color {
-          @include custom-property.declaration($key, $value);
+      @media (prefers-color-scheme: light) {
+        .#{config.$prefix}--#{'' + $name}-#{$inner-name} {
+          @include apply-theme-map($light);
+        }
+        .#{config.$prefix}--#{'' + $name}-#{$inner-name}--compliment {
+          @include apply-theme-map($dark);
         }
       }
+      @media (prefers-color-scheme: dark) {
+        .#{config.$prefix}--#{'' + $name}-#{$inner-name} {
+          @include apply-theme-map($dark);
+        }
+        .#{config.$prefix}--#{'' + $name}-#{$inner-name}--compliment {
+          @include apply-theme-map($light);
+        }
+      }
+    }
+  } @else {
+    .#{config.$prefix}--#{'' + $name} {
+      @include apply-theme-map($theme);
     }
   }
 }


### PR DESCRIPTION
This needs a bit of re-work as the `GlobalTheme` component had almost entirely slipped me by. Mainly because `<Theme>` did not allow me to follow system preferences I nearly always rolled my own CSS.  Thought I'd submit regardless for feedback to see if, with some additional changes it would be considered.

This PR adds a possible mechanism for use with `<Theme>` to defer to system color preferences.

The benefit of something like this would be to remove the need for Carbon consumers to implement there own theme classes and media queries to use system settings.

#### Changelog

**Changed**

- Modified GlobalTheme/Theme to include new options and a `compliment` property. The compliment property allows a system prefs based UI to still switch to an alternative. 
- Modified the CSS ouput by `zones.scss` to include media queries and new classes.
- Updated the Theme story.

