### PR TITLE
feat(vertical-tabs): new tab variant

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Canvas, Story } from '@storybook/blocks';
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from './Tabs';
+import { Tabs, TabList, TabListVertical, Tab, TabPanels, TabPanel } from './Tabs';
 import * as TabsStories from './Tabs.stories';
 import { Grid, Column } from '../Grid';
 
@@ -20,6 +20,7 @@ import { Grid, Column } from '../Grid';
   - [Contained Tabs](#contained-tabs)
   - [Icon Tabs](#icon-tabs)
   - [Dismissable Tabs](#dismissable-tabs)
+  - [Vertical Tabs](#vertical-tabs)
 - [Component API](#component-api)
   - [Tab - render content on click](#tab---render-content-on-click)
   - [Tabs and the Grid - fullWidth prop](#tabs-and-the-grid---fullwidth-prop)
@@ -181,6 +182,12 @@ And there you have it! Working dismissable tabs.
 
 <Canvas>
   <Story of={TabsStories.Dismissable} />
+</Canvas>
+
+### Vertical tabs
+
+<Canvas>
+  <Story of={TabsStories.Vertical} />
 </Canvas>
 
 ## Component API

--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -39,6 +39,7 @@ export default {
   component: Tabs,
   subcomponents: {
     TabList,
+    TabListVertical,
     Tab,
     TabPanels,
     TabPanel,
@@ -356,50 +357,6 @@ export const IconOnly = () => (
   </Tabs>
 );
 
-export const Vertical = () => (
-  <div>
-    <Tabs>
-      <TabListVertical aria-label="List of tabs">
-        <Tab>Dashboard</Tab>
-        <Tab>
-          Extra long label that will go two lines then truncate when it goes
-          beyond the Tab length
-        </Tab>
-        <Tab>Activity</Tab>
-        <Tab>Analyze</Tab>
-        <Tab>Investigate </Tab>
-        <Tab>Learn</Tab>
-        <Tab disabled>Settings</Tab>
-      </TabListVertical>
-      <TabPanels>
-        <TabPanel>Tab Panel 1</TabPanel>
-        <TabPanel>
-          <form style={{ margin: '2em' }}>
-            <legend className={`cds--label`}>Validation example</legend>
-            <Checkbox id="cb" labelText="Accept privacy policy" />
-            <Button
-              style={{ marginTop: '1rem', marginBottom: '1rem' }}
-              type="submit">
-              Submit
-            </Button>
-            <TextInput
-              type="text"
-              labelText="Text input label"
-              helperText="Optional help text"
-              id="text-input-1"
-            />
-          </form>
-        </TabPanel>
-        <TabPanel>Tab Panel 3</TabPanel>
-        <TabPanel>Tab Panel 4</TabPanel>
-        <TabPanel>Tab Panel 5</TabPanel>
-        <TabPanel>Tab Panel 6</TabPanel>
-        <TabPanel>Tab Panel 7</TabPanel>
-      </TabPanels>
-    </Tabs>
-  </div>
-);
-
 export const Contained = () => (
   <Tabs>
     <TabList aria-label="List of tabs" contained>
@@ -592,6 +549,50 @@ export const ContainedFullWidth = () => (
       </Tabs>
     </Column>
   </Grid>
+);
+
+export const Vertical = () => (
+  <div>
+    <Tabs>
+      <TabListVertical aria-label="List of tabs">
+        <Tab>Dashboard</Tab>
+        <Tab>
+          Extra long label that will go two lines then truncate when it goes
+          beyond the Tab length
+        </Tab>
+        <Tab>Activity</Tab>
+        <Tab>Analyze</Tab>
+        <Tab>Investigate </Tab>
+        <Tab>Learn</Tab>
+        <Tab disabled>Settings</Tab>
+      </TabListVertical>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>
+          <form style={{ margin: '2em' }}>
+            <legend className={`cds--label`}>Validation example</legend>
+            <Checkbox id="cb" labelText="Accept privacy policy" />
+            <Button
+              style={{ marginTop: '1rem', marginBottom: '1rem' }}
+              type="submit">
+              Submit
+            </Button>
+            <TextInput
+              type="text"
+              labelText="Text input label"
+              helperText="Optional help text"
+              id="text-input-1"
+            />
+          </form>
+        </TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+        <TabPanel>Tab Panel 4</TabPanel>
+        <TabPanel>Tab Panel 5</TabPanel>
+        <TabPanel>Tab Panel 6</TabPanel>
+        <TabPanel>Tab Panel 7</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </div>
 );
 
 export const Skeleton = () => {

--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -6,7 +6,15 @@
  */
 
 import React, { useState } from 'react';
-import { Tabs, TabList, Tab, TabPanels, TabPanel, IconTab } from './Tabs';
+import {
+  Tabs,
+  TabList,
+  TabListVertical,
+  Tab,
+  TabPanels,
+  TabPanel,
+  IconTab,
+} from './Tabs';
 import TextInput from '../TextInput';
 import Checkbox from '../Checkbox';
 import Button from '../Button';
@@ -346,6 +354,50 @@ export const IconOnly = () => (
       <TabPanel>Tab Panel 4</TabPanel>
     </TabPanels>
   </Tabs>
+);
+
+export const Vertical = () => (
+  <div>
+    <Tabs>
+      <TabListVertical aria-label="List of tabs">
+        <Tab>Dashboard</Tab>
+        <Tab>
+          Extra long label that will go two lines then truncate when it goes
+          beyond the Tab length
+        </Tab>
+        <Tab>Activity</Tab>
+        <Tab>Analyze</Tab>
+        <Tab>Investigate </Tab>
+        <Tab>Learn</Tab>
+        <Tab disabled>Settings</Tab>
+      </TabListVertical>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>
+          <form style={{ margin: '2em' }}>
+            <legend className={`cds--label`}>Validation example</legend>
+            <Checkbox id="cb" labelText="Accept privacy policy" />
+            <Button
+              style={{ marginTop: '1rem', marginBottom: '1rem' }}
+              type="submit">
+              Submit
+            </Button>
+            <TextInput
+              type="text"
+              labelText="Text input label"
+              helperText="Optional help text"
+              id="text-input-1"
+            />
+          </form>
+        </TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+        <TabPanel>Tab Panel 4</TabPanel>
+        <TabPanel>Tab Panel 5</TabPanel>
+        <TabPanel>Tab Panel 6</TabPanel>
+        <TabPanel>Tab Panel 7</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </div>
 );
 
 export const Contained = () => (

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -737,6 +737,12 @@ export interface TabListVerticalProps extends DivAttributes {
    * Specify an optional className to be added to the container node
    */
   className?: string;
+
+  /**
+   * Choose whether to automatically scroll to newly selected tabs
+   * on component rerender
+   */
+  scrollIntoView?: boolean;
 }
 // type TabElement = HTMLElement & { disabled?: boolean };
 
@@ -745,6 +751,7 @@ function TabListVertical({
   'aria-label': label,
   children,
   className: customClassName,
+  scrollIntoView,
   ...rest
 }: TabListVerticalProps) {
   const { activeIndex, selectedIndex, setSelectedIndex, setActiveIndex } =
@@ -803,6 +810,25 @@ function TabListVertical({
       }
     }
   });
+
+  useEffect(() => {
+    function handler() {
+      const tab = tabs.current[selectedIndex];
+      if (scrollIntoView && tab) {
+        tab.scrollIntoView({
+          block: 'nearest',
+          inline: 'nearest',
+        });
+      }
+    }
+    window.addEventListener('resize', handler);
+
+    handler();
+
+    return () => {
+      window.removeEventListener('resize', handler);
+    };
+  }, [selectedIndex, scrollIntoView]);
 
   useEffect(() => {
     const element = ref.current;

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -829,7 +829,7 @@ function TabListVertical({
 
   if (isSm) {
     return (
-      <TabList {...rest} aria-label={label}>
+      <TabList {...rest} aria-label={label} contained>
         {children}
       </TabList>
     );

--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -59,6 +59,7 @@
     inline-size: 100%;
     max-block-size: custom-property.get-var('layout-size-height-xl');
     min-block-size: layout.size('height');
+    overflow-x: hidden;
 
     &.#{$prefix}--tabs--contained {
       @include layout.use('size', $min: 'sm', $max: 'xl', $default: 'lg');
@@ -74,6 +75,39 @@
 
       &::-webkit-scrollbar {
         display: none;
+      }
+    }
+
+    &.#{$prefix}--tabs--vertical {
+      background: $layer;
+      border-inline-end: 1px solid $border-subtle;
+      float: inline-start;
+      inline-size: 25%;
+      max-block-size: none;
+
+      .#{$prefix}--tab--list {
+        flex-direction: column;
+        inline-size: 100%;
+        overflow-x: visible;
+        overflow-y: auto;
+      }
+
+      .#{$prefix}--tab--list-gradient_bottom {
+        position: absolute;
+        background: linear-gradient(to bottom, transparent, $layer);
+        block-size: $spacing-10;
+        inset-block-end: 0;
+        inset-inline: 0;
+        pointer-events: none;
+      }
+
+      .#{$prefix}--tab--list-gradient_top {
+        position: absolute;
+        background: linear-gradient(to top, transparent, $layer);
+        block-size: $spacing-10;
+        inset-block-start: 0;
+        inset-inline: 0;
+        pointer-events: none;
       }
     }
 
@@ -282,7 +316,17 @@
       margin-inline-start: 0;
     }
 
-    &.#{$prefix}--tabs--contained
+    &.#{$prefix}--tabs--vertical .#{$prefix}--tabs__nav-item {
+      flex: none;
+      background-color: $layer-01;
+      block-size: $spacing-10;
+      border-block-end: 1px solid $border-subtle;
+      box-shadow: inset 3px 0 0 0 $border-subtle;
+      inline-size: 100%;
+      margin-inline-start: 0;
+    }
+
+    &.#{$prefix}--tabs--contained:not(.#{$prefix}--tabs--vertical)
       .#{$prefix}--tabs__nav-item--selected
       + div
       + .#{$prefix}--tabs__nav-item {
@@ -431,7 +475,8 @@
       }
     }
 
-    &.#{$prefix}--tabs--contained .#{$prefix}--tabs__nav-link {
+    &.#{$prefix}--tabs--contained:not(.#{$prefix}--tabs--vertical)
+      .#{$prefix}--tabs__nav-link {
       border-block-end: 0;
       padding-inline: layout.density('padding-inline');
     }
@@ -446,6 +491,11 @@
       @include type-style('label-01');
 
       min-block-size: convert.to-rem(16px);
+    }
+
+    &.#{$prefix}--tabs--vertical:not(.#{$prefix}--tabs--tall)
+      .#{$prefix}--tabs__nav-item-label {
+      line-height: var(--cds-body-compact-01-line-height);
     }
 
     //-----------------------------
@@ -511,6 +561,13 @@
       box-shadow: inset 0 2px 0 0 $border-interactive;
     }
 
+    &.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected {
+      border-inline-start: none;
+      // Draws the border without affecting the inner-content
+      box-shadow: inset 3px 0 0 0 $border-interactive;
+    }
+
     &.#{$prefix}--tabs--contained .#{$prefix}--tabs__nav-item--selected,
     .#{$prefix}--tabs__nav-item--selected,
     .#{$prefix}--tabs__nav-item--selected:focus
@@ -571,6 +628,15 @@
       background-color: button.$button-disabled;
     }
 
+    &.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled,
+    &.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
+      background-color: $layer;
+      border-block-end: 1px solid $border-subtle;
+      box-shadow: inset 3px 0 0 0 $border-disabled;
+    }
+
     .#{$prefix}--tabs__nav-item--disabled:focus,
     .#{$prefix}--tabs__nav-item--disabled:active {
       border-block-end: $tab-underline-disabled;
@@ -599,7 +665,8 @@
       border-block-end-color: $border-subtle;
     }
 
