### PR TITLE
fix(a11y): stop SR announcement for hidden labels

### DIFF
--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -287,7 +287,11 @@ const Select = React.forwardRef(function Select(
     <div className={classNames(`${prefix}--form-item`, className)}>
       <div className={selectClasses}>
         {!noLabel && (
-          <Text as="label" htmlFor={id} className={labelClasses}>
+          <Text
+            as="label"
+            htmlFor={id}
+            className={labelClasses}
+            aria-hidden={hideLabel}>
             {labelText}
           </Text>
         )}


### PR DESCRIPTION
Closes #

SR should not announce the label when hideLabel is true

#### Changelog

Added aria-hidden attribute

#### Testing / Reviewing

Open From the Select - playground story
set the hide label Boolean to "True" and observe the SR do not announce label.
