### PR TITLE
fix(16830): add onBlur event to inputProps in FilterableMultiSelect

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -662,6 +662,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect<
         }
       },
       onFocus: () => setInputFocused(true),
+      onBlur: () => setInputFocused(false),
     })
   );
   const menuProps = getMenuProps({}, { suppressRefError: true });


### PR DESCRIPTION
Closes #16830

As mentioned in the issue, the focus on the `FilterableMultiSelect` did not disappear when clicking on another point or switching to another input. This is because there is an `onFocus` event in the `inputProps` but not an `onBlur` event, so the focus was not disappearing. I just added `onBlur` to `inputProps` and the problem was solved.

#### Changelog

**New**

- Added `onBlur` event to `inputProps` in `FilterableMultiSelect`.

**Changed**

- N/A

**Removed**

- N/A

#### Testing / Reviewing

- If you test the old version and then the new version, you will immediately see that the problem is solved.
- Now when you click out, the dropdown closes first and then the focus disappears on the next click.
