### PR TITLE
fix(storybook): update Percy config, add plex CDN as an allowed hostname

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -5,3 +5,6 @@ snapshot:
     - 360
     - 1366
   minHeight: 1024
+discovery:
+  allowed-hostnames:
+    - 1.www.s81c.com


### PR DESCRIPTION
I've been noticing that we've been having some churn on our Percy status checks since https://github.com/carbon-design-system/carbon/pull/17308. I believe this config update should ensure that plex always loads from the CDN and we'll stop seeing snapshots using non-plex fonts.

#### Changelog

**New**

- add akamai cdn as an allowed hostname in percy config

#### Testing / Reviewing

- Review the percy status check, there may be some snapshot updates needed but they should all be using Plex and not another font
