### PR TITLE
fix: tab component error

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1216,7 +1216,7 @@ const Tab = forwardRef<HTMLElement, TabProps>(function Tab(
 
   useLayoutEffect(() => {
     function handler() {
-      const elementTabId = document.getElementById(`${id}`);
+      const elementTabId = document.getElementById(`${id}`) || tabRef.current;
       const newElement = elementTabId?.getElementsByClassName(
         `${prefix}--tabs__nav-item-label`
       )[0];


### PR DESCRIPTION
Closes #16948 

Tab component was giving error while using shadow DOM

#### Testing / Reviewing

Tab component should not give error with shadow DOM.