### PR TITLE
fix(menu): include leave intent delay for sub menus

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1524,6 +1524,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Kilian-Collender",
+      "name": "Kilian Collender",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37899503?v=4",
+      "profile": "https://github.com/Kilian-Collender",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/2nikhiltom"><img src="https://avatars.githubusercontent.com/2nikhiltom?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nikhil Tomar</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=2nikhiltom" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/aninaantony"><img src="https://avatars.githubusercontent.com/u/164350784?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anina Antony</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=aninaantony" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/ychavoya"><img src="https://avatars.githubusercontent.com/u/7907338?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Yael Chavoya</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ychavoya" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Kilian-Collender"><img src="https://avatars.githubusercontent.com/u/37899503?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kilian Collender</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Kilian-Collender" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4566,6 +4566,9 @@ Map {
   "MenuItem" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "propTypes": Object {
+      "aria-label": Object {
+        "type": "string",
+      },
       "children": Object {
         "type": "node",
       },

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4566,9 +4566,6 @@ Map {
   "MenuItem" => Object {
     "$$typeof": Symbol(react.forward_ref),
     "propTypes": Object {
-      "aria-label": Object {
-        "type": "string",
-      },
       "children": Object {
         "type": "node",
       },

--- a/packages/react/src/components/Menu/Menu-test.js
+++ b/packages/react/src/components/Menu/Menu-test.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Menu, MenuItem, MenuItemSelectable, MenuItemRadioGroup } from './';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 describe('Menu', () => {
@@ -96,6 +96,76 @@ describe('Menu', () => {
 
       expect(spy).toHaveBeenCalled();
       spy.mockRestore();
+    });
+  });
+
+  describe('Submenu behavior', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      render(
+        <Menu open>
+          <MenuItem label="Submenu">
+            <MenuItem label="Item" />
+          </MenuItem>
+        </Menu>
+      );
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+    it('should only show parent and not then submenu when not hovered', () => {
+      const menus = screen.getAllByRole('menu');
+      expect(menus.length).toBe(2);
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).not.toHaveClass('cds--menu--open');
+    });
+
+    it('should show sub menu when hovered for hoverIntentDelay', async () => {
+      const menus = screen.getAllByRole('menu');
+      await act(() =>
+        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }))
+      );
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).not.toHaveClass('cds--menu--open');
+
+      await act(() => jest.runOnlyPendingTimers());
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).toHaveClass('cds--menu--open');
+    });
+
+    it('should close sub menu on leave after leaveIntentDelay', async () => {
+      const menus = screen.getAllByRole('menu');
+      await act(() => {
+        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }));
+        jest.runOnlyPendingTimers();
+      });
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).toHaveClass('cds--menu--open');
+
+      await act(() => {
+        fireEvent.mouseLeave(screen.getByRole('menuitem', { name: 'Submenu' }));
+        jest.runOnlyPendingTimers();
+      });
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).not.toHaveClass('cds--menu--open');
+    });
+
+    it('should cancel close sub menu on leave and reenter before leaveIntentDelay', async () => {
+      const menus = screen.getAllByRole('menu');
+      await act(() => {
+        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }));
+        jest.runOnlyPendingTimers();
+      });
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).toHaveClass('cds--menu--open');
+
+      await act(() => {
+        fireEvent.mouseLeave(screen.getByRole('menuitem', { name: 'Submenu' }));
+        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }));
+        jest.runOnlyPendingTimers();
+      });
+      expect(menus[0]).toHaveClass('cds--menu--open');
+      expect(menus[1]).toHaveClass('cds--menu--open');
     });
   });
 });

