### PR TITLE
fix: performance by removing lodash by react-fast-compare

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,7 +61,6 @@
     "invariant": "^2.2.3",
     "lodash.debounce": "^4.0.8",
     "lodash.findlast": "^4.5.0",
-    "lodash.isequal": "^4.5.0",
     "lodash.omit": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.7.2",

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -16,7 +16,7 @@ import Downshift, {
   UseComboboxStateChangeTypes,
   UseMultipleSelectionInterface,
 } from 'downshift';
-import isEqual from 'lodash.isequal';
+import isEqual from 'react-fast-compare';
 import PropTypes from 'prop-types';
 import React, {
   useContext,

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -13,7 +13,7 @@ import {
   UseSelectProps,
   UseSelectStateChangeTypes,
 } from 'downshift';
-import isEqual from 'lodash.isequal';
+import isEqual from 'react-fast-compare';
 import PropTypes from 'prop-types';
 import React, {
   ForwardedRef,

--- a/packages/react/src/internal/Selection.js
+++ b/packages/react/src/internal/Selection.js
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash.isequal';
+import isEqual from 'react-fast-compare';
 
 function callOnChangeHandler({
   isControlled,

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -56,7 +56,6 @@
     "browserslist-config-carbon": "^11.2.0",
     "css": "^3.0.0",
     "cssnano": "^7.0.0",
-    "lodash.isequal": "^4.5.0",
     "postcss": "^8.4.14",
     "postcss-flexbugs-fixes": "^5.0.2",
     "rimraf": "^5.0.0",

--- a/packages/styles/scss/__tests__/zone-test.js
+++ b/packages/styles/scss/__tests__/zone-test.js
@@ -11,7 +11,7 @@
 
 const { SassRenderer } = require('@carbon/test-utils/scss');
 const css = require('css');
-const isEqual = require('lodash.isequal');
+const isEqual = require('react-fast-compare');
 
 const { render } = SassRenderer.create(__dirname);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,7 +2131,6 @@ __metadata:
     browserslist-config-carbon: "npm:^11.2.0"
     css: "npm:^3.0.0"
     cssnano: "npm:^7.0.0"
-    lodash.isequal: "npm:^4.5.0"
     postcss: "npm:^8.4.14"
     postcss-flexbugs-fixes: "npm:^5.0.2"
     rimraf: "npm:^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,7 +2069,6 @@ __metadata:
     invariant: "npm:^2.2.3"
     lodash.debounce: "npm:^4.0.8"
     lodash.findlast: "npm:^4.5.0"
-    lodash.isequal: "npm:^4.5.0"
     lodash.omit: "npm:^4.5.0"
     lodash.throttle: "npm:^4.1.1"
     mini-css-extract-plugin: "npm:^2.4.5"


### PR DESCRIPTION
Closes #17061

This is use react-fast-compare to compare the elements and other things, use lodash.isEqual will hurt performance issue from: https://github.com/facebook/react/issues/19811

#### Changelog

**Changed**

- replace the lodash.isequal with react-fast-compare to improve performance

#### Testing / Reviewing

this is just a 3rd party package replacement, we just need to make sure the multiselect and filterable multiselect  can be rendered properly.

