### PR TITLE
fix(icons): add file extension to icon imports

### DIFF
--- a/packages/web-components/src/components/ai-label/ai-label.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.ts
@@ -13,7 +13,7 @@ import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import CDSToggleTip from '../toggle-tip/toggletip';
 import styles from './ai-label.scss?lit';
-import Undo16 from '@carbon/icons/lib/undo/16';
+import Undo16 from '@carbon/icons/lib/undo/16.js';
 import { AI_LABEL_SIZE, AI_LABEL_KIND } from './defs';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 

--- a/packages/web-components/src/components/progress-indicator/progress-step-skeleton.ts
+++ b/packages/web-components/src/components/progress-indicator/progress-step-skeleton.ts
@@ -11,7 +11,7 @@ import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import styles from './progress-indicator.scss?lit';
-import CircleDash from '@carbon/icons/lib/circle-dash/16';
+import CircleDash from '@carbon/icons/lib/circle-dash/16.js';
 import '../skeleton-text';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 


### PR DESCRIPTION
Closes #18532 

Adds file extension to icon imports.

#### Changelog


**Changed**

- add `.js` file extension to icon imports

#### Testing / Reviewing
- unzip [example](https://github.com/user-attachments/files/18691746/icon-imports-with-fix.zip) and run

```bash
yarn && yarn build
npx http-serve dist
```

The example should build and render with no errors.
