### PR TITLE
fix: fixed tag tokens from 80 to 70

### DIFF
--- a/packages/themes/src/component-tokens/tag/tokens.js
+++ b/packages/themes/src/component-tokens/tag/tokens.js
@@ -82,8 +82,8 @@ export const tagBackgroundRed = {
 };
 
 export const tagColorRed = {
-  whiteTheme: red80,
-  g10: red80,
+  whiteTheme: red70,
+  g10: red70,
   g90: red20,
   g100: red20,
 };
@@ -103,8 +103,8 @@ export const tagBackgroundMagenta = {
 };
 
 export const tagColorMagenta = {
-  whiteTheme: magenta80,
-  g10: magenta80,
+  whiteTheme: magenta70,
+  g10: magenta70,
   g90: magenta20,
   g100: magenta20,
 };
@@ -124,8 +124,8 @@ export const tagBackgroundPurple = {
 };
 
 export const tagColorPurple = {
-  whiteTheme: purple80,
-  g10: purple80,
+  whiteTheme: purple70,
+  g10: purple70,
   g90: purple20,
   g100: purple20,
 };
@@ -145,8 +145,8 @@ export const tagBackgroundBlue = {
 };
 
 export const tagColorBlue = {
-  whiteTheme: blue80,
-  g10: blue80,
+  whiteTheme: blue70,
+  g10: blue70,
   g90: blue20,
   g100: blue20,
 };
@@ -166,8 +166,8 @@ export const tagBackgroundCyan = {
 };
 
 export const tagColorCyan = {
-  whiteTheme: cyan80,
-  g10: cyan80,
+  whiteTheme: cyan70,
+  g10: cyan70,
   g90: cyan20,
   g100: cyan20,
 };
@@ -185,8 +185,8 @@ export const tagBackgroundTeal = {
   g100: teal70,
 };
 export const tagColorTeal = {
-  whiteTheme: teal80,
-  g10: teal80,
+  whiteTheme: teal70,
+  g10: teal70,
   g90: teal20,
   g100: teal20,
 };
@@ -206,8 +206,8 @@ export const tagBackgroundGreen = {
 };
 
 export const tagColorGreen = {
-  whiteTheme: green80,
-  g10: green80,
+  whiteTheme: green70,
+  g10: green70,
   g90: green20,
   g100: green20,
 };


### PR DESCRIPTION
Closes #17629 

Fixed tokens for tagColor from 80 to 70

#### Testing / Reviewing

- Tags should be using the color 70
![Screenshot 2024-10-11 at 10 17 30](https://github.com/user-attachments/assets/b6e9c3f3-6dac-4dfa-b763-aa029b149e83)
