### PR TITLE
Fixed renovate bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,10 +11,12 @@
 
     // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
     'npm:unpublishSafe',
-
-    // https://docs.renovatebot.com/presets-schedule/#scheduledaily
-    'schedule:every weekday',
   ],
+  "schedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday",
+    "every weekend"
+  ]
   vulnerabilityAlerts: {
     enabled: true,
   },


### PR DESCRIPTION
The `schedule` should go outside of the `extends`.

Inside the `extends` works just a few strings.

![Screenshot 2024-08-09 at 11 27 26](https://github.com/user-attachments/assets/dcb1402b-d9b0-4c24-b492-505109509e6c)

If we want to move to weekday we should have set outside of `extends` and set under `schedule`

![Screenshot 2024-08-09 at 11 28 04](https://github.com/user-attachments/assets/7ecbe9d0-b0b0-40b5-923e-e00ce7b2cd94)

A tricky detail to spot. That is why we haven't seen renovate PRs recently. Here it is the docs:
https://docs.renovatebot.com/presets-schedule/#scheduledaily:~:text=Schedule%20for%20typical%20non%2Doffice%20hours%20(night%20time%20and%20weekends).