### PR TITLE
feat(tabs): take fade out in contained tabs scroll button

### DIFF
--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -125,24 +125,10 @@
     .#{$prefix}--tab--overflow-nav-button--next::before {
       position: absolute;
       z-index: 1;
-      background: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0),
-        $background
-      );
       block-size: 100%;
       content: '';
       inline-size: $spacing-03;
       inset-inline-start: -$spacing-03;
-    }
-
-    &.#{$prefix}--tabs--contained
-      .#{$prefix}--tab--overflow-nav-button--next::before {
-      background-image: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0),
-        $layer-accent
-      );
     }
 
     .#{$prefix}--tab--overflow-nav-button--previous {
@@ -155,20 +141,10 @@
     .#{$prefix}--tab--overflow-nav-button--previous::before {
       position: absolute;
       z-index: 1;
-      background: linear-gradient(to left, rgba(255, 255, 255, 0), $background);
       block-size: 100%;
       content: '';
       inline-size: $spacing-03;
       inset-inline-end: -$spacing-03;
-    }
-
-    &.#{$prefix}--tabs--contained
-      .#{$prefix}--tab--overflow-nav-button--previous::before {
-      background-image: linear-gradient(
-        to left,
-        rgba(255, 255, 255, 0),
-        $layer-accent
-      );
     }
 
     .#{$prefix}--tabs--light .#{$prefix}--tabs__overflow-indicator--left {


### PR DESCRIPTION


<img width="428" alt="Screenshot 2024-05-20 at 7 04 19 PM" src="https://github.com/carbon-design-system/carbon/assets/72991264/91e3fb7b-764b-4ad2-925d-5e40e42422c0">

<img width="494" alt="Screenshot 2024-05-20 at 7 04 44 PM" src="https://github.com/carbon-design-system/carbon/assets/72991264/098d516a-50ed-4ddb-b7c2-4589969ffaf8">

#### Changelog

**Changed**
Left scroll button:
<img width="441" alt="Screenshot 2024-05-20 at 7 05 26 PM" src="https://github.com/carbon-design-system/carbon/assets/72991264/3d7ea8aa-fc53-46df-90b2-14ead76d3e32">


Right scroll button:
<img width="424" alt="Screenshot 2024-05-20 at 7 05 09 PM" src="https://github.com/carbon-design-system/carbon/assets/72991264/7f8fdf55-43f2-4dcb-9893-6612c4133250">



The disabled token is already apprearing here:
<img width="1468" alt="Screenshot 2024-05-20 at 6 18 23 PM" src="https://github.com/carbon-design-system/carbon/assets/72991264/2eeb16a6-0afd-4ebd-a3d3-2162a3d8f38f">

#### Testing / Reviewing

Start story book with `yarn storybook`
Narrow your screen so that the scrollable button is visible
