### PR TITLE
fix: update web-component exports

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -32,17 +32,10 @@
   },
   "type": "module",
   "exports": {
-    "./es/components/*": {
-      "default": "./es/components/*"
-    },
-    "./es/globals/": {
-      "default": "./es/globals/"
-    },
-    "./es": "./es/index.js",
-    "./es/": "./es/",
-    "./lib/": "./lib/",
-    "./dist/": "./dist/",
-    "./scss/": "./scss/",
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./dist/*": "./dist/*",
+    "./scss/*": "./scss/*",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Closes #18311 

[Similar to this PR](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/pull/10955), almost all the folder mappings (except `es/components/*` in the exports field of `@carbon/web-components` package.json are deprecated. The `*` is needed for Node 18+ applications.

#### Changelog

**Changed**

- update the folder mappings, removing the specific `"./es/components/*` and `./es/globals/` subpaths since `./es/*` should cover these paths.


#### Testing / Reviewing

We'll probably have to build this PR locally and do a `yarn pack` within the web-components folder to generate the `package.tgz` to test with
