### PR TITLE
fix(slider): disabled focus and styles

### DIFF
--- a/packages/react/src/components/Slider/Slider-test.js
+++ b/packages/react/src/components/Slider/Slider-test.js
@@ -962,7 +962,7 @@ describe('Slider', () => {
 
       await click(lowerThumb);
       await keyboard('{ArrowRight}');
-      expect(lowerThumb).toHaveFocus();
+      expect(lowerThumb).not.toHaveFocus();
       expect(lowerInput).toHaveValue(initialValueLower);
       expect(lowerThumb).toHaveAttribute(
         'aria-valuenow',

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -1520,7 +1520,7 @@ class Slider extends PureComponent<SliderProps> {
                       className={lowerThumbClasses}
                       role="slider"
                       id={twoHandles ? undefined : id}
-                      tabIndex={!readOnly ? 0 : -1}
+                      tabIndex={readOnly || disabled ? undefined : 0}
                       aria-valuetext={`${formatLabel(value, '')}`}
                       aria-valuemax={twoHandles ? valueUpper : max}
                       aria-valuemin={min}
@@ -1554,7 +1554,7 @@ class Slider extends PureComponent<SliderProps> {
                       <div
                         className={upperThumbClasses}
                         role="slider"
-                        tabIndex={!readOnly ? 0 : -1}
+                        tabIndex={readOnly || disabled ? undefined : 0}
                         aria-valuemax={max}
                         aria-valuemin={value}
                         aria-valuenow={valueUpper}

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -388,6 +388,20 @@
     }
   }
 
+  .#{$prefix}--slider--disabled .#{$prefix}--slider__thumb--lower,
+  .#{$prefix}--slider--disabled .#{$prefix}--slider__thumb--upper {
+    background-color: transparent;
+
+    &:hover,
+    &:focus {
+      transform: none;
+    }
+
+    .#{$prefix}--slider__thumb-icon {
+      fill: $border-disabled;
+    }
+  }
+
   .#{$prefix}--slider--disabled .#{$prefix}--slider__track,
   .#{$prefix}--slider--disabled .#{$prefix}--slider__filled-track,
   .#{$prefix}--slider--disabled

--- a/packages/styles/scss/components/slider/_slider.scss
+++ b/packages/styles/scss/components/slider/_slider.scss
@@ -392,8 +392,10 @@
   .#{$prefix}--slider--disabled .#{$prefix}--slider__thumb--upper {
     background-color: transparent;
 
+    &:active,
     &:hover,
     &:focus {
+      background-color: transparent;
       transform: none;
     }
 


### PR DESCRIPTION
Closes #16633 

When putting the slider in a disabled state the user could still focus to it. This updates so you can no longer focus on the element when it's disabled. 

Also, the disabled styles looked a bit off for two sliders
before: 
<img width="496" alt="Screenshot 2024-10-07 at 3 49 50 PM" src="https://github.com/user-attachments/assets/a7eeffff-a673-43b8-956d-b65a6fef8218">


after:
<img width="576" alt="Screenshot 2024-10-07 at 3 34 17 PM" src="https://github.com/user-attachments/assets/054f7d6a-bd41-41e2-871c-3ef7eeead3c7">

#### Changelog

**New**

- added styles for sliders with a upper and lower slider on disabled
- included disabled state on `tabIndex` 

**Changed**

- update test to properly check that there is no focusable element when disabled


#### Testing / Reviewing

go to slider stories and turn on disabled state
since the controls aren't turned on for the two sliders I tested it locally in storybook but updating a story with the prop `disabled`
