### PR TITLE
fix(16991): fix keyboard navigation's  focus lock issue in DatePicker

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -902,6 +902,33 @@ const DatePicker = React.forwardRef(function DatePicker(
     }
   }, [value, prefix]); //eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    if (!calendarRef.current || !startInputField.current) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === 'Tab' &&
+        !event.shiftKey &&
+        document.activeElement === endInputField.current &&
+        calendarRef.current.isOpen
+      ) {
+        calendarRef.current.close();
+        // Remove focus from endDate calendar input
+        document.activeElement instanceof HTMLElement && // this is to fix the TS warning
+          document?.activeElement?.blur();
+
+        onCalendarClose(
+          calendarRef.current.selectedDates,
+          '',
+          calendarRef.current,
+          event
+        );
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [calendarRef, startInputField, endInputField, onCalendarClose]);
+
   let fluidError;
   if (isFluid) {
     if (invalid) {

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -906,7 +906,7 @@ const DatePicker = React.forwardRef(function DatePicker(
     if (!calendarRef.current || !startInputField.current) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
-        event.key === 'Tab' &&
+        match(event, keys.Tab) &&
         !event.shiftKey &&
         document.activeElement === endInputField.current &&
         calendarRef.current.isOpen


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16991

This PR fixes keyboard navigation issue with DatePicker: Now focus moves out of datePicker to the next focusable element in the DOM on Tab key press


#### Changelog

Adds to `useEffect` to remove the focus from calendar on Tab key 

It checks if the pressed key is '`Tab`' (without Shift) and if the `endInputField` is focused and that the calendar is `open`  
If the condition matches : It close the calendar and  remove focus from the `endInputField` 

#### Testing / Reviewing

Select the dates using keyboard after selection of end date press tab and verify that the focus moves to the next focusable element in the DOM