### PR TITLE
fix(tabs): ellipsis should only be applied with vertical variant

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1217,10 +1217,12 @@ const Tab = forwardRef<HTMLElement, TabProps>(function Tab(
   useLayoutEffect(() => {
     function handler() {
       const elementTabId = document.getElementById(`${id}`) || tabRef.current;
-      const newElement = elementTabId?.getElementsByClassName(
-        `${prefix}--tabs__nav-item-label`
-      )[0];
-      isEllipsisActive(newElement);
+      if (elementTabId?.closest(`.${prefix}--tabs--vertical`)) {
+        const newElement = elementTabId?.getElementsByClassName(
+          `${prefix}--tabs__nav-item-label`
+        )[0];
+        isEllipsisActive(newElement);
+      }
     }
     handler();
     window.addEventListener('resize', handler);


### PR DESCRIPTION
Closes #16999

FF displaying odd styles and sometimes accidentally applying a tooltip when not applicable 

**Changed**

- added an additional if statement when checking if Ellipsis should be applied by seeing if parent element is using vertical tabs

#### Testing / Reviewing

tested in storybook 
