### PR TITLE
feat: added polymorphicprops to popover

### DIFF
--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -32,6 +32,10 @@ import {
 } from '@floating-ui/react';
 import { hide } from '@floating-ui/dom';
 import { useFeatureFlag } from '../FeatureFlags';
+import {
+  PolymorphicComponentPropWithRef,
+  PolymorphicRef,
+} from '../../internal/PolymorphicProps';
 
 export interface PopoverContext {
   setFloating: React.Ref<HTMLSpanElement>;
@@ -151,350 +155,337 @@ export interface PopoverBaseProps {
   open: boolean;
 }
 
-export type PopoverProps<E extends ElementType> = PolymorphicProps<
-  E,
-  PopoverBaseProps
->;
+export type PopoverProps<E extends React.ElementType> =
+  PolymorphicComponentPropWithRef<E, PopoverBaseProps>;
 
-export interface PopoverComponent {
-  <E extends ElementType = 'span'>(
-    props: PopoverProps<E> & { forwardRef?: ForwardedRef<ElementType> }
-  ): JSX.Element | null;
+export type PopoverComponent = <E extends React.ElementType = 'span'>(
+  props: PopoverProps<E>
+) => React.ReactElement | any;
+
+export const Popover: PopoverComponent & {
   displayName?: string;
   propTypes?: WeakValidationMap<PopoverProps<any>>;
-}
+} = React.forwardRef(function PopoverRenderFunction<
+  E extends ElementType = 'span',
+>(
+  {
+    isTabTip,
+    align: initialAlign = isTabTip ? 'bottom-start' : 'bottom',
+    as: BaseComponent = 'span' as E,
+    autoAlign = false,
+    autoAlignBoundary,
+    caret = isTabTip ? false : true,
+    className: customClassName,
+    children,
+    dropShadow = true,
+    highContrast = false,
+    onRequestClose,
+    open,
+    alignmentAxisOffset,
+    ...rest
+  }: PopoverProps<E>,
+  forwardRef: PolymorphicRef<E>
+) {
+  const prefix = usePrefix();
+  const floating = useRef<HTMLSpanElement>(null);
+  const caretRef = useRef<HTMLSpanElement>(null);
+  const popover = useRef<Element>(null);
+  const enableFloatingStyles =
+    useFeatureFlag('enable-v12-dynamic-floating-styles') || autoAlign;
 
-export const Popover: PopoverComponent = React.forwardRef(
-  function PopoverRenderFunction<E extends ElementType = 'span'>(
-    {
-      isTabTip,
-      align: initialAlign = isTabTip ? 'bottom-start' : 'bottom',
-      as: BaseComponent = 'span' as E,
-      autoAlign = false,
-      autoAlignBoundary,
-      caret = isTabTip ? false : true,
-      className: customClassName,
-      children,
-      dropShadow = true,
-      highContrast = false,
-      onRequestClose,
-      open,
-      alignmentAxisOffset,
-      ...rest
-    }: PopoverProps<E>,
-    forwardRef: ForwardedRef<Element>
-  ) {
-    const prefix = usePrefix();
-    const floating = useRef<HTMLSpanElement>(null);
-    const caretRef = useRef<HTMLSpanElement>(null);
-    const popover = useRef<Element>(null);
-    const enableFloatingStyles =
-      useFeatureFlag('enable-v12-dynamic-floating-styles') || autoAlign;
+  let align = mapPopoverAlignProp(initialAlign);
 
-    let align = mapPopoverAlignProp(initialAlign);
+  // If the `Popover` is the last focusable item in the tab order, it should also close when the browser window loses focus  (#12922)
+  useWindowEvent('blur', () => {
+    if (open) {
+      onRequestClose?.();
+    }
+  });
 
-    // If the `Popover` is the last focusable item in the tab order, it should also close when the browser window loses focus  (#12922)
-    useWindowEvent('blur', () => {
-      if (open) {
-        onRequestClose?.();
-      }
-    });
+  useWindowEvent('click', (event: Event) => {
+    if (open && !popover?.current?.contains(event.target as Node)) {
+      onRequestClose?.();
+    }
+  });
 
-    useWindowEvent('click', (event: Event) => {
-      if (open && !popover?.current?.contains(event.target as Node)) {
-        onRequestClose?.();
-      }
-    });
-
-    // Slug styling places a border around the popover content so the caret
-    // needs to be placed 1px further outside the popover content. To do so,
-    // we look to see if any of the children has a className containing "slug"
-    const initialCaretHeight = React.Children.toArray(children).some((x) => {
-      return (
-        (x as any)?.props?.className?.includes('slug') ||
-        (x as any)?.props?.className?.includes('ai-label')
-      );
-    })
-      ? 7
-      : 6;
-    // These defaults match the defaults defined in packages/styles/scss/components/popover/_popover.scss
-    const popoverDimensions = useRef({
-      offset: 10,
-      caretHeight: initialCaretHeight,
-    });
-
-    useIsomorphicEffect(() => {
-      // The popover is only offset when a caret is present. Technically, the custom properties
-      // accessed below can be set by a user even if caret=false, but doing so does not follow
-      // the design specification for Popover.
-      if (caret && popover.current) {
-        // Gather the dimensions of the caret and prefer the values set via custom properties.
-        // If a value is not set via a custom property, provide a default value that matches the
-        // default values defined in the sass style file
-        const getStyle = window.getComputedStyle(popover.current, null);
-        const offsetProperty = getStyle.getPropertyValue(
-          '--cds-popover-offset'
-        );
-        const caretProperty = getStyle.getPropertyValue(
-          '--cds-popover-caret-height'
-        );
-
-        // Handle if the property values are in px or rem.
-        // We want to store just the base number value without a unit suffix
-        if (offsetProperty) {
-          popoverDimensions.current.offset = offsetProperty.includes('px')
-            ? Number(offsetProperty.split('px', 1)[0]) * 1
-            : Number(offsetProperty.split('rem', 1)[0]) * 16;
-        }
-
-        if (caretProperty) {
-          popoverDimensions.current.caretHeight = caretProperty.includes('px')
-            ? Number(caretProperty.split('px', 1)[0]) * 1
-            : Number(caretProperty.split('rem', 1)[0]) * 16;
-        }
-      }
-    });
-    const { refs, floatingStyles, placement, middlewareData } = useFloating(
-      enableFloatingStyles
-        ? {
-            placement: align,
-
-            // The floating element is positioned relative to its nearest
-            // containing block (usually the viewport). It will in many cases also
-            // “break” the floating element out of a clipping ancestor.
-            // https://floating-ui.com/docs/misc#clipping
-            strategy: 'fixed',
-
-            // Middleware order matters, arrow should be last
-            middleware: [
-              offset(
-                !isTabTip
-                  ? {
-                      alignmentAxis: alignmentAxisOffset,
-                      mainAxis: popoverDimensions?.current?.offset,
-                    }
-                  : 0
-              ),
-              autoAlign &&
-                flip({
-                  fallbackPlacements: align.includes('bottom')
-                    ? [
-                        'bottom',
-                        'bottom-start',
-                        'bottom-end',
-                        'right',
-                        'right-start',
-                        'right-end',
-                        'left',
-                        'left-start',
-                        'left-end',
-                        'top',
-                        'top-start',
-                        'top-end',
-                      ]
-                    : [
-                        'top',
-                        'top-start',
-                        'top-end',
-                        'left',
-                        'left-start',
-                        'left-end',
-                        'right',
-                        'right-start',
-                        'right-end',
-                        'bottom',
-                        'bottom-start',
-                        'bottom-end',
-                      ],
-
-                  fallbackStrategy: 'initialPlacement',
-                  fallbackAxisSideDirection: 'start',
-                  boundary: autoAlignBoundary,
-                }),
-              arrow({
-                element: caretRef,
-              }),
-              autoAlign && hide(),
-            ],
-            whileElementsMounted: autoUpdate,
-          }
-        : {}
-      // When autoAlign is turned off & the `enable-v12-dynamic-floating-styles` feature flag is not
-      // enabled, floating-ui will not be used
+  // Slug styling places a border around the popover content so the caret
+  // needs to be placed 1px further outside the popover content. To do so,
+  // we look to see if any of the children has a className containing "slug"
+  const initialCaretHeight = React.Children.toArray(children).some((x) => {
+    return (
+      (x as any)?.props?.className?.includes('slug') ||
+      (x as any)?.props?.className?.includes('ai-label')
     );
+  })
+    ? 7
+    : 6;
+  // These defaults match the defaults defined in packages/styles/scss/components/popover/_popover.scss
+  const popoverDimensions = useRef({
+    offset: 10,
+    caretHeight: initialCaretHeight,
+  });
 
-    const value = useMemo(() => {
-      return {
-        floating,
-        setFloating: refs.setFloating,
-        caretRef,
-        autoAlign: autoAlign,
-      };
-    }, [refs.setFloating, autoAlign]);
+  useIsomorphicEffect(() => {
+    // The popover is only offset when a caret is present. Technically, the custom properties
+    // accessed below can be set by a user even if caret=false, but doing so does not follow
+    // the design specification for Popover.
+    if (caret && popover.current) {
+      // Gather the dimensions of the caret and prefer the values set via custom properties.
+      // If a value is not set via a custom property, provide a default value that matches the
+      // default values defined in the sass style file
+      const getStyle = window.getComputedStyle(popover.current, null);
+      const offsetProperty = getStyle.getPropertyValue('--cds-popover-offset');
+      const caretProperty = getStyle.getPropertyValue(
+        '--cds-popover-caret-height'
+      );
 
-    if (isTabTip) {
-      const tabTipAlignments: PopoverAlignment[] = [
-        'bottom-start',
-        'bottom-end',
-      ];
+      // Handle if the property values are in px or rem.
+      // We want to store just the base number value without a unit suffix
+      if (offsetProperty) {
+        popoverDimensions.current.offset = offsetProperty.includes('px')
+          ? Number(offsetProperty.split('px', 1)[0]) * 1
+          : Number(offsetProperty.split('rem', 1)[0]) * 16;
+      }
 
-      if (!tabTipAlignments.includes(align)) {
-        align = 'bottom-start';
+      if (caretProperty) {
+        popoverDimensions.current.caretHeight = caretProperty.includes('px')
+          ? Number(caretProperty.split('px', 1)[0]) * 1
+          : Number(caretProperty.split('rem', 1)[0]) * 16;
       }
     }
+  });
+  const { refs, floatingStyles, placement, middlewareData } = useFloating(
+    enableFloatingStyles
+      ? {
+          placement: align,
 
-    useEffect(() => {
-      if (enableFloatingStyles) {
-        const updatedFloatingStyles = {
-          ...floatingStyles,
-          visibility: middlewareData.hide?.referenceHidden
-            ? 'hidden'
-            : 'visible',
-        };
-        Object.keys(updatedFloatingStyles).forEach((style) => {
-          if (refs.floating.current) {
-            refs.floating.current.style[style] = updatedFloatingStyles[style];
-          }
-        });
+          // The floating element is positioned relative to its nearest
+          // containing block (usually the viewport). It will in many cases also
+          // “break” the floating element out of a clipping ancestor.
+          // https://floating-ui.com/docs/misc#clipping
+          strategy: 'fixed',
 
-        if (
-          caret &&
-          middlewareData &&
-          middlewareData.arrow &&
-          caretRef?.current
-        ) {
-          const { x, y } = middlewareData.arrow;
+          // Middleware order matters, arrow should be last
+          middleware: [
+            offset(
+              !isTabTip
+                ? {
+                    alignmentAxis: alignmentAxisOffset,
+                    mainAxis: popoverDimensions?.current?.offset,
+                  }
+                : 0
+            ),
+            autoAlign &&
+              flip({
+                fallbackPlacements: align.includes('bottom')
+                  ? [
+                      'bottom',
+                      'bottom-start',
+                      'bottom-end',
+                      'right',
+                      'right-start',
+                      'right-end',
+                      'left',
+                      'left-start',
+                      'left-end',
+                      'top',
+                      'top-start',
+                      'top-end',
+                    ]
+                  : [
+                      'top',
+                      'top-start',
+                      'top-end',
+                      'left',
+                      'left-start',
+                      'left-end',
+                      'right',
+                      'right-start',
+                      'right-end',
+                      'bottom',
+                      'bottom-start',
+                      'bottom-end',
+                    ],
 
-          const staticSide = {
-            top: 'bottom',
-            right: 'left',
-            bottom: 'top',
-            left: 'right',
-          }[placement.split('-')[0]];
-
-          caretRef.current.style.left = x != null ? `${x}px` : '';
-          caretRef.current.style.top = y != null ? `${y}px` : '';
-
-          // Ensure the static side gets unset when flipping to other placements' axes.
-          caretRef.current.style.right = '';
-          caretRef.current.style.bottom = '';
-
-          if (staticSide) {
-            caretRef.current.style[staticSide] = `${-popoverDimensions?.current
-              ?.caretHeight}px`;
-          }
+                fallbackStrategy: 'initialPlacement',
+                fallbackAxisSideDirection: 'start',
+                boundary: autoAlignBoundary,
+              }),
+            arrow({
+              element: caretRef,
+            }),
+            autoAlign && hide(),
+          ],
+          whileElementsMounted: autoUpdate,
         }
-      }
-    }, [
-      floatingStyles,
-      refs.floating,
-      enableFloatingStyles,
-      middlewareData,
-      placement,
-      caret,
-    ]);
+      : {}
+    // When autoAlign is turned off & the `enable-v12-dynamic-floating-styles` feature flag is not
+    // enabled, floating-ui will not be used
+  );
 
-    const ref = useMergedRefs([forwardRef, popover]);
-    const currentAlignment =
-      autoAlign && placement !== align ? placement : align;
-    const className = cx(
-      {
-        [`${prefix}--popover-container`]: true,
-        [`${prefix}--popover--caret`]: caret,
-        [`${prefix}--popover--drop-shadow`]: dropShadow,
-        [`${prefix}--popover--high-contrast`]: highContrast,
-        [`${prefix}--popover--open`]: open,
-        [`${prefix}--popover--auto-align ${prefix}--autoalign`]:
-          enableFloatingStyles,
-        [`${prefix}--popover--${currentAlignment}`]: true,
-        [`${prefix}--popover--tab-tip`]: isTabTip,
-      },
-      customClassName
-    );
+  const value = useMemo(() => {
+    return {
+      floating,
+      setFloating: refs.setFloating,
+      caretRef,
+      autoAlign: autoAlign,
+    };
+  }, [refs.setFloating, autoAlign]);
 
-    const mappedChildren = React.Children.map(children, (child) => {
-      const item = child as any;
-      const displayName = item?.type?.displayName;
+  if (isTabTip) {
+    const tabTipAlignments: PopoverAlignment[] = ['bottom-start', 'bottom-end'];
 
-      /**
-       * Only trigger elements (button) or trigger components (ToggletipButton) should be
-       * cloned because these will be decorated with a trigger-specific className and ref.
-       *
-       * There are also some specific components that should not be cloned when autoAlign
-       * is on, even if they are a trigger element.
-       */
-      const isTriggerElement = item?.type === 'button';
-      const isTriggerComponent =
-        enableFloatingStyles &&
-        displayName &&
-        ['ToggletipButton'].includes(displayName);
-      const isAllowedTriggerComponent =
-        enableFloatingStyles &&
-        !['ToggletipContent', 'PopoverContent'].includes(displayName);
+    if (!tabTipAlignments.includes(align)) {
+      align = 'bottom-start';
+    }
+  }
+
+  useEffect(() => {
+    if (enableFloatingStyles) {
+      const updatedFloatingStyles = {
+        ...floatingStyles,
+        visibility: middlewareData.hide?.referenceHidden ? 'hidden' : 'visible',
+      };
+      Object.keys(updatedFloatingStyles).forEach((style) => {
+        if (refs.floating.current) {
+          refs.floating.current.style[style] = updatedFloatingStyles[style];
+        }
+      });
 
       if (
-        React.isValidElement(item) &&
-        (isTriggerElement || isTriggerComponent || isAllowedTriggerComponent)
+        caret &&
+        middlewareData &&
+        middlewareData.arrow &&
+        caretRef?.current
       ) {
-        const className = (item?.props as any)?.className;
-        const ref = (item?.props as any).ref;
-        const tabTipClasses = cx(
-          `${prefix}--popover--tab-tip__button`,
-          className
-        );
+        const { x, y } = middlewareData.arrow;
 
-        return React.cloneElement(item as any, {
-          className:
-            isTabTip && item?.type === 'button'
-              ? tabTipClasses
-              : className || '',
+        const staticSide = {
+          top: 'bottom',
+          right: 'left',
+          bottom: 'top',
+          left: 'right',
+        }[placement.split('-')[0]];
 
-          // With cloneElement, if you pass a `ref`, it overrides the original ref.
-          // https://react.dev/reference/react/cloneElement#parameters
-          // The block below works around this and ensures that the original ref is still
-          // called while allowing the floating-ui reference element to be set as well.
-          // `useMergedRefs` can't be used here because hooks can't be called from within a callback.
-          // More here: https://github.com/facebook/react/issues/8873#issuecomment-489579878
-          ref: (node) => {
-            // For a popover, there isn't an explicit trigger component, it's just the first child that's
-            // passed in which should *not* be PopoverContent.
-            // For a toggletip there is a specific trigger component, ToggletipButton.
-            // In either of these caes we want to set this as the reference node for floating-ui autoAlign
-            // positioning.
-            if (
-              (enableFloatingStyles &&
-                (item?.type as any)?.displayName !== 'PopoverContent') ||
-              (enableFloatingStyles &&
-                (item?.type as any)?.displayName === 'ToggletipButton')
-            ) {
-              // Set the reference element for floating-ui
-              refs.setReference(node);
-            }
+        caretRef.current.style.left = x != null ? `${x}px` : '';
+        caretRef.current.style.top = y != null ? `${y}px` : '';
 
-            // Call the original ref, if any
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref !== null && ref !== undefined) {
-              ref.current = node;
-            }
-          },
-        });
-      } else {
-        return item;
+        // Ensure the static side gets unset when flipping to other placements' axes.
+        caretRef.current.style.right = '';
+        caretRef.current.style.bottom = '';
+
+        if (staticSide) {
+          caretRef.current.style[staticSide] = `${-popoverDimensions?.current
+            ?.caretHeight}px`;
+        }
       }
-    });
+    }
+  }, [
+    floatingStyles,
+    refs.floating,
+    enableFloatingStyles,
+    middlewareData,
+    placement,
+    caret,
+  ]);
 
-    const BaseComponentAsAny = BaseComponent as any;
+  const ref = useMergedRefs([forwardRef, popover]);
+  const currentAlignment = autoAlign && placement !== align ? placement : align;
+  const className = cx(
+    {
+      [`${prefix}--popover-container`]: true,
+      [`${prefix}--popover--caret`]: caret,
+      [`${prefix}--popover--drop-shadow`]: dropShadow,
+      [`${prefix}--popover--high-contrast`]: highContrast,
+      [`${prefix}--popover--open`]: open,
+      [`${prefix}--popover--auto-align ${prefix}--autoalign`]:
+        enableFloatingStyles,
+      [`${prefix}--popover--${currentAlignment}`]: true,
+      [`${prefix}--popover--tab-tip`]: isTabTip,
+    },
+    customClassName
+  );
 
-    return (
-      <PopoverContext.Provider value={value}>
-        <BaseComponentAsAny {...rest} className={className} ref={ref}>
-          {enableFloatingStyles || isTabTip ? mappedChildren : children}
-        </BaseComponentAsAny>
-      </PopoverContext.Provider>
-    );
-  }
-) as PopoverComponent;
+  const mappedChildren = React.Children.map(children, (child) => {
+    const item = child as any;
+    const displayName = item?.type?.displayName;
+
+    /**
+     * Only trigger elements (button) or trigger components (ToggletipButton) should be
+     * cloned because these will be decorated with a trigger-specific className and ref.
+     *
+     * There are also some specific components that should not be cloned when autoAlign
+     * is on, even if they are a trigger element.
+     */
+    const isTriggerElement = item?.type === 'button';
+    const isTriggerComponent =
+      enableFloatingStyles &&
+      displayName &&
+      ['ToggletipButton'].includes(displayName);
+    const isAllowedTriggerComponent =
+      enableFloatingStyles &&
+      !['ToggletipContent', 'PopoverContent'].includes(displayName);
+
+    if (
+      React.isValidElement(item) &&
+      (isTriggerElement || isTriggerComponent || isAllowedTriggerComponent)
+    ) {
+      const className = (item?.props as any)?.className;
+      const ref = (item?.props as any).ref;
+      const tabTipClasses = cx(
+        `${prefix}--popover--tab-tip__button`,
+        className
+      );
+
+      return React.cloneElement(item as any, {
+        className:
+          isTabTip && item?.type === 'button' ? tabTipClasses : className || '',
+
+        // With cloneElement, if you pass a `ref`, it overrides the original ref.
+        // https://react.dev/reference/react/cloneElement#parameters
+        // The block below works around this and ensures that the original ref is still
+        // called while allowing the floating-ui reference element to be set as well.
+        // `useMergedRefs` can't be used here because hooks can't be called from within a callback.
+        // More here: https://github.com/facebook/react/issues/8873#issuecomment-489579878
+        ref: (node) => {
+          // For a popover, there isn't an explicit trigger component, it's just the first child that's
+          // passed in which should *not* be PopoverContent.
+          // For a toggletip there is a specific trigger component, ToggletipButton.
+          // In either of these caes we want to set this as the reference node for floating-ui autoAlign
+          // positioning.
+          if (
+            (enableFloatingStyles &&
+              (item?.type as any)?.displayName !== 'PopoverContent') ||
+            (enableFloatingStyles &&
+              (item?.type as any)?.displayName === 'ToggletipButton')
+          ) {
+            // Set the reference element for floating-ui
+            refs.setReference(node);
+          }
+
+          // Call the original ref, if any
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref !== null && ref !== undefined) {
+            ref.current = node;
+          }
+        },
+      });
+    } else {
+      return item;
+    }
+  });
+
+  const BaseComponentAsAny = BaseComponent as React.ElementType;
+
+  return (
+    <PopoverContext.Provider value={value}>
+      <BaseComponentAsAny {...rest} className={className} ref={ref}>
+        {enableFloatingStyles || isTabTip ? mappedChildren : children}
+      </BaseComponentAsAny>
+    </PopoverContext.Provider>
+  );
+}) as PopoverComponent;
 
 // Note: this displayName is temporarily set so that Storybook ArgTable
 // correctly displays the name of this component


### PR DESCRIPTION
Closes #18424

Added strong PolymorphicProps for `Popover`.

#### Changelog

**Changed**

- Changed the way the PolymorphicProp is validated.
- NOTE: The only changes are in the way the `type`
      <details>
        <summary>Code example</summary>

            export type PopoverProps<E extends React.ElementType> =
              PolymorphicComponentPropWithRef<E, PopoverBaseProps>;
            
            export type PopoverComponent = <E extends React.ElementType = 'span'>(
              props: PopoverProps<E>
            ) => React.ReactElement | any;
            
            export const Popover: PopoverComponent & {
              displayName?: string;
              propTypes?: WeakValidationMap<PopoverProps<any>>;
            } = React.forwardRef(function PopoverRenderFunction<
              E extends ElementType = 'span',
            >(
              {
                isTabTip,
                align: initialAlign = isTabTip ? 'bottom-start' : 'bottom',
                as: BaseComponent = 'span' as E,
                autoAlign = false,
                autoAlignBoundary,
                caret = isTabTip ? false : true,
                className: customClassName,
                children,
                dropShadow = true,
                highContrast = false,
                onRequestClose,
                open,
                alignmentAxisOffset,
                ...rest
              }: PopoverProps<E>,
              forwardRef: PolymorphicRef<E>
            ) {

#### Testing / Reviewing

- CI should pass
- You can also pull down the PR locally to test, but here it is a screenshot:
