### PR TITLE
feat: Added strong PolymorphicProps

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -6,10 +6,11 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { ForwardRefReturn } from '../../types/common';
+import Link from '../Link';
 
 export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   /**

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -6,11 +6,10 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { PropsWithChildren, useRef } from 'react';
+import React, { PropsWithChildren } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { ForwardRefReturn } from '../../types/common';
-import Link from '../Link';
 
 export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   /**

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -12,6 +12,10 @@ import { composeEventHandlers } from '../../tools/events';
 import { PolymorphicProps } from '../../types/common';
 import { PopoverAlignment } from '../Popover';
 import ButtonBase from './ButtonBase';
+import {
+  PolymorphicComponentPropWithRef,
+  PolymorphicRef,
+} from '../../internal/PolymorphicProps';
 
 export const ButtonKinds = [
   'primary',
@@ -102,15 +106,13 @@ export interface ButtonBaseProps
   tooltipPosition?: ButtonTooltipPosition;
 }
 
-export type ButtonProps<T extends React.ElementType> = PolymorphicProps<
-  T,
-  ButtonBaseProps
->;
+export type ButtonProps<T extends React.ElementType> =
+  PolymorphicComponentPropWithRef<T, ButtonBaseProps>;
 
-export type ButtonComponent = <T extends React.ElementType>(
+type ButtonComponent = <T extends React.ElementType = 'button'>(
   props: ButtonProps<T>,
   context?: any
-) => React.ReactElement<any, any> | null;
+) => React.ReactElement | any;
 
 function isIconOnlyButton(
   hasIconOnly: ButtonBaseProps['hasIconOnly'],
@@ -123,87 +125,89 @@ function isIconOnlyButton(
   return false;
 }
 
-const Button = React.forwardRef(function Button<T extends React.ElementType>(
-  props: ButtonProps<T>,
-  ref: React.Ref<unknown>
-) {
-  const tooltipRef = useRef(null);
-  const {
-    as,
-    autoAlign = false,
-    children,
-    hasIconOnly = false,
-    iconDescription,
-    kind = 'primary',
-    onBlur,
-    onClick,
-    onFocus,
-    onMouseEnter,
-    onMouseLeave,
-    renderIcon: ButtonImageElement,
-    size,
-    tooltipAlignment = 'center',
-    tooltipPosition = 'top',
-    ...rest
-  } = props;
+const Button: ButtonComponent = React.forwardRef(
+  <T extends React.ElementType = 'button'>(
+    props: ButtonProps<T>,
+    ref: PolymorphicRef<T>
+  ) => {
+    const tooltipRef = useRef(null);
+    const {
+      as,
+      autoAlign = false,
+      children,
+      hasIconOnly = false,
+      iconDescription,
+      kind = 'primary',
+      onBlur,
+      onClick,
+      onFocus,
+      onMouseEnter,
+      onMouseLeave,
+      renderIcon: ButtonImageElement,
+      size,
+      tooltipAlignment = 'center',
+      tooltipPosition = 'top',
+      ...rest
+    } = props;
 
-  const handleClick = (evt: React.MouseEvent) => {
-    // Prevent clicks on the tooltip from triggering the button click event
-    if (evt.target === tooltipRef.current) {
-      evt.preventDefault();
-    }
-  };
+    const handleClick = (evt: React.MouseEvent) => {
+      // Prevent clicks on the tooltip from triggering the button click event
+      if (evt.target === tooltipRef.current) {
+        evt.preventDefault();
+      }
+    };
 
-  const iconOnlyImage = !ButtonImageElement ? null : <ButtonImageElement />;
+    const iconOnlyImage = !ButtonImageElement ? null : <ButtonImageElement />;
 
-  if (!isIconOnlyButton(hasIconOnly, kind)) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { tooltipAlignment, ...propsWithoutTooltipAlignment } = props;
-    return <ButtonBase ref={ref} {...propsWithoutTooltipAlignment} />;
-  } else {
-    let align: PopoverAlignment | undefined = undefined;
+    if (!isIconOnlyButton(hasIconOnly, kind)) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { tooltipAlignment, ...propsWithoutTooltipAlignment } = props;
+      return <ButtonBase ref={ref} {...propsWithoutTooltipAlignment} />;
+    } else {
+      let align: PopoverAlignment | undefined = undefined;
 
-    if (tooltipPosition === 'top' || tooltipPosition === 'bottom') {
-      if (tooltipAlignment === 'center') {
+      if (tooltipPosition === 'top' || tooltipPosition === 'bottom') {
+        if (tooltipAlignment === 'center') {
+          align = tooltipPosition;
+        }
+        if (tooltipAlignment === 'end') {
+          align = `${tooltipPosition}-end`;
+        }
+        if (tooltipAlignment === 'start') {
+          align = `${tooltipPosition}-start`;
+        }
+      }
+
+      if (tooltipPosition === 'right' || tooltipPosition === 'left') {
         align = tooltipPosition;
       }
-      if (tooltipAlignment === 'end') {
-        align = `${tooltipPosition}-end`;
-      }
-      if (tooltipAlignment === 'start') {
-        align = `${tooltipPosition}-start`;
-      }
-    }
 
-    if (tooltipPosition === 'right' || tooltipPosition === 'left') {
-      align = tooltipPosition;
+      return (
+        <IconButton
+          {...rest}
+          ref={ref}
+          as={as}
+          align={align}
+          label={iconDescription}
+          kind={kind}
+          size={size}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          autoAlign={autoAlign}
+          onClick={composeEventHandlers([onClick, handleClick])}
+          renderIcon={iconOnlyImage ? null : ButtonImageElement} // avoid doubling the icon.
+        >
+          {iconOnlyImage ?? children}
+        </IconButton>
+      );
     }
-
-    return (
-      <IconButton
-        {...rest}
-        ref={ref}
-        as={as}
-        align={align}
-        label={iconDescription}
-        kind={kind}
-        size={size}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        autoAlign={autoAlign}
-        onClick={composeEventHandlers([onClick, handleClick])}
-        renderIcon={iconOnlyImage ? null : ButtonImageElement} // avoid doubling the icon.
-      >
-        {iconOnlyImage ?? children}
-      </IconButton>
-    );
   }
-});
+);
 
-Button.displayName = 'Button';
-Button.propTypes = {
+(Button as React.FC).displayName = 'Button';
+(Button as React.FC).propTypes = {
   /**
    * Specify how the button itself should be rendered.
    * Make sure to apply all props to the root node and render children appropriately

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -128,7 +128,7 @@ function isIconOnlyButton(
 const Button: ButtonComponent = React.forwardRef(
   <T extends React.ElementType = 'button'>(
     props: ButtonProps<T>,
-    ref: PolymorphicRef<T>
+    ref: React.Ref<unknown>
   ) => {
     const tooltipRef = useRef(null);
     const {

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -109,7 +109,7 @@ export interface ButtonBaseProps
 export type ButtonProps<T extends React.ElementType> =
   PolymorphicComponentPropWithRef<T, ButtonBaseProps>;
 
-type ButtonComponent = <T extends React.ElementType = 'button'>(
+export type ButtonComponent = <T extends React.ElementType = 'button'>(
   props: ButtonProps<T>,
   context?: any
 ) => React.ReactElement | any;

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -16,6 +16,10 @@ import React, {
 } from 'react';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
+import {
+  PolymorphicComponentPropWithRef,
+  PolymorphicRef,
+} from '../../internal/PolymorphicProps';
 
 export interface LinkBaseProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /**
@@ -68,67 +72,70 @@ export interface LinkBaseProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   visited?: boolean;
 }
 
-export type LinkProps<E extends ElementType> = PolymorphicProps<
-  E,
-  LinkBaseProps
->;
+export type LinkProps<T extends React.ElementType> =
+  PolymorphicComponentPropWithRef<T, LinkBaseProps>;
 
-const Link = React.forwardRef(function Link<E extends React.ElementType>(
-  {
-    as: BaseComponent,
-    children,
-    className: customClassName,
-    href,
-    disabled = false,
-    inline = false,
-    visited = false,
-    renderIcon: Icon,
-    size,
-    target,
-    ...rest
-  }: LinkProps<E>,
-  ref
-) {
-  const prefix = usePrefix();
-  const className = cx(`${prefix}--link`, customClassName, {
-    [`${prefix}--link--disabled`]: disabled,
-    [`${prefix}--link--inline`]: inline,
-    [`${prefix}--link--visited`]: visited,
-    [`${prefix}--link--${size}`]: size,
-  });
-  const rel = target === '_blank' ? 'noopener' : undefined;
-  const linkProps: AnchorHTMLAttributes<HTMLAnchorElement> = {
-    className: BaseComponent ? undefined : className,
-    rel,
-    target,
-  };
+type LinkComponent = <T extends React.ElementType = 'a'>(
+  props: LinkProps<T>
+) => React.ReactElement | any;
 
-  // Reference for disabled links:
-  // https://www.scottohara.me/blog/2021/05/28/disabled-links.html
-  if (!disabled) {
-    linkProps.href = href;
-  } else {
-    linkProps.role = 'link';
-    linkProps['aria-disabled'] = true;
+const Link: LinkComponent = React.forwardRef(
+  <T extends React.ElementType = 'a'>(
+    {
+      as: BaseComponent,
+      children,
+      className: customClassName,
+      href,
+      disabled = false,
+      inline = false,
+      visited = false,
+      renderIcon: Icon,
+      size,
+      target,
+      ...rest
+    }: LinkProps<T>,
+    ref: PolymorphicRef<T>
+  ) => {
+    const prefix = usePrefix();
+    const className = cx(`${prefix}--link`, customClassName, {
+      [`${prefix}--link--disabled`]: disabled,
+      [`${prefix}--link--inline`]: inline,
+      [`${prefix}--link--visited`]: visited,
+      [`${prefix}--link--${size}`]: size,
+    });
+    const rel = target === '_blank' ? 'noopener' : undefined;
+    const linkProps: AnchorHTMLAttributes<HTMLAnchorElement> = {
+      className: BaseComponent ? undefined : className,
+      rel,
+      target,
+    };
+
+    // Reference for disabled links:
+    // https://www.scottohara.me/blog/2021/05/28/disabled-links.html
+    if (!disabled) {
+      linkProps.href = href;
+    } else {
+      linkProps.role = 'link';
+      linkProps['aria-disabled'] = true;
+    }
+
+    const BaseComponentAsAny = (BaseComponent ?? 'a') as any;
+
+    return (
+      <BaseComponentAsAny ref={ref} {...linkProps} {...rest}>
+        {children}
+        {!inline && Icon && (
+          <div className={`${prefix}--link__icon`}>
+            <Icon />
+          </div>
+        )}
+      </BaseComponentAsAny>
+    );
   }
+);
 
-  const BaseComponentAsAny = (BaseComponent ?? 'a') as any;
-
-  return (
-    <BaseComponentAsAny ref={ref} {...linkProps} {...rest}>
-      {children}
-      {!inline && Icon && (
-        <div className={`${prefix}--link__icon`}>
-          <Icon />
-        </div>
-      )}
-    </BaseComponentAsAny>
-  );
-});
-
-Link.displayName = 'Link';
-
-Link.propTypes = {
+(Link as React.FC).displayName = 'Link';
+(Link as React.FC).propTypes = {
   /**
    * Provide a custom element or component to render the top-level node for the
    * component.

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -264,7 +264,7 @@ const Modal = React.forwardRef(function Modal(
 ) {
   const prefix = usePrefix();
   const button = useRef<HTMLButtonElement>(null);
-  const secondaryButton = useRef();
+  const secondaryButton = useRef<HTMLButtonElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const innerModal = useRef<HTMLDivElement>(null);
   const startTrap = useRef<HTMLSpanElement>(null);

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -157,7 +157,8 @@ const DismissibleTag = <T extends React.ElementType>({
       renderIcon={renderIcon}
       disabled={disabled}
       className={tagClasses}
-      id={tagId}>
+      id={tagId}
+      {...otherProps}>
       <div className={`${prefix}--interactive--tag-children`}>
         <Text
           title={tagTitle ? tagTitle : text}

--- a/packages/react/src/components/Tag/DismissibleTag.tsx
+++ b/packages/react/src/components/Tag/DismissibleTag.tsx
@@ -104,7 +104,7 @@ const DismissibleTag = <T extends React.ElementType>({
   ...other
 }: DismissibleTagProps<T>) => {
   const prefix = usePrefix();
-  const tagLabelRef = useRef<HTMLElement>();
+  const tagLabelRef = useRef<HTMLDivElement>(null);
   const tagId = id || `tag-${useId()}`;
   const tagClasses = classNames(`${prefix}--tag--filter`, className);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
@@ -157,8 +157,7 @@ const DismissibleTag = <T extends React.ElementType>({
       renderIcon={renderIcon}
       disabled={disabled}
       className={tagClasses}
-      id={tagId}
-      {...otherProps}>
+      id={tagId}>
       <div className={`${prefix}--interactive--tag-children`}>
         <Text
           title={tagTitle ? tagTitle : text}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -127,7 +127,7 @@ const OperationalTag = <T extends React.ElementType>({
           disabled={disabled}
           className={tagClasses}
           id={tagId}
-          {...(other as Omit<OperationalTagBaseProps, keyof TagBaseProps>)}>
+          {...other}>
           <Text title={text} className={`${prefix}--tag__label`}>
             {text}
           </Text>
@@ -146,7 +146,7 @@ const OperationalTag = <T extends React.ElementType>({
       disabled={disabled}
       className={tagClasses}
       id={tagId}
-      {...(other as Omit<OperationalTagBaseProps, keyof TagBaseProps>)}>
+      {...other}>
       <Text title={text} className={`${prefix}--tag__label`}>
         {text}
       </Text>

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -17,7 +17,7 @@ import classNames from 'classnames';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
-import Tag, { SIZES, TagBaseProps } from './Tag';
+import Tag, { SIZES } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';
@@ -119,7 +119,6 @@ const OperationalTag = <T extends React.ElementType>({
         onMouseEnter={() => false}
         closeOnActivation>
         <Tag
-          as="button"
           ref={tagRef}
           type={type}
           size={size}
@@ -138,7 +137,6 @@ const OperationalTag = <T extends React.ElementType>({
 
   return (
     <Tag
-      as="button"
       ref={tagRef}
       type={type}
       size={size}

--- a/packages/react/src/components/Tag/OperationalTag.tsx
+++ b/packages/react/src/components/Tag/OperationalTag.tsx
@@ -17,7 +17,7 @@ import classNames from 'classnames';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
-import Tag, { SIZES } from './Tag';
+import Tag, { SIZES, TagBaseProps } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';
@@ -91,7 +91,7 @@ const OperationalTag = <T extends React.ElementType>({
   ...other
 }: OperationalTagProps<T>) => {
   const prefix = usePrefix();
-  const tagRef = useRef<HTMLElement>();
+  const tagRef = useRef<HTMLButtonElement>(null);
   const tagId = id || `tag-${useId()}`;
   const tagClasses = classNames(`${prefix}--tag--operational`, className);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
@@ -119,6 +119,7 @@ const OperationalTag = <T extends React.ElementType>({
         onMouseEnter={() => false}
         closeOnActivation>
         <Tag
+          as="button"
           ref={tagRef}
           type={type}
           size={size}
@@ -126,7 +127,7 @@ const OperationalTag = <T extends React.ElementType>({
           disabled={disabled}
           className={tagClasses}
           id={tagId}
-          {...other}>
+          {...(other as Omit<OperationalTagBaseProps, keyof TagBaseProps>)}>
           <Text title={text} className={`${prefix}--tag__label`}>
             {text}
           </Text>
@@ -137,6 +138,7 @@ const OperationalTag = <T extends React.ElementType>({
 
   return (
     <Tag
+      as="button"
       ref={tagRef}
       type={type}
       size={size}
@@ -144,7 +146,7 @@ const OperationalTag = <T extends React.ElementType>({
       disabled={disabled}
       className={tagClasses}
       id={tagId}
-      {...other}>
+      {...(other as Omit<OperationalTagBaseProps, keyof TagBaseProps>)}>
       <Text title={text} className={`${prefix}--tag__label`}>
         {text}
       </Text>

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -109,8 +109,6 @@ const SelectableTag = <T extends React.ElementType>({
     onClick?.(e);
   };
 
-  console.log('other', other);
-
   if (isEllipsisApplied) {
     return (
       <Tooltip

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
-import Tag, { SIZES } from './Tag';
+import Tag, { SIZES, TagBaseProps } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';
@@ -109,6 +109,8 @@ const SelectableTag = <T extends React.ElementType>({
     onClick?.(e);
   };
 
+  console.log('other', other);
+
   if (isEllipsisApplied) {
     return (
       <Tooltip
@@ -118,7 +120,6 @@ const SelectableTag = <T extends React.ElementType>({
         leaveDelayMs={0}
         onMouseEnter={() => false}>
         <Tag
-          as="button"
           aria-pressed={selectedTag !== false}
           ref={tagRef}
           size={size}
@@ -138,7 +139,6 @@ const SelectableTag = <T extends React.ElementType>({
 
   return (
     <Tag
-      as="button"
       aria-pressed={selectedTag !== false}
       ref={tagRef}
       size={size}

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
 import { PolymorphicProps } from '../../types/common';
-import Tag, { SIZES, TagBaseProps } from './Tag';
+import Tag, { SIZES } from './Tag';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Text';
 import { isEllipsisActive } from './isEllipsisActive';

--- a/packages/react/src/components/Tag/SelectableTag.tsx
+++ b/packages/react/src/components/Tag/SelectableTag.tsx
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
+import React, { useLayoutEffect, useState, useRef, MouseEvent } from 'react';
 import classNames from 'classnames';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
@@ -46,7 +46,7 @@ export interface SelectableTagBaseProps {
   /**
    * Provide an optional function to be called when the tag is clicked.
    */
