### PR TITLE
fix: export props for components

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import React, { PropsWithChildren } from 'react';
 import { AccordionProvider } from './AccordionProvider';
 
-interface AccordionProps {
+export interface AccordionProps {
   /**
    * Specify the alignment of the accordion heading
    * title and chevron. Defaults to `end`.

--- a/packages/react/src/components/Accordion/index.tsx
+++ b/packages/react/src/components/Accordion/index.tsx
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Accordion from './Accordion';
+import Accordion, { type AccordionProps } from './Accordion';
 
 export default Accordion;
-export { Accordion };
+export { Accordion, type AccordionProps };
 export { default as AccordionItem } from './AccordionItem';
 export { default as AccordionSkeleton } from './Accordion.Skeleton';

--- a/packages/react/src/components/Button/index.ts
+++ b/packages/react/src/components/Button/index.ts
@@ -6,8 +6,8 @@
  */
 
 import Button from './Button';
-
+import { type ButtonProps } from './Button';
 export default Button;
-export { Button };
+export { Button, type ButtonProps };
 export * from './Button';
 export { default as ButtonSkeleton } from './Button.Skeleton';

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -569,7 +569,7 @@ type DropdownComponentProps<ItemType> = React.PropsWithoutRef<
     React.RefAttributes<HTMLButtonElement>
 >;
 
-interface DropdownComponent {
+export interface DropdownComponent {
   <ItemType>(
     props: DropdownComponentProps<ItemType>
   ): React.ReactElement | null;

--- a/packages/react/src/components/Dropdown/index.ts
+++ b/packages/react/src/components/Dropdown/index.ts
@@ -8,10 +8,11 @@
 import Dropdown, {
   type DropdownTranslationKey,
   type OnChangeData,
+  type DropdownProps,
 } from './Dropdown';
 
 export type { DropdownTranslationKey, OnChangeData };
-export { Dropdown };
+export { Dropdown, type DropdownProps };
 export { default as DropdownSkeleton } from './Dropdown.Skeleton';
 
 export default Dropdown;

--- a/packages/react/src/components/FormLabel/index.ts
+++ b/packages/react/src/components/FormLabel/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import FormLabel from './FormLabel';
+import FormLabel, { type FormLabelProps } from './FormLabel';
 
 export default FormLabel;
-export { FormLabel };
+export { FormLabel, type FormLabelProps };

--- a/packages/react/src/components/Grid/Column.tsx
+++ b/packages/react/src/components/Grid/Column.tsx
@@ -17,7 +17,7 @@ type ColumnSpanPercent = '25%' | '50%' | '75%' | '100%';
 
 type ColumnSpanSimple = boolean | number | ColumnSpanPercent;
 
-interface ColumnSpanObject {
+export interface ColumnSpanObject {
   span?: ColumnSpanSimple;
 
   offset?: number;
@@ -29,7 +29,7 @@ interface ColumnSpanObject {
 
 export type ColumnSpan = ColumnSpanSimple | ColumnSpanObject;
 
-interface ColumnBaseProps {
+export interface ColumnBaseProps {
   /**
    * Pass in content that will be rendered within the `Column`
    */

--- a/packages/react/src/components/Grid/GridTypes.ts
+++ b/packages/react/src/components/Grid/GridTypes.ts
@@ -7,7 +7,7 @@
 
 import { PolymorphicProps } from '../../types/common';
 
-interface GridBaseProps {
+export interface GridBaseProps {
   /**
    * Pass in content that will be rendered within the `Grid`
    */

--- a/packages/react/src/components/Grid/index.ts
+++ b/packages/react/src/components/Grid/index.ts
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { type GridProps } from './GridTypes';
+export { type GridProps };
 export { FlexGrid } from './FlexGrid';
 export { Grid } from './Grid';
 export { default as Row } from './Row';
-export { default as Column } from './Column';
+export { default as Column, type ColumnProps } from './Column';
 export { ColumnHang } from './ColumnHang';
 export { GridSettings } from './GridContext';

--- a/packages/react/src/components/StructuredList/index.tsx
+++ b/packages/react/src/components/StructuredList/index.tsx
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { type StructuredListWrapperProps } from './StructuredList';
 export * from './StructuredList';
 export {
   default as StructuredListSkeleton,
   type StructuredListSkeletonProps,
 } from './StructuredList.Skeleton';
+export { type StructuredListWrapperProps };


### PR DESCRIPTION
Closes #16364       **Accordion**
Closes #16366       **Structured List**
Closes #16367       **Button**
Closes #16368       **Button**
Closes #16369       **Column**
Closes #16370       **Dropdown**
Closes #16371        **FormLabel**
Closes #16372       **Grid**

Exporting the typescript props for the above mentioned components as part of typescript adoption
(This PR is mentioned as 1, as we have more components where props needs to be exported so there will be more PRs regarding this)

#### Changelog

**Changed**

- exporting interfaces from the `.tsx` files if not done
- Importing them to `index.ts` and exporting them explicitly so that users can import them directly with the component.

#### Testing / Reviewing

No changes to the component, so new testing observations.
