### PR TITLE
fix(header-panel): v10 backport - allow vertical overflow when expanded

### DIFF
--- a/packages/components/src/components/ui-shell/_header-panel.scss
+++ b/packages/components/src/components/ui-shell/_header-panel.scss
@@ -41,6 +41,7 @@
     width: carbon--mini-units(32);
     border-right: 1px solid $shell-panel-border;
     border-left: 1px solid $shell-panel-border;
+    overflow-y: auto;
   }
 }
 

--- a/packages/styles/scss/components/ui-shell/header-panel/_header-panel.scss
+++ b/packages/styles/scss/components/ui-shell/header-panel/_header-panel.scss
@@ -37,5 +37,6 @@
     width: mini-units(32);
     border-right: 1px solid $border-subtle;
     border-left: 1px solid $border-subtle;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
Ref https://github.com/carbon-design-system/carbon/issues/17159
v10 backport of #17160:

> 
> When `HeaderPanel` is expanded, the content is not vertically scrollable if there is overflow. See the original bug report for repro steps.
> 
> The root cause is that the `--header-panel` selector has `overflow: hidden` for the transition. However, the expanded state should allow vertical scrolling as needed.
> 
> The proposed fix is to set `overflow-y: auto` on the expanded state to only afford a scrollbar as needed.
> 
> **Note** that this fix should ideally be backported to v10.
> 
> ### Before
> <img alt="Screenshot 2024-08-13 at 9 15 02 AM" width="439" src="https://private-user-images.githubusercontent.com/10718366/357493775-29155e2c-1241-4289-bbe1-59580251d720.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM4MzQ3NTksIm5iZiI6MTcyMzgzNDQ1OSwicGF0aCI6Ii8xMDcxODM2Ni8zNTc0OTM3NzUtMjkxNTVlMmMtMTI0MS00Mjg5LWJiZTEtNTk1ODAyNTFkNzIwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MTYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODE2VDE4NTQxOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTkxZjE0YjVhZWE4YzdhZGI1MjUyZjdhYTJjNjBjNTVhMzJiMTU1ZGUwNDViZWU5MDQ1M2NiNDZlYjdhNmUyZmEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.5sKZbmQCJy87zmVsbG5FlMcJLkYTTELriG_tucQEqWg">
> ### After
> <img alt="Screenshot 2024-08-13 at 9 15 18 AM" width="439" src="https://private-user-images.githubusercontent.com/10718366/357493780-fda64996-99d4-4077-8202-e9ff085e94e1.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM4MzQ3NTksIm5iZiI6MTcyMzgzNDQ1OSwicGF0aCI6Ii8xMDcxODM2Ni8zNTc0OTM3ODAtZmRhNjQ5OTYtOTlkNC00MDc3LTgyMDItZTlmZjA4NWU5NGUxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MTYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODE2VDE4NTQxOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTliYmE2NzY0MTYxODI0MGFjMGQyOWEyZTNhZTFmNDQyMDc2YmJhNGQzZmQxNzFhN2Y1NTNiMmQyMmM2NjJjOTAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.XMQodsSzXlJA3tj8DM0LHDT9OlxBgXWu_LD0jdbp7a8">
> #### Changelog
> **Changed**
> 
> * fix(header-panel): allow vertical overflow when expanded
> 
> #### Testing / Reviewing
> * Test the PR Preview: https://deploy-preview-17160--v11-carbon-react.netlify.app/?path=/story/components-ui-shell-header--header-w-actions-and-switcher

