### PR TITLE
fix: add autoAlign to inner IconButton

### DIFF
--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -575,7 +575,7 @@ exports[`DataTable behaves as expected selection should render and match snapsho
           class="cds--overflow-menu__wrapper"
         >
           <span
-            class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+            class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--top cds--tooltip cds--icon-tooltip"
           >
             <div
               class="cds--tooltip-trigger__wrapper"
@@ -617,12 +617,13 @@ exports[`DataTable behaves as expected selection should render and match snapsho
             >
               <span
                 class="cds--popover-content cds--tooltip-content"
+                style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
               >
                 Settings
+                <span
+                  class="cds--popover-caret cds--popover--auto-align"
+                />
               </span>
-              <span
-                class="cds--popover-caret"
-              />
             </span>
           </span>
         </span>
@@ -1012,7 +1013,7 @@ exports[`DataTable renders as expected - Component API should render and match s
           class="cds--overflow-menu__wrapper"
         >
           <span
-            class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+            class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--top cds--tooltip cds--icon-tooltip"
           >
             <div
               class="cds--tooltip-trigger__wrapper"
@@ -1054,12 +1055,13 @@ exports[`DataTable renders as expected - Component API should render and match s
             >
               <span
                 class="cds--popover-content cds--tooltip-content"
+                style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
               >
                 Settings
+                <span
+                  class="cds--popover-caret cds--popover--auto-align"
+                />
               </span>
-              <span
-                class="cds--popover-caret"
-              />
             </span>
           </span>
         </span>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableToolbarMenu-test.js.snap
@@ -6,7 +6,7 @@ exports[`TableToolbarMenu renders as expected - Component API should render 1`] 
     class="cds--overflow-menu__wrapper"
   >
     <span
-      class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+      class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--top cds--tooltip cds--icon-tooltip"
     >
       <div
         class="cds--tooltip-trigger__wrapper"
@@ -45,12 +45,13 @@ exports[`TableToolbarMenu renders as expected - Component API should render 1`] 
       >
         <span
           class="cds--popover-content cds--tooltip-content"
+          style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         >
           Add
+          <span
+            class="cds--popover-caret cds--popover--auto-align"
+          />
         </span>
-        <span
-          class="cds--popover-caret"
-        />
       </span>
     </span>
   </span>

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -719,6 +719,7 @@ class OverflowMenu extends React.Component<
             aria-haspopup
             aria-expanded={open}
             aria-controls={open ? menuBodyId : undefined}
+            autoAlign={true}
             className={overflowMenuClasses}
             onClick={this.handleClick}
             id={id}


### PR DESCRIPTION
Closes #17305

Added the autoAlign prop to allow the inner IconButton to use the floating-ui component. This allows for the tooltip popover to render over the table rather than inside it, preventing the overflow scrollbar from appearing.

#### Changelog

**Changed**

- Added `autoAlign={true}` prop to inner IconButton in OverflowMenu

#### Testing / Reviewing

- Verified that the autoAlign property on the IconButton within a OverMenu within a DataTable is honored.