### PR TITLE
ci: skip merge-playwright-reports job on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
 
   merge-playwright-reports:
     # Merge reports after *-runner jobs, even if some shards have failed
-    if: ${{ !cancelled() }}
+    if: ${{ github.repository == 'carbon-design-system/carbon' && !cancelled() }}
     needs: [vrt-runner, avt-runner]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18733

Skipped `merge-playwright-reports` job on forks.

#### Changelog

**Changed**

- Skipped `merge-playwright-reports` job on forks.

#### Testing / Reviewing

Run CI on your fork with these changes. The build should pass.
