### PR TITLE
fix(16337): close DatePicker calendar on away click when inside Modal or ComposedModal

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4725,6 +4725,9 @@ Map {
       "isFullWidth": Object {
         "type": "bool",
       },
+      "isNested": Object {
+        "type": "bool",
+      },
       "launcherButtonRef": Object {
         "args": Array [
           Array [

--- a/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.js
+++ b/packages/react/src/components/DatePicker/plugins/fixEventsPlugin.js
@@ -109,9 +109,10 @@ export default (config) => (fp) => {
         if (inputTo.value) {
           fp.setDate(
             [inputFrom.value, inputTo.value],
-            true,
+            false,
             fp.config.dateFormat
           );
+          fp.updateValue();
         }
       }
     }

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -16,6 +16,8 @@ import Dropdown from '../Dropdown';
 import SelectItem from '../SelectItem';
 import TextInput from '../TextInput';
 import mdx from './Modal.mdx';
+import DatePicker from '../DatePicker';
+import DatePickerInput from '../DatePickerInput';
 import {
   StructuredListWrapper,
   StructuredListHead,
@@ -45,9 +47,10 @@ export const Default = () => {
         modalHeading="Add a custom domain"
         modalLabel="Account resources"
         primaryButtonText="Add"
+        // isNested
         secondaryButtonText="Cancel">
         <p style={{ marginBottom: '1rem' }}>
-          Custom domains direct requests for your apps in this Cloud Foundry
+          nikhil domains direct requests for your apps in this Cloud Foundry
           organization to a URL that you own. A custom domain can be a shared
           domain, a shared subdomain, or a shared domain and host.
         </p>
@@ -87,6 +90,20 @@ export const Default = () => {
           ]}
           itemToString={(item) => (item ? item.text : '')}
         />
+        <DatePicker datePickerType="range">
+          <DatePickerInput
+            id="date-picker-input-id-start"
+            placeholder="mm/dd/yyyy"
+            labelText="Start date"
+            size="md"
+          />
+          <DatePickerInput
+            id="date-picker-input-id-finish"
+            placeholder="mm/dd/yyyy"
+            labelText="End date"
+            size="md"
+          />
+        </DatePicker>
       </Modal>
     </>
   );

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -47,10 +47,10 @@ export const Default = () => {
         modalHeading="Add a custom domain"
         modalLabel="Account resources"
         primaryButtonText="Add"
-        // isNested
+        //isNested
         secondaryButtonText="Cancel">
         <p style={{ marginBottom: '1rem' }}>
-          nikhil domains direct requests for your apps in this Cloud Foundry
+          Custom domains direct requests for your apps in this Cloud Foundry
           organization to a URL that you own. A custom domain can be a shared
           domain, a shared subdomain, or a shared domain and host.
         </p>

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -290,7 +290,6 @@ const Modal = React.forwardRef(function Modal(
 
   function handleKeyDown(evt: React.KeyboardEvent<HTMLDivElement>) {
     if (isNested) {
-      console.log('isNested', isNested);
       evt.stopPropagation();
     }
 
@@ -324,7 +323,6 @@ const Modal = React.forwardRef(function Modal(
   function handleMousedown(evt: React.MouseEvent<HTMLDivElement>) {
     const target = evt.target as Node;
     if (isNested) {
-      console.log('isNested', isNested);
       evt.stopPropagation();
     }
 

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -289,9 +289,7 @@ const Modal = React.forwardRef(function Modal(
   }
 
   function handleKeyDown(evt: React.KeyboardEvent<HTMLDivElement>) {
-    if (isNested) {
-      evt.stopPropagation();
-    }
+    isNested && evt.stopPropagation();
 
     if (open) {
       if (match(evt, keys.Escape)) {
@@ -322,9 +320,7 @@ const Modal = React.forwardRef(function Modal(
 
   function handleMousedown(evt: React.MouseEvent<HTMLDivElement>) {
     const target = evt.target as Node;
-    if (isNested) {
-      evt.stopPropagation();
-    }
+    isNested && evt.stopPropagation();
 
     if (
       !preventCloseOnClickOutside &&

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -215,6 +215,11 @@ export interface ModalProps extends ReactAttr<HTMLDivElement> {
    * **Experimental**: Provide a `Slug` component to be rendered inside the `Modal` component
    */
   slug?: ReactNode;
+
+  /**
+   * Specify if the Modal has any nested Modals.
+   */
+  isNested?: boolean;
 }
 
 const Modal = React.forwardRef(function Modal(
@@ -250,6 +255,7 @@ const Modal = React.forwardRef(function Modal(
     loadingIconDescription,
     onLoadingSuccess = noopFn,
     slug,
+    isNested,
     ...rest
   }: ModalProps,
   ref: React.LegacyRef<HTMLDivElement>
@@ -283,7 +289,11 @@ const Modal = React.forwardRef(function Modal(
   }
 
   function handleKeyDown(evt: React.KeyboardEvent<HTMLDivElement>) {
-    evt.stopPropagation();
+    if (isNested) {
+      console.log('isNested', isNested);
+      evt.stopPropagation();
+    }
+
     if (open) {
       if (match(evt, keys.Escape)) {
         onRequestClose(evt);
@@ -313,7 +323,11 @@ const Modal = React.forwardRef(function Modal(
 
   function handleMousedown(evt: React.MouseEvent<HTMLDivElement>) {
     const target = evt.target as Node;
-    evt.stopPropagation();
+    if (isNested) {
+      console.log('isNested', isNested);
+      evt.stopPropagation();
+    }
+
     if (
       !preventCloseOnClickOutside &&
       !elementOrParentIsFloatingMenu(target, selectorsFloatingMenus) &&
@@ -663,6 +677,11 @@ Modal.propTypes = {
    * Specify whether or not the Modal content should have any inner padding.
    */
   isFullWidth: PropTypes.bool,
+
+  /**
+   * Specify if the Modal has any nested Modals.
+   */
+  isNested: PropTypes.bool,
 
   /**
    * Provide a ref to return focus to once the modal is closed.


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16337

The root bug with  DatePicker was : When using the datepicker with a range selection, the end date calendar does not close when the user clicks away, causing it to always stay open ([Issue](https://github.com/carbon-design-system/carbon/issues/16740) -> [PR](https://github.com/carbon-design-system/carbon/pull/16742))

Fix for https://github.com/carbon-design-system/carbon/issues/16337 is dependent on  [PR](https://github.com/carbon-design-system/carbon/pull/16742)
Also this issue was happing because `evt.stopPropagation()` was added on `Mousedown` event to add support for [Nest modal](https://github.com/carbon-design-system/carbon/pull/14320)

To fix https://github.com/carbon-design-system/carbon/issues/16337  : I thought to keep this action behind a prop 

- Introduced a new prop `isNested`, in modal.tsx.
- The event handler will now run `evt.stopPropagation()` only when the `isNested` prop is present.


<img width="577" alt="image" src="https://github.com/carbon-design-system/carbon/assets/63502271/a7d7f199-b257-4e48-aa2c-cc149dc7aaab">


- Additionally, we can update the documentation to include guidelines advising against the use of DatePickers within nested modals.




I am looking for reviews and suggestions on this.
If `isNested` prop works as a fix , I will be implementing this is in `ComposedModal` as well 

#### Testing / Reviewing

- Take pull in local
- Open Modal storybook->default 
- Select start and end date in the datepicker 
- Open end date calendar, do not select any date and click outside of calendar and verify if calendar closes 

Verify the functionlity when `isNested`  is passed 
- Pass `isNested` as a prop in `Modal`
- Select start and end date in the datepicker 
- 
<img width="611" alt="image" src="https://github.com/carbon-design-system/carbon/assets/63502271/787f5025-6ac4-4cac-a1f4-b2ee5cb8a1fb">

-  Open end date calendar, do not select any date and click outside of calendar and verify that does not close 

