### PR TITLE
fix: word counter position when text area have cols

### DIFF
--- a/packages/styles/scss/components/text-area/_text-area.scss
+++ b/packages/styles/scss/components/text-area/_text-area.scss
@@ -104,6 +104,12 @@
     inline-size: 1px;
   }
 
+  .#{$prefix}--form-item {
+    &:has(.#{$prefix}--text-area__wrapper--cols) {
+      inline-size: fit-content;
+    }
+  }
+
   //-----------------------------
   // Disabled
   //-----------------------------


### PR DESCRIPTION
Closes #16791 

Word Counter is correctly placed with  textarea element when user passes cols property

#### Changelog

**Changed**

- fixed some styles

#### Testing / Reviewing

Pass cols prop in Textarea component
Keep changing the cols value , the word counter should not be fixed at corner out of textArea
