### PR TITLE
fix(header-panel): allow vertical overflow when expanded

### DIFF
--- a/packages/styles/scss/components/ui-shell/header-panel/_header-panel.scss
+++ b/packages/styles/scss/components/ui-shell/header-panel/_header-panel.scss
@@ -38,5 +38,6 @@
     border-inline-end: 1px solid $border-subtle;
     border-inline-start: 1px solid $border-subtle;
     inline-size: mini-units(32);
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
Closes #17159

When `HeaderPanel` is expanded, the content is not vertically scrollable if there is overflow. See the original bug report for repro steps.

The root cause is that the `--header-panel` selector has `overflow: hidden` for the transition. However, the expanded state should allow vertical scrolling as needed.

The proposed fix is to set `overflow-y: auto` on the expanded state to only afford a scrollbar as needed.

**Note** that this fix should ideally be backported to v10.

---

### Before

<img width="439" alt="Screenshot 2024-08-13 at 9 15 02 AM" src="https://github.com/user-attachments/assets/29155e2c-1241-4289-bbe1-59580251d720">

### After

<img width="439" alt="Screenshot 2024-08-13 at 9 15 18 AM" src="https://github.com/user-attachments/assets/fda64996-99d4-4077-8202-e9ff085e94e1">



#### Changelog

**Changed**

- fix(header-panel): allow vertical overflow when expanded

#### Testing / Reviewing

- Test the PR Preview: https://deploy-preview-17160--v11-carbon-react.netlify.app/?path=/story/components-ui-shell-header--header-w-actions-and-switcher
