### PR TITLE
fix(modal): spacing below scrolling content

### DIFF
--- a/packages/styles/scss/components/modal/_modal.scss
+++ b/packages/styles/scss/components/modal/_modal.scss
@@ -363,7 +363,7 @@
 
   // Required so overflow-indicator disappears at end of content
   .#{$prefix}--modal-scroll-content > *:last-child {
-    padding-block-end: $spacing-06;
+    margin-block-end: $spacing-06;
   }
 
   // -----------------------------


### PR DESCRIPTION
Closes #15890



#### Changelog

**Changed**

- update padding to margin on last element of modal with scrolling content



#### Testing / Reviewing

Visually nothing should have changed with modal, you can add something like a button as the last element in storybook to test this update. Previously it would have applied padding inside the button vs. margin below. 