### PR TITLE
fix(16575): modify useIsTruncated hook in ListBoxMenuItem

### DIFF
--- a/packages/react/src/components/ListBox/ListBoxMenuItem.tsx
+++ b/packages/react/src/components/ListBox/ListBoxMenuItem.tsx
@@ -16,8 +16,7 @@ function useIsTruncated(ref) {
 
   useEffect(() => {
     const element = ref.current;
-    const { offsetWidth, scrollWidth } =
-      element.lastElementChild?.lastElementChild || element;
+    const { offsetWidth, scrollWidth } = element;
     setIsTruncated(offsetWidth < scrollWidth);
   }, [ref, setIsTruncated]);
 


### PR DESCRIPTION
Reference #16575

When the dropdown item is selected, in the control in ```useIsTruncated``` hook, ```element.lastElementChild?.lastElementChild``` always be the path of the checkmark svg. OffsetWidth of this path was undefined and scrollWidth was 0. Because of that ```useIsTruncated``` returns false and the tooltip was not working. I modified the inside of the hook. it always gets the offsetWidth and scrollWidth of the element so it works fine.

#### Changelog

**New**

- N/A

**Changed**

-  Modified ```useIsTruncated``` hook in ```ListBoxMenuItem``` component to always use the element's offsetWidth and scrollWidth, fixing the issue with the tooltip not displaying.

**Removed**

- Removed the nested element control from the ```useIsTruncated``` hook that references the path of the checkmark svg.

#### Testing / Reviewing

The full text of the dropdown item now appears in the tooltip on hover, whether the item is selected or not. You can see the issue before it was fixed in the issue closed by this commit.
