### PR TITLE
docs(tooltip): revert to peviously correct stories, use help icon

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.stories.js
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.js
@@ -7,10 +7,9 @@
 
 import './story.scss';
 
+import { Help } from '@carbon/icons-react';
 import React, { useRef, useEffect } from 'react';
-import { SquareOutline } from '@carbon/icons-react';
 import { Tooltip } from './';
-import Button from './../Button';
 import mdx from './Tooltip.mdx';
 
 export default {
@@ -56,7 +55,9 @@ export const Default = () => {
     'Occasionally, services are updated in a specified time window to ensure no down time for customers.';
   return (
     <Tooltip align="bottom" label={label}>
-      <Button>This button has a tooltip</Button>
+      <button className="sb-tooltip-trigger" type="button">
+        <Help />
+      </button>
     </Tooltip>
   );
 };
@@ -64,7 +65,9 @@ export const Default = () => {
 export const Alignment = () => {
   return (
     <Tooltip label="Tooltip alignment" align="bottom-left">
-      <Button>This button has a tooltip</Button>
+      <button className="sb-tooltip-trigger" type="button">
+        <Help />
+      </button>
     </Tooltip>
   );
 };
@@ -86,7 +89,9 @@ export const ExperimentalAutoAlign = () => {
           left: '2500px',
         }}>
         <Tooltip label={tooltipLabel} align="top" autoAlign>
-          <Button ref={ref}>This button has a tooltip</Button>
+          <button className="sb-tooltip-trigger" type="button" ref={ref}>
+            <Help />
+          </button>
         </Tooltip>
       </div>
     </div>
@@ -96,7 +101,9 @@ export const ExperimentalAutoAlign = () => {
 export const Duration = () => {
   return (
     <Tooltip label="Label one" enterDelayMs={0} leaveDelayMs={300}>
-      <Button>This button has a tooltip</Button>
+      <button className="sb-tooltip-trigger" type="button">
+        <Help />
+      </button>
     </Tooltip>
   );
 };
@@ -120,8 +127,8 @@ const PlaygroundStory = (props) => {
       label={label}
       leaveDelayMs={leaveDelayMs}
       closeOnActivation={closeOnActivation}>
-      <button type="button">
-        <SquareOutline />
+      <button className="sb-tooltip-trigger" type="button">
+        <Help />
       </button>
     </Tooltip>
   );


### PR DESCRIPTION
Follow up to https://github.com/carbon-design-system/carbon/pull/17006, this reverts the tooltip stories back to correct examples that use the help icon instead of the information icon (which previously created confusion) 

Related: 
* https://github.com/carbon-design-system/carbon/issues/12921
* https://github.com/carbon-design-system/carbon-design-kit/issues/721
* https://github.com/carbon-design-system/carbon/pull/15887
* https://github.com/carbon-design-system/carbon-website/issues/3956

#### Changelog

**Changed**

- update tooltip story file

#### Testing / Reviewing

- Ensure the Tooltip stories work and render as expected
