### PR TITLE
ci(merge-rate): update to run on Wednesday and align with sprint schedule

### DIFF
--- a/.github/workflows/metrics-merge-rate.yml
+++ b/.github/workflows/metrics-merge-rate.yml
@@ -2,7 +2,7 @@ name: Calculate PR Merge Rate
 
 on:
   schedule:
-    - cron: '0 12 * * 1' # Runs every Monday at 12:00 UTC
+    - cron: '0 1 * * 3' # Runs at 1:00 AM UTC every Wednesday
   workflow_dispatch: # Allows manual runs from the GitHub Actions tab
 
 jobs:


### PR DESCRIPTION
This will ensure that the merge rate captures the past week, aligning with sprint start/timelines instead of Mondays.

#### Changelog

**Changed**

- update merge rate workflow cron