### PR TITLE
fix: focus-trapped-within-menuitem

### DIFF
--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -237,7 +237,6 @@ const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
   }
 
   function focusItem(e?: React.KeyboardEvent<HTMLUListElement>) {
-    e?.preventDefault();
     const currentItem = focusableItems.findIndex((item) =>
       item.ref?.current?.contains(document.activeElement)
     );
@@ -266,6 +265,7 @@ const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
     if (indexToFocus !== currentItem) {
       const nodeToFocus = focusableItems[indexToFocus];
       nodeToFocus.ref?.current?.focus();
+      e?.preventDefault();
     }
   }
 


### PR DESCRIPTION
Closes #17277 

Focus trapped in menuItem of menuButton

#### Changelog

**Changed**

place e.preventDefault to required condition only instead of whole focus method.

#### Testing / Reviewing

To test focus trapped issue
1. Go to Storybook> MenuButton> Default
2. Open the menuButton and press tab key - it should change the focus to next tabable element.

To test Scroll issue
1. Go to Storybook> MenuButton> ExperimentalAutoAlign
2. Open the menuButton and press up/down arrow keys, it should not scroll the page.
