### PR TITLE
Added `decorator` to `DatepickerInput` component

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2725,6 +2725,9 @@ Map {
         ],
         "type": "oneOf",
       },
+      "decorator": Object {
+        "type": "node",
+      },
       "disabled": Object {
         "type": "bool",
       },
@@ -2771,9 +2774,7 @@ Map {
         ],
         "type": "oneOf",
       },
-      "slug": Object {
-        "type": "node",
-      },
+      "slug": [Function],
       "type": Object {
         "type": "string",
       },

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -196,14 +196,14 @@ describe('DatePicker', () => {
     expect(ref).toHaveBeenCalledWith(container.firstChild);
   });
 
-  it('should respect slug prop', () => {
+  it('should respect decorator prop', () => {
     render(
       <DatePickerInput
         id="date-picker-input-id-start"
         placeholder="mm/dd/yyyy"
         labelText="Date Picker label"
         data-testid="input-value"
-        slug={<AILabel />}
+        decorator={<AILabel />}
       />
     );
 

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -212,6 +212,24 @@ describe('DatePicker', () => {
     );
   });
 
+  it('should respect deprecated slug prop', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <DatePickerInput
+        id="date-picker-input-id-start"
+        placeholder="mm/dd/yyyy"
+        labelText="Date Picker label"
+        data-testid="input-value"
+        slug={<AILabel />}
+      />
+    );
+
+    expect(screen.getByRole('button')).toHaveClass(
+      `${prefix}--ai-label__button`
+    );
+    spy.mockRestore();
+  });
+
   it('should respect parseDate prop', async () => {
     const parseDate = jest.fn();
     parseDate.mockReturnValueOnce(new Date('1989/01/20'));

--- a/packages/react/src/components/DatePicker/DatePicker.stories.js
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.js
@@ -15,9 +15,10 @@ import DatePickerInput from '../DatePickerInput';
 import Button from '../Button';
 import { AILabel, AILabelContent, AILabelActions } from '../AILabel';
 import { IconButton } from '../IconButton';
-import { View, FolderOpen, Folders } from '@carbon/icons-react';
+import { View, FolderOpen, Folders, Information } from '@carbon/icons-react';
 
 import mdx from './DatePicker.mdx';
+import { Tooltip } from '../Tooltip';
 
 export default {
   title: 'Components/DatePicker',
@@ -172,7 +173,22 @@ export const withAILabel = () => (
         labelText="Date Picker label"
         size="md"
         id="date-picker"
-        slug={aiLabel}
+        decorator={aiLabel}
+      />
+    </DatePicker>
+
+    {/* Test decorator with Tooltip TO BE REMOVED!! */}
+    <DatePicker datePickerType="single">
+      <DatePickerInput
+        placeholder="mm/dd/yyyy"
+        labelText="Date Picker label"
+        size="md"
+        id="date-picker"
+        decorator={
+          <Tooltip>
+            <Information></Information>
+          </Tooltip>
+        }
       />
     </DatePicker>
   </div>

--- a/packages/react/src/components/DatePicker/DatePicker.stories.js
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.js
@@ -166,7 +166,7 @@ const aiLabel = (
 );
 
 export const withAILabel = () => (
-  <div style={{ width: 400 }}>
+  <div style={{ width: 400, display: 'flex', gap: '1rem' }}>
     <DatePicker datePickerType="single">
       <DatePickerInput
         placeholder="mm/dd/yyyy"
@@ -186,7 +186,7 @@ export const withAILabel = () => (
         id="date-picker"
         decorator={
           <Tooltip>
-            <Information></Information>
+            <Information />
           </Tooltip>
         }
       />

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -226,7 +226,7 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
 
   // AILabel always size `mini`
   let normalizedDecorator = React.isValidElement(slug ?? decorator)
-    ? slug ?? decorator
+    ? (slug ?? decorator)
     : null;
   if (
     normalizedDecorator &&

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -8,12 +8,13 @@
 import { Calendar, WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import cx from 'classnames';
 import PropTypes, { ReactElementLike, ReactNodeArray } from 'prop-types';
-import React, { ForwardedRef, useContext } from 'react';
+import React, { ForwardedRef, ReactNode, useContext } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 import { useId } from '../../internal/useId';
 import { ReactAttr } from '../../types/common';
 import { Text } from '../Text';
+import deprecate from '../../prop-types/deprecate';
 
 type ExcludedAttributes = 'value' | 'onChange' | 'locale' | 'children';
 export type ReactNodeLike =
@@ -37,6 +38,11 @@ export interface DatePickerInputProps
    * * `range` - With calendar dropdown and a date range.
    */
   datePickerType?: 'simple' | 'single' | 'range';
+
+  /**
+   * **Experimental**: Provide a `decorator` component to be rendered inside the `RadioButton` component
+   */
+  decorator?: ReactNode;
 
   /**
    * Specify whether or not the input should be disabled
@@ -111,6 +117,7 @@ export interface DatePickerInputProps
   size?: 'sm' | 'md' | 'lg';
 
   /**
+   * @deprecated please use decorator instead.
    * **Experimental**: Provide a `Slug` component to be rendered inside the `DatePickerInput` component
    */
   slug?: ReactNodeLike;
@@ -137,6 +144,7 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
 ) {
   const {
     datePickerType,
+    decorator,
     disabled = false,
     helperText,
     hideLabel,
@@ -178,6 +186,7 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
     [`${prefix}--date-picker-input__wrapper--invalid`]: invalid,
     [`${prefix}--date-picker-input__wrapper--warn`]: warn,
     [`${prefix}--date-picker-input__wrapper--slug`]: slug,
+    [`${prefix}--date-picker-input__wrapper--decorator`]: decorator,
   });
   const labelClasses = cx(`${prefix}--label`, {
     [`${prefix}--visually-hidden`]: hideLabel,
@@ -215,12 +224,20 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
   }
   const input = <input {...inputProps} />;
 
-  // Slug is always size `mini`
-  let normalizedSlug;
-  if (slug && slug['type']?.displayName === 'AILabel') {
-    normalizedSlug = React.cloneElement(slug as React.ReactElement<any>, {
-      size: 'mini',
-    });
+  // AILabel always size `mini`
+  let normalizedDecorator = React.isValidElement(slug ?? decorator)
+    ? slug ?? decorator
+    : null;
+  if (
+    normalizedDecorator &&
+    normalizedDecorator['type']?.displayName === 'AILabel'
+  ) {
+    normalizedDecorator = React.cloneElement(
+      normalizedDecorator as React.ReactElement<any>,
+      {
+        size: 'mini',
+      }
+    );
   }
 
   return (
@@ -233,7 +250,16 @@ const DatePickerInput = React.forwardRef(function DatePickerInput(
       <div className={wrapperClasses}>
         <span>
           {input}
-          {normalizedSlug}
+          {slug ? (
+            normalizedDecorator
+          ) : decorator ? (
+            <div
+              className={`${prefix}--date-picker-input-inner-wrapper--decorator`}>
+              {normalizedDecorator}
+            </div>
+          ) : (
+            ''
+          )}
           {isFluid && <DatePickerIcon datePickerType={datePickerType} />}
           <DatePickerIcon
             datePickerType={datePickerType}
@@ -279,6 +305,11 @@ DatePickerInput.propTypes = {
    * * `range` - With calendar dropdown and a date range.
    */
   datePickerType: PropTypes.oneOf(['simple', 'single', 'range']),
+
+  /**
+   * **Experimental**: Provide a decorator component to be rendered inside the `RadioButton` component
+   */
+  decorator: PropTypes.node,
 
   /**
    * Specify whether or not the input should be disabled
@@ -358,10 +389,10 @@ DatePickerInput.propTypes = {
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
 
-  /**
-   * **Experimental**: Provide a `Slug` component to be rendered inside the `DatePickerInput` component
-   */
-  slug: PropTypes.node,
+  slug: deprecate(
+    PropTypes.node,
+    'The `slug` prop has been deprecated and will be removed in the next major version. Use the decorator prop instead.'
+  ),
 
   /**
    * Specify the type of the `<input>`

--- a/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/packages/react/src/components/DatePickerInput/DatePickerInput.tsx
@@ -40,7 +40,7 @@ export interface DatePickerInputProps
   datePickerType?: 'simple' | 'single' | 'range';
 
   /**
-   * **Experimental**: Provide a `decorator` component to be rendered inside the `RadioButton` component
+   * **Experimental**: Provide a `decorator` component to be rendered inside the `DatePickerInput` component
    */
   decorator?: ReactNode;
 

--- a/packages/react/src/components/Form/Form.stories.js
+++ b/packages/react/src/components/Form/Form.stories.js
@@ -313,7 +313,7 @@ export const withAILabel = (args) => {
               labelText="Date Picker label"
               size="md"
               id="date-picker"
-              slug={aiLabel}
+              decorator={aiLabel}
               {...rest}
             />
           </DatePicker>

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -194,7 +194,6 @@
   .#{$prefix}--date-picker-input__wrapper--decorator
     .#{$prefix}--date-picker-input-inner-wrapper--decorator
     > *,
-  .#{$prefix}--date-picker-input__wrapper--decorator .#{$prefix}--decorator,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--ai-label,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--slug {
     position: absolute;

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -191,14 +191,28 @@
   }
 
   // Styles for `AILabel` rendered inside `DatePickerInput`
+  .#{$prefix}--date-picker-input__wrapper--decorator
+    .#{$prefix}--date-picker-input-inner-wrapper--decorator,
+  .#{$prefix}--date-picker-input__wrapper--decorator .#{$prefix}--decorator,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--ai-label,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--slug {
     position: absolute;
+    block-size: 1rem;
     inset-block-start: 50%;
     inset-inline-end: $spacing-08;
     transform: translateY(-50%);
   }
 
+  .#{$prefix}--date-picker-input__wrapper--decorator
+    .#{$prefix}--date-picker__input:has(
+      ~ .#{$prefix}--date-picker-input-inner-wrapper--decorator
+        .#{$prefix}--ai-label
+    ):not(
+      :has(
+          ~ .#{$prefix}--date-picker-input-inner-wrapper--decorator
+            .#{$prefix}--ai-label--revert
+        )
+    ),
   .#{$prefix}--date-picker-input__wrapper--slug
     .#{$prefix}--date-picker__input:has(~ .#{$prefix}--ai-label):not(
       :has(~ .#{$prefix}--ai-label--revert)

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -192,7 +192,8 @@
 
   // Styles for `AILabel` rendered inside `DatePickerInput`
   .#{$prefix}--date-picker-input__wrapper--decorator
-    .#{$prefix}--date-picker-input-inner-wrapper--decorator,
+    .#{$prefix}--date-picker-input-inner-wrapper--decorator
+    > *,
   .#{$prefix}--date-picker-input__wrapper--decorator .#{$prefix}--decorator,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--ai-label,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--slug {

--- a/packages/styles/scss/components/date-picker/_date-picker.scss
+++ b/packages/styles/scss/components/date-picker/_date-picker.scss
@@ -194,14 +194,20 @@
   .#{$prefix}--date-picker-input__wrapper--decorator
     .#{$prefix}--date-picker-input-inner-wrapper--decorator
     > *,
-  .#{$prefix}--date-picker-input__wrapper--decorator .#{$prefix}--decorator,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--ai-label,
   .#{$prefix}--date-picker-input__wrapper--slug .#{$prefix}--slug {
     position: absolute;
-    block-size: 1rem;
     inset-block-start: 50%;
     inset-inline-end: $spacing-08;
     transform: translateY(-50%);
+  }
+
+  .#{$prefix}--date-picker-input__wrapper--decorator
+    .#{$prefix}--date-picker-input-inner-wrapper--decorator:not(
+      :has(.#{$prefix}--ai-label)
+    )
+    > * {
+    block-size: 1rem;
   }
 
   .#{$prefix}--date-picker-input__wrapper--decorator

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -60,7 +60,8 @@
     inline-size: 100%;
     min-inline-size: 9.375rem;
     padding-inline: $spacing-05 $spacing-12;
-    transition: background-color $duration-fast-01 motion(standard, productive),
+    transition:
+      background-color $duration-fast-01 motion(standard, productive),
       outline $duration-fast-01 motion(standard, productive);
 
     &:focus {

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -60,8 +60,7 @@
     inline-size: 100%;
     min-inline-size: 9.375rem;
     padding-inline: $spacing-05 $spacing-12;
-    transition:
-      background-color $duration-fast-01 motion(standard, productive),
+    transition: background-color $duration-fast-01 motion(standard, productive),
       outline $duration-fast-01 motion(standard, productive);
 
     &:focus {
@@ -433,6 +432,7 @@
   .#{$prefix}--number__input-wrapper--slug .#{$prefix}--ai-label,
   .#{$prefix}--number__input-wrapper--slug .#{$prefix}--slug {
     position: absolute;
+    block-size: 1rem;
     inset-block-start: 50%;
     inset-inline-end: $spacing-12;
     transform: translateY(-50%);

--- a/packages/styles/scss/components/number-input/_number-input.scss
+++ b/packages/styles/scss/components/number-input/_number-input.scss
@@ -432,10 +432,17 @@
   .#{$prefix}--number__input-wrapper--slug .#{$prefix}--ai-label,
   .#{$prefix}--number__input-wrapper--slug .#{$prefix}--slug {
     position: absolute;
-    block-size: 1rem;
     inset-block-start: 50%;
     inset-inline-end: $spacing-12;
     transform: translateY(-50%);
+  }
+
+  .#{$prefix}--number__input-wrapper--decorator
+    .#{$prefix}--number__input-inner-wrapper--decorator:not(
+      :has(.#{$prefix}--ai-label)
+    )
+    > * {
+    block-size: 1rem;
   }
 
   .#{$prefix}--number__input-wrapper--decorator


### PR DESCRIPTION
Closes #17991

Added decorator to `Datepicker` 

#### Changelog

**New**

- New `decorator` prop added to `DatepickerInput` component

**Changed**

- Deprecated `slug` prop
- Update rendering slug to render the decorator component but still set the size if it's an AILabel
- Updated test file
- Added an `block-size` to the style to fix the alignment _(this fix can be used on components that are inside an input)_

#### Testing / Reviewing

- Make sure the `Datepicker` still work as expected and the one with `decorator` also works fine

- [ ] Delete `DatepickerInput` with `Tooltip`