### PR TITLE
React|WC Parity: Link 

### DIFF
--- a/packages/web-components/src/components/link/link.mdx
+++ b/packages/web-components/src/components/link/link.mdx
@@ -15,6 +15,14 @@ import * as LinkStories from './link.stories';
 Represents a link. Provided for convenience purpose, you can alternatively use
 `<a class="cds--link">` with Carbon style in place in light DOM.
 
+## Overview
+
+Links are used as navigational elements and can be used on their own or inline
+with text. They provide a lightweight option for navigation but like other
+interactive elements, too many links will clutter a page and make it difficult
+for users to identify their next steps. This is especially true for inline
+links, which should be used sparingly.
+
 ## Getting started
 
 Here's a quick example to get you started.
@@ -36,7 +44,9 @@ import '@carbon/web-components/es/components/list/index.js';
 
 ## Paired with icon
 
-Import the desired icon and incorporate with the link text:
+If the text of your link doesn't correspond to the action represented by the
+icon, consider incorporating an `aria-label` for the icon. This will ensure that
+visually impaired users can comprehend the outcome of clicking the link.
 
 ```javascript
 import Download16 from '@carbon/icons/lib/download/16.js';

--- a/packages/web-components/src/components/link/link.stories.ts
+++ b/packages/web-components/src/components/link/link.stories.ts
@@ -9,7 +9,7 @@
 
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import Download16 from '@carbon/icons/lib/download/16.js';
+import ArrowRight16 from '@carbon/icons/lib/arrow--right/16.js';
 import { LINK_SIZE } from './link';
 
 const defaultArgs = {
@@ -41,7 +41,19 @@ const controls = {
 };
 
 export const Default = {
-  render: () => html` <cds-link href="#"> Link </cds-link> `,
+  argTypes: controls,
+  args: defaultArgs,
+  render: ({ disabled, href, inline, size, visited, onClick }) => html`
+    <cds-link
+      ?disabled="${disabled}"
+      href="${ifDefined(href)}"
+      size="${ifDefined(size)}"
+      ?inline="${inline}"
+      ?visited="${visited}"
+      @click="${onClick}">
+      Link
+    </cds-link>
+  `,
 };
 
 export const Inline = {
@@ -77,23 +89,7 @@ export const PairedWithIcon = {
       href="${ifDefined(href)}"
       size="${ifDefined(size)}"
       @click="${onClick}">
-      Download ${Download16({ slot: 'icon' })}
-    </cds-link>
-  `,
-};
-
-export const Playground = {
-  argTypes: controls,
-  args: defaultArgs,
-  render: ({ disabled, href, inline, size, visited, onClick }) => html`
-    <cds-link
-      ?disabled="${disabled}"
-      href="${ifDefined(href)}"
-      size="${ifDefined(size)}"
-      ?inline="${inline}"
-      ?visited="${visited}"
-      @click="${onClick}">
-      Link
+      Carbon Docs ${ArrowRight16({ slot: 'icon' })}
     </cds-link>
   `,
 };

--- a/packages/web-components/src/components/link/link.stories.ts
+++ b/packages/web-components/src/components/link/link.stories.ts
@@ -80,9 +80,7 @@ export const Inline = {
 
 export const PairedWithIcon = {
   args: defaultArgs,
-  parameters: {
-    controls: { exclude: /(.*?)/ },
-  },
+  argTypes: controls,
   render: ({ disabled, href, size, onClick }) => html`
     <cds-link
       ?disabled="${disabled}"


### PR DESCRIPTION
Closes #17924 

Link - React and Web Components parity

#### Changelog

**Changed**

- Changed the overview docs to match React on text
- Changed Paired With Icon variant to match React
- Added controls to Default story

**Changed**

- Removed Playground story

#### Testing / Reviewing

- CI should pass
- Component should work as expected