### PR TITLE
 Adds horizontal variant in CheckboxGroup

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -544,6 +544,15 @@ Map {
         "isRequired": true,
         "type": "node",
       },
+      "orientation": Object {
+        "args": Array [
+          Array [
+            "horizontal",
+            "vertical",
+          ],
+        ],
+        "type": "oneOf",
+      },
       "readOnly": Object {
         "type": "bool",
       },

--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -45,7 +45,10 @@ export const Default = () => {
 
 export const Horizontal = () => {
   return (
-    <CheckboxGroup orientation="horizontal" {...fieldsetCheckboxProps()}>
+    <CheckboxGroup
+      orientation="horizontal"
+      {...fieldsetCheckboxProps()}
+      helperText="Helper text goes here">
       <Checkbox labelText={`Checkbox label`} id="checkbox-label-1" />
       <Checkbox labelText={`Checkbox label`} id="checkbox-label-2" />
       <Checkbox labelText={`Checkbox label`} id="checkbox-label-3" />
@@ -195,5 +198,10 @@ Playground.argTypes = {
     table: {
       disable: true,
     },
+  },
+  orientation: {
+    description: 'Provide how checkbox should be displayed',
+    control: 'select',
+    options: ['horizontal', 'vertical'],
   },
 };

--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -43,6 +43,16 @@ export const Default = () => {
   );
 };
 
+export const Horizontal = () => {
+  return (
+    <CheckboxGroup orientation="horizontal" {...fieldsetCheckboxProps()}>
+      <Checkbox labelText={`Checkbox label`} id="checkbox-label-1" />
+      <Checkbox labelText={`Checkbox label`} id="checkbox-label-2" />
+      <Checkbox labelText={`Checkbox label`} id="checkbox-label-3" />
+    </CheckboxGroup>
+  );
+};
+
 export const Single = () => {
   return (
     <>

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup-test.js
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup-test.js
@@ -161,4 +161,17 @@ describe('CheckboxGroup', () => {
 
     expect(container.firstChild).toHaveClass(`${prefix}--checkbox-group--slug`);
   });
+  it('should render checkboxes horizontally', () => {
+    const { container } = render(
+      <CheckboxGroup orientation="horizontal" legendText="test-horizental-prop">
+        <Checkbox labelText="Checkbox label 1" id="checkbox-label-1" />
+        <Checkbox labelText="Checkbox label 2" id="checkbox-label-2" />
+        <Checkbox labelText="Checkbox label 3" id="checkbox-label-3" />
+      </CheckboxGroup>
+    );
+
+    expect(container.firstChild).toHaveClass(
+      `${prefix}--checkbox-group--horizontal`
+    );
+  });
 });

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.js
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.js
@@ -138,7 +138,7 @@ CheckboxGroup.propTypes = {
   legendText: PropTypes.node.isRequired,
 
   /**
-   * Provide where checkbox should be placed
+   * Provide the orientation for how the checkbox should be displayed
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.js
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.js
@@ -26,6 +26,7 @@ function CheckboxGroup({
   warn,
   warnText,
   slug,
+  orientation = 'vertical',
   ...rest
 }) {
   const prefix = usePrefix();
@@ -46,6 +47,7 @@ function CheckboxGroup({
   ) : null;
 
   const fieldsetClasses = cx(`${prefix}--checkbox-group`, className, {
+    [`${prefix}--checkbox-group--${orientation}`]: orientation === 'horizontal',
     [`${prefix}--checkbox-group--readonly`]: readOnly,
     [`${prefix}--checkbox-group--invalid`]: !readOnly && invalid,
     [`${prefix}--checkbox-group--warning`]: showWarning,
@@ -67,6 +69,7 @@ function CheckboxGroup({
       data-invalid={invalid ? true : undefined}
       aria-labelledby={rest['aria-labelledby'] || legendId}
       aria-readonly={readOnly}
+      orientation="vertical"
       aria-describedby={!invalid && !warn && helper ? helperId : undefined}
       {...rest}>
       <legend
@@ -133,6 +136,11 @@ CheckboxGroup.propTypes = {
    * Provide the text to be rendered inside of the fieldset <legend>
    */
   legendText: PropTypes.node.isRequired,
+
+  /**
+   * Provide where checkbox should be placed
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 
   /**
    * Whether the CheckboxGroup should be read-only

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -409,5 +409,5 @@
     .#{$prefix}--label + .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
       margin-block-start: 0;
     }
-
+}
 }

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -401,12 +401,15 @@
         margin-inline-end: $spacing-05;
       }
     }
+
     .#{$prefix}--checkbox-label-text {
       padding-inline-start: $spacing-03;
     }
+
     .#{$prefix}--label + .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
       margin-block-start: 0;
     }
+
     .#{$prefix}--checkbox-group__validation-msg,
     .#{$prefix}--form__helper-text {
       position: absolute;

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -388,6 +388,7 @@
 
   // horizontal checkbox group
   .#{$prefix}--checkbox-group--horizontal {
+    position: relative;
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -400,9 +401,17 @@
         margin-inline-end: $spacing-05;
       }
     }
-
+    .#{$prefix}--checkbox-label-text {
+      padding-inline-start: $spacing-03;
+    }
     .#{$prefix}--label + .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
       margin-block-start: 0;
+    }
+    .#{$prefix}--checkbox-group__validation-msg,
+    .#{$prefix}--form__helper-text {
+      position: absolute;
+      inset-block-end: -($spacing-02 + $spacing-05);
+      inset-inline-start: 0;
     }
   }
 }

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -390,7 +390,7 @@
   .#{$prefix}--checkbox-group--horizontal {
     position: relative;
     display: flex;
-    flex-direction: row;
+    flex-flow: row wrap;
     justify-content: flex-start;
 
     .#{$prefix}--form-item {
@@ -409,5 +409,5 @@
     .#{$prefix}--label + .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
       margin-block-start: 0;
     }
-}
+  }
 }

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -410,11 +410,4 @@
       margin-block-start: 0;
     }
 
-    .#{$prefix}--checkbox-group__validation-msg,
-    .#{$prefix}--form__helper-text {
-      position: absolute;
-      inset-block-end: -($spacing-02 + $spacing-05);
-      inset-inline-start: 0;
-    }
-  }
 }

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -385,4 +385,24 @@
     line-height: inherit;
     margin-block-start: convert.to-rem(-1px);
   }
+
+  // horizontal checkbox group
+  .#{$prefix}--checkbox-group--horizontal {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+
+    .#{$prefix}--form-item {
+      flex: none;
+      margin-block-end: 0;
+
+      &:not(:last-of-type) {
+        margin-inline-end: $spacing-05;
+      }
+    }
+
+    .#{$prefix}--label + .#{$prefix}--form-item.#{$prefix}--checkbox-wrapper {
+      margin-block-start: 0;
+    }
+  }
 }


### PR DESCRIPTION
Closes #16486

Adds horizontal variant in CheckboxGroup

#### Changelog

**New**

- Adds new `orientation` optional prop ([reference from RadioButtonGroup](https://github.com/carbon-design-system/carbon/blob/f7065bcb00028c79a8253ad8478600ed5a0d3bb2/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx#L97C2-L97C43))
- Adds `orientation` to playground 
- Updates storybook to demo horizontal variant in CheckboxGroup
- New styles are added 
- Adds a test to verify if correct classnames are applied when `orientation` is set to `horizontal` 

The parent `<fieldset> ` uses `display: flex` for horizontal alignment, causing issues with the alignment of the warning messages. 
To avoid breaking changes in the DOM structure, class usage and styles , I have applied `position: absolute `to the warning message `<div>` to ensure it appears correctly below the `<fieldset>`.

<img width="831" alt="image" src="https://github.com/carbon-design-system/carbon/assets/63502271/f2d9bd5e-18d2-41ec-b045-000185c3a269">



#### Testing / Reviewing

Open deploy preview and navigate to CheckboxGroup story to verify if horizontal variant is working good.
Also verify `orientation` prop working in playground 

