### PR TITLE
fix(react): use `useId` instead of `getInstanceId`

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -11,10 +11,8 @@ import classNames from 'classnames';
 import { Text } from '../Text';
 import { usePrefix } from '../../internal/usePrefix';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { noopFn } from '../../internal/noopFn';
-
-const getInstanceId = setupGetInstanceId();
 
 type ExcludedAttributes = 'id' | 'onChange' | 'onClick' | 'type';
 
@@ -127,7 +125,7 @@ const Checkbox = React.forwardRef(
     const showWarning = !readOnly && !invalid && warn;
     const showHelper = !invalid && !warn;
 
-    const checkboxGroupInstanceId = getInstanceId();
+    const checkboxGroupInstanceId = useId();
 
     const helperId = !helperText
       ? undefined

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -10,9 +10,7 @@ import React, { ReactNode } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
-
-const getInstanceId = setupGetInstanceId();
+import { useId } from '../../internal/useId';
 
 export interface CheckboxGroupProps {
   children?: ReactNode;
@@ -54,7 +52,7 @@ const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
   const showWarning = !readOnly && !invalid && warn;
   const showHelper = !invalid && !warn;
 
-  const checkboxGroupInstanceId = getInstanceId();
+  const checkboxGroupInstanceId = useId();
 
   const helperId = !helperText
     ? undefined

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -39,7 +39,7 @@ import ListBox, {
 } from '../ListBox';
 import { ListBoxTrigger, ListBoxSelection } from '../ListBox/next';
 import { match, keys } from '../../internal/keyboard';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import mergeRefs from '../../tools/mergeRefs';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
@@ -121,8 +121,6 @@ const findHighlightedIndex = <ItemType,>(
 
   return -1;
 };
-
-const getInstanceId = setupGetInstanceId();
 
 type ExcludedAttributes = 'id' | 'onChange' | 'onClick' | 'type' | 'size';
 
@@ -379,7 +377,7 @@ const ComboBox = forwardRef(
     const prefix = usePrefix();
     const { isFluid } = useContext(FormContext);
     const textInput = useRef<HTMLInputElement>(null);
-    const comboBoxInstanceId = getInstanceId();
+    const comboBoxInstanceId = useId();
     const [inputValue, setInputValue] = useState(
       getInputValue({
         initialSelectedItem,

--- a/packages/react/src/components/DataTable/TableToolbarSearch.tsx
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.tsx
@@ -18,12 +18,10 @@ import React, {
   RefObject,
 } from 'react';
 import Search, { SearchProps } from '../Search';
-import setupGetInstanceId from './tools/instanceId';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { noopFn } from '../../internal/noopFn';
 import { InternationalProps } from '../../types/common';
-
-const getInstanceId = setupGetInstanceId();
 
 export type TableToolbarTranslationKey =
   | 'carbon.table.toolbar.search.label'
@@ -150,7 +148,7 @@ const TableToolbarSearch = ({
 
   const expanded = controlled ? expandedProp : expandedState;
   const [value, setValue] = useState(defaultValue || '');
-  const uniqueId = useMemo(getInstanceId, []);
+  const uniqueId = useId();
   const [focusTarget, setFocusTarget] = useState<RefObject<HTMLElement> | null>(
     null
   );

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -10,20 +10,20 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
     >
       <h4
         class="cds--data-table-header__title"
-        id="tc-:r5k:-title"
+        id="tc-:r63:-title"
       >
         DataTable with selection
       </h4>
       <p
         class="cds--data-table-header__description"
-        id="tc-:r5k:-description"
+        id="tc-:r63:-description"
       />
     </div>
     <div
       class="cds--data-table-content"
     >
       <table
-        aria-labelledby="tc-:r5k:-title"
+        aria-labelledby="tc-:r63:-title"
         class="cds--data-table cds--data-table--lg"
       >
         <thead>
@@ -182,20 +182,20 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
     >
       <h4
         class="cds--data-table-header__title"
-        id="tc-:r5e:-title"
+        id="tc-:r5t:-title"
       >
         DataTable with selection
       </h4>
       <p
         class="cds--data-table-header__description"
-        id="tc-:r5e:-description"
+        id="tc-:r5t:-description"
       />
     </div>
     <div
       class="cds--data-table-content"
     >
       <table
-        aria-labelledby="tc-:r5e:-title"
+        aria-labelledby="tc-:r5t:-title"
         class="cds--data-table cds--data-table--lg"
       >
         <thead>
@@ -354,13 +354,13 @@ exports[`DataTable behaves as expected selection should render and match snapsho
     >
       <h4
         class="cds--data-table-header__title"
-        id="tc-:r28:-title"
+        id="tc-:r2e:-title"
       >
         DataTable with selection
       </h4>
       <p
         class="cds--data-table-header__description"
-        id="tc-:r28:-description"
+        id="tc-:r2e:-description"
       />
     </div>
     <section
@@ -571,7 +571,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-labelledby="tooltip-:r2f:"
+                aria-labelledby="tooltip-:r2m:"
                 class="cds--btn--icon-only cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--primary"
                 title="Settings"
                 type="button"
@@ -600,7 +600,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
             <span
               aria-hidden="true"
               class="cds--popover"
-              id="tooltip-:r2f:"
+              id="tooltip-:r2m:"
               role="tooltip"
             >
               <span
@@ -626,7 +626,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
       class="cds--data-table-content"
     >
       <table
-        aria-labelledby="tc-:r28:-title"
+        aria-labelledby="tc-:r2e:-title"
         class="cds--data-table cds--data-table--lg"
       >
         <thead>
@@ -797,13 +797,13 @@ exports[`DataTable renders as expected - Component API should render and match s
     >
       <h4
         class="cds--data-table-header__title"
-        id="tc-:rc:-title"
+        id="tc-:rd:-title"
       >
         DataTable with toolbar
       </h4>
       <p
         class="cds--data-table-header__description"
-        id="tc-:rc:-description"
+        id="tc-:rd:-description"
       />
     </div>
     <section
@@ -1002,7 +1002,7 @@ exports[`DataTable renders as expected - Component API should render and match s
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-labelledby="tooltip-:ri:"
+                aria-labelledby="tooltip-:rk:"
                 class="cds--btn--icon-only cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--primary"
                 title="Settings"
                 type="button"
@@ -1031,7 +1031,7 @@ exports[`DataTable renders as expected - Component API should render and match s
             <span
               aria-hidden="true"
               class="cds--popover"
-              id="tooltip-:ri:"
+              id="tooltip-:rk:"
               role="tooltip"
             >
               <span
@@ -1057,7 +1057,7 @@ exports[`DataTable renders as expected - Component API should render and match s
       class="cds--data-table-content"
     >
       <table
-        aria-labelledby="tc-:rc:-title"
+        aria-labelledby="tc-:rd:-title"
         class="cds--data-table cds--data-table--lg cds--data-table--visible-overflow-menu"
       >
         <thead>

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -11,11 +11,10 @@ import PropTypes, { ReactElementLike, ReactNodeArray } from 'prop-types';
 import React, { ForwardedRef, useContext } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { ReactAttr } from '../../types/common';
 import { Text } from '../Text';
 
-const getInstanceId = setupGetInstanceId();
 type ExcludedAttributes = 'value' | 'onChange' | 'locale' | 'children';
 export type ReactNodeLike =
   | ReactElementLike
@@ -158,7 +157,7 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
   } = props;
   const prefix = usePrefix();
   const { isFluid } = useContext(FormContext);
-  const datePickerInputInstanceId = getInstanceId();
+  const datePickerInputInstanceId = useId();
   const datePickerInputProps = {
     id,
     onChange: (event) => {

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -40,15 +40,13 @@ import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { ReactAttr } from '../../types/common';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import {
   useFloating,
   flip,
   autoUpdate,
   size as floatingSize,
 } from '@floating-ui/react';
-
-const getInstanceId = setupGetInstanceId();
 
 const {
   ToggleButtonKeyDownArrowDown,
@@ -335,7 +333,7 @@ const Dropdown = React.forwardRef(
         return isObject && 'disabled' in item && item.disabled === true;
       },
     };
-    const { current: dropdownInstanceId } = useRef(getInstanceId());
+    const dropdownInstanceId = useId();
 
     function stateReducer(state, actionAndChanges) {
       const { changes, props, type } = actionAndChanges;

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -21,7 +21,7 @@ import wrapFocus, {
 } from '../../internal/wrapFocus';
 import debounce from 'lodash.debounce';
 import useIsomorphicEffect from '../../internal/useIsomorphicEffect';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { keys, match } from '../../internal/keyboard';
 import { IconButton } from '../IconButton';
@@ -31,8 +31,6 @@ import { ReactAttr } from '../../types/common';
 import { InlineLoadingStatus } from '../InlineLoading/InlineLoading';
 import { useFeatureFlag } from '../FeatureFlags';
 import { composeEventHandlers } from '../../tools/events';
-
-const getInstanceId = setupGetInstanceId();
 
 export const ModalSizes = ['xs', 'sm', 'md', 'lg'] as const;
 
@@ -264,7 +262,7 @@ const Modal = React.forwardRef(function Modal(
   const startTrap = useRef<HTMLSpanElement>(null);
   const endTrap = useRef<HTMLSpanElement>(null);
   const [isScrollable, setIsScrollable] = useState(false);
-  const modalInstanceId = `modal-${getInstanceId()}`;
+  const modalInstanceId = `modal-${useId()}`;
   const modalLabelId = `${prefix}--modal-header__label--${modalInstanceId}`;
   const modalHeadingId = `${prefix}--modal-header__heading--${modalInstanceId}`;
   const modalBodyId = `${prefix}--modal-body--${modalInstanceId}`;

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -36,7 +36,7 @@ import {
 } from './MultiSelectPropTypes';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
 import { useSelection } from '../../internal/Selection';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import mergeRefs from '../../tools/mergeRefs';
 import deprecate from '../../prop-types/deprecate';
 import { keys, match } from '../../internal/keyboard';
@@ -52,7 +52,6 @@ import {
   autoUpdate,
 } from '@floating-ui/react';
 
-const getInstanceId = setupGetInstanceId();
 const {
   ItemClick,
   ToggleButtonBlur,
@@ -328,7 +327,7 @@ const MultiSelect = React.forwardRef(
   ) => {
     const prefix = usePrefix();
     const { isFluid } = useContext(FormContext);
-    const { current: multiSelectInstanceId } = useRef(getInstanceId());
+    const multiSelectInstanceId = useId();
     const [isFocused, setIsFocused] = useState(false);
     const [inputFocused, setInputFocused] = useState(false);
     const [isOpen, setIsOpen] = useState(open || false);

--- a/packages/react/src/components/Pagination/experimental/PageSelector.js
+++ b/packages/react/src/components/Pagination/experimental/PageSelector.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useId } from '../../internal/useId';
+import { useId } from '../../../internal/useId';
 import Select from '../../Select';
 import SelectItem from '../../SelectItem';
 import { usePrefix } from '../../../internal/usePrefix';

--- a/packages/react/src/components/Pagination/experimental/PageSelector.js
+++ b/packages/react/src/components/Pagination/experimental/PageSelector.js
@@ -8,12 +8,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import setupGetInstanceId from '../../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import Select from '../../Select';
 import SelectItem from '../../SelectItem';
 import { usePrefix } from '../../../internal/usePrefix';
 
-const getInstanceId = setupGetInstanceId();
 function PageSelector({
   className = null,
   currentPage,
@@ -24,7 +23,7 @@ function PageSelector({
 }) {
   const prefix = usePrefix();
   const namespace = `${prefix}--unstable-pagination__page-selector`;
-  const instanceId = `${namespace}__select-${getInstanceId()}`;
+  const instanceId = `${namespace}__select-${useId()}`;
 
   const renderPages = (total) => {
     const pages = [];

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -19,9 +19,7 @@ import { Legend } from '../Text';
 import { usePrefix } from '../../internal/usePrefix';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import mergeRefs from '../../tools/mergeRefs';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
-
-const getInstanceId = setupGetInstanceId();
+import { useId } from '../../internal/useId';
 
 export const RadioButtonGroupContext = createContext(null);
 
@@ -157,7 +155,7 @@ const RadioButtonGroup = React.forwardRef(
     const [selected, setSelected] = useState(valueSelected ?? defaultSelected);
     const [prevValueSelected, setPrevValueSelected] = useState(valueSelected);
 
-    const { current: radioButtonGroupInstanceId } = useRef(getInstanceId());
+    const radioButtonGroupInstanceId = useId();
 
     /**
      * prop + state alignment - getDerivedStateFromProps

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -24,11 +24,9 @@ import {
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { composeEventHandlers } from '../../tools/events';
 import { Text } from '../Text';
-
-const getInstanceId = setupGetInstanceId();
 
 type ExcludedAttributes = 'size';
 
@@ -165,7 +163,7 @@ const Select = React.forwardRef(function Select(
   const { isFluid } = useContext(FormContext);
   const [isFocused, setIsFocused] = useState(false);
   const [title, setTitle] = useState('');
-  const { current: selectInstanceId } = useRef(getInstanceId());
+  const selectInstanceId = useId();
 
   const selectClasses = classNames({
     [`${prefix}--select`]: true,

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 import Tag, { SIZES, TYPES } from './Tag';
@@ -16,8 +16,6 @@ import { Close } from '@carbon/icons-react';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';
-
-const getInstanceId = setupGetInstanceId();
 
 export interface DismissibleTagBaseProps {
   /**
@@ -93,7 +91,7 @@ const DismissibleTag = <T extends React.ElementType>({
 }: DismissibleTagProps<T>) => {
   const prefix = usePrefix();
   const tagLabelRef = useRef<HTMLElement>();
-  const tagId = id || `tag-${getInstanceId()}`;
+  const tagId = id || `tag-${useId()}`;
   const tagClasses = classNames(`${prefix}--tag--filter`, className);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -14,15 +14,13 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 import Tag, { SIZES } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';
-
-const getInstanceId = setupGetInstanceId();
 
 const TYPES = {
   red: 'Red',
@@ -100,7 +98,7 @@ const OperationalTag = <T extends React.ElementType>({
 }: OperationalTagProps<T>) => {
   const prefix = usePrefix();
   const tagRef = useRef<HTMLElement>();
-  const tagId = id || `tag-${getInstanceId()}`;
+  const tagId = id || `tag-${useId()}`;
   const tagClasses = classNames(`${prefix}--tag--operational`, className);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -8,15 +8,13 @@
 import PropTypes from 'prop-types';
 import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 import Tag, { SIZES } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';
-
-const getInstanceId = setupGetInstanceId();
 
 export interface SelectableTagBaseProps {
   /**
@@ -80,7 +78,7 @@ const SelectableTag = <T extends React.ElementType>({
 }: SelectableTagProps<T>) => {
   const prefix = usePrefix();
   const tagRef = useRef<HTMLElement>();
-  const tagId = id || `tag-${getInstanceId()}`;
+  const tagId = id || `tag-${useId()}`;
   const [selectedTag, setSelectedTag] = useState(selected);
   const tagClasses = classNames(`${prefix}--tag--selectable`, className, {
     [`${prefix}--tag--selectable-selected`]: selectedTag,

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -15,7 +15,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { Close } from '@carbon/icons-react';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
 import { Text } from '../Text';
@@ -24,7 +24,6 @@ import { DefinitionTooltip } from '../Tooltip';
 import { isEllipsisActive } from './isEllipsisActive';
 import { useMergeRefs } from '@floating-ui/react';
 
-const getInstanceId = setupGetInstanceId();
 export const TYPES = {
   red: 'Red',
   magenta: 'Magenta',
@@ -131,7 +130,7 @@ const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
   const prefix = usePrefix();
   const tagRef = useRef<HTMLElement>();
   const ref = useMergeRefs([forwardRef, tagRef]);
-  const tagId = id || `tag-${getInstanceId()}`;
+  const tagId = id || `tag-${useId()}`;
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
   useLayoutEffect(() => {

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -21,11 +21,9 @@ import { FormContext } from '../FluidForm';
 import { useAnnouncer } from '../../internal/useAnnouncer';
 import useIsomorphicEffect from '../../internal/useIsomorphicEffect';
 import { useMergedRefs } from '../../internal/useMergedRefs';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { noopFn } from '../../internal/noopFn';
 import { Text } from '../Text';
-
-const getInstanceId = setupGetInstanceId();
 
 export interface TextAreaProps
   extends React.InputHTMLAttributes<HTMLTextAreaElement> {
@@ -185,7 +183,7 @@ const TextArea = React.forwardRef((props: TextAreaProps, forwardRef) => {
   const { isFluid } = useContext(FormContext);
   const { defaultValue, value } = other;
 
-  const { current: textAreaInstanceId } = useRef(getInstanceId());
+  const textAreaInstanceId = useId();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const ref = useMergedRefs([forwardRef, textareaRef]) as

--- a/packages/react/src/components/TextInput/ControlledPasswordInput.tsx
+++ b/packages/react/src/components/TextInput/ControlledPasswordInput.tsx
@@ -6,11 +6,9 @@ import { textInputProps } from './util';
 import { warning } from '../../internal/warning';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
-import setupGetInstanceId from '../../tools/setupGetInstanceId';
+import { useId } from '../../internal/useId';
 import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
-
-const getInstanceId = setupGetInstanceId();
 
 let didWarnAboutDeprecation = false;
 
@@ -149,7 +147,7 @@ const ControlledPasswordInput = React.forwardRef(
     ref
   ) {
     const prefix = usePrefix();
-    const { current: controlledPasswordInstanceId } = useRef(getInstanceId());
+    const controlledPasswordInstanceId = useId();
 
     if (__DEV__) {
       warning(


### PR DESCRIPTION
[Brought up in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1721175434456939), there's quite a few components that use `setupGetInstanceId()` where they could/should be using `useId()` because:

1. `useId` in React 18+ is unified between server and client
2. `useId` has internal state to guard the id from changing based on rerenders of the parent component

The specific issue that highlighted this was that Modal's unique id changes every time it re-renders ([example](https://stackblitz.com/edit/github-n6nfpx-ecsmnm?file=package.json)). To avoid this you currently have to move state downwards ([example](https://stackblitz.com/edit/github-n6nfpx?file=package.json)), which isn't possible in all cases. Elsewhere in the codebase setupGetInstanceId was already guarded from changing on re-renders by using `useMemo` or `useRef`. 

There are still two class-based components that cannot take advantage of this, OverflowMenu (the old implementation, not the feature flagged one) and DataTable.

#### Changelog

**Changed**

- Modify functional components to utilize `useId` instead of `setupGetInstanceId`

#### Testing / Reviewing

For each component:

1. Go to the playground story of each component
2. Open the inspector, find the element with the class containing the unique id
3. Modify a prop in the controls pane, the id should not change


<details><summary>Example of a failure (in prod right now)</summary>
<p>

https://github.com/user-attachments/assets/cb0ad18d-8fa6-4515-8fc2-c7a3feb0d8d9

</p>
</details> 


<details><summary>Example with this PR</summary>
<p>

https://github.com/user-attachments/assets/5b7f7e99-89e8-456c-a246-8db609bdba45

</p>
</details> 






