### PR TITLE
fix: added pollymorphic props to sidenavmenuitem

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -10,10 +10,8 @@ import React, { PropsWithChildren } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { ForwardRefReturn } from '../../types/common';
-import SideNav from '../UIShell/SideNav';
-import SideNavItems from '../UIShell/SideNavItems';
 import { SideNavMenu } from '../UIShell';
-import SideNavMenuItem from '../../../lib/components/UIShell/SideNavMenuItem';
+import SideNavMenuItem from '../UIShell/SideNavMenuItem';
 
 export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -58,7 +56,7 @@ const Breadcrumb: ForwardRefReturn<HTMLElement, BreadcrumbProps> =
         <ol className={className}>{children}</ol>
         {/* <SideNavItems> */}
         <SideNavMenu title="Large menu" large>
-          <SideNavMenuItem as="section">Menu 1</SideNavMenuItem>
+          <SideNavMenuItem as="a">Menu 1</SideNavMenuItem>
           <SideNavMenuItem as="div">Menu 2</SideNavMenuItem>
         </SideNavMenu>
         {/* </SideNavItems> */}

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -10,6 +10,10 @@ import React, { PropsWithChildren } from 'react';
 import cx from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { ForwardRefReturn } from '../../types/common';
+import SideNav from '../UIShell/SideNav';
+import SideNavItems from '../UIShell/SideNavItems';
+import { SideNavMenu } from '../UIShell';
+import SideNavMenuItem from '../../../lib/components/UIShell/SideNavMenuItem';
 
 export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -52,6 +56,12 @@ const Breadcrumb: ForwardRefReturn<HTMLElement, BreadcrumbProps> =
         ref={ref}
         {...rest}>
         <ol className={className}>{children}</ol>
+        {/* <SideNavItems> */}
+        <SideNavMenu title="Large menu" large>
+          <SideNavMenuItem as="section">Menu 1</SideNavMenuItem>
+          <SideNavMenuItem as="div">Menu 2</SideNavMenuItem>
+        </SideNavMenu>
+        {/* </SideNavItems> */}
       </nav>
     );
   });

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -54,12 +54,6 @@ const Breadcrumb: ForwardRefReturn<HTMLElement, BreadcrumbProps> =
         ref={ref}
         {...rest}>
         <ol className={className}>{children}</ol>
-        {/* <SideNavItems> */}
-        <SideNavMenu title="Large menu" large>
-          <SideNavMenuItem as="a">Menu 1</SideNavMenuItem>
-          <SideNavMenuItem as="div">Menu 2</SideNavMenuItem>
-        </SideNavMenu>
-        {/* </SideNavItems> */}
       </nav>
     );
   });

--- a/packages/react/src/components/UIShell/SideNavMenuItem.tsx
+++ b/packages/react/src/components/UIShell/SideNavMenuItem.tsx
@@ -6,13 +6,17 @@
  */
 
 import cx from 'classnames';
-import PropTypes from 'prop-types';
+import PropTypes, { WeakValidationMap } from 'prop-types';
 import React, { ElementType, ForwardedRef, Ref, ComponentProps } from 'react';
 import SideNavLinkText from './SideNavLinkText';
 import Link from './Link';
 import { usePrefix } from '../../internal/usePrefix';
+import {
+  PolymorphicComponentPropWithRef,
+  PolymorphicRef,
+} from '../../internal/PolymorphicProps';
 
