### PR TITLE
feat: make `highContrast` and `dropShadow` props configurable

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4231,8 +4231,14 @@ Map {
       "disabled": Object {
         "type": "bool",
       },
+      "dropShadow": Object {
+        "type": "bool",
+      },
       "enterDelayMs": Object {
         "type": "number",
+      },
+      "highContrast": Object {
+        "type": "bool",
       },
       "href": Object {
         "type": "string",
@@ -9587,8 +9593,14 @@ Map {
       "description": Object {
         "type": "node",
       },
+      "dropShadow": Object {
+        "type": "bool",
+      },
       "enterDelayMs": Object {
         "type": "number",
+      },
+      "highContrast": Object {
+        "type": "bool",
       },
       "label": Object {
         "type": "node",

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -108,9 +108,19 @@ export interface IconButtonProps
   disabled?: boolean;
 
   /**
+   * Specify whether a drop shadow should be rendered on the tooltip
+   */
+  dropShadow?: boolean;
+
+  /**
    * Specify the duration in milliseconds to delay before displaying the tooltip
    */
   enterDelayMs?: number;
+
+  /**
+   * Render the tooltip using the high-contrast theme
+   */
+  highContrast?: boolean;
 
   /**
    * Specify whether the IconButton is currently selected
@@ -156,7 +166,9 @@ const IconButton = React.forwardRef(function IconButton(
     closeOnActivation = true,
     defaultOpen = false,
     disabled,
+    dropShadow = false,
     enterDelayMs = 100,
+    highContrast = true,
     kind,
     label,
     leaveDelayMs = 100,
@@ -180,7 +192,9 @@ const IconButton = React.forwardRef(function IconButton(
       closeOnActivation={closeOnActivation}
       className={tooltipClasses}
       defaultOpen={defaultOpen}
+      dropShadow={dropShadow}
       enterDelayMs={enterDelayMs}
+      highContrast={highContrast}
       label={label}
       leaveDelayMs={leaveDelayMs}>
       <ButtonBase
@@ -284,6 +298,11 @@ IconButton.propTypes = {
   defaultOpen: PropTypes.bool,
 
   /**
+   * Specify whether a drop shadow should be rendered on the tooltip
+   */
+  dropShadow: PropTypes.bool,
+
+  /**
    * Specify whether the Button should be disabled, or not
    */
   disabled: PropTypes.bool,
@@ -296,8 +315,12 @@ IconButton.propTypes = {
   /**
    * Specify whether the IconButton is currently selected
    */
-
   isSelected: PropTypes.bool,
+
+  /**
+   * Render the tooltip using the high-contrast theme
+   */
+  highContrast: PropTypes.bool,
 
   /**
    * Specify the type of button to be used as the base for the IconButton

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -61,9 +61,19 @@ interface TooltipBaseProps {
   description?: React.ReactNode;
 
   /**
+   * Specify whether a drop shadow should be rendered
+   */
+  dropShadow?: boolean;
+
+  /**
    * Specify the duration in milliseconds to delay before displaying the tooltip
    */
   enterDelayMs?: number;
+
+  /**
+   * Render the component using the high-contrast theme
+   */
+  highContrast?: boolean;
 
   /**
    * Provide the label to be rendered inside of the Tooltip. The label will use
@@ -97,6 +107,8 @@ function Tooltip<T extends React.ElementType>({
   leaveDelayMs = 300,
   defaultOpen = false,
   closeOnActivation = false,
+  dropShadow = false,
+  highContrast = true,
   ...rest
 }: TooltipProps<T>) {
   const tooltipRef = useRef<HTMLSpanElement>(null);
@@ -248,8 +260,8 @@ function Tooltip<T extends React.ElementType>({
       {...rest}
       align={align}
       className={cx(`${prefix}--tooltip`, customClassName)}
-      dropShadow={false}
-      highContrast
+      dropShadow={dropShadow}
+      highContrast={highContrast}
       onKeyDown={onKeyDown}
       onMouseLeave={onMouseLeave}
       open={open}>
@@ -338,9 +350,19 @@ Tooltip.propTypes = {
   description: PropTypes.node,
 
   /**
+   * Specify whether a drop shadow should be rendered
+   */
+  dropShadow: PropTypes.bool,
+
+  /**
    * Specify the duration in milliseconds to delay before displaying the tooltip
    */
   enterDelayMs: PropTypes.number,
+
+  /**
+   * Render the component using the high-contrast theme
+   */
+  highContrast: PropTypes.bool,
 
   /**
    * Provide the label to be rendered inside of the Tooltip. The label will use


### PR DESCRIPTION
Related https://github.com/carbon-design-system/carbon-labs/issues/418 #11347

This PR makes the `highContrast` and `dropShadow` Popover props configurable in the Tooltip and IconButton. The default values will remain as-is, but this change will allow the new UI shell side nav variant to inherit these styles as needed without the style overrides.

#### Changelog

**Changed**

- expose `highContrast` and `dropShadow` props in the Tooltip and IconButton

