### PR TITLE
fix(notification): background-warning-token to use yellow10

### DIFF
--- a/packages/styles/scss/components/notification/_tokens.scss
+++ b/packages/styles/scss/components/notification/_tokens.scss
@@ -84,30 +84,15 @@ $notification-background-info: (
 ) !default;
 
 $notification-background-warning: (
-  fallback:
-    color.mix(
-      map.get(notification.$color-map, yellow-30),
-      map.get(notification.$color-map, white-0),
-      15%
-    ),
+  fallback: map.get(notification.$notification-background-warning, white-theme),
   values: (
     (
       theme: themes.$white,
-      value:
-        color.mix(
-          map.get(notification.$color-map, yellow-30),
-          map.get(notification.$color-map, white-0),
-          15%
-        ),
+      value: map.get(notification.$notification-background-warning, white-theme),
     ),
     (
       theme: themes.$g10,
-      value:
-        color.mix(
-          map.get(notification.$color-map, yellow-30),
-          map.get(notification.$color-map, white-0),
-          15%
-        ),
+      value: map.get(notification.$notification-background-warning, g-10),
     ),
     (
       theme: themes.$g90,

--- a/packages/themes/src/component-tokens/notification/tokens.js
+++ b/packages/themes/src/component-tokens/notification/tokens.js
@@ -4,7 +4,7 @@ import {
   gray90,
   green10,
   blue10,
-  yellow30,
+  yellow10,
   white0,
 } from '@carbon/colors';
 import {
@@ -50,14 +50,9 @@ export const notificationBackgroundInfo = {
   g100: gray90,
 };
 
-export const colorMap = {
-  yellow30,
-  white0,
-};
-
 export const notificationBackgroundWarning = {
-  whiteTheme: colorMap,
-  g10: colorMap,
+  whiteTheme: yellow10,
+  g10: yellow10,
   g90: gray80,
   g100: gray90,
 };


### PR DESCRIPTION
Closes #17586

update notification-background-warning-token to use yellow10
<img width="1549" alt="Screenshot 2024-09-30 at 5 21 18 PM" src="https://github.com/user-attachments/assets/a281043d-43cb-4f77-9bdf-c9936105d8e1">
<img width="802" alt="Screenshot 2024-09-30 at 5 21 57 PM" src="https://github.com/user-attachments/assets/0ef276e9-2214-4305-9008-a2a03ce897a6">



#### Changelog


**Changed**

- using yellow10 now instead of mixing colors


#### Testing / Reviewing

- go to the playground of notification stories
- turn on low-contrast 
- set kind to `warning`
- confirm correct color in the background
