### PR TITLE
docs(grid): update 2x grid links in docs

### DIFF
--- a/packages/react/src/components/AspectRatio/AspectRatio.mdx
+++ b/packages/react/src/components/AspectRatio/AspectRatio.mdx
@@ -9,7 +9,7 @@ import { AspectRatio } from '.';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/AspectRatio)
 &nbsp;|&nbsp;
-[Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview#aspect-ratio)
+[Usage guidelines](https://carbondesignsystem.com/elements/2x-grid/overview/#aspect-ratio)
 
 {/* <!-- START doctoc generated TOC please keep comment here to allow auto update --> <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE --> */}
 

--- a/packages/react/src/components/Grid/FlexGrid.mdx
+++ b/packages/react/src/components/Grid/FlexGrid.mdx
@@ -7,7 +7,7 @@ import * as FlexGridStories from './FlexGrid.stories';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Grid)
 &nbsp;|&nbsp;
-[Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview)
+[Usage guidelines](https://carbondesignsystem.com/elements/2x-grid/overview/)
 
 {/* prettier-ignore-start */}
 
@@ -35,7 +35,7 @@ import * as FlexGridStories from './FlexGrid.stories';
 {/* prettier-ignore-end */}
 
 Carbon's grid components help developers use the
-[2x Grid](https://www.carbondesignsystem.com/guidelines/2x-grid/overview). The
+[2x Grid](https://carbondesignsystem.com/elements/2x-grid/overview/). The
 project provides `FlexGrid`, `Row`, and `Column` components which can be used to
 build a variety of layouts. You can import these components from
 `@carbon/react`:

--- a/packages/react/src/components/Grid/Grid.mdx
+++ b/packages/react/src/components/Grid/Grid.mdx
@@ -7,7 +7,7 @@ import * as GridStories from './Grid.stories';
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Grid)
 &nbsp;|&nbsp;
-[Usage guidelines](https://www.carbondesignsystem.com/guidelines/2x-grid/overview)
+[Usage guidelines](https://carbondesignsystem.com/elements/2x-grid/overview/)
 
 {/* prettier-ignore-start */}
 
@@ -36,7 +36,7 @@ import * as GridStories from './Grid.stories';
 {/* prettier-ignore-end */}
 
 Carbon's grid components help developers use the
-[2x Grid](https://www.carbondesignsystem.com/guidelines/2x-grid/overview). The
+[2x Grid](https://carbondesignsystem.com/elements/2x-grid/overview/). The
 project provides `Grid` and `Column` components which can be used to build a
 variety of layouts. You can import these components from `@carbon/react`:
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/4371

Update 2x Grid URL in Storybook docs.

#### Changelog

**Changed**

- update 2x grid URL in docs

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
