### PR TITLE
fix(PasswordInput): tooltip issue in show password label or hide password label

### DIFF
--- a/packages/react/src/components/TextInput/PasswordInput.stories.js
+++ b/packages/react/src/components/TextInput/PasswordInput.stories.js
@@ -37,6 +37,8 @@ export const Playground = (args) => (
       labelText="Text input label"
       helperText="Optional help text"
       autoComplete="true"
+      hidePasswordLabel="sssfdfddcff dfdfdf"
+      showPasswordLabel=""
     />
   </div>
 );

--- a/packages/react/src/components/TextInput/PasswordInput.stories.js
+++ b/packages/react/src/components/TextInput/PasswordInput.stories.js
@@ -37,8 +37,6 @@ export const Playground = (args) => (
       labelText="Text input label"
       helperText="Optional help text"
       autoComplete="true"
-      hidePasswordLabel="sssfdfddcff dfdfdf"
-      showPasswordLabel=""
     />
   </div>
 );

--- a/packages/react/src/components/TextInput/PasswordInput.tsx
+++ b/packages/react/src/components/TextInput/PasswordInput.tsx
@@ -329,6 +329,11 @@ const PasswordInput = React.forwardRef(function PasswordInput(
   if (tooltipPosition === 'right' || tooltipPosition === 'left') {
     align = tooltipPosition;
   }
+  if (!hidePasswordLabel || hidePasswordLabel.trim() === '') {
+    console.warn('Warning: The "hidePasswordLabel" should not be blank.');
+  } else if (!showPasswordLabel || showPasswordLabel.trim() === '') {
+    console.warn('Warning: The "showPasswordLabel" should not be blank.');
+  }
   const input = (
     <>
       <input
@@ -349,6 +354,7 @@ const PasswordInput = React.forwardRef(function PasswordInput(
         data-toggle-password-visibility={inputType === 'password'}
       />
       {isFluid && <hr className={`${prefix}--text-input__divider`} />}
+
       <Tooltip
         align={align}
         className={`${prefix}--toggle-password-tooltip`}

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -132,7 +132,11 @@
   }
 
   .#{$prefix}--toggle-password-tooltip .#{$prefix}--popover {
-    inset-inline-start: -(convert.to-rem(40px));
+    inset-inline-start: -($spacing-08);
+  }
+
+  .#{$prefix}--toggle-password-tooltip .#{$prefix}--popover-content {
+    min-inline-size: $spacing-08;
   }
 
   .#{$prefix}--text-input--sm


### PR DESCRIPTION
Closes #16924 

fixed broken tooltip if label is blank and added a console warning if label is blank.

**New**

 added a console warning if showPasswordLabel or hidePasswordLabel is blank.