### PR TITLE
fix(pagination-nav): enforce a minimum of 4 items shown

### DIFF
--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -292,7 +292,7 @@ interface PaginationNavProps
   disableOverflow?: boolean;
 
   /**
-   * The number of items to be shown.
+   * The number of items to be shown (minimum of 4).
    */
   itemsShown?: number;
 
@@ -398,8 +398,8 @@ const PaginationNav = React.forwardRef<HTMLElement, PaginationNavProps>(
 
     // re-calculate cuts if props.totalItems or props.itemsShown change
     useEffect(() => {
-      setItemsDisplayedOnPage(itemsShown >= 4 ? itemsShown : 4);
-      setCuts(calculateCuts(currentPage, totalItems, itemsShown));
+      setItemsDisplayedOnPage(Math.max(itemsShown, 4));
+      setCuts(calculateCuts(currentPage, totalItems, Math.max(itemsShown, 4)));
     }, [totalItems, itemsShown]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // update cuts if necessary whenever currentPage changes
@@ -622,7 +622,7 @@ PaginationNav.propTypes = {
   disableOverflow: PropTypes.bool, // eslint-disable-line react/prop-types
 
   /**
-   * The number of items to be shown.
+   * The number of items to be shown (minimum of 4).
    */
   itemsShown: PropTypes.number,
 

--- a/packages/react/src/components/PaginationNav/PaginationNav.tsx
+++ b/packages/react/src/components/PaginationNav/PaginationNav.tsx
@@ -292,7 +292,7 @@ interface PaginationNavProps
   disableOverflow?: boolean;
 
   /**
-   * The number of items to be shown (minimum of 4).
+   * The number of items to be shown (minimum of 4 unless props.items < 4).
    */
   itemsShown?: number;
 
@@ -622,7 +622,7 @@ PaginationNav.propTypes = {
   disableOverflow: PropTypes.bool, // eslint-disable-line react/prop-types
 
   /**
-   * The number of items to be shown (minimum of 4).
+   * The number of items to be shown (minimum of 4 unless props.items < 4).
    */
   itemsShown: PropTypes.number,
 


### PR DESCRIPTION
The minimum number of items shown on the PaginationNav was intended to be 4. Many parts of the code referenced this but in the `useEffect` that triggers when `props.itemsShown` or `props.items` changes, one of the two functions wasn't provided with this limitation. Therefore, in some scenarios, the component was able to be set to `3` which causes visual and interaction issues.

This PR enforces the intended minimum of 4 and adds this note to the prop types.

#### Changelog

**Changed**

- Ensure a minimum of 4 items (unless `props.items` is less than 4 and therefore no truncation would happen).

#### Testing / Reviewing

1. Start local storybook
2. Navigate to the Playground story for PaginationNav
3. Change `props.itemsShown` to 1, 2, or 3.
4. It should still show 4 items (incl. overflow indicators)