### PR TITLE
feat(slider): expose formatLabel to value tooltip

### DIFF
--- a/e2e/components/Slider/Slider-test.avt.e2e.js
+++ b/e2e/components/Slider/Slider-test.avt.e2e.js
@@ -92,6 +92,20 @@ test.describe('@avt Slider', () => {
     await expect(page).toHaveNoACViolations('Slider-with-layer');
   });
 
+  test('@avt-advanced-states slider with custom format', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Slider',
+      id: 'components-slider--slider-with-custom-value-label',
+      globals: {
+        theme: 'white',
+      },
+    });
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('slider')).toHaveValue('Medium');
+    await expect(page).toHaveNoACViolations('Slider-with-custom-value-label');
+  });
+
   // Prevent timeout
   test.slow('@avt-keyboard-nav', async ({ page }) => {
     await visitStory(page, {

--- a/e2e/components/Slider/Slider-test.avt.e2e.js
+++ b/e2e/components/Slider/Slider-test.avt.e2e.js
@@ -92,19 +92,45 @@ test.describe('@avt Slider', () => {
     await expect(page).toHaveNoACViolations('Slider-with-layer');
   });
 
-  test('@avt-advanced-states slider with custom format', async ({ page }) => {
-    await visitStory(page, {
-      component: 'Slider',
-      id: 'components-slider--slider-with-custom-value-label',
-      globals: {
-        theme: 'white',
-      },
-    });
+  test.slow(
+    '@avt-advanced-states slider with custom format',
+    async ({ page }) => {
+      await visitStory(page, {
+        component: 'Slider',
+        id: 'components-slider--slider-with-custom-value-label',
+        globals: {
+          theme: 'white',
+        },
+      });
 
-    await page.keyboard.press('Tab');
-    await expect(page.getByRole('slider')).toHaveValue('Medium');
-    await expect(page).toHaveNoACViolations('Slider-with-custom-value-label');
-  });
+      // Test for label changes
+      // Initial value
+      await page.keyboard.press('Tab');
+      await expect(page.getByRole('slider')).toBeVisible();
+      await page.keyboard.press('Tab');
+
+      await expect(page.getByRole('slider')).toHaveAttribute(
+        'aria-valuetext',
+        'Medium'
+      );
+      // Move to high
+      await page.keyboard.press('Shift+ArrowRight');
+      await expect(page.getByRole('slider')).toHaveAttribute(
+        'aria-valuetext',
+        'High'
+      );
+
+      // Move to Low
+      await page.keyboard.press('Shift+ArrowLeft');
+      await page.keyboard.press('Shift+ArrowLeft');
+      await expect(page.getByRole('slider')).toHaveAttribute(
+        'aria-valuetext',
+        'Low'
+      );
+
+      await expect(page).toHaveNoACViolations('Slider-with-custom-value-label');
+    }
+  );
 
   // Prevent timeout
   test.slow('@avt-keyboard-nav', async ({ page }) => {

--- a/e2e/components/Slider/Slider-test.avt.e2e.js
+++ b/e2e/components/Slider/Slider-test.avt.e2e.js
@@ -92,45 +92,44 @@ test.describe('@avt Slider', () => {
     await expect(page).toHaveNoACViolations('Slider-with-layer');
   });
 
-  test.slow(
-    '@avt-advanced-states slider with custom format',
-    async ({ page }) => {
-      await visitStory(page, {
-        component: 'Slider',
-        id: 'components-slider--slider-with-custom-value-label',
-        globals: {
-          theme: 'white',
-        },
-      });
+  test('@avt-advanced-states slider with custom format', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Slider',
+      id: 'components-slider--slider-with-custom-value-label',
+      globals: {
+        theme: 'white',
+      },
+    });
 
-      // Test for label changes
-      // Initial value
-      await page.keyboard.press('Tab');
-      await expect(page.getByRole('slider')).toBeVisible();
-      await page.keyboard.press('Tab');
+    await expect(page).toHaveNoACViolations('Slider-with-custom-value-label');
+  });
 
-      await expect(page.getByRole('slider')).toHaveAttribute(
-        'aria-valuetext',
-        'Medium'
-      );
-      // Move to high
-      await page.keyboard.press('Shift+ArrowRight');
-      await expect(page.getByRole('slider')).toHaveAttribute(
-        'aria-valuetext',
-        'High'
-      );
+  test.slow('@avt-keyboard-nav slider with custom format', async ({ page }) => {
+    // Test for label changes
+    // Initial value
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('slider')).toBeVisible();
+    await page.keyboard.press('Tab');
 
-      // Move to Low
-      await page.keyboard.press('Shift+ArrowLeft');
-      await page.keyboard.press('Shift+ArrowLeft');
-      await expect(page.getByRole('slider')).toHaveAttribute(
-        'aria-valuetext',
-        'Low'
-      );
+    await expect(page.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      'Medium'
+    );
+    // Move to high
+    await page.keyboard.press('Shift+ArrowRight');
+    await expect(page.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      'High'
+    );
 
-      await expect(page).toHaveNoACViolations('Slider-with-custom-value-label');
-    }
-  );
+    // Move to Low
+    await page.keyboard.press('Shift+ArrowLeft');
+    await page.keyboard.press('Shift+ArrowLeft');
+    await expect(page.getByRole('slider')).toHaveAttribute(
+      'aria-valuetext',
+      'Low'
+    );
+  });
 
   // Prevent timeout
   test.slow('@avt-keyboard-nav', async ({ page }) => {

--- a/e2e/components/Slider/Slider-test.avt.e2e.js
+++ b/e2e/components/Slider/Slider-test.avt.e2e.js
@@ -105,6 +105,14 @@ test.describe('@avt Slider', () => {
   });
 
   test.slow('@avt-keyboard-nav slider with custom format', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Slider',
+      id: 'components-slider--slider-with-custom-value-label',
+      globals: {
+        theme: 'white',
+      },
+    });
+
     // Test for label changes
     // Initial value
     await page.keyboard.press('Tab');

--- a/e2e/components/Slider/Slider-test.e2e.js
+++ b/e2e/components/Slider/Slider-test.e2e.js
@@ -37,6 +37,14 @@ test.describe('Slider', () => {
           theme,
         });
       });
+
+      test('slider with formatLabel @vrt', async ({ page }) => {
+        await snapshotStory(page, {
+          component: 'Slider',
+          id: 'components-slider--slider-with-custom-value-label',
+          theme,
+        });
+      });
     });
   });
 });

