### PR TITLE
fix(button): center align ghost button icons

### DIFF
--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -119,6 +119,7 @@
 
     .#{$prefix}--btn__icon {
       position: static;
+      align-self: center;
       margin-inline-start: $spacing-03;
     }
 


### PR DESCRIPTION
Closes #17082

this PR updates the ghost button icons to be center aligned

<img width="103" alt="image" src="https://github.com/user-attachments/assets/4d90881f-141f-4e53-adf2-bd94cbfbdb5b">

