### PR TITLE
feat: improve `RadioButton` and `RadioButtonGroup` types

### DIFF
--- a/packages/react/src/components/RadioButton/RadioButton.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.tsx
@@ -72,8 +72,8 @@ export interface RadioButtonProps
    * the underlying `<input>` changes
    */
   onChange?: (
-    value: string | number,
-    name: string | undefined,
+    value: RadioButtonProps['value'],
+    name: RadioButtonProps['name'],
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
 
@@ -98,80 +98,85 @@ export interface RadioButtonProps
   required?: boolean;
 }
 
-const RadioButton = React.forwardRef((props: RadioButtonProps, ref) => {
-  const {
-    className,
-    disabled,
-    hideLabel,
-    id,
-    labelPosition = 'right',
-    labelText = '',
-    name,
-    onChange = () => {},
-    value = '',
-    slug,
-    required,
-    ...rest
-  } = props;
+const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
+  (props, ref) => {
+    const {
+      className,
+      disabled,
+      hideLabel,
+      id,
+      labelPosition = 'right',
+      labelText = '',
+      name,
+      onChange = () => {},
+      value = '',
+      slug,
+      required,
+      ...rest
+    } = props;
 
-  const prefix = usePrefix();
-  const uid = useId('radio-button');
-  const uniqueId = id || uid;
+    const prefix = usePrefix();
+    const uid = useId('radio-button');
+    const uniqueId = id || uid;
 
-  function handleOnChange(event) {
-    onChange(value, name, event);
-  }
-
-  const innerLabelClasses = classNames(`${prefix}--radio-button__label-text`, {
-    [`${prefix}--visually-hidden`]: hideLabel,
-  });
-
-  const wrapperClasses = classNames(
-    className,
-    `${prefix}--radio-button-wrapper`,
-    {
-      [`${prefix}--radio-button-wrapper--label-${labelPosition}`]:
-        labelPosition !== 'right',
-      [`${prefix}--radio-button-wrapper--slug`]: slug,
+    function handleOnChange(event: React.ChangeEvent<HTMLInputElement>) {
+      onChange(value, name, event);
     }
-  );
 
-  const inputRef = useRef<HTMLInputElement>(null);
+    const innerLabelClasses = classNames(
+      `${prefix}--radio-button__label-text`,
+      {
+        [`${prefix}--visually-hidden`]: hideLabel,
+      }
+    );
 
-  let normalizedSlug;
-  if (slug && React.isValidElement(slug)) {
-    const size = slug.props?.['kind'] === 'inline' ? 'md' : 'mini';
-    normalizedSlug = React.cloneElement(slug as React.ReactElement<any>, {
-      size,
-    });
+    const wrapperClasses = classNames(
+      className,
+      `${prefix}--radio-button-wrapper`,
+      {
+        [`${prefix}--radio-button-wrapper--label-${labelPosition}`]:
+          labelPosition !== 'right',
+        [`${prefix}--radio-button-wrapper--slug`]: slug,
+      }
+    );
+
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    let normalizedSlug: React.ReactElement | undefined;
+    if (slug && React.isValidElement(slug)) {
+      const size = slug.props?.['kind'] === 'inline' ? 'md' : 'mini';
+      normalizedSlug = React.cloneElement(slug as React.ReactElement<any>, {
+        size,
+      });
+    }
+
+    return (
+      <div className={wrapperClasses}>
+        <input
+          {...rest}
+          type="radio"
+          className={`${prefix}--radio-button`}
+          onChange={handleOnChange}
+          id={uniqueId}
+          ref={mergeRefs(inputRef, ref)}
+          disabled={disabled}
+          value={value}
+          name={name}
+          required={required}
+        />
+        <label htmlFor={uniqueId} className={`${prefix}--radio-button__label`}>
+          <span className={`${prefix}--radio-button__appearance`} />
+          {labelText && (
+            <Text className={innerLabelClasses}>
+              {labelText}
+              {normalizedSlug}
+            </Text>
+          )}
+        </label>
+      </div>
+    );
   }
-
-  return (
-    <div className={wrapperClasses}>
-      <input
-        {...rest}
-        type="radio"
-        className={`${prefix}--radio-button`}
-        onChange={handleOnChange}
-        id={uniqueId}
-        ref={mergeRefs(inputRef, ref)}
-        disabled={disabled}
-        value={value}
-        name={name}
-        required={required}
-      />
-      <label htmlFor={uniqueId} className={`${prefix}--radio-button__label`}>
-        <span className={`${prefix}--radio-button__appearance`} />
-        {labelText && (
-          <Text className={innerLabelClasses}>
-            {labelText}
-            {normalizedSlug}
-          </Text>
-        )}
-      </label>
-    </div>
-  );
-});
+);
 
 RadioButton.displayName = 'RadioButton';
 

--- a/packages/react/src/components/RadioButton/index.ts
+++ b/packages/react/src/components/RadioButton/index.ts
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import RadioButton from './RadioButton';
+import RadioButton, { RadioButtonProps } from './RadioButton';
 
 export default RadioButton;
 export { RadioButton };
+
+export type { RadioButtonProps };

--- a/packages/react/src/components/RadioButtonGroup/index.ts
+++ b/packages/react/src/components/RadioButtonGroup/index.ts
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import RadioButtonGroup from './RadioButtonGroup';
+import RadioButtonGroup, { RadioButtonGroupProps } from './RadioButtonGroup';
 
 export default RadioButtonGroup;
 export { RadioButtonGroup };
+
+export type { RadioButtonGroupProps };


### PR DESCRIPTION
In #16186, the `selection` argument of `RadioButtonGroup`'s `onChange` prop was changed to `ReactNode` instead of `string | number` as written in the PR description. In addition to fixing that I have added some missing types and improved others.


#### Changelog

- Export prop interfaces for `RadioButton` and `RadioButtonGroup`.
- Narrow `onChange` argument type for `RadioButtonGroupProps`.
- Reference `RadioButtonProps` for `RadioButtonGroup` types where we are expecting a `RadioButton` value.
- Add missing types for component `refs` and event handlers in `RadioButton` and `RadioButtonGroup`.
- Simplify `getRadioButtons()` with a type assertion on `children` argument and refactoring to use an early return statement.

#### Testing / Reviewing

- [ ] Check `RadioButton` and `RadioButtonGroup` for type errors
- [ ] Check for regressions with `RadioButtons` used inside of a group (e.g., radio buttons are still correctly displayed and the group value changes when radio selections change.)
