### PR TITLE
WIP | fix: stopped combobox's `onChange`  throwing undefined when selected item is clicked again and fixed keyboard interaction

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -379,6 +379,28 @@ export const _fullyControlled = (args) => {
   );
 };
 
+export const Test = () => {
+  const [selectedItem, setSelectedItem] = useState('1');
+  const onChange = ({ selectedItem }) => {
+    console.log('Parent onChange called with:', selectedItem);
+    setSelectedItem(selectedItem);
+  };
+
+  return (
+    <div>
+      <ComboBox
+        id="3"
+        items={['1', '2', '3']}
+        selectedItem={selectedItem}
+        titleText="ComboBox title"
+        helperText="Combobox helper text"
+        onChange={onChange}
+        allowCustomValue
+      />
+    </div>
+  );
+};
+
 _fullyControlled.argTypes = { ...sharedArgTypes };
 
 AutocompleteWithTypeahead.argTypes = {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -778,13 +778,15 @@ const ComboBox = forwardRef(
       onStateChange: ({ type, selectedItem: newSelectedItem }) => {
         if (
           type === useCombobox.stateChangeTypes.ItemClick &&
-          !isEqual(selectedItemProp, newSelectedItem)
+          newSelectedItem !== undefined &&
+          !isEqual(selectedItem, newSelectedItem)
         ) {
           onChange({ selectedItem: newSelectedItem });
         }
         if (
-          type === useCombobox.stateChangeTypes.FunctionSelectItem ||
-          type === useCombobox.stateChangeTypes.InputKeyDownEnter
+          (type === useCombobox.stateChangeTypes.FunctionSelectItem ||
+            type === useCombobox.stateChangeTypes.InputKeyDownEnter) &&
+          newSelectedItem !== undefined
         ) {
           onChange({ selectedItem: newSelectedItem });
         }
@@ -965,14 +967,6 @@ const ComboBox = forwardRef(
                         ]
                       );
                     }
-
-                    // Since `onChange` does not normally fire when the menu is closed, we should
-                    // manually fire it when `allowCustomValue` is provided, the menu is closing,
-                    // and there is a value.
-                    if (allowCustomValue && isOpen && inputValue) {
-                      onChange({ selectedItem, inputValue });
-                    }
-
                     event.preventDownshiftDefault = true;
                     event?.persist?.();
                   }


### PR DESCRIPTION
Closes #18286 
Closes #18386 

18226 issue:  stops the onChange handler from firing with undefined when the same item is clicked. Now it does not fire `onChange` handler when the selected item is clicked again.

Second: The keyboard interaction would fire 2 `onChange` handlers, one with previously selected value and one with the new selected value.


#### Changelog

**Changed**

- modified the `onStateChange` to include a check for being undefined:
` newSelectedItem !== undefined `

**Removed**

- ~~if (allowCustomValue && isOpen && inputValue) {~~
    ~~onChange({ selectedItem, inputValue });~~
~~}~~

Removed this condition as this was firing the onChange with previous selected value when the combobox is interacted with keyboard

#### Testing / Reviewing

- Open the test story
- keep the console open
- select item '2' by using keyboard
- see that console has a log:
`Parent onChange called with: 2`