### PR TITLE
docs(web-components): add missed storybook import extensions

### DIFF
--- a/packages/web-components/docs/welcome.mdx
+++ b/packages/web-components/docs/welcome.mdx
@@ -52,8 +52,8 @@ The first thing you need is **setting up a module bundler** to resolve ECMAScrip
 Once you set up a module bundler, you can start importing our component modules, for example:
 
 ```javascript
-import '@carbon/web-components/es/components/dropdown/dropdown';
-import '@carbon/web-components/es/components/dropdown/dropdown-item';
+import '@carbon/web-components/es/components/dropdown/dropdown.js';
+import '@carbon/web-components/es/components/dropdown/dropdown-item.js';
 ```
 
 Once you've imported the component modules, you can use our components in the same manner as native HTML tags, for example:


### PR DESCRIPTION
The plain ESM standard imports should have extensions.