-  onClick?: (e: Event) => void;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
 
   /**
    * Specify the state of the selectable tag.
@@ -83,7 +83,7 @@ const SelectableTag = <T extends React.ElementType>({
   ...other
 }: SelectableTagProps<T>) => {
   const prefix = usePrefix();
-  const tagRef = useRef<HTMLElement>();
+  const tagRef = useRef<HTMLButtonElement>(null);
   const tagId = id || `tag-${useId()}`;
   const [selectedTag, setSelectedTag] = useState(selected);
   const tagClasses = classNames(`${prefix}--tag--selectable`, className, {
@@ -103,7 +103,7 @@ const SelectableTag = <T extends React.ElementType>({
     `${prefix}--tag-label-tooltip`
   );
 
-  const handleClick = (e: Event) => {
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     setSelectedTag(!selectedTag);
     onChange?.(!selectedTag);
     onClick?.(e);
@@ -118,6 +118,7 @@ const SelectableTag = <T extends React.ElementType>({
         leaveDelayMs={0}
         onMouseEnter={() => false}>
         <Tag
+          as="button"
           aria-pressed={selectedTag !== false}
           ref={tagRef}
           size={size}
@@ -137,6 +138,7 @@ const SelectableTag = <T extends React.ElementType>({
 
   return (
     <Tag
+      as="button"
       aria-pressed={selectedTag !== false}
       ref={tagRef}
       size={size}

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -6,18 +6,11 @@
  */
 
 import PropTypes from 'prop-types';
