### PR TITLE
fix(Notification): remove tabindex on close buttons

### DIFF
--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -493,7 +493,6 @@ export function ToastNotification({
         <NotificationButton
           notificationType="toast"
           onClick={handleCloseButtonClick}
-          aria-hidden="true"
           aria-label={deprecatedAriaLabel || ariaLabel}
         />
       )}
@@ -738,7 +737,6 @@ export function InlineNotification({
         <NotificationButton
           notificationType="inline"
           onClick={handleCloseButtonClick}
-          aria-hidden="true"
           aria-label={ariaLabel}
         />
       )}

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -495,7 +495,6 @@ export function ToastNotification({
           onClick={handleCloseButtonClick}
           aria-hidden="true"
           aria-label={deprecatedAriaLabel || ariaLabel}
-          tabIndex={-1}
         />
       )}
     </div>
@@ -741,7 +740,6 @@ export function InlineNotification({
           onClick={handleCloseButtonClick}
           aria-hidden="true"
           aria-label={ariaLabel}
-          tabIndex={-1}
         />
       )}
     </div>

--- a/packages/react/src/components/Notification/__tests__/Notification-test.js
+++ b/packages/react/src/components/Notification/__tests__/Notification-test.js
@@ -124,17 +124,6 @@ describe('ToastNotification', () => {
     spy.mockRestore();
   });
 
-  it('close button is rendered by default and includes aria-hidden=true', () => {
-    render(<ToastNotification title="Notification title" />);
-
-    const closeButton = screen.queryByRole('button', {
-      hidden: true,
-    });
-
-    expect(closeButton).toBeInTheDocument();
-    expect(closeButton).toHaveAttribute('aria-hidden', 'true');
-  });
-
   it('does not render close button when `hideCloseButton` is provided', () => {
     render(<ToastNotification title="Notification title" hideCloseButton />);
     const closeButton = screen.queryByRole('button', {
@@ -253,16 +242,6 @@ describe('InlineNotification', () => {
 
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
-  });
-
-  it('close button is rendered by default and includes aria-hidden=true', () => {
-    render(<InlineNotification title="Notification title" />);
-
-    const closeButton = screen.queryByRole('button', {
-      hidden: true,
-    });
-    expect(closeButton).toBeInTheDocument();
-    expect(closeButton).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('does not render close button when `hideCloseButton` is provided', () => {

--- a/packages/react/src/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
+++ b/packages/react/src/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
@@ -138,7 +138,6 @@ exports[`InlineNotification should render 1`] = `
       aria-hidden="true"
       aria-label="close notification"
       class="cds--inline-notification__close-button"
-      tabindex="-1"
       title="close notification"
       type="button"
     >
@@ -205,7 +204,6 @@ exports[`ToastNotification should render 1`] = `
       aria-hidden="true"
       aria-label="close notification"
       class="cds--toast-notification__close-button"
-      tabindex="-1"
       title="close notification"
       type="button"
     >

--- a/packages/react/src/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
+++ b/packages/react/src/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
@@ -135,7 +135,6 @@ exports[`InlineNotification should render 1`] = `
       </div>
     </div>
     <button
-      aria-hidden="true"
       aria-label="close notification"
       class="cds--inline-notification__close-button"
       title="close notification"
@@ -201,7 +200,6 @@ exports[`ToastNotification should render 1`] = `
       </div>
     </div>
     <button
-      aria-hidden="true"
       aria-label="close notification"
       class="cds--toast-notification__close-button"
       title="close notification"


### PR DESCRIPTION
Closes #15907

this PR updates the notification components so that the buttons to dismiss the notifications are accessible via keyboard

#### Changelog

**Changed**

- test snapshots

**Removed**

- notification close buttons

#### Testing / Reviewing

view the notification stories and confirm that the close buttons are accessible via keyboard