### PR TITLE
fix(15337): remove  from release names in update automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           script: |
             github.rest.repos.createRelease({
               tag_name: context.ref,
-              name: context.ref,
+              name: ${{ github.ref_name }},
               draft: false,
               prerelease: true,
               owner: context.repo.owner,


### PR DESCRIPTION
Closes #15337

This PR removes "refs/tags/" prefix from release names in update automation.

Updates createRelease to use `${{  github.ref_name }}` instead of `context.ref`

```
script: |
            github.rest.repos.createRelease({
              tag_name: context.ref,
              name: ${{ github.ref_name }},
              draft: false,
              prerelease: true,
              owner: context.repo.owner,
              repo: context.repo.repo,
            });
```


Reference : https://github.com/orgs/community/discussions/26686


<img width="949" alt="image" src="https://github.com/carbon-design-system/carbon/assets/63502271/d030d368-16ef-44b1-a560-39500e3ffe90">


#### Testing / Reviewing

Verify if "refs/tags/" prefix is removed from the release name