### PR TITLE
refactor(16054): replaces ReactNodeLike with ReactNode

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -7,7 +7,7 @@
 
 import cx from 'classnames';
 import { useCombobox, UseComboboxProps } from 'downshift';
-import PropTypes, { ReactNodeLike } from 'prop-types';
+import PropTypes from 'prop-types';
 import React, {
   useContext,
   useEffect,
@@ -280,7 +280,7 @@ export interface ComboBoxProps<ItemType>
   /**
    * **Experimental**: Provide a `Slug` component to be rendered inside the `ComboBox` component
    */
-  slug?: ReactNodeLike;
+  slug?: ReactNode;
 
   /**
    * Provide text to be used in a `<label>` element that is tied to the

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -17,7 +17,7 @@ import Downshift, {
   UseMultipleSelectionInterface,
 } from 'downshift';
 import isEqual from 'lodash.isequal';
-import PropTypes, { ReactNodeLike } from 'prop-types';
+import PropTypes from 'prop-types';
 import React, {
   useContext,
   useState,
@@ -240,7 +240,7 @@ export interface FilterableMultiSelectProps<Item extends ItemBase>
   /**
    * **Experimental**: Provide a `Slug` component to be rendered inside the `Checkbox` component
    */
-  slug?: ReactNodeLike;
+  slug?: ReactNode;
 
   /**
    * Provide text to be used in a `<label>` element that is tied to the


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16480 - `FilterableMultiSelect ` 
Closes https://github.com/carbon-design-system/carbon/issues/16481 - `ComboBox `


This PR fixes inconsistencies and Normalizes the usage of types `ReactNode` and `ReactNodeLike` in components .
Now the component props accept [ReactNode](https://github.com/eps1lon/DefinitelyTyped/blob/master/types/react/index.d.ts#L479) instead of  [ReactNodeLike](https://github.com/eps1lon/DefinitelyTyped/blob/master/types/prop-types/index.d.ts#L14)



#### Changelog

Changed from `ReactNodeLike` to `ReactNode`


#### Testing / Reviewing

This should not require any visual/functional testing, please verification if the existing functionality is intact.