### PR TITLE
chore(dependabot): update config to not apply labels to PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    labels: []


### PR DESCRIPTION
These labels are noisy and visually clutter the PR list. They provide no tangible benefit to our workflows - I think it's worth removing them

#### Changelog

**Changed**

- update `dependabot.yml` to no longer label PRs

#### Testing / Reviewing

- Let me know if you disagree! If others on the team are using these we can leave them in. My assumption is nobody uses them 👀 
