### PR TITLE
docs: adds typeahead prop doc in overview.mdx

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.mdx
+++ b/packages/react/src/components/ComboBox/ComboBox.mdx
@@ -69,6 +69,12 @@ changes.
 For more information, checkout the Downshift `useCombobox` props
 [documentation](https://github.com/downshift-js/downshift/tree/v9.0.7/src/hooks/useCombobox#basic-props)
 
+## typeahead Prop
+
+The `typeahead` prop enables predictive text and autocomplete functionality in the ComboBox. When enabled, it displays inline suggestions as you type, using a built-in prefix-matching filter that ignores the `shouldFilterItem` prop. Pressing `Tab` will complete the input with the first matching suggestion, while arrow keys can still be used to navigate through filtered options.
+
+When combined with the `allowCustomValue` prop, the ComboBox supports both custom values and typeahead suggestions.
+
 ### Combobox `downshiftActions`
 
 The downshift action methods are made available through the `downshiftActions`

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -141,7 +141,15 @@ export const AutocompleteWithTypeahead = (args) => {
         onChange={args.onChange}
         helperText="Combobox helper text"
         id="carbon-combobox"
-        items={['Apple', 'Orange', 'Banana', 'Pineapple', 'Raspberry', 'Lime']}
+        items={[
+          'Apple',
+          'Apricot',
+          'Avocado',
+          'Banana',
+          'Blackberry',
+          'Blueberry',
+          'Cantaloupe',
+        ]}
         titleText="ComboBox title"
         typeahead
       />


### PR DESCRIPTION
Closes #https://github.com/carbon-design-system/carbon/issues/17690

Documents typeahead prop in overview.mdx


#### Changelog

**New**

Updated typeahead storybook example's option list to better demonstrate the navigation of filtered options using the up and down arrow keys and to show filtering behaviors 
Documents typeahead prop in overview.mdx


#### Testing / Reviewing

review docs changes 
