### PR TITLE
fix(selectabletile): remove deprecated annotation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1470,6 +1470,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "jesnajoseijk",
+      "name": "jesnajoseijk",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38346258?v=4",
+      "profile": "https://github.com/jesnajoseijk",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/mranjana"><img src="https://avatars.githubusercontent.com/u/91003483?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anjana M R</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mranjana" title="Code">💻</a></td>
     <td align="center"><a href="https://cuppajoey.com/"><img src="https://avatars.githubusercontent.com/u/14837881?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joseph Schultz</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=cuppajoey" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/anjaly0606"><img src="https://avatars.githubusercontent.com/u/99959496?v=4?s=100" width="100px;" alt=""/><br /><sub><b>anjaly0606</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=anjaly0606" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jesnajoseijk"><img src="https://avatars.githubusercontent.com/u/38346258?v=4?s=100" width="100px;" alt=""/><br /><sub><b>jesnajoseijk</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=jesnajoseijk" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -406,7 +406,7 @@ export interface SelectableTileProps extends HTMLAttributes<HTMLDivElement> {
 
   /**
    * The value of the `<input>`.
-   * @deprecated
+   *
    */
   value: string | number;
 }
@@ -596,7 +596,7 @@ SelectableTile.propTypes = {
 
   /**
    * The value of the `<input>`.
-   * @deprecated
+   *
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16977

removed the unnecessary deprecated annotation

#### Changelog

**New**

- {{new thing}}

**Changed**

- Tile.tsx

**Removed**

- @deprecated annotation for selectabletile value parameter

#### Testing / Reviewing

The component shouldn't show value as deprecated as in https://stackblitz.com/edit/vitejs-vite-dbavtk?file=src%2FApp.tsx
