### PR TITLE
fix(date-picker): add check for calendar before setting

### DIFF
--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -389,26 +389,27 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
       value,
     } = this;
 
-    if (dateFormat) {
-      this._setCalendar('dateFormat', calendar);
-    }
+    if (calendar) {
+      if (dateFormat) {
+        this._setCalendar('dateFormat', calendar);
+      }
 
-    if (minDate || maxDate) {
-      this._setCalendar('date', calendar);
-    }
+      if (minDate || maxDate) {
+        this._setCalendar('date', calendar);
+      }
 
-    if (open) {
-      this._setCalendar('open', calendar);
-    }
+      if (open) {
+        this._setCalendar('open', calendar);
+      }
 
-    if (disabled || readonly) {
-      this._setCalendar('disabled', calendar);
+      if (disabled || readonly) {
+        this._setCalendar('disabled', calendar);
+      }
+      if (value) {
+        this._setCalendar('value', calendar);
+      }
     }
-    if (value) {
-      this._setCalendar('value', calendar);
-    }
-
-    return this.calendar;
+    return calendar;
   }
 
   /**

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -520,24 +520,29 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
 
   updated(changedProperties) {
     const { calendar } = this;
-    if (calendar && changedProperties.has('dateFormat')) {
-      this._setCalendar('dateFormat', calendar);
-    }
-    if (changedProperties.has('minDate') || changedProperties.has('maxDate')) {
-      this._setCalendar('date', calendar);
-    }
+    if (calendar) {
+      if (changedProperties.has('dateFormat')) {
+        this._setCalendar('dateFormat', calendar);
+      }
+      if (
+        changedProperties.has('minDate') ||
+        changedProperties.has('maxDate')
+      ) {
+        this._setCalendar('date', calendar);
+      }
 
-    if (changedProperties.has('open') && calendar) {
-      this._setCalendar('open', calendar);
-    }
-    if (
-      changedProperties.has('disabled') ||
-      changedProperties.has('readonly')
-    ) {
-      this._setCalendar('disabled', calendar);
-    }
-    if (changedProperties.has('value')) {
-      this._setCalendar('value', calendar);
+      if (changedProperties.has('open')) {
+        this._setCalendar('open', calendar);
+      }
+      if (
+        changedProperties.has('disabled') ||
+        changedProperties.has('readonly')
+      ) {
+        this._setCalendar('disabled', calendar);
+      }
+      if (changedProperties.has('value')) {
+        this._setCalendar('value', calendar);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #18182 

Error in console appears when `calendar` is not instantiated but properties are passed in to the date-picker component. This PR adds a check to ensure `calendar` is not null before setting the properties. 

#### Changelog

**Changed**

- add check for `calendar` before triggering `_setCalendar` method

#### Testing / Reviewing

Go to [`date-picker` playground story](https://deploy-preview-18448--v11-carbon-web-components.netlify.app/?path=/story/components-date-picker--playground) and check that there is no

``` Uncaught (in promise) TypeError: Cannot read properties of null (reading 'set')```

error showing up in the console