### PR TITLE
fix(combobox): rendering aria-label

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -102,6 +102,21 @@ describe('ComboBox', () => {
     });
   });
 
+  it('should display titleText', () => {
+    render(<ComboBox {...mockProps} titleText="Combobox title" />);
+
+    expect(screen.getByText('Combobox title')).toBeInTheDocument();
+  });
+
+  it('should confirm custom aria-label is on the input', () => {
+    render(<ComboBox {...mockProps} aria-label="custom aria-label" />);
+
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-label',
+      'custom aria-label'
+    );
+  });
+
   it('should select the correct item from the filtered list after text input on click', async () => {
     const user = userEvent.setup();
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -784,7 +784,6 @@ const ComboBox = forwardRef(
     const menuProps = useMemo(
       () =>
         getMenuProps({
-          'aria-label': deprecatedAriaLabel || ariaLabel,
           ref: autoAlign ? refs.setFloating : null,
         }),
       [
@@ -827,6 +826,9 @@ const ComboBox = forwardRef(
               aria-haspopup="listbox"
               title={textInput?.current?.value}
               {...getInputProps({
+                'aria-label': titleText
+                  ? undefined
+                  : deprecatedAriaLabel || ariaLabel,
                 'aria-controls': isOpen ? undefined : menuProps.id,
                 placeholder,
                 ref: mergeRefs(textInput, ref),


### PR DESCRIPTION
Closes #16557

Combobox was ignoring the `aria-label` prop

#### Changelog

**Changed**

- previously `aria-label` was being applied to the `menuProps`, but the menu was already being given an `aria-label` from the `listboxMenuIcon`
- moved `aria-label` to `inputProps` and handle the scenario when `titleText` isn't provided

#### Testing / Reviewing

- pull down the branch
- open storybook
- go to combobox
- add an aria-label to the combobox
- run the IBM accessibility checker