--- a/packages/react/src/components/Menu/Menu-test.js
+++ b/packages/react/src/components/Menu/Menu-test.js
@@ -123,7 +123,9 @@ describe('Menu', () => {
     it('should show sub menu when hovered for hoverIntentDelay', async () => {
       const menus = screen.getAllByRole('menu');
       await act(() =>
-        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }))
+        fireEvent.mouseEnter(
+          screen.getByRole('menuitem', { name: 'Submenu Submenu' })
+        )
       );
       expect(menus[0]).toHaveClass('cds--menu--open');
       expect(menus[1]).not.toHaveClass('cds--menu--open');
@@ -136,14 +138,18 @@ describe('Menu', () => {
     it('should close sub menu on leave after leaveIntentDelay', async () => {
       const menus = screen.getAllByRole('menu');
       await act(() => {
-        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }));
+        fireEvent.mouseEnter(
+          screen.getByRole('menuitem', { name: 'Submenu Submenu' })
+        );
         jest.runOnlyPendingTimers();
       });
       expect(menus[0]).toHaveClass('cds--menu--open');
       expect(menus[1]).toHaveClass('cds--menu--open');
 
       await act(() => {
-        fireEvent.mouseLeave(screen.getByRole('menuitem', { name: 'Submenu' }));
+        fireEvent.mouseLeave(
+          screen.getByRole('menuitem', { name: 'Submenu Submenu' })
+        );
         jest.runOnlyPendingTimers();
       });
       expect(menus[0]).toHaveClass('cds--menu--open');
@@ -153,15 +159,21 @@ describe('Menu', () => {
     it('should cancel close sub menu on leave and reenter before leaveIntentDelay', async () => {
       const menus = screen.getAllByRole('menu');
       await act(() => {
-        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }));
+        fireEvent.mouseEnter(
+          screen.getByRole('menuitem', { name: 'Submenu Submenu' })
+        );
         jest.runOnlyPendingTimers();
       });
       expect(menus[0]).toHaveClass('cds--menu--open');
       expect(menus[1]).toHaveClass('cds--menu--open');
 
       await act(() => {
-        fireEvent.mouseLeave(screen.getByRole('menuitem', { name: 'Submenu' }));
-        fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Submenu' }));
+        fireEvent.mouseLeave(
+          screen.getByRole('menuitem', { name: 'Submenu Submenu' })
+        );
+        fireEvent.mouseEnter(
+          screen.getByRole('menuitem', { name: 'Submenu Submenu' })
+        );
         jest.runOnlyPendingTimers();
       });
       expect(menus[0]).toHaveClass('cds--menu--open');

--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -234,7 +234,7 @@ const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
 
   function focusItem(e?: React.KeyboardEvent<HTMLUListElement>) {
     const currentItem = focusableItems.findIndex((item) =>
-      item.ref.current.contains(document.activeElement)
+      item.ref?.current?.contains(document.activeElement)
     );
     let indexToFocus = currentItem;
 

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -80,6 +80,7 @@ export interface MenuItemProps extends LiHTMLAttributes<HTMLLIElement> {
 }
 
 const hoverIntentDelay = 150; // in ms
+const leaveIntentDelay = 300; // in ms
 
 export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
   function MenuItem(
@@ -110,6 +111,10 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
     const hasChildren = Boolean(children);
     const [submenuOpen, setSubmenuOpen] = useState(false);
     const hoverIntentTimeout = useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
+
+    const leaveIntentTimeout = useRef<ReturnType<typeof setTimeout> | null>(
       null
     );
 
@@ -169,6 +174,11 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
     }
 
     function handleMouseEnter() {
+      if (leaveIntentTimeout.current) {
+        // When mouse reenters before closing keep sub menu open
+        clearTimeout(leaveIntentTimeout.current);
+        leaveIntentTimeout.current = null;
+      }
       hoverIntentTimeout.current = setTimeout(() => {
         openSubmenu();
       }, hoverIntentDelay);
@@ -177,8 +187,12 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
     function handleMouseLeave() {
       if (hoverIntentTimeout.current) {
         clearTimeout(hoverIntentTimeout.current);
-        closeSubmenu();
-        menuItem.current?.focus();
+        // Avoid closing the sub menu as soon as mouse leaves
+        // prevents accidental closure due to scroll bar
+        leaveIntentTimeout.current = setTimeout(() => {
+          closeSubmenu();
+          menuItem.current?.focus();
+        }, leaveIntentDelay);
       }
     }
 
@@ -241,6 +255,7 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
         aria-disabled={isDisabled ?? undefined}
         aria-haspopup={hasChildren ?? undefined}
         aria-expanded={hasChildren ? submenuOpen : undefined}
+        aria-label={label}
         onClick={handleClick}
         onMouseEnter={hasChildren ? handleMouseEnter : undefined}
         onMouseLeave={hasChildren ? handleMouseLeave : undefined}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -255,7 +255,6 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
         aria-disabled={isDisabled ?? undefined}
         aria-haspopup={hasChildren ?? undefined}
         aria-expanded={hasChildren ? submenuOpen : undefined}
-        aria-label={label}
         onClick={handleClick}
         onMouseEnter={hasChildren ? handleMouseEnter : undefined}
         onMouseLeave={hasChildren ? handleMouseLeave : undefined}

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -85,6 +85,7 @@ const leaveIntentDelay = 300; // in ms
 export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
   function MenuItem(
     {
+      ['aria-label']: ariaLabel,
       children,
       className,
       disabled,
@@ -255,6 +256,7 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
         aria-disabled={isDisabled ?? undefined}
         aria-haspopup={hasChildren ?? undefined}
         aria-expanded={hasChildren ? submenuOpen : undefined}
+        aria-label={ariaLabel || label}
         onClick={handleClick}
         onMouseEnter={hasChildren ? handleMouseEnter : undefined}
         onMouseLeave={hasChildren ? handleMouseLeave : undefined}
@@ -292,6 +294,11 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
 );
 
 MenuItem.propTypes = {
+  /**
+   * Specify the aria-label for li element
+   */
+  ['aria-label']: PropTypes.string,
+
   /**
    * Optionally provide another Menu to create a submenu. props.children can't be used to specify the content of the MenuItem itself. Use props.label instead.
    */

--- a/packages/react/src/components/Menu/MenuItem.tsx
+++ b/packages/react/src/components/Menu/MenuItem.tsx
@@ -85,7 +85,6 @@ const leaveIntentDelay = 300; // in ms
 export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
   function MenuItem(
     {
-      ['aria-label']: ariaLabel,
       children,
       className,
       disabled,
@@ -256,7 +255,6 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
         aria-disabled={isDisabled ?? undefined}
         aria-haspopup={hasChildren ?? undefined}
         aria-expanded={hasChildren ? submenuOpen : undefined}
-        aria-label={ariaLabel || label}
         onClick={handleClick}
         onMouseEnter={hasChildren ? handleMouseEnter : undefined}
         onMouseLeave={hasChildren ? handleMouseLeave : undefined}
@@ -294,11 +292,6 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
 );
 
 MenuItem.propTypes = {
-  /**
-   * Specify the aria-label for li element
-   */
-  ['aria-label']: PropTypes.string,
-
   /**
    * Optionally provide another Menu to create a submenu. props.children can't be used to specify the content of the MenuItem itself. Use props.label instead.
    */


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16395

[Menu component does not protect access to refs in focusItem](https://github.com/carbon-design-system/carbon/issues/16395) by adding protection to the accessing of the refs.

#### Changelog

**New**

Adds leave intent delay for sub menu as it can accidentally trigger a premature closure of the sub menu in the following cases:

1. the mouse moves across and down as the user selects a lower sub menu, causing the mouse to leave the menuItem.
2. the menu has a scroll bar, as the mouse crosses this to enter the sub menu it triggers the closure before the user can access the sub menu.

Including a delay in the closure allows for the users mouse to reenter the submenu and cancel the closure of the menu.

**Changed**

- The sub menu does not close immediately when the mouse leave the menu item or menu items children.
- Add optional menu item aria-label that uses prop or label value

#### Testing / Reviewing

Unit tests have been added to validate the opening and closing of the sub menu using fake timers.

Manual testing can be easily done by opening the submenu and quickly moving the mouse out and back into the menu item and the menu will close.
