### PR TITLE
fix: web componet dynamic row changes

### DIFF
--- a/packages/web-components/src/components/data-table/stories/data-table-expansion.stories.ts
+++ b/packages/web-components/src/components/data-table/stories/data-table-expansion.stories.ts
@@ -255,115 +255,116 @@ export const BatchExpansion = {
 export const Playground = {
   args: defaultArgs,
   argTypes: controls,
-  render: ({
-    isSortable,
-    locale,
-    size,
-    useStaticWidth,
-    useZebraStyles,
-  }) => html`
-    <cds-table
-      expandable
-      ?is-sortable=${isSortable}
-      locale="${locale}"
-      size="${size}"
-      ?use-static-width="${useStaticWidth}"
-      ?use-zebra-styles="${useZebraStyles}">
-      <cds-table-header-title slot="title">DataTable</cds-table-header-title>
-      <cds-table-header-description slot="description"
-        >With expansion</cds-table-header-description
-      >
+  render: ({ isSortable, locale, size, useStaticWidth, useZebraStyles }) => {
+    setTimeout(() => {
+      const tableBody = document.querySelector('cds-table-body');
+      if (tableBody) {
+        tableBody.innerHTML = `<cds-table-row>
+            <cds-table-cell>Load Balancer 3</cds-table-cell>
+            <cds-table-cell>HTTP</cds-table-cell>
+            <cds-table-cell>3000</cds-table-cell>
+            <cds-table-cell>Round robin</cds-table-cell>
+            <cds-table-cell>Kevin's VM Groups</cds-table-cell>
+            <cds-table-cell
+              ><cds-link disabled>Disabled</cds-link></cds-table-cell
+            >
+          </cds-table-row>
+          <cds-table-expanded-row>
+            <h6>Expandable row content</h6>
+            <div>Description here</div>
+          </cds-table-expanded-row>
+          <cds-table-row>
+            <cds-table-cell>Load Balancer 1</cds-table-cell>
+            <cds-table-cell>HTTP</cds-table-cell>
+            <cds-table-cell>443</cds-table-cell>
+            <cds-table-cell>Round robin</cds-table-cell>
+            <cds-table-cell>Maureen's VM Groups</cds-table-cell>
+            <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
+          </cds-table-row>
+          <cds-table-expanded-row>
+            <h6>Expandable row content</h6>
+            <div>Description here</div>
+          </cds-table-expanded-row>
+          <cds-table-row>
+            <cds-table-cell>Load Balancer 2</cds-table-cell>
+            <cds-table-cell>HTTP</cds-table-cell>
+            <cds-table-cell>80</cds-table-cell>
+            <cds-table-cell>DNS delegation</cds-table-cell>
+            <cds-table-cell>Andrew's VM Groups</cds-table-cell>
+            <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
+          </cds-table-row>
+          <cds-table-expanded-row>
+            <h6>Expandable row content</h6>
+            <div>Description here</div>
+          </cds-table-expanded-row>
+          <cds-table-row>
+            <cds-table-cell>Load Balancer 6</cds-table-cell>
+            <cds-table-cell>HTTP</cds-table-cell>
+            <cds-table-cell>3000</cds-table-cell>
+            <cds-table-cell>Round robin</cds-table-cell>
+            <cds-table-cell>Marc's VM Groups</cds-table-cell>
+            <cds-table-cell
+              ><cds-link disabled>Disabled</cds-link></cds-table-cell
+            >
+          </cds-table-row>
+          <cds-table-expanded-row>
+            <h6>Expandable row content</h6>
+            <div>Description here</div>
+          </cds-table-expanded-row>
+          <cds-table-row>
+            <cds-table-cell>Load Balancer 4</cds-table-cell>
+            <cds-table-cell>HTTP</cds-table-cell>
+            <cds-table-cell>443</cds-table-cell>
+            <cds-table-cell>Round robin</cds-table-cell>
+            <cds-table-cell>Mel's VM Groups</cds-table-cell>
+            <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
+          </cds-table-row>
+          <cds-table-expanded-row>
+            <h6>Expandable row content</h6>
+            <div>Description here</div>
+          </cds-table-expanded-row>
+          <cds-table-row>
+            <cds-table-cell>Load Balancer 5</cds-table-cell>
+            <cds-table-cell>HTTP</cds-table-cell>
+            <cds-table-cell>80</cds-table-cell>
+            <cds-table-cell>DNS delegation</cds-table-cell>
+            <cds-table-cell>Ronja's VM Groups</cds-table-cell>
+            <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
+          </cds-table-row>
+          <cds-table-expanded-row>
+            <h6>Expandable row content</h6>
+            <div>Description here</div>
+          </cds-table-expanded-row>`;
+      }
+    }, 1);
 
-      <cds-table-head>
-        <cds-table-header-row>
-          <cds-table-header-cell>Name</cds-table-header-cell>
-          <cds-table-header-cell>Protocol</cds-table-header-cell>
-          <cds-table-header-cell>Port</cds-table-header-cell>
-          <cds-table-header-cell>Rule</cds-table-header-cell>
-          <cds-table-header-cell>Attached groups</cds-table-header-cell>
-          <cds-table-header-cell>Status</cds-table-header-cell>
-        </cds-table-header-row>
-      </cds-table-head>
-      <cds-table-body>
-        <cds-table-row>
-          <cds-table-cell>Load Balancer 3</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>3000</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Kevin's VM Groups</cds-table-cell>
-          <cds-table-cell
-            ><cds-link disabled>Disabled</cds-link></cds-table-cell
-          >
-        </cds-table-row>
-        <cds-table-expanded-row>
-          <h6>Expandable row content</h6>
-          <div>Description here</div>
-        </cds-table-expanded-row>
-        <cds-table-row>
-          <cds-table-cell>Load Balancer 1</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>443</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Maureen's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-expanded-row>
-          <h6>Expandable row content</h6>
-          <div>Description here</div>
-        </cds-table-expanded-row>
-        <cds-table-row>
-          <cds-table-cell>Load Balancer 2</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>80</cds-table-cell>
-          <cds-table-cell>DNS delegation</cds-table-cell>
-          <cds-table-cell>Andrew's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-expanded-row>
-          <h6>Expandable row content</h6>
-          <div>Description here</div>
-        </cds-table-expanded-row>
-        <cds-table-row>
-          <cds-table-cell>Load Balancer 6</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>3000</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Marc's VM Groups</cds-table-cell>
-          <cds-table-cell
-            ><cds-link disabled>Disabled</cds-link></cds-table-cell
-          >
-        </cds-table-row>
-        <cds-table-expanded-row>
-          <h6>Expandable row content</h6>
-          <div>Description here</div>
-        </cds-table-expanded-row>
-        <cds-table-row>
-          <cds-table-cell>Load Balancer 4</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>443</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Mel's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-expanded-row>
-          <h6>Expandable row content</h6>
-          <div>Description here</div>
-        </cds-table-expanded-row>
-        <cds-table-row>
-          <cds-table-cell>Load Balancer 5</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>80</cds-table-cell>
-          <cds-table-cell>DNS delegation</cds-table-cell>
-          <cds-table-cell>Ronja's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-expanded-row>
-          <h6>Expandable row content</h6>
-          <div>Description here</div>
-        </cds-table-expanded-row>
-      </cds-table-body>
-    </cds-table>
-  `,
+    return html`
+      <cds-table
+        expandable
+        ?is-sortable=${isSortable}
+        locale="${locale}"
+        size="${size}"
+        ?use-static-width="${useStaticWidth}"
+        ?use-zebra-styles="${useZebraStyles}">
+        <cds-table-header-title slot="title">DataTable</cds-table-header-title>
+        <cds-table-header-description slot="description"
+          >With expansion</cds-table-header-description
+        >
+
+        <cds-table-head>
+          <cds-table-header-row>
+            <cds-table-header-cell>Name</cds-table-header-cell>
+            <cds-table-header-cell>Protocol</cds-table-header-cell>
+            <cds-table-header-cell>Port</cds-table-header-cell>
+            <cds-table-header-cell>Rule</cds-table-header-cell>
+            <cds-table-header-cell>Attached groups</cds-table-header-cell>
+            <cds-table-header-cell>Status</cds-table-header-cell>
+          </cds-table-header-row>
+        </cds-table-head>
+        <cds-table-body> </cds-table-body>
+      </cds-table>
+    `;
+  },
 };
 
 const meta = {

--- a/packages/web-components/src/components/data-table/table-body.ts
+++ b/packages/web-components/src/components/data-table/table-body.ts
@@ -46,6 +46,12 @@ class CDSTableBody extends LitElement {
    */
   private _handleSlotChange = () => {
     this._updateZebra();
+    this.dispatchEvent(
+      new CustomEvent(
+        (this.constructor as typeof CDSTableBody).eventTableBodyContentChange,
+        { bubbles: true, cancelable: false }
+      )
+    );
   };
 
   /**
@@ -78,6 +84,13 @@ class CDSTableBody extends LitElement {
   render() {
     const { _handleSlotChange: handleSlotChange } = this;
     return html` <slot @slotchange="${handleSlotChange}"></slot> `;
+  }
+
+  /**
+   * The name of the custom event fired after the body slot content changes
+   */
+  static get eventTableBodyContentChange() {
+    return `${prefix}-table-body-content-change`;
   }
 
   static styles = styles;


### PR DESCRIPTION
Closes #17894

Rows changed dynamically, e.g. by pagination, make the internals of `cds-table` stale. Specifically things like `expandable` are not persisted between pages.

#### Changelog

**Changed**

- packages/web-components/src/components/data-table/stories/data-table-expansion.stories.ts - delay the rendering of the table rows for the `Playground` story to simulate changing rows at runtime.
- packages/web-components/src/components/data-table/table-body.ts - raise `cds-table-body-content-change` from table body when the slot contents change.
- packages/web-components/src/components/data-table/table.ts - update this._tableBody, this._tableExpandedRows, this._tableRows and re-run assigning expandable to rows on `cds-table-body-content-change`.

#### Testing / Reviewing

Verified in altered storybook story.