### PR TITLE
fix(Tabs): Allow rendering Tabs and TabPanels conditionally again

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1717,7 +1717,7 @@ function TabPanels({ children }: TabPanelsProps) {
   return (
     <>
       {React.Children.map(children, (child, index) => {
-        return (
+        return !isElement(child) ? null : (
           <TabPanelContext.Provider value={index}>
             {React.cloneElement(child as React.ReactElement<any>, {
               ref: (element: HTMLDivElement) => {

--- a/packages/react/src/components/Tabs/__tests__/Tabs-test.js
+++ b/packages/react/src/components/Tabs/__tests__/Tabs-test.js
@@ -64,6 +64,30 @@ describe('Tabs', () => {
     );
 
     expect(container.firstChild).toHaveClass('custom-class');
+    expect(container);
+  });
+
+  it('should not render conditionally excluded tabs and panels', () => {
+    const condition = false;
+    render(
+      <Tabs>
+        <TabList aria-label="List of tabs" data-test-id="test-id">
+          <Tab>Tab Label 1</Tab>
+          {condition ? (
+            <Tab data-test-id="excluded-tab">Tab Label 2</Tab>
+          ) : null}
+        </TabList>
+        <TabPanels>
+          <TabPanel>Tab Panel 1</TabPanel>
+          {condition ? (
+            <TabPanel data-test-id="excluded-panel">Tab Panel 2</TabPanel>
+          ) : null}
+        </TabPanels>
+      </Tabs>
+    );
+
+    expect(screen.queryByTestId('excluded-tab')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('excluded-panel')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
This change allows users to conditionally render children of TabPanels again: If children are not filtered for nullish/falsy values before cloning them, `React.cloneElement` will fail with: `Error: React.cloneElement(...): The argument must be a React element, but you passed null.`.

This regression has been introduced with commit: [f4066328a01bd9431f16ccc0c8b646f1f6d8a26e, Tabs.tsx:L1257](https://github.com/carbon-design-system/carbon/commit/f4066328a01bd9431f16ccc0c8b646f1f6d8a26e#diff-f9758cf530377bb77168e71a8d55e9119623bb529f72191a4c9ed340c208f1c6L1257)

#### Changelog

**Changed**
- filter children of `TabPanels` for nullish or falsy values using `isElement` before cloning them.

#### Testing / Reviewing

* An example of the current behavior can be seen on this stackblitz fork: https://stackblitz.com/edit/github-isyfyz-yyf8cu?file=src%2FApp.jsx (open the developer console to view the React error)
* A component test has been added to verify the correct behavior.
