### PR TITLE
fix: update icon button types and docs

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -193,6 +193,14 @@ const Button: ButtonComponent = React.forwardRef(
       }
 
       return (
+        // @ts-expect-error - `IconButton` does not support all `size`s that
+        // `Button` supports.
+        //
+        // TODO: What should be done here?
+        // 1. Should the `IconButton` not be rendered if the `size` is not
+        //    supported?
+        // 2. Should an error be thrown?
+        // 3. Something else?
         <IconButton
           {...rest}
           ref={ref}

--- a/packages/react/src/components/Button/ButtonBase.tsx
+++ b/packages/react/src/components/Button/ButtonBase.tsx
@@ -45,6 +45,7 @@ const ButtonBase = React.forwardRef(function ButtonBase<
     [`${prefix}--btn`]: true,
     [`${prefix}--btn--sm`]: size === 'sm' && !isExpressive, // TODO: V12 - Remove this class
     [`${prefix}--btn--md`]: size === 'md' && !isExpressive, // TODO: V12 - Remove this class
+    [`${prefix}--btn--lg`]: size === 'lg' && !isExpressive, // TODO: V12 - Remove this class
     [`${prefix}--btn--xl`]: size === 'xl', // TODO: V12 - Remove this class
     [`${prefix}--btn--2xl`]: size === '2xl', // TODO: V12 - Remove this class
     [`${prefix}--layout--size-${size}`]: size,

--- a/packages/react/src/components/Button/__tests__/Button-test.js
+++ b/packages/react/src/components/Button/__tests__/Button-test.js
@@ -97,11 +97,7 @@ describe('Button', () => {
   ])(
     'should set the expected classes for the button of kind: `%s`',
     (kind, className) => {
-      render(
-        <Button className={className} kind={kind}>
-          test
-        </Button>
-      );
+      render(<Button kind={kind}>test</Button>);
       expect(screen.getByText('test')).toHaveClass(className);
     }
   );
@@ -115,11 +111,7 @@ describe('Button', () => {
   ])(
     'should set the expected classes for the button of size: `%s`',
     (size, className) => {
-      render(
-        <Button className={className} size={size}>
-          test
-        </Button>
-      );
+      render(<Button size={size}>test</Button>);
       expect(screen.getByText('test')).toHaveClass(className);
     }
   );

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -152,9 +152,9 @@ export interface IconButtonProps
   rel?: React.AnchorHTMLAttributes<HTMLAnchorElement>['rel'];
 
   /**
-   * Specify the size of the Button. Defaults to `md`.
+   * Specify the size of the Button.
    */
-  size?: ButtonSize;
+  size?: Extract<ButtonSize, 'sm' | 'md' | 'lg'>;
 
   /**
    * Optionally specify a `target` when using an `<a>` element.
@@ -356,7 +356,7 @@ IconButton.propTypes = {
   rel: PropTypes.string,
 
   /**
-   * Specify the size of the Button. Defaults to `md`.
+   * Specify the size of the Button.
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/17956

Updated `IconButton` types and documentation.

#### Changelog

**Changed**

- Updated `IconButton` types and documentation.
- Updated `Button` tests.

#### Testing / Reviewing

My understanding of the `Button` tests was that there was a bug in them. The test titles say 'should set the expected classes for the button of <prop>: `%s`'. Doesn't that mean if the prop is set on the `Button` that the code would apply the right class to it? If so, I'm not sure how these tests were ever going to fail considering the `className`s were explictly set in them.

```sh
yarn test packages/react/src/components/Button packages/react/src/components/IconButton
```

If the changes in this pull request are correct and the `IconButton` is supposed to be `lg` by default, does the following code need to be changed too?

https://github.com/carbon-design-system/carbon/blob/a60a4d3071663b240c3122d8bc2c3558c788346f/packages/web-components/src/components/icon-button/icon-button.ts#L64-L68