### PR TITLE
fix(tag): add type="button" to interactive tag

### DIFF
--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -224,6 +224,7 @@ const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
       disabled={disabled}
       className={tagClasses}
       id={tagId}
+      type={ComponentTag === 'button' ? 'button' : undefined}
       {...other}>
       {CustomIconElement && size !== 'sm' ? (
         <div className={`${prefix}--tag__custom-icon`}>


### PR DESCRIPTION
Closes #17240

#### Changelog

**New**

- Add `type="button"` to tags that use `button` as the base element

#### Testing / Reviewing

- In the local storybook, visit the "unstable_InteractiveTag/Operational" story
- Inspect the tags and ensure the `<button>` has `type="button"`
- Recreate a demo inside a `<form>` with the reproduction code of #17240 
