### PR TITLE
fix: changed types from `string` to `ReactNode` for `InlineNotification` and `ToastNotification`

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4325,7 +4325,7 @@ Map {
         "type": "string",
       },
       "subtitle": Object {
-        "type": "string",
+        "type": "node",
       },
       "title": Object {
         "type": "string",
@@ -9100,7 +9100,7 @@ Map {
         "type": "string",
       },
       "subtitle": Object {
-        "type": "string",
+        "type": "node",
       },
       "timeout": Object {
         "type": "number",

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -378,7 +378,7 @@ export interface ToastNotificationProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Specify the subtitle
    */
-  subtitle?: string;
+  subtitle?: ReactNode;
 
   /**
    * Specify an optional duration the notification should be closed in
@@ -574,7 +574,7 @@ ToastNotification.propTypes = {
   /**
    * Specify the subtitle
    */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
 
   /**
    * Specify an optional duration the notification should be closed in
@@ -654,7 +654,7 @@ export interface InlineNotificationProps
   /**
    * Specify the subtitle
    */
-  subtitle?: string;
+  subtitle?: ReactNode;
 
   /**
    * Specify the title
@@ -806,7 +806,7 @@ InlineNotification.propTypes = {
   /**
    * Specify the subtitle
    */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
 
   /**
    * Specify the title


### PR DESCRIPTION
Closes #16909 

fix: changed types from `string` to `ReactNode` for `InlineNotification` and `ToastNotification` for both typescript interfaces and prop-types

#### Changelog

**Changed**

- changed `string` to `ReactNode` for `InlineNotification`
- changed `PropTypes.string` to `PropTypes.node` for `InlineNotification`
- changed `string` to `ReactNode` for `ToastNotification`
- changed `PropTypes.string` to `PropTypes.node` for `ToastNotification`


#### Testing / Reviewing

Pull down to local, try to pass a component or any element which is not a string and is `ReactNode` and no warning should come up for typings.
