### PR TITLE
fix(search): resolve descrepancy in close button aria-label prop

### DIFF
--- a/packages/web-components/src/components/search/search.stories.ts
+++ b/packages/web-components/src/components/search/search.stories.ts
@@ -117,7 +117,7 @@ export const Expandable = {
       <cds-search
         size="lg"
         expandable
-        close-button-assistive-text="Clear search input"
+        close-button-label-text="Clear search input"
         label-text="Search"
         placeholder="Find your items"
         type="text"></cds-search>
@@ -173,7 +173,7 @@ export const Playground = {
     return html`
       <cds-search
         autocomplete="${autoComplete}"
-        close-button-assistive-text="${ifDefined(closeButtonLabelText)}"
+        close-button-label-text="${ifDefined(closeButtonLabelText)}"
         color-scheme="${ifDefined(colorScheme)}"
         ?disabled="${disabled}"
         label-text="${ifDefined(labelText)}"


### PR DESCRIPTION
Closes #17930 

#### Changelog

**Changed**

- Changed prop `close-button-assistive-text` to `close-button-label-text`

#### Testing / Reviewing

1. Turn on screen reader
2. Open `search` component storybook
3. Using the `tab` key focus the close button
4. Expect the `close-button-label-text` is announced
