### PR TITLE
fix(codesnippet): inline button should be width of content

### DIFF
--- a/config/stylelint-config-carbon/rules/limit-language-features.js
+++ b/config/stylelint-config-carbon/rules/limit-language-features.js
@@ -81,12 +81,6 @@ module.exports = {
     'declaration-property-unit-allowed-list': {
       '/^animation/': ['ms'],
     },
-    // Specify a blacklist of disallowed property and value pairs within
-    // declarations.
-    'declaration-property-value-disallowed-list': {
-      // Disallow unset as it is unsupported in IE11
-      '/.*/': ['unset'],
-    },
     // Specify a whitelist of allowed property and value pairs within
     // declarations.
     'declaration-property-value-allowed-list': OFF,

--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -300,6 +300,7 @@ $copy-btn-feedback: $background-inverse !default;
   .#{$prefix}--snippet--inline.#{$prefix}--btn {
     block-size: 1.25rem;
     inline-size: initial;
+    max-inline-size: unset;
     min-block-size: 1.25rem;
     padding-inline: 0;
   }

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -224,7 +224,6 @@
   .#{$prefix}--slider__thumb--lower,
   .#{$prefix}--slider__thumb--upper {
     position: absolute;
-    /* stylelint-disable-next-line declaration-property-value-disallowed-list */
     border-radius: unset;
     background-color: transparent;
     box-shadow: none;


### PR DESCRIPTION
[Reported in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1724954498462949), the inline code snippet button was incorrectly limited to 320px wide causing a display issue:

![image](https://github.com/user-attachments/assets/850de32e-9a56-4e4f-8f5c-4371ee7c8a88)


#### Changelog

**Changed**

- Update code snippet styles to unset the max-inline-width

**Removed**

- Remove the `declaration-property-value-disallowed-list` rule that disallowed `unset` due to lack of support in IE11. IE11 isn't in our support matrix anymore, so I think this can be safely removed from the config

#### Testing / Reviewing

- Go the code snippet inline story, edit the text to be a really long string. It should display properly. 

https://github.com/user-attachments/assets/3855998f-756c-4522-a87d-c50628dbe9e6


