### PR TITLE
fix(tabs): move react-is to peer dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,6 +46,7 @@
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
     "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+    "react-is": "^18.3.1 || ^19.0.0",
     "sass": "^1.33.0"
   },
   "dependencies": {
@@ -64,7 +65,6 @@
     "invariant": "^2.2.3",
     "prop-types": "^15.7.2",
     "react-fast-compare": "^3.2.2",
-    "react-is": "^18.3.1",
     "tabbable": "^6.2.0",
     "use-resize-observer": "^6.0.0",
     "window-or-global": "^1.0.1"
@@ -119,6 +119,7 @@
     "prop-types": "^15.7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-is": "^18.3.1",
     "remark-gfm": "^4.0.0",
     "requestanimationframe": "^0.0.23",
     "rimraf": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,6 +2077,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
+    react-is: ^18.3.1 || ^19.0.0
     sass: ^1.33.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Closes #18574 

In #18207 we've found that the original issue reporting problems with Tabs and react 19 (#16620) was fixed simply by updating the react-is version to v19. We've opted to delay #18207 for now and instead just open up the react peer dependency ranges to include v19, https://github.com/carbon-design-system/carbon/pull/18458. 

The issue with tabs came up again because `react-is` was a hard dep and locked to v18. This PR updates `react-is` to be a peer dependency allowing both v18 and v19. I also added `react-is` to devDeps so that internally the project still uses v18.

#### Changelog

**Changed**

- moved react-is to peer dependencies
- expanded the ranges for allowed react-is versions