### PR TITLE
chore(project): ensure end-of-support packages are not published anymore

### DIFF
--- a/packages/carbon-components-react/package.json
+++ b/packages/carbon-components-react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "carbon-components-react",
+  "private": true,
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences. This package reached end of support on September 30, 2024 and will not receive any more updates.",
   "version": "8.68.0-rc.0",
   "license": "Apache-2.0",

--- a/packages/carbon-components/package.json
+++ b/packages/carbon-components/package.json
@@ -1,5 +1,6 @@
 {
   "name": "carbon-components",
+  "private": true,
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences. This package reached end of support on September 30, 2024 and will not receive any more updates.",
   "version": "11.67.0-rc.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/17633
Part of #12494 

#### Changelog

**Changed**

- Mark `carbon-components` and `carbon-components-react` as `private` so they will not be published to npm

#### Testing / Reviewing

- You can try a local dry run of publishing to npm if you want to, but we'll be able to do a true test of this live when we release this week.