-export type SideNavMenuItemProps = ComponentProps<typeof Link> & {
+export interface SideNavMenuItemBaseProps {
   /**
    * Specify the children to be rendered inside of the `SideNavMenuItem`
    */
@@ -34,23 +38,32 @@ export type SideNavMenuItemProps = ComponentProps<typeof Link> & {
    * Optionally provide an href for the underlying li`
    */
   href?: string;
+}
 
-  /**
-   * Optional component to render instead of default Link
-   */
-  as?: ElementType;
-};
+export interface SideNavMenuItemComponent {
+  <E extends ElementType = typeof Link>(
+    props: SideNavMenuItemProps<E>
+  ): JSX.Element | null;
+  displayName?: string;
+  propTypes?: WeakValidationMap<SideNavMenuItemProps<any>>;
+}
 
-const SideNavMenuItem = React.forwardRef<HTMLElement, SideNavMenuItemProps>(
-  function SideNavMenuItem(props, ref: ForwardedRef<HTMLElement>) {
-    const prefix = usePrefix();
-    const {
+export type SideNavMenuItemProps<T extends ElementType> =
+  PolymorphicComponentPropWithRef<T, SideNavMenuItemBaseProps>;
+
+const SideNavMenuItem: SideNavMenuItemComponent = React.forwardRef(
+  <T extends ElementType = typeof Link>(
+    {
       children,
       className: customClassName,
-      as: Component = Link,
+      as,
       isActive,
       ...rest
-    } = props;
+    }: SideNavMenuItemProps<T>,
+    ref?: PolymorphicRef<T>
+  ) => {
+    const prefix = usePrefix();
+    const Component = as || Link;
     const className = cx(`${prefix}--side-nav__menu-item`, customClassName);
     const linkClassName = cx({
       [`${prefix}--side-nav__link`]: true,
@@ -68,7 +81,7 @@ const SideNavMenuItem = React.forwardRef<HTMLElement, SideNavMenuItemProps>(
       </li>
     );
   }
-);
+) as SideNavMenuItemComponent;
 
 SideNavMenuItem.displayName = 'SideNavMenuItem';
 SideNavMenuItem.propTypes = {

--- a/packages/react/src/components/UIShell/UIShell.SideNav.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.SideNav.stories.js
@@ -188,10 +188,12 @@ export const FixedSideNav = () => (
       aria-label="Side navigation">
       <SideNavItems>
         <SideNavMenu title="L0 menu">
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          <SideNavMenuItem as="div" href="https://www.carbondesignsystem.com/">
             L0 menu item
           </SideNavMenuItem>
-          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
+          <SideNavMenuItem
+            as="section"
+            href="https://www.carbondesignsystem.com/">
             L0 menu item
           </SideNavMenuItem>
           <SideNavMenuItem href="https://www.carbondesignsystem.com/">

--- a/packages/react/src/components/UIShell/UIShell.SideNav.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.SideNav.stories.js
@@ -173,6 +173,29 @@ export default {
   },
 };
 
+export const Test = () => {
+  return (
+    <SideNavItems>
+      <SideNavMenuItem
+        as="button"
+        onClick={() => {
+          console.log('Button clicked');
+          window.location.href = 'https://www.carbondesignsystem.com/';
+        }}>
+        L0 menu item
+      </SideNavMenuItem>
+      <SideNavLink
+        as="button"
+        onClick={() => {
+          console.log('Button clicked');
+          window.location.href = 'https://www.carbondesignsystem.com/';
+        }}>
+        L0 menu item
+      </SideNavLink>
+    </SideNavItems>
+  );
+};
+
 export const FixedSideNav = () => (
   <>
     <Header aria-label="IBM Platform Name">
@@ -188,12 +211,10 @@ export const FixedSideNav = () => (
       aria-label="Side navigation">
       <SideNavItems>
         <SideNavMenu title="L0 menu">
-          <SideNavMenuItem as="div" href="https://www.carbondesignsystem.com/">
+          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
             L0 menu item
           </SideNavMenuItem>
-          <SideNavMenuItem
-            as="section"
-            href="https://www.carbondesignsystem.com/">
+          <SideNavMenuItem href="https://www.carbondesignsystem.com/">
             L0 menu item
           </SideNavMenuItem>
           <SideNavMenuItem href="https://www.carbondesignsystem.com/">
@@ -224,7 +245,7 @@ export const FixedSideNav = () => (
             L0 menu item
           </SideNavMenuItem>
         </SideNavMenu>
-        <SideNavLink href="https://www.carbondesignsystem.com/">
+        <SideNavLink as="button" href="https://www.carbondesignsystem.com/">
           L0 link
         </SideNavLink>
         <SideNavLink href="https://www.carbondesignsystem.com/">

--- a/packages/react/src/components/UIShell/__tests__/SideNavMenuItem-test.js
+++ b/packages/react/src/components/UIShell/__tests__/SideNavMenuItem-test.js
@@ -46,4 +46,14 @@ describe('SideNavMenuItem', () => {
     );
     expect(ref).toHaveBeenCalledWith(screen.getByRole('link'));
   });
+
+  it('should support custom elements with the `as` prop', () => {
+    render(
+      <SideNavMenuItem as="button" data-testid="sidenav-menuitem">
+        Menu Item Text
+      </SideNavMenuItem>
+    );
+    const menuItem = screen.getByTestId('sidenav-menuitem');
+    expect(menuItem.tagName).toBe('BUTTON');
+  });
 });

--- a/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
+++ b/packages/styles/scss/components/ui-shell/side-nav/_side-nav.scss
@@ -329,6 +329,7 @@
   // Side-nav > Link
   //----------------------------------------------------------------------------
   a.#{$prefix}--side-nav__link,
+  button.#{$prefix}--side-nav__link,
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item,
   .#{$prefix}--side-nav
     .#{$prefix}--header__menu-title[aria-expanded='true']
@@ -348,11 +349,13 @@
       outline $duration-fast-02;
   }
 
-  .#{$prefix}--side-nav__item--large a.#{$prefix}--side-nav__link {
+  .#{$prefix}--side-nav__item--large a.#{$prefix}--side-nav__link,
+  .#{$prefix}--side-nav__item--large button.#{$prefix}--side-nav__link {
     block-size: mini-units(6);
   }
 
   a.#{$prefix}--side-nav__link > .#{$prefix}--side-nav__link-text,
+  button.#{$prefix}--side-nav__link > .#{$prefix}--side-nav__link-text,
   .#{$prefix}--side-nav
     a.#{$prefix}--header__menu-item
     .#{$prefix}--text-truncate-end {
@@ -366,24 +369,32 @@
   }
 
   a.#{$prefix}--side-nav__link:focus,
+  button.#{$prefix}--side-nav__link:focus,
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item:focus {
     @include focus-outline('outline');
   }
 
   a.#{$prefix}--side-nav__link[aria-current='page'],
-  a.#{$prefix}--side-nav__link--current {
+  a.#{$prefix}--side-nav__link--current,
+  button.#{$prefix}--side-nav__link[aria-current='page'],
+  button.#{$prefix}--side-nav__link--current {
     background-color: $background-selected;
     font-weight: 600;
   }
 
   a.#{$prefix}--side-nav__link[aria-current='page']
     .#{$prefix}--side-nav__link-text,
-  a.#{$prefix}--side-nav__link--current .#{$prefix}--side-nav__link-text {
+  a.#{$prefix}--side-nav__link--current .#{$prefix}--side-nav__link-text,
+  button.#{$prefix}--side-nav__link[aria-current='page']
+    .#{$prefix}--side-nav__link-text,
+  button.#{$prefix}--side-nav__link--current .#{$prefix}--side-nav__link-text {
     color: $text-primary;
   }
 
   a.#{$prefix}--side-nav__link[aria-current='page']::before,
-  a.#{$prefix}--side-nav__link--current::before {
+  a.#{$prefix}--side-nav__link--current::before,
+  button.#{$prefix}--side-nav__link[aria-current='page']::before,
+  button.#{$prefix}--side-nav__link--current::before {
     position: absolute;
     background-color: $border-interactive;
     content: '';
@@ -392,6 +403,14 @@
     inset-inline-start: 0;
   }
 
+  // Button reset styles
+  button.#{$prefix}--side-nav__link {
+    border: none;
+    background: none;
+    cursor: pointer;
+    inline-size: 100%;
+    text-align: start;
+  }
   //----------------------------------------------------------------------------
   // Side-nav > Icons
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #18430 

Changelog
Changed

- Updated SideNavMenuItem to implement the polymorphic pattern, allowing it to render as different elements using the as prop
- Added proper TypeScript type safety for polymorphic functionality
- Added custom styles for button elements to maintain visual consistency
- Added test cases to verify proper rendering with different element types

Testing / Reviewing

UI Verification:

- Added test stories in UI shell → SideNav, rendering both SideNavMenuItem and SideNavLink as buttons
- Verify proper rendering in the UI
- Inspect the DOM to confirm elements are properly rendered as buttons


Test Coverage:

- Added unit tests to verify the as prop functionality works correctly
- Verify all test cases pass, especially for button element support

PS: Test story will be deleted once I get reviews its just for basic testing for reviewer
