### PR TITLE
feat(combobox): expose downshift actions through downshiftActions ref prop

### DIFF
--- a/achecker.js
+++ b/achecker.js
@@ -10,7 +10,7 @@
 const path = require('path');
 
 module.exports = {
-  ruleArchive: 'latest',
+  ruleArchive: '17June2024',
   policies: ['Custom_Ruleset'],
   failLevels: ['violation'],
   reportLevels: [

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1278,6 +1278,16 @@ Map {
       "disabled": Object {
         "type": "bool",
       },
+      "downshiftActions": Object {
+        "args": Array [
+          Object {
+            "current": Object {
+              "type": "any",
+            },
+          },
+        ],
+        "type": "exact",
+      },
       "downshiftProps": Object {
         "type": "object",
       },

--- a/packages/react/src/components/ComboBox/ComboBox.mdx
+++ b/packages/react/src/components/ComboBox/ComboBox.mdx
@@ -49,18 +49,64 @@ next element.
 <Combobox disabled />
 ```
 
-## Combobox `downshiftProps`
+## Combobox uses Downshift
 
 Our `Combobox` component utilizes [Downshift](https://www.downshift-js.com/)
 under the hood to help provide complex yet accessible custom dropdown
-components. We provide access to the built in Downshift features with this prop.
+components.
 
-Use with caution: anything you define here overrides the components' internal
-handling of that prop. Downshift internals are subject to change, and in some
-cases they can not be shimmed to shield you from potentially breaking changes.
+### `downshiftProps`
 
-For more information, checkout the Downshift prop
-[documentation](https://www.downshift-js.com/downshift#props-used-in-examples)
+`downshiftProps` is made available as a passthrough to the underlying downshift
+`useCombobox` hook.
+
+**Use with caution:** anything you define here overrides the components'
+internal handling of that prop. Downshift internals are subject to change, and
+in some cases they can not be shimmed to shield you from potentially breaking
+changes.
+
+For more information, checkout the Downshift `useCombobox` props
+[documentation](https://github.com/downshift-js/downshift/tree/v9.0.7/src/hooks/useCombobox#basic-props)
+
+### Combobox `downshiftActions`
+
+The downshift action methods are made available through the `downshiftActions`
+prop. While not recommended, this prop allows you to modify downshift's internal
+state without having to fully control the component.
+
+**Use with caution:** calling these actions modifies the internal state of
+downshift. It may conflict with or override the state management used within
+Combobox. Downshift APIs and internals are subject to change, and in some cases
+they can not be shimmed by Carbon to shield you from potentially breaking
+changes.
+
+#### `downshiftActions` Usage
+
+Provide a ref that will be mutated to contain an object of downshift action
+functions. These can be called to change the internal state of the downshift
+useCombobox hook.
+
+```
+const downshiftActions = useRef();
+
+return (
+  <ComboBox
+    ...
+    downshiftActions={downshiftActions}
+    downshiftProps={{
+      onStateChange: (changes) => {
+        if (changes.selectedItem === null) {
+          downshiftActions?.current?.openMenu?.();
+          return;
+        }
+      },
+    }}
+  />
+);
+```
+
+For more information, checkout the Downshift `useCombobox` action functions
+[documentation](https://github.com/downshift-js/downshift/tree/v9.0.7/src/hooks/useCombobox#actions)
 
 ## Placeholders and Labeling
 

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -65,7 +65,7 @@ export default {
   },
 };
 
-export const DownshiftPropsTest = () => {
+export const DownshiftActionsTest = () => {
   const downshiftActions = useRef();
 
   return (
@@ -79,71 +79,21 @@ export const DownshiftPropsTest = () => {
         helperText="Combobox helper text"
         downshiftActions={downshiftActions}
         downshiftProps={{
-          //         reset: () => void
-          // openMenu: () => void
-          // closeMenu: () => void
-          // toggleMenu: () => void
-          // selectItem: (item: Item | null) => void
-          // setHighlightedIndex: (index: number) => void
-          // setInputValue: (inputValue: string) => void
-
-          // if (changes.selectedItem === null) {
-          //   component?.setState({
-          //     isOpen: true,
-          //   });
-          //   return;
-          // }
-          // if (changes?.isOpen && component?.inputValue === 'Item 1') {
-          //   component?.setState({
-          //     inputValue: '',
-          //   });
-          //   return;
-          // }
-          // if (changes?.isClosed && component?.inputValue !== 'Item 1') {
-          //   component?.setState({
-          //     inputValue: 'Item 1',
-          //   });
-          //   return;
-          // }
-
-          //   {
-          //     "type": "__input_blur__",
-          //     "highlightedIndex": -1,
-          //     "isOpen": false,
-          //     "selectedItem": null,
-          //     "inputValue": ""
-          // }
-          onSelectedItemChange: (changes) => {
-            // console.log('onSelectedItemChange', changes);
-            // keep the menu open after selection
-            // downshiftActions.current.openMenu();
-          },
-          onIsOpenChange: (changes) => {
-            console.log('onIsOpenChange', changes);
-            console.log('downshiftActions', downshiftActions);
-
-            const { isOpen, selectedItem, inputValue } = changes;
-
-            if (!selectedItem) {
-              downshiftActions.current.openMenu();
-            }
-
-            if (isOpen && inputValue === 'Option 1') {
-              downshiftActions.current.setInputValue('');
-            }
-
-            if (!isOpen && inputValue !== 'Option 1') {
-              downshiftActions.current.setInputValue('Option 1');
-            }
-          },
-          onHighlightedIndexChange: (changes) => {
-            // console.log('onHighlightedIndexChange', changes);
-          },
-          onInputChange: (changes) => {
-            // console.log('onInputChange', changes);
-          },
           onStateChange: (changes) => {
-            // console.log('onStateChange', changes);
+            console.log('onStateChange changes', changes);
+
+            if (changes.selectedItem === null) {
+              downshiftActions?.current?.openMenu?.();
+              return;
+            }
+            if (changes?.isOpen && component?.inputValue === 'Option 1') {
+              downshiftActions?.current?.setInputValue?.('');
+              return;
+            }
+            if (!changes?.isOpen && component?.inputValue !== 'Option 1') {
+              downshiftActions?.current?.setInputValue?.('Option 1');
+              return;
+            }
           },
         }}
       />

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { WithLayer } from '../../../.storybook/templates/WithLayer';
 
@@ -63,6 +63,92 @@ export default {
       page: mdx,
     },
   },
+};
+
+export const DownshiftPropsTest = () => {
+  const downshiftActions = useRef();
+
+  return (
+    <div style={{ width: 300 }}>
+      <ComboBox
+        onChange={() => {}}
+        id="carbon-combobox"
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+        titleText="ComboBox title"
+        helperText="Combobox helper text"
+        downshiftActions={downshiftActions}
+        downshiftProps={{
+          //         reset: () => void
+          // openMenu: () => void
+          // closeMenu: () => void
+          // toggleMenu: () => void
+          // selectItem: (item: Item | null) => void
+          // setHighlightedIndex: (index: number) => void
+          // setInputValue: (inputValue: string) => void
+
+          // if (changes.selectedItem === null) {
+          //   component?.setState({
+          //     isOpen: true,
+          //   });
+          //   return;
+          // }
+          // if (changes?.isOpen && component?.inputValue === 'Item 1') {
+          //   component?.setState({
+          //     inputValue: '',
+          //   });
+          //   return;
+          // }
+          // if (changes?.isClosed && component?.inputValue !== 'Item 1') {
+          //   component?.setState({
+          //     inputValue: 'Item 1',
+          //   });
+          //   return;
+          // }
+
+          //   {
+          //     "type": "__input_blur__",
+          //     "highlightedIndex": -1,
+          //     "isOpen": false,
+          //     "selectedItem": null,
+          //     "inputValue": ""
+          // }
+          onSelectedItemChange: (changes) => {
+            // console.log('onSelectedItemChange', changes);
+            // keep the menu open after selection
+            // downshiftActions.current.openMenu();
+          },
+          onIsOpenChange: (changes) => {
+            console.log('onIsOpenChange', changes);
+            console.log('downshiftActions', downshiftActions);
+
+            const { isOpen, selectedItem, inputValue } = changes;
+
+            if (!selectedItem) {
+              downshiftActions.current.openMenu();
+            }
+
+            if (isOpen && inputValue === 'Option 1') {
+              downshiftActions.current.setInputValue('');
+            }
+
+            if (!isOpen && inputValue !== 'Option 1') {
+              downshiftActions.current.setInputValue('Option 1');
+            }
+          },
+          onHighlightedIndexChange: (changes) => {
+            // console.log('onHighlightedIndexChange', changes);
+          },
+          onInputChange: (changes) => {
+            // console.log('onInputChange', changes);
+          },
+          onStateChange: (changes) => {
+            // console.log('onStateChange', changes);
+          },
+        }}
+      />
+    </div>
+  );
 };
 
 export const Default = () => (

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -86,11 +86,11 @@ export const DownshiftActionsTest = () => {
               downshiftActions?.current?.openMenu?.();
               return;
             }
-            if (changes?.isOpen && component?.inputValue === 'Option 1') {
+            if (changes?.isOpen && changes?.inputValue === 'Option 1') {
               downshiftActions?.current?.setInputValue?.('');
               return;
             }
-            if (!changes?.isOpen && component?.inputValue !== 'Option 1') {
+            if (!changes?.isOpen && changes?.inputValue !== 'Option 1') {
               downshiftActions?.current?.setInputValue?.('Option 1');
               return;
             }

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -209,7 +209,9 @@ export interface ComboBoxProps<ItemType>
    * cases they can not be shimmed by Carbon to shield you from potentially breaking
    * changes.
    */
-  downshiftActions?: React.MutableRefObject<UseComboboxActions<ItemType>>;
+  downshiftActions?: React.MutableRefObject<
+    UseComboboxActions<ItemType> | undefined
+  >;
 
   /**
    * Provide helper text that is used alongside the control label for
@@ -1011,11 +1013,7 @@ ComboBox.propTypes = {
    * cases they can not be shimmed by Carbon to shield you from potentially breaking
    * changes.
    */
-
-  downshiftActions: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.object }),
-  ]),
+  downshiftActions: PropTypes.exact({ current: PropTypes.any }),
 
   /**
    * Provide helper text that is used alongside the control label for

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -678,7 +678,15 @@ const ComboBox = forwardRef(
           toggleMenu,
         };
       }
-    }, [downshiftActions, setHighlightedIndex, reset]);
+    }, [
+      closeMenu,
+      openMenu,
+      reset,
+      selectItem,
+      setHighlightedIndex,
+      downshiftSetInputValue,
+      toggleMenu,
+    ]);
 
     const buttonProps = getToggleButtonProps({
       disabled: disabled || readOnly,

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -6,7 +6,7 @@
  */
 
 import cx from 'classnames';
-import { useCombobox, UseComboboxProps } from 'downshift';
+import { useCombobox, UseComboboxProps, UseComboboxActions } from 'downshift';
 import PropTypes from 'prop-types';
 import React, {
   useContext,
@@ -188,12 +188,28 @@ export interface ComboBoxProps<ItemType>
   disabled?: boolean;
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
+   *
    */
   downshiftProps?: Partial<UseComboboxProps<ItemType>>;
+
+  /**
+   * Provide a ref that will be mutated to contain an object of downshift
+   * action functions. These can be called to change the internal state of the
+   * downshift useCombobox hook.
+   *
+   * **Use with caution:** calling these actions modifies the internal state of
+   * downshift. It may conflict with or override the state management used within
+   * Combobox. Downshift APIs and internals are subject to change, and in some
+   * cases they can not be shimmed by Carbon to shield you from potentially breaking
+   * changes.
+   */
+  downshiftActions?: React.MutableRefObject<UseComboboxActions<ItemType>>;
 
   /**
    * Provide helper text that is used alongside the control label for
@@ -336,6 +352,7 @@ const ComboBox = forwardRef(
       className: containerClassName,
       direction = 'bottom',
       disabled = false,
+      downshiftActions,
       downshiftProps,
       helperText,
       id,
@@ -590,17 +607,26 @@ const ComboBox = forwardRef(
     }
 
     const {
+      // Prop getters
       getInputProps,
       getItemProps,
       getLabelProps,
       getMenuProps,
       getToggleButtonProps,
+
+      // State
       isOpen,
       highlightedIndex,
-      selectItem,
       selectedItem,
-      toggleMenu,
+
+      // Actions
+      closeMenu,
+      openMenu,
+      reset,
+      selectItem,
       setHighlightedIndex,
+      setInputValue: downshiftSetInputValue,
+      toggleMenu,
     } = useCombobox({
       items: filterItems(items, itemToString, inputValue),
       inputValue: inputValue,
@@ -636,6 +662,23 @@ const ComboBox = forwardRef(
       },
       ...downshiftProps,
     });
+
+    useEffect(() => {
+      // Used to expose the downshift actions to consumers for use with downshiftProps
+      // An odd pattern, here we mutate the value stored in the ref provided from the consumer.
+      // A riff of https://gist.github.com/gaearon/1a018a023347fe1c2476073330cc5509
+      if (downshiftActions) {
+        downshiftActions.current = {
+          closeMenu,
+          openMenu,
+          reset,
+          selectItem,
+          setHighlightedIndex,
+          setInputValue: downshiftSetInputValue,
+          toggleMenu,
+        };
+      }
+    }, [downshiftActions, setHighlightedIndex, reset]);
 
     const buttonProps = getToggleButtonProps({
       disabled: disabled || readOnly,
@@ -729,7 +772,7 @@ const ComboBox = forwardRef(
               {...getInputProps({
                 'aria-controls': isOpen ? undefined : menuProps.id,
                 placeholder,
-                ref: { ...mergeRefs(textInput, ref) },
+                ref: mergeRefs(textInput, ref),
                 onKeyDown: (
                   event: KeyboardEvent<HTMLInputElement> & {
                     preventDownshiftDefault: boolean;
@@ -938,14 +981,34 @@ ComboBox.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps: PropTypes.object as React.Validator<
     UseComboboxProps<unknown>
   >,
+
+  /**
+   * Provide a ref that will be mutated to contain an object of downshift
+   * action functions. These can be called to change the internal state of the
+   * downshift useCombobox hook.
+   *
+   * **Use with caution:** calling these actions modifies the internal state of
+   * downshift. It may conflict with or override the state management used within
+   * Combobox. Downshift APIs and internals are subject to change, and in some
+   * cases they can not be shimmed by Carbon to shield you from potentially breaking
+   * changes.
+   */
+
+  downshiftActions: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.object }),
+  ]),
+
   /**
    * Provide helper text that is used alongside the control label for
    * additional help

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -109,10 +109,12 @@ export interface DropdownProps<ItemType>
   disabled?: boolean;
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps?: Partial<UseSelectProps<ItemType>>;
 
@@ -662,10 +664,12 @@ Dropdown.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps: PropTypes.object as React.Validator<UseSelectProps<unknown>>,
 

--- a/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.js
+++ b/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.js
@@ -69,10 +69,12 @@ FluidMultiSelect.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps: PropTypes.object,
 

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -139,10 +139,12 @@ export interface FilterableMultiSelectProps<ItemType>
   disabled?: boolean;
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps?: UseMultipleSelectionProps<ItemType>;
 
@@ -968,10 +970,12 @@ FilterableMultiSelect.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   // @ts-ignore
   downshiftProps: PropTypes.shape(Downshift.propTypes),

--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -136,10 +136,12 @@ export interface MultiSelectProps<ItemType>
   disabled?: ListBoxProps['disabled'];
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps?: Partial<UseSelectProps<ItemType>>;
 
@@ -850,10 +852,12 @@ MultiSelect.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Additional props passed to Downshift. Use with caution: anything you define
-   * here overrides the components' internal handling of that prop. Downshift
-   * internals are subject to change, and in some cases they can not be shimmed
-   * to shield you from potentially breaking changes.
+   * Additional props passed to Downshift.
+   *
+   * **Use with caution:** anything you define here overrides the components'
+   * internal handling of that prop. Downshift APIs and internals are subject to
+   * change, and in some cases they can not be shimmed by Carbon to shield you
+   * from potentially breaking changes.
    */
   downshiftProps: PropTypes.object as React.Validator<UseSelectProps<unknown>>,
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/17027

Follow up to https://github.com/carbon-design-system/carbon/pull/17089, this ensures that downshift action functions can be called from within parent components using Combobox.

<details><summary>Click to expand notes on compatibility</summary>
<p>

The functionality behind both `downshiftProps` and `downshiftActions` isn't guaranteed and is subject to change. This PR patches a functionality mismatch internal to downshift. It does not cover all previous action:

| Actions previously available | Actions made available in this PR |
| ---------------------------- | --------------------------------- |
| clearSelection               |                                   |
| clearItems                   |                                   |
| closeMenu                    | closeMenu                         |
| openMenu                     | openMenu                          |
| selectHighlightedItem        |                                   |
| selectItem                   | selectItem                        |
| selectItemAtIndex            |                                   |
| setHighlightedIndex          | setHighlightedIndex               |
| toggleMenu                   | toggleMenu                        |
| reset                        | reset                             |
| setItemCount                 |                                   |
| unsetItemCount               |                                   |
| setState                     |                                   |
|                              | setInputValue                     |

If a consumer was using an action that is no longer available, such as `setState`, a functional equivalent can usually be found. This will require a code change in consuming projects.

```diff
- stateAndHelpers.setState({ inputValue: 'Item 1' });
+ downshiftActions.current.setInputValue('Item 1');
```


</p>
</details> 





#### Changelog

**New**

- Add `downshiftActions` prop to Combobox

**Changed**

- Update Combobox documentation for `downshiftActions` and `downshiftProps`
- Improve disclaimer warnings on both these props across all relevant downshift components
- Fix a bug in Combobox where the forwarded ref was not properly being applied through incorrect `mergeRefs` usage

#### Testing / Reviewing

The new test story in storybook implements the same logic referenced in the original issue report's [stackblitz reproduction](https://stackblitz.com/edit/github-v56j87?file=src%2FApp.jsx).

Go to the test story and validate base functionality. There should be no other changes to Combobox stories.

- [ ] ⚠️ Need to remove test story before merging
