### PR TITLE
docs(multiselect): do not select disabled items on "select all" button

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -338,7 +338,11 @@ export const _Controlled = () => {
       />
       <br />
       <ButtonSet>
-        <Button id="all" onClick={() => setSelectedItems(items)}>
+        <Button
+          id="all"
+          onClick={() =>
+            setSelectedItems(items.filter((item) => !item.disabled))
+          }>
           Select all
         </Button>
         <Button


### PR DESCRIPTION
Closes  #16445

#### Changelog

**Changed**

-  Updated an example in the storybook to prevent selecting a disabled item in the Controlled MultiSelect story


#### Testing / Reviewing

Open the "Multiselect / Controlled" story in the storybook and click on the "Select All" button, the disabled items should not be selected
