### PR TITLE
fix: memoize getMenuProps for Multiselect and Filterable Multiselect

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -654,6 +654,7 @@ const ComboBox = forwardRef(
       (helperText && !isFluid && helperTextId) ||
       undefined;
 
+    // Memoize the value of getMenuProps to avoid an infinite loop
     const menuProps = useMemo(
       () =>
         getMenuProps({

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -30,6 +30,7 @@ import React, {
   type KeyboardEvent,
   ReactElement,
   useLayoutEffect,
+  useMemo,
 } from 'react';
 import { defaultFilterItems } from '../ComboBox/tools/filter';
 import {
@@ -718,7 +719,18 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect<
       },
     })
   );
-  const menuProps = getMenuProps({}, { suppressRefError: true });
+
+  // Memoize the value of getMenuProps to avoid an infinite loop
+  const menuProps = useMemo(
+    () =>
+      getMenuProps(
+        {
+          ref: autoAlign ? refs.setFloating : null,
+        },
+        { suppressRefError: true }
+      ),
+    [autoAlign]
+  );
 
   const handleFocus = (evt: FocusEvent<HTMLDivElement> | undefined) => {
     if (
@@ -766,7 +778,9 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect<
         warnText={warnText}
         isOpen={isOpen}
         size={size}>
-        <div className={`${prefix}--list-box__field`} ref={refs.setReference}>
+        <div
+          className={`${prefix}--list-box__field`}
+          ref={autoAlign ? refs.setReference : null}>
           {controlledSelectedItems.length > 0 && (
             // @ts-expect-error: It is expecting a non-required prop called: "onClearSelection"
             <ListBoxSelection
@@ -819,7 +833,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect<
         </div>
         {normalizedSlug}
 
-        <ListBox.Menu {...menuProps} ref={refs.setFloating}>
+        <ListBox.Menu {...menuProps}>
           {isOpen
             ? sortedItems.map((item, index) => {
                 const isChecked =

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -652,6 +652,15 @@ const MultiSelect = React.forwardRef(
       selectedItems.length > 0 &&
       selectedItems.map((item) => (item as selectedItemType)?.text);
 
+    // Memoize the value of getMenuProps to avoid an infinite loop
+    const menuProps = useMemo(
+      () =>
+        getMenuProps({
+          ref: autoAlign ? refs.setFloating : null,
+        }),
+      [autoAlign]
+    );
+
     return (
       <div className={wrapperClasses}>
         <label className={titleClasses} {...getLabelProps()}>
@@ -687,7 +696,7 @@ const MultiSelect = React.forwardRef(
           )}
           <div
             className={multiSelectFieldWrapperClasses}
-            ref={refs.setReference}>
+            ref={autoAlign ? refs.setReference : null}>
             {selectedItems.length > 0 && (
               <ListBox.Selection
                 readOnly={readOnly}
@@ -723,10 +732,7 @@ const MultiSelect = React.forwardRef(
             </button>
             {normalizedSlug}
           </div>
-          <ListBox.Menu
-            {...getMenuProps({
-              ref: refs.setFloating,
-            })}>
+          <ListBox.Menu {...menuProps}>
             {isOpen &&
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               sortItems!(


### PR DESCRIPTION
Closes #16867
Closes #17021 
Closes #17020

This PR does these  primary things to Multiselect and Filterable Multiselect
1. Memoize the value of `getMenuProps` to avoid an infinite loop
2. Only apply floating ui refs when `autoAlign={true}`

The first fixes the problem for max depth call that results in infinite loop, the second is an indirect improvement. If the refs had initially been guarded, this bug would've been isolated to users using `autoAlign`. Because the refs were not guarded, the bug was present for everyone regardless of if `autoAlign` was being used.

This PR also verifies if the refs of components - **popover**, **tooltip**, **dropdown**,  are guarded with autoalign prop.

#### Changelog

**Changed**

- Wrap `getMenuProps` in `useMemo` to **multiselect** and **filterable multiselect**
- Conditionally apply or verify refs in **multiselect** , **filterable multiselect** , **popover**, **tooltip**, **dropdown**

#### Testing / Reviewing

- Go to the default multiselect story. Type super fast - like just totally spam the keyboard. The component should not error
- Do the same on the `with experimental autoalign` multiselect story
- Ensure `autoAlign` works as expected on multiselect by resizing the browser window, playing with scroll, and opening/closing the listbox
- Do the same for filterable multiselect.