### PR TITLE
fix: announcing next and previous button in pagination and paginationNav

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -405,6 +405,7 @@ const Pagination = React.forwardRef(function Pagination(
             kind="ghost"
             className={backButtonClasses}
             label={backwardText}
+            aria-label={backwardText}
             onClick={decrementPage}
             ref={backBtnRef}>
             <CaretLeft />
@@ -415,6 +416,7 @@ const Pagination = React.forwardRef(function Pagination(
             kind="ghost"
             className={forwardButtonClasses}
             label={forwardText}
+            aria-label={forwardText}
             onClick={incrementPage}
             ref={forwardBtnRef}>
             <CaretRight />

--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -110,7 +110,6 @@ function DirectionButton({
         disabled={disabled}
         kind="ghost"
         label={label}
-        aria-label={label}
         onClick={onClick}>
         {direction === 'forward' ? <CaretRight /> : <CaretLeft />}
       </IconButton>

--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -110,6 +110,7 @@ function DirectionButton({
         disabled={disabled}
         kind="ghost"
         label={label}
+        aria-label={label}
         onClick={onClick}>
         {direction === 'forward' ? <CaretRight /> : <CaretLeft />}
       </IconButton>
@@ -445,6 +446,7 @@ const PaginationNav = React.forwardRef<HTMLElement, PaginationNavProps>(
         <ul className={`${prefix}--pagination-nav__list`}>
           <DirectionButton
             direction="backward"
+            aria-label={t('carbon.pagination-nav.previous')}
             label={t('carbon.pagination-nav.previous')}
             disabled={backwardButtonDisabled}
             onClick={jumpToPrevious}
@@ -516,6 +518,7 @@ const PaginationNav = React.forwardRef<HTMLElement, PaginationNavProps>(
 
           <DirectionButton
             direction="forward"
+            aria-label={t('carbon.pagination-nav.next')}
             label={t('carbon.pagination-nav.next')}
             disabled={forwardButtonDisabled}
             onClick={jumpToNext}


### PR DESCRIPTION
Closes #14683 

Pagination, PaginationNav - There is no label for the prev and next buttons

#### Changelog

**New**

- Added aria-label to Previous and next button in pagination and pagination nav.

#### Testing / Reviewing

Test Pagination and panginationNav in VO Iphone Safari.
