### PR TITLE
fix: screenreader reading the toggletip content

### DIFF
--- a/packages/react/src/components/Toggletip/index.tsx
+++ b/packages/react/src/components/Toggletip/index.tsx
@@ -348,7 +348,9 @@ const ToggletipContent = React.forwardRef<
     <PopoverContent
       className={customClassName}
       {...toggletip?.contentProps}
-      ref={ref}>
+      ref={ref}
+      role="region"
+      aria-live="polite">
       <div className={`${prefix}--toggletip-content`}>{children}</div>
     </PopoverContent>
   );

--- a/packages/react/src/components/Toggletip/index.tsx
+++ b/packages/react/src/components/Toggletip/index.tsx
@@ -349,7 +349,6 @@ const ToggletipContent = React.forwardRef<
       className={customClassName}
       {...toggletip?.contentProps}
       ref={ref}
-      role="region"
       aria-live="polite">
       <div className={`${prefix}--toggletip-content`}>{children}</div>
     </PopoverContent>


### PR DESCRIPTION
Closes #18228 

Screenreader was not reading Toggletip content

#### Changelog

**Changed**

added aria-live and role to toggletip content


#### Testing / Reviewing

Screen reader should be able to read toggletip content.