### PR TITLE
fix(selectable-tile): don't require deprecated property "value"

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -6984,9 +6984,7 @@ Map {
         "type": "string",
       },
       "light": [Function],
-      "name": Object {
-        "type": "string",
-      },
+      "name": [Function],
       "onChange": Object {
         "type": "func",
       },
@@ -7008,20 +7006,7 @@ Map {
       "title": Object {
         "type": "string",
       },
-      "value": Object {
-        "args": Array [
-          Array [
-            Object {
-              "type": "string",
-            },
-            Object {
-              "type": "number",
-            },
-          ],
-        ],
-        "isRequired": true,
-        "type": "oneOfType",
-      },
+      "value": [Function],
     },
     "render": [Function],
   },

--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -111,12 +111,7 @@ describe('Tile', () => {
       const onClick = jest.fn();
       render(
         <div role="group" aria-label="selectable tiles">
-          <SelectableTile
-            disabled
-            id="tile-1"
-            name="tiles"
-            onClick={onClick}
-            value="value">
+          <SelectableTile disabled id="tile-1" onClick={onClick}>
             <span role="img" aria-label="vertical traffic light">
               🚦
             </span>
@@ -130,25 +125,13 @@ describe('Tile', () => {
     it('should cycle elements in document tab order', async () => {
       render(
         <div role="group" aria-label="selectable tiles">
-          <SelectableTile
-            data-testid="element"
-            id="tile-1"
-            name="tiles"
-            value="value">
+          <SelectableTile data-testid="element" id="tile-1">
             tile 1
           </SelectableTile>
-          <SelectableTile
-            data-testid="element"
-            id="tile-2"
-            name="tiles"
-            value="value">
+          <SelectableTile data-testid="element" id="tile-2">
             tile 2
           </SelectableTile>
-          <SelectableTile
-            data-testid="element"
-            id="tile-3"
-            name="tiles"
-            value="value">
+          <SelectableTile data-testid="element" id="tile-3">
             tile 3
           </SelectableTile>
         </div>
@@ -180,11 +163,7 @@ describe('Tile', () => {
 
     it('should respect slug prop', () => {
       render(
-        <SelectableTile
-          slug={<AILabel />}
-          id="tile-1"
-          name="tiles"
-          value="value">
+        <SelectableTile slug={<AILabel />} id="tile-1">
           Default tile
         </SelectableTile>
       );
@@ -440,7 +419,7 @@ describe('Tile', () => {
 
   it('respect selected prop', async () => {
     const { container } = render(
-      <SelectableTile id="selectable-tile-1" selected value={'test'}>
+      <SelectableTile id="selectable-tile-1" selected>
         Option 1
       </SelectableTile>
     );

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -561,7 +561,10 @@ SelectableTile.propTypes = {
    * The `name` of the `<input>`.
    * @deprecated
    */
-  name: PropTypes.string,
+  name: deprecate(
+    PropTypes.string,
+    'The `name` property is no longer used.  It will be removed in the next major release.'
+  ),
 
   /**
    * The empty handler of the `<input>`.
@@ -602,7 +605,10 @@ SelectableTile.propTypes = {
    * The value of the `<input>`.
    * @deprecated
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  value: deprecate(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    'The `value` property is no longer used.  It will be removed in the next major release.`'
+  ),
 };
 
 export interface ExpandableTileProps extends HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
Fixes #16977.
Refs #13537, #13631.

Update PropTypes so "name" and "value" are reported as deprecated. (The descriptions already included @deprecated, but that's different.)

More importantly, stop marking "value" as required. Properties cannot be deprecated and required at the same time.

#### Changelog

**Changed**

- declarations for SelectableTile "name" and "value" properties

#### Testing / Reviewing

Tested locally.  Updated snapshot, and updated test file to stop using the deprecated parameters.
