### PR TITLE
chore: add package selection to enhancement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -15,13 +15,12 @@ body:
     id: package
     attributes:
       label: Package
-      description: Which package(s) are you using?
+      description: Which package(s) are you using? You can select more than one.
       multiple: true
       options:
         - '@carbon/react'
+        - '@carbon/web-components'
         - '@carbon/styles'
-        - 'carbon-components'
-        - 'carbon-components-react'
         - '@carbon/colors'
         - '@carbon/elements'
         - '@carbon/grid'
@@ -35,8 +34,6 @@ body:
         - '@carbon/themes'
         - '@carbon/type'
         - '@carbon/upgrade'
-        - '@carbon/web-components'
-        - 'carbon-components-svelte'
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
@@ -41,6 +41,31 @@ body:
       description:
         Provide sample content, references, or audits of solutions solving the
         same problem in other applications/websites.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package(s) does this request apply to?
+      multiple: true
+      options:
+        - '@carbon/react'
+        - '@carbon/web-components'
+        - '@carbon/styles'
+        - '@carbon/colors'
+        - '@carbon/elements'
+        - '@carbon/grid'
+        - '@carbon/icons'
+        - '@carbon/icons-react'
+        - '@carbon/icons-vue'
+        - '@carbon/layout'
+        - '@carbon/motion'
+        - '@carbon/pictograms'
+        - '@carbon/pictograms-react'
+        - '@carbon/themes'
+        - '@carbon/type'
+        - '@carbon/upgrade'
+    validations:
+      required: true
   - type: input
     id: application
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
@@ -64,6 +64,7 @@ body:
         - '@carbon/themes'
         - '@carbon/type'
         - '@carbon/upgrade'
+        - "I'm not sure"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
@@ -45,7 +45,7 @@ body:
     id: package
     attributes:
       label: Package
-      description: Which package(s) does this request apply to?
+      description: Which package(s) does this request apply to? You can select more than one.
       multiple: true
       options:
         - '@carbon/react'


### PR DESCRIPTION
We noticed this today in a team triage meeting that in some cases enhancement requests apply to only certain packages. This adds a required multiselect dropdown to the enhancement issue template. 

#### Changelog

**Changed**

- add package selection to enhancement issue template

#### Testing / Reviewing

n/a
