### PR TITLE
fix(content-switcher): remove redundant shadowRoot query for tooltip

### DIFF
--- a/packages/web-components/src/components/content-switcher/content-switcher-item.ts
+++ b/packages/web-components/src/components/content-switcher/content-switcher-item.ts
@@ -96,7 +96,6 @@ export default class CDSContentSwitcherItem extends FocusMixin(LitElement) {
     if (changedProperties) {
       this.shadowRoot
         ?.querySelector(`${prefix}-tooltip`)
-        ?.shadowRoot?.querySelector(`.${prefix}--tooltip`)
         ?.classList.add(`${prefix}--icon-tooltip`);
     }
   }


### PR DESCRIPTION
**Closes #17911**

For the `ContentSwitcher` component, the tooltip text for the first icon button was being cut off.

#### Changelog

**Removed:**

The line ?.shadowRoot?.querySelector(\`.${prefix}--tooltip\`) was removed because it contained a redundant query on the shadowRoot. The tooltip now behaves as expected, and also matches the behavior of the same component in React. 

#### Testing / Reviewing

- CI should pass.
- The tooltip should be consistent for all three icon buttons, and all tooltips should be fully readable.
- The behavior should be the same for both hover and click interactions on the buttons.
- Tooltip behavior should match that of the React component.