-    &.#{$prefix}--tabs--contained .#{$prefix}--tabs__nav-item--disabled {
+    &.#{$prefix}--tabs--contained:not(.#{$prefix}--tabs--vertical)
+      .#{$prefix}--tabs__nav-item--disabled {
       border-block-end: none;
       color: $text-on-color-disabled;
     }
@@ -617,6 +684,11 @@
 
   .#{$prefix}--tabs--contained ~ .#{$prefix}--tab-content {
     background: $layer;
+  }
+
+  .#{$prefix}--tabs--vertical ~ .#{$prefix}--tab-content {
+    float: inline-start;
+    inline-size: 75%;
   }
 
   .#{$prefix}--tab-content--interactive {
@@ -686,6 +758,19 @@
     }
     .#{$prefix}--tabs__nav-item--icon {
       margin-inline-start: auto;
+    }
+  }
+}
+
+.#{$prefix}--tabs.#{$prefix}--tabs--vertical {
+  .#{$prefix}--tabs__nav-link {
+    .#{$prefix}--tabs__nav-item-label {
+      display: -webkit-box;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      text-overflow: ellipsis;
+      white-space: normal;
     }
   }
 }

--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -548,6 +548,7 @@
         .#{$prefix}--tabs__nav-item--hover-off
       ):hover {
       background-color: $layer-hover;
+      box-shadow: inset 3px 0 0 0 $border-strong;
     }
 
     //-----------------------------

