### PR TITLE
fix: type definition for onSelect prop in TreeView component

### DIFF
--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -58,7 +58,7 @@ export type TreeViewProps = {
    * Specify the size of the tree from a list of available sizes.
    */
   size?: 'xs' | 'sm';
-} & React.HTMLAttributes<HTMLUListElement>;
+} & Omit<React.HTMLAttributes<HTMLUListElement>, 'onSelect'>;
 
 type TreeViewComponent = {
   (props: TreeViewProps): JSX.Element;


### PR DESCRIPTION
Closes [#17151](https://github.com/carbon-design-system/carbon/issues/17151)

#### Changelog

**Changed**

- Changed type for `TreeView` to skip the conflicting type after the type interesction with `React.HTMLAttributes<HTMLUListElement>`

