### PR TITLE
fix(Dropdown): remove extra space at the end

### DIFF
--- a/packages/styles/scss/components/dropdown/_dropdown.scss
+++ b/packages/styles/scss/components/dropdown/_dropdown.scss
@@ -27,7 +27,7 @@
     display: inline-grid;
     align-items: center;
     grid-gap: 0 convert.to-rem(24px);
-    grid-template: auto auto / auto min-content;
+    grid-template: auto / auto min-content;
 
     .#{$prefix}--label {
       @include type-style('body-compact-01');


### PR DESCRIPTION
Closes #17750

#### Changelog

**Changed**

- Changed from `grid` to `flex` so that it only add `gap` if there is more than 1 child element to the wrapper.
  - are there any drawbacks to this change?

**Removed**

- Removed `.#{$prefix}--form-requirement` it seems not used since there is no reference from `Dropdown.tsx`

#### Testing / Reviewing

No other inline elements:
<img width="350" alt="Screenshot 2024-10-15 at 7 29 47 PM" src="https://github.com/user-attachments/assets/ff4b3518-3645-4587-909c-f8d26112119e">

When there are other inline elements:
<img width="303" alt="Screenshot 2024-10-15 at 7 07 10 PM" src="https://github.com/user-attachments/assets/cf127ca8-1f1a-4eb7-ab1b-265818913811">

