### PR TITLE
fix(lint-staged): ensure commands use locally installed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,18 +120,15 @@
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
-      "prettier -v",
-      "prettier --cache --write",
+      "yarn prettier --cache --write",
       "eslint"
     ],
     "**/*.scss": [
-      "prettier -v",
-      "prettier --cache --write",
+      "yarn prettier --cache --write",
       "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
     ],
     "!(*sass).md": [
-      "prettier -v",
-      "prettier --cache --write"
+      "yarn prettier --cache --write"
     ],
     "README.md": [
       "all-contributors generate"

--- a/package.json
+++ b/package.json
@@ -120,14 +120,17 @@
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
+      "prettier -v",
       "prettier --cache --write",
       "eslint"
     ],
     "**/*.scss": [
+      "prettier -v",
       "prettier --cache --write",
       "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
     ],
     "!(*sass).md": [
+      "prettier -v",
       "prettier --cache --write"
     ],
     "README.md": [

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -229,6 +229,47 @@ Playground.story = {
   ],
 };
 
+export const ExperimentalAutoAlign = () => {
+  const [open, setOpen] = useState(true);
+  const ref = useRef();
+
+  useEffect(() => {
+    ref?.current?.scrollIntoView({ block: 'center', inline: 'center' });
+  });
+
+  return (
+    <div style={{ width: '5000px', height: '5000px' }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: '2500px',
+          left: '2500px',
+        }}>
+        <Popover open={open} align="top" autoAlign ref={ref}>
+          <div className="playground-trigger">
+            <CheckboxIcon
+              onClick={() => {
+                setOpen(!open);
+              }}
+            />
+          </div>
+          <PopoverContent className="p-3">
+            <div>
+              <p className="popover-title">This popover uses autoAlign</p>
+              <p className="popover-details">
+                Scroll the container up, down, left or right to observe how the
+                popover will automatically change its position in attempt to
+                stay within the viewport. This works on initial render in
+                addition to on scroll.
+              </p>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
+};
+
 export const TabTipExperimentalAutoAlign = () => {
   const [open, setOpen] = useState(true);
   const ref = useRef();

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -229,47 +229,6 @@ Playground.story = {
   ],
 };
 
-export const ExperimentalAutoAlign = () => {
-  const [open, setOpen] = useState(true);
-  const ref = useRef();
-
-  useEffect(() => {
-    ref?.current?.scrollIntoView({ block: 'center', inline: 'center' });
-  });
-
-  return (
-    <div style={{ width: '5000px', height: '5000px' }}>
-      <div
-        style={{
-          position: 'absolute',
-          top: '2500px',
-          left: '2500px',
-        }}>
-        <Popover open={open} align="top" autoAlign ref={ref}>
-          <div className="playground-trigger">
-            <CheckboxIcon
-              onClick={() => {
-                setOpen(!open);
-              }}
-            />
-          </div>
-          <PopoverContent className="p-3">
-            <div>
-              <p className="popover-title">This popover uses autoAlign</p>
-              <p className="popover-details">
-                Scroll the container up, down, left or right to observe how the
-                popover will automatically change its position in attempt to
-                stay within the viewport. This works on initial render in
-                addition to on scroll.
-              </p>
-            </div>
-          </PopoverContent>
-        </Popover>
-      </div>
-    </div>
-  );
-};
-
 export const TabTipExperimentalAutoAlign = () => {
   const [open, setOpen] = useState(true);
   const ref = useRef();


### PR DESCRIPTION
Fixes a weird race condition where running `yarn format` or using prettier in vscode formats the code to prettier@v3, then lint-staged reformats it to prettier@v2. You push up and open a PR, the `format` check fails. Running `yarn format` locally again presents changes - if these are committed with `--no-verify` to bypass lint-staged, the status check passes.

Somehow lint-staged is using the prettier v2 aliased package we have installed. Using yarn to invoke prettier instead seems to fix it.

#### Changelog

**Changed**

- update lint-staged config in root package.json

#### Testing / Reviewing

- pull down locally, make a change similar to what's in here https://github.com/carbon-design-system/carbon/pull/18107/commits/10970419950e682912ae98a532ea3be1cad7a295, commit it up, the formatting should remain the format of prettier v3
