### PR TITLE
fix: added children's type to interface

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -8,7 +8,7 @@
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import PropTypes from 'prop-types';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactNode } from 'react';
 import { AccordionProvider } from './AccordionProvider';
 
 export interface AccordionProps {
@@ -23,6 +23,11 @@ export interface AccordionProps {
    * the container node.
    */
   className?: string;
+
+  /**
+   * Pass in the children that will be rendered within the Accordion
+   */
+  children?: ReactNode;
 
   /**
    * Specify whether an individual AccordionItem


### PR DESCRIPTION
Closes #17401 

Added children's typing in the interface. The children has been referenced in the propTypes which was missing from the interface.

#### Changelog

**New**

- added children's typing as `ReactNode`



#### Testing / Reviewing

Make sure no console errors are present related to typescript.
