### PR TITLE
test(Accordion): V10 - fix Accordion a11y tests

### DIFF
--- a/achecker.js
+++ b/achecker.js
@@ -10,7 +10,7 @@
 const path = require('path');
 
 module.exports = {
-  ruleArchive: '18March2024',
+  ruleArchive: 'latest',
   policies: ['Custom_Ruleset'],
   failLevels: ['violation'],
   reportLevels: [

--- a/packages/react/src/components/Accordion/__tests__/Accordion-test.js
+++ b/packages/react/src/components/Accordion/__tests__/Accordion-test.js
@@ -49,13 +49,13 @@ describe('Accordion', () => {
         </Accordion>
       );
 
-      await expect(screen.getByText('Heading A')).toHaveNoAxeViolations();
+      await expect(screen.getByText('Panel A')).toHaveNoAxeViolations();
 
       // click to open
-      userEvent.click(screen.getByText('Heading A'));
+      userEvent.click(screen.getByText('Panel A'));
 
       // test when open
-      await expect(screen.getByText('Heading A')).toHaveNoAxeViolations();
+      await expect(screen.getByText('Panel A')).toHaveNoAxeViolations();
     });
 
     it('should have no Accessibility Checker violations', async () => {
@@ -75,15 +75,15 @@ describe('Accordion', () => {
         </main>
       );
 
-      await expect(screen.getByText('Heading A')).toHaveNoACViolations(
+      await expect(screen.getByText('Panel A')).toHaveNoACViolations(
         'Accordion'
       );
 
       // click to open
-      userEvent.click(screen.getByText('Heading A'));
+      userEvent.click(screen.getByText('Panel A'));
 
       // test when open
-      await expect(screen.getByText('Heading A')).toHaveNoACViolations(
+      await expect(screen.getByText('Panel A')).toHaveNoACViolations(
         'Opened Accordion'
       );
     });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16274

Name mismatches were causing test failures 

#### Changelog

**Changed**

- Switched aChecker ruleset to `latest`
- Ensure `Accordion` test selectors match to the correct element 


#### Testing / Reviewing

Ensure all tests pass
