### PR TITLE
refactor: reverts  useFeatureFlag's return statement

### DIFF
--- a/packages/react/src/components/FeatureFlags/index.tsx
+++ b/packages/react/src/components/FeatureFlags/index.tsx
@@ -160,8 +160,7 @@ function useChangedValue<T>(
  */
 function useFeatureFlag(flag) {
   const scope = useContext(FeatureFlagContext);
-  //updated to return false for undefined flags
-  return scope.enabled(flag) ?? false;
+  return scope.enabled(flag);
 }
 
 /**


### PR DESCRIPTION

Reverted `return scope.enabled(flag) ?? false;` to `return scope.enabled(flag) `
because an [error](https://github.com/carbon-design-system/carbon/blob/c300d451e97f16ebbc9df35744173430b2318740/packages/feature-flags/src/FeatureFlagScope.js#L26) is thrown for undefined flags rather than returning undefined

#### Changelog

**Changed**
`return scope.enabled(flag) ?? false;` to `return scope.enabled(flag) `

#### Testing / Reviewing
CI should pass

