### PR TITLE
fix: border issue for expandable interactive tile for feature flags

### DIFF
--- a/packages/styles/scss/components/tile/_tile.scss
+++ b/packages/styles/scss/components/tile/_tile.scss
@@ -232,6 +232,12 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
     inline-size: $-icon-container-size;
     inset-block-end: 0;
     inset-inline-end: 0;
+    @if (
+      enabled('enable-experimental-tile-contrast') or
+        $enable-experimental-tile-contrast
+    ) {
+      border: 1px solid $border-disabled;
+    }
 
     &:focus {
       outline: 2px solid $focus;
@@ -271,6 +277,7 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
   }
 
   .#{$prefix}--tile--expandable.#{$prefix}--tile--expandable--interactive {
+    border: none;
     cursor: default;
     transition: max-height $duration-moderate-01 motion(standard, productive);
 


### PR DESCRIPTION
Closes #15940 

Since the entire tile is not clickable, the border should be around the button instead of being around the tile

#### Changelog

**New**

- Added border to button for expandable interactive tile for feature flags

**Removed**

- Removed border from the whole expandable interactive tile since its not clickable

#### Testing / Reviewing

Go to Feature Flags -> Tile -> Expandable With Interactive Tile  
- Tile should not have the border instead there should be border on the chevron button
- These styles should not effect any other type of tile whether in feature flags or a normal component
- Same styles should be present in the component using the Expandable With Interactive Tile (Ex: Expandable with Layer in feature flags)