--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -466,6 +466,28 @@ describe('Slider', () => {
         expect(rangeLabels[0]).toHaveTextContent('0-min');
         expect(rangeLabels[1]).toHaveTextContent('100-max');
       });
+
+      it('supports custom formatting on the tooltip when input is hidden', () => {
+        const { container } = renderSlider({
+          min: 0,
+          max: 100,
+          value: 50,
+          formatLabel: (value) => `${value}%`,
+          hideTextInput: true,
+        });
+
+        const rangeLabels = container.querySelectorAll(
+          `.${prefix}--slider__range-label`
+        );
+
+        const valueLabel = container.querySelector(
+          `.${prefix}--popover-content.${prefix}--tooltip-content`
+        );
+
+        expect(rangeLabels[0]).toHaveTextContent('0%');
+        expect(rangeLabels[1]).toHaveTextContent('100%');
+        expect(valueLabel).toHaveTextContent('50%');
+      });
     });
 
     describe('Key/mouse event processing', () => {
@@ -742,6 +764,30 @@ describe('Slider', () => {
       );
       expect(lowerInput).toHaveAttribute('type', 'hidden');
       expect(upperInput).toHaveAttribute('type', 'hidden');
+    });
+
+    it('supports custom formatting on the tooltip when input is hidden', () => {
+      const { container } = renderTwoHandleSlider({
+        min: 0,
+        max: 100,
+        value: 50,
+        unstable_valueUpper: 70,
+        formatLabel: (value) => `${value}%`,
+        hideTextInput: true,
+      });
+
+      const rangeLabels = container.querySelectorAll(
+        `.${prefix}--slider__range-label`
+      );
+
+      const valueLabels = container.querySelectorAll(
+        `.${prefix}--popover-content.${prefix}--tooltip-content`
+      );
+
+      expect(rangeLabels[0]).toHaveTextContent('0%');
+      expect(rangeLabels[1]).toHaveTextContent('100%');
+      expect(valueLabels[0]).toHaveTextContent('50%');
+      expect(valueLabels[1]).toHaveTextContent('70%');
     });
 
     it('allows user to set invalid value when typing in input field', async () => {

--- a/packages/react/src/components/Slider/Slider.stories.js
+++ b/packages/react/src/components/Slider/Slider.stories.js
@@ -53,6 +53,41 @@ export const SliderWithHiddenInputs = () => (
   />
 );
 
+export const SliderWithHiddenInputsAndFormatLabel = () => (
+  <Slider
+    labelText="Slider label with percentage"
+    value={50}
+    min={0}
+    max={100}
+    stepMultiplier={10}
+    step={1}
+    noValidate
+    hideTextInput
+    formatLabel={(val) => `${val}%`}
+  />
+);
+
+export const SliderWithHiddenInputsAndCustomFormat = () => (
+  <Slider
+    labelText="Slider label with low/medium/high"
+    value={50}
+    min={0}
+    max={100}
+    stepMultiplier={10}
+    step={1}
+    noValidate
+    hideTextInput
+    formatLabel={(val) => {
+      if (val < 25) {
+        return 'Low';
+      } else if (val > 75) {
+        return 'High';
+      }
+      return 'Medium';
+    }}
+  />
+);
+
 export const ControlledSlider = () => {
   const [val, setVal] = useState(87);
   return (

--- a/packages/react/src/components/Slider/Slider.stories.js
+++ b/packages/react/src/components/Slider/Slider.stories.js
@@ -53,27 +53,13 @@ export const SliderWithHiddenInputs = () => (
   />
 );
 
-export const SliderWithHiddenInputsAndFormatLabel = () => (
-  <Slider
-    labelText="Slider label with percentage"
-    value={50}
-    min={0}
-    max={100}
-    stepMultiplier={10}
-    step={1}
-    noValidate
-    hideTextInput
-    formatLabel={(val) => `${val}%`}
-  />
-);
-
 export const SliderWithCustomValueLabel = () => (
   <Slider
     labelText="Slider label with low/medium/high"
     value={50}
     min={0}
     max={100}
-    stepMultiplier={10}
+    stepMultiplier={50}
     step={1}
     noValidate
     hideTextInput

--- a/packages/react/src/components/Slider/Slider.stories.js
+++ b/packages/react/src/components/Slider/Slider.stories.js
@@ -67,7 +67,7 @@ export const SliderWithHiddenInputsAndFormatLabel = () => (
   />
 );
 
-export const SliderWithHiddenInputsAndCustomFormat = () => (
+export const SliderWithCustomValueLabel = () => (
   <Slider
     labelText="Slider label with low/medium/high"
     value={50}

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -1529,6 +1529,7 @@ class Slider extends PureComponent<SliderProps> {
                       role="slider"
                       id={twoHandles ? undefined : id}
                       tabIndex={!readOnly ? 0 : -1}
+                      aria-valuetext={`${formatLabel(value, '')}`}
                       aria-valuemax={twoHandles ? valueUpper : max}
                       aria-valuemin={min}
                       aria-valuenow={value}

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -153,7 +153,7 @@ export interface SliderProps
   disabled?: boolean;
 
   /**
-   * The callback to format the label associated with the minimum/maximum value.
+   * The callback to format the label associated with the minimum/maximum value and the value tooltip when hideTextInput is true.
    */
   formatLabel?: (value: number, label: string | undefined) => string;
 
@@ -1521,7 +1521,7 @@ class Slider extends PureComponent<SliderProps> {
                   <ThumbWrapper
                     hasTooltip={hideTextInput}
                     className={lowerThumbWrapperClasses}
-                    label={`${value}`}
+                    label={`${formatLabel(value, '')}`}
                     align="top"
                     {...lowerThumbWrapperProps}>
                     <div
@@ -1555,7 +1555,7 @@ class Slider extends PureComponent<SliderProps> {
                     <ThumbWrapper
                       hasTooltip={hideTextInput}
                       className={upperThumbWrapperClasses}
-                      label={`${valueUpper}`}
+                      label={`${formatLabel(valueUpper || 0, '')}`}
                       align="top"
                       {...upperThumbWrapperProps}>
                       <div


### PR DESCRIPTION
This PR exposes formatLabel to the tooltip for devs to use

- expose formatLabel to thumbWrapper for twoHandles as well as single handle.
- add examples on storybooks on how it could be used

Doesn't close a PR but gets us closer to the comment here: https://github.com/carbon-design-system/carbon/issues/7581#issuecomment-1113437295

#### Changelog

**New**

- `formatLabel` now also works with the Tooltips for the thumbs which gives you more options on how to customize how the value looks.
- Two new storybooks added to describe the change

**Changed**

- Changed the definition of `formatLabel` to represent the above addition

#### Testing / Reviewing

- Ran unit test to make sure nothing is breaking
- You can test it by changing the storybooks:
    - [Slider With Hidden Inputs And Custom Format](http://localhost:3001/?path=/story/components-slider--slider-with-hidden-inputs-and-custom-format)
    - [Slider With Hidden Inputs And Format Label](http://localhost:3001/?path=/story/components-slider--slider-with-hidden-inputs-and-format-label)
    
#### Screenshots

![Screenshot 2024-05-29 at 10 13 36 AM](https://github.com/carbon-design-system/carbon/assets/8481567/000e7884-adff-455e-be4b-21386c567c93)
![Screenshot 2024-05-29 at 10 13 49 AM](https://github.com/carbon-design-system/carbon/assets/8481567/48de7554-9e41-4b8d-acad-facf0adbbbb7)
![Screenshot 2024-05-29 at 10 13 56 AM](https://github.com/carbon-design-system/carbon/assets/8481567/6eae387f-1077-4b82-a837-508f73c077fd)
