### PR TITLE
fix: makes aria-label prop optional in TabelExpandHeader 

### DIFF
--- a/packages/react/src/components/DataTable/TableExpandHeader.tsx
+++ b/packages/react/src/components/DataTable/TableExpandHeader.tsx
@@ -31,7 +31,7 @@ type TableExpandHeaderPropsBase = {
    * Specify the string read by a voice reader when the expand trigger is
    * focused
    */
-  ['aria-label']: string;
+  ['aria-label']?: string;
 
   /**
    * @deprecated The enableExpando prop is being replaced by `enableToggle`
@@ -150,7 +150,7 @@ TableExpandHeader.propTypes = {
   className: PropTypes.string,
 
   /**
-   * The enableExpando prop is being replaced by enableToggle
+   * The enableExpando prop is being replaced by TableExpandHeader
    */
   enableExpando: deprecate(
     PropTypes.bool,

--- a/packages/react/src/components/DataTable/__tests__/TableExpandHeader-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableExpandHeader-test.js
@@ -31,7 +31,7 @@ describe('TableExpandHeader', () => {
           <TableHead>
             <TableRow>
               <TableExpandHeader
-                ariaLabel="test-label"
+                aria-label="test-label"
                 isExpanded={false}
                 onExpand={jest.fn()}
                 className="custom-class"
@@ -43,12 +43,12 @@ describe('TableExpandHeader', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should respect ariaLabel prop', () => {
+    it('should respect aria-label prop', () => {
       render(
         <Table>
           <TableHead>
             <TableRow>
-              <TableExpandHeader isExpanded enableToggle ariaLabel="Expand" />
+              <TableExpandHeader isExpanded aria-label="Expand" enableToggle />
             </TableRow>
           </TableHead>
         </Table>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/17309

Makes aria-label prop optional 

#### Changelog

aria-label prop optional 
updated test cases to use `aria-label` instead if deprecated  `ariaLabel` 

#### Testing / Reviewing

Verify of functionality is intact and changes makes sense  
