### PR TITLE
fix(radiobuttongroup): accessibility

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6591,6 +6591,9 @@ Map {
       "helperText": Object {
         "type": "node",
       },
+      "hideLegendText": Object {
+        "type": "bool",
+      },
       "invalid": Object {
         "type": "bool",
       },

--- a/packages/react/src/components/RadioButton/RadioButton.stories.js
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.js
@@ -236,6 +236,7 @@ Playground.args = {
   invalidText: 'Invalid selection',
   warn: false,
   warnText: 'Please notice the warning',
+  hideLegendText: false,
 };
 
 Playground.argTypes = {
@@ -270,6 +271,13 @@ Playground.argTypes = {
       'Provide the text that is displayed when the control is in an invalid state',
     control: {
       type: 'text',
+    },
+  },
+  hideLegendText: {
+    description:
+      'Specify whether the `legendText` should be hidden, or not. Provide a `legendText` to meet accessibility standards if `hideLegendText` is true',
+    control: {
+      type: 'boolean',
     },
   },
   orientation: {

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -56,6 +56,11 @@ export interface RadioButtonGroupProps
   helperText?: ReactNode;
 
   /**
+   * Specify whether the `legendText` should be hidden, or not. Provide a `legendText` to meet accessibility standards if `hideLegendText` is true
+   */
+  hideLegendText?: boolean;
+
+  /**
    * Specify whether the control is currently invalid
    */
   invalid?: boolean;
@@ -135,6 +140,7 @@ const RadioButtonGroup = React.forwardRef(
       defaultSelected,
       disabled,
       helperText,
+      hideLegendText = false,
       invalid = false,
       invalidText,
       labelPosition = 'right',
@@ -250,12 +256,13 @@ const RadioButtonGroup = React.forwardRef(
     return (
       <div className={wrapperClasses} ref={mergeRefs(divRef, ref)}>
         <fieldset
+          aria-label={legendText?.toString()}
           className={fieldsetClasses}
           disabled={disabled}
           data-invalid={invalid ? true : undefined}
           aria-describedby={showHelper && helperText ? helperId : undefined}
           {...rest}>
-          {legendText && (
+          {legendText && !hideLegendText && (
             <Legend className={`${prefix}--label`}>
               {legendText}
               {normalizedSlug}
@@ -312,6 +319,11 @@ RadioButtonGroup.propTypes = {
    * Provide text that is used alongside the control label for additional help
    */
   helperText: PropTypes.node,
+
+  /**
+   * Specify whether the `legendText` should be hidden, or not. Provide a `legendText` to meet accessibility standards if `hideLegendText` is true
+   */
+  hideLegendText: PropTypes.bool,
 
   /**
    * Specify whether the control is currently invalid

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -253,17 +253,20 @@ const RadioButtonGroup = React.forwardRef(
       });
     }
 
+    const legendTextClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--visually-hidden`]: hideLegendText,
+    });
+
     return (
       <div className={wrapperClasses} ref={mergeRefs(divRef, ref)}>
         <fieldset
-          aria-label={legendText?.toString()}
           className={fieldsetClasses}
           disabled={disabled}
           data-invalid={invalid ? true : undefined}
           aria-describedby={showHelper && helperText ? helperId : undefined}
           {...rest}>
-          {legendText && !hideLegendText && (
-            <Legend className={`${prefix}--label`}>
+          {legendText && (
+            <Legend className={legendTextClasses}>
               {legendText}
               {normalizedSlug}
             </Legend>


### PR DESCRIPTION
Closes #17753 

Added a new prop called `hideLegendText` to hide the `legendText` visually, the `<legend>` still on the DOM to meet accessibility standards.

#### Testing / Reviewing

- Toggle the prop on the `Playground`
- Run IBM Accessibility Checker