### PR TITLE
fix(skeleton): adjust to work with any text-align property

### DIFF
--- a/packages/styles/scss/utilities/_skeleton.scss
+++ b/packages/styles/scss/utilities/_skeleton.scss
@@ -36,6 +36,7 @@
     block-size: 100%;
     content: '';
     inline-size: 100%;
+    inset-inline-start: 0;
     will-change: transform-origin, transform, opacity;
 
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Closes #17236

Fix so that animation starts in the correct place regardless of text-align set. 

#### Changelog

**New**

- Set the start(left) position for the animation.


#### Testing / Reviewing

Nothing should have changed with any skeleton text stories. To test you can set the text-align either locally or in dev console to right and/or center and it should display the same. 
