### PR TITLE
refactor: converted index.js to index.ts for `OverflowMenu`

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -106,7 +106,7 @@ type IconProps = {
   'aria-label'?: string;
 };
 
-interface OverflowMenuProps {
+export interface OverflowMenuProps {
   /**
    * Specify a label to be read by screen readers on the container node
    */

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -7,7 +7,7 @@
 
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ComponentType } from 'react';
 import classNames from 'classnames';
 import ClickListener from '../../internal/ClickListener';
 import FloatingMenu, {
@@ -97,15 +97,20 @@ export const getMenuOffset = (menuBody, direction, trigger, flip) => {
 };
 
 interface Offset {
-  top: number;
-  left: number;
+  top?: number | null | undefined;
+  left?: number | null | undefined;
 }
+
+type IconProps = {
+  className?: string;
+  'aria-label'?: string;
+};
 
 interface OverflowMenuProps {
   /**
    * Specify a label to be read by screen readers on the container node
    */
-  ['aria-label']: string;
+  ['aria-label']?: string;
 
   /**
    * Deprecated, please use `aria-label` instead.
@@ -198,7 +203,7 @@ interface OverflowMenuProps {
   /**
    * Function called to override icon rendering.
    */
-  renderIcon?: React.ElementType;
+  renderIcon?: ComponentType<IconProps>;
 
   /**
    * Specify a CSS selector that matches the DOM element that should

--- a/packages/react/src/components/OverflowMenu/index.tsx
+++ b/packages/react/src/components/OverflowMenu/index.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { useFeatureFlag } from '../FeatureFlags';
+import { type OverflowMenuProps } from './OverflowMenu';
 
 import { OverflowMenu as OverflowMenuV12 } from './next';
 
@@ -30,4 +31,4 @@ function OverflowMenu(props) {
 OverflowMenu.displayName = 'OverflowMenu';
 
 export default OverflowMenu;
-export { OverflowMenu };
+export { OverflowMenu, type OverflowMenuProps };

--- a/packages/react/src/components/OverflowMenu/index.tsx
+++ b/packages/react/src/components/OverflowMenu/index.tsx
@@ -13,7 +13,9 @@ import { OverflowMenu as OverflowMenuV12 } from './next';
 import { OverflowMenu as OverflowMenuComponent } from './OverflowMenu';
 import { createClassWrapper } from '../../internal/createClassWrapper';
 
-const OverflowMenuV11 = createClassWrapper(OverflowMenuComponent);
+const OverflowMenuV11 = createClassWrapper(
+  OverflowMenuComponent as typeof React.Component
+);
 
 function OverflowMenu(props) {
   const enableV12OverflowMenu = useFeatureFlag('enable-v12-overflowmenu');


### PR DESCRIPTION
Main issue: #16154
Closes #16444 
Closes #16447 as part of exporting props for `Overflowmenu`

Changed from Index.js to Index.tsx as part of typescript adoption.

#### Changelog

**New**

- New index.tsx file

**Changed**

- Asserted `OverflowMenuComponent` as `typeof React.Component` for type assertion
- Changed `renderIcon`'s type as `ComponentType<IconProps>`
- Broadened `Offset` interface to accept `null` and `undefined` matching `PropType` assertion
- Added `IconProps` type as part of `renderIcon`'s assertion
- made `aria-label` as option in the main interface
- exported `OverflowMenuProps`


#### Testing / Reviewing

- Run the deploy preview with overflowmenu and check the functionality to be intact
- This code might have a breaking change, if so please let me know.
