### PR TITLE
fix(18204): remove redundant aria-label in inline mode for AILabel component 

### DIFF
--- a/packages/react/src/components/AILabel/__tests__/AILabel-test.js
+++ b/packages/react/src/components/AILabel/__tests__/AILabel-test.js
@@ -157,4 +157,25 @@ describe('AILabelActions', () => {
 
     expect(screen.getByText('View details')).toBeInTheDocument();
   });
+  describe('Labels and kind prop', () => {
+    it('should use empty label for inline kind', () => {
+      render(<AILabel kind="inline" aiText="AI" textLabel="Text goes here" />);
+      expect(screen.getByRole('button')).toHaveAttribute('aria-label', '');
+    });
+
+    it('should set aria-label when kind is default', () => {
+      render(<AILabel aiText="AI" />);
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'AI Show information'
+      );
+    });
+
+    it('should let visible text serve as accessible name in inline mode', () => {
+      render(<AILabel kind="inline" aiText="AI" textLabel="Text goes here" />);
+      expect(
+        screen.getByRole('button', { name: 'AI Text goes here' })
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/react/src/components/AILabel/index.tsx
+++ b/packages/react/src/components/AILabel/index.tsx
@@ -214,7 +214,7 @@ export const AILabel = React.forwardRef<HTMLDivElement, AILabelProps>(
             {...rest}>
             <ToggletipButton
               className={aiLabelButtonClasses}
-              label={kind === 'inline' ? null : ariaLabelText}>
+              label={kind === 'inline' ? '' : ariaLabelText}>
               <span className={`${prefix}--ai-label__text`}>{aiText}</span>
               {kind === 'inline' && (aiTextLabel || textLabel) && (
                 <span className={`${prefix}--ai-label__additional-text`}>

--- a/packages/react/src/components/AILabel/index.tsx
+++ b/packages/react/src/components/AILabel/index.tsx
@@ -214,7 +214,7 @@ export const AILabel = React.forwardRef<HTMLDivElement, AILabelProps>(
             {...rest}>
             <ToggletipButton
               className={aiLabelButtonClasses}
-              label={ariaLabelText}>
+              label={kind === 'inline' ? null : ariaLabelText}>
               <span className={`${prefix}--ai-label__text`}>{aiText}</span>
               {kind === 'inline' && (aiTextLabel || textLabel) && (
                 <span className={`${prefix}--ai-label__additional-text`}>

--- a/packages/react/src/components/Tag/Tag-test.js
+++ b/packages/react/src/components/Tag/Tag-test.js
@@ -80,13 +80,10 @@ describe('Tag', () => {
           type="red"
           title="Close tag"
           text="Tag content"
-          decorator={<AILabel />}
+          decorator={<AILabel aiText="AI" />}
         />
       );
-
-      expect(
-        screen.getByRole('button', { name: 'AI Show information' })
-      ).toBeInTheDocument();
+      expect(screen.getByText('AI')).toBeInTheDocument();
     });
 
     it('should respect deprecated slug prop', () => {
@@ -96,13 +93,10 @@ describe('Tag', () => {
           type="red"
           title="Close tag"
           text="Tag content"
-          slug={<AILabel />}
+          slug={<AILabel aiText="AI" />}
         />
       );
-
-      expect(
-        screen.getByRole('button', { name: 'AI Show information' })
-      ).toBeInTheDocument();
+      expect(screen.getByText('AI')).toBeInTheDocument();
       spy.mockRestore();
     });
   });
@@ -123,20 +117,14 @@ describe('Tag', () => {
   });
 
   it('should respect decorator prop', () => {
-    render(<Tag type="red" decorator={<AILabel />} />);
-
-    expect(
-      screen.getByRole('button', { name: 'AI Show information' })
-    ).toBeInTheDocument();
+    render(<Tag type="red" decorator={<AILabel aiText="AI" />} />);
+    expect(screen.getByText('AI')).toBeInTheDocument();
   });
 
   it('should respect deprecated slug prop', () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    render(<Tag type="red" slug={<AILabel />} />);
-
-    expect(
-      screen.getByRole('button', { name: 'AI Show information' })
-    ).toBeInTheDocument();
+    render(<Tag type="red" slug={<AILabel aiText="AI" />} />);
+    expect(screen.getByText('AI')).toBeInTheDocument();
     spy.mockRestore();
   });
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18204

For `kind="inline"` in  AILabel, aria-label duplicated visible text content (see phill's comment on the issue)
This PR sets empty  aria-label when kind='inline' to let native text content serve as accessible name:

`label={kind === 'inline' ? '' : ariaLabelText`}

#### Changelog

**Removed**
makes aria-label empty when kind='inline'
Added test cases to validate the cases  
updated tests in Tabs 

#### Testing / Reviewing

visit expandable AILabel storybook in [deploy preview](https://deploy-preview-18407--v11-carbon-react.netlify.app/iframe.html?args=&globals=&id=components-ailabel--default&viewMode=story)
run Accessibility Checker with 3.1.75 and later versions and verify "a11y Violation - Accessible name does not match or contain the visible label text " is not seen