### PR TITLE
fix(Notification): add NPE check in escape close handler

### DIFF
--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -54,7 +54,7 @@ function useEscapeToClose(ref, callback, override = true) {
     // The callback should only be called when focus is on or within the container
     const elementContainsFocus =
       (ref.current && document.activeElement === ref.current) ||
-      ref.current.contains(document.activeElement);
+      ref.current?.contains(document.activeElement);
 
     if (matches(event, [keys.Escape]) && override && elementContainsFocus) {
       callback(event);


### PR DESCRIPTION
Closes #16874 

This PR adds a NPE check to the Notification <kbd>Esc</kbd> key handler to prevent console errors after dismissal

#### Changelog

**Changed**

- Notification `useEscapeToClose` handler

#### Testing / Reviewing

- view the Actionable Notification story
- dismiss the notification
- press <kbd>Tab</Tab>
- confirm no errors are logged in the console