### PR TITLE
chore: swap assert syntax with 'with' to accommodate Node >=22

### DIFF
--- a/packages/web-components/tasks/build.js
+++ b/packages/web-components/tasks/build.js
@@ -23,7 +23,7 @@ import path from 'path';
 import postcss from 'postcss';
 import typescript from '@rollup/plugin-typescript';
 
-import * as packageJson from '../package.json' assert { type: 'json' };
+import * as packageJson from '../package.json' with { type: 'json' };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
When running the web-components build on Node v23, the following line errors out

```
import * as packageJson from '../package.json' assert { type: 'json' };
```

[due to the "import assertions" no longer being supported](https://stackoverflow.com/a/78876692). Fix is to use `with` instead. This will break in older Node versions like 16 || 17, but that doesn't matter as we specify Carbon needs >=18. 

#### Changelog

**Changed**

- swap `assert` keyword with `with`

#### Testing / Reviewing

See that the ci-checks, especially the build, pass
