### PR TITLE
fix(17398): fix Datepicker issue with Keyboard Navigation in Firefox

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -911,6 +911,7 @@ const DatePicker = React.forwardRef(function DatePicker(
         document.activeElement === endInputField.current &&
         calendarRef.current.isOpen
       ) {
+        event.preventDefault();
         calendarRef.current.close();
         // Remove focus from endDate calendar input
         document.activeElement instanceof HTMLElement && // this is to fix the TS warning


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/17398

This fixes the keyboard (Tab) navigation order in FireFox 

#### Changelog

added  event.preventDefault(); 

#### Testing / Reviewing
open deploy preview in FireFox
Open DatePicker -  "range with Calendar"  storybook example 
Select the dates using keyboard after selection of end date press tab and verify that the focus moves to the next focusable element in the DOM
Also verify in other browser 
