### PR TITLE
Updated schedule in renovate and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,19 +1,22 @@
 {
-  "extends": [
+  extends: [
     // https://docs.renovatebot.com/presets-config/#configjs-lib
-    "config:js-lib",
+    'config:js-lib',
 
     // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
-    ":maintainLockFilesWeekly",
+    ':maintainLockFilesWeekly',
 
     // https://docs.renovatebot.com/presets-default/#preservesemverranges
-    ":preserveSemverRanges",
+    ':preserveSemverRanges',
 
     // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
-    "npm:unpublishSafe",
+    'npm:unpublishSafe',
 
     // https://docs.renovatebot.com/presets-schedule/#scheduledaily
-    "schedule:earlyMondays",
+    'schedule:weekday',
   ],
-  "rebaseWhen": "never",
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+  rebaseWhen: 'never',
 }


### PR DESCRIPTION
Closes #16214

Updated the schedule in renovate and dependabot. Now we are relying on renovate instead of dependabot.
Dependabot still be around, but it run once a week. We are gonna test this schedule to see if it works better.

#### Testing / Reviewing

- Check the PR queue. If you see any duplication between Renovate and Dependabot, let me know.