### PR TITLE
docs: recorded `Containedlistitem` usage depreciation

### DIFF
--- a/packages/react/src/components/ContainedList/ContainedList.mdx
+++ b/packages/react/src/components/ContainedList/ContainedList.mdx
@@ -100,9 +100,6 @@ render inline to the Contained List title, please see the
 also remain persistent under the title, so that it remains visible on scroll,
 when there are many list items passed in.
 
-`ContainedList.ContainedListItem` is deprecated, use
-`import { ContainedListItem } from '@carbon/react`
-import instead.
 
 ```js
 export const WithPersistentSearch = () => {
@@ -142,6 +139,10 @@ export const WithPersistentSearch = () => {
   );
 };
 ```
+
+`ContainedList.ContainedListItem` is deprecated, use
+`import { ContainedListItem } from '@carbon/react`
+import instead.
 
 <Canvas>
   <Story of={ContainedListStories.WithPersistentSearch} />

--- a/packages/react/src/components/ContainedList/ContainedList.mdx
+++ b/packages/react/src/components/ContainedList/ContainedList.mdx
@@ -100,6 +100,10 @@ render inline to the Contained List title, please see the
 also remain persistent under the title, so that it remains visible on scroll,
 when there are many list items passed in.
 
+`ContainedList.ContainedListItem` is deprecated, use
+`import { ContainedListItem } from '@carbon/react`
+import instead.
+
 ```js
 export const WithPersistentSearch = () => {
   const [searchTerm, setSearchTerm] = useState('');


### PR DESCRIPTION
Closes third task of #16354

Recorded the depreciation of the usage, `ContainedList.ContainedListItem` in the mdx docs.

#### Changelog

**New**

- added the depreciation message and how to use the new import.

#### Testing / Reviewing

check the github docs for ContainedList.mdx to see the latest doc update
