### PR TITLE
fix: deprecated `ContainedList.ContainedListItem`

### DIFF
--- a/packages/react/src/components/ContainedList/__tests__/ContainedList-test.js
+++ b/packages/react/src/components/ContainedList/__tests__/ContainedList-test.js
@@ -44,6 +44,7 @@ function TestComponent({ list, item }) {
 
 beforeEach(() => {
   // eslint-disable-next-line testing-library/no-render-in-lifecycle
+  jest.mock('../../../internal/deprecateFieldOnObject');
   wrapper = render(<TestComponent />);
 });
 

--- a/packages/react/src/components/ContainedList/index.ts
+++ b/packages/react/src/components/ContainedList/index.ts
@@ -5,11 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { deprecateFieldOnObject } from '../../internal/deprecateFieldOnObject';
 import ContainedList from './ContainedList';
 import ContainedListItem from './ContainedListItem';
 
 ContainedList.ContainedListItem = ContainedListItem;
 
+if (__DEV__) {
+  deprecateFieldOnObject(ContainedList, 'ContainedListItem', ContainedListItem);
+}
 export { ContainedListItem };
 export default ContainedList;
 export { ContainedList };


### PR DESCRIPTION
Closes First task of #16354 

Deprecates `ContainedList.ContainedListItem` usage

#### Changelog


**Changed**

- used `DeprecateFieldOnObject` to mark the usage of `ContainedList.ContainedListItem` as deprecated
- Added the test mock for `DeprecateFieldOnObject`


#### Testing / Reviewing

Please add an item as `ContainedList.ContainedListItem` and see the warning in the console