--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -541,6 +541,15 @@
       color: $text-primary;
     }
 
+    &.#{$prefix}--tabs--vertical
+      .#{$prefix}--tabs__nav-item:not(
+        .#{$prefix}--tabs__nav-item--selected
+      ):not(.#{$prefix}--tabs__nav-item--disabled):not(
+        .#{$prefix}--tabs__nav-item--hover-off
+      ):hover {
+      background-color: $layer-hover;
+    }
+
     //-----------------------------
     // Item Selected
     //-----------------------------
@@ -634,7 +643,6 @@
       .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--disabled:hover {
       background-color: $layer;
       border-block-end: 1px solid $border-subtle;
-      box-shadow: inset 3px 0 0 0 $border-disabled;
     }
 
     .#{$prefix}--tabs__nav-item--disabled:focus,


### PR DESCRIPTION
#16305 

Adds a new vertical variant to tabs
<img width="1021" alt="Screenshot 2024-06-05 at 10 54 44 AM" src="https://github.com/carbon-design-system/carbon/assets/20210594/0d97f927-7a69-46a8-9a09-e33b6aaecb15">

#### Changelog

**New**

- TabListVertical component
- TabPanels new update to check if vertical variant and set the same max height to each TabPanel
- Tab new update to add ellipsis with Tooltip only on vertical variant

**Changed**

- added `overflow-x: hidden` to default Tabs ... fixed an issue where an unwanted horizontal scroll would appear if the length of the tabs is too long

-----
**Other notes:**

- using `float: inline-start` to align the vertical tabs. This avoid wrapping the component in `<Grid>`, which causes complexities when going between `sm` and other breakpoints, but I know `float` isn't really used any more
- for TabPanels, I have to unhide/hide each Panel to get the current height and then use `style.height = ...` for each TabPanel  to set what the height of the largest height for each. I am not noticing any flashing, but could be a concern
- keeping as a draft since waiting for confirmed overflow styles and if the `sm` breakpoint should be default tabs or contained tabs
- still need to update docs too

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
