### PR TITLE
fix(`eslint-config-carbon`): move `best-practices.js` back to cjs module export

### DIFF
--- a/config/eslint-config-carbon/rules/best-practices.js
+++ b/config/eslint-config-carbon/rules/best-practices.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-export default {
+module.exports = {
   rules: {
     // @see https://eslint.org/docs/rules/curly
     curly: 'error',


### PR DESCRIPTION
Closes #18305

The export in `eslint-config-carbon/rules/best-practices.js` was changed [here](https://github.com/carbon-design-system/carbon/pull/17770/files#diff-3dd0b17cbf9a8eaeae7b59ca03a36c7ad5d8b0848bce3e58a4b3b7d6faee180aR10) to `export default {}` but no other file in the package or the package.json for this package was changed to ESM.

This should address the errors we're seeing in #18305 and allow `ibm-products` to move to eslint v9.

#### Changelog

**Changed**

- `config/eslint-config-carbon/rules/best-practices.js`

#### Testing / Reviewing

Will verify PR checks in this PR
