### PR TITLE
fix(menu): remove explicit color token from icons

### DIFF
--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -77,19 +77,11 @@
     &:focus {
       @include focus-outline('outline');
     }
-
-    svg {
-      color: $icon-secondary;
-    }
   }
 
   .#{$prefix}--menu-item:hover {
     background-color: $layer-hover;
     color: $text-primary;
-
-    svg {
-      color: $icon-primary;
-    }
   }
 
   $supported-sizes: (


### PR DESCRIPTION
I noticed that the icons in Menus (MenuButton, ComboButton) didn't render in the correct color when the item was disabled or danger (hover). This PR removes the explicit color definition and therefore relies on the default `currentColor` to sync the icons with the text.

| Scenario | Screenshot |
| :- | :- |
| Before – disabled | <img width="220" alt="image" src="https://github.com/carbon-design-system/carbon/assets/28265588/b61b2237-83bd-4966-af89-4f32697d44a2"> |
| After – disabled | <img width="257" alt="image" src="https://github.com/carbon-design-system/carbon/assets/28265588/9fb55dcf-0943-44f5-bc7d-c29b6ebe5ee6"> |
| Before – danger | <img width="207" alt="image" src="https://github.com/carbon-design-system/carbon/assets/28265588/5978206f-9a1e-498f-be5c-1486512c025d"> |
| After – danger | <img width="258" alt="image" src="https://github.com/carbon-design-system/carbon/assets/28265588/b6e3852e-54d7-4cac-b3b5-8845b320600f"> |


#### Changelog

**Removed**

- Removed explicit color definition from icons in menus

#### Testing / Reviewing

Storybook

@alisonjoseph I noticed that you explicitly mentioned adding colors to the svgs in #15236. I tested several scenarios in storybook and the color seems to be inherited correctly, but I wanted to make sure I'm not missing an edge case you found?
