### PR TITLE
fix(Tabs): handle activation mode scrolling in separate `useIsomorphicEffect`s

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -606,13 +606,13 @@ function TabList({
 
   useIsomorphicEffect(() => {
     if (ref.current) {
-      //adding 1 in calculation for firefox support
+      // adding 1 in calculation for firefox support
       setIsScrollable(ref.current.scrollWidth > ref.current.clientWidth + 1);
     }
 
     function handler() {
       if (ref.current) {
-        //adding 1 in calculation for firefox support
+        // adding 1 in calculation for firefox support
         setIsScrollable(ref.current.scrollWidth > ref.current.clientWidth + 1);
       }
     }

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -565,6 +565,40 @@ function TabList({
     }
   }
 
+  /**
+   * Scroll the tab into view if it is not already visible
+   * @param tab - The tab to scroll into view
+   * @returns {void}
+   */
+  function scrollTabIntoView(tab) {
+    if (!isScrollable || !ref.current) {
+      return;
+    }
+    if (tab) {
+      // The width of the "scroll buttons"
+      const { width: tabWidth } = tab.getBoundingClientRect();
+
+      // The start and end position of the selected tab
+      const start = tab.offsetLeft;
+      const end = tab.offsetLeft + tabWidth;
+
+      // The start and end of the visible area for the tabs
+      const visibleStart = ref.current.scrollLeft + buttonWidth;
+      const visibleEnd =
+        ref.current.scrollLeft + ref.current.clientWidth - buttonWidth;
+
+      // The beginning of the tab is clipped and not visible
+      if (start < visibleStart) {
+        setScrollLeft(start - buttonWidth);
+      }
+
+      // The end of the tab is clipped and not visible
+      if (end > visibleEnd) {
+        setScrollLeft(end + buttonWidth - ref.current.clientWidth);
+      }
+    }
+  }
+
   useEffectOnce(() => {
     const tab = tabs.current[selectedIndex];
     if (scrollIntoView && tab) {

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -666,39 +666,21 @@ function TabList({
     }
   }, [scrollLeft]);
 
+  // scroll manual tabs when active index changes (focus outline movement)
   useIsomorphicEffect(() => {
-    if (!isScrollable || !ref.current) {
-      return;
-    }
-
     const tab =
       activation === 'manual'
         ? tabs.current[activeIndex]
         : tabs.current[selectedIndex];
-    if (tab) {
-      // The width of the "scroll buttons"
 
-      // The start and end position of the selected tab
-      const { width: tabWidth } = tab.getBoundingClientRect();
-      const start = tab.offsetLeft;
-      const end = tab.offsetLeft + tabWidth;
+    scrollTabIntoView(tab);
+  }, [activation, activeIndex]);
 
-      // The start and end of the visible area for the tabs
-      const visibleStart = ref.current.scrollLeft + buttonWidth;
-      const visibleEnd =
-        ref.current.scrollLeft + ref.current.clientWidth - buttonWidth;
-
-      // The beginning of the tab is clipped and not visible
-      if (start < visibleStart) {
-        setScrollLeft(start - buttonWidth);
-      }
-
-      // The end of the tab is clipped and not visible
-      if (end > visibleEnd) {
-        setScrollLeft(end + buttonWidth - ref.current.clientWidth);
-      }
-    }
-  }, [activation, activeIndex, selectedIndex, isScrollable, children]);
+  // scroll tabs when selected index changes
+  useIsomorphicEffect(() => {
+    const tab = tabs.current[selectedIndex];
+    scrollTabIntoView(tab);
+  }, [selectedIndex, isScrollable, children]);
 
   usePressable(previousButton, {
     onPress({ longPress }) {


### PR DESCRIPTION
**NOTE: there is a test story that should be removed before merge**

---

Closes #17274

This PR updates the Tab component to scroll programmatically selected tabs into view, regardless of tab `activation` type

Prior to this PR, Tabs in manual `activation` mode would only scroll when the active tab changed. Normally this is not an issue but when the selected tab is modified programmatically, the lack of user interaction means the selection does not occur on the active tab.

By splitting the existing `useIsomorphicEffect` into two separate hooks, they can handle `manual` and `auto` activation modes separately. This ensures that the component will scroll as needed both when changing the selected tab and when changing the active tab in manual `activation mode

#### Changelog

**New**

- `scrollTabIntoView` Tab method

**Changed**

- split existing `useIsomorphicEffect` that handled scrolling into two distinct `useIsomorphicEffect`s for each `activation` mode

#### Testing / Reviewing

- visit the temporary Test Tabs story
- confirm that both activation modes will scroll the correct tabs into view as needed
