### PR TITLE
chore(project): update the postinstall messages for deprecated packages

### DIFF
--- a/packages/carbon-components-react/scripts/postinstall.js
+++ b/packages/carbon-components-react/scripts/postinstall.js
@@ -4,12 +4,8 @@ const chalk = require('chalk');
 
 console.warn(
   chalk.yellow('Warning: ') +
+    'the ' +
     chalk.cyan('carbon-components-react') +
-    " will soon be deprecated and no longer receive updates. We recommend to move to it's replacement, " +
-    chalk.cyan('@carbon/react') +
-    '  at your earliest convenience. Please visit ' +
-    chalk.dim.underline.italic(
-      'https://github.com/carbon-design-system/carbon/discussions/12179'
-    ) +
-    ' for more information on the package strategy, deprecation, and plan of action.'
+    ' package is no longer supported. More info at ' +
+    chalk.dim.underline.italic('https://carbondesignsystem.com/deprecations/')
 );

--- a/packages/carbon-components/scripts/postinstall.js
+++ b/packages/carbon-components/scripts/postinstall.js
@@ -4,12 +4,8 @@ const chalk = require('chalk');
 
 console.warn(
   chalk.yellow('Warning: ') +
+    'the ' +
     chalk.cyan('carbon-components') +
-    " will soon be deprecated and no longer receive updates. We recommend to move to it's replacement, " +
-    chalk.cyan('@carbon/styles') +
-    '  at your earliest convenience. Please visit ' +
-    chalk.dim.underline.italic(
-      'https://github.com/carbon-design-system/carbon/discussions/12179'
-    ) +
-    ' for more information on the package strategy, deprecation, and plan of action.'
+    ' package is no longer supported. More info at ' +
+    chalk.dim.underline.italic('https://carbondesignsystem.com/deprecations/')
 );


### PR DESCRIPTION
This is a bit redundant since npm emits the warning now, but I think it's worth having the correct info in case someone sees it in their logs.

#### Changelog

**Changed**

- update `carbon-components` and `carbon-components-react` postinstall message to reflect their end-of-support status and match the message emitted by npm