### PR TITLE
fix: floating ui on combobutton

### DIFF
--- a/packages/react/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/react/src/components/ComboButton/ComboButton.stories.js
@@ -36,6 +36,22 @@ export const Default = () => (
   </ComboButton>
 );
 
+export const ExperimentalAutoAlign = () => (
+  <div style={{ width: '5000px', height: '5000px' }}>
+    <div
+      style={{
+        position: 'absolute',
+        bottom: '20px',
+      }}>
+      <ComboButton label="Primary action">
+        <MenuItem label="Second action with a long label description" />
+        <MenuItem label="Third action" />
+        <MenuItem label="Fourth action" disabled />
+      </ComboButton>
+    </div>{' '}
+  </div>
+);
+
 export const WithDanger = () => (
   <ComboButton label="Primary action">
     <MenuItem label="Second action with a long label description" />


### PR DESCRIPTION
Closes #16540  

This PR enhances ComboButton experimental autoAlign functionality to automatically position the floating element to be within view, even on scroll.

This uses [floating-ui](https://floating-ui.com/) and relies solely on the fixed strategy, using position: fixed on the floating element. In the majority of cases, ComboButton floating elements will no longer be clipped by parents with overflow: hidden.

Changed

- Use floating-ui for positioning  floating element.
- Feed floating-ui the values of ComboButton custom properties (flip,size) when possible.

Removed

- Sending X and Y coordinates for the floating element (Menu) from ComboButton. All the calculations like width of floating element , X and Y positions are calculated by floating UI itself.

Testing / Reviewing

- View the ComboButton stories, there is autoalign experiment story in there. Ensure it works as intended and there's no regressions.
- Make sure that the menu does not detach itself from ComboButton when you scroll.