### PR TITLE
Fixed scrollIntoView in `Combobox` and `Dropdown`

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -29,7 +29,7 @@ const prefix = 'cds';
 
 describe('ComboBox', () => {
   let mockProps;
-
+  window.HTMLElement.prototype.scrollIntoView = function () {};
   beforeEach(() => {
     mockProps = {
       id: 'test-combobox',

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -603,7 +603,7 @@ const ComboBox = forwardRef(
         onChange({ selectedItem });
       },
       onHighlightedIndexChange: ({ highlightedIndex }) => {
-        if (highlightedIndex! > -1) {
+        if (highlightedIndex! > -1 && typeof window !== undefined) {
           const itemArray = document.querySelectorAll(
             `li.${prefix}--list-box__menu-item[role="option"]`
           );

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -607,9 +607,9 @@ const ComboBox = forwardRef(
           const itemArray = document.querySelectorAll(
             `li.${prefix}--list-box__menu-item[role="option"]`
           );
-          const selectedItem = itemArray[highlightedIndex!];
-          if (selectedItem) {
-            selectedItem.scrollIntoView({
+          const highlightedItem = itemArray[highlightedIndex!];
+          if (highlightedItem) {
+            highlightedItem.scrollIntoView({
               behavior: 'smooth',
               block: 'nearest',
             });

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -450,8 +450,22 @@ const ComboBox = forwardRef(
 
     const stateReducer = React.useCallback(
       (state, actionAndChanges) => {
-        const { type, changes } = actionAndChanges;
+        const { type, props, changes } = actionAndChanges;
         const { highlightedIndex } = changes;
+
+        // This function enables scrolling into view when navigating items and
+        // focuses on the selected item when the dropdown is open
+        const scrollNavigation = () => {
+          Promise.resolve().then(() => {
+            if (highlightedIndex > -1) {
+              const itemArray = document.querySelectorAll(
+                `li.${prefix}--list-box__menu-item[role="option"]`
+              );
+              props.scrollIntoView(itemArray[highlightedIndex]);
+            }
+          });
+        };
+
         switch (type) {
           case InputBlur:
             if (
@@ -488,6 +502,7 @@ const ComboBox = forwardRef(
             }
           case FunctionToggleMenu:
           case ToggleButtonClick:
+            scrollNavigation();
             if (changes.isOpen && !changes.selectedItem) {
               return { ...changes, highlightedIndex: 0 };
             }
@@ -498,6 +513,7 @@ const ComboBox = forwardRef(
 
           case InputKeyDownArrowUp:
           case InputKeyDownArrowDown:
+            scrollNavigation();
             if (highlightedIndex === -1) {
               return {
                 ...changes,
@@ -598,7 +614,6 @@ const ComboBox = forwardRef(
         setInputValue(inputValue || '');
         setHighlightedIndex(indexToHighlight(inputValue));
       },
-
       onSelectedItemChange({ selectedItem }) {
         onChange({ selectedItem });
       },

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -450,21 +450,8 @@ const ComboBox = forwardRef(
 
     const stateReducer = React.useCallback(
       (state, actionAndChanges) => {
-        const { type, props, changes } = actionAndChanges;
+        const { type, changes } = actionAndChanges;
         const { highlightedIndex } = changes;
-
-        // This function enables scrolling into view when navigating items and
-        // focuses on the selected item when the dropdown is open
-        const scrollNavigation = () => {
-          Promise.resolve().then(() => {
-            if (highlightedIndex > -1) {
-              const itemArray = document.querySelectorAll(
-                `li.${prefix}--list-box__menu-item[role="option"]`
-              );
-              props.scrollIntoView(itemArray[highlightedIndex]);
-            }
-          });
-        };
 
         switch (type) {
           case InputBlur:
@@ -502,7 +489,6 @@ const ComboBox = forwardRef(
             }
           case FunctionToggleMenu:
           case ToggleButtonClick:
-            scrollNavigation();
             if (changes.isOpen && !changes.selectedItem) {
               return { ...changes, highlightedIndex: 0 };
             }
@@ -513,7 +499,6 @@ const ComboBox = forwardRef(
 
           case InputKeyDownArrowUp:
           case InputKeyDownArrowDown:
-            scrollNavigation();
             if (highlightedIndex === -1) {
               return {
                 ...changes,
@@ -617,7 +602,20 @@ const ComboBox = forwardRef(
       onSelectedItemChange({ selectedItem }) {
         onChange({ selectedItem });
       },
-
+      onHighlightedIndexChange: ({ highlightedIndex }) => {
+        if (highlightedIndex! > -1) {
+          const itemArray = document.querySelectorAll(
+            `li.${prefix}--list-box__menu-item[role="option"]`
+          );
+          const selectedItem = itemArray[highlightedIndex!];
+          if (selectedItem) {
+            selectedItem.scrollIntoView({
+              behavior: 'smooth',
+              block: 'nearest',
+            });
+          }
+        }
+      },
       initialSelectedItem: initialSelectedItem,
       inputId: id,
       stateReducer,

--- a/packages/react/src/components/Dropdown/Dropdown-test.js
+++ b/packages/react/src/components/Dropdown/Dropdown-test.js
@@ -193,6 +193,7 @@ describe('Dropdown', () => {
   });
 
   describe('Component API', () => {
+    window.HTMLElement.prototype.scrollIntoView = function () {};
     it('should accept a `ref` for the underlying button element', async () => {
       const ref = React.createRef();
       render(<Dropdown {...mockProps} ref={ref} />);

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -67,6 +67,15 @@ const items = [
   {
     text: 'Option 5',
   },
+  {
+    text: 'Option 6',
+  },
+  {
+    text: 'Option 7',
+  },
+  {
+    text: 'Option 8',
+  },
 ];
 
 export const ExperimentalAutoAlign = () => (

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -328,7 +328,7 @@ const Dropdown = React.forwardRef(
         return isObject && 'disabled' in item && item.disabled === true;
       },
       onHighlightedIndexChange: ({ highlightedIndex }) => {
-        if (highlightedIndex! > -1) {
+        if (highlightedIndex! > -1 && typeof window !== undefined) {
           const itemArray = document.querySelectorAll(
             `li.${prefix}--list-box__menu-item[role="option"]`
           );

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -332,9 +332,9 @@ const Dropdown = React.forwardRef(
           const itemArray = document.querySelectorAll(
             `li.${prefix}--list-box__menu-item[role="option"]`
           );
-          const selectedItem = itemArray[highlightedIndex!];
-          if (selectedItem) {
-            selectedItem.scrollIntoView({
+          const highlightedItem = itemArray[highlightedIndex!];
+          if (highlightedItem) {
+            highlightedItem.scrollIntoView({
               behavior: 'smooth',
               block: 'nearest',
             });

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -56,6 +56,7 @@ const {
   ToggleButtonKeyDownEnd,
   ItemMouseMove,
   MenuMouseLeave,
+  ToggleButtonClick,
 } = useSelect.stateChangeTypes as UseSelectInterface['stateChangeTypes'] & {
   ToggleButtonClick: UseSelectStateChangeTypes.ToggleButtonClick;
 };
@@ -340,17 +341,27 @@ const Dropdown = React.forwardRef(
       const { changes, props, type } = actionAndChanges;
       const { highlightedIndex } = changes;
 
-      switch (type) {
-        case ToggleButtonKeyDownArrowDown:
-        case ToggleButtonKeyDownArrowUp:
-        case ToggleButtonKeyDownHome:
-        case ToggleButtonKeyDownEnd:
+      // This function enables scrolling into view when navigating items and
+      // focuses on the selected item when the dropdown is open
+      const scrollNavigation = () => {
+        Promise.resolve().then(() => {
           if (highlightedIndex > -1) {
             const itemArray = document.querySelectorAll(
               `li.${prefix}--list-box__menu-item[role="option"]`
             );
             props.scrollIntoView(itemArray[highlightedIndex]);
           }
+        });
+      };
+
+      switch (type) {
+        case ToggleButtonKeyDownArrowDown:
+        case ToggleButtonKeyDownArrowUp:
+        case ToggleButtonKeyDownHome:
+        case ToggleButtonKeyDownEnd:
+        case ToggleButtonClick:
+          scrollNavigation();
+
           return changes;
         case ItemMouseMove:
         case MenuMouseLeave:

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -49,17 +49,10 @@ import {
   size as floatingSize,
 } from '@floating-ui/react';
 
-const {
-  ToggleButtonKeyDownArrowDown,
-  ToggleButtonKeyDownArrowUp,
-  ToggleButtonKeyDownHome,
-  ToggleButtonKeyDownEnd,
-  ItemMouseMove,
-  MenuMouseLeave,
-  ToggleButtonClick,
-} = useSelect.stateChangeTypes as UseSelectInterface['stateChangeTypes'] & {
-  ToggleButtonClick: UseSelectStateChangeTypes.ToggleButtonClick;
-};
+const { ItemMouseMove, MenuMouseLeave } =
+  useSelect.stateChangeTypes as UseSelectInterface['stateChangeTypes'] & {
+    ToggleButtonClick: UseSelectStateChangeTypes.ToggleButtonClick;
+  };
 
 const defaultItemToString = <ItemType,>(item?: ItemType | null): string => {
   if (typeof item === 'string') {
@@ -334,35 +327,27 @@ const Dropdown = React.forwardRef(
         const isObject = item !== null && typeof item === 'object';
         return isObject && 'disabled' in item && item.disabled === true;
       },
+      onHighlightedIndexChange: ({ highlightedIndex }) => {
+        if (highlightedIndex! > -1) {
+          const itemArray = document.querySelectorAll(
+            `li.${prefix}--list-box__menu-item[role="option"]`
+          );
+          const selectedItem = itemArray[highlightedIndex!];
+          if (selectedItem) {
+            selectedItem.scrollIntoView({
+              behavior: 'smooth',
+              block: 'nearest',
+            });
+          }
+        }
+      },
     };
     const dropdownInstanceId = useId();
 
     function stateReducer(state, actionAndChanges) {
-      const { changes, props, type } = actionAndChanges;
-      const { highlightedIndex } = changes;
-
-      // This function enables scrolling into view when navigating items and
-      // focuses on the selected item when the dropdown is open
-      const scrollNavigation = () => {
-        Promise.resolve().then(() => {
-          if (highlightedIndex > -1) {
-            const itemArray = document.querySelectorAll(
-              `li.${prefix}--list-box__menu-item[role="option"]`
-            );
-            props.scrollIntoView(itemArray[highlightedIndex]);
-          }
-        });
-      };
+      const { changes, type } = actionAndChanges;
 
       switch (type) {
-        case ToggleButtonKeyDownArrowDown:
-        case ToggleButtonKeyDownArrowUp:
-        case ToggleButtonKeyDownHome:
-        case ToggleButtonKeyDownEnd:
-        case ToggleButtonClick:
-          scrollNavigation();
-
-          return changes;
         case ItemMouseMove:
         case MenuMouseLeave:
           return { ...changes, highlightedIndex: state.highlightedIndex };

--- a/packages/react/src/components/FluidComboBox/__tests__/FluidComboBox-test.js
+++ b/packages/react/src/components/FluidComboBox/__tests__/FluidComboBox-test.js
@@ -27,7 +27,7 @@ const openMenu = async () => {
 
 describe('FluidComboBox', () => {
   let mockProps;
-
+  window.HTMLElement.prototype.scrollIntoView = function () {};
   beforeEach(() => {
     mockProps = {
       id: 'test-fluidcombobox',

--- a/packages/react/src/components/FluidDropdown/__tests__/FluidDropdown-test.js
+++ b/packages/react/src/components/FluidDropdown/__tests__/FluidDropdown-test.js
@@ -177,6 +177,7 @@ describe('FluidDropdown', () => {
   });
 
   describe('Component API', () => {
+    window.HTMLElement.prototype.scrollIntoView = function () {};
     it('should accept a `ref` for the underlying button element', async () => {
       const ref = React.createRef();
       render(<FluidDropdown {...mockProps} ref={ref} />);


### PR DESCRIPTION
Closes #16935
Closes #15978

This fixes the arrow navigaiton in `Combobox` and also adds the scrollIntoView when the user opens the `Combobox` or `Dropdown` components and the selected item is not visible.

We are using the prop `onHighlightedIndexChange` to ensure the items insided the `ul` are rendered before the `scrollIntoView` be called.

I had this line in the tests because of this error: https://github.com/jsdom/jsdom/issues/1695
```jsx
window.HTMLElement.prototype.scrollIntoView = function () {};
```

#### Changelog

#### Testing / Reviewing

- Ensure you can navigate in `Combobox`.
- Ensure that any item not visible is scrolled into view when the menu is opened in `Combobox` and `Dropdown`.

- [ ] Remove more options from `Dropdown`