### PR TITLE
chore(storybook): move feature flag overview under welcome section

### DIFF
--- a/packages/react/src/components/FeatureFlags/overview.mdx
+++ b/packages/react/src/components/FeatureFlags/overview.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Experimental/Feature Flags" />
+<Meta title="Getting Started/Feature Flags" />
 
 # Feature Flags
 
@@ -117,11 +117,14 @@ Feature flags can also be enabled via the provided `enable()` mixin
 
 ## FeatureFlags Prop Update
 
-The `FeatureFlags` component has been updated to improve compatibility. The `flags` object prop is now deprecated and is replaced with individual boolean props for each feature flag.
+The `FeatureFlags` component has been updated to improve compatibility. The
+`flags` object prop is now deprecated and is replaced with individual boolean
+props for each feature flag.
 
-The `flags` prop will be removed in a future release. Instead, use individual boolean props for each feature flag. 
-A `featureflag-deprecate-flags-prop` codemod has been provided to help deprecate the `flags` object prop and switch to individual boolean props.
-
+The `flags` prop will be removed in a future release. Instead, use individual
+boolean props for each feature flag. A `featureflag-deprecate-flags-prop`
+codemod has been provided to help deprecate the `flags` object prop and switch
+to individual boolean props.
 
 ```bash
 npx @carbon/upgrade migrate featureflag-deprecate-flags-prop --write
@@ -130,9 +133,9 @@ npx @carbon/upgrade migrate featureflag-deprecate-flags-prop --write
 ```jsx
 //Before migration
 
- <FeatureFlags   
+ <FeatureFlags
   flags={{
-    'enable-v12-tile-default-icons': true, 
+    'enable-v12-tile-default-icons': true,
   }}>
     <App />
   </FeatureFlags>


### PR DESCRIPTION
Closes #17573 

We are moving the feature flag overview to sit underneath the welcome section in storybook in order for the feature flag documentation to be more visible

<img width="842" alt="Screenshot 2024-10-08 at 4 21 18 PM" src="https://github.com/user-attachments/assets/3624565a-988c-47bf-a4d8-13b91f9d8600">


#### Changelog

**Changed**

- change pathing for Feature Flag overview.mdx to be under the "Getting Started" section in storybook

#### Testing / Reviewing

Check deploy preview and make sure the feature flag overview is visible on the left hand side under "Welcome"
