### PR TITLE
fix: 16446 fix calendar icon css issue

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.stories.js
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.js
@@ -61,6 +61,17 @@ export const SingleWithCalendar = () => (
   </DatePicker>
 );
 
+export const CalendarWithInline = () => (
+  <DatePicker datePickerType="single" inline={true}>
+    <DatePickerInput
+      placeholder="mm/dd/yyyy"
+      labelText="Date Picker label"
+      id="date-picker-single"
+      size="md"
+    />
+  </DatePicker>
+);
+
 export const RangeWithCalendar = () => {
   return (
     <DatePicker datePickerType="range">

--- a/packages/styles/scss/components/date-picker/_flatpickr.scss
+++ b/packages/styles/scss/components/date-picker/_flatpickr.scss
@@ -145,9 +145,9 @@
   }
 
   .flatpickr-calendar.inline {
-    position: relative;
+    position: absolute;
     display: block;
-    inset-block-start: convert.to-rem(2px);
+    inset-block-start: auto;
   }
 
   .flatpickr-calendar.static {


### PR DESCRIPTION
Closes #16446 

Calendar icon CSS issue fix when inline props is true
DatePicker story added with inline props true

#### Changelog

**Changed**

- Changed flatpickr calendar position to absolute and inset block start to auto 

#### Testing / Reviewing

- Tested in storybook when inline props is set to true. calendar icon is showing correctly