### PR TITLE
chore(ibm-common): add ibm-common.js to web components storybook

### DIFF
--- a/packages/web-components/.storybook/manager-head.html
+++ b/packages/web-components/.storybook/manager-head.html
@@ -44,6 +44,34 @@
   type="module"
   src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/latest/footer.min.js"></script>
 
+<!-- Tealium/GA Set up -->
+<script type="text/javascript">
+  window._ibmAnalytics = {
+    settings: {
+      name: 'CarbonWebComponentsStorybook',
+      isSpa: true,
+      tealiumProfileName: 'ibm-web-app',
+    },
+    onLoad: [['ibmStats.pageview', []]],
+  };
+  digitalData = {
+    page: {
+      pageInfo: {
+        ibm: {
+          siteId: 'IBM_' + _ibmAnalytics.settings.name,
+        },
+      },
+      category: {
+        primaryCategory: 'PC100',
+      },
+    },
+  };
+</script>
+<script
+  src="//1.www.s81c.com/common/stats/ibm-common.js"
+  type="text/javascript"
+  async="async"></script>
+
 <style type="text/css">
   footer {
     position: absolute;


### PR DESCRIPTION
Noticed that the web component storybook was not instrumented with ibm-common.js, so adding that here.

#### Changelog

**Changed**

- add `ibm-common.js` and DDO object to storybook manager head (web components)

