### PR TITLE
feat(DataTable): add double toolbar prop

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1670,6 +1670,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "pilarfernandezz",
+      "name": "Pilar Fernandez",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38540218?v=4",
+      "profile": "https://github.com/pilarfernandezz",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -309,10 +309,11 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/Neues"><img src="https://avatars.githubusercontent.com/u/9409245?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Noah Sgorbati</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Neues" title="Code">💻</a> <a href="https://github.com/carbon-design-system/carbon/commits?author=Neues" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/divya-281"><img src="https://avatars.githubusercontent.com/u/72991264?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Divya G</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=divya-281" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/soumyaraju"><img src="https://avatars.githubusercontent.com/u/41182657?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Soumya Raju</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=soumyaraju" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/ziyadzulfikar"><img src="https://avatars.githubusercontent.com/u/56788667?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ziyad Bin Sulfi</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ziyadzulfikar" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ziyadzulfikar"><img src="https://avatars.githubusercontent.com/u/56788667?v=4?s=100" width="100px;" alt=""/><br /><sub><b>ziyadzulfikar</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=ziyadzulfikar" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/mariat189"><img src="https://avatars.githubusercontent.com/u/74430463?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mariat</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mariat189" title="Code">💻</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://github.com/mariat189"><img src="https://avatars.githubusercontent.com/u/74430463?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mariat</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mariat189" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/pilarfernandezz"><img src="https://avatars.githubusercontent.com/u/38540218?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Pilar Fernandez</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=pilarfernandezz" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1906,6 +1906,9 @@ Map {
         "stickyHeader": Object {
           "type": "bool",
         },
+        "useDoubleToolbar": Object {
+          "type": "bool",
+        },
         "useStaticWidth": Object {
           "type": "bool",
         },
@@ -2275,6 +2278,9 @@ Map {
           ],
           "type": "oneOf",
         },
+        "useDoubleToolbar": Object {
+          "type": "bool",
+        },
       },
     },
     "TableToolbarAction": Object {
@@ -2495,6 +2501,9 @@ Map {
       },
       "translateWithId": Object {
         "type": "func",
+      },
+      "useDoubleToolbar": Object {
+        "type": "bool",
       },
       "useStaticWidth": Object {
         "type": "bool",
@@ -7939,6 +7948,9 @@ Map {
       "stickyHeader": Object {
         "type": "bool",
       },
+      "useDoubleToolbar": Object {
+        "type": "bool",
+      },
       "useStaticWidth": Object {
         "type": "bool",
       },
@@ -8307,6 +8319,9 @@ Map {
           ],
         ],
         "type": "oneOf",
+      },
+      "useDoubleToolbar": Object {
+        "type": "bool",
       },
     },
   },

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -175,6 +175,7 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
   };
   getToolbarProps: (getToolbarPropsArgs?: { [key: string]: unknown }) => {
     size: 'sm' | undefined;
+    useDoubleToolbar: boolean | undefined;
     [key: string]: unknown;
   };
   getBatchActionProps: (getBatchActionPropsArgs?: {
@@ -195,6 +196,7 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
     stickyHeader?: boolean;
     useStaticWidth?: boolean;
     useZebraStyles?: boolean;
+    useDoubleToolbar?: boolean;
   };
   getTableContainerProps: () => {
     stickyHeader?: boolean;
@@ -255,6 +257,7 @@ export interface DataTableProps<RowType, ColTypes extends any[]>
   stickyHeader?: boolean;
   useStaticWidth?: boolean;
   useZebraStyles?: boolean;
+  useDoubleToolbar?: boolean;
 }
 
 interface DataTableState<ColTypes extends any[]> {
@@ -377,6 +380,11 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
      * `true` to add useZebraStyles striping.
      */
     useZebraStyles: PropTypes.bool,
+
+    /**
+     * `true` to display batch actions bar bellow the datagrid toolbar.
+     */
+    useDoubleToolbar: PropTypes.bool,
   };
 
   static translationKeys = Object.values(translationKeys);
@@ -678,13 +686,15 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
     props = {}
   ): {
     size: 'sm' | undefined;
+    useDoubleToolbar: boolean | undefined;
     [key: string]: unknown;
   } => {
-    const { size } = this.props;
+    const { size, useDoubleToolbar } = this.props;
     const isSmall = size === 'xs' || size === 'sm';
     return {
       ...props,
       size: isSmall ? 'sm' : undefined,
+      useDoubleToolbar,
     };
   };
 
