### PR TITLE
feat: nested checkbox

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -9,6 +9,7 @@ import React from 'react';
 import { default as Checkbox, CheckboxSkeleton } from './';
 import mdx from './Checkbox.mdx';
 import CheckboxGroup from '../CheckboxGroup';
+import NestedCheckbox from './NestedCheckbox';
 
 const checkboxEvents = {
   className: 'some-class',
@@ -85,6 +86,17 @@ export const Single = () => {
 };
 
 export const Skeleton = () => <CheckboxSkeleton />;
+
+export const Nested = () => {
+  return (
+    <CheckboxGroup {...fieldsetCheckboxProps()}>
+      <NestedCheckbox labelText={`Parent label`} id="parent-checkbox-label-1">
+        <Checkbox labelText={`Child label 1`} id="checkbox-label-1" />
+        <Checkbox labelText={`Child label 2`} id="checkbox-label-2" />
+      </NestedCheckbox>
+    </CheckboxGroup>
+  );
+};
 
 export const Playground = (args) => (
   <CheckboxGroup {...fieldsetCheckboxProps()} {...args}>

--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -93,6 +93,15 @@ export const Nested = () => {
       <NestedCheckbox labelText={`Parent label`} id="parent-checkbox-label-1">
         <Checkbox labelText={`Child label 1`} id="checkbox-label-1" />
         <Checkbox labelText={`Child label 2`} id="checkbox-label-2" />
+        <NestedCheckbox
+          labelText={`Parent label 2`}
+          id="parent-checkbox-label-2">
+          <Checkbox labelText={`Child label 5`} id="checkbox-label-5" />
+          <Checkbox labelText={`Child label 6`} id="checkbox-label-6" />
+          <Checkbox labelText={`Child label 7`} id="checkbox-label-7" />
+        </NestedCheckbox>
+        <Checkbox labelText={`Child label 3`} id="checkbox-label-3" />
+        <Checkbox labelText={`Child label 4`} id="checkbox-label-4" />
       </NestedCheckbox>
     </CheckboxGroup>
   );

--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -10,6 +10,7 @@ import { default as Checkbox, CheckboxSkeleton } from './';
 import mdx from './Checkbox.mdx';
 import CheckboxGroup from '../CheckboxGroup';
 import NestedCheckbox from './NestedCheckbox';
+import { useState } from 'react';
 
 const checkboxEvents = {
   className: 'some-class',
@@ -88,15 +89,28 @@ export const Single = () => {
 export const Skeleton = () => <CheckboxSkeleton />;
 
 export const Nested = () => {
+  const [test, setTest] = useState(true);
+  const updater = (a, up) => {
+    setTest(up.checked);
+  };
   return (
     <CheckboxGroup {...fieldsetCheckboxProps()}>
       <NestedCheckbox labelText={`Parent label`} id="parent-checkbox-label-1">
-        <Checkbox labelText={`Child label 1`} id="checkbox-label-1" />
+        <Checkbox
+          checked={test}
+          onChange={updater}
+          labelText={`Child label 1`}
+          id="checkbox-label-1"
+        />
         <Checkbox labelText={`Child label 2`} id="checkbox-label-2" />
         <NestedCheckbox
           labelText={`Parent label 2`}
           id="parent-checkbox-label-2">
-          <Checkbox labelText={`Child label 5`} id="checkbox-label-5" />
+          <Checkbox
+            checked={true}
+            labelText={`Child label 5`}
+            id="checkbox-label-5"
+          />
           <Checkbox labelText={`Child label 6`} id="checkbox-label-6" />
           <Checkbox labelText={`Child label 7`} id="checkbox-label-7" />
         </NestedCheckbox>

--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -89,19 +89,10 @@ export const Single = () => {
 export const Skeleton = () => <CheckboxSkeleton />;
 
 export const Nested = () => {
-  const [test, setTest] = useState(true);
-  const updater = (a, up) => {
-    setTest(up.checked);
-  };
   return (
     <CheckboxGroup {...fieldsetCheckboxProps()}>
       <NestedCheckbox labelText={`Parent label`} id="parent-checkbox-label-1">
-        <Checkbox
-          checked={test}
-          onChange={updater}
-          labelText={`Child label 1`}
-          id="checkbox-label-1"
-        />
+        <Checkbox labelText={`Child label 1`} id="checkbox-label-1" />
         <Checkbox labelText={`Child label 2`} id="checkbox-label-2" />
         <NestedCheckbox
           labelText={`Parent label 2`}

--- a/packages/react/src/components/Checkbox/NestedCheckbox.tsx
+++ b/packages/react/src/components/Checkbox/NestedCheckbox.tsx
@@ -1,5 +1,11 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState, ReactElement, ReactNode } from 'react';
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import Checkbox, { CheckboxProps } from './Checkbox';
@@ -47,10 +53,13 @@ const NestedCheckbox = React.forwardRef(
       });
       setChildrenCheckState(map);
     }, [checked, children]);
-    let childrenCheckedCount = 0;
-    childrenCheckState.forEach(
-      (value) => (childrenCheckedCount += value ? 1 : 0)
-    );
+
+    const childrenCheckedCount = useMemo(() => {
+      let counter = 0;
+      childrenCheckState.forEach((value) => (counter += value ? 1 : 0));
+      return counter;
+    }, [childrenCheckState]);
+
     const prefix = usePrefix();
     const showWarning = !readOnly && !invalid && warn;
     const wrapperClasses = classNames(

--- a/packages/react/src/components/Checkbox/NestedCheckbox.tsx
+++ b/packages/react/src/components/Checkbox/NestedCheckbox.tsx
@@ -1,0 +1,210 @@
+import PropTypes from 'prop-types';
+import React, { useState, ReactElement, ReactNode } from 'react';
+import classNames from 'classnames';
+import { usePrefix } from '../../internal/usePrefix';
+import Checkbox, { CheckboxProps } from './Checkbox';
+import { noopFn } from '../../internal/noopFn';
+
+export enum NestedCheckboxStates {
+  Checked,
+  Indeterminate,
+  Unchecked,
+}
+
+export interface NestedCheckboxProps extends CheckboxProps {
+  /**
+   * Provide a collection of `<Checkbox>` components to render in the group
+   */
+  children?: ReactNode;
+}
+
+const NestedCheckbox = React.forwardRef(
+  ({
+    checked,
+    children,
+    className,
+    defaultChecked,
+    invalid,
+    onChange = noopFn,
+    readOnly,
+    warn,
+    slug,
+    ...rest
+  }: NestedCheckboxProps) => {
+    const [checkState, setCheckState] = useState(
+      checked || defaultChecked
+        ? NestedCheckboxStates.Checked
+        : NestedCheckboxStates.Unchecked
+    );
+    const prefix = usePrefix();
+    const showWarning = !readOnly && !invalid && warn;
+    const wrapperClasses = classNames(
+      `${prefix}--form-item`,
+      `${prefix}--nested-checkbox-wrapper`,
+      className,
+      {
+        [`${prefix}--nested-checkbox-wrapper--readonly`]: readOnly,
+        [`${prefix}--nested-checkbox-wrapper--invalid`]: !readOnly && invalid,
+        [`${prefix}--nested-checkbox-wrapper--warning`]: showWarning,
+        [`${prefix}--nested-checkbox-wrapper--slug`]: slug,
+      }
+    );
+
+    const handleOnChange = (event, { checked, id }) => {
+      setCheckState((prev) => {
+        return prev === NestedCheckboxStates.Checked ||
+          prev === NestedCheckboxStates.Indeterminate
+          ? NestedCheckboxStates.Unchecked
+          : NestedCheckboxStates.Checked;
+      });
+      if (typeof onChange === 'function') {
+        onChange(event, { checked, id });
+      }
+    };
+
+    function getCheckboxes() {
+      const mappedChildren = React.Children.map(children, (checkbox) => {
+        if (checkbox) {
+          const { checked, onChange } =
+            (checkbox as ReactElement)?.props ?? undefined;
+          const handleChildChange = (event, { checked, id }) => {
+            setCheckState(
+              checked
+                ? NestedCheckboxStates.Indeterminate
+                : NestedCheckboxStates.Unchecked
+            );
+            if (typeof onChange === 'function') {
+              onChange(event, { checked, id });
+            }
+          };
+          const newProps = {
+            checked:
+              checkState === NestedCheckboxStates.Checked ? true : checked,
+            onChange: handleChildChange,
+          };
+          return React.cloneElement(checkbox as ReactElement, newProps);
+        }
+      });
+
+      return mappedChildren;
+    }
+
+    return (
+      <div className={wrapperClasses}>
+        <Checkbox
+          checked={checkState === NestedCheckboxStates.Checked}
+          defaultChecked={defaultChecked}
+          indeterminate={checkState === NestedCheckboxStates.Indeterminate}
+          invalid={invalid}
+          onChange={handleOnChange}
+          readOnly={readOnly}
+          warn={warn}
+          slug={slug}
+          {...rest}
+        />
+        <div className={`${prefix}--nested-checkbox__children`}>
+          {getCheckboxes()}
+        </div>
+      </div>
+    );
+  }
+);
+
+NestedCheckbox.propTypes = {
+  /**
+   * Specify whether the underlying input should be checked
+   */
+  checked: PropTypes.bool,
+
+  /**
+   * The list of children checkboxes to be within this nested CheckBox
+   */
+  children: PropTypes.node,
+
+  /**
+   * Specify an optional className to be applied to the <label> node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify whether the underlying input should be checked by default
+   */
+  defaultChecked: PropTypes.bool,
+
+  /**
+   * Specify whether the Checkbox should be disabled
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Provide text for the form group for additional help
+   */
+  helperText: PropTypes.node,
+
+  /**
+   * Specify whether the label should be hidden, or not
+   */
+  hideLabel: PropTypes.bool,
+
+  /**
+   * Provide an `id` to uniquely identify the Checkbox input
+   */
+  id: PropTypes.string.isRequired,
+
+  /**
+   * Specify whether the Checkbox is in an indeterminate state
+   */
+  indeterminate: PropTypes.bool,
+
+  /**
+   * Specify whether the Checkbox is currently invalid
+   */
+  invalid: PropTypes.bool,
+
+  /**
+   * Provide the text that is displayed when the Checkbox is in an invalid state
+   */
+  invalidText: PropTypes.node,
+
+  /**
+   * Provide a label to provide a description of the Checkbox input that you are
+   * exposing to the user
+   */
+  labelText: PropTypes.node.isRequired,
+
+  /**
+   * Provide an optional handler that is called when the internal state of
+   * Checkbox changes. This handler is called with event and state info.
+   * `(event, { checked, id }) => void`
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * Specify whether the Checkbox is read-only
+   */
+  readOnly: PropTypes.bool,
+
+  /**
+   * **Experimental**: Provide a `Slug` component to be rendered inside the `Checkbox` component
+   */
+  slug: PropTypes.node,
+
+  /**
+   * Specify a title for the <label> node for the Checkbox
+   */
+  title: PropTypes.string,
+
+  /**
+   * Specify whether the Checkbox is currently in warning state
+   */
+  warn: PropTypes.bool,
+
+  /**
+   * Provide the text that is displayed when the Checkbox is in warning state
+   */
+  warnText: PropTypes.node,
+};
+
+NestedCheckbox.displayName = 'NestedCheckbox';
+
+export default NestedCheckbox;

--- a/packages/react/src/components/Checkbox/NestedCheckbox.tsx
+++ b/packages/react/src/components/Checkbox/NestedCheckbox.tsx
@@ -41,16 +41,24 @@ const NestedCheckbox = React.forwardRef(
     const [childrenCheckState, setChildrenCheckState] = useState(() => {
       const map = new Map();
       React.Children.forEach(children, (child) => {
-        const { id } = (child as ReactElement)?.props ?? undefined;
-        map.set(id, checked ?? false);
+        const { checked: childChecked, id } =
+          (child as ReactElement)?.props ?? undefined;
+        map.set(id, checked ?? childChecked ?? false);
       });
       return map;
     });
     useEffect(() => {
       const map = new Map();
       React.Children.forEach(children, (child) => {
-        const { id } = (child as ReactElement)?.props ?? undefined;
-        map.set(id, checked ?? false);
+        const {
+          checked: childChecked,
+          id,
+          onChange,
+        } = (child as ReactElement)?.props ?? undefined;
+        map.set(id, checked ?? childChecked ?? false);
+        if (typeof onChange === 'function' && checked) {
+          onChange(null, { checked, id });
+        }
       });
       setChildrenCheckState(map);
     }, [checked, children]);

--- a/packages/styles/scss/components/checkbox/_checkbox.scss
+++ b/packages/styles/scss/components/checkbox/_checkbox.scss
@@ -351,6 +351,13 @@
     position: relative;
   }
 
+  //-----------------------------------------------
+  // NestedCheckbox
+  //-----------------------------------------------
+  .#{$prefix}--nested-checkbox__children {
+    margin-inline-start: convert.to-rem(28px);
+  }
+
   // RTL overrides
   [dir='rtl'] .#{$prefix}--checkbox-label::after {
     margin-block-start: 0;


### PR DESCRIPTION
Closes #12434

creates a new component called `<NestedCheckbox/>` that allows the user to control a group of checkbox from a single parent checkbox

#### Changelog

**New**

- the NestedCheckbox component

**Changed**

- Checkbox story documentation

**Removed**

- N/A

#### Testing / Reviewing

ensure that the unit tests run properly. Ensure that the Nested section of the checkbox on the stories runs correctly. Ensure the overview runs and the documentation for NestedCheckbox is there and accurate.
