### PR TITLE
Update IconButtonKinds

### DIFF
--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -17,8 +17,12 @@ import deprecateValuesWithin from '../../prop-types/deprecateValuesWithin';
 export const IconButtonKinds = [
   'primary',
   'secondary',
+  'tertiary',
   'ghost',
   'tertiary',
+  'danger',
+  'danger--tertiary',
+  'danger--ghost'
 ] as const;
 
 export type IconButtonKind = (typeof IconButtonKinds)[number];


### PR DESCRIPTION
Add missing danger kinds

Closes #7211 , #11484 

Refers to #14300, #14307, #17036

The `IconButtonKinds` were missing the danger options, even though the styles existed and the results are compelling.

I do not understand the reasoning behind why a destructive action should not be accessible via an `IconButton`, as mentioned in #4176. Any destructive action should require confirmation, such as through a modal. Using `IconButtons` helps reduce the visual load and keeps the UI slim and focused. Forcing designers or developers to use a regular button is not an ideal solution. Designers should have the flexibility to make this decision based on the specific context and the action's consequences.

If you agree with the suggested changes, I would be happy to update the Storybook story and the documentation in this PR as well.


#### Changelog

**New**

- Adds `danger`, `danger--tertiary`, `danger--ghost` to the possible `IconButtonKinds`.
- This change does not affect the runtime code but resolves a distracting error message caused by prop type validation.


#### Testing / Reviewing

- Run storybook, visit the `IconButton` story, select e.g. `danger` as kind and check the console. There should be no prop type validation error.
