### PR TITLE
fix: useTheme removed from API in error

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -300,7 +300,12 @@ export {
   TextDirection as unstable_TextDirection,
 } from './components/Text';
 export { DefinitionTooltip } from './components/Tooltip/DefinitionTooltip';
-export { GlobalTheme, Theme, usePrefersDarkScheme } from './components/Theme';
+export {
+  GlobalTheme,
+  Theme,
+  usePrefersDarkScheme,
+  useTheme,
+} from './components/Theme';
 export { usePrefix } from './internal/usePrefix';
 export { useIdPrefix } from './internal/useIdPrefix';
 export {


### PR DESCRIPTION
Addresses API change made in error in #16230

Removal of useTheme changes the API removing the ability to check the current theme.

NOTE: Perhaps tests of components and functions exposed in the public API should import directly from `packages/react/src/index`. 

#### Changelog

**Changed**

- packages/react/src/index

#### Testing / Reviewing

Ran tests.

