### PR TITLE
Fixed `highlight` token color

### DIFF
--- a/packages/themes/src/g100.js
+++ b/packages/themes/src/g100.js
@@ -10,7 +10,7 @@ import {
   blue40,
   blue60,
   blue70,
-  blue80,
+  blue90,
 
   // Gray
   gray10,
@@ -204,7 +204,7 @@ export const skeletonElement = gray80;
 
 // Misc
 export const interactive = blue50;
-export const highlight = blue80;
+export const highlight = blue90;
 export const overlay = rgba(black, 0.65);
 export const toggleOff = gray60;
 export const shadow = rgba(black, 0.8);

--- a/packages/themes/src/g90.js
+++ b/packages/themes/src/g90.js
@@ -10,6 +10,7 @@ import {
   blue40,
   blue60,
   blue70,
+  blue80,
 
   // Gray
   gray10,
@@ -204,7 +205,7 @@ export const skeletonElement = gray70;
 
 // Misc
 export const interactive = blue50;
-export const highlight = blue70;
+export const highlight = blue80;
 export const overlay = rgba(black, 0.65);
 export const toggleOff = gray50;
 export const shadow = rgba(black, 0.8);


### PR DESCRIPTION
Closes #17371

Fixed g90 and g100 themes.

I tested locally the token and now it is returning the correct color.

#### Testing / Reviewing

- When using the `highlight` token it should show the correct colors