### PR TITLE
chore: update add to project workflow to add AI4UX

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,8 +11,10 @@ env:
   DESIGN_SYSTEM_PROJECT_URL: https://github.com/orgs/carbon-design-system/projects/39
   PROPOSALS_PROJECT_URL: https://github.com/orgs/carbon-design-system/projects/51
   TYPESCRIPT_PROJECT_URL: https://github.com/orgs/carbon-design-system/projects/53
+  AI4UX_PROJECT_URL: https://github.com/orgs/carbon-design-system/projects/82
   LABEL_ENHANCEMENT: 'type: enhancement 💡'
   LABEL_TYPESCRIPT: 'area: typescript'
+  LABEL_AI4UX: 'area: AI4UX'
 
 jobs:
   add-to-proposals-project:
@@ -33,6 +35,16 @@ jobs:
         with:
           labeled: ${{ env.LABEL_TYPESCRIPT }}
           project-url: ${{ env.TYPESCRIPT_PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+  add-to-ai4ux-project:
+    name: Add issue with AI4UX label to the AI4UX project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@9bfe908f2eaa7ba10340b31e314148fcfe6a2458 # v1.0.1
+        with:
+          labeled: ${{ env.LABEL_AI4UX }}
+          project-url: ${{ env.AI4UX_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
   add-to-design-system-project:


### PR DESCRIPTION
- Update add to project workflow so when `area: AI4UX` label is added it gets added to the correct project. https://github.com/orgs/carbon-design-system/projects/82