### PR TITLE
chore(issue-templates): always apply needs triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
@@ -2,7 +2,7 @@ name: Accessibility Issue ♿
 description: Report an accessibility or usability issue.
 title: '[a11y]: '
 type: 'bug'
-labels: ['type: a11y ♿', 'type: bug 🐛']
+labels: ['type: a11y ♿', 'type: bug 🐛', 'status: needs triage 🕵️‍♀️']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
@@ -38,6 +38,7 @@ body:
         - '@carbon/themes'
         - '@carbon/type'
         - '@carbon/upgrade'
+        - '@carbon/web-components'
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -3,7 +3,7 @@ description:
   Something not working as expected? This is the place to report your issue.
 title: '[Bug]: '
 type: 'bug'
-labels: 'type: bug 🐛'
+labels: ['type: bug 🐛', 'status: needs triage 🕵️‍♀️']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/DESIGN_DEFECT.yaml
+++ b/.github/ISSUE_TEMPLATE/DESIGN_DEFECT.yaml
@@ -36,6 +36,7 @@ body:
         - '@carbon/themes'
         - '@carbon/type'
         - '@carbon/upgrade'
+        - '@carbon/web-components'
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/DESIGN_DEFECT.yaml
+++ b/.github/ISSUE_TEMPLATE/DESIGN_DEFECT.yaml
@@ -2,7 +2,7 @@ name: Design defect 🎨
 description: Report a visual design issue
 title: '[Bug]: '
 type: 'bug'
-labels: 'type: bug 🐛'
+labels: ['type: bug 🐛', 'status: needs triage 🕵️‍♀️']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
@@ -2,7 +2,7 @@ name: Feature request or enhancement 💡
 description: Suggest an idea for this project.
 title: '[Feature Request]: '
 type: 'enhancement'
-labels: 'type: enhancement 💡'
+labels: ['type: enhancement 💡', 'status: needs triage 🕵️‍♀️']
 body:
   - type: markdown
     attributes:
@@ -18,26 +18,34 @@ body:
     attributes:
       label: The problem
       description:
-        'Provide a clear and concise description of what the problem this new feature is trying to solve. (For example, I find it frustrating when...). Be sure to attach screenshots or videos to illustrate the problem.'
+        'Provide a clear and concise description of what the problem this new
+        feature is trying to solve. (For example, I find it frustrating
+        when...). Be sure to attach screenshots or videos to illustrate the
+        problem.'
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
       label: The solution
-      description: 'Provide a clear and concise description of what you would like to happen instead. Be sure to attach screenshots or videos to illustrate the solution if possible. Design specs are highly encouraged.'
+      description:
+        'Provide a clear and concise description of what you would like to
+        happen instead. Be sure to attach screenshots or videos to illustrate
+        the solution if possible. Design specs are highly encouraged.'
     validations:
       required: true
   - type: textarea
     id: user-research
     attributes:
       label: Examples
-      description: Provide sample content, references, or audits of solutions solving the same problem in other applications/websites.
+      description:
+        Provide sample content, references, or audits of solutions solving the
+        same problem in other applications/websites.
   - type: input
     id: application
     attributes:
       label: Application/PAL
-      description: "What application and/or PAL do you work on?"
+      description: 'What application and/or PAL do you work on?'
   - type: dropdown
     id: priority
     attributes:
@@ -56,7 +64,10 @@ body:
       value:
         '_Carbon is a collaborative system. We encourage teams to build
         components and submit them for integration as either add-ons or core
-        components. To better understand our feature request process and what happends after you submit this issue, [check out the docs](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/support.md#type-enhancement-) on Github._'
+        components. To better understand our feature request process and what
+        happends after you submit this issue, [check out the
+        docs](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/support.md#type-enhancement-)
+        on Github._'
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/QUESTION.yaml
+++ b/.github/ISSUE_TEMPLATE/QUESTION.yaml
@@ -1,7 +1,7 @@
 name: Question ❓
 description: Usage question or discussion about Carbon components.
 title: '[Question]: '
-labels: 'type: question ❓'
+labels: ['type: question ❓', 'status: needs triage 🕵️‍♀️']
 body:
   - type: markdown
     attributes:
@@ -26,7 +26,9 @@ body:
       value: '- `#carbon-react` for questions about `@carbon/react`.'
   - type: markdown
     attributes:
-      value: '- `#carbon-web-components` for questions about `@carbon/web-components`.'
+      value:
+        '- `#carbon-web-components` for questions about
+        `@carbon/web-components`.'
   - type: markdown
     attributes:
       value:


### PR DESCRIPTION
If a collaborator opens up an issue, that issue does not get the https://github.com/carbon-design-system/carbon/labels/status%3A%20needs%20triage%20%F0%9F%95%B5%EF%B8%8F%E2%80%8D%E2%99%80%EF%B8%8F label. This PR updates the issue templates to apply this label regardless, while still allowing the collaborator "exception" to happen on any issue that is opened without using a template.

#### Changelog

**Changed**

- Update issue templates to apply the needs triage label
