### PR TITLE
chore(tests): add accordion unit tests and snapshots

### DIFF
--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -560,6 +560,11 @@ snapshot and include it in your pull request for review. This helps core
 reviewers to determine if api changes are being made in a backwards compatible
 way to avoid breaking changes.
 
+Snapshots for web components can be found in their respective component
+directories. To test or update snapshots, run `yarn test` or
+`yarn test:updateSnaphots`. These commands must be run from the
+`packages/web-components` directory.
+
 ### Working with icons and pictograms
 
 We get work submitted by the IBM Brand team, along with other designers at IBM,

--- a/packages/web-components/src/components/accordion/__tests__/__snapshots__/accordion-test.snap.js
+++ b/packages/web-components/src/components/accordion/__tests__/__snapshots__/accordion-test.snap.js
@@ -1,12 +1,41 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots['cds-accordion should render with minimum attributes'] =
-  `<cds-accordion
+snapshots['cds-accordion should render'] = `<cds-accordion
   alignment="END"
   role="list"
   size="md"
 >
+  <cds-accordion-item
+    alignment="END"
+    role="listitem"
+    size="md"
+    title="Heading A"
+  >
+    <p>
+      Panel A
+    </p>
+  </cds-accordion-item>
+  <cds-accordion-item
+    alignment="END"
+    role="listitem"
+    size="md"
+    title="Heading B"
+  >
+    <p>
+      Panel B
+    </p>
+  </cds-accordion-item>
+  <cds-accordion-item
+    alignment="END"
+    role="listitem"
+    size="md"
+    title="Heading C"
+  >
+    <p>
+      Panel C
+    </p>
+  </cds-accordion-item>
 </cds-accordion>
 `;
-/* end snapshot cds-accordion should render with minimum attributes */
+/* end snapshot cds-accordion should render */

--- a/packages/web-components/src/components/accordion/__tests__/accordion-test.js
+++ b/packages/web-components/src/components/accordion/__tests__/accordion-test.js
@@ -7,13 +7,155 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, fixture, expect } from '@open-wc/testing';
+import { expect, fixture, html, triggerFocusFor } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
 import '@carbon/web-components/es/components/accordion/index.js';
 
+const accordion = html`
+  <cds-accordion>
+    <cds-accordion-item title="Heading A">
+      <p>Panel A</p>
+    </cds-accordion-item>
+    <cds-accordion-item title="Heading B">
+      <p>Panel B</p>
+    </cds-accordion-item>
+    <cds-accordion-item title="Heading C">
+      <p>Panel C</p>
+    </cds-accordion-item>
+  </cds-accordion>
+`;
+
 describe('cds-accordion', function () {
-  it('should render with minimum attributes', async () => {
-    const el = await fixture(html`<cds-accordion></cds-accordion>`);
+  it('should render', async () => {
+    const el = await fixture(accordion);
 
     await expect(el).dom.to.equalSnapshot();
+  });
+
+  describe('automated verification testing', () => {
+    it('should have no Axe violations', async () => {
+      const el = await fixture(accordion);
+      const firstItem = el.firstElementChild;
+
+      await expect(firstItem).to.be.accessible();
+
+      // click to open
+      await firstItem.click();
+
+      // test when open
+      await expect(firstItem).to.be.accessible();
+    });
+  });
+
+  describe('basic keyboard accessibility testing', () => {
+    it('should receive focus', async () => {
+      const el = await fixture(accordion);
+      const firstItem = el.firstElementChild;
+
+      await triggerFocusFor(firstItem);
+      expect(document.activeElement).to.equal(firstItem);
+    });
+
+    it('should open with enter', async () => {
+      const el = await fixture(accordion);
+      const firstItem = el.firstElementChild;
+
+      await triggerFocusFor(firstItem);
+      await sendKeys({ press: 'Enter' });
+
+      expect(firstItem.hasAttribute('open'));
+    });
+
+    it('should open with spacebar', async () => {
+      const el = await fixture(accordion);
+      const firstItem = el.firstElementChild;
+
+      await triggerFocusFor(firstItem);
+      await sendKeys({ press: 'Space' });
+
+      expect(firstItem.hasAttribute('open'));
+    });
+  });
+
+  describe('Flush align', () => {
+    it('should align to the left if prop isFlush is passed', async () => {
+      const el = await fixture(
+        html`<cds-accordion isFlush>
+          <cds-accordion-item title="Heading A">
+            <p>Panel A</p>
+          </cds-accordion-item>
+          <cds-accordion-item title="Heading B">
+            <p>Panel B</p>
+          </cds-accordion-item>
+          <cds-accordion-item title="Heading C">
+            <p>Panel C</p>
+          </cds-accordion-item>
+        </cds-accordion>`
+      );
+
+      expect(el.hasAttribute('isFlush'));
+    });
+
+    it('should not align to left if alignment="start"', async () => {
+      const el = await fixture(
+        html`<cds-accordion isFlush alignment="start">
+          <cds-accordion-item title="Heading A" alignment="start">
+            <p>Panel A</p>
+          </cds-accordion-item>
+          <cds-accordion-item title="Heading B" alignment="start">
+            <p>Panel B</p>
+          </cds-accordion-item>
+          <cds-accordion-item title="Heading C" alignment="start">
+            <p>Panel C</p>
+          </cds-accordion-item>
+        </cds-accordion>`
+      );
+      const firstItem = el.firstElementChild;
+
+      expect(firstItem.hasAttribute('isFlush')).to.be.false;
+    });
+  });
+
+  describe('Expand/Collapse All', async () => {
+    const el = await fixture(accordion);
+    const elItems = el.querySelectorAll('cds-accordion-item');
+    const expandAllButton = document.createElement('cds-button');
+    const collapseAllButton = document.createElement('cds-button');
+
+    expandAllButton.addEventListener('click', () => {
+      elItems.forEach((item) => {
+        item.setAttribute('open', '');
+      });
+    });
+
+    collapseAllButton.addEventListener('click', () => {
+      elItems.forEach((item) => {
+        item.removeAttribute('open');
+      });
+    });
+
+    it('should expand All on click to button', async () => {
+      await expandAllButton.click();
+
+      elItems.forEach((item) => {
+        expect(item.hasAttribute('open'));
+      });
+    });
+
+    it('should collapse All on click to button', async () => {
+      await expandAllButton.click();
+      await collapseAllButton.click();
+
+      elItems.forEach((item) => {
+        expect(item.hasAttribute('open')).to.be.false;
+      });
+    });
+  });
+
+  // The 'ordered' feature has not yet been added to the web component.
+  // See the React component for more information.
+  xdescribe('Ordered List', () => {
+    it('should be an ol if prop ordered is passed as true', () => {});
+    it('should be a ul if prop ordered is passed as false', () => {});
   });
 });

--- a/packages/web-components/src/components/accordion/accordion.stories.ts
+++ b/packages/web-components/src/components/accordion/accordion.stories.ts
@@ -105,6 +105,66 @@ export const Default = {
   },
 };
 
+export const Controlled = {
+  // This story doesn't accept any args.
+  args: {},
+  argTypes: {},
+  render: () => {
+    const toggleItems = (isOpen) => {
+      document.querySelectorAll('cds-accordion-item').forEach((item) => {
+        if (isOpen) {
+          item.setAttribute('open', '');
+        } else {
+          item.removeAttribute('open');
+        }
+      });
+    };
+    return html`
+      <cds-button @click=${() => toggleItems(true)}
+        >Click to expand all</cds-button
+      >
+      <cds-button @click=${() => toggleItems(false)}
+        >Click to collapse all</cds-button
+      >
+
+      <cds-accordion>
+        <cds-accordion-item title="Section 1 title">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </p>
+        </cds-accordion-item>
+        <cds-accordion-item title="Section 2 title">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </p>
+        </cds-accordion-item>
+        <cds-accordion-item title="Section 3 title">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </p>
+        </cds-accordion-item>
+        <cds-accordion-item title="Section 4 title">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </p>
+        </cds-accordion-item>
+      </cds-accordion>
+    `;
+  },
+};
+
 export const Skeleton = {
   args: {
     alignment: args['alignment'],


### PR DESCRIPTION
Closes #18779 

Update tests to match React `accordion`.

#### Changelog

**New**

- add `Controlled` story to Storybook
- add additional unit tests
- update Developer handbook docs with instructions on how to update snapshots

#### Testing / Reviewing

Run `yarn test` in `packages/web-components` to make sure tests pass. (From GH [CI workflow](https://github.com/carbon-design-system/carbon/actions/runs/13708029399/job/38338056715?pr=18780#step:7:24))