### PR TITLE
fix(Dropdown): make titleText required

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -220,7 +220,7 @@ export interface DropdownProps<ItemType>
    * Provide the title text that will be read by a screen reader when
    * visiting this control
    */
-  titleText?: ReactNode;
+  titleText: ReactNode;
 
   /**
    * The dropdown type, `default` or `inline`


### PR DESCRIPTION
Closes #16602
related #12809

This PR makes the `titleText` prop required for the dropdown component again to resolve console errors when the prop is undefined

#### Changelog

**Changed**

- `titleText` required in dropdown component agani

#### Testing / Reviewing

confirm no prop type errors are logged when `titleText` is missing or undefined in dropdown components