### PR TITLE
fix: added export to selectprops interface

### DIFF
--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -30,7 +30,7 @@ import { Text } from '../Text';
 
 type ExcludedAttributes = 'size';
 
-interface SelectProps
+export interface SelectProps
   extends Omit<ComponentPropsWithRef<'select'>, ExcludedAttributes> {
   /**
    * Provide the contents of your Select


### PR DESCRIPTION
Closes #16545 

Exporting the `SelectProps` interface

#### Testing / Reviewing

- Users should be able to use the interface