### PR TITLE
fix(text-input): fix warn and invalid icon overlap with password toggle

### DIFF
--- a/packages/web-components/src/components/text-input/text-input.scss
+++ b/packages/web-components/src/components/text-input/text-input.scss
@@ -34,28 +34,14 @@ $css--plex: true !default;
   }
 }
 
-:host(#{$prefix}-text-input[show-password-visibility-toggle]) {
+:host(#{$prefix}-text-input[show-password-visibility-toggle])
   .#{$prefix}--text-input {
-    padding-inline-end: $spacing-08;
-  }
+  padding-inline-end: $spacing-08;
+}
 
-  &[size='sm'] {
-    .#{$prefix}--text-input__invalid-icon {
-      inset-inline-end: $spacing-07;
-    }
-  }
-
-  &[size='md'] {
-    .#{$prefix}--text-input__invalid-icon {
-      inset-inline-end: $spacing-07;
-    }
-  }
-
-  &[size='lg'] {
-    .#{$prefix}--text-input__invalid-icon {
-      inset-inline-end: $spacing-07;
-    }
-  }
+:host(#{$prefix}-text-input[show-password-visibility-toggle])
+  .#{$prefix}--text-input__invalid-icon {
+  inset-inline-end: $spacing-08;
 }
 
 :host(#{$prefix}-text-input[warn]),

--- a/packages/web-components/src/components/text-input/text-input.stories.ts
+++ b/packages/web-components/src/components/text-input/text-input.stories.ts
@@ -68,6 +68,7 @@ const args = {
   maxCount: '100',
   placeholder: 'Placeholder text',
   playgroundWidth: 300,
+  showPasswordVisibilityToggle: false,
   size: INPUT_SIZE.MEDIUM,
   readonly: false,
   type: 'text',
@@ -128,6 +129,11 @@ const argTypes = {
       max: 800,
       step: 50,
     },
+  },
+  showPasswordVisibilityToggle: {
+    control: 'boolean',
+    description:
+      'Show password visibility toggle (show-password-visibility-toggle)',
   },
   size: {
     control: 'select',
@@ -228,6 +234,7 @@ export const Playground = {
     placeholder,
     playgroundWidth,
     readonly,
+    showPasswordVisibilityToggle,
     size,
     type,
     value,
@@ -248,6 +255,9 @@ export const Playground = {
         max-count="${ifDefined(maxCount)}"
         placeholder="${ifDefined(placeholder)}"
         ?readonly="${ifDefined(readonly)}"
+        ?show-password-visibility-toggle="${ifDefined(
+          showPasswordVisibilityToggle
+        )}"
         size="${ifDefined(size)}"
         type="${ifDefined(type)}"
         value="${ifDefined(value)}"


### PR DESCRIPTION
Closes #18518 

This PR fixes the overlapping that occurs with the invalid / warn icon and the password toggle icon.

#### Changelog

**Changed**

- simplify the style code and adjusting the spacing for the invalid / warn icon class

#### Testing / Reviewing

Go to deploy preview Text Input playground and set `showPasswordVisibilityToggle` and `invalid` controls to true. Confirm the icons do not overlap