### PR TITLE
fix(staticnotification): remove staticnotification from top of sidebar

### DIFF
--- a/packages/react/src/components/Notification/stories/StaticNotification.mdx
+++ b/packages/react/src/components/Notification/stories/StaticNotification.mdx
@@ -1,4 +1,4 @@
-import { ArgTypes, Canvas, Story, Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 <Meta isTemplate />
 

--- a/packages/react/src/components/Notification/stories/StaticNotification.mdx
+++ b/packages/react/src/components/Notification/stories/StaticNotification.mdx
@@ -1,3 +1,7 @@
+import { ArgTypes, Canvas, Story, Meta } from '@storybook/blocks';
+
+<Meta isTemplate />
+
 # StaticNotification has been renamed to Callout
 
 Run the following codemod to automatically update usages in your project:

--- a/packages/react/src/components/Notification/stories/StaticNotification.stories.js
+++ b/packages/react/src/components/Notification/stories/StaticNotification.stories.js
@@ -13,6 +13,7 @@ import mdx from './StaticNotification.mdx';
 
 export default {
   title: 'Experimental/unstable__StaticNotification',
+  component: StaticNotification,
   parameters: {
     docs: {
       page: mdx,


### PR DESCRIPTION

Fixes the sidebar so StaticNotification docs page sits in it's proper spot in the left nav instead of being at the top 

![image](https://github.com/user-attachments/assets/c93ff0ad-739d-4091-8df2-e2edc22c9c03)

Related https://github.com/carbon-design-system/carbon/pull/17443
#### Changelog

**Changed**

- Mark the docs .mdx page as a template so storybook handles it properly

#### Testing / Reviewing

- Deploy preview should show that it sits in the correct spot and is not like the above screenshot anymore
