### PR TITLE
fix(a11y): stop SR announcement for hidden labels for Textinput, TimePicker

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -357,7 +357,7 @@ const TextInput = React.forwardRef(function TextInput(
 
   // AILabel is always size `mini`
   let normalizedDecorator = React.isValidElement(slug ?? decorator)
-    ? slug ?? decorator
+    ? (slug ?? decorator)
     : null;
   if (
     normalizedDecorator &&

--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -293,7 +293,11 @@ const TextInput = React.forwardRef(function TextInput(
     ) : null;
 
   const label = labelText ? (
-    <Text as="label" htmlFor={id} className={labelClasses}>
+    <Text
+      as="label"
+      htmlFor={id}
+      className={labelClasses}
+      aria-hidden={hideLabel}>
       {labelText}
     </Text>
   ) : null;
@@ -353,7 +357,7 @@ const TextInput = React.forwardRef(function TextInput(
 
   // AILabel is always size `mini`
   let normalizedDecorator = React.isValidElement(slug ?? decorator)
-    ? (slug ?? decorator)
+    ? slug ?? decorator
     : null;
   if (
     normalizedDecorator &&

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -225,7 +225,7 @@ const TimePicker: TimePickerComponent = React.forwardRef<
   });
 
   const label = labelText ? (
-    <label htmlFor={id} className={labelClasses}>
+    <label htmlFor={id} className={labelClasses} aria-hidden={hideLabel}>
       {labelText}
     </label>
   ) : null;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/16752 https://github.com/carbon-design-system/carbon/issues/16862

SR should not announce the label when `hideLabel` is true


#### Changelog

**New**
Added `aria-hidden` attribute


#### Testing / Reviewing

- open deploy preview - turn on screen reader 

- for both Textinput and TimePicker components 
     -set the hide label Boolean to "True" and observe the SR do not announce label
