### PR TITLE
fix(elements): reconfigure elements previews next config

### DIFF
--- a/packages/colors/examples/preview/next.config.js
+++ b/packages/colors/examples/preview/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/colors/examples/preview',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/colors/examples/preview/package.json
+++ b/packages/colors/examples/preview/package.json
@@ -7,7 +7,7 @@
   "source": "index.html",
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/colors": "link:../../",

--- a/packages/grid/examples/css-grid/next.config.js
+++ b/packages/grid/examples/css-grid/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/grid/examples/css-grid',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/grid/examples/css-grid/package.json
+++ b/packages/grid/examples/css-grid/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/colors": "link:../../../colors",

--- a/packages/grid/examples/preview/next.config.js
+++ b/packages/grid/examples/preview/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/grid/examples/preview',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/grid/examples/preview/package.json
+++ b/packages/grid/examples/preview/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "devDependencies": {
     "@carbon/grid": "^11.9.0",

--- a/packages/icons/examples/preview/next.config.js
+++ b/packages/icons/examples/preview/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/icons/examples/preview',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/icons/examples/preview/package.json
+++ b/packages/icons/examples/preview/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/styles": "link:../../../styles",

--- a/packages/layout/examples/preview/next.config.js
+++ b/packages/layout/examples/preview/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/layout/examples/preview',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/layout/examples/preview/package.json
+++ b/packages/layout/examples/preview/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/layout": "link:../../",

--- a/packages/pictograms/examples/preview/next.config.js
+++ b/packages/pictograms/examples/preview/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/pictograms/examples/preview',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/pictograms/examples/preview/package.json
+++ b/packages/pictograms/examples/preview/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/styles": "link:../../../styles",

--- a/packages/themes/examples/preview-v10/next.config.js
+++ b/packages/themes/examples/preview-v10/next.config.js
@@ -10,6 +10,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
       basePath: '/themes/examples/preview-v10',
+      output: 'export',
+      distDir: 'build',
     };
   }
 

--- a/packages/themes/examples/preview-v10/package.json
+++ b/packages/themes/examples/preview-v10/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/grid": "^10.43.1",

--- a/packages/themes/examples/preview/next.config.js
+++ b/packages/themes/examples/preview/next.config.js
@@ -13,6 +13,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
       basePath: '/themes/examples/preview',
+      output: 'export',
+      distDir: 'build',
     };
   }
 

--- a/packages/themes/examples/preview/package.json
+++ b/packages/themes/examples/preview/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/colors": "link:../../../colors",

--- a/packages/type/examples/preview/next.config.js
+++ b/packages/type/examples/preview/next.config.js
@@ -4,6 +4,8 @@ module.exports = (phase, { defaultConfig }) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     return {
         basePath: '/type/examples/preview',
+        output: 'export',
+        distDir: 'build',
     }
   }
 

--- a/packages/type/examples/preview/package.json
+++ b/packages/type/examples/preview/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "develop": "next",
-    "build": "next build && next export -o build"
+    "build": "next build"
   },
   "dependencies": {
     "@carbon/styles": "link:../../../styles",


### PR DESCRIPTION
I think this should fix the elements previews - they're currently failing because of [this piece](https://nextjs.org/docs/pages/building-your-application/upgrading/version-14#:~:text=The%20next%20export%20command%20has%20been%20removed%20in%20favor%20of%20output%3A%20%27export%27%20config.%20Please%20see%20the%20docs%20for%20more%20information) we missed when reviewing the dependabot/renovate PRs updating nextjs from 13 -> 14

* [More here](https://nextjs.org/docs/app/building-your-application/deploying/static-exports)

#### Changelog

**Changed**

- update nextjs config to use `output: 'export'`

**Removed**

- no longer use `next export`

#### Testing / Reviewing

- In theory the elements netlify deploy preview should work on this PR, though I'm not sure. Might have to merge this and watch the production deployment in netlify to see if it works properly.