### PR TITLE
fix(inline-dropdown): remove unnecessary column with props.hideLabel

### DIFF
--- a/packages/styles/scss/components/dropdown/_dropdown.scss
+++ b/packages/styles/scss/components/dropdown/_dropdown.scss
@@ -29,6 +29,10 @@
     grid-gap: 0 convert.to-rem(24px);
     grid-template: auto / auto min-content;
 
+    &:has(.#{$prefix}--label.#{$prefix}--visually-hidden) {
+      grid-template: auto / auto;
+    }
+
     .#{$prefix}--label {
       @include type-style('body-compact-01');
     }
@@ -215,8 +219,7 @@
   .#{$prefix}--dropdown-item {
     position: relative;
     opacity: 0;
-    transition:
-      visibility $duration-fast-01 motion(standard, productive),
+    transition: visibility $duration-fast-01 motion(standard, productive),
       opacity $duration-fast-01 motion(standard, productive),
       background-color $duration-fast-01 motion(standard, productive);
     visibility: inherit;

--- a/packages/styles/scss/components/dropdown/_dropdown.scss
+++ b/packages/styles/scss/components/dropdown/_dropdown.scss
@@ -219,7 +219,8 @@
   .#{$prefix}--dropdown-item {
     position: relative;
     opacity: 0;
-    transition: visibility $duration-fast-01 motion(standard, productive),
+    transition:
+      visibility $duration-fast-01 motion(standard, productive),
       opacity $duration-fast-01 motion(standard, productive),
       background-color $duration-fast-01 motion(standard, productive);
     visibility: inherit;


### PR DESCRIPTION
This fixes a bug where an inline dropdown with `props.hideLabel` is trailed with an unnecessary grid column, leading to dead space and layout issues.

Before
<img width="473" alt="image" src="https://github.com/user-attachments/assets/db345fe6-7fc2-41b4-ab87-d4ed44fcd423">

After
<img width="471" alt="image" src="https://github.com/user-attachments/assets/56c71b4b-82f5-4a24-a047-0abfa71dbe7d">


#### Changelog

**Changed**

- Added selector to change the `grid-template` when the inline dropdown has a hidden label.

#### Testing / Reviewing

```jsx
<Dropdown
  …
  type="inline"
  hideLabel
/>
```
