### PR TITLE
fix(icon-helpers): specify `types` entrypoint

### DIFF
--- a/packages/icon-helpers/package.json
+++ b/packages/icon-helpers/package.json
@@ -4,6 +4,7 @@
   "version": "10.55.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "module": "es/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [`@carbon/icon-helpers`](https://www.npmjs.com/package/@carbon/icon-helpers?activeTab=code) package includes TypeScript definitions, but is missing an explicit `types` entrypoint in the package.json.

#### Changelog


**Changed**

- fix(icon-helpers): specify `types` entrypoint


#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
