### PR TITLE
fix(utilities): include types folder in npm release

### DIFF
--- a/packages/utilities-react/package.json
+++ b/packages/utilities-react/package.json
@@ -15,6 +15,7 @@
   "files": [
     "es",
     "lib",
+    "types",
     "telemetry.yml"
   ],
   "keywords": [

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,6 +15,7 @@
   "files": [
     "es",
     "lib",
+    "types",
     "telemetry.yml"
   ],
   "keywords": [


### PR DESCRIPTION
Despite them being typed packages and the types being built, `@carbon/utilities` and `@carbon/utilities-react` currently don't publish their `types` folder to npm.

#### Changelog

**New**

- Add `types` to `files` in `package.json`

#### Testing / Reviewing

- `cd packages/utilities`
- `npm pack --dry-run`
- Verify all `*.d.ts` files within the `types` folder would be added to the tarball
