### PR TITLE
refactor(icons): move componets/icon to elements/icons

### DIFF
--- a/packages/web-components/src/components/icons/docs/overview.mdx
+++ b/packages/web-components/src/components/icons/docs/overview.mdx
@@ -6,19 +6,19 @@
   variants={[
     {
       label: 'Default',
-      variant: 'components-icon--default'
+      variant: 'elements-icons--default'
     },
     {
       label: 'With Custom Class',
-      variant: 'components-icon--with-custom-class'
+      variant: 'elements-icons--with-custom-class'
     },
     {
       label: 'With aria-label',
-      variant: 'components-icon--with-aria-label'
+      variant: 'elements-icons--with-aria-label'
     },
     {
       label: 'With Title',
-      variant: 'components-icon--with-title'
+      variant: 'elements-icons--with-title'
     }
   ]}
 />

--- a/packages/web-components/src/components/icons/icons.mdx
+++ b/packages/web-components/src/components/icons/icons.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Meta } from '@storybook/blocks';
-import * as IconStories from './icon.stories';
+import * as IconsStories from './icons.stories';
 
-<Meta of={IconStories} />
+<Meta of={IconsStories} />
 
-# Icon
+# Icons
 
 Icons can be utilized by specifying the icon name and size in the import.
 
@@ -27,5 +27,5 @@ function App() {
   );
 ```
 
-Icon library can be found
+Icons library can be found
 [here](https://www.carbondesignsystem.com/guidelines/icons/library).

--- a/packages/web-components/src/components/icons/icons.stories.ts
+++ b/packages/web-components/src/components/icons/icons.stories.ts
@@ -72,7 +72,7 @@ export const withTitle = {
 };
 
 const meta = {
-  title: 'Components/Icon',
+  title: 'Elements/Icons',
 };
 
 export default meta;


### PR DESCRIPTION
Closes #17936 

Moved `components/icon` to `elements/icons` to sync with React

#### Changelog

**New**

- A new `Elements` section in Storybook

**Changed**

- Moved `components/icon` stories to `elements/icons`
- Renamed `icon.*` files to `icons.*`

**Removed**

- Stories `components/icon`

#### Testing / Reviewing

1. Direct to web-components storybook
2. Scroll down in the left sidebar to find the new `Elements` section
3. Can find the `Icons` stories there