@@ -706,6 +716,7 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
   getTableProps = () => {
     const {
       useZebraStyles,
+      useDoubleToolbar,
       size = 'lg',
       isSortable,
       useStaticWidth,
@@ -715,6 +726,7 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
     } = this.props;
     return {
       useZebraStyles,
+      useDoubleToolbar,
       size,
       isSortable,
       useStaticWidth,

--- a/packages/react/src/components/DataTable/Table.tsx
+++ b/packages/react/src/components/DataTable/Table.tsx
@@ -54,6 +54,11 @@ interface TableProps {
    * `true` to add useZebraStyles striping.
    */
   useZebraStyles?: boolean;
+
+  /**
+   * `true` to display batch actions bar bellow the datagrid toolbar.
+   */
+  useDoubleToolbar?: boolean;
 }
 
 const isElementWrappingContent = (
@@ -102,6 +107,7 @@ export const Table = ({
   className,
   children,
   useZebraStyles,
+  useDoubleToolbar,
   size = 'lg',
   isSortable = false,
   useStaticWidth,
@@ -287,6 +293,11 @@ Table.propTypes = {
    * `true` to add useZebraStyles striping.
    */
   useZebraStyles: PropTypes.bool,
+
+  /**
+   * `true` to display batch actions bar bellow the datagrid toolbar.
+   */
+  useDoubleToolbar: PropTypes.bool,
 };
 
 export default Table;

--- a/packages/react/src/components/DataTable/TableToolbar.tsx
+++ b/packages/react/src/components/DataTable/TableToolbar.tsx
@@ -34,19 +34,30 @@ export interface TableToolbarProps
    * `lg` Change the row height of table
    */
   size?: 'sm' | 'lg';
+  /**
+   *  Display batch actions bar bellow the datagrid toolbar.
+   */
+  useDoubleToolbar?: boolean | undefined;
 }
 
 const TableToolbar: React.FC<TableToolbarProps> = ({
   ['aria-label']: ariaLabel = 'data table toolbar',
   ariaLabel: deprecatedAriaLabel,
   children,
+  useDoubleToolbar,
   size,
   ...rest
 }) => {
   const prefix = usePrefix();
+  const shouldShowBatchActions =
+    children && children[0]?.props.shouldShowBatchActions;
   const className = cx({
     [`${prefix}--table-toolbar`]: true,
     [`${prefix}--table-toolbar--${size}`]: size,
+    [`${prefix}--table-toolbar--${size}--double-menu`]:
+      size && shouldShowBatchActions && useDoubleToolbar,
+    [`${prefix}--table-toolbar--double-menu`]:
+      shouldShowBatchActions && useDoubleToolbar,
   });
   return (
     <section
@@ -84,6 +95,11 @@ TableToolbar.propTypes = {
    * `lg` Change the row height of table
    */
   size: PropTypes.oneOf(['sm', 'lg']),
+
+  /**
+   *  Display batch actions bar bellow the datagrid toolbar.
+   */
+  useDoubleToolbar: PropTypes.bool,
 };
 
 export default TableToolbar;

--- a/packages/react/src/components/DataTable/__tests__/TableToolbar-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableToolbar-test.js
@@ -7,6 +7,8 @@
 
 import React from 'react';
 import TableToolbar from '../TableToolbar';
+import TableBatchActions from '../TableBatchActions';
+import TableToolbarContent from '../TableToolbarContent';
 import { render, screen } from '@testing-library/react';
 
 describe('TableToolbar', () => {
@@ -43,6 +45,37 @@ describe('TableToolbar', () => {
       const { container } = render(<TableToolbar size="sm" />);
 
       expect(container.firstChild).toHaveClass('cds--table-toolbar--sm');
+    });
+  });
+
+  describe('with double toolbar', () => {
+    it('should set the doubleToolbar class with `useDoubleToolbar`', () => {
+      const { rerender } = render(
+        <TableToolbar>
+          <TableBatchActions
+            shouldShowBatchActions={true}
+            totalSelected={0}
+            onCancel={() => {}}></TableBatchActions>
+          <TableToolbarContent />
+        </TableToolbar>
+      );
+
+      expect(screen.getByRole('region')).not.toHaveClass(
+        'cds--table-toolbar--double-menu'
+      );
+
+      rerender(
+        <TableToolbar useDoubleToolbar={true}>
+          <TableBatchActions
+            shouldShowBatchActions={true}
+            totalSelected={0}
+            onCancel={() => {}}></TableBatchActions>
+          <TableToolbarContent />
+        </TableToolbar>
+      );
+      expect(screen.getByRole('region')).toHaveClass(
+        'cds--table-toolbar--double-menu'
+      );
     });
   });
 });

--- a/packages/styles/scss/components/data-table/action/_data-table-action.scss
+++ b/packages/styles/scss/components/data-table/action/_data-table-action.scss
@@ -33,6 +33,9 @@
     inline-size: 100%;
     min-block-size: $spacing-09;
   }
+  .#{$prefix}--table-toolbar--double-menu {
+    block-size: calc(6rem + 1px);
+  }
 
   .#{$prefix}--toolbar-content {
     display: flex;
@@ -40,8 +43,7 @@
     block-size: $spacing-09;
     inline-size: 100%;
     transform: translate3d(0, 0, 0);
-    transition:
-      transform $duration-fast-02 motion(standard, productive),
+    transition: transform $duration-fast-02 motion(standard, productive),
       clip-path $duration-fast-02 motion(standard, productive);
   }
 
@@ -80,8 +82,7 @@
     box-shadow: none;
     cursor: pointer;
     inline-size: $spacing-09;
-    transition:
-      width $transition-expansion $standard-easing,
+    transition: width $transition-expansion $standard-easing,
       background-color $duration-fast-02 motion(entrance, productive);
 
     &:hover {
@@ -379,12 +380,15 @@
     inline-size: $spacing-09;
   }
 
-  .#{$prefix}--batch-actions--active ~ .#{$prefix}--toolbar-search-container,
-  .#{$prefix}--batch-actions--active ~ .#{$prefix}--toolbar-content {
+  :not(.#{$prefix}--table-toolbar--double-menu)
+    ~ .#{$prefix}--batch-actions--active
+    ~ .#{$prefix}--toolbar-search-container,
+  :not(.#{$prefix}--table-toolbar--double-menu)
+    ~ .#{$prefix}--batch-actions--active
+    ~ .#{$prefix}--toolbar-content {
     clip-path: polygon(0 0, 100% 0, 100% 0, 0 0);
     transform: translate3d(0, 48px, 0);
-    transition:
-      transform $duration-fast-02 motion(standard, productive),
+    transition: transform $duration-fast-02 motion(standard, productive),
       clip-path $duration-fast-02 motion(standard, productive);
   }
 
@@ -403,8 +407,7 @@
     opacity: 0;
     pointer-events: none;
     transform: translate3d(0, 48px, 0);
-    transition:
-      transform $duration-fast-02 motion(standard, productive),
+    transition: transform $duration-fast-02 motion(standard, productive),
       clip-path $duration-fast-02 motion(standard, productive),
       opacity $duration-fast-02 motion(standard, productive);
     will-change: transform;
@@ -625,6 +628,11 @@
       block-size: 2rem;
       inline-size: 2rem;
     }
+  }
+
+  .#{$prefix}--table-toolbar--sm--double-menu {
+    block-size: convert.to-rem(65px);
+    min-block-size: convert.to-rem(65px);
   }
 
   .#{$prefix}--search--disabled .#{$prefix}--search-magnifier-icon:hover {


### PR DESCRIPTION
Closes #17844

This PR allows both Batch Actions and Actions toolbars to be displayed simultaneously.
Right now the Batch Actions toolbar overrides the Actions toolbar when there is some row selected. With that, the search bar and actions buttons can not be changed/clicked.

<img width="1591" alt="image" src="https://github.com/user-attachments/assets/fa7c0869-1f51-4cdf-9c7e-530d0d4025bc">

#### Changelog

**New**

- Added ```useDoubleToolbar``` property to Table and TableToolbar.  

**Changed**

- The default value for the prop is ``` false```, maintaining the current behavior. 
- If the prop is ```true``` the Batch Actions toolbar will be displayed bellow the Actions toolbar.


#### Testing / Reviewing

Change the prop to true and select any row in the DataTable. The blue Batch Actions toolbar should be displayed bellow the Actions toolbar. Should be possible to click in the Actions buttons and edit the search bar input.
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/8a701a5d-dfcc-4669-b09e-cb7a33b2d737">