-import React, {
-  useLayoutEffect,
-  useState,
-  ReactNode,
-  useRef,
-  ForwardedRef,
-} from 'react';
+import React, { useLayoutEffect, useState, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
 import { Close } from '@carbon/icons-react';
 import { useId } from '../../internal/useId';
 import { usePrefix } from '../../internal/usePrefix';
-import { PolymorphicProps } from '../../types/common';
 import { Text } from '../Text';
 import deprecate from '../../prop-types/deprecate';
 import { DefinitionTooltip } from '../Tooltip';

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -20,6 +20,9 @@ import {
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
 } from '../../internal/PolymorphicProps';
+import { SelectableTagBaseProps, SelectableTagProps } from './SelectableTag';
+import { OperationalTagBaseProps } from './OperationalTag';
+import { DismissibleTagBaseProps } from './DismissibleTag';
 
 export const TYPES = {
   red: 'Red',
@@ -111,7 +114,11 @@ export type TagProps<T extends React.ElementType> =
   PolymorphicComponentPropWithRef<T, TagBaseProps>;
 
 type TagComponent = <T extends React.ElementType = 'div'>(
-  props: TagProps<T>
+  props:
+    | TagProps<T>
+    | OperationalTagBaseProps
+    | SelectableTagBaseProps
+    | DismissibleTagBaseProps
 ) => React.ReactElement | any;
 
 const Tag: TagComponent = React.forwardRef(

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -23,6 +23,10 @@ import deprecate from '../../prop-types/deprecate';
 import { DefinitionTooltip } from '../Tooltip';
 import { isEllipsisActive } from './isEllipsisActive';
 import { useMergeRefs } from '@floating-ui/react';
+import {
+  PolymorphicComponentPropWithRef,
+  PolymorphicRef,
+} from '../../internal/PolymorphicProps';
 
 export const TYPES = {
   red: 'Red',
@@ -110,93 +114,141 @@ export interface TagBaseProps {
   type?: keyof typeof TYPES;
 }
 
-export type TagProps<T extends React.ElementType> = PolymorphicProps<
-  T,
-  TagBaseProps
->;
+export type TagProps<T extends React.ElementType> =
+  PolymorphicComponentPropWithRef<T, TagBaseProps>;
 
-const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
-  {
-    children,
-    className,
-    decorator,
-    id,
-    type,
-    filter, // remove filter in next major release - V12
-    renderIcon: CustomIconElement,
-    title = 'Clear filter', // remove title in next major release - V12
-    disabled,
-    onClose, // remove onClose in next major release - V12
-    size,
-    as: BaseComponent,
-    slug,
-    ...other
-  }: TagProps<T>,
-  forwardRef: ForwardedRef<HTMLElement | undefined>
-) {
-  const prefix = usePrefix();
-  const tagRef = useRef<HTMLElement>();
-  const ref = useMergeRefs([forwardRef, tagRef]);
-  const tagId = id || `tag-${useId()}`;
-  const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
+type TagComponent = <T extends React.ElementType = 'div'>(
+  props: TagProps<T>
+) => React.ReactElement | any;
 
-  useLayoutEffect(() => {
-    const newElement = tagRef.current?.getElementsByClassName(
-      `${prefix}--tag__label`
-    )[0];
-    setIsEllipsisApplied(isEllipsisActive(newElement));
-  }, [prefix, tagRef]);
+const Tag: TagComponent = React.forwardRef(
+  <T extends React.ElementType = 'div'>(
+    {
+      children,
+      className,
+      decorator,
+      id,
+      type,
+      filter, // remove filter in next major release - V12
+      renderIcon: CustomIconElement,
+      title = 'Clear filter', // remove title in next major release - V12
+      disabled,
+      onClose, // remove onClose in next major release - V12
+      size,
+      as: BaseComponent,
+      slug,
+      ...other
+    }: TagProps<T>,
+    forwardRef: PolymorphicRef<T>
+  ) => {
+    const prefix = usePrefix();
+    const tagRef = useRef<HTMLElement>();
+    const ref = useMergeRefs([forwardRef, tagRef]);
+    const tagId = id || `tag-${useId()}`;
+    const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
 
-  const conditions = [
-    `${prefix}--tag--selectable`,
-    `${prefix}--tag--filter`,
-    `${prefix}--tag--operational`,
-  ];
+    useLayoutEffect(() => {
+      const newElement = tagRef.current?.getElementsByClassName(
+        `${prefix}--tag__label`
+      )[0];
+      setIsEllipsisApplied(isEllipsisActive(newElement));
+    }, [prefix, tagRef]);
 
-  const isInteractiveTag = conditions.some((el) => className?.includes(el));
+    const conditions = [
+      `${prefix}--tag--selectable`,
+      `${prefix}--tag--filter`,
+      `${prefix}--tag--operational`,
+    ];
 
-  const tagClasses = classNames(`${prefix}--tag`, className, {
-    [`${prefix}--tag--disabled`]: disabled,
-    [`${prefix}--tag--filter`]: filter,
-    [`${prefix}--tag--${size}`]: size, // TODO: V12 - Remove this class
-    [`${prefix}--layout--size-${size}`]: size,
-    [`${prefix}--tag--${type}`]: type,
-    [`${prefix}--tag--interactive`]:
-      other.onClick && !isInteractiveTag && isEllipsisApplied,
-  });
+    const isInteractiveTag = conditions.some((el) => className?.includes(el));
 
-  const typeText =
-    type !== undefined && type in Object.keys(TYPES) ? TYPES[type] : '';
+    const tagClasses = classNames(`${prefix}--tag`, className, {
+      [`${prefix}--tag--disabled`]: disabled,
+      [`${prefix}--tag--filter`]: filter,
+      [`${prefix}--tag--${size}`]: size, // TODO: V12 - Remove this class
+      [`${prefix}--layout--size-${size}`]: size,
+      [`${prefix}--tag--${type}`]: type,
+      [`${prefix}--tag--interactive`]:
+        other.onClick && !isInteractiveTag && isEllipsisApplied,
+    });
 
-  const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (onClose) {
-      event.stopPropagation();
-      onClose(event);
-    }
-  };
+    const typeText =
+      type !== undefined && type in Object.keys(TYPES) ? TYPES[type] : '';
 
-  // AILabel is always size `sm` and `inline`
-  let normalizedDecorator = React.isValidElement(slug ?? decorator)
-    ? (slug ?? decorator)
-    : null;
-  if (
-    normalizedDecorator &&
-    normalizedDecorator['type']?.displayName === 'AILabel' &&
-    !isInteractiveTag
-  ) {
-    normalizedDecorator = React.cloneElement(
-      normalizedDecorator as React.ReactElement<any>,
-      {
-        size: 'sm',
-        kind: 'inline',
+    const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (onClose) {
+        event.stopPropagation();
+        onClose(event);
       }
-    );
-  }
+    };
 
-  if (filter) {
-    const ComponentTag = (BaseComponent as React.ElementType) ?? 'div';
+    // AILabel is always size `sm` and `inline`
+    let normalizedDecorator = React.isValidElement(slug ?? decorator)
+      ? (slug ?? decorator)
+      : null;
+    if (
+      normalizedDecorator &&
+      normalizedDecorator['type']?.displayName === 'AILabel' &&
+      !isInteractiveTag
+    ) {
+      normalizedDecorator = React.cloneElement(
+        normalizedDecorator as React.ReactElement<any>,
+        {
+          size: 'sm',
+          kind: 'inline',
+        }
+      );
+    }
+
+    if (filter) {
+      const ComponentTag = (BaseComponent as React.ElementType) ?? 'div';
+      return (
+        <ComponentTag className={tagClasses} id={tagId} {...other}>
+          {CustomIconElement && size !== 'sm' ? (
+            <div className={`${prefix}--tag__custom-icon`}>
+              <CustomIconElement />
+            </div>
+          ) : (
+            ''
+          )}
+
+          <Text
+            title={typeof children === 'string' ? children : undefined}
+            className={`${prefix}--tag__label`}>
+            {children !== null && children !== undefined ? children : typeText}
+          </Text>
+          {normalizedDecorator}
+          <button
+            type="button"
+            className={`${prefix}--tag__close-icon`}
+            onClick={handleClose}
+            disabled={disabled}
+            aria-label={title}
+            title={title}>
+            <Close />
+          </button>
+        </ComponentTag>
+      );
+    }
+
+    const ComponentTag =
+      BaseComponent ??
+      (other.onClick || className?.includes(`${prefix}--tag--operational`)
+        ? 'button'
+        : 'div');
+
+    const labelClasses = classNames({
+      [`${prefix}--tag__label`]: !isInteractiveTag,
+    });
+
     return (
-      <ComponentTag className={tagClasses} id={tagId} {...other}>
+      <ComponentTag
+        ref={ref}
+        disabled={disabled}
+        className={tagClasses}
+        id={tagId}
+        type={ComponentTag === 'button' ? 'button' : undefined}
+        {...other}>
         {CustomIconElement && size !== 'sm' ? (
           <div className={`${prefix}--tag__custom-icon`}>
             <CustomIconElement />
@@ -204,58 +256,28 @@ const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
         ) : (
           ''
         )}
-
-        <Text
-          title={typeof children === 'string' ? children : undefined}
-          className={`${prefix}--tag__label`}>
-          {children !== null && children !== undefined ? children : typeText}
-        </Text>
-        {normalizedDecorator}
-        <button
-          type="button"
-          className={`${prefix}--tag__close-icon`}
-          onClick={handleClose}
-          disabled={disabled}
-          aria-label={title}
-          title={title}>
-          <Close />
-        </button>
-      </ComponentTag>
-    );
-  }
-
-  const ComponentTag =
-    BaseComponent ??
-    (other.onClick || className?.includes(`${prefix}--tag--operational`)
-      ? 'button'
-      : 'div');
-
-  const labelClasses = classNames({
-    [`${prefix}--tag__label`]: !isInteractiveTag,
-  });
-
-  return (
-    <ComponentTag
-      ref={ref}
-      disabled={disabled}
-      className={tagClasses}
-      id={tagId}
-      type={ComponentTag === 'button' ? 'button' : undefined}
-      {...other}>
-      {CustomIconElement && size !== 'sm' ? (
-        <div className={`${prefix}--tag__custom-icon`}>
-          <CustomIconElement />
-        </div>
-      ) : (
-        ''
-      )}
-      {isEllipsisApplied && !isInteractiveTag ? (
-        <DefinitionTooltip
-          openOnHover={false}
-          definition={
-            children !== null && children !== undefined ? children : typeText
-          }
-          className={`${prefix}--definition--tooltip--tag`}>
+        {isEllipsisApplied && !isInteractiveTag ? (
+          <DefinitionTooltip
+            openOnHover={false}
+            definition={
+              children !== null && children !== undefined ? children : typeText
+            }
+            className={`${prefix}--definition--tooltip--tag`}>
+            <Text
+              title={
+                children !== null &&
+                children !== undefined &&
+                typeof children === 'string'
+                  ? children
+                  : typeText
+              }
+              className={labelClasses}>
+              {children !== null && children !== undefined
+                ? children
+                : typeText}
+            </Text>
+          </DefinitionTooltip>
+        ) : (
           <Text
             title={
               children !== null &&
@@ -267,32 +289,22 @@ const Tag = React.forwardRef(function Tag<T extends React.ElementType>(
             className={labelClasses}>
             {children !== null && children !== undefined ? children : typeText}
           </Text>
-        </DefinitionTooltip>
-      ) : (
-        <Text
-          title={
-            children !== null &&
-            children !== undefined &&
-            typeof children === 'string'
-              ? children
-              : typeText
-          }
-          className={labelClasses}>
-          {children !== null && children !== undefined ? children : typeText}
-        </Text>
-      )}
-      {slug ? (
-        normalizedDecorator
-      ) : decorator ? (
-        <div className={`${prefix}--tag__decorator`}>{normalizedDecorator}</div>
-      ) : (
-        ''
-      )}
-    </ComponentTag>
-  );
-});
+        )}
+        {slug ? (
+          normalizedDecorator
+        ) : decorator ? (
+          <div className={`${prefix}--tag__decorator`}>
+            {normalizedDecorator}
+          </div>
+        ) : (
+          ''
+        )}
+      </ComponentTag>
+    );
+  }
+);
 
-Tag.propTypes = {
+(Tag as React.FC).propTypes = {
   /**
    * Provide an alternative tag or component to use instead of the default
    * wrapping element

--- a/packages/react/src/components/UIShell/HeaderGlobalAction.tsx
+++ b/packages/react/src/components/UIShell/HeaderGlobalAction.tsx
@@ -66,7 +66,7 @@ const HeaderGlobalAction: React.FC<HeaderGlobalActionProps> = React.forwardRef(
       tooltipAlignment,
       ...rest
     },
-    ref
+    ref: React.Ref<HTMLButtonElement>
   ) {
     const prefix = usePrefix();
     const className = cx({


### PR DESCRIPTION
Closes #18369
Closes #18370 
Closes #18371 

Added strong PolymorphicProps for `Tag`, `Button` and `Link`.

#### Changelog

**Changed**

- Changed the way the PolymorphicProp is validated.
- NOTE: The only changes are in the way the `type`
      <details>
        <summary>Code example</summary>

        export type LinkProps<T extends React.ElementType> =
          PolymorphicComponentPropWithRef<T, LinkBaseProps>;
        
        type LinkComponent = <T extends React.ElementType = 'a'>(
          props: LinkProps<T>
        ) => React.ReactElement | any;
        
        const Link: LinkComponent = React.forwardRef(
          <T extends React.ElementType = 'a'>(
            {
              as: BaseComponent,
              children,
              className: customClassName,
              href,
              disabled = false,
              inline = false,
              visited = false,
              renderIcon: Icon,
              size,
              target,
              ...rest
            }: LinkProps<T>,
            ref: PolymorphicRef<T>
          ) => {   

#### Testing / Reviewing

- CI should pass
- You can also pull down the PR locally to test, but here it is a screenshot:

![Screenshot 2025-01-20 at 09 18 19](https://github.com/user-attachments/assets/22275097-03f9-4b23-b893-f1a3d8c57425)
