### PR TITLE
chore(codeowners): update teams and review rotation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,25 +3,25 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, this team will
 # be requested for review when someone opens a pull request.
-* @carbon-design-system/developers-system-reviewers
+* @carbon-design-system/monorepo-reviewers @carbon-design-system/monorepo-lead-reviewers
 
 
 # Core icons and pictograms
-/packages/icons/src/svg/        @laurenmrice @carbon-design-system/brand-icons @carbon-design-system/developers-system-reviewers
-/packages/pictograms/src/svg/   @laurenmrice @carbon-design-system/brand-pictograms @carbon-design-system/developers-system-reviewers
+/packages/icons/src/svg/        @laurenmrice @carbon-design-system/brand-icons @carbon-design-system/monorepo-reviewers @carbon-design-system/monorepo-lead-reviewers
+/packages/pictograms/src/svg/   @laurenmrice @carbon-design-system/brand-pictograms @carbon-design-system/monorepo-reviewers @carbon-design-system/monorepo-lead-reviewers
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that modifies
 # public api snapshot files, only this team and not the global
 # owner(s) will be requested for a review.
-# The release team should be notified of Public API changes in
+# Admins and leads should be notified of Public API changes in
 # the system
-**/PublicAPI-test.js        @carbon-design-system/release
-**/PublicAPI-test.js.snap   @carbon-design-system/release
+**/PublicAPI-test.js        @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
+**/PublicAPI-test.js.snap   @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
 
 
-# Admins should be notified of changes to CI/CD workflows
+# Admins and leads should be notified of changes to CI/CD workflows
 # codeowners, and any other config present in .github.
 # This should always be the last entry in this file.
-/.github/           @carbon-design-system/developers-system-admins
-/.github/CODEOWNERS @carbon-design-system/developers-system-admins
+/.github/           @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
+/.github/CODEOWNERS @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers

--- a/.prettierignore
+++ b/.prettierignore
@@ -63,3 +63,6 @@ packages/upgrade/**/*.output.tsx
 
 # Accessibility Verification Testing
 **/.avt/**
+
+# CODEOWNERS
+CODEOWNERS


### PR DESCRIPTION
I've created two new teams! 🎉 

* @carbon-design-system/monorepo-reviewers 
* @carbon-design-system/monorepo-lead-reviewers 

This PR updates the codeowners file so that by default both teams are codeowners for every file in the repo. 

This repo requires 2 reviews on each PR. I configured each team's code review settings to automatically assign 1 member to a PR. This way every PR by default should be assigned 1 review from the reviewers, and 1 review from the lead reviewers. Let's double check this works as expected once this is merged.

> [!IMPORTANT]  
> As both teams are codeowners, a PR can technically be merged with two reviews by either group.
>
> 2 `monorepo-lead-reviewers` approve, 0 `monorepo-reviewers` approve = merge
> 2 `monorepo-reviewers`  approve, 0 `monorepo-lead-reviewers` approve = merge
>
> As a team let's avoid this and shoot for 1:1 on every PR to ensure excellent code quality and provide opportunities to grow our review skills together. 💪 