### PR TITLE
fix(tag): use refs to handle component access

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -8240,6 +8240,7 @@ Map {
     },
   },
   "Tag" => Object {
+    "$$typeof": Symbol(react.forward_ref),
     "propTypes": Object {
       "as": Object {
         "type": "elementType",
@@ -8305,6 +8306,7 @@ Map {
         "type": "oneOf",
       },
     },
+    "render": [Function],
   },
   "TagSkeleton" => Object {
     "propTypes": Object {

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useState, ReactNode } from 'react';
+import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import { usePrefix } from '../../internal/usePrefix';
@@ -15,6 +15,7 @@ import Tag, { SIZES, TYPES } from './Tag';
 import { Close } from '@carbon/icons-react';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
+import { isEllipsisActive } from './isEllipsisActive';
 
 const getInstanceId = setupGetInstanceId();
 
@@ -91,22 +92,17 @@ const DismissibleTag = <T extends React.ElementType>({
   ...other
 }: DismissibleTagProps<T>) => {
   const prefix = usePrefix();
+  const tagLabelRef = useRef<HTMLElement>();
   const tagId = id || `tag-${getInstanceId()}`;
   const tagClasses = classNames(`${prefix}--tag--filter`, className);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
-  const isEllipsisActive = (element: any) => {
-    setIsEllipsisApplied(element.offsetWidth < element.scrollWidth);
-    return element.offsetWidth < element.scrollWidth;
-  };
-
   useLayoutEffect(() => {
-    const elementTagId = document.querySelector(`#${tagId}`);
-    const newElement = elementTagId?.getElementsByClassName(
+    const newElement = tagLabelRef.current?.getElementsByClassName(
       `${prefix}--tag__label`
     )[0];
-    isEllipsisActive(newElement);
-  }, [prefix, tagId]);
+    setIsEllipsisApplied(isEllipsisActive(newElement));
+  }, [prefix, tagLabelRef]);
   const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (onClose) {
       event.stopPropagation();
@@ -135,6 +131,7 @@ const DismissibleTag = <T extends React.ElementType>({
 
   return (
     <Tag<any>
+      ref={tagLabelRef}
       type={type}
       size={size}
       renderIcon={renderIcon}

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -130,7 +130,8 @@ const DismissibleTag = <T extends React.ElementType>({
   const dismissLabel = `Dismiss "${text}"`;
 
   return (
-    <Tag<any>
+    // @ts-ignore-error Popover throws a TS error everytime is imported
+    <Tag
       ref={tagLabelRef}
       type={type}
       size={size}

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -130,7 +130,7 @@ const DismissibleTag = <T extends React.ElementType>({
   const dismissLabel = `Dismiss "${text}"`;
 
   return (
-    // @ts-ignore-error Popover throws a TS error everytime is imported
+    // @ts-ignore-error Tag throws a TS error everytime is imported
     <Tag
       ref={tagLabelRef}
       type={type}

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -130,7 +130,6 @@ const DismissibleTag = <T extends React.ElementType>({
   const dismissLabel = `Dismiss "${text}"`;
 
   return (
-    // @ts-ignore-error Tag throws a TS error everytime is imported
     <Tag
       ref={tagLabelRef}
       type={type}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -134,7 +134,7 @@ const OperationalTag = <T extends React.ElementType>({
         leaveDelayMs={0}
         onMouseEnter={false}
         closeOnActivation>
-        {/* @ts-ignore-error Popover throws a TS error everytime is imported */}
+        {/* @ts-ignore-error Tag throws a TS error everytime is imported */}
         <Tag
           ref={tagRef}
           type={type}
@@ -154,7 +154,7 @@ const OperationalTag = <T extends React.ElementType>({
   }
 
   return (
-    // @ts-ignore-error Popover throws a TS error everytime is imported
+    // @ts-ignore-error Tag throws a TS error everytime is imported
     <Tag
       ref={tagRef}
       type={type}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -11,6 +11,7 @@ import React, {
   useLayoutEffect,
   useState,
   ReactNode,
+  useRef,
 } from 'react';
 import classNames from 'classnames';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
@@ -19,6 +20,7 @@ import { PolymorphicProps } from '../../types/common';
 import Tag, { SIZES } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
+import { isEllipsisActive } from './isEllipsisActive';
 
 const getInstanceId = setupGetInstanceId();
 
@@ -97,23 +99,18 @@ const OperationalTag = <T extends React.ElementType>({
   ...other
 }: OperationalTagProps<T>) => {
   const prefix = usePrefix();
+  const tagRef = useRef<HTMLElement>();
   const tagId = id || `tag-${getInstanceId()}`;
   const tagClasses = classNames(`${prefix}--tag--operational`, className);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
-  const isEllipsisActive = (element: any) => {
-    setIsEllipsisApplied(element.offsetWidth < element.scrollWidth);
-    return element.offsetWidth < element.scrollWidth;
-  };
-
   useLayoutEffect(() => {
-    const elementTagId = document.querySelector(`#${tagId}`);
-    const newElement = elementTagId?.getElementsByClassName(
+    const newElement = tagRef.current?.getElementsByClassName(
       `${prefix}--tag__label`
     )[0];
 
-    isEllipsisActive(newElement);
-  }, [prefix, tagId]);
+    setIsEllipsisApplied(isEllipsisActive(newElement));
+  }, [prefix, tagRef]);
 
   let normalizedSlug;
   if (slug && slug['type']?.displayName === 'Slug') {
@@ -138,6 +135,7 @@ const OperationalTag = <T extends React.ElementType>({
         onMouseEnter={false}
         closeOnActivation>
         <Tag<any>
+          ref={tagRef}
           type={type}
           size={size}
           renderIcon={renderIcon}
@@ -156,6 +154,7 @@ const OperationalTag = <T extends React.ElementType>({
 
   return (
     <Tag<any>
+      ref={tagRef}
       type={type}
       size={size}
       renderIcon={renderIcon}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -134,7 +134,8 @@ const OperationalTag = <T extends React.ElementType>({
         leaveDelayMs={0}
         onMouseEnter={false}
         closeOnActivation>
-        <Tag<any>
+        {/* @ts-ignore-error Popover throws a TS error everytime is imported */}
+        <Tag
           ref={tagRef}
           type={type}
           size={size}
@@ -153,7 +154,8 @@ const OperationalTag = <T extends React.ElementType>({
   }
 
   return (
-    <Tag<any>
+    // @ts-ignore-error Popover throws a TS error everytime is imported
+    <Tag
       ref={tagRef}
       type={type}
       size={size}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -134,7 +134,6 @@ const OperationalTag = <T extends React.ElementType>({
         leaveDelayMs={0}
         onMouseEnter={() => false}
         closeOnActivation>
-        {/* @ts-ignore-error Tag throws a TS error everytime is imported */}
         <Tag
           ref={tagRef}
           type={type}
@@ -154,7 +153,6 @@ const OperationalTag = <T extends React.ElementType>({
   }
 
   return (
-    // @ts-ignore-error Tag throws a TS error everytime is imported
     <Tag
       ref={tagRef}
       type={type}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -132,7 +132,7 @@ const OperationalTag = <T extends React.ElementType>({
         align="bottom"
         className={tooltipClasses}
         leaveDelayMs={0}
-        onMouseEnter={false}
+        onMouseEnter={() => false}
         closeOnActivation>
         {/* @ts-ignore-error Tag throws a TS error everytime is imported */}
         <Tag

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -119,7 +119,7 @@ const SelectableTag = <T extends React.ElementType>({
         className={tooltipClasses}
         leaveDelayMs={0}
         onMouseEnter={false}>
-        {/* @ts-ignore-error Popover throws a TS error everytime is imported */}
+        {/* @ts-ignore-error Tag throws a TS error everytime is imported */}
 
         <Tag
           ref={tagRef}
@@ -141,7 +141,7 @@ const SelectableTag = <T extends React.ElementType>({
   }
 
   return (
-    // @ts-ignore-error Popover throws a TS error everytime is imported
+    // @ts-ignore-error Tag throws a TS error everytime is imported
     <Tag
       ref={tagRef}
       slug={slug}

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -119,7 +119,9 @@ const SelectableTag = <T extends React.ElementType>({
         className={tooltipClasses}
         leaveDelayMs={0}
         onMouseEnter={false}>
-        <Tag<any>
+        {/* @ts-ignore-error Popover throws a TS error everytime is imported */}
+
+        <Tag
           ref={tagRef}
           slug={slug}
           size={size}
@@ -139,7 +141,8 @@ const SelectableTag = <T extends React.ElementType>({
   }
 
   return (
-    <Tag<any>
+    // @ts-ignore-error Popover throws a TS error everytime is imported
+    <Tag
       ref={tagRef}
       slug={slug}
       size={size}

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -119,7 +119,6 @@ const SelectableTag = <T extends React.ElementType>({
         className={tooltipClasses}
         leaveDelayMs={0}
         onMouseEnter={() => false}>
-        {/* @ts-ignore-error Tag throws a TS error everytime is imported */}
         <Tag
           ref={tagRef}
           slug={slug}
@@ -140,7 +139,6 @@ const SelectableTag = <T extends React.ElementType>({
   }
 
   return (
-    // @ts-ignore-error Tag throws a TS error everytime is imported
     <Tag
       ref={tagRef}
       slug={slug}

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -118,9 +118,8 @@ const SelectableTag = <T extends React.ElementType>({
         align="bottom"
         className={tooltipClasses}
         leaveDelayMs={0}
-        onMouseEnter={false}>
+        onMouseEnter={() => false}>
         {/* @ts-ignore-error Tag throws a TS error everytime is imported */}
-
         <Tag
           ref={tagRef}
           slug={slug}

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useState, ReactNode } from 'react';
+import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
 import { usePrefix } from '../../internal/usePrefix';
@@ -14,6 +14,7 @@ import { PolymorphicProps } from '../../types/common';
 import Tag, { SIZES } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
+import { isEllipsisActive } from './isEllipsisActive';
 
 const getInstanceId = setupGetInstanceId();
 
@@ -78,6 +79,7 @@ const SelectableTag = <T extends React.ElementType>({
   ...other
 }: SelectableTagProps<T>) => {
   const prefix = usePrefix();
+  const tagRef = useRef<HTMLElement>();
   const tagId = id || `tag-${getInstanceId()}`;
   const [selectedTag, setSelectedTag] = useState(selected);
   const tagClasses = classNames(`${prefix}--tag--selectable`, className, {
@@ -85,18 +87,12 @@ const SelectableTag = <T extends React.ElementType>({
   });
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
-  const isEllipsisActive = (element: any) => {
-    setIsEllipsisApplied(element.offsetWidth < element.scrollWidth);
-    return element.offsetWidth < element.scrollWidth;
-  };
-
   useLayoutEffect(() => {
-    const elementTagId = document.querySelector(`#${tagId}`);
-    const newElement = elementTagId?.getElementsByClassName(
+    const newElement = tagRef.current?.getElementsByClassName(
       `${prefix}--tag__label`
     )[0];
-    isEllipsisActive(newElement);
-  }, [prefix, tagId]);
+    setIsEllipsisApplied(isEllipsisActive(newElement));
+  }, [prefix, tagRef]);
 
   let normalizedSlug;
   if (slug && slug['type']?.displayName === 'Slug') {
@@ -124,6 +120,7 @@ const SelectableTag = <T extends React.ElementType>({
         leaveDelayMs={0}
         onMouseEnter={false}>
         <Tag<any>
+          ref={tagRef}
           slug={slug}
           size={size}
           renderIcon={renderIcon}
@@ -143,6 +140,7 @@ const SelectableTag = <T extends React.ElementType>({
 
   return (
     <Tag<any>
+      ref={tagRef}
       slug={slug}
       size={size}
       renderIcon={renderIcon}

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useState, ReactNode } from 'react';
+import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
 import { Close } from '@carbon/icons-react';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
@@ -15,6 +15,7 @@ import { PolymorphicProps } from '../../types/common';
 import { Text } from '../Text';
 import deprecate from '../../prop-types/deprecate';
 import { DefinitionTooltip } from '../Tooltip';
+import { isEllipsisActive } from './isEllipsisActive';
 
 const getInstanceId = setupGetInstanceId();
 export const TYPES = {
@@ -118,21 +119,16 @@ const Tag = <T extends React.ElementType>({
   ...other
 }: TagProps<T>) => {
   const prefix = usePrefix();
+  const tagRef = useRef<HTMLElement>();
   const tagId = id || `tag-${getInstanceId()}`;
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
-  const isEllipsisActive = (element: any) => {
-    setIsEllipsisApplied(element.offsetWidth < element.scrollWidth);
-    return element.offsetWidth < element.scrollWidth;
-  };
-
   useLayoutEffect(() => {
-    const elementTagId = document.querySelector(`#${tagId}`);
-    const newElement = elementTagId?.getElementsByClassName(
+    const newElement = tagRef.current?.getElementsByClassName(
       `${prefix}--tag__label`
     )[0];
-    isEllipsisActive(newElement);
-  }, [prefix, tagId]);
+    setIsEllipsisApplied(isEllipsisActive(newElement));
+  }, [prefix, tagRef]);
 
   const conditions = [
     `${prefix}--tag--selectable`,
@@ -174,7 +170,7 @@ const Tag = <T extends React.ElementType>({
   if (filter) {
     const ComponentTag = BaseComponent ?? 'div';
     return (
-      <ComponentTag className={tagClasses} id={tagId} {...other}>
+      <ComponentTag ref={tagRef} className={tagClasses} id={tagId} {...other}>
         {CustomIconElement && size !== 'sm' ? (
           <div className={`${prefix}--tag__custom-icon`}>
             <CustomIconElement />
@@ -215,6 +211,7 @@ const Tag = <T extends React.ElementType>({
 
   return (
     <ComponentTag
+      ref={tagRef}
       disabled={disabled}
       className={tagClasses}
       id={tagId}

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -56,7 +56,7 @@ export interface TagBaseProps {
   disabled?: boolean;
 
   /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Use DismissibleTag instead.
+   * @deprecated The `filter` prop has been deprecated and will be removed in the next major version. Use DismissibleTag instead.
    */
   filter?: boolean;
 
@@ -66,7 +66,7 @@ export interface TagBaseProps {
   id?: string;
 
   /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Use DismissibleTag instead.
+   * @deprecated The `onClose` prop has been deprecated and will be removed in the next major version. Use DismissibleTag instead.
    */
   onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 
@@ -88,7 +88,7 @@ export interface TagBaseProps {
   slug?: ReactNode;
 
   /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Use DismissibleTag instead.
+   * @deprecated The `title` prop has been deprecated and will be removed in the next major version. Use DismissibleTag instead.
    */
   title?: string;
 
@@ -280,7 +280,7 @@ Tag.propTypes = {
    */
   filter: deprecate(
     PropTypes.bool,
-    'This property is deprecated and will be removed in the next major version. Use DismissibleTag instead.'
+    'The `filter` prop has been deprecated and will be removed in the next major version. Use DismissibleTag instead.'
   ),
 
   /**
@@ -293,7 +293,7 @@ Tag.propTypes = {
    */
   onClose: deprecate(
     PropTypes.func,
-    'This property is deprecated and will be removed in the next major version. Use DismissibleTag instead.'
+    'The `onClose` prop has been deprecated and will be removed in the next major version. Use DismissibleTag instead.'
   ),
 
   /**
@@ -318,7 +318,7 @@ Tag.propTypes = {
    */
   title: deprecate(
     PropTypes.string,
-    'This property is deprecated and will be removed in the next major version. Use DismissibleTag instead.'
+    'The `title` prop has been deprecated and will be removed in the next major version. Use DismissibleTag instead.'
   ),
 
   /**

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -181,7 +181,7 @@ const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
   if (filter) {
     const ComponentTag = (BaseComponent as React.ElementType) ?? 'div';
     return (
-      <ComponentTag ref={tagRef} className={tagClasses} id={tagId} {...other}>
+      <ComponentTag className={tagClasses} id={tagId} {...other}>
         {CustomIconElement && size !== 'sm' ? (
           <div className={`${prefix}--tag__custom-icon`}>
             <CustomIconElement />

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -6,7 +6,13 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
+import React, {
+  useLayoutEffect,
+  useState,
+  ReactNode,
+  useRef,
+  ForwardedRef,
+} from 'react';
 import classNames from 'classnames';
 import { Close } from '@carbon/icons-react';
 import setupGetInstanceId from '../../tools/setupGetInstanceId';
@@ -16,6 +22,7 @@ import { Text } from '../Text';
 import deprecate from '../../prop-types/deprecate';
 import { DefinitionTooltip } from '../Tooltip';
 import { isEllipsisActive } from './isEllipsisActive';
+import { useMergeRefs } from '@floating-ui/react';
 
 const getInstanceId = setupGetInstanceId();
 export const TYPES = {
@@ -103,23 +110,27 @@ export type TagProps<T extends React.ElementType> = PolymorphicProps<
   TagBaseProps
 >;
 
-const Tag = <T extends React.ElementType>({
-  children,
-  className,
-  id,
-  type,
-  filter, // remove filter in next major release - V12
-  renderIcon: CustomIconElement,
-  title = 'Clear filter', // remove title in next major release - V12
-  disabled,
-  onClose, // remove onClose in next major release - V12
-  size,
-  as: BaseComponent,
-  slug,
-  ...other
-}: TagProps<T>) => {
+const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
+  {
+    children,
+    className,
+    id,
+    type,
+    filter, // remove filter in next major release - V12
+    renderIcon: CustomIconElement,
+    title = 'Clear filter', // remove title in next major release - V12
+    disabled,
+    onClose, // remove onClose in next major release - V12
+    size,
+    as: BaseComponent,
+    slug,
+    ...other
+  }: TagProps<T>,
+  forwardRef: ForwardedRef<Element>
+) {
   const prefix = usePrefix();
   const tagRef = useRef<HTMLElement>();
+  const ref = useMergeRefs([forwardRef, tagRef]);
   const tagId = id || `tag-${getInstanceId()}`;
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
@@ -211,7 +222,7 @@ const Tag = <T extends React.ElementType>({
 
   return (
     <ComponentTag
-      ref={tagRef}
+      ref={ref}
       disabled={disabled}
       className={tagClasses}
       id={tagId}
@@ -251,7 +262,7 @@ const Tag = <T extends React.ElementType>({
       {normalizedSlug}
     </ComponentTag>
   );
-};
+});
 
 Tag.propTypes = {
   /**

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -168,7 +168,7 @@ const Tag = <T extends React.ElementType>({
   }
 
   if (filter) {
-    const ComponentTag = BaseComponent ?? 'div';
+    const ComponentTag = (BaseComponent as React.ElementType) ?? 'div';
     return (
       <ComponentTag ref={tagRef} className={tagClasses} id={tagId} {...other}>
         {CustomIconElement && size !== 'sm' ? (

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -126,7 +126,7 @@ const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
     slug,
     ...other
   }: TagProps<T>,
-  forwardRef: ForwardedRef<Element>
+  forwardRef: ForwardedRef<HTMLElement | undefined>
 ) {
   const prefix = usePrefix();
   const tagRef = useRef<HTMLElement>();

--- a/packages/react/src/components/Tag/isEllipsisActive.ts
+++ b/packages/react/src/components/Tag/isEllipsisActive.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const isEllipsisActive = (element: any) => {
+  if (element) {
+    return element?.offsetWidth < element?.scrollWidth;
+  }
+  return false;
+};

--- a/packages/react/src/components/Tag/isEllipsisActive.ts
+++ b/packages/react/src/components/Tag/isEllipsisActive.ts
@@ -7,6 +7,7 @@
 
 export const isEllipsisActive = (element: any) => {
   if (element) {
+    console.log('element offste', element?.offsetWidth < element?.scrollWidth);
     return element?.offsetWidth < element?.scrollWidth;
   }
   return false;

--- a/packages/react/src/components/Tag/isEllipsisActive.ts
+++ b/packages/react/src/components/Tag/isEllipsisActive.ts
@@ -7,7 +7,6 @@
 
 export const isEllipsisActive = (element: any) => {
   if (element) {
-    console.log('element offste', element?.offsetWidth < element?.scrollWidth);
     return element?.offsetWidth < element?.scrollWidth;
   }
   return false;

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -182,7 +182,7 @@ function Tooltip<T extends React.ElementType>({
 
   function onMouseEnter() {
     // Interactive Tags should not support onMouseEnter
-    if (!rest?.onMouseEnter?.()) {
+    if (!rest?.onMouseEnter) {
       setIsPointerIntersecting(true);
       setOpen(true, enterDelayMs);
     }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16570

When using the querySelector it is easily broken if the id has reserved characters also the isEllipsisActive helper had no protection for a non element. So now using refs to access the DOM element and the helper has been extracted for reuse and includes extra protection.

#### Changelog

**New**

- {{new thing}}

**Changed**

- Update how the tag components reference themselves

**Removed**

- {{removed thing}}

#### Testing / Reviewing

- Follow the example in the original bug to test that the original issue does not take place.

N.B. There was no testing in place around the recent changes that were added, it is strongly advised that we need tests here both unit and E2E.
