### PR TITLE
fix(search): a11y warning on search not expanded

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -502,9 +502,9 @@ exports[`DataTable behaves as expected selection should render and match snapsho
         >
           <div
             aria-expanded="false"
-            aria-label="button"
+            aria-label=""
             class="cds--search-magnifier"
-            role="button"
+            role=""
             tabindex="-1"
           >
             <svg
@@ -936,9 +936,9 @@ exports[`DataTable renders as expected - Component API should render and match s
         >
           <div
             aria-expanded="false"
-            aria-label="button"
+            aria-label=""
             class="cds--search-magnifier"
-            role="button"
+            role=""
             tabindex="-1"
           >
             <svg

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -502,9 +502,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
         >
           <div
             aria-expanded="false"
-            aria-label=""
             class="cds--search-magnifier"
-            role=""
             tabindex="-1"
           >
             <svg
@@ -936,9 +934,7 @@ exports[`DataTable renders as expected - Component API should render and match s
         >
           <div
             aria-expanded="false"
-            aria-label=""
             class="cds--search-magnifier"
-            role=""
             tabindex="-1"
           >
             <svg

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -501,7 +501,6 @@ exports[`DataTable behaves as expected selection should render and match snapsho
           role="search"
         >
           <div
-            aria-expanded="false"
             class="cds--search-magnifier"
             tabindex="-1"
           >
@@ -933,7 +932,6 @@ exports[`DataTable renders as expected - Component API should render and match s
           role="search"
         >
           <div
-            aria-expanded="false"
             class="cds--search-magnifier"
             tabindex="-1"
           >

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -9,9 +9,9 @@ exports[`TableToolbarSearch renders as expected - Component API should render 1`
   >
     <div
       aria-expanded="false"
-      aria-label="button"
+      aria-label=""
       class="cds--search-magnifier"
-      role="button"
+      role=""
       tabindex="-1"
     >
       <svg

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -8,7 +8,6 @@ exports[`TableToolbarSearch renders as expected - Component API should render 1`
     role="search"
   >
     <div
-      aria-expanded="false"
       class="cds--search-magnifier"
       tabindex="-1"
     >

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -9,9 +9,7 @@ exports[`TableToolbarSearch renders as expected - Component API should render 1`
   >
     <div
       aria-expanded="false"
-      aria-label=""
       class="cds--search-magnifier"
-      role=""
       tabindex="-1"
     >
       <svg

--- a/packages/react/src/components/Search/Search-test.js
+++ b/packages/react/src/components/Search/Search-test.js
@@ -154,8 +154,9 @@ describe('Search', () => {
     it('should have tabbable input and untabbable button if not expandable', async () => {
       render(<Search labelText="test-search" />);
 
-      // will have 2 buttons which is the close button and div with a role button
-      expect(screen.getAllByRole('button').length).toBe(2);
+      // will have 1 button which is the close button
+      expect(screen.getAllByRole('button').length).toBe(1);
+      // search icon not tabbable if not exandable
       expect(screen.getByRole('searchbox')).not.toHaveAttribute(
         'tabIndex',
         '-1'

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -228,9 +228,9 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
       however, it does not need a keyboard event bc the input element gets focus on keyboard nav and expands that way*/}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div
-        aria-label={onExpand ? 'button' : ''}
+        aria-label={onExpand ? 'button' : undefined}
         aria-labelledby={onExpand ? uniqueId : undefined}
-        role={onExpand ? 'button' : ''}
+        role={onExpand ? 'button' : undefined}
         className={`${prefix}--search-magnifier`}
         onClick={onExpand}
         onKeyDown={handleExpandButtonKeyDown}

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -228,9 +228,9 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
       however, it does not need a keyboard event bc the input element gets focus on keyboard nav and expands that way*/}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div
-        aria-label="button"
+        aria-label={onExpand ? 'button' : ''}
         aria-labelledby={onExpand ? uniqueId : undefined}
-        role="button"
+        role={onExpand ? 'button' : ''}
         className={`${prefix}--search-magnifier`}
         onClick={onExpand}
         onKeyDown={handleExpandButtonKeyDown}

--- a/packages/react/src/components/Search/Search.tsx
+++ b/packages/react/src/components/Search/Search.tsx
@@ -236,7 +236,13 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(function Search(
         onKeyDown={handleExpandButtonKeyDown}
         tabIndex={onExpand && !isExpanded ? 0 : -1}
         ref={expandButtonRef}
-        aria-expanded={onExpand && isExpanded ? true : false}
+        aria-expanded={
+          onExpand && isExpanded
+            ? true
+            : onExpand && !isExpanded
+            ? false
+            : undefined
+        }
         aria-controls={onExpand ? uniqueId : undefined}>
         <CustomSearchIcon icon={renderIcon} />
       </div>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/4766

IBM Equal Access Accessibility Checker - warning on the search icon with `role="button"` since it's not tabbable

#### Changelog

**Changed**

- added a conditional on the `aria-label` and `role` for the search icon to only have values when `onExpand`

#### Testing / Reviewing

Ran the IBM Equal Access Accessibility checker on the component

Before:
<img width="1725" alt="Screenshot 2024-06-26 at 9 58 07 AM" src="https://github.com/carbon-design-system/carbon/assets/20210594/18d90cf3-8341-4137-b22e-7334c50780f5">

After:
<img width="1689" alt="Screenshot 2024-06-26 at 9 57 24 AM" src="https://github.com/carbon-design-system/carbon/assets/20210594/ed00cc2b-5870-47bb-aeb6-61356dfc6ff9">

