### PR TITLE
fix: added rel prop in switcher item

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -7566,6 +7566,9 @@ Map {
       "onKeyDown": Object {
         "type": "func",
       },
+      "rel": Object {
+        "type": "string",
+      },
       "tabIndex": Object {
         "type": "number",
       },

--- a/packages/react/src/components/UIShell/SwitcherItem.tsx
+++ b/packages/react/src/components/UIShell/SwitcherItem.tsx
@@ -58,6 +58,10 @@ interface BaseSwitcherItemProps {
    * Specify where to open the link.
    */
   target?: HTMLAttributeAnchorTarget;
+  /**
+   * The rel property for the link.
+   */
+  rel?: string;
 }
 
 interface SwitcherItemWithAriaLabel extends BaseSwitcherItemProps {
@@ -89,6 +93,7 @@ const SwitcherItem = forwardRef<ElementType, SwitcherItemProps>(
       onKeyDown = () => {},
       href,
       target,
+      rel,
       ...rest
     } = props;
 
@@ -132,6 +137,7 @@ const SwitcherItem = forwardRef<ElementType, SwitcherItemProps>(
           }}
           href={href}
           target={target}
+          rel={rel}
           ref={forwardRef}
           {...rest}
           className={linkClassName}
@@ -183,6 +189,10 @@ SwitcherItem.propTypes = {
    * Specify where to open the link.
    */
   target: PropTypes.string,
+  /**
+   * The rel property for the link.
+   */
+  rel: PropTypes.string,
 };
 
 export default SwitcherItem;


### PR DESCRIPTION
Closes #17052 

Added optional 'rel' prop to `BaseSwitcherItemProps`.

**New**
Added rel prop to `BaseSwitcherItemProps`

#### Testing / Reviewing
```tsx
<Switcher aria-label="Switcher Container" expanded={true}>
  <SwitcherItem aria-label="Link 1" href="#" rel="norelerror">
    Link 1
  </SwitcherItem>
</Switcher>
```

Test the usage of `SwitcherItem` with the `rel` prop in a TypeScript environment within a `Switcher` component. Verify that the  TypeScript compiler should not throw error and the component renders without errors and correctly applies the provided `rel` attribute


