### PR TITLE
fix: tooltip word break

### DIFF
--- a/packages/web-components/src/components/tooltip/tooltip.scss
+++ b/packages/web-components/src/components/tooltip/tooltip.scss
@@ -39,7 +39,9 @@
   }
 }
 
-:host(#{prefix}-tooltip-content) {
+:host(#{$prefix}-tooltip-content) {
+  word-break: break-word;
+
   ::slotted(.#{$prefix}-tooltip-content) {
     @extend .#{$prefix}--tooltip-content;
   }

--- a/packages/web-components/src/components/tooltip/tooltip.stories.ts
+++ b/packages/web-components/src/components/tooltip/tooltip.stories.ts
@@ -89,6 +89,22 @@ export const Default = {
   `,
 };
 
+export const Test = {
+  render: () => html`
+    <cds-tooltip align="bottom">
+      <button
+        class="sb-tooltip-trigger"
+        role="button"
+        aria-labelledby="content">
+        ${Information16()}
+      </button>
+      <cds-tooltip-content id="content">
+        gfsghfsfsgggggghgsghsghgtuurutcxcrtstshgstsyststshsststststtstsffsfsgssjdstysyhgwtjyrkjgrutrwqtwyfyhygfhyiijfioyfdsrtkwjiutwjhqgwiyusrqjfterhtwgyqurtwu
+      </cds-tooltip-content>
+    </cds-tooltip>
+  `,
+};
+
 export const Alignment = {
   render: () => html`
     <cds-tooltip align="bottom-left">

--- a/packages/web-components/src/components/tooltip/tooltip.stories.ts
+++ b/packages/web-components/src/components/tooltip/tooltip.stories.ts
@@ -89,22 +89,6 @@ export const Default = {
   `,
 };
 
-export const Test = {
-  render: () => html`
-    <cds-tooltip align="bottom">
-      <button
-        class="sb-tooltip-trigger"
-        role="button"
-        aria-labelledby="content">
-        ${Information16()}
-      </button>
-      <cds-tooltip-content id="content">
-        gfsghfsfsgggggghgsghsghgtuurutcxcrtstshgstsyststshsststststtstsffsfsgssjdstysyhgwtjyrkjgrutrwqtwyfyhygfhyiijfioyfdsrtkwjiutwjhqgwiyusrqjfterhtwgyqurtwu
-      </cds-tooltip-content>
-    </cds-tooltip>
-  `,
-};
-
 export const Alignment = {
   render: () => html`
     <cds-tooltip align="bottom-left">


### PR DESCRIPTION
Closes #18161 
Adds word-break support for tooltip content to handle long text without spaces

#### Changelog
**Changed**
- Added `word-break: break-word` to tooltip content styles to properly handle long text without spaces
- Optimized SCSS structure for tooltip content styling

#### Testing / Reviewing
Steps to verify:
Go to Test story in tooltip word without space should not overflow , it should break.
**Note- Test file will be deleted once the PR gets reviewed.**
