### PR TITLE
fix: update compareItems type in MultiSelect

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelectPropTypes.ts
+++ b/packages/react/src/components/MultiSelect/MultiSelectPropTypes.ts
@@ -62,11 +62,7 @@ export interface MultiSelectSortingProps<ItemType> {
    * Provide a compare function that is used to determine the ordering of
    * options. See 'sortItems' for more control.
    */
-  compareItems?(
-    item1: ItemType,
-    item2: ItemType,
-    options: SharedOptions
-  ): number;
+  compareItems?(item1: string, item2: string, options: SharedOptions): number;
 
   /**
    * Provide a method that sorts all options in the control. Overriding this

--- a/packages/react/src/components/MultiSelect/MultiSelectPropTypes.ts
+++ b/packages/react/src/components/MultiSelect/MultiSelectPropTypes.ts
@@ -46,14 +46,14 @@ interface SharedOptions {
   locale: string;
 }
 
+interface CompareItems {
+  (itemA: string, itemB: string, options: SharedOptions): number;
+}
+
 export interface SortItemsOptions<ItemType>
   extends SharedOptions,
     DownshiftTypedProps<ItemType> {
-  compareItems(
-    item1: ItemType,
-    item2: ItemType,
-    options: SharedOptions
-  ): number;
+  compareItems: CompareItems;
   selectedItems: ItemType[];
 }
 
@@ -62,7 +62,7 @@ export interface MultiSelectSortingProps<ItemType> {
    * Provide a compare function that is used to determine the ordering of
    * options. See 'sortItems' for more control.
    */
-  compareItems?(item1: string, item2: string, options: SharedOptions): number;
+  compareItems?: CompareItems;
 
   /**
    * Provide a method that sorts all options in the control. Overriding this

--- a/packages/react/src/components/MultiSelect/tools/__tests__/sorting-test.js
+++ b/packages/react/src/components/MultiSelect/tools/__tests__/sorting-test.js
@@ -128,3 +128,17 @@ describe('defaultSortItems', () => {
     ]);
   });
 });
+
+describe('defaultCompareItems', () => {
+  it('should return a negative number if the first string comes before the second', () => {
+    expect(defaultCompareItems('a', 'b', { locale: 'en' })).toBeLessThan(0);
+  });
+
+  it('should return a positive number if the first string comes after the second', () => {
+    expect(defaultCompareItems('z', 'y', { locale: 'en' })).toBeGreaterThan(0);
+  });
+
+  it('should return 0 if both strings are equal', () => {
+    expect(defaultCompareItems('same', 'same', { locale: 'en' })).toEqual(0);
+  });
+});

--- a/packages/react/src/components/MultiSelect/tools/sorting.js
+++ b/packages/react/src/components/MultiSelect/tools/sorting.js
@@ -6,14 +6,15 @@
  */
 
 /**
- * Use the local `localCompare` with the `numeric` option to sort two,
- * potentially alpha-numeric, strings in a list of items.
+ * Use the locale `localeCompare` with the `numeric` option to sort two
+ * alpha-numeric strings.
  *
- * @param {ItemType} itemA
- * @param {ItemType} itemB
- * @param {object} options
- * @param {string} options.locale
- * @returns {number}
+ * @param {string} itemA - The first string to compare.
+ * @param {string} itemB - The second string to compare.
+ * @param {object} options - Options for comparing.
+ * @param {string} options.locale - The locale to use for comparison.
+ * @returns {number} A negative number if itemA comes before itemB, a positive
+ *   number if itemA comes after itemB, or 0 if they are equal.
  */
 export const defaultCompareItems = (itemA, itemB, { locale }) =>
   itemA.localeCompare(itemB, locale, {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18199

Updated `compareItems` type in `MultiSelect`.

#### Changelog

**New**

- Added `defaultCompareItems` tests.

**Changed**

- Updated `compareItems` type in `MultiSelect`.

#### Testing / Reviewing

- Run the test that was added.
- Use `compareItems` in a TypeScript file similar to the reproduction in the issue and check for errors.
