### PR TITLE
fix: filterItems prop should be optional in FilterableMultiSelectProps

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -159,7 +159,7 @@ export interface FilterableMultiSelectProps<ItemType>
   /**
    * Default sorter is assigned if not provided.
    */
-  filterItems(
+  filterItems?(
     items: readonly ItemType[],
     extra: {
       inputValue: string | null;


### PR DESCRIPTION
Closes #16993

filterItems prop should be optional in FilterableMultiSelectProps 

#### Changelog

**New**

**Changed**

- Added `?` to prop for it to be optional

**Removed**

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
