### PR TITLE
fix: overflow menu with 3 level nested options display issue

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.featureflag.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.featureflag.stories.js
@@ -78,7 +78,12 @@ export const Nested = () => {
         <MenuItem label="Level 1" />
         <MenuItem label="Level 1" />
         <MenuItem label="Level 1">
-          <MenuItem label="Level 2" />
+          <MenuItem label="Level 2">
+            <MenuItem label="Level 3" />
+            <MenuItem label="Level 3">
+              <MenuItem label="Level 4" />
+            </MenuItem>
+          </MenuItem>
           <MenuItem label="Level 2" />
           <MenuItem label="Level 2" />
         </MenuItem>

--- a/packages/styles/scss/components/menu/_menu.scss
+++ b/packages/styles/scss/components/menu/_menu.scss
@@ -56,6 +56,7 @@
   }
 
   .#{$prefix}--menu--shown {
+    overflow: visible;
     opacity: 1;
   }
 


### PR DESCRIPTION
Closes #18320 

Overflow menu with 3 level of nested values had display issue

#### Changelog

**Changed**

Apply css styles 

#### Testing / Reviewing

1. Go to Storybook > OverflowMenu > Feature Flag > Nested
2. Hover on overflowmenu upto 4 levels, It should display correctly