### PR TITLE
fix(web-component): deploy storybook missing nojekyll file

### DIFF
--- a/.github/workflows/deploy-web-components-storybook.yml
+++ b/.github/workflows/deploy-web-components-storybook.yml
@@ -37,6 +37,7 @@ jobs:
           yarn storybook:build
       - name: Create CNAME
         run: |
+          touch packages/web-components/storybook-static/.nojekyll
           touch packages/web-components/storybook-static/CNAME
           echo "web-components.carbondesignsystem.com" > packages/web-components/storybook-static/CNAME
       - name: Push to Web Components repo


### PR DESCRIPTION
Closes #

the web component storybook was displaying this issue
<img width="1419" alt="Screenshot 2024-09-26 at 2 38 34 PM" src="https://github.com/user-attachments/assets/f35b4fca-1b56-4702-abd3-3148ab6e3766">

#### Changelog

**New**

- when pushing the storybook-static changes we also need to include a `.nojekyll` file

#### Testing / Reviewing

https://web-components.carbondesignsystem.com/?path=/docs/introduction-welcome--overview confirmed the storybok is loading properly
