### PR TITLE
feat: codemod to enable v12 tile default icons

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -59,6 +59,7 @@ packages/**/examples/**
 # Upgrade
 packages/upgrade/cli.js
 packages/upgrade/**/*.output.js
+packages/upgrade/**/*.output.tsx
 
 # Accessibility Verification Testing
 **/.avt/**

--- a/packages/upgrade/src/upgrades.js
+++ b/packages/upgrade/src/upgrades.js
@@ -397,6 +397,64 @@ export const upgrades = [
         },
       },
       {
+        name: 'enable-v12-tile-default-icons',
+        description: `
+          Wrap Tile and TileGroup components with FeatureFlags enableV12TileDefaultIcons
+      
+          Transforms:
+          1. TileGroup with Tiles:
+          <TileGroup>
+            <Tile>...</Tile>
+          </TileGroup>
+      
+          Into:
+          <FeatureFlags enableV12TileDefaultIcons>
+            <TileGroup>
+              <Tile>...</Tile>
+            </TileGroup>
+          </FeatureFlags>
+      
+          2. Standalone Tile:
+          <Tile>...</Tile>
+      
+          Into:
+          <FeatureFlags enableV12TileDefaultIcons>
+            <Tile>...</Tile>
+          </FeatureFlags>
+        `,
+        migrate: async (options) => {
+          const transform = path.join(
+            TRANSFORM_DIR,
+            'enable-v12-tile-default-icons.js'
+          );
+          const paths =
+            Array.isArray(options.paths) && options.paths.length > 0
+              ? options.paths
+              : await glob(['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'], {
+                  cwd: options.workspaceDir,
+                  ignore: [
+                    '**/es/**',
+                    '**/lib/**',
+                    '**/umd/**',
+                    '**/node_modules/**',
+                    '**/storybook-static/**',
+                    '**/dist/**',
+                    '**/build/**',
+                    '**/*.d.ts',
+                    '**/coverage/**',
+                  ],
+                });
+
+          await run({
+            dry: !options.write,
+            transform,
+            paths,
+            verbose: options.verbose,
+            parser: 'tsx', // Enable parsing of TSX files
+          });
+        },
+      },
+      {
         name: 'ibm-products-update-http-errors',
         description:
           'Rewrites HttpError403, HttpError404, HttpErrorOther to FullPageError',

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.js
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.js
@@ -4,74 +4,53 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 function TestComponent() {
   return (
-    // prettier-ignore
     <div>
       {/* Case 1: Unwrapped TileGroup */}
       <TileGroup legend="TestGroup" name="test">
-        <Tile>
-          Option 1
-        </Tile>
-        <Tile>
-          Option 2
-        </Tile>
+        <Tile>Option 1</Tile>
+        <Tile>Option 2</Tile>
       </TileGroup>
 
       {/* Wrapped standalone missing flag prop */}
       <FeatureFlags>
         <TileGroup legend="Missing Attribute" name="wrapped">
-          <Tile>
-            Already Wrapped Option 1
-          </Tile>
-          <Tile>
-            Already Wrapped Option 2
-          </Tile>
+          <Tile>Already Wrapped Option 1</Tile>
+          <Tile>Already Wrapped Option 2</Tile>
         </TileGroup>
       </FeatureFlags>
 
       {/* Case 3: Already wrapped with other attributes */}
       <FeatureFlags enable-v12-tile-radio-icons>
         <TileGroup legend="Other Attribute" name="other-wrapped">
-          <Tile>
-            Other Flag Option 1
-          </Tile>
+          <Tile>Other Flag Option 1</Tile>
         </TileGroup>
       </FeatureFlags>
 
       {/* Case 4: Already wrapped with correct attribute */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="Correct Wrapped" name="correct">
-          <Tile>
-            Correctly Wrapped Option
-          </Tile>
+          <Tile>Correctly Wrapped Option</Tile>
         </TileGroup>
       </FeatureFlags>
 
       {/* Case 5: Standalone Tiles with different scenarios */}
       <Stack>
         {/* Unwrapped standalone */}
-        <Tile>
-          Standalone Tile
-        </Tile>
+        <Tile>Standalone Tile</Tile>
 
         {/* Wrapped standalone missing flag prop */}
         <FeatureFlags>
-          <Tile>
-            Wrapped Standalone
-          </Tile>
+          <Tile>Wrapped Standalone</Tile>
         </FeatureFlags>
 
         {/* Wrapped standalone with other flag */}
         <FeatureFlags enable-v12-tile-radio-icons>
-          <Tile>
-            Other Flag Standalone
-          </Tile>
+          <Tile>Other Flag Standalone</Tile>
         </FeatureFlags>
 
         {/* Correctly wrapped standalone */}
         <FeatureFlags enableV12TileDefaultIcons>
-          <Tile>
-            Correct Standalone
-          </Tile>
+          <Tile>Correct Standalone</Tile>
         </FeatureFlags>
       </Stack>
 
@@ -79,13 +58,9 @@ function TestComponent() {
       <div className="nested">
         <TileGroup legend="Nested Group" name="nested">
           <div className="wrapper">
-            <Tile>
-              Nested Option 1
-            </Tile>
+            <Tile>Nested Option 1</Tile>
           </div>
-          <Tile>
-            Nested Option 2
-          </Tile>
+          <Tile>Nested Option 2</Tile>
         </TileGroup>
       </div>
     </div>

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.js
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { TileGroup, Tile, Stack } from '@carbon/react';
+import { FeatureFlags } from '@carbon/feature-flags';
+
+function TestComponent() {
+  return (
+    // prettier-ignore
+    <div>
+      {/* Case 1: Unwrapped TileGroup */}
+      <TileGroup legend="TestGroup" name="test">
+        <Tile>
+          Option 1
+        </Tile>
+        <Tile>
+          Option 2
+        </Tile>
+      </TileGroup>
+
+      {/* Wrapped standalone missing flag prop */}
+      <FeatureFlags>
+        <TileGroup legend="Missing Attribute" name="wrapped">
+          <Tile>
+            Already Wrapped Option 1
+          </Tile>
+          <Tile>
+            Already Wrapped Option 2
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+
+      {/* Case 3: Already wrapped with other attributes */}
+      <FeatureFlags enable-v12-tile-radio-icons>
+        <TileGroup legend="Other Attribute" name="other-wrapped">
+          <Tile>
+            Other Flag Option 1
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+
+      {/* Case 4: Already wrapped with correct attribute */}
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="Correct Wrapped" name="correct">
+          <Tile>
+            Correctly Wrapped Option
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+
+      {/* Case 5: Standalone Tiles with different scenarios */}
+      <Stack>
+        {/* Unwrapped standalone */}
+        <Tile>
+          Standalone Tile
+        </Tile>
+
+        {/* Wrapped standalone missing flag prop */}
+        <FeatureFlags>
+          <Tile>
+            Wrapped Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Wrapped standalone with other flag */}
+        <FeatureFlags enable-v12-tile-radio-icons>
+          <Tile>
+            Other Flag Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Correctly wrapped standalone */}
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile>
+            Correct Standalone
+          </Tile>
+        </FeatureFlags>
+      </Stack>
+
+      {/* Case 6: Nested structures */}
+      <div className="nested">
+        <TileGroup legend="Nested Group" name="nested">
+          <div className="wrapper">
+            <Tile>
+              Nested Option 1
+            </Tile>
+          </div>
+          <Tile>
+            Nested Option 2
+          </Tile>
+        </TileGroup>
+      </div>
+    </div>
+  );
+}
+
+export default TestComponent;

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
@@ -4,74 +4,53 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 const TestComponent: React.FC = () => {
   return (
-    // prettier-ignore
     <div>
       {/* Case 1: Unwrapped TileGroup */}
       <TileGroup legend="TestGroup" name="test">
-        <Tile id="test-1">
-          Option 1
-        </Tile>
-        <Tile id="test-2">
-          Option 2
-        </Tile>
+        <Tile id="test-1">Option 1</Tile>
+        <Tile id="test-2">Option 2</Tile>
       </TileGroup>
 
       {/* Wrapped standalone missing flag prop */}
       <FeatureFlags>
         <TileGroup legend="Missing Attribute" name="wrapped">
-          <Tile id="wrapped-1">
-            Already Wrapped Option 1
-          </Tile>
-          <Tile id="wrapped-2">
-            Already Wrapped Option 2
-          </Tile>
+          <Tile id="wrapped-1">Already Wrapped Option 1</Tile>
+          <Tile id="wrapped-2">Already Wrapped Option 2</Tile>
         </TileGroup>
       </FeatureFlags>
 
       {/* Case 3: Already wrapped with other flags */}
       <FeatureFlags enable-v12-tile-radio-icons>
         <TileGroup legend="Other Attribute" name="other-wrapped">
-          <Tile id="other-1">
-            Other Flag Option 1
-          </Tile>
+          <Tile id="other-1">Other Flag Option 1</Tile>
         </TileGroup>
       </FeatureFlags>
 
       {/* Case 4: Already wrapped with correct flag */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="Correct Wrapped" name="correct">
-          <Tile id="correct-1">
-            Correctly Wrapped Option
-          </Tile>
+          <Tile id="correct-1">Correctly Wrapped Option</Tile>
         </TileGroup>
       </FeatureFlags>
 
       {/* Case 5: Standalone Tiles with different scenarios */}
       <Stack>
         {/* Unwrapped standalone */}
-        <Tile id="standalone">
-          Standalone Tile
-        </Tile>
+        <Tile id="standalone">Standalone Tile</Tile>
 
         {/* Wrapped standalone missing flag prop */}
         <FeatureFlags>
-          <Tile id="wrapped-standalone">
-            Wrapped Standalone
-          </Tile>
+          <Tile id="wrapped-standalone">Wrapped Standalone</Tile>
         </FeatureFlags>
 
         {/* Wrapped standalone with other flag */}
         <FeatureFlags enable-v12-tile-radio-icons>
-          <Tile id="other-standalone">
-            Other Flag Standalone
-          </Tile>
+          <Tile id="other-standalone">Other Flag Standalone</Tile>
         </FeatureFlags>
 
         {/* Correctly wrapped standalone */}
         <FeatureFlags enableV12TileDefaultIcons>
-          <Tile id="correct-standalone">
-            Correct Standalone
-          </Tile>
+          <Tile id="correct-standalone">Correct Standalone</Tile>
         </FeatureFlags>
       </Stack>
 
@@ -79,13 +58,9 @@ const TestComponent: React.FC = () => {
       <div className="nested">
         <TileGroup legend="Nested Group" name="nested">
           <div className="wrapper">
-            <Tile id="nested-1">
-              Nested Option 1
-            </Tile>
+            <Tile id="nested-1">Nested Option 1</Tile>
           </div>
-          <Tile id="nested-2">
-            Nested Option 2
-          </Tile>
+          <Tile id="nested-2">Nested Option 2</Tile>
         </TileGroup>
       </div>
     </div>

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
@@ -16,6 +16,7 @@ const TestComponent: React.FC = () => {
         <TileGroup legend="Missing Attribute" name="wrapped">
           <Tile id="wrapped-1">Already Wrapped Option 1</Tile>
           <Tile id="wrapped-2">Already Wrapped Option 2</Tile>
+          <Tile id="wrapped-3">Already Wrapped Option 3</Tile>
         </TileGroup>
       </FeatureFlags>
 

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { TileGroup, Tile, Stack } from '@carbon/react';
+import { FeatureFlags } from '@carbon/feature-flags';
+
+const TestComponent: React.FC = () => {
+  return (
+    // prettier-ignore
+    <div>
+      {/* Case 1: Unwrapped TileGroup */}
+      <TileGroup legend="TestGroup" name="test">
+        <Tile id="test-1">
+          Option 1
+        </Tile>
+        <Tile id="test-2">
+          Option 2
+        </Tile>
+      </TileGroup>
+
+      {/* Wrapped standalone missing flag prop */}
+      <FeatureFlags>
+        <TileGroup legend="Missing Attribute" name="wrapped">
+          <Tile id="wrapped-1">
+            Already Wrapped Option 1
+          </Tile>
+          <Tile id="wrapped-2">
+            Already Wrapped Option 2
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+
+      {/* Case 3: Already wrapped with other flags */}
+      <FeatureFlags enable-v12-tile-radio-icons>
+        <TileGroup legend="Other Attribute" name="other-wrapped">
+          <Tile id="other-1">
+            Other Flag Option 1
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+
+      {/* Case 4: Already wrapped with correct flag */}
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="Correct Wrapped" name="correct">
+          <Tile id="correct-1">
+            Correctly Wrapped Option
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+
+      {/* Case 5: Standalone Tiles with different scenarios */}
+      <Stack>
+        {/* Unwrapped standalone */}
+        <Tile id="standalone">
+          Standalone Tile
+        </Tile>
+
+        {/* Wrapped standalone missing flag prop */}
+        <FeatureFlags>
+          <Tile id="wrapped-standalone">
+            Wrapped Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Wrapped standalone with other flag */}
+        <FeatureFlags enable-v12-tile-radio-icons>
+          <Tile id="other-standalone">
+            Other Flag Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Correctly wrapped standalone */}
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile id="correct-standalone">
+            Correct Standalone
+          </Tile>
+        </FeatureFlags>
+      </Stack>
+
+      {/* Case 6: Nested structures */}
+      <div className="nested">
+        <TileGroup legend="Nested Group" name="nested">
+          <div className="wrapper">
+            <Tile id="nested-1">
+              Nested Option 1
+            </Tile>
+          </div>
+          <Tile id="nested-2">
+            Nested Option 2
+          </Tile>
+        </TileGroup>
+      </div>
+    </div>
+  );
+};
+
+export default TestComponent;

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.input.tsx
@@ -4,6 +4,7 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 const TestComponent: React.FC = () => {
   return (
+    //prettier-ignore
     <div>
       {/* Case 1: Unwrapped TileGroup */}
       <TileGroup legend="TestGroup" name="test">

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.js
@@ -4,7 +4,6 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 function TestComponent() {
   return (
-    // prettier-ignore
     (<div>
       {/* Case 1: Unwrapped TileGroup */}
       <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { TileGroup, Tile, Stack } from '@carbon/react';
+import { FeatureFlags } from '@carbon/feature-flags';
+
+function TestComponent() {
+  return (
+    // prettier-ignore
+    (<div>
+      {/* Case 1: Unwrapped TileGroup */}
+      <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">
+          <Tile>
+            Option 1
+          </Tile>
+          <Tile>
+            Option 2
+          </Tile>
+        </TileGroup></FeatureFlags>
+      {/* Wrapped standalone missing flag prop */}
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="Missing Attribute" name="wrapped">
+          <Tile>
+            Already Wrapped Option 1
+          </Tile>
+          <Tile>
+            Already Wrapped Option 2
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+      {/* Case 3: Already wrapped with other attributes */}
+      <FeatureFlags enable-v12-tile-radio-icons enableV12TileDefaultIcons>
+        <TileGroup legend="Other Attribute" name="other-wrapped">
+          <Tile>
+            Other Flag Option 1
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+      {/* Case 4: Already wrapped with correct attribute */}
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="Correct Wrapped" name="correct">
+          <Tile>
+            Correctly Wrapped Option
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+      {/* Case 5: Standalone Tiles with different scenarios */}
+      <Stack>
+        {/* Unwrapped standalone */}
+        <FeatureFlags enableV12TileDefaultIcons><Tile>
+            Standalone Tile
+          </Tile></FeatureFlags>
+
+        {/* Wrapped standalone missing flag prop */}
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile>
+            Wrapped Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Wrapped standalone with other flag */}
+        <FeatureFlags enable-v12-tile-radio-icons enableV12TileDefaultIcons>
+          <Tile>
+            Other Flag Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Correctly wrapped standalone */}
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile>
+            Correct Standalone
+          </Tile>
+        </FeatureFlags>
+      </Stack>
+      {/* Case 6: Nested structures */}
+      <div className="nested">
+        <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="Nested Group" name="nested">
+            <div className="wrapper">
+              <Tile>
+                Nested Option 1
+              </Tile>
+            </div>
+            <Tile>
+              Nested Option 2
+            </Tile>
+          </TileGroup></FeatureFlags>
+      </div>
+    </div>)
+  );
+}
+
+export default TestComponent;

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -4,86 +4,67 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 const TestComponent: React.FC = () => {
   return (
-    // prettier-ignore
-    (<div>
+    <div>
       {/* Case 1: Unwrapped TileGroup */}
-      <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">
-          <Tile id="test-1">
-            Option 1
-          </Tile>
-          <Tile id="test-2">
-            Option 2
-          </Tile>
-        </TileGroup></FeatureFlags>
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="TestGroup" name="test">
+          <Tile id="test-1">Option 1</Tile>
+          <Tile id="test-2">Option 2</Tile>
+        </TileGroup>
+      </FeatureFlags>
       {/* Wrapped standalone missing flag prop */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="Missing Attribute" name="wrapped">
-          <Tile id="wrapped-1">
-            Already Wrapped Option 1
-          </Tile>
-          <Tile id="wrapped-2">
-            Already Wrapped Option 2
-          </Tile>
+          <Tile id="wrapped-1">Already Wrapped Option 1</Tile>
+          <Tile id="wrapped-2">Already Wrapped Option 2</Tile>
         </TileGroup>
       </FeatureFlags>
       {/* Case 3: Already wrapped with other flags */}
       <FeatureFlags enable-v12-tile-radio-icons enableV12TileDefaultIcons>
         <TileGroup legend="Other Attribute" name="other-wrapped">
-          <Tile id="other-1">
-            Other Flag Option 1
-          </Tile>
+          <Tile id="other-1">Other Flag Option 1</Tile>
         </TileGroup>
       </FeatureFlags>
       {/* Case 4: Already wrapped with correct flag */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="Correct Wrapped" name="correct">
-          <Tile id="correct-1">
-            Correctly Wrapped Option
-          </Tile>
+          <Tile id="correct-1">Correctly Wrapped Option</Tile>
         </TileGroup>
       </FeatureFlags>
       {/* Case 5: Standalone Tiles with different scenarios */}
       <Stack>
         {/* Unwrapped standalone */}
-        <FeatureFlags enableV12TileDefaultIcons><Tile id="standalone">
-            Standalone Tile
-          </Tile></FeatureFlags>
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile id="standalone">Standalone Tile</Tile>
+        </FeatureFlags>
 
         {/* Wrapped standalone missing flag prop */}
         <FeatureFlags enableV12TileDefaultIcons>
-          <Tile id="wrapped-standalone">
-            Wrapped Standalone
-          </Tile>
+          <Tile id="wrapped-standalone">Wrapped Standalone</Tile>
         </FeatureFlags>
 
         {/* Wrapped standalone with other flag */}
         <FeatureFlags enable-v12-tile-radio-icons enableV12TileDefaultIcons>
-          <Tile id="other-standalone">
-            Other Flag Standalone
-          </Tile>
+          <Tile id="other-standalone">Other Flag Standalone</Tile>
         </FeatureFlags>
 
         {/* Correctly wrapped standalone */}
         <FeatureFlags enableV12TileDefaultIcons>
-          <Tile id="correct-standalone">
-            Correct Standalone
-          </Tile>
+          <Tile id="correct-standalone">Correct Standalone</Tile>
         </FeatureFlags>
       </Stack>
       {/* Case 6: Nested structures */}
       <div className="nested">
-        <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="Nested Group" name="nested">
+        <FeatureFlags enableV12TileDefaultIcons>
+          <TileGroup legend="Nested Group" name="nested">
             <div className="wrapper">
-              <Tile id="nested-1">
-                Nested Option 1
-              </Tile>
+              <Tile id="nested-1">Nested Option 1</Tile>
             </div>
-            <Tile id="nested-2">
-              Nested Option 2
-            </Tile>
-          </TileGroup></FeatureFlags>
+            <Tile id="nested-2">Nested Option 2</Tile>
+          </TileGroup>
+        </FeatureFlags>
       </div>
-    </div>)
+    </div>
   );
 };
 

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -4,7 +4,7 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 const TestComponent: React.FC = () => {
   return (
-    <div>
+    (<div>
       {/* Case 1: Unwrapped TileGroup */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="TestGroup" name="test">
@@ -64,7 +64,7 @@ const TestComponent: React.FC = () => {
           </TileGroup>
         </FeatureFlags>
       </div>
-    </div>
+    </div>)
   );
 };
 

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -5,7 +5,7 @@ import { FeatureFlags } from '@carbon/feature-flags';
 const TestComponent: React.FC = () => {
   return (
     // prettier-ignore
-    <div>
+    (<div>
       {/* Case 1: Unwrapped TileGroup */}
       <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">
           <Tile id="test-1">
@@ -83,7 +83,7 @@ const TestComponent: React.FC = () => {
             </Tile>
           </TileGroup></FeatureFlags>
       </div>
-    </div>
+    </div>)
   );
 };
 

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -4,7 +4,7 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 const TestComponent: React.FC = () => {
   return (
-    (<div>
+    <div>
       {/* Case 1: Unwrapped TileGroup */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="TestGroup" name="test">
@@ -17,6 +17,7 @@ const TestComponent: React.FC = () => {
         <TileGroup legend="Missing Attribute" name="wrapped">
           <Tile id="wrapped-1">Already Wrapped Option 1</Tile>
           <Tile id="wrapped-2">Already Wrapped Option 2</Tile>
+          <Tile id="wrapped-3">Already Wrapped Option 3</Tile>
         </TileGroup>
       </FeatureFlags>
       {/* Case 3: Already wrapped with other flags */}
@@ -64,7 +65,7 @@ const TestComponent: React.FC = () => {
           </TileGroup>
         </FeatureFlags>
       </div>
-    </div>)
+    </div>
   );
 };
 

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { TileGroup, Tile, Stack } from '@carbon/react';
+import { FeatureFlags } from '@carbon/feature-flags';
+
+const TestComponent: React.FC = () => {
+  return (
+    // prettier-ignore
+    <div>
+      {/* Case 1: Unwrapped TileGroup */}
+      <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">
+          <Tile id="test-1">
+            Option 1
+          </Tile>
+          <Tile id="test-2">
+            Option 2
+          </Tile>
+        </TileGroup></FeatureFlags>
+      {/* Wrapped standalone missing flag prop */}
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="Missing Attribute" name="wrapped">
+          <Tile id="wrapped-1">
+            Already Wrapped Option 1
+          </Tile>
+          <Tile id="wrapped-2">
+            Already Wrapped Option 2
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+      {/* Case 3: Already wrapped with other flags */}
+      <FeatureFlags enable-v12-tile-radio-icons enableV12TileDefaultIcons>
+        <TileGroup legend="Other Attribute" name="other-wrapped">
+          <Tile id="other-1">
+            Other Flag Option 1
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+      {/* Case 4: Already wrapped with correct flag */}
+      <FeatureFlags enableV12TileDefaultIcons>
+        <TileGroup legend="Correct Wrapped" name="correct">
+          <Tile id="correct-1">
+            Correctly Wrapped Option
+          </Tile>
+        </TileGroup>
+      </FeatureFlags>
+      {/* Case 5: Standalone Tiles with different scenarios */}
+      <Stack>
+        {/* Unwrapped standalone */}
+        <FeatureFlags enableV12TileDefaultIcons><Tile id="standalone">
+            Standalone Tile
+          </Tile></FeatureFlags>
+
+        {/* Wrapped standalone missing flag prop */}
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile id="wrapped-standalone">
+            Wrapped Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Wrapped standalone with other flag */}
+        <FeatureFlags enable-v12-tile-radio-icons enableV12TileDefaultIcons>
+          <Tile id="other-standalone">
+            Other Flag Standalone
+          </Tile>
+        </FeatureFlags>
+
+        {/* Correctly wrapped standalone */}
+        <FeatureFlags enableV12TileDefaultIcons>
+          <Tile id="correct-standalone">
+            Correct Standalone
+          </Tile>
+        </FeatureFlags>
+      </Stack>
+      {/* Case 6: Nested structures */}
+      <div className="nested">
+        <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="Nested Group" name="nested">
+            <div className="wrapper">
+              <Tile id="nested-1">
+                Nested Option 1
+              </Tile>
+            </div>
+            <Tile id="nested-2">
+              Nested Option 2
+            </Tile>
+          </TileGroup></FeatureFlags>
+      </div>
+    </div>
+  );
+};
+
+export default TestComponent;

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -4,14 +4,13 @@ import { FeatureFlags } from '@carbon/feature-flags';
 
 const TestComponent: React.FC = () => {
   return (
+    //prettier-ignore
     <div>
       {/* Case 1: Unwrapped TileGroup */}
-      <FeatureFlags enableV12TileDefaultIcons>
-        <TileGroup legend="TestGroup" name="test">
+      <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">
           <Tile id="test-1">Option 1</Tile>
           <Tile id="test-2">Option 2</Tile>
-        </TileGroup>
-      </FeatureFlags>
+        </TileGroup></FeatureFlags>
       {/* Wrapped standalone missing flag prop */}
       <FeatureFlags enableV12TileDefaultIcons>
         <TileGroup legend="Missing Attribute" name="wrapped">
@@ -35,9 +34,7 @@ const TestComponent: React.FC = () => {
       {/* Case 5: Standalone Tiles with different scenarios */}
       <Stack>
         {/* Unwrapped standalone */}
-        <FeatureFlags enableV12TileDefaultIcons>
-          <Tile id="standalone">Standalone Tile</Tile>
-        </FeatureFlags>
+        <FeatureFlags enableV12TileDefaultIcons><Tile id="standalone">Standalone Tile</Tile></FeatureFlags>
 
         {/* Wrapped standalone missing flag prop */}
         <FeatureFlags enableV12TileDefaultIcons>
@@ -56,14 +53,12 @@ const TestComponent: React.FC = () => {
       </Stack>
       {/* Case 6: Nested structures */}
       <div className="nested">
-        <FeatureFlags enableV12TileDefaultIcons>
-          <TileGroup legend="Nested Group" name="nested">
+        <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="Nested Group" name="nested">
             <div className="wrapper">
               <Tile id="nested-1">Nested Option 1</Tile>
             </div>
             <Tile id="nested-2">Nested Option 2</Tile>
-          </TileGroup>
-        </FeatureFlags>
+          </TileGroup></FeatureFlags>
       </div>
     </div>
   );

--- a/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
+++ b/packages/upgrade/transforms/__testfixtures__/enable-v12-tile-default-icons.output.tsx
@@ -5,7 +5,7 @@ import { FeatureFlags } from '@carbon/feature-flags';
 const TestComponent: React.FC = () => {
   return (
     //prettier-ignore
-    <div>
+    (<div>
       {/* Case 1: Unwrapped TileGroup */}
       <FeatureFlags enableV12TileDefaultIcons><TileGroup legend="TestGroup" name="test">
           <Tile id="test-1">Option 1</Tile>
@@ -60,7 +60,7 @@ const TestComponent: React.FC = () => {
             <Tile id="nested-2">Nested Option 2</Tile>
           </TileGroup></FeatureFlags>
       </div>
-    </div>
+    </div>)
   );
 };
 

--- a/packages/upgrade/transforms/__tests__/enable-v12-tile-default-icons-test.js
+++ b/packages/upgrade/transforms/__tests__/enable-v12-tile-default-icons-test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { defineTest } = require('jscodeshift/dist/testUtils');
+
+defineTest(__dirname, 'enable-v12-tile-default-icons');

--- a/packages/upgrade/transforms/enable-v12-tile-default-icons.js
+++ b/packages/upgrade/transforms/enable-v12-tile-default-icons.js
@@ -1,0 +1,183 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Migrate Tile components by wrapping them with FeatureFlags
+ */
+
+'use strict';
+
+const defaultOptions = {
+  quote: 'single',
+  trailingComma: true,
+};
+
+function transform(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  const printOptions = options.printOptions || defaultOptions;
+
+  // Early return if no Tile components found
+  if (
+    !root
+      .find(j.JSXElement, { openingElement: { name: { name: 'Tile' } } })
+      .size()
+  ) {
+    return null;
+  }
+
+  let needsFeatureFlagsImport = false;
+
+  // First update all existing FeatureFlags wrappers that need the attribute
+  root
+    .find(j.JSXElement, {
+      openingElement: { name: { name: 'FeatureFlags' } },
+    })
+    .forEach((path) => {
+      const hasTileInside =
+        j(path)
+          .find(j.JSXElement, {
+            openingElement: { name: { name: 'Tile' } },
+          })
+          .size() > 0;
+
+      const hasTileGroupWithTile =
+        j(path)
+          .find(j.JSXElement, {
+            openingElement: { name: { name: 'TileGroup' } },
+          })
+          .filter((tileGroupPath) => {
+            return (
+              j(tileGroupPath)
+                .find(j.JSXElement, {
+                  openingElement: { name: { name: 'Tile' } },
+                })
+                .size() > 0
+            );
+          })
+          .size() > 0;
+
+      if (hasTileInside || hasTileGroupWithTile) {
+        const hasAttribute = path.node.openingElement.attributes.some(
+          (attr) =>
+            attr.type === 'JSXAttribute' &&
+            attr.name.name === 'enableV12TileDefaultIcons'
+        );
+
+        if (!hasAttribute) {
+          path.node.openingElement.attributes.push(
+            j.jsxAttribute(j.jsxIdentifier('enableV12TileDefaultIcons'))
+          );
+          needsFeatureFlagsImport = true;
+        }
+      }
+    });
+
+  // Handle Tiles within TileGroups
+  root
+    .find(j.JSXElement, {
+      openingElement: { name: { name: 'TileGroup' } },
+    })
+    .forEach((path) => {
+      const hasTile =
+        j(path)
+          .find(j.JSXElement, {
+            openingElement: { name: { name: 'Tile' } },
+          })
+          .size() > 0;
+
+      const wrappingFeatureFlags = j(path).closest(j.JSXElement, {
+        openingElement: { name: { name: 'FeatureFlags' } },
+      });
+
+      if (hasTile) {
+        if (wrappingFeatureFlags.size() === 0) {
+          // Not wrapped, add wrapper
+          const featureFlagsWrapper = j.jsxElement(
+            j.jsxOpeningElement(
+              j.jsxIdentifier('FeatureFlags'),
+              [j.jsxAttribute(j.jsxIdentifier('enableV12TileDefaultIcons'))],
+              false
+            ),
+            j.jsxClosingElement(j.jsxIdentifier('FeatureFlags')),
+            [path.node]
+          );
+
+          j(path).replaceWith(featureFlagsWrapper);
+          needsFeatureFlagsImport = true;
+        }
+      }
+    });
+
+  // Handle standalone Tiles
+  root
+    .find(j.JSXElement, {
+      openingElement: { name: { name: 'Tile' } },
+    })
+    .forEach((path) => {
+      const isInsideTileGroup =
+        j(path)
+          .closest(j.JSXElement, {
+            openingElement: { name: { name: 'TileGroup' } },
+          })
+          .size() > 0;
+
+      const wrappingFeatureFlags = j(path).closest(j.JSXElement, {
+        openingElement: { name: { name: 'FeatureFlags' } },
+      });
+
+      if (!isInsideTileGroup) {
+        if (wrappingFeatureFlags.size() === 0) {
+          // Not wrapped, add wrapper
+          const featureFlagsWrapper = j.jsxElement(
+            j.jsxOpeningElement(
+              j.jsxIdentifier('FeatureFlags'),
+              [j.jsxAttribute(j.jsxIdentifier('enableV12TileDefaultIcons'))],
+              false
+            ),
+            j.jsxClosingElement(j.jsxIdentifier('FeatureFlags')),
+            [path.node]
+          );
+
+          j(path).replaceWith(featureFlagsWrapper);
+          needsFeatureFlagsImport = true;
+        }
+      }
+    });
+
+  // Add FeatureFlags import only if we've added wrappers or attributes
+  if (needsFeatureFlagsImport) {
+    const hasFeatureFlagsImport =
+      root
+        .find(j.ImportDeclaration, {
+          source: { value: '@carbon/feature-flags' },
+        })
+        .size() > 0;
+
+    if (!hasFeatureFlagsImport) {
+      // Find the last import declaration
+      const lastImport = root.find(j.ImportDeclaration).at(-1);
+      const featureFlagsImport = j.importDeclaration(
+        [j.importSpecifier(j.identifier('FeatureFlags'))],
+        j.literal('@carbon/feature-flags')
+      );
+
+      if (lastImport.size() > 0) {
+        // Add newline after the last import
+        const newline = j.template.statement`\n`;
+        lastImport.insertAfter(newline);
+        lastImport.insertAfter(featureFlagsImport);
+      } else {
+        // If no imports exist, add at the beginning of the file
+        root.get().node.program.body.unshift(featureFlagsImport);
+      }
+    }
+  }
+
+  return root.toSource(printOptions);
+}
+
+module.exports = transform;
+module.exports.parser = 'tsx';

--- a/packages/upgrade/transforms/enable-v12-tile-default-icons.js
+++ b/packages/upgrade/transforms/enable-v12-tile-default-icons.js
@@ -12,6 +12,8 @@
 const defaultOptions = {
   quote: 'single',
   trailingComma: true,
+  arrowParensAlways: true,
+  parser: 'tsx',
 };
 
 function transform(fileInfo, api, options) {

--- a/packages/upgrade/transforms/enable-v12-tile-default-icons.js
+++ b/packages/upgrade/transforms/enable-v12-tile-default-icons.js
@@ -12,8 +12,6 @@
 const defaultOptions = {
   quote: 'single',
   trailingComma: true,
-  arrowParensAlways: true,
-  parser: 'tsx',
 };
 
 function transform(fileInfo, api, options) {


### PR DESCRIPTION
Closes #18365 
Enable v12 tile radio icons via feature flags
Wrap Tile and TileGroup components with FeatureFlags enableV12TileDefaultIcons
      
          Transforms:
          1. TileGroup with Tiles:
          <TileGroup>
            <Tile>...</Tile>
          </TileGroup>
      
          Into:
          <FeatureFlags enableV12TileDefaultIcons>
            <TileGroup>
              <Tile>...</Tile>
            </TileGroup>
          </FeatureFlags>
      
          2. Standalone Tile:
          <Tile>...</Tile>
      
          Into:
          <FeatureFlags enableV12TileDefaultIcons>
            <Tile>...</Tile>
          </FeatureFlags>

#### Changeloga

**New**
- Added codemod to automatically wrap RadioTile components with FeatureFlags enableV12TileRadioIcons

**Removed**
- None

#### Testing / Reviewing

- Run `yarn build` in `packages/upgrade`
- Using the sample project in the fixtures directory:
  - Run the default upgrade command: `../../bin/carbon-upgrade.js`
  - Choose the sample-project directory
  - Choose the default path
  - Verify no errors occur and that changes are printed to the console (in this case import changes)
  - Run the migration command: `../../bin/carbon-upgrade.js migrate update-carbon-components-react-import-to-scoped`
  - Choose the sample-project directory
  - Verify no errors occur and that changes are printed to the console