### PR TITLE
Fix SelectableTile typescript declaration for "value".

### DIFF
--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -439,7 +439,7 @@ export interface SelectableTileProps extends HTMLAttributes<HTMLDivElement> {
    * The value of the `<input>`.
    * @deprecated
    */
-  value: string | number;
+  value?: string | number;
 }
 
 export const SelectableTile = React.forwardRef<


### PR DESCRIPTION
Closes #16977

I previously fixed PropTypes but forgot to update the Typescript declaration.

#### Changelog

**Changed**

- Update SelectableTile.value typescript declaration to make value optional.

#### Testing / Reviewing

Tested locally.
