### PR TITLE
fix(accordion): remove max block sizing on accordion content

### DIFF
--- a/packages/web-components/src/components/accordion/accordion-item.ts
+++ b/packages/web-components/src/components/accordion/accordion-item.ts
@@ -107,18 +107,6 @@ class CDSAccordionItem extends FocusMixin(LitElement) {
         )
       );
     }
-
-    const content = this.shadowRoot!.querySelector(
-      `.${prefix}--accordion__wrapper`
-    ) as HTMLElement;
-
-    if (this.open) {
-      // accordion opens
-      content!.style.maxBlockSize = content!.scrollHeight + 15 + 'px';
-    } else {
-      // accordion closes
-      content!.style.maxBlockSize = '';
-    }
   }
 
   /**


### PR DESCRIPTION
Closes #18510

Accordion content is overlapping with other accordion items, visible currently in Storybook. This PR removes the `max-block-sizing` placed on the accordion content - there is no need to add the scroll height as I don't see this logic appearing the React implementation (`max-block-sizing` is set to `fit-content` when accordion-item is open)


<img width="1389" alt="Image" src="https://github.com/user-attachments/assets/eb9faa20-e99b-49db-8cec-61c15682258f" />

#### Changelog

**Removed**

- max-block-sizing logic on accordion content

#### Testing / Reviewing

Go to Web Components deploy preview and check in the default accordion story that when opening the accordion, the content does not overlap
