### PR TITLE
refactor(16054): Normalize usage of types |  replace ReactNodeLike with ReactNode 

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes, { ReactNodeLike } from 'prop-types';
-import React from 'react';
+import PropTypes from 'prop-types';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { Text } from '../Text';
 import { usePrefix } from '../../internal/usePrefix';
@@ -32,7 +32,7 @@ export interface CheckboxProps
    * Provide a label to provide a description of the Checkbox input that you are
    * exposing to the user
    */
-  labelText: NonNullable<ReactNodeLike>;
+  labelText: NonNullable<ReactNode>;
 
   /**
    * Specify whether the underlying input should be checked by default
@@ -47,7 +47,7 @@ export interface CheckboxProps
   /**
    * Provide text for the form group for additional help
    */
-  helperText?: React.ReactNode;
+  helperText?: ReactNode;
 
   /**
    * Specify whether the label should be hidden, or not
@@ -67,12 +67,12 @@ export interface CheckboxProps
   /**
    * Provide the text that is displayed when the Checkbox is in an invalid state
    */
-  invalidText?: React.ReactNode;
+  invalidText?: ReactNode;
 
   /**
    * **Experimental**: Provide a `Slug` component to be rendered inside the `Checkbox` component
    */
-  slug?: ReactNodeLike;
+  slug?: ReactNode;
 
   /**
    * Specify whether the Checkbox is currently invalid
@@ -82,7 +82,7 @@ export interface CheckboxProps
   /**
    * Provide the text that is displayed when the Checkbox is in an invalid state
    */
-  warnText?: React.ReactNode;
+  warnText?: ReactNode;
 
   /**
    * Provide an optional handler that is called when the internal state of

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -10,7 +10,7 @@ import React, {
   type RefObject,
 } from 'react';
 import { isElement } from 'react-is';
-import PropTypes, { ReactNodeLike } from 'prop-types';
+import PropTypes from 'prop-types';
 import { ModalHeader, type ModalHeaderProps } from './ModalHeader';
 import { ModalFooter, type ModalFooterProps } from './ModalFooter';
 import debounce from 'lodash.debounce';
@@ -212,7 +212,7 @@ export interface ComposedModalProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * **Experimental**: Provide a `Slug` component to be rendered inside the `ComposedModal` component
    */
-  slug?: ReactNodeLike;
+  slug?: ReactNode;
 }
 
 const ComposedModal = React.forwardRef<HTMLDivElement, ComposedModalProps>(

--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -6,8 +6,8 @@
  */
 
 import cx from 'classnames';
-import PropTypes, { ReactNodeLike } from 'prop-types';
-import React, { type MouseEventHandler, useRef } from 'react';
+import PropTypes from 'prop-types';
+import React, { type MouseEventHandler, useRef, ReactNode } from 'react';
 import {
   ArrowUp as Arrow,
   ArrowsVertical as Arrows,
@@ -24,7 +24,7 @@ const defaultScope = 'col';
 export type TableHeaderTranslationKey = 'carbon.table.header.icon.description';
 
 export interface TableHeaderTranslationArgs {
-  header: React.ReactNode;
+  header: ReactNode;
   isSortHeader?: boolean;
   sortDirection?: DataTableSortState;
   sortStates: typeof sortStates;
@@ -68,7 +68,7 @@ interface TableHeaderProps
   /**
    * Pass in children that will be embedded in the table header label
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
 
   /**
    * Specify an optional className to be applied to the container node
@@ -112,7 +112,7 @@ interface TableHeaderProps
   /**
    * **Experimental**: Provide a `Slug` component to be rendered inside the `TableSlugRow` component
    */
-  slug?: ReactNodeLike;
+  slug?: ReactNode;
 
   /**
    * Specify which direction we are currently sorting by, should be one of DESC,

--- a/packages/react/src/components/DataTable/TableSlugRow.tsx
+++ b/packages/react/src/components/DataTable/TableSlugRow.tsx
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PropTypes, { ReactNodeLike } from 'prop-types';
-import React from 'react';
+import PropTypes from 'prop-types';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 
@@ -19,7 +19,7 @@ export interface TableSlugRowProps {
   /**
    * Provide a `Slug` component to be rendered inside the `TableSlugRow` component
    */
-  slug?: ReactNodeLike;
+  slug?: ReactNode;
 }
 
 const TableSlugRow = ({ className, slug }: TableSlugRowProps) => {


### PR DESCRIPTION

Closes https://github.com/carbon-design-system/carbon/issues/16449 - `CheckBox`
Closes  https://github.com/carbon-design-system/carbon/issues/16450 - `ComposedModal`
Closes https://github.com/carbon-design-system/carbon/issues/16451 -`TableHeader`
Closes https://github.com/carbon-design-system/carbon/issues/16452 - `TableSlugRow`

This PR fixes inconsistencies and Normalizes the usage of types `ReactNode` and `ReactNodeLike` in components .
Now the component props accept [ReactNode](https://github.com/eps1lon/DefinitelyTyped/blob/master/types/react/index.d.ts#L479) instead of  [ReactNodeLike](https://github.com/eps1lon/DefinitelyTyped/blob/master/types/prop-types/index.d.ts#L14)



#### Changelog

Changed from `ReactNodeLike` to `ReactNode`


#### Testing / Reviewing

This should not require any visual/functional testing, please verification if the existing functionality is intact.
