### PR TITLE
docs(colors): fix broken link in sass.md

### DIFF
--- a/packages/colors/docs/sass.md
+++ b/packages/colors/docs/sass.md
@@ -16,8 +16,7 @@ the following:
 }
 ```
 
-For a full list of colors exported, refer to the [exports](#exports) section
-below.
+For a full list of colors exported, refer to the [API](#api) section below.
 
 In addition to individual colors, you can also access a `Map` of all colors from
 the IBM Design Language using the `$colors` variable.


### PR DESCRIPTION
Fixes a broken link in the colors sass docs.