### PR TITLE
Fix types for translateWithId() methods.

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -45,6 +45,7 @@ import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { useFloating, flip, autoUpdate } from '@floating-ui/react';
+import { InternationalProps } from '../../types/common';
 
 const {
   InputBlur,
@@ -144,7 +145,8 @@ type TranslationKey =
 
 type ItemToStringHandler<ItemType> = (item: ItemType | null) => string;
 export interface ComboBoxProps<ItemType>
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes> {
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes>,
+    InternationalProps<TranslationKey> {
   /**
    * Specify whether or not the ComboBox should allow a value that is
    * not in the list to be entered in the input
@@ -307,12 +309,6 @@ export interface ComboBoxProps<ItemType>
    * combobox via ARIA attributes.
    */
   titleText?: ReactNode;
-
-  /**
-   * Specify a custom translation function that takes in a message identifier
-   * and returns the localized string for the message
-   */
-  translateWithId?: (id: TranslationKey) => string;
 
   /**
    * Specify whether the control is currently in warning state

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -129,6 +129,19 @@ interface OnChangeData<ItemType> {
   inputValue?: string | null;
 }
 
+/**
+ * Message ids that will be passed to translateWithId().
+ * Combination of message ids from ListBox/next/ListBoxSelection.js and
+ * ListBox/next/ListBoxTrigger.js, but we can't access those values directly
+ * because those components aren't Typescript.  (If you try, TranslationKey
+ * ends up just being defined as "string".)
+ */
+type TranslationKey =
+  | 'close.menu'
+  | 'open.menu'
+  | 'clear.all'
+  | 'clear.selection';
+
 type ItemToStringHandler<ItemType> = (item: ItemType | null) => string;
 export interface ComboBoxProps<ItemType>
   extends Omit<InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes> {
@@ -299,7 +312,7 @@ export interface ComboBoxProps<ItemType>
    * Specify a custom translation function that takes in a message identifier
    * and returns the localized string for the message
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (id: TranslationKey) => string;
 
   /**
    * Specify whether the control is currently in warning state
@@ -661,7 +674,13 @@ const ComboBox = forwardRef(
           'aria-label': deprecatedAriaLabel || ariaLabel,
           ref: autoAlign ? refs.setFloating : null,
         }),
-      [autoAlign, deprecatedAriaLabel, ariaLabel]
+      [
+        autoAlign,
+        deprecatedAriaLabel,
+        ariaLabel,
+        getMenuProps,
+        refs.setFloating,
+      ]
     );
 
     return (

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -45,7 +45,7 @@ import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { useFloating, flip, autoUpdate } from '@floating-ui/react';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const {
   InputBlur,
@@ -146,7 +146,7 @@ type TranslationKey =
 type ItemToStringHandler<ItemType> = (item: ItemType | null) => string;
 export interface ComboBoxProps<ItemType>
   extends Omit<InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes>,
-    InternationalProps<TranslationKey> {
+    TranslateWithId<TranslationKey> {
   /**
    * Specify whether or not the ComboBox should allow a value that is
    * not in the list to be entered in the input

--- a/packages/react/src/components/ComboButton/index.tsx
+++ b/packages/react/src/components/ComboButton/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@floating-ui/react';
 import mergeRefs from '../../tools/mergeRefs';
 import { MenuAlignment } from '../MenuButton';
+import { InternationalProps } from '../../types/common';
 
 const defaultTranslations = {
   'carbon.combo-button.additional-actions': 'Additional actions',
@@ -37,7 +38,7 @@ function defaultTranslateWithId(messageId: string) {
   return defaultTranslations[messageId];
 }
 
-interface ComboButtonProps {
+interface ComboButtonProps extends InternationalProps<TranslationKey> {
   /**
    * A collection of `MenuItems` to be rendered as additional actions for this `ComboButton`.
    */
@@ -77,12 +78,6 @@ interface ComboButtonProps {
    * Specify how the trigger tooltip should be aligned.
    */
   tooltipAlignment?: React.ComponentProps<typeof IconButton>['align'];
-
-  /**
-   * Optional method that takes in a message `id` and returns an
-   * internationalized string.
-   */
-  translateWithId?: (id: TranslationKey) => string;
 }
 
 const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(

--- a/packages/react/src/components/ComboButton/index.tsx
+++ b/packages/react/src/components/ComboButton/index.tsx
@@ -28,6 +28,11 @@ const defaultTranslations = {
   'carbon.combo-button.additional-actions': 'Additional actions',
 };
 
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = keyof typeof defaultTranslations;
+
 function defaultTranslateWithId(messageId: string) {
   return defaultTranslations[messageId];
 }
@@ -77,7 +82,7 @@ interface ComboButtonProps {
    * Optional method that takes in a message `id` and returns an
    * internationalized string.
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (id: TranslationKey) => string;
 }
 
 const ComboButton = React.forwardRef<HTMLDivElement, ComboButtonProps>(

--- a/packages/react/src/components/ComboButton/index.tsx
+++ b/packages/react/src/components/ComboButton/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@floating-ui/react';
 import mergeRefs from '../../tools/mergeRefs';
 import { MenuAlignment } from '../MenuButton';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const defaultTranslations = {
   'carbon.combo-button.additional-actions': 'Additional actions',
@@ -38,7 +38,7 @@ function defaultTranslateWithId(messageId: string) {
   return defaultTranslations[messageId];
 }
 
-interface ComboButtonProps extends InternationalProps<TranslationKey> {
+interface ComboButtonProps extends TranslateWithId<TranslationKey> {
   /**
    * A collection of `MenuItems` to be rendered as additional actions for this `ComboButton`.
    */

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -37,7 +37,7 @@ import TableToolbarAction from './TableToolbarAction';
 import TableToolbarContent from './TableToolbarContent';
 import TableToolbarSearch from './TableToolbarSearch';
 import TableToolbarMenu from './TableToolbarMenu';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const getInstanceId = setupGetInstanceId();
 
@@ -218,7 +218,7 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
 }
 
 export interface DataTableProps<RowType, ColTypes extends any[]>
-  extends InternationalProps<TranslationKey> {
+  extends TranslateWithId<TranslationKey> {
   children?: (
     renderProps: DataTableRenderProps<RowType, ColTypes>
   ) => React.ReactElement;

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -49,7 +49,12 @@ const translationKeys = {
   unselectAll: 'carbon.table.all.unselect',
   selectRow: 'carbon.table.row.select',
   unselectRow: 'carbon.table.row.unselect',
-};
+} as const;
+
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = (typeof translationKeys)[keyof typeof translationKeys];
 
 const defaultTranslations = {
   [translationKeys.expandAll]: 'Expand all rows',
@@ -243,7 +248,7 @@ export interface DataTableProps<RowType, ColTypes extends any[]> {
     }
   ) => number;
   stickyHeader?: boolean;
-  translateWithId?: (id: string) => string;
+  translateWithId?: (id: TranslationKey) => string;
   useStaticWidth?: boolean;
   useZebraStyles?: boolean;
 }

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -37,6 +37,7 @@ import TableToolbarAction from './TableToolbarAction';
 import TableToolbarContent from './TableToolbarContent';
 import TableToolbarSearch from './TableToolbarSearch';
 import TableToolbarMenu from './TableToolbarMenu';
+import { InternationalProps } from '../../types/common';
 
 const getInstanceId = setupGetInstanceId();
 
@@ -216,7 +217,8 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
   radio: boolean | undefined;
 }
 
-export interface DataTableProps<RowType, ColTypes extends any[]> {
+export interface DataTableProps<RowType, ColTypes extends any[]>
+  extends InternationalProps<TranslationKey> {
   children?: (
     renderProps: DataTableRenderProps<RowType, ColTypes>
   ) => React.ReactElement;
@@ -248,7 +250,6 @@ export interface DataTableProps<RowType, ColTypes extends any[]> {
     }
   ) => number;
   stickyHeader?: boolean;
-  translateWithId?: (id: TranslationKey) => string;
   useStaticWidth?: boolean;
   useZebraStyles?: boolean;
 }

--- a/packages/react/src/components/DataTable/TableBatchActions.tsx
+++ b/packages/react/src/components/DataTable/TableBatchActions.tsx
@@ -12,7 +12,7 @@ import Button from '../Button';
 import TableActionList from './TableActionList';
 import { Text } from '../Text';
 import { usePrefix } from '../../internal/usePrefix';
-import type { InternationalProps } from '../../types/common';
+import type { TranslateWithId } from '../../types/common';
 
 const TableBatchActionsTranslationKeys = [
   'carbon.table.batch.cancel',
@@ -31,7 +31,7 @@ export interface TableBatchActionsTranslationArgs {
 
 export interface TableBatchActionsProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    InternationalProps<
+    TranslateWithId<
       TableBatchActionsTranslationKey,
       TableBatchActionsTranslationArgs
     > {

--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -16,7 +16,7 @@ import classNames from 'classnames';
 import { sortStates } from './state/sorting';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
-import { ReactAttr } from '../../types/common';
+import { InternationalProps, ReactAttr } from '../../types/common';
 import { DataTableSortState } from './state/sortStates';
 
 const defaultScope = 'col';
@@ -64,7 +64,11 @@ const sortDirections: { [key: string]: 'none' | 'ascending' | 'descending' } = {
 };
 
 interface TableHeaderProps
-  extends ReactAttr<HTMLTableCellElement & HTMLButtonElement> {
+  extends ReactAttr<HTMLTableCellElement & HTMLButtonElement>,
+    InternationalProps<
+      TableHeaderTranslationKey,
+      { header; sortDirection; isSortHeader; sortStates }
+    > {
   /**
    * Pass in children that will be embedded in the table header label
    */
@@ -119,16 +123,6 @@ interface TableHeaderProps
    * NONE, or ASC.
    */
   sortDirection?: string;
-
-  /**
-   * Supply a method to translate internal strings with your i18n tool of
-   * choice. Translation keys are available on the `translationKeys` field for
-   * this component.
-   */
-  translateWithId?: (
-    key: TableHeaderTranslationKey,
-    { header, sortDirection, isSortHeader, sortStates }
-  ) => string;
 }
 
 const TableHeader = React.forwardRef(function TableHeader(

--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -16,7 +16,7 @@ import classNames from 'classnames';
 import { sortStates } from './state/sorting';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
-import { InternationalProps, ReactAttr } from '../../types/common';
+import { TranslateWithId, ReactAttr } from '../../types/common';
 import { DataTableSortState } from './state/sortStates';
 
 const defaultScope = 'col';
@@ -65,7 +65,7 @@ const sortDirections: { [key: string]: 'none' | 'ascending' | 'descending' } = {
 
 interface TableHeaderProps
   extends ReactAttr<HTMLTableCellElement & HTMLButtonElement>,
-    InternationalProps<
+    TranslateWithId<
       TableHeaderTranslationKey,
       { header; sortDirection; isSortHeader; sortStates }
     > {

--- a/packages/react/src/components/DataTable/TableToolbarSearch.tsx
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.tsx
@@ -9,7 +9,6 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, {
   ChangeEvent,
-  useMemo,
   useRef,
   useState,
   useEffect,
@@ -23,16 +22,19 @@ import { usePrefix } from '../../internal/usePrefix';
 import { noopFn } from '../../internal/noopFn';
 import { InternationalProps } from '../../types/common';
 
+/**
+ * Message ids that will be passed to translateWithId().
+ */
 export type TableToolbarTranslationKey =
   | 'carbon.table.toolbar.search.label'
   | 'carbon.table.toolbar.search.placeholder';
 
-const translationKeys = {
+const translationKeys: Record<TableToolbarTranslationKey, string> = {
   'carbon.table.toolbar.search.label': 'Filter table',
   'carbon.table.toolbar.search.placeholder': 'Filter table',
 };
 
-const translateWithId = (id: string): string => {
+const translateWithId = (id: TableToolbarTranslationKey): string => {
   return translationKeys[id];
 };
 

--- a/packages/react/src/components/DataTable/TableToolbarSearch.tsx
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.tsx
@@ -20,7 +20,7 @@ import Search, { SearchProps } from '../Search';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { noopFn } from '../../internal/noopFn';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 /**
  * Message ids that will be passed to translateWithId().
@@ -54,7 +54,7 @@ export type TableToolbarSearchHandleExpand = (
 
 export interface TableToolbarSearchProps
   extends Omit<SearchProps, ExcludedInheritedProps>,
-    InternationalProps<TableToolbarTranslationKey> {
+    TranslateWithId<TableToolbarTranslationKey> {
   /**
    * Specifies if the search should initially render in an expanded state
    */

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -40,7 +40,7 @@ import mergeRefs from '../../tools/mergeRefs';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
-import { ReactAttr } from '../../types/common';
+import { InternationalProps, ReactAttr } from '../../types/common';
 import { useId } from '../../internal/useId';
 import {
   useFloating,
@@ -85,7 +85,8 @@ export interface OnChangeData<ItemType> {
 }
 
 export interface DropdownProps<ItemType>
-  extends Omit<ReactAttr<HTMLDivElement>, ExcludedAttributes> {
+  extends Omit<ReactAttr<HTMLDivElement>, ExcludedAttributes>,
+    InternationalProps<ListBoxMenuIconTranslationKey> {
   /**
    * Specify a label to be read by screen readers on the container node
    * 'aria-label' of the ListBox component.
@@ -219,14 +220,6 @@ export interface DropdownProps<ItemType>
    * visiting this control
    */
   titleText?: ReactNode;
-
-  /**
-   * Callback function for translating ListBoxMenuIcon SVG title
-   */
-  translateWithId?(
-    messageId: ListBoxMenuIconTranslationKey,
-    args?: Record<string, unknown>
-  ): string;
 
   /**
    * The dropdown type, `default` or `inline`

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -40,7 +40,7 @@ import mergeRefs from '../../tools/mergeRefs';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
-import { InternationalProps, ReactAttr } from '../../types/common';
+import { TranslateWithId, ReactAttr } from '../../types/common';
 import { useId } from '../../internal/useId';
 import {
   useFloating,
@@ -86,7 +86,7 @@ export interface OnChangeData<ItemType> {
 
 export interface DropdownProps<ItemType>
   extends Omit<ReactAttr<HTMLDivElement>, ExcludedAttributes>,
-    InternationalProps<ListBoxMenuIconTranslationKey> {
+    TranslateWithId<ListBoxMenuIconTranslationKey> {
   /**
    * Specify a label to be read by screen readers on the container node
    * 'aria-label' of the ListBox component.

--- a/packages/react/src/components/ListBox/ListBoxMenuIcon.tsx
+++ b/packages/react/src/components/ListBox/ListBoxMenuIcon.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ChevronDown } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
+import { InternationalProps } from '../../types/common';
 
 export type ListBoxMenuIconTranslationKey = 'close.menu' | 'open.menu';
 
@@ -21,22 +22,13 @@ const defaultTranslations: Record<ListBoxMenuIconTranslationKey, string> = {
 const defaultTranslateWithId = (id: ListBoxMenuIconTranslationKey): string =>
   defaultTranslations[id];
 
-export interface ListBoxMenuIconProps {
+export interface ListBoxMenuIconProps
+  extends InternationalProps<ListBoxMenuIconTranslationKey> {
   /**
    * Specify whether the menu is currently open, which will influence the
    * direction of the menu icon
    */
   isOpen: boolean;
-
-  /**
-   * i18n hook used to provide the appropriate description for the given menu
-   * icon. This function takes in a ListBoxMenuIconTranslationKey and should
-   * return a string message for that given message id.
-   */
-  translateWithId?(
-    messageId: ListBoxMenuIconTranslationKey,
-    args?: Record<string, unknown>
-  ): string;
 }
 
 export type ListBoxMenuIconComponent = React.FC<ListBoxMenuIconProps>;

--- a/packages/react/src/components/ListBox/ListBoxMenuIcon.tsx
+++ b/packages/react/src/components/ListBox/ListBoxMenuIcon.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ChevronDown } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 export type ListBoxMenuIconTranslationKey = 'close.menu' | 'open.menu';
 
@@ -23,7 +23,7 @@ const defaultTranslateWithId = (id: ListBoxMenuIconTranslationKey): string =>
   defaultTranslations[id];
 
 export interface ListBoxMenuIconProps
-  extends InternationalProps<ListBoxMenuIconTranslationKey> {
+  extends TranslateWithId<ListBoxMenuIconTranslationKey> {
   /**
    * Specify whether the menu is currently open, which will influence the
    * direction of the menu icon

--- a/packages/react/src/components/ListBox/ListBoxSelection.tsx
+++ b/packages/react/src/components/ListBox/ListBoxSelection.tsx
@@ -11,8 +11,10 @@ import PropTypes from 'prop-types';
 import { Close } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
 import { KeyboardEvent, MouseEvent } from 'react';
+import { InternationalProps } from '../../types/common';
 
-export interface ListBoxSelectionProps {
+export interface ListBoxSelectionProps
+  extends InternationalProps<TranslationKey> {
   /**
    * Specify a function to be invoked when a user interacts with the clear
    * selection element.
@@ -44,16 +46,6 @@ export interface ListBoxSelectionProps {
    * whether the selection should display a badge or a single clear icon.
    */
   selectionCount?: number;
-
-  /**
-   * i18n hook used to provide the appropriate description for the given menu
-   * icon. This function takes in an id defined in `translationIds` and should
-   * return a string message for that given message id.
-   */
-  translateWithId?(
-    messageId: TranslationKey,
-    args?: Record<string, unknown>
-  ): string;
 }
 
 export type ListBoxSelectionComponent = React.FC<ListBoxSelectionProps>;

--- a/packages/react/src/components/ListBox/ListBoxSelection.tsx
+++ b/packages/react/src/components/ListBox/ListBoxSelection.tsx
@@ -50,7 +50,10 @@ export interface ListBoxSelectionProps {
    * icon. This function takes in an id defined in `translationIds` and should
    * return a string message for that given message id.
    */
-  translateWithId?(messageId: string, args?: Record<string, unknown>): string;
+  translateWithId?(
+    messageId: TranslationKey,
+    args?: Record<string, unknown>
+  ): string;
 }
 
 export type ListBoxSelectionComponent = React.FC<ListBoxSelectionProps>;
@@ -58,7 +61,12 @@ export type ListBoxSelectionComponent = React.FC<ListBoxSelectionProps>;
 export const translationIds = {
   'clear.all': 'clear.all',
   'clear.selection': 'clear.selection',
-};
+} as const;
+
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = keyof typeof translationIds;
 
 const defaultTranslations = {
   [translationIds['clear.all']]: 'Clear all selected items',

--- a/packages/react/src/components/ListBox/ListBoxSelection.tsx
+++ b/packages/react/src/components/ListBox/ListBoxSelection.tsx
@@ -11,10 +11,9 @@ import PropTypes from 'prop-types';
 import { Close } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
 import { KeyboardEvent, MouseEvent } from 'react';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
-export interface ListBoxSelectionProps
-  extends InternationalProps<TranslationKey> {
+export interface ListBoxSelectionProps extends TranslateWithId<TranslationKey> {
   /**
    * Specify a function to be invoked when a user interacts with the clear
    * selection element.

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -81,6 +81,19 @@ const {
 } =
   useMultipleSelection.stateChangeTypes as UseMultipleSelectionInterface['stateChangeTypes'];
 
+/**
+ * Message ids that will be passed to translateWithId().
+ * Combination of message ids from ListBox/next/ListBoxSelection.js and
+ * ListBox/next/ListBoxTrigger.js, but we can't access those values directly
+ * because those components aren't Typescript.  (If you try, TranslationKey
+ * ends up just being defined as "string".)
+ */
+type TranslationKey =
+  | 'close.menu'
+  | 'open.menu'
+  | 'clear.all'
+  | 'clear.selection';
+
 export interface FilterableMultiSelectProps<ItemType>
   extends MultiSelectSortingProps<ItemType> {
   /**
@@ -265,7 +278,10 @@ export interface FilterableMultiSelectProps<ItemType>
   /**
    * Callback function for translating ListBoxMenuIcon SVG title
    */
-  translateWithId?(messageId: string, args?: Record<string, unknown>): string;
+  translateWithId?(
+    messageId: TranslationKey,
+    args?: Record<string, unknown>
+  ): string;
 
   type?: 'default' | 'inline';
 
@@ -729,7 +745,7 @@ const FilterableMultiSelect = React.forwardRef(function FilterableMultiSelect<
         },
         { suppressRefError: true }
       ),
-    [autoAlign]
+    [autoAlign, getMenuProps, refs.setFloating]
   );
 
   const handleFocus = (evt: FocusEvent<HTMLDivElement> | undefined) => {

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -37,7 +37,10 @@ import {
   type MultiSelectSortingProps,
   sortingPropTypes,
 } from './MultiSelectPropTypes';
-import ListBox, { PropTypes as ListBoxPropTypes } from '../ListBox';
+import ListBox, {
+  ListBoxMenuIconTranslationKey,
+  PropTypes as ListBoxPropTypes,
+} from '../ListBox';
 import { ListBoxTrigger, ListBoxSelection } from '../ListBox/next';
 import { match, keys } from '../../internal/keyboard';
 import { defaultItemToString } from './tools/itemToString';
@@ -54,6 +57,7 @@ import {
   size as floatingSize,
   autoUpdate,
 } from '@floating-ui/react';
+import { InternationalProps } from '../../types/common';
 
 const {
   InputBlur,
@@ -95,7 +99,8 @@ type TranslationKey =
   | 'clear.selection';
 
 export interface FilterableMultiSelectProps<ItemType>
-  extends MultiSelectSortingProps<ItemType> {
+  extends MultiSelectSortingProps<ItemType>,
+    InternationalProps<TranslationKey> {
   /**
    * Specify a label to be read by screen readers on the container node
    * @deprecated
@@ -274,14 +279,6 @@ export interface FilterableMultiSelectProps<ItemType>
    * combobox via ARIA attributes.
    */
   titleText?: ReactNode;
-
-  /**
-   * Callback function for translating ListBoxMenuIcon SVG title
-   */
-  translateWithId?(
-    messageId: TranslationKey,
-    args?: Record<string, unknown>
-  ): string;
 
   type?: 'default' | 'inline';
 

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -57,7 +57,7 @@ import {
   size as floatingSize,
   autoUpdate,
 } from '@floating-ui/react';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const {
   InputBlur,
@@ -100,7 +100,7 @@ type TranslationKey =
 
 export interface FilterableMultiSelectProps<ItemType>
   extends MultiSelectSortingProps<ItemType>,
-    InternationalProps<TranslationKey> {
+    TranslateWithId<TranslationKey> {
   /**
    * Specify a label to be read by screen readers on the container node
    * @deprecated

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -43,7 +43,7 @@ import { keys, match } from '../../internal/keyboard';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { ListBoxProps } from '../ListBox/ListBox';
-import type { InternationalProps } from '../../types/common';
+import type { TranslateWithId } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
 import {
   useFloating,
@@ -98,7 +98,7 @@ interface OnChangeData<ItemType> {
 
 export interface MultiSelectProps<ItemType>
   extends MultiSelectSortingProps<ItemType>,
-    InternationalProps<
+    TranslateWithId<
       'close.menu' | 'open.menu' | 'clear.all' | 'clear.selection'
     > {
   /**

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -22,6 +22,7 @@ import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
 import { FormContext } from '../FluidForm';
 import { Text } from '../Text';
+import { InternationalProps } from '../../types/common';
 
 export const translationIds = {
   'increment.number': 'increment.number',
@@ -50,10 +51,8 @@ type ExcludedAttributes =
   | 'value';
 
 export interface NumberInputProps
-  extends Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    ExcludedAttributes
-  > {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes>,
+    InternationalProps<TranslationKey> {
   /**
    * `true` to allow empty string.
    */
@@ -180,11 +179,6 @@ export interface NumberInputProps
    * Specify how much the values should increase/decrease upon clicking on up/down button
    */
   step?: number;
-
-  /**
-   * Provide custom text for the component for each translation id
-   */
-  translateWithId?: (id: TranslationKey) => string;
 
   /**
    * Specify the value of the input

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -22,7 +22,7 @@ import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
 import { FormContext } from '../FluidForm';
 import { Text } from '../Text';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 export const translationIds = {
   'increment.number': 'increment.number',
@@ -52,7 +52,7 @@ type ExcludedAttributes =
 
 export interface NumberInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes>,
-    InternationalProps<TranslationKey> {
+    TranslateWithId<TranslationKey> {
   /**
    * `true` to allow empty string.
    */

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -26,7 +26,12 @@ import { Text } from '../Text';
 export const translationIds = {
   'increment.number': 'increment.number',
   'decrement.number': 'decrement.number',
-};
+} as const;
+
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = keyof typeof translationIds;
 
 const defaultTranslations = {
   [translationIds['increment.number']]: 'Increment number',
@@ -179,7 +184,7 @@ export interface NumberInputProps
   /**
    * Provide custom text for the component for each translation id
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (id: TranslationKey) => string;
 
   /**
    * Specify the value of the input

--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -15,6 +15,7 @@ import {
 } from '@carbon/icons-react';
 import { IconButton } from '../IconButton';
 import { usePrefix } from '../../internal/usePrefix';
+import { InternationalProps } from '../../types/common';
 
 const translationIds = {
   'carbon.pagination-nav.next': 'Next',
@@ -122,7 +123,10 @@ function DirectionButton({
   );
 }
 
-interface PaginationItemProps {
+interface PaginationItemProps
+  extends InternationalProps<
+    'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
+  > {
   /**
    * Whether or not this is the currently active page.
    */
@@ -137,14 +141,6 @@ interface PaginationItemProps {
    * The page number this item represents.
    */
   page?: number;
-
-  /**
-   * Specify a custom translation function that takes in a message identifier
-   * and returns the localized string for the message
-   */
-  translateWithId?: (
-    id: 'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
-  ) => string;
 }
 
 function PaginationItem({
@@ -177,7 +173,10 @@ function PaginationItem({
   );
 }
 
-interface PaginationOverflowProps {
+interface PaginationOverflowProps
+  extends InternationalProps<
+    'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
+  > {
   /**
    * How many items to display in this overflow.
    */
@@ -198,14 +197,6 @@ interface PaginationOverflowProps {
    * Set this to true if you are having performance problems with large data sets.
    */
   disableOverflow?: boolean;
-
-  /**
-   * Specify a custom translation function that takes in a message identifier
-   * and returns the localized string for the message
-   */
-  translateWithId?: (
-    id: 'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
-  ) => string;
 }
 
 function PaginationOverflow({
@@ -287,7 +278,8 @@ function PaginationOverflow({
 }
 
 interface PaginationNavProps
-  extends Omit<React.HTMLAttributes<HTMLElement>, 'onChange'> {
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'onChange'>,
+    InternationalProps<TranslationKey> {
   /**
    * Additional CSS class names.
    */
@@ -323,12 +315,6 @@ interface PaginationNavProps
    * The total number of items.
    */
   totalItems?: number;
-
-  /**
-   * Specify a custom translation function that takes in a message identifier
-   * and returns the localized string for the message
-   */
-  translateWithId?: (id: TranslationKey) => string;
 }
 
 const PaginationNav = React.forwardRef<HTMLElement, PaginationNavProps>(

--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -22,7 +22,12 @@ const translationIds = {
   'carbon.pagination-nav.item': 'Page',
   'carbon.pagination-nav.active': 'Active',
   'carbon.pagination-nav.of': 'of',
-};
+} as const;
+
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = keyof typeof translationIds;
 
 function translateWithId(messageId: string): string {
   return translationIds[messageId];
@@ -137,7 +142,9 @@ interface PaginationItemProps {
    * Specify a custom translation function that takes in a message identifier
    * and returns the localized string for the message
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (
+    id: 'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
+  ) => string;
 }
 
 function PaginationItem({
@@ -196,7 +203,9 @@ interface PaginationOverflowProps {
    * Specify a custom translation function that takes in a message identifier
    * and returns the localized string for the message
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (
+    id: 'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
+  ) => string;
 }
 
 function PaginationOverflow({
@@ -319,7 +328,7 @@ interface PaginationNavProps
    * Specify a custom translation function that takes in a message identifier
    * and returns the localized string for the message
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (id: TranslationKey) => string;
 }
 
 const PaginationNav = React.forwardRef<HTMLElement, PaginationNavProps>(

--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -15,7 +15,7 @@ import {
 } from '@carbon/icons-react';
 import { IconButton } from '../IconButton';
 import { usePrefix } from '../../internal/usePrefix';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const translationIds = {
   'carbon.pagination-nav.next': 'Next',
@@ -124,7 +124,7 @@ function DirectionButton({
 }
 
 interface PaginationItemProps
-  extends InternationalProps<
+  extends TranslateWithId<
     'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
   > {
   /**
@@ -174,7 +174,7 @@ function PaginationItem({
 }
 
 interface PaginationOverflowProps
-  extends InternationalProps<
+  extends TranslateWithId<
     'carbon.pagination-nav.item' | 'carbon.pagination-nav.active'
   > {
   /**
@@ -279,7 +279,7 @@ function PaginationOverflow({
 
 interface PaginationNavProps
   extends Omit<React.HTMLAttributes<HTMLElement>, 'onChange'>,
-    InternationalProps<TranslationKey> {
+    TranslateWithId<TranslationKey> {
   /**
    * Additional CSS class names.
    */

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -17,7 +17,7 @@ import {
 } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
 import { Text } from '../Text';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const defaultTranslations = {
   'carbon.progress-step.complete': 'Complete',
@@ -162,7 +162,7 @@ ProgressIndicator.propTypes = {
   vertical: PropTypes.bool,
 };
 
-export interface ProgressStepProps extends InternationalProps<TranslationKey> {
+export interface ProgressStepProps extends TranslateWithId<TranslationKey> {
   /**
    * Provide an optional className to be applied to the containing `<li>` node
    */

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -23,7 +23,12 @@ const defaultTranslations = {
   'carbon.progress-step.incomplete': 'Incomplete',
   'carbon.progress-step.current': 'Current',
   'carbon.progress-step.invalid': 'Invalid',
-};
+} as const;
+
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = keyof typeof defaultTranslations;
 
 function translateWithId(messageId) {
   return defaultTranslations[messageId];
@@ -225,7 +230,7 @@ export interface ProgressStepProps {
    * Optional method that takes in a message id and returns an
    * internationalized string.
    */
-  translateWithId?: (id: string) => string;
+  translateWithId?: (id: TranslationKey) => string;
 }
 
 function ProgressStep({

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -17,6 +17,7 @@ import {
 } from '@carbon/icons-react';
 import { usePrefix } from '../../internal/usePrefix';
 import { Text } from '../Text';
+import { InternationalProps } from '../../types/common';
 
 const defaultTranslations = {
   'carbon.progress-step.complete': 'Complete',
@@ -161,7 +162,7 @@ ProgressIndicator.propTypes = {
   vertical: PropTypes.bool,
 };
 
-export interface ProgressStepProps {
+export interface ProgressStepProps extends InternationalProps<TranslationKey> {
   /**
    * Provide an optional className to be applied to the containing `<li>` node
    */
@@ -225,12 +226,6 @@ export interface ProgressStepProps {
    * The ID of the tooltip content.
    */
   tooltipId?: string;
-
-  /**
-   * Optional method that takes in a message id and returns an
-   * internationalized string.
-   */
-  translateWithId?: (id: TranslationKey) => string;
 }
 
 function ProgressStep({

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -29,6 +29,7 @@ import {
   UpperHandle,
   UpperHandleFocus,
 } from './SliderHandles';
+import { InternationalProps } from '../../types/common';
 
 const ThumbWrapper = ({
   hasTooltip = false,
@@ -124,11 +125,10 @@ enum HandlePosition {
 }
 
 type ExcludedAttributes = 'onChange' | 'onBlur';
+
 export interface SliderProps
-  extends Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    ExcludedAttributes
-  > {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes>,
+    InternationalProps<TranslationKey, { correctedValue?: string }> {
   /**
    * The `ariaLabel` for the `<input>`.
    */
@@ -276,16 +276,6 @@ export interface SliderProps
    * which will be `(max - min) / stepMultiplier`.
    */
   stepMultiplier?: number;
-
-  /**
-   * Supply a method to translate internal strings with your i18n tool of
-   * choice. Translation keys are available on the `translationIds` field for
-   * this component.
-   */
-  translateWithId?: (
-    translationId: TranslationKey,
-    translationState: { correctedValue?: string }
-  ) => string;
 
   /**
    * The value of the slider. When there are two handles, value is the lower

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -29,7 +29,7 @@ import {
   UpperHandle,
   UpperHandleFocus,
 } from './SliderHandles';
-import { InternationalProps } from '../../types/common';
+import { TranslateWithId } from '../../types/common';
 
 const ThumbWrapper = ({
   hasTooltip = false,
@@ -128,7 +128,7 @@ type ExcludedAttributes = 'onChange' | 'onBlur';
 
 export interface SliderProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, ExcludedAttributes>,
-    InternationalProps<TranslationKey, { correctedValue?: string }> {
+    TranslateWithId<TranslationKey, { correctedValue?: string }> {
   /**
    * The `ariaLabel` for the `<input>`.
    */

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -78,16 +78,18 @@ ThumbWrapper.propTypes = {
 
 const translationIds = {
   autoCorrectAnnouncement: 'carbon.slider.auto-correct-announcement',
-};
+} as const;
+
+/**
+ * Message ids that will be passed to translateWithId().
+ */
+type TranslationKey = (typeof translationIds)[keyof typeof translationIds];
 
 function translateWithId(
-  translationId,
+  translationId: TranslationKey,
   translationState?: { correctedValue?: string }
 ) {
-  if (
-    translationId === translationIds.autoCorrectAnnouncement &&
-    translationState?.correctedValue
-  ) {
+  if (translationState?.correctedValue) {
     const { correctedValue } = translationState;
     return `The inputted value "${correctedValue}" was corrected to the nearest allowed digit.`;
   }
@@ -281,7 +283,7 @@ export interface SliderProps
    * this component.
    */
   translateWithId?: (
-    translationId: string,
+    translationId: TranslationKey,
     translationState: { correctedValue?: string }
   ) => string;
 

--- a/packages/react/src/types/common.ts
+++ b/packages/react/src/types/common.ts
@@ -19,13 +19,19 @@ export type PolymorphicProps<Element extends React.ElementType, Props> = Props &
     as?: Element;
   };
 
-export interface InternationalProps<
-  MID = string,
-  ARGS = Record<string, unknown>
-> {
+export interface TranslateWithId<MID = string, ARGS = Record<string, unknown>> {
   /**
    * Supply a method to translate internal strings with your i18n tool of
    * choice.
    */
   translateWithId?(messageId: MID, args?: ARGS): string;
 }
+
+/**
+ * Alias of TranslateWithId. Will be removed in v12
+ * @deprecated Use TranslateWithId instead
+ */
+export type InternationalProps<
+  MID = string,
+  ARGS = Record<string, unknown>
+> = TranslateWithId<MID, ARGS>;


### PR DESCRIPTION
Closes #17054

Add proper types for parameter to translateWithId() methods.
Each component's translateWithId() method can only take a certain
list of keys, not any string.  Update the Typescript to notate this.

Also, update components to extend InternationalProps rather than defining translateWithId() directly.

For historical reasons most of the existing translation keys are declared in a convoluted way.  For example:
    
```ts
export const translationIds = {
      'increment.number': 'increment.number',
      'decrement.number': 'decrement.number',
};
 
type TranslationKey = keyof typeof translationIds;
```
  
The simpler way is just:

```ts    
type TranslationKey = 'increment.number' |  'decrement.number’;
```
    
I didn’t update that in this PR, but it’s something to consider for the future.
    
#### Changelog

**Changed**

- Declarations of translateWithId() methods

#### Testing / Reviewing

I tested the changes against my app and it now compiles without any casts needed.
