### PR TITLE
fix(dropdown): memoize floating ui ref to prevent max call depth

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -14,6 +14,7 @@ import React, {
   MouseEvent,
   ReactNode,
   useEffect,
+  useMemo,
 } from 'react';
 import {
   useSelect,
@@ -497,8 +498,13 @@ const Dropdown = React.forwardRef(
           },
         };
 
-    const menuProps = getMenuProps();
-    const menuRef = mergeRefs(menuProps.ref, refs.setFloating);
+    const menuProps = useMemo(
+      () =>
+        getMenuProps({
+          ref: autoAlign ? refs.setFloating : null,
+        }),
+      [autoAlign]
+    );
 
     // Slug is always size `mini`
     let normalizedSlug;
@@ -527,7 +533,7 @@ const Dropdown = React.forwardRef(
           warnText={warnText}
           light={light}
           isOpen={isOpen}
-          ref={refs.setReference}
+          ref={autoAlign ? refs.setReference : null}
           id={id}>
           {invalid && (
             <WarningFilled className={`${prefix}--list-box__invalid-icon`} />
@@ -567,7 +573,7 @@ const Dropdown = React.forwardRef(
             />
           </button>
           {normalizedSlug}
-          <ListBox.Menu {...menuProps} ref={menuRef}>
+          <ListBox.Menu {...menuProps}>
             {isOpen &&
               items.map((item, index) => {
                 const isObject = item !== null && typeof item === 'object';


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/17001

Applies similar approach as for the Combobox component (in https://github.com/carbon-design-system/carbon/pull/16866) to memoize the value of `getMenuProps` to avoid an infinite loop.

#### Changelog

**Changed**

- Wrap `getMenuProps` in `useMemo`
- Conditionally apply refs

#### Testing / Reviewing

- Go to default dropdown story. Verify there is no regression for default behaviour.
- Ensure autoAlign works as expected on dropdown by resizing the browser window, playing with scroll, and opening/closing the listbox
- The original issue only appeared when running cypress tests, only way to validate this fixes the bug in that case would be to add a cypress test for the Dropdown component.

Note: The fix was validated in an existing app by applying a patch.