### PR TITLE
fix(pagination): focus buttons web components

### DIFF
--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -49,6 +49,7 @@ $css--plex: true !default;
 :host(#{$prefix}-button[pagination]),
 :host(#{$prefix}-modal-footer-button[pagination]) {
   .#{$prefix}--btn {
+    padding: 0;
     border: none;
     border-inline-start: 1px solid $border-subtle;
     transition: none;

--- a/packages/web-components/src/components/pagination/pagination.ts
+++ b/packages/web-components/src/components/pagination/pagination.ts
@@ -124,6 +124,16 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
     if (newStart !== oldStart) {
       this._handleUserInitiatedChangeStart(newStart);
     }
+    // reset focus to forward button if it reaches the beginning
+    if (this.page === 1) {
+      const { selectorForwardButton } = this
+        .constructor as typeof CDSPagination;
+      (
+        this.shadowRoot?.querySelector(
+          `[button-class-name*=${selectorForwardButton}]`
+        ) as HTMLElement
+      ).focus();
+    }
   }
 
   /**
@@ -135,6 +145,16 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
     const newStart = oldStart + pageSize;
     if (newStart < (totalItems == null ? Infinity : totalItems)) {
       this._handleUserInitiatedChangeStart(newStart);
+    }
+    // reset focus to previous button if it reaches the end
+    if (this.page === this.totalPages) {
+      const { selectorPreviousButton } = this
+        .constructor as typeof CDSPagination;
+      (
+        this.shadowRoot?.querySelector(
+          `[button-class-name*=${selectorPreviousButton}]`
+        ) as HTMLElement
+      ).focus();
     }
   }
 
@@ -468,6 +488,20 @@ class CDSPagination extends FocusMixin(HostListenerMixin(LitElement)) {
    */
   static get selectorPageSizesSelect() {
     return `${prefix}-select`;
+  }
+
+  /**
+   * A selector that will return the previous button.
+   */
+  static get selectorPreviousButton() {
+    return `${prefix}--pagination__button--backward`;
+  }
+
+  /**
+   * A selector that will return the forward button.
+   */
+  static get selectorForwardButton() {
+    return `${prefix}--pagination__button--forward`;
   }
 
   /**


### PR DESCRIPTION
Closes #17767 (Web components)

pagination not resetting focus when reaching the end of the foward/previous buttons

#### Changelog

**Changed**

- updated to reset focus
- added padding: 0; so buttons aren't getting pushed

#### Testing / Reviewing

go to Web components storybook 
- pagination story
- click or tab/enter on the forward/previous buttons and make sure the focus is properly updated at the beginning at the end and beginning