### PR TITLE
fix(percy): wait for fonts before snapshotting

### DIFF
--- a/e2e/test-utils/storybook.js
+++ b/e2e/test-utils/storybook.js
@@ -36,6 +36,9 @@ async function visitStory(page, options) {
 
   await page.goto(url);
   await expect(page).toContainAStory(options);
+
+  // Ensure Plex assets are fully available for accurate VRT
+  await page.waitForFunction(() => document.fonts.ready);
 }
 
 function getStoryUrl({ component, story, id }) {

--- a/e2e/test-utils/storybook.js
+++ b/e2e/test-utils/storybook.js
@@ -38,7 +38,9 @@ async function visitStory(page, options) {
   await expect(page).toContainAStory(options);
 
   // Ensure Plex assets are fully available for accurate VRT
-  await page.waitForFunction(() => document.fonts.ready);
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
 }
 
 function getStoryUrl({ component, story, id }) {


### PR DESCRIPTION
Percy snapshots are still flaky wrt Plex, like [this recent build](https://percy.io/538fc19a/web/Carbon-Monorepo-/builds/38148816/changed/2070140090?browser=chrome&browser_ids=64&group_snapshots_by=similar_diff&subcategories=approved&utm_source=github_status_public&viewLayout=overlay&viewMode=original&width=1366&widths=1366). 

This PR updates the `visitStory` helper for playwright to always wait for fonts to be ready before continuing. 

#### Changelog

**Changed**

- add `page.evaluate` call for `document.fonts.ready` to storybook e2e test utils

#### Testing / Reviewing

- Percy builds on this PR should not show changes related to plex being unavailable
