### PR TITLE
chore(tests): skip flaky tests - menu avt, slider onDrag

### DIFF
--- a/e2e/components/Menu/Menu-test.avt.e2e.js
+++ b/e2e/components/Menu/Menu-test.avt.e2e.js
@@ -22,7 +22,7 @@ test.describe('@avt Menu', () => {
     await expect(page).toHaveNoACViolations('Menu @avt-default-state');
   });
 
-  test('@avt-keyboard-nav Menu', async ({ page }) => {
+  test.fixme('@avt-keyboard-nav Menu', async ({ page }) => {
     await visitStory(page, {
       component: 'Menu',
       id: 'components-menu--playground',

--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -296,7 +296,7 @@ describe('Slider', () => {
         expect(onChange).not.toHaveBeenCalled();
       });
 
-      it('gracefully tolerates empty event passed to _onDrag', () => {
+      it.skip('gracefully tolerates empty event passed to _onDrag', () => {
         const { mouseDown, mouseUp, mouseMove } = fireEvent;
         const { container } = renderSlider({
           ariaLabelInput: inputAriaValue,


### PR DESCRIPTION
These tests continue to intermittently fail despite efforts to fix them. They're impeding valid PRs status checks and causing the merge queue to fail and remove multiple PRs.

I've added a new section to https://github.com/carbon-design-system/carbon/issues/16319 to make sure we fix these. 

#### Changelog

**Removed**

- `Menu-test.avt.e2e.js:25:3 › @avt Menu › @avt-keyboard-nav Menu`
- `Slider › behaves as expected - Two Handle Slider Component API › Error handling, expected behavior from event handlers › gracefully tolerates empty event passed to _onDrag`

#### Testing / Reviewing

- Has anyone else seen flaky tests in addition to these?
