### PR TITLE
feat: add stackblitz to components

### DIFF
--- a/packages/react/src/components/Theme/Theme.mdx
+++ b/packages/react/src/components/Theme/Theme.mdx
@@ -1,5 +1,6 @@
 import { ArgTypes, Story, Canvas, Meta } from '@storybook/blocks';
 import * as ThemeStories from './Theme.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 <Meta isTemplate />
 
@@ -116,7 +117,6 @@ function ExamplePage() {
   );
 }
 ```
-
 <Canvas of={ThemeStories.Default} />
 
 ## Getting the current theme in a component

--- a/packages/react/src/components/Tile/Tile.mdx
+++ b/packages/react/src/components/Tile/Tile.mdx
@@ -15,6 +15,18 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 ## Table of Contents
 
+- [Tile](#Tile)
+  - [Overview](#overview)
+  - [Clickable](#clickable)
+  - [Expandable](#expandable)
+  - [Expandable with Interactive](#expandable-with-interactive)
+  - [Selectable](#selectable)
+  - [Radio](#radio)
+  - [AI Label](#ai-label)
+  - [Experimental Improved Contrast](#experimental-improved-contrast)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
 ## Overview
 
 <Canvas
@@ -64,7 +76,7 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
   ]}
 />
 
-## Multi Select
+## Selectable
 
 <Canvas
   of={TileStories.Selectable}

--- a/packages/react/src/components/TimePicker/TimePicker.mdx
+++ b/packages/react/src/components/TimePicker/TimePicker.mdx
@@ -1,4 +1,6 @@
-import { ArgTypes, Meta } from '@storybook/blocks';
+import { ArgTypes, Meta, Canvas } from '@storybook/blocks';
+import * as TimePickerStories from './TimePicker.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 <Meta isTemplate />
 
@@ -12,7 +14,22 @@ import { ArgTypes, Meta } from '@storybook/blocks';
 
 ## Table of Contents
 
+- [TimePicker](#timePicker)
+    - [Overview](#overview)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
 ## Overview
+
+<Canvas
+  of={TimePickerStories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(TimePickerStories.Default),
+    },
+  ]}
+/>
 
 ## Component API
 

--- a/packages/react/src/components/Toggle/Toggle.mdx
+++ b/packages/react/src/components/Toggle/Toggle.mdx
@@ -1,4 +1,6 @@
-import { ArgTypes, Meta } from '@storybook/blocks';
+import { ArgTypes, Meta, Canvas } from '@storybook/blocks';
+import * as ToggleStories from './Toggle.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 <Meta isTemplate />
 
@@ -12,7 +14,61 @@ import { ArgTypes, Meta } from '@storybook/blocks';
 
 ## Table of Contents
 
+- [Toggle](#toggle)
+    - [Overview](#overview)
+    - [Small Toggle](#small-toggle)
+    - [Skeleton](#skeleton)
+    - [With Accessible Labels](#with-accessible-lables)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
 ## Overview
+
+<Canvas
+  of={ToggleStories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(ToggleStories.Default),
+    },
+  ]}
+/>
+
+## Small Toggle
+
+<Canvas
+  of={ToggleStories.SmallToggle}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(ToggleStories.SmallToggle),
+    },
+  ]}
+/>
+
+## Skeleton
+
+<Canvas
+  of={ToggleStories.Skeleton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(ToggleStories.Skeleton),
+    },
+  ]}
+/>
+
+## With Accessible Labels
+
+<Canvas
+  of={ToggleStories.WithAccessibleLabels}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(ToggleStories.WithAccessibleLabels),
+    },
+  ]}
+/>
 
 ## Component API
 

--- a/packages/react/src/components/Toggle/Toggle.stories.js
+++ b/packages/react/src/components/Toggle/Toggle.stories.js
@@ -9,22 +9,30 @@ import React from 'react';
 
 import { VStack } from '../Stack';
 import Toggle, { ToggleSkeleton } from '../Toggle';
+import mdx from './Toggle.mdx';
 
 export default {
   title: 'Components/Toggle',
   component: Toggle,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
 };
 
-export const Default = (args) => (
-  <Toggle
-    labelText="Label"
-    labelA="Off"
-    labelB="On"
-    defaultToggled
-    id="toggle-3"
-    {...args}
-  />
-);
+export const Default = (args) => {
+  return (
+    <Toggle
+      labelText="Label"
+      labelA="Off"
+      labelB="On"
+      defaultToggled
+      id="toggle-3"
+      {...args}
+    />
+  );
+};
 
 Default.argTypes = {
   className: {
@@ -69,44 +77,50 @@ Default.argTypes = {
   },
 };
 
-export const SmallToggle = () => (
-  <Toggle
-    size="sm"
-    labelText="Label"
-    labelA="Off"
-    labelB="On"
-    defaultToggled
-    id="toggle-2"
-  />
-);
+export const SmallToggle = () => {
+  return (
+    <Toggle
+      size="sm"
+      labelText="Label"
+      labelA="Off"
+      labelB="On"
+      defaultToggled
+      id="toggle-2"
+    />
+  );
+};
 
-export const WithAccessibleLabels = () => (
-  <VStack gap={7}>
-    <Toggle id="toggle-4" labelText="Label" />
+export const WithAccessibleLabels = () => {
+  return (
+    <VStack gap={7}>
+      <Toggle id="toggle-4" labelText="Label" />
 
-    <Toggle id="toggle-5" labelText="Label" hideLabel />
+      <Toggle id="toggle-5" labelText="Label" hideLabel />
 
-    <div>
-      <div id="toggle-6-label" style={{ marginBlockEnd: '0.5rem' }}>
-        Internal aria-label toggle
+      <div>
+        <div id="toggle-6-label" style={{ marginBlockEnd: '0.5rem' }}>
+          Internal aria-label toggle
+        </div>
+        <Toggle aria-labelledby="toggle-6-label" id="toggle-6" />
       </div>
-      <Toggle aria-labelledby="toggle-6-label" id="toggle-6" />
-    </div>
 
+      <div>
+        <label
+          id="toggle-7-label"
+          htmlFor="toggle-7"
+          style={{ display: 'block', marginBlockEnd: '0.5rem' }}>
+          External toggle label
+        </label>
+        <Toggle aria-labelledby="toggle-7-label" id="toggle-7" />
+      </div>
+    </VStack>
+  );
+};
+
+export const Skeleton = () => {
+  return (
     <div>
-      <label
-        id="toggle-7-label"
-        htmlFor="toggle-7"
-        style={{ display: 'block', marginBlockEnd: '0.5rem' }}>
-        External toggle label
-      </label>
-      <Toggle aria-labelledby="toggle-7-label" id="toggle-7" />
+      <ToggleSkeleton />
     </div>
-  </VStack>
-);
-
-export const Skeleton = () => (
-  <div>
-    <ToggleSkeleton />
-  </div>
-);
+  );
+};

--- a/packages/react/src/components/Toggletip/Toggletip.mdx
+++ b/packages/react/src/components/Toggletip/Toggletip.mdx
@@ -1,4 +1,6 @@
-import { ArgTypes, Meta } from '@storybook/blocks';
+import { ArgTypes, Meta, Canvas } from '@storybook/blocks';
+import * as ToggletipStories from './Toggletip.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 <Meta isTemplate />
 
@@ -12,6 +14,7 @@ import { ArgTypes, Meta } from '@storybook/blocks';
 
 ## Table of Contents
 
+- [Toggletip](#Toggletip)
 - [Overview](#overview)
   - [Toggletips vs Tooltips](#toggletips-vs-tooltips)
 - [Component API](#component-api)

--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -16,6 +16,7 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 ## Table of Contents
 
+- [Tooltip](#Tooltip)
 - [Overview](#overview)
   - [Toggletips vs Tooltips](#toggletips-vs-tooltips)
   - [Customizing the content of a tooltip](#customizing-the-content-of-a-tooltip)

--- a/packages/react/src/components/TreeView/TreeView.mdx
+++ b/packages/react/src/components/TreeView/TreeView.mdx
@@ -14,6 +14,14 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 ## Table of Contents
 
+- [TreeView](#TreeView)
+  - [Overview](#overview)
+  - [With Controlled Expansion](#with-controlled-expansion)
+  - [With Custom Icons](#with-custom-icons)
+  - [Temp](#temp)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
 ## Overview
 
 TreeView is a component that allows users to navigate through a hierarchy of
@@ -67,6 +75,22 @@ TreeView.
       onClick: () =>
         stackblitzPrefillConfig(
           TreeViewStories.WithIcons,
+          "import { Document, Folder } from '@carbon/icons-react';"
+        ),
+    },
+  ]}
+/>
+
+## Temp
+
+<Canvas
+  of={TreeViewStories.Temp}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig(
+          TreeViewStories.Temp,
           "import { Document, Folder } from '@carbon/icons-react';"
         ),
     },

--- a/packages/react/src/components/TreeView/Treeview.stories.js
+++ b/packages/react/src/components/TreeView/Treeview.stories.js
@@ -12,176 +12,6 @@ import { default as TreeView, TreeNode } from './';
 import mdx from './TreeView.mdx';
 import './story.scss';
 
-const nodes = [
-  {
-    id: '1',
-    value: 'Artificial intelligence',
-    label: <span>Artificial intelligence</span>,
-    renderIcon: Document,
-  },
-  {
-    id: '2',
-    value: 'Blockchain',
-    label: 'Blockchain',
-    renderIcon: Document,
-  },
-  {
-    id: '3',
-    value: 'Business automation',
-    label: 'Business automation',
-    renderIcon: Folder,
-    children: [
-      {
-        id: '3-1',
-        value: 'Business process automation',
-        label: 'Business process automation',
-        renderIcon: Document,
-      },
-      {
-        id: '3-2',
-        value: 'Business process mapping',
-        label: 'Business process mapping',
-        renderIcon: Document,
-      },
-    ],
-  },
-  {
-    id: '4',
-    value: 'Business operations',
-    label: 'Business operations',
-    renderIcon: Document,
-  },
-  {
-    id: '5',
-    value: 'Cloud computing',
-    label: 'Cloud computing',
-    isExpanded: true,
-    renderIcon: Folder,
-    children: [
-      {
-        id: '5-1',
-        value: 'Containers',
-        label: 'Containers',
-        renderIcon: Document,
-      },
-      {
-        id: '5-2',
-        value: 'Databases',
-        label: 'Databases',
-        renderIcon: Document,
-      },
-      {
-        id: '5-3',
-        value: 'DevOps',
-        label: 'DevOps',
-        isExpanded: true,
-        renderIcon: Folder,
-        children: [
-          {
-            id: '5-4',
-            value: 'Solutions',
-            label: 'Solutions',
-            renderIcon: Document,
-          },
-          {
-            id: '5-5',
-            value: 'Case studies',
-            label: 'Case studies',
-            isExpanded: true,
-            renderIcon: Folder,
-            children: [
-              {
-                id: '5-6',
-                value: 'Resources',
-                label: 'Resources',
-                renderIcon: Document,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    id: '6',
-    value: 'Data & Analytics',
-    label: 'Data & Analytics',
-    renderIcon: Folder,
-    children: [
-      {
-        id: '6-1',
-        value: 'Big data',
-        label: 'Big data',
-        renderIcon: Document,
-      },
-      {
-        id: '6-2',
-        value: 'Business intelligence',
-        label: 'Business intelligence',
-        renderIcon: Document,
-      },
-    ],
-  },
-  {
-    id: '7',
-    value: 'Models',
-    label: 'Models',
-    isExpanded: true,
-    disabled: true,
-    renderIcon: Folder,
-    children: [
-      {
-        id: '7-1',
-        value: 'Audit',
-        label: 'Audit',
-        renderIcon: Document,
-      },
-      {
-        id: '7-2',
-        value: 'Monthly data',
-        label: 'Monthly data',
-        renderIcon: Document,
-      },
-      {
-        id: '8',
-        value: 'Data warehouse',
-        label: 'Data warehouse',
-        isExpanded: true,
-        renderIcon: Folder,
-        children: [
-          {
-            id: '8-1',
-            value: 'Report samples',
-            label: 'Report samples',
-            renderIcon: Document,
-          },
-          {
-            id: '8-2',
-            value: 'Sales performance',
-            label: 'Sales performance',
-            renderIcon: Document,
-          },
-        ],
-      },
-    ],
-  },
-];
-
-function renderTree({ nodes, expanded, withIcons = false }) {
-  if (!nodes) {
-    return;
-  }
-  return nodes.map(({ children, renderIcon, isExpanded, ...nodeProps }) => (
-    <TreeNode
-      key={nodeProps.id}
-      renderIcon={withIcons ? renderIcon : null}
-      isExpanded={expanded ?? isExpanded}
-      {...nodeProps}>
-      {renderTree({ nodes: children, expanded, withIcons })}
-    </TreeNode>
-  ));
-}
-
 export default {
   title: 'components/TreeView',
   component: TreeView,
@@ -778,11 +608,13 @@ export const WithControlledExpansion = () => {
   );
 };
 
-export const Temp = () => (
-  <TreeView label="Tree View">
-    <TreeNode label="Enabled">
-      <TreeNode label="Disabled" disabled />
-    </TreeNode>
-    <TreeNode label="Disabled" disabled></TreeNode>
-  </TreeView>
-);
+export const Temp = () => {
+  return (
+    <TreeView label="Tree View">
+      <TreeNode label="Enabled">
+        <TreeNode label="Disabled" disabled />
+      </TreeNode>
+      <TreeNode label="Disabled" disabled></TreeNode>
+    </TreeView>
+  );
+};

--- a/packages/react/src/components/UnorderedList/UnorderedList.mdx
+++ b/packages/react/src/components/UnorderedList/UnorderedList.mdx
@@ -1,4 +1,6 @@
-import { ArgTypes, Meta } from '@storybook/blocks';
+import { ArgTypes, Meta, Canvas } from '@storybook/blocks';
+import * as UnorderedList from './UnorderedList.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 <Meta isTemplate />
 
@@ -12,7 +14,35 @@ import { ArgTypes, Meta } from '@storybook/blocks';
 
 ## Table of Contents
 
+- [UnorderedList](#UnorderedList)
+    - [Overview](#overview)
+    - [Nested](#Nested)
+- [Component API](#component-api)
+- [Feedback](#feedback)
+
 ## Overview
+
+<Canvas
+  of={UnorderedList.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(UnorderedList.Default),
+    },
+  ]}
+/>
+
+## Nested
+
+<Canvas
+  of={UnorderedList.Nested}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(UnorderedList.Nested),
+    },
+  ]}
+/>
 
 ## Component API
 

--- a/packages/react/src/components/UnorderedList/UnorderedList.stories.js
+++ b/packages/react/src/components/UnorderedList/UnorderedList.stories.js
@@ -9,14 +9,7 @@ import React from 'react';
 
 import ListItem from '../ListItem';
 import UnorderedList from '../UnorderedList';
-
-const props = {
-  regular: () => {
-    return {
-      isExpressive: false,
-    };
-  },
-};
+import mdx from './UnorderedList.mdx';
 
 export default {
   title: 'Components/UnorderedList',
@@ -24,15 +17,22 @@ export default {
   subcomponents: {
     ListItem,
   },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
 };
 
-export const Default = (args) => (
-  <UnorderedList {...args}>
-    <ListItem>Unordered List level 1</ListItem>
-    <ListItem>Unordered List level 1</ListItem>
-    <ListItem>Unordered List level 1</ListItem>
-  </UnorderedList>
-);
+export const Default = (args) => {
+  return (
+    <UnorderedList {...args}>
+      <ListItem>Unordered List level 1</ListItem>
+      <ListItem>Unordered List level 1</ListItem>
+      <ListItem>Unordered List level 1</ListItem>
+    </UnorderedList>
+  );
+};
 
 Default.args = {
   isExpressive: false,
@@ -47,6 +47,13 @@ Default.argTypes = {
 };
 
 export const Nested = () => {
+  const props = {
+    regular: () => {
+      return {
+        isExpressive: false,
+      };
+    },
+  };
   const regularProps = props.regular();
 
   return (


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18475

Second wave of components docs update to added "Open in Stackblitz".

#### Changelog

**Changed**

- Added Canvas to some components, so "Open in Stackblitz" should be displayed in storybook.
- Updated and created mdx file to some components.

#### Testing / Reviewing

- CI should pass
- Stories should work as expected
- Try to open a few stories on Stackblitz
- Need refinement and more tests
