### PR TITLE
ci(actions): close issues with no reproduction

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e #v9.0.0
         with:
           any-of-issue-labels:
-            "status: waiting for author's response 💬,status: needs more info 🤷‍♀️"
+            "status: waiting for author's response 💬,status: needs more info 🤷‍♀️,status: needs reproduction"
           only-pr-labels: ''
           stale-issue-message: |
             This issue has been marked as stale because it has required additional


### PR DESCRIPTION
Part of #13138, specifically:

> Triage automation: Auto close issues that have needs reproduction label for x days (7 days ?)

### Implementation

There's no easy way to work out when a label was applied from the GitHub API. Instead, we just check for issues with the `status: needs reproduction` label that haven't been updated at all in the last X days.

This action would currently close the following two issues, but may apply to more if you start automatically adding the "need reproduction" label to new issues.

```
ID      TITLE                                                                          LABELS                                                              UPDATED           
#17321  [Bug]: Problems when update from carbon-components to @Carbon/react            type: bug 🐛, status: needs triage 🕵️, status: needs reproduction    about 27 days ago
#16083  [a11y]: SideNavMenuItem is not keyboard operable, unable to focus using tab    type: a11y ♿, status: needs reproduction                            about 2 months ago
```
