### PR TITLE
Fix DefinitionTooltip not opening on first click

### DIFF
--- a/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
@@ -116,8 +116,10 @@ const DefinitionTooltip: React.FC<DefinitionTooltipProps> = ({
         onBlur={() => {
           setOpen(false);
         }}
-        onClick={() => {
-          setOpen(!isOpen);
+        onMouseDown={(event) => {
+          // We use onMouseDown rather than onClick to make sure this triggers
+          // before onFocus.
+          if (event.button === 0) setOpen(!isOpen);
         }}
         onKeyDown={onKeyDown}
         type="button">


### PR DESCRIPTION
Closes #17070

The problem was `onFocus` opened the tooltip, then the `onClick` from the same event immediately closed it again.

This PR proposes a fix by changing `onClick` to `onMouseDown`, which occurs before `onFocus`.

#### Changelog

**Changed**

- Fixed bug whereby `DefinitionTooltip` with `openOnHover=false` immediately closed the first time it was clicked.

#### Testing / Reviewing

Open storybook, go to `DefinitionTooltip`, set `openOnHover` to `false`, then click the component.

https://github.com/user-attachments/assets/f1df60a3-9099-4f7e-b1d5-e11ae10596e7