### PR TITLE
Dropdown does not announce items in JAWS

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -49,28 +49,22 @@ export default {
 
 const items = [
   {
-    id: 'option-0',
     text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
   },
   {
-    id: 'option-1',
     text: 'Option 1',
   },
   {
-    id: 'option-2',
     text: 'Option 2',
   },
   {
-    id: 'option-3',
     text: 'Option 3 - a disabled item',
     disabled: true,
   },
   {
-    id: 'option-4',
     text: 'Option 4',
   },
   {
-    id: 'option-5',
     text: 'Option 5',
   },
 ];


### PR DESCRIPTION
Closes #16260

After we added this code from this [PR](https://github.com/carbon-design-system/carbon/pull/15249) the Dropdown is not announcing the items when using JAWS. That is because we are declaring our own `id` instead of using the from `downshift`.

I tested with their [example on the website](https://www.downshift-js.com/downshift/#usage-with-getrootprops) to see if declaring the `id` there would have the same result and it happens the same thing, the JAWS can't read the items. I opened an [issue](https://github.com/downshift-js/downshift/issues/1607) in the downshift github.

We can either remove the `id` that we have as an example like it's done on this PR, or we can remove the code from the PR mentioned above. I would just remove the `ids` for now.

#### Testing / Reviewing

- Go to Dropdown and use JAWS with arrow navigation
- Should read properly now