### PR TITLE
docs(v11md): modified type-style mixin usage with fluid tokens

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -2136,3 +2136,11 @@ were importing `@carbon/type/scss/styles` in v10 you would now only import
 |                      | display-02              | fluid-display-02   | Updated   |
 |                      | display-03              | fluid-display-03   | Updated   |
 |                      | display-04              | fluid-display-04   | Updated   |
+
+When applying a fluid token with the `type-style()` mixin, you'll need to pass a
+second parameter to indicate it's a fluid token:
+
+```diff
+- @include type.type-style('expressive-heading-04');
++ @include type.type-style('fluid-heading-04', true);
+```


### PR DESCRIPTION
[Surfaced in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1723130796503469), this documents a piece of migration that we missed regarding the second parameter of the type-style mixin.

#### Changelog

**Changed**

- update migration guide to specify type-style usage with fluid tokens

#### Testing / Reviewing

- Review content for readability and accuracy.
