### PR TITLE
fix(type-tokens): do not emit type custom properties by default

### DIFF
--- a/packages/styles/scss/__tests__/__snapshots__/config-test.js.snap
+++ b/packages/styles/scss/__tests__/__snapshots__/config-test.js.snap
@@ -4,7 +4,7 @@ exports[`@carbon/styles/scss/config Public API 1`] = `
 Object {
   "css--body": true,
   "css--default-type": true,
-  "css--emit-type-custom-props": true,
+  "css--emit-type-custom-props": false,
   "css--font-face": true,
   "css--reset": true,
   "flex-grid-columns": 16,

--- a/packages/styles/scss/__tests__/__snapshots__/type-test.js.snap
+++ b/packages/styles/scss/__tests__/__snapshots__/type-test.js.snap
@@ -9,3088 +9,13 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 38,
-              "line": 2,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 2,
-            },
-          },
-          "property": "--cds-caption-01-font-size",
-          "type": "declaration",
-          "value": "0.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 3,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 3,
-            },
-          },
-          "property": "--cds-caption-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 4,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 4,
-            },
-          },
-          "property": "--cds-caption-01-line-height",
-          "type": "declaration",
-          "value": "1.33333",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 5,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 5,
-            },
-          },
-          "property": "--cds-caption-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 6,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 6,
-            },
-          },
-          "property": "--cds-caption-02-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 7,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 7,
-            },
-          },
-          "property": "--cds-caption-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 8,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 8,
-            },
-          },
-          "property": "--cds-caption-02-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 9,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 9,
-            },
-          },
-          "property": "--cds-caption-02-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 10,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 10,
-            },
-          },
-          "property": "--cds-label-01-font-size",
-          "type": "declaration",
-          "value": "0.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 34,
-              "line": 11,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 11,
-            },
-          },
-          "property": "--cds-label-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 12,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 12,
-            },
-          },
-          "property": "--cds-label-01-line-height",
-          "type": "declaration",
-          "value": "1.33333",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 13,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 13,
-            },
-          },
-          "property": "--cds-label-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 14,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 14,
-            },
-          },
-          "property": "--cds-label-02-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 34,
-              "line": 15,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 15,
-            },
-          },
-          "property": "--cds-label-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 16,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 16,
-            },
-          },
-          "property": "--cds-label-02-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 17,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 17,
-            },
-          },
-          "property": "--cds-label-02-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 18,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 18,
-            },
-          },
-          "property": "--cds-helper-text-01-font-size",
-          "type": "declaration",
-          "value": "0.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 44,
-              "line": 19,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 19,
-            },
-          },
-          "property": "--cds-helper-text-01-line-height",
-          "type": "declaration",
-          "value": "1.33333",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 20,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 20,
-            },
-          },
-          "property": "--cds-helper-text-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 43,
-              "line": 21,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 21,
-            },
-          },
-          "property": "--cds-helper-text-02-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 22,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 22,
-            },
-          },
-          "property": "--cds-helper-text-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 44,
-              "line": 23,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 23,
-            },
-          },
-          "property": "--cds-helper-text-02-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 24,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 24,
-            },
-          },
-          "property": "--cds-helper-text-02-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 25,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 25,
-            },
-          },
-          "property": "--cds-body-short-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 26,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 26,
-            },
-          },
-          "property": "--cds-body-short-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 43,
-              "line": 27,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 27,
-            },
-          },
-          "property": "--cds-body-short-01-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 45,
-              "line": 28,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 28,
-            },
-          },
-          "property": "--cds-body-short-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 29,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 29,
-            },
-          },
-          "property": "--cds-body-short-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 30,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 30,
-            },
-          },
-          "property": "--cds-body-short-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 41,
-              "line": 31,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 31,
-            },
-          },
-          "property": "--cds-body-short-02-line-height",
-          "type": "declaration",
-          "value": "1.375",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 32,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 32,
-            },
-          },
-          "property": "--cds-body-short-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 41,
-              "line": 33,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 33,
-            },
-          },
-          "property": "--cds-body-long-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 34,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 34,
-            },
-          },
-          "property": "--cds-body-long-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 35,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 35,
-            },
-          },
-          "property": "--cds-body-long-01-line-height",
-          "type": "declaration",
-          "value": "1.42857",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 44,
-              "line": 36,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 36,
-            },
-          },
-          "property": "--cds-body-long-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 37,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 37,
-            },
-          },
-          "property": "--cds-body-long-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 38,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 38,
-            },
-          },
-          "property": "--cds-body-long-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 39,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 39,
-            },
-          },
-          "property": "--cds-body-long-02-line-height",
-          "type": "declaration",
-          "value": "1.5",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 40,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 40,
-            },
-          },
-          "property": "--cds-body-long-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 123,
-              "line": 41,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 41,
-            },
-          },
-          "property": "--cds-code-01-font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 35,
-              "line": 42,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 42,
-            },
-          },
-          "property": "--cds-code-01-font-size",
-          "type": "declaration",
-          "value": "0.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 33,
-              "line": 43,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 43,
-            },
-          },
-          "property": "--cds-code-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 44,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 44,
-            },
-          },
-          "property": "--cds-code-01-line-height",
-          "type": "declaration",
-          "value": "1.33333",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 45,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 45,
-            },
-          },
-          "property": "--cds-code-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 123,
-              "line": 46,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 46,
-            },
-          },
-          "property": "--cds-code-02-font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 47,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 47,
-            },
-          },
-          "property": "--cds-code-02-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 33,
-              "line": 48,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 48,
-            },
-          },
-          "property": "--cds-code-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 49,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 49,
-            },
-          },
-          "property": "--cds-code-02-line-height",
-          "type": "declaration",
-          "value": "1.42857",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 50,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 50,
-            },
-          },
-          "property": "--cds-code-02-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 51,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 51,
-            },
-          },
-          "property": "--cds-heading-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 52,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 52,
-            },
-          },
-          "property": "--cds-heading-01-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 53,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 53,
-            },
-          },
-          "property": "--cds-heading-01-line-height",
-          "type": "declaration",
-          "value": "1.42857",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 54,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 54,
-            },
-          },
-          "property": "--cds-heading-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 35,
-              "line": 55,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 55,
-            },
-          },
-          "property": "--cds-heading-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 56,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 56,
-            },
-          },
-          "property": "--cds-heading-02-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 57,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 57,
-            },
-          },
-          "property": "--cds-heading-02-line-height",
-          "type": "declaration",
-          "value": "1.5",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 58,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 58,
-            },
-          },
-          "property": "--cds-heading-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 59,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 59,
-            },
-          },
-          "property": "--cds-productive-heading-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 60,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 60,
-            },
-          },
-          "property": "--cds-productive-heading-01-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 51,
-              "line": 61,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 61,
-            },
-          },
-          "property": "--cds-productive-heading-01-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 53,
-              "line": 62,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 62,
-            },
-          },
-          "property": "--cds-productive-heading-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 63,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 63,
-            },
-          },
-          "property": "--cds-productive-heading-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 64,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 64,
-            },
-          },
-          "property": "--cds-productive-heading-02-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 65,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 65,
-            },
-          },
-          "property": "--cds-productive-heading-02-line-height",
-          "type": "declaration",
-          "value": "1.375",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 66,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 66,
-            },
-          },
-          "property": "--cds-productive-heading-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 67,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 67,
-            },
-          },
-          "property": "--cds-productive-heading-03-font-size",
-          "type": "declaration",
-          "value": "1.25rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 68,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 68,
-            },
-          },
-          "property": "--cds-productive-heading-03-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 69,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 69,
-            },
-          },
-          "property": "--cds-productive-heading-03-line-height",
-          "type": "declaration",
-          "value": "1.4",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 70,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 70,
-            },
-          },
-          "property": "--cds-productive-heading-03-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 71,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 71,
-            },
-          },
-          "property": "--cds-productive-heading-04-font-size",
-          "type": "declaration",
-          "value": "1.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 72,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 72,
-            },
-          },
-          "property": "--cds-productive-heading-04-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 51,
-              "line": 73,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 73,
-            },
-          },
-          "property": "--cds-productive-heading-04-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 74,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 74,
-            },
-          },
-          "property": "--cds-productive-heading-04-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 75,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 75,
-            },
-          },
-          "property": "--cds-productive-heading-05-font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 76,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 76,
-            },
-          },
-          "property": "--cds-productive-heading-05-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 77,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 77,
-            },
-          },
-          "property": "--cds-productive-heading-05-line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 78,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 78,
-            },
-          },
-          "property": "--cds-productive-heading-05-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 79,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 79,
-            },
-          },
-          "property": "--cds-productive-heading-06-font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 80,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 80,
-            },
-          },
-          "property": "--cds-productive-heading-06-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 81,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 81,
-            },
-          },
-          "property": "--cds-productive-heading-06-line-height",
-          "type": "declaration",
-          "value": "1.199",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 82,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 82,
-            },
-          },
-          "property": "--cds-productive-heading-06-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 83,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 83,
-            },
-          },
-          "property": "--cds-productive-heading-07-font-size",
-          "type": "declaration",
-          "value": "3.375rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 84,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 84,
-            },
-          },
-          "property": "--cds-productive-heading-07-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 85,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 85,
-            },
-          },
-          "property": "--cds-productive-heading-07-line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 86,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 86,
-            },
-          },
-          "property": "--cds-productive-heading-07-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 87,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 87,
-            },
-          },
-          "property": "--cds-expressive-paragraph-01-font-size",
-          "type": "declaration",
-          "value": "1.5rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 88,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 88,
-            },
-          },
-          "property": "--cds-expressive-paragraph-01-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 51,
-              "line": 89,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 89,
-            },
-          },
-          "property": "--cds-expressive-paragraph-01-line-height",
-          "type": "declaration",
-          "value": "1.334",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 90,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 90,
-            },
-          },
-          "property": "--cds-expressive-paragraph-01-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 91,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 91,
-            },
-          },
-          "property": "--cds-expressive-heading-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 92,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 92,
-            },
-          },
-          "property": "--cds-expressive-heading-01-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 51,
-              "line": 93,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 93,
-            },
-          },
-          "property": "--cds-expressive-heading-01-line-height",
-          "type": "declaration",
-          "value": "1.42857",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 53,
-              "line": 94,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 94,
-            },
-          },
-          "property": "--cds-expressive-heading-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 95,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 95,
-            },
-          },
-          "property": "--cds-expressive-heading-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 96,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 96,
-            },
-          },
-          "property": "--cds-expressive-heading-02-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 97,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 97,
-            },
-          },
-          "property": "--cds-expressive-heading-02-line-height",
-          "type": "declaration",
-          "value": "1.5",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 98,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 98,
-            },
-          },
-          "property": "--cds-expressive-heading-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 99,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 99,
-            },
-          },
-          "property": "--cds-expressive-heading-03-font-size",
-          "type": "declaration",
-          "value": "1.25rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 100,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 100,
-            },
-          },
-          "property": "--cds-expressive-heading-03-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 101,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 101,
-            },
-          },
-          "property": "--cds-expressive-heading-03-line-height",
-          "type": "declaration",
-          "value": "1.4",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 102,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 102,
-            },
-          },
-          "property": "--cds-expressive-heading-03-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 49,
-              "line": 103,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 103,
-            },
-          },
-          "property": "--cds-expressive-heading-04-font-size",
-          "type": "declaration",
-          "value": "1.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 104,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 104,
-            },
-          },
-          "property": "--cds-expressive-heading-04-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 51,
-              "line": 105,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 105,
-            },
-          },
-          "property": "--cds-expressive-heading-04-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 106,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 106,
-            },
-          },
-          "property": "--cds-expressive-heading-04-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 107,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 107,
-            },
-          },
-          "property": "--cds-expressive-heading-05-font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 108,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 108,
-            },
-          },
-          "property": "--cds-expressive-heading-05-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 109,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 109,
-            },
-          },
-          "property": "--cds-expressive-heading-05-line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 110,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 110,
-            },
-          },
-          "property": "--cds-expressive-heading-05-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 111,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 111,
-            },
-          },
-          "property": "--cds-expressive-heading-06-font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 112,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 112,
-            },
-          },
-          "property": "--cds-expressive-heading-06-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 113,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 113,
-            },
-          },
-          "property": "--cds-expressive-heading-06-line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 114,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 114,
-            },
-          },
-          "property": "--cds-expressive-heading-06-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 125,
-              "line": 115,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 115,
-            },
-          },
-          "property": "--cds-quotation-01-font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 116,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 116,
-            },
-          },
-          "property": "--cds-quotation-01-font-size",
-          "type": "declaration",
-          "value": "1.25rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 117,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 117,
-            },
-          },
-          "property": "--cds-quotation-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 118,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 118,
-            },
-          },
-          "property": "--cds-quotation-01-line-height",
-          "type": "declaration",
-          "value": "1.3",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 119,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 119,
-            },
-          },
-          "property": "--cds-quotation-01-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 125,
-              "line": 120,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 120,
-            },
-          },
-          "property": "--cds-quotation-02-font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 121,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 121,
-            },
-          },
-          "property": "--cds-quotation-02-font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 122,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 122,
-            },
-          },
-          "property": "--cds-quotation-02-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 123,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 123,
-            },
-          },
-          "property": "--cds-quotation-02-line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 124,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 124,
-            },
-          },
-          "property": "--cds-quotation-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 125,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 125,
-            },
-          },
-          "property": "--cds-display-01-font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 126,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 126,
-            },
-          },
-          "property": "--cds-display-01-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 127,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 127,
-            },
-          },
-          "property": "--cds-display-01-line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 128,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 128,
-            },
-          },
-          "property": "--cds-display-01-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 129,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 129,
-            },
-          },
-          "property": "--cds-display-02-font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 130,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 130,
-            },
-          },
-          "property": "--cds-display-02-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 131,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 131,
-            },
-          },
-          "property": "--cds-display-02-line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 132,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 132,
-            },
-          },
-          "property": "--cds-display-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 133,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 133,
-            },
-          },
-          "property": "--cds-display-03-font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 134,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 134,
-            },
-          },
-          "property": "--cds-display-03-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 135,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 135,
-            },
-          },
-          "property": "--cds-display-03-line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 136,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 136,
-            },
-          },
-          "property": "--cds-display-03-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 137,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 137,
-            },
-          },
-          "property": "--cds-display-04-font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 138,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 138,
-            },
-          },
-          "property": "--cds-display-04-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 139,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 139,
-            },
-          },
-          "property": "--cds-display-04-line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 140,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 140,
-            },
-          },
-          "property": "--cds-display-04-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 141,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 141,
-            },
-          },
-          "property": "--cds-legal-01-font-size",
-          "type": "declaration",
-          "value": "0.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 34,
-              "line": 142,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 142,
-            },
-          },
-          "property": "--cds-legal-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 143,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 143,
-            },
-          },
-          "property": "--cds-legal-01-line-height",
-          "type": "declaration",
-          "value": "1.33333",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 144,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 144,
-            },
-          },
-          "property": "--cds-legal-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.32px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 145,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 145,
-            },
-          },
-          "property": "--cds-legal-02-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 34,
-              "line": 146,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 146,
-            },
-          },
-          "property": "--cds-legal-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 147,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 147,
-            },
-          },
-          "property": "--cds-legal-02-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 148,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 148,
-            },
-          },
-          "property": "--cds-legal-02-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 44,
-              "line": 149,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 149,
-            },
-          },
-          "property": "--cds-body-compact-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 41,
-              "line": 150,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 150,
-            },
-          },
-          "property": "--cds-body-compact-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 45,
-              "line": 151,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 151,
-            },
-          },
-          "property": "--cds-body-compact-01-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 152,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 152,
-            },
-          },
-          "property": "--cds-body-compact-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 153,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 153,
-            },
-          },
-          "property": "--cds-body-compact-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 41,
-              "line": 154,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 154,
-            },
-          },
-          "property": "--cds-body-compact-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 43,
-              "line": 155,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 155,
-            },
-          },
-          "property": "--cds-body-compact-02-line-height",
-          "type": "declaration",
-          "value": "1.375",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 42,
-              "line": 156,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 156,
-            },
-          },
-          "property": "--cds-body-compact-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 47,
-              "line": 157,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 157,
-            },
-          },
-          "property": "--cds-heading-compact-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 44,
-              "line": 158,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 158,
-            },
-          },
-          "property": "--cds-heading-compact-01-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 48,
-              "line": 159,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 159,
-            },
-          },
-          "property": "--cds-heading-compact-01-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 50,
-              "line": 160,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 160,
-            },
-          },
-          "property": "--cds-heading-compact-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 43,
-              "line": 161,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 161,
-            },
-          },
-          "property": "--cds-heading-compact-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 44,
-              "line": 162,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 162,
-            },
-          },
-          "property": "--cds-heading-compact-02-font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 46,
-              "line": 163,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 163,
-            },
-          },
-          "property": "--cds-heading-compact-02-line-height",
-          "type": "declaration",
-          "value": "1.375",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 45,
-              "line": 164,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 164,
-            },
-          },
-          "property": "--cds-heading-compact-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 165,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 165,
-            },
-          },
-          "property": "--cds-body-01-font-size",
-          "type": "declaration",
-          "value": "0.875rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 33,
-              "line": 166,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 166,
-            },
-          },
-          "property": "--cds-body-01-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 167,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 167,
-            },
-          },
-          "property": "--cds-body-01-line-height",
-          "type": "declaration",
-          "value": "1.42857",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 168,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 168,
-            },
-          },
-          "property": "--cds-body-01-letter-spacing",
-          "type": "declaration",
-          "value": "0.16px",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 32,
-              "line": 169,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 169,
-            },
-          },
-          "property": "--cds-body-02-font-size",
-          "type": "declaration",
-          "value": "1rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 33,
-              "line": 170,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 170,
-            },
-          },
-          "property": "--cds-body-02-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 33,
-              "line": 171,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 171,
-            },
-          },
-          "property": "--cds-body-02-line-height",
-          "type": "declaration",
-          "value": "1.5",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 34,
-              "line": 172,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 172,
-            },
-          },
-          "property": "--cds-body-02-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 173,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 173,
-            },
-          },
-          "property": "--cds-heading-03-font-size",
-          "type": "declaration",
-          "value": "1.25rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 174,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 174,
-            },
-          },
-          "property": "--cds-heading-03-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 175,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 175,
-            },
-          },
-          "property": "--cds-heading-03-line-height",
-          "type": "declaration",
-          "value": "1.4",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 176,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 176,
-            },
-          },
-          "property": "--cds-heading-03-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 177,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 177,
-            },
-          },
-          "property": "--cds-heading-04-font-size",
-          "type": "declaration",
-          "value": "1.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 178,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 178,
-            },
-          },
-          "property": "--cds-heading-04-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 40,
-              "line": 179,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 179,
-            },
-          },
-          "property": "--cds-heading-04-line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 180,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 180,
-            },
-          },
-          "property": "--cds-heading-04-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 35,
-              "line": 181,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 181,
-            },
-          },
-          "property": "--cds-heading-05-font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 182,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 182,
-            },
-          },
-          "property": "--cds-heading-05-font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 183,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 183,
-            },
-          },
-          "property": "--cds-heading-05-line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 184,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 184,
-            },
-          },
-          "property": "--cds-heading-05-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 185,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 185,
-            },
-          },
-          "property": "--cds-heading-06-font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 186,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 186,
-            },
-          },
-          "property": "--cds-heading-06-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 38,
-              "line": 187,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 187,
-            },
-          },
-          "property": "--cds-heading-06-line-height",
-          "type": "declaration",
-          "value": "1.199",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 188,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 188,
-            },
-          },
-          "property": "--cds-heading-06-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 39,
-              "line": 189,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 189,
-            },
-          },
-          "property": "--cds-heading-07-font-size",
-          "type": "declaration",
-          "value": "3.375rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 36,
-              "line": 190,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 190,
-            },
-          },
-          "property": "--cds-heading-07-font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 191,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 191,
-            },
-          },
-          "property": "--cds-heading-07-line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 37,
-              "line": 192,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 192,
-            },
-          },
-          "property": "--cds-heading-07-letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 193,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "selectors": Array [
-        ":root",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
               "column": 109,
-              "line": 196,
+              "line": 2,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 196,
+              "line": 2,
             },
           },
           "property": "font-family",
@@ -3101,12 +26,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 197,
+          "line": 3,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 195,
+          "line": 1,
         },
       },
       "selectors": Array [
@@ -3120,12 +45,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 110,
-              "line": 200,
+              "line": 6,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 200,
+              "line": 6,
             },
           },
           "property": "font-family",
@@ -3136,12 +61,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 201,
+          "line": 7,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 199,
+          "line": 5,
         },
       },
       "selectors": Array [
@@ -3155,12 +80,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 120,
-              "line": 204,
+              "line": 10,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 204,
+              "line": 10,
             },
           },
           "property": "font-family",
@@ -3171,12 +96,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 205,
+          "line": 11,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 203,
+          "line": 9,
         },
       },
       "selectors": Array [
@@ -3190,12 +115,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 117,
-              "line": 208,
+              "line": 14,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 208,
+              "line": 14,
             },
           },
           "property": "font-family",
@@ -3206,12 +131,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 209,
+          "line": 15,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 207,
+          "line": 13,
         },
       },
       "selectors": Array [
@@ -3225,12 +150,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 121,
-              "line": 212,
+              "line": 18,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 212,
+              "line": 18,
             },
           },
           "property": "font-family",
@@ -3241,12 +166,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 213,
+          "line": 19,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 211,
+          "line": 17,
         },
       },
       "selectors": Array [
@@ -3260,12 +185,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 117,
-              "line": 216,
+              "line": 22,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 216,
+              "line": 22,
             },
           },
           "property": "font-family",
@@ -3276,12 +201,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 217,
+          "line": 23,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 215,
+          "line": 21,
         },
       },
       "selectors": Array [
@@ -3295,12 +220,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 113,
-              "line": 220,
+              "line": 26,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 220,
+              "line": 26,
             },
           },
           "property": "font-family",
@@ -3311,12 +236,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 221,
+          "line": 27,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 219,
+          "line": 25,
         },
       },
       "selectors": Array [
@@ -3330,12 +255,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 113,
-              "line": 224,
+              "line": 30,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 224,
+              "line": 30,
             },
           },
           "property": "font-family",
@@ -3346,12 +271,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 225,
+          "line": 31,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 223,
+          "line": 29,
         },
       },
       "selectors": Array [
@@ -3365,12 +290,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 122,
-              "line": 228,
+              "line": 34,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 228,
+              "line": 34,
             },
           },
           "property": "font-family",
@@ -3381,12 +306,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 229,
+          "line": 35,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 227,
+          "line": 33,
         },
       },
       "selectors": Array [
@@ -3400,12 +325,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 115,
-              "line": 232,
+              "line": 38,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 232,
+              "line": 38,
             },
           },
           "property": "font-family",
@@ -3416,12 +341,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 233,
+          "line": 39,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 231,
+          "line": 37,
         },
       },
       "selectors": Array [
@@ -3435,12 +360,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 106,
-              "line": 236,
+              "line": 42,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 236,
+              "line": 42,
             },
           },
           "property": "font-family",
@@ -3451,12 +376,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 237,
+          "line": 43,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 235,
+          "line": 41,
         },
       },
       "selectors": Array [
@@ -3470,12 +395,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 240,
+              "line": 46,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 240,
+              "line": 46,
             },
           },
           "property": "font-weight",
@@ -3486,12 +411,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 241,
+          "line": 47,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 239,
+          "line": 45,
         },
       },
       "selectors": Array [
@@ -3505,12 +430,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 244,
+              "line": 50,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 244,
+              "line": 50,
             },
           },
           "property": "font-weight",
@@ -3521,12 +446,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 245,
+          "line": 51,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 243,
+          "line": 49,
         },
       },
       "selectors": Array [
@@ -3540,12 +465,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 248,
+              "line": 54,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 248,
+              "line": 54,
             },
           },
           "property": "font-weight",
@@ -3556,12 +481,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 249,
+          "line": 55,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 247,
+          "line": 53,
         },
       },
       "selectors": Array [
@@ -3575,12 +500,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 21,
-              "line": 252,
+              "line": 58,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 252,
+              "line": 58,
             },
           },
           "property": "font-style",
@@ -3591,12 +516,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 253,
+          "line": 59,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 251,
+          "line": 57,
         },
       },
       "selectors": Array [
@@ -3610,12 +535,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 256,
+              "line": 62,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 256,
+              "line": 62,
             },
           },
           "property": "font-size",
@@ -3626,12 +551,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 257,
+              "line": 63,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 257,
+              "line": 63,
             },
           },
           "property": "font-weight",
@@ -3642,12 +567,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 258,
+              "line": 64,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 258,
+              "line": 64,
             },
           },
           "property": "line-height",
@@ -3658,12 +583,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 63,
-              "line": 259,
+              "line": 65,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 259,
+              "line": 65,
             },
           },
           "property": "letter-spacing",
@@ -3674,12 +599,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 260,
+          "line": 66,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 255,
+          "line": 61,
         },
       },
       "selectors": Array [
@@ -3693,12 +618,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 263,
+              "line": 69,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 263,
+              "line": 69,
             },
           },
           "property": "font-size",
@@ -3709,12 +634,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 264,
+              "line": 70,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 264,
+              "line": 70,
             },
           },
           "property": "font-weight",
@@ -3725,12 +650,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 265,
+              "line": 71,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 265,
+              "line": 71,
             },
           },
           "property": "line-height",
@@ -3741,12 +666,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 63,
-              "line": 266,
+              "line": 72,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 266,
+              "line": 72,
             },
           },
           "property": "letter-spacing",
@@ -3757,12 +682,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 267,
+          "line": 73,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 262,
+          "line": 68,
         },
       },
       "selectors": Array [
@@ -3776,12 +701,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 270,
+              "line": 76,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 270,
+              "line": 76,
             },
           },
           "property": "font-size",
@@ -3792,12 +717,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 271,
+              "line": 77,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 271,
+              "line": 77,
             },
           },
           "property": "font-weight",
@@ -3808,12 +733,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 272,
+              "line": 78,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 272,
+              "line": 78,
             },
           },
           "property": "line-height",
@@ -3824,12 +749,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 273,
+              "line": 79,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 273,
+              "line": 79,
             },
           },
           "property": "letter-spacing",
@@ -3840,12 +765,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 274,
+          "line": 80,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 269,
+          "line": 75,
         },
       },
       "selectors": Array [
@@ -3859,12 +784,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 53,
-              "line": 277,
+              "line": 83,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 277,
+              "line": 83,
             },
           },
           "property": "font-size",
@@ -3875,12 +800,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 278,
+              "line": 84,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 278,
+              "line": 84,
             },
           },
           "property": "font-weight",
@@ -3891,12 +816,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 279,
+              "line": 85,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 279,
+              "line": 85,
             },
           },
           "property": "line-height",
@@ -3907,12 +832,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 280,
+              "line": 86,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 280,
+              "line": 86,
             },
           },
           "property": "letter-spacing",
@@ -3923,12 +848,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 281,
+          "line": 87,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 276,
+          "line": 82,
         },
       },
       "selectors": Array [
@@ -3942,12 +867,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 284,
+              "line": 90,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 284,
+              "line": 90,
             },
           },
           "property": "font-size",
@@ -3958,12 +883,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 285,
+              "line": 91,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 285,
+              "line": 91,
             },
           },
           "property": "line-height",
@@ -3974,12 +899,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 67,
-              "line": 286,
+              "line": 92,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 286,
+              "line": 92,
             },
           },
           "property": "letter-spacing",
@@ -3990,12 +915,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 287,
+          "line": 93,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 283,
+          "line": 89,
         },
       },
       "selectors": Array [
@@ -4009,12 +934,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 59,
-              "line": 290,
+              "line": 96,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 290,
+              "line": 96,
             },
           },
           "property": "font-size",
@@ -4025,12 +950,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 291,
+              "line": 97,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 291,
+              "line": 97,
             },
           },
           "property": "font-weight",
@@ -4041,12 +966,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 292,
+              "line": 98,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 292,
+              "line": 98,
             },
           },
           "property": "line-height",
@@ -4057,12 +982,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 67,
-              "line": 293,
+              "line": 99,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 293,
+              "line": 99,
             },
           },
           "property": "letter-spacing",
@@ -4073,12 +998,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 294,
+          "line": 100,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 289,
+          "line": 95,
         },
       },
       "selectors": Array [
@@ -4092,12 +1017,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 297,
+              "line": 103,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 297,
+              "line": 103,
             },
           },
           "property": "font-size",
@@ -4108,12 +1033,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 57,
-              "line": 298,
+              "line": 104,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 298,
+              "line": 104,
             },
           },
           "property": "font-weight",
@@ -4124,12 +1049,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 299,
+              "line": 105,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 299,
+              "line": 105,
             },
           },
           "property": "line-height",
@@ -4140,12 +1065,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 300,
+              "line": 106,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 300,
+              "line": 106,
             },
           },
           "property": "letter-spacing",
@@ -4156,12 +1081,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 301,
+          "line": 107,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 296,
+          "line": 102,
         },
       },
       "selectors": Array [
@@ -4175,12 +1100,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 304,
+              "line": 110,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 304,
+              "line": 110,
             },
           },
           "property": "font-size",
@@ -4191,12 +1116,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 57,
-              "line": 305,
+              "line": 111,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 305,
+              "line": 111,
             },
           },
           "property": "font-weight",
@@ -4207,12 +1132,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 59,
-              "line": 306,
+              "line": 112,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 306,
+              "line": 112,
             },
           },
           "property": "line-height",
@@ -4223,12 +1148,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 307,
+              "line": 113,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 307,
+              "line": 113,
             },
           },
           "property": "letter-spacing",
@@ -4239,12 +1164,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 308,
+          "line": 114,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 303,
+          "line": 109,
         },
       },
       "selectors": Array [
@@ -4258,12 +1183,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 57,
-              "line": 311,
+              "line": 117,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 311,
+              "line": 117,
             },
           },
           "property": "font-size",
@@ -4274,12 +1199,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 312,
+              "line": 118,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 312,
+              "line": 118,
             },
           },
           "property": "font-weight",
@@ -4290,12 +1215,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 60,
-              "line": 313,
+              "line": 119,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 313,
+              "line": 119,
             },
           },
           "property": "line-height",
@@ -4306,12 +1231,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 314,
+              "line": 120,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 314,
+              "line": 120,
             },
           },
           "property": "letter-spacing",
@@ -4322,12 +1247,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 315,
+          "line": 121,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 310,
+          "line": 116,
         },
       },
       "selectors": Array [
@@ -4341,12 +1266,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 53,
-              "line": 318,
+              "line": 124,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 318,
+              "line": 124,
             },
           },
           "property": "font-size",
@@ -4357,12 +1282,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 319,
+              "line": 125,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 319,
+              "line": 125,
             },
           },
           "property": "font-weight",
@@ -4373,12 +1298,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 320,
+              "line": 126,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 320,
+              "line": 126,
             },
           },
           "property": "line-height",
@@ -4389,12 +1314,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 60,
-              "line": 321,
+              "line": 127,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 321,
+              "line": 127,
             },
           },
           "property": "letter-spacing",
@@ -4405,12 +1330,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 322,
+          "line": 128,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 317,
+          "line": 123,
         },
       },
       "selectors": Array [
@@ -4424,12 +1349,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 141,
-              "line": 325,
+              "line": 131,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 325,
+              "line": 131,
             },
           },
           "property": "font-family",
@@ -4440,12 +1365,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 326,
+              "line": 132,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 326,
+              "line": 132,
             },
           },
           "property": "font-size",
@@ -4456,12 +1381,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 327,
+              "line": 133,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 327,
+              "line": 133,
             },
           },
           "property": "font-weight",
@@ -4472,12 +1397,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 328,
+              "line": 134,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 328,
+              "line": 134,
             },
           },
           "property": "line-height",
@@ -4488,12 +1413,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 60,
-              "line": 329,
+              "line": 135,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 329,
+              "line": 135,
             },
           },
           "property": "letter-spacing",
@@ -4504,12 +1429,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 330,
+          "line": 136,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 324,
+          "line": 130,
         },
       },
       "selectors": Array [
@@ -4523,12 +1448,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 141,
-              "line": 333,
+              "line": 139,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 333,
+              "line": 139,
             },
           },
           "property": "font-family",
@@ -4539,12 +1464,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 334,
+              "line": 140,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 334,
+              "line": 140,
             },
           },
           "property": "font-size",
@@ -4555,12 +1480,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 335,
+              "line": 141,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 335,
+              "line": 141,
             },
           },
           "property": "font-weight",
@@ -4571,12 +1496,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 336,
+              "line": 142,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 336,
+              "line": 142,
             },
           },
           "property": "line-height",
@@ -4587,12 +1512,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 60,
-              "line": 337,
+              "line": 143,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 337,
+              "line": 143,
             },
           },
           "property": "letter-spacing",
@@ -4603,12 +1528,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 338,
+          "line": 144,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 332,
+          "line": 138,
         },
       },
       "selectors": Array [
@@ -4622,12 +1547,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 341,
+              "line": 147,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 341,
+              "line": 147,
             },
           },
           "property": "font-size",
@@ -4638,12 +1563,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 342,
+              "line": 148,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 342,
+              "line": 148,
             },
           },
           "property": "font-weight",
@@ -4654,12 +1579,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 343,
+              "line": 149,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 343,
+              "line": 149,
             },
           },
           "property": "line-height",
@@ -4670,12 +1595,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 63,
-              "line": 344,
+              "line": 150,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 344,
+              "line": 150,
             },
           },
           "property": "letter-spacing",
@@ -4686,12 +1611,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 345,
+          "line": 151,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 340,
+          "line": 146,
         },
       },
       "selectors": Array [
@@ -4705,12 +1630,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 348,
+              "line": 154,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 348,
+              "line": 154,
             },
           },
           "property": "font-size",
@@ -4721,12 +1646,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 349,
+              "line": 155,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 349,
+              "line": 155,
             },
           },
           "property": "font-weight",
@@ -4737,12 +1662,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 350,
+              "line": 156,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 350,
+              "line": 156,
             },
           },
           "property": "line-height",
@@ -4753,12 +1678,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 351,
+              "line": 157,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 351,
+              "line": 157,
             },
           },
           "property": "letter-spacing",
@@ -4769,12 +1694,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 352,
+          "line": 158,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 347,
+          "line": 153,
         },
       },
       "selectors": Array [
@@ -4788,12 +1713,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 355,
+              "line": 161,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 355,
+              "line": 161,
             },
           },
           "property": "font-size",
@@ -4804,12 +1729,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 356,
+              "line": 162,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 356,
+              "line": 162,
             },
           },
           "property": "font-weight",
@@ -4820,12 +1745,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 357,
+              "line": 163,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 357,
+              "line": 163,
             },
           },
           "property": "line-height",
@@ -4836,12 +1761,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 74,
-              "line": 358,
+              "line": 164,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 358,
+              "line": 164,
             },
           },
           "property": "letter-spacing",
@@ -4852,12 +1777,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 359,
+          "line": 165,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 354,
+          "line": 160,
         },
       },
       "selectors": Array [
@@ -4871,12 +1796,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 362,
+              "line": 168,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 362,
+              "line": 168,
             },
           },
           "property": "font-size",
@@ -4887,12 +1812,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 363,
+              "line": 169,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 363,
+              "line": 169,
             },
           },
           "property": "font-weight",
@@ -4903,12 +1828,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 67,
-              "line": 364,
+              "line": 170,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 364,
+              "line": 170,
             },
           },
           "property": "line-height",
@@ -4919,12 +1844,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 365,
+              "line": 171,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 365,
+              "line": 171,
             },
           },
           "property": "letter-spacing",
@@ -4935,12 +1860,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 366,
+          "line": 172,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 361,
+          "line": 167,
         },
       },
       "selectors": Array [
@@ -4954,12 +1879,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 369,
+              "line": 175,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 369,
+              "line": 175,
             },
           },
           "property": "font-size",
@@ -4970,12 +1895,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 370,
+              "line": 176,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 370,
+              "line": 176,
             },
           },
           "property": "font-weight",
@@ -4986,12 +1911,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 371,
+              "line": 177,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 371,
+              "line": 177,
             },
           },
           "property": "line-height",
@@ -5002,12 +1927,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 372,
+              "line": 178,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 372,
+              "line": 178,
             },
           },
           "property": "letter-spacing",
@@ -5018,12 +1943,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 373,
+          "line": 179,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 368,
+          "line": 174,
         },
       },
       "selectors": Array [
@@ -5037,12 +1962,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 376,
+              "line": 182,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 376,
+              "line": 182,
             },
           },
           "property": "font-size",
@@ -5053,12 +1978,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 377,
+              "line": 183,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 377,
+              "line": 183,
             },
           },
           "property": "font-weight",
@@ -5069,12 +1994,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 378,
+              "line": 184,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 378,
+              "line": 184,
             },
           },
           "property": "line-height",
@@ -5085,12 +2010,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 379,
+              "line": 185,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 379,
+              "line": 185,
             },
           },
           "property": "letter-spacing",
@@ -5101,12 +2026,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 380,
+          "line": 186,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 375,
+          "line": 181,
         },
       },
       "selectors": Array [
@@ -5120,12 +2045,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 383,
+              "line": 189,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 383,
+              "line": 189,
             },
           },
           "property": "font-size",
@@ -5136,12 +2061,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 384,
+              "line": 190,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 384,
+              "line": 190,
             },
           },
           "property": "font-weight",
@@ -5152,12 +2077,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 385,
+              "line": 191,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 385,
+              "line": 191,
             },
           },
           "property": "line-height",
@@ -5168,12 +2093,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 386,
+              "line": 192,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 386,
+              "line": 192,
             },
           },
           "property": "letter-spacing",
@@ -5184,12 +2109,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 387,
+          "line": 193,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 382,
+          "line": 188,
         },
       },
       "selectors": Array [
@@ -5203,12 +2128,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 390,
+              "line": 196,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 390,
+              "line": 196,
             },
           },
           "property": "font-size",
@@ -5219,12 +2144,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 391,
+              "line": 197,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 391,
+              "line": 197,
             },
           },
           "property": "font-weight",
@@ -5235,12 +2160,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 67,
-              "line": 392,
+              "line": 198,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 392,
+              "line": 198,
             },
           },
           "property": "line-height",
@@ -5251,12 +2176,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 393,
+              "line": 199,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 393,
+              "line": 199,
             },
           },
           "property": "letter-spacing",
@@ -5267,12 +2192,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 394,
+          "line": 200,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 389,
+          "line": 195,
         },
       },
       "selectors": Array [
@@ -5286,12 +2211,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 397,
+              "line": 203,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 397,
+              "line": 203,
             },
           },
           "property": "font-size",
@@ -5302,12 +2227,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 398,
+              "line": 204,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 398,
+              "line": 204,
             },
           },
           "property": "font-weight",
@@ -5318,12 +2243,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 399,
+              "line": 205,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 399,
+              "line": 205,
             },
           },
           "property": "line-height",
@@ -5334,12 +2259,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 400,
+              "line": 206,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 400,
+              "line": 206,
             },
           },
           "property": "letter-spacing",
@@ -5350,12 +2275,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 401,
+          "line": 207,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 396,
+          "line": 202,
         },
       },
       "selectors": Array [
@@ -5369,12 +2294,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 404,
+              "line": 210,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 404,
+              "line": 210,
             },
           },
           "property": "font-size",
@@ -5385,12 +2310,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 405,
+              "line": 211,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 405,
+              "line": 211,
             },
           },
           "property": "font-weight",
@@ -5401,12 +2326,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 21,
-              "line": 406,
+              "line": 212,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 406,
+              "line": 212,
             },
           },
           "property": "line-height",
@@ -5417,12 +2342,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 407,
+              "line": 213,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 407,
+              "line": 213,
             },
           },
           "property": "letter-spacing",
@@ -5433,12 +2358,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 408,
+              "line": 214,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 408,
+              "line": 214,
             },
           },
           "property": "font-size",
@@ -5449,12 +2374,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 409,
+          "line": 215,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 403,
+          "line": 209,
         },
       },
       "selectors": Array [
@@ -5467,12 +2392,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 416,
+          "line": 222,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 410,
+          "line": 216,
         },
       },
       "rules": Array [
@@ -5482,12 +2407,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 412,
+                  "line": 218,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 412,
+                  "line": 218,
                 },
               },
               "property": "font-size",
@@ -5498,12 +2423,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 25,
-                  "line": 413,
+                  "line": 219,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 413,
+                  "line": 219,
                 },
               },
               "property": "line-height",
@@ -5514,12 +2439,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 59,
-                  "line": 414,
+                  "line": 220,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 414,
+                  "line": 220,
                 },
               },
               "property": "font-size",
@@ -5530,12 +2455,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 415,
+              "line": 221,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 411,
+              "line": 217,
             },
           },
           "selectors": Array [
@@ -5551,12 +2476,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 423,
+          "line": 229,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 417,
+          "line": 223,
         },
       },
       "rules": Array [
@@ -5566,12 +2491,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 20,
-                  "line": 419,
+                  "line": 225,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 419,
+                  "line": 225,
                 },
               },
               "property": "font-size",
@@ -5582,12 +2507,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 420,
+                  "line": 226,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 420,
+                  "line": 226,
                 },
               },
               "property": "line-height",
@@ -5598,12 +2523,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 20,
-                  "line": 421,
+                  "line": 227,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 421,
+                  "line": 227,
                 },
               },
               "property": "font-size",
@@ -5614,12 +2539,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 422,
+              "line": 228,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 418,
+              "line": 224,
             },
           },
           "selectors": Array [
@@ -5636,12 +2561,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 426,
+              "line": 232,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 426,
+              "line": 232,
             },
           },
           "property": "font-size",
@@ -5652,12 +2577,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 427,
+              "line": 233,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 427,
+              "line": 233,
             },
           },
           "property": "font-weight",
@@ -5668,12 +2593,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 428,
+              "line": 234,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 428,
+              "line": 234,
             },
           },
           "property": "line-height",
@@ -5684,12 +2609,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 74,
-              "line": 429,
+              "line": 235,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 429,
+              "line": 235,
             },
           },
           "property": "letter-spacing",
@@ -5700,12 +2625,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 430,
+          "line": 236,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 425,
+          "line": 231,
         },
       },
       "selectors": Array [
@@ -5719,12 +2644,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 433,
+              "line": 239,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 433,
+              "line": 239,
             },
           },
           "property": "font-size",
@@ -5735,12 +2660,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 434,
+              "line": 240,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 434,
+              "line": 240,
             },
           },
           "property": "font-weight",
@@ -5751,12 +2676,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 65,
-              "line": 435,
+              "line": 241,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 435,
+              "line": 241,
             },
           },
           "property": "line-height",
@@ -5767,12 +2692,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 69,
-              "line": 436,
+              "line": 242,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 436,
+              "line": 242,
             },
           },
           "property": "letter-spacing",
@@ -5783,12 +2708,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 437,
+          "line": 243,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 432,
+          "line": 238,
         },
       },
       "selectors": Array [
@@ -5802,12 +2727,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 21,
-              "line": 440,
+              "line": 246,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 440,
+              "line": 246,
             },
           },
           "property": "font-size",
@@ -5818,12 +2743,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 441,
+              "line": 247,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 441,
+              "line": 247,
             },
           },
           "property": "font-weight",
@@ -5834,12 +2759,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 442,
+              "line": 248,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 442,
+              "line": 248,
             },
           },
           "property": "line-height",
@@ -5850,12 +2775,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 443,
+              "line": 249,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 443,
+              "line": 249,
             },
           },
           "property": "letter-spacing",
@@ -5866,12 +2791,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 444,
+              "line": 250,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 444,
+              "line": 250,
             },
           },
           "property": "font-size",
@@ -5882,12 +2807,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 445,
+          "line": 251,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 439,
+          "line": 245,
         },
       },
       "selectors": Array [
@@ -5900,7 +2825,2349 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 452,
+          "line": 258,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 252,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 254,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 254,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 255,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 255,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.4",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 59,
+                  "line": 256,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 256,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.25rem + 0.25 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 257,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 253,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-03",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 265,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 259,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 261,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 261,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.5rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 262,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 262,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.334",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 263,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 263,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.5rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 264,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 260,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-03",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 21,
+              "line": 268,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 268,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "1.75rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 269,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 269,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "400",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 23,
+              "line": 270,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 270,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.28572",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 271,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 271,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 57,
+              "line": 272,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 272,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(1.75rem + 0.25 * (100vw - 20rem) / 62)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 273,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 267,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-expressive-heading-04",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 281,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 274,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 276,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 276,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 277,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 277,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.25",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 278,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 278,
+                },
+              },
+              "property": "font-weight",
+              "type": "declaration",
+              "value": "400",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 53,
+                  "line": 279,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 279,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2rem + 0 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 280,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 275,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-04",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 288,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 282,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 284,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 284,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 285,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 285,
+                },
+              },
+              "property": "font-weight",
+              "type": "declaration",
+              "value": "400",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 286,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 286,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 287,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 283,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-04",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 291,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 291,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 292,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 292,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "400",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 293,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 293,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.25",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 294,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 294,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 295,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 295,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 296,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 290,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-expressive-heading-05",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 304,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 297,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 299,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 299,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 300,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 300,
+                },
+              },
+              "property": "font-weight",
+              "type": "declaration",
+              "value": "300",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 301,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 301,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.22",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 302,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 302,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 303,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 298,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 311,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 305,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 307,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 307,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 308,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 308,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.19",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 309,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 309,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 310,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 306,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 318,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 312,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 314,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 314,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 315,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 315,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.17",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 316,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 316,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 317,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 313,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 324,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 319,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 321,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 321,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 322,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 322,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 323,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 320,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 327,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 327,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 328,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 328,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "600",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 329,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 329,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.25",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 330,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 330,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 331,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 331,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 332,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 326,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-expressive-heading-06",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 339,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 333,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 335,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 335,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 336,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 336,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.22",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 337,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 337,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 338,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 334,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 346,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 340,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 342,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 342,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 343,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 343,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.19",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 344,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 344,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 345,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 341,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 353,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 347,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 349,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 349,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 350,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 350,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.17",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 351,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 351,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 352,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 348,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 359,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 354,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 356,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 356,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 357,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 357,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 358,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 355,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-expressive-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 106,
+              "line": 362,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 362,
+            },
+          },
+          "property": "font-family",
+          "type": "declaration",
+          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 21,
+              "line": 363,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 363,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "1.25rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 364,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 364,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "400",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 365,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 365,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.3",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 366,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 366,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 367,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 367,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(1.25rem + 0 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 368,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 361,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-quotation-01",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 374,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 369,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 371,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 371,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 59,
+                  "line": 372,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 372,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.25rem + 0.25 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 373,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 370,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 381,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 375,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 377,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 377,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.5rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 378,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 378,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.334",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 58,
+                  "line": 379,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 379,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.5rem + 0.25 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 380,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 376,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 388,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 382,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 384,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 384,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 25,
+                  "line": 385,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 385,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.28572",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 59,
+                  "line": 386,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 386,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.75rem + 0.25 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 387,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 383,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 395,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 389,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 391,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 391,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 392,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 392,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.25",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 393,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 393,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 394,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 390,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 106,
+              "line": 398,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 398,
+            },
+          },
+          "property": "font-family",
+          "type": "declaration",
+          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 399,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 399,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 400,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 400,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "300",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 401,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 401,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.25",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 402,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 402,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 403,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 403,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 404,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 397,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-quotation-02",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 411,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 405,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 407,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 407,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 408,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 408,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.22",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 409,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 409,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 410,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 406,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 418,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 412,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 414,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 414,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 415,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 415,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.19",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 416,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 416,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 417,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 413,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 425,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 419,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 421,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 421,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 422,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 422,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.17",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 423,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 423,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 424,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 420,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 431,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 426,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 428,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 428,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 429,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 429,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 430,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 427,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 22,
+              "line": 434,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 434,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2.625rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 435,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 435,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "300",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 436,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 436,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.19",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 437,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 437,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 55,
+              "line": 438,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 438,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2.625rem + 0 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 439,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 433,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-display-01",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 445,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 440,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 442,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 442,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 443,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 443,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.75 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 444,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 441,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-display-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 451,
         },
         "source": undefined,
         "start": Object {
@@ -5914,2355 +5181,13 @@ Object {
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 23,
+                  "column": 24,
                   "line": 448,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
                   "line": 448,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 449,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 449,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.4",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 59,
-                  "line": 450,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 450,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.25rem + 0.25 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 451,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 447,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-03",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 459,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 453,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 455,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 455,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.5rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 456,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 456,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.334",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 457,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 457,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.5rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 458,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 454,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-03",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 21,
-              "line": 462,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 462,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "1.75rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 463,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 463,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 23,
-              "line": 464,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 464,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.28572",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 465,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 465,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 57,
-              "line": 466,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 466,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(1.75rem + 0.25 * (100vw - 20rem) / 62)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 467,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 461,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-expressive-heading-04",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 475,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 468,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 470,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 470,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 471,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 471,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.25",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 472,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 472,
-                },
-              },
-              "property": "font-weight",
-              "type": "declaration",
-              "value": "400",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 53,
-                  "line": 473,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 473,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2rem + 0 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 474,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 469,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-04",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 482,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 476,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 478,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 478,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 479,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 479,
-                },
-              },
-              "property": "font-weight",
-              "type": "declaration",
-              "value": "400",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 480,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 480,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 481,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 477,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-04",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 485,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 485,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 486,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 486,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 487,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 487,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 488,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 488,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 489,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 489,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 490,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 484,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-expressive-heading-05",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 498,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 491,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 493,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 493,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 494,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 494,
-                },
-              },
-              "property": "font-weight",
-              "type": "declaration",
-              "value": "300",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 495,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 495,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.22",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 496,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 496,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 497,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 492,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-05",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 505,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 499,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 501,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 501,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 502,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 502,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.19",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 503,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 503,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 504,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 500,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-05",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 512,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 506,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 508,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 508,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 509,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 509,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.17",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 510,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 510,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 511,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 507,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-05",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 518,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 513,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 515,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 515,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 516,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 516,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 517,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 514,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-05",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 521,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 521,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 522,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 522,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 523,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 523,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 524,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 524,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 525,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 525,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 526,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 520,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-expressive-heading-06",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 533,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 527,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 529,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 529,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 530,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 530,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.22",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 531,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 531,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 532,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 528,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-06",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 540,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 534,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 536,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 536,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 537,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 537,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.19",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 538,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 538,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 539,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 535,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-06",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 547,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 541,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 543,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 543,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 544,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 544,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.17",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 545,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 545,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 546,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 542,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-06",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 553,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 548,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 550,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 550,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 551,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 551,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 552,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 549,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-expressive-heading-06",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 106,
-              "line": 556,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 556,
-            },
-          },
-          "property": "font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 21,
-              "line": 557,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 557,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "1.25rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 558,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 558,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 559,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 559,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.3",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 560,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 560,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 561,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 561,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(1.25rem + 0 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 562,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 555,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-quotation-01",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 568,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 563,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 565,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 565,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 59,
-                  "line": 566,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 566,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.25rem + 0.25 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 567,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 564,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 575,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 569,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 571,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 571,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.5rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 572,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 572,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.334",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 58,
-                  "line": 573,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 573,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.5rem + 0.25 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 574,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 570,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 582,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 576,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 578,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 578,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 25,
-                  "line": 579,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 579,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.28572",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 59,
-                  "line": 580,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 580,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.75rem + 0.25 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 581,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 577,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 589,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 583,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 585,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 585,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 586,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 586,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.25",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 587,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 587,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 588,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 584,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 106,
-              "line": 592,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 592,
-            },
-          },
-          "property": "font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 593,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 593,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 594,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 594,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 595,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 595,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 596,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 596,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 597,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 597,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 598,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 591,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-quotation-02",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 605,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 599,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 601,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 601,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 602,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 602,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.22",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 603,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 603,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 604,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 600,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 612,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 606,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 608,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 608,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 609,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 609,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.19",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 610,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 610,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 611,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 607,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 619,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 613,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 615,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 615,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 616,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 616,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.17",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 617,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 617,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 618,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 614,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 625,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 620,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 622,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 622,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 623,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 623,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 624,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 621,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 22,
-              "line": 628,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 628,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 629,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 629,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 630,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 630,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 631,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 631,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 55,
-              "line": 632,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 632,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2.625rem + 0 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 633,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 627,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-display-01",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 639,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 634,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 636,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 636,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 637,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 637,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.75 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 638,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 635,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-display-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 645,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 640,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 642,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 642,
                 },
               },
               "property": "font-size",
@@ -8273,12 +5198,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 61,
-                  "line": 643,
+                  "line": 449,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 643,
+                  "line": 449,
                 },
               },
               "property": "font-size",
@@ -8289,12 +5214,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 644,
+              "line": 450,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 641,
+              "line": 447,
             },
           },
           "selectors": Array [
@@ -8310,12 +5235,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 652,
+          "line": 458,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 646,
+          "line": 452,
         },
       },
       "rules": Array [
@@ -8325,12 +5250,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 648,
+                  "line": 454,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 648,
+                  "line": 454,
                 },
               },
               "property": "font-size",
@@ -8341,12 +5266,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 649,
+                  "line": 455,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 649,
+                  "line": 455,
                 },
               },
               "property": "line-height",
@@ -8357,12 +5282,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 56,
-                  "line": 650,
+                  "line": 456,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 650,
+                  "line": 456,
                 },
               },
               "property": "font-size",
@@ -8373,12 +5298,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 651,
+              "line": 457,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 647,
+              "line": 453,
             },
           },
           "selectors": Array [
@@ -8394,12 +5319,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 659,
+          "line": 465,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 653,
+          "line": 459,
         },
       },
       "rules": Array [
@@ -8409,12 +5334,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 655,
+                  "line": 461,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 655,
+                  "line": 461,
                 },
               },
               "property": "font-size",
@@ -8425,12 +5350,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 656,
+                  "line": 462,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 656,
+                  "line": 462,
                 },
               },
               "property": "line-height",
@@ -8441,12 +5366,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 657,
+                  "line": 463,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 657,
+                  "line": 463,
                 },
               },
               "property": "font-size",
@@ -8457,12 +5382,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 658,
+              "line": 464,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 654,
+              "line": 460,
             },
           },
           "selectors": Array [
@@ -8479,12 +5404,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 22,
-              "line": 662,
+              "line": 468,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 662,
+              "line": 468,
             },
           },
           "property": "font-size",
@@ -8495,12 +5420,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 663,
+              "line": 469,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 663,
+              "line": 469,
             },
           },
           "property": "font-weight",
@@ -8511,12 +5436,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 664,
+              "line": 470,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 664,
+              "line": 470,
             },
           },
           "property": "line-height",
@@ -8527,12 +5452,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 665,
+              "line": 471,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 665,
+              "line": 471,
             },
           },
           "property": "letter-spacing",
@@ -8543,12 +5468,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 666,
+              "line": 472,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 666,
+              "line": 472,
             },
           },
           "property": "font-size",
@@ -8559,12 +5484,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 667,
+          "line": 473,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 661,
+          "line": 467,
         },
       },
       "selectors": Array [
@@ -8577,12 +5502,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 673,
+          "line": 479,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 668,
+          "line": 474,
         },
       },
       "rules": Array [
@@ -8592,12 +5517,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 24,
-                  "line": 670,
+                  "line": 476,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 670,
+                  "line": 476,
                 },
               },
               "property": "font-size",
@@ -8608,12 +5533,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 60,
-                  "line": 671,
+                  "line": 477,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 671,
+                  "line": 477,
                 },
               },
               "property": "font-size",
@@ -8624,12 +5549,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 672,
+              "line": 478,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 669,
+              "line": 475,
             },
           },
           "selectors": Array [
@@ -8645,12 +5570,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 679,
+          "line": 485,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 674,
+          "line": 480,
         },
       },
       "rules": Array [
@@ -8660,12 +5585,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 24,
-                  "line": 676,
+                  "line": 482,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 676,
+                  "line": 482,
                 },
               },
               "property": "font-size",
@@ -8676,12 +5601,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 61,
-                  "line": 677,
+                  "line": 483,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 677,
+                  "line": 483,
                 },
               },
               "property": "font-size",
@@ -8692,12 +5617,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 678,
+              "line": 484,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 675,
+              "line": 481,
             },
           },
           "selectors": Array [
@@ -8713,12 +5638,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 686,
+          "line": 492,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 680,
+          "line": 486,
         },
       },
       "rules": Array [
@@ -8728,12 +5653,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 682,
+                  "line": 488,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 682,
+                  "line": 488,
                 },
               },
               "property": "font-size",
@@ -8744,12 +5669,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 683,
+                  "line": 489,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 683,
+                  "line": 489,
                 },
               },
               "property": "line-height",
@@ -8760,12 +5685,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 56,
-                  "line": 684,
+                  "line": 490,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 684,
+                  "line": 490,
                 },
               },
               "property": "font-size",
@@ -8776,12 +5701,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 685,
+              "line": 491,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 681,
+              "line": 487,
             },
           },
           "selectors": Array [
@@ -8797,12 +5722,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 693,
+          "line": 499,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 687,
+          "line": 493,
         },
       },
       "rules": Array [
@@ -8812,12 +5737,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 689,
+                  "line": 495,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 689,
+                  "line": 495,
                 },
               },
               "property": "font-size",
@@ -8828,12 +5753,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 690,
+                  "line": 496,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 690,
+                  "line": 496,
                 },
               },
               "property": "line-height",
@@ -8844,12 +5769,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 691,
+                  "line": 497,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 691,
+                  "line": 497,
                 },
               },
               "property": "font-size",
@@ -8860,12 +5785,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 692,
+              "line": 498,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 688,
+              "line": 494,
             },
           },
           "selectors": Array [
@@ -8882,12 +5807,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 22,
-              "line": 696,
+              "line": 502,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 696,
+              "line": 502,
             },
           },
           "property": "font-size",
@@ -8898,12 +5823,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 697,
+              "line": 503,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 697,
+              "line": 503,
             },
           },
           "property": "font-weight",
@@ -8914,12 +5839,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 698,
+              "line": 504,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 698,
+              "line": 504,
             },
           },
           "property": "line-height",
@@ -8930,12 +5855,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 699,
+              "line": 505,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 699,
+              "line": 505,
             },
           },
           "property": "letter-spacing",
@@ -8946,12 +5871,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 700,
+              "line": 506,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 700,
+              "line": 506,
             },
           },
           "property": "font-size",
@@ -8962,12 +5887,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 701,
+          "line": 507,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 695,
+          "line": 501,
         },
       },
       "selectors": Array [
@@ -8980,12 +5905,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 708,
+          "line": 514,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 702,
+          "line": 508,
         },
       },
       "rules": Array [
@@ -8995,12 +5920,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 24,
-                  "line": 704,
+                  "line": 510,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 704,
+                  "line": 510,
                 },
               },
               "property": "font-size",
@@ -9011,12 +5936,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 705,
+                  "line": 511,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 705,
+                  "line": 511,
                 },
               },
               "property": "line-height",
@@ -9027,12 +5952,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 61,
-                  "line": 706,
+                  "line": 512,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 706,
+                  "line": 512,
                 },
               },
               "property": "font-size",
@@ -9043,12 +5968,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 707,
+              "line": 513,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 703,
+              "line": 509,
             },
           },
           "selectors": Array [
@@ -9064,12 +5989,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 716,
+          "line": 522,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 709,
+          "line": 515,
         },
       },
       "rules": Array [
@@ -9079,12 +6004,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 711,
+                  "line": 517,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 711,
+                  "line": 517,
                 },
               },
               "property": "font-size",
@@ -9095,12 +6020,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 712,
+                  "line": 518,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 712,
+                  "line": 518,
                 },
               },
               "property": "line-height",
@@ -9111,12 +6036,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 713,
+                  "line": 519,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 713,
+                  "line": 519,
                 },
               },
               "property": "letter-spacing",
@@ -9127,12 +6052,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 56,
-                  "line": 714,
+                  "line": 520,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 714,
+                  "line": 520,
                 },
               },
               "property": "font-size",
@@ -9143,12 +6068,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 715,
+              "line": 521,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 710,
+              "line": 516,
             },
           },
           "selectors": Array [
@@ -9164,12 +6089,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 724,
+          "line": 530,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 717,
+          "line": 523,
         },
       },
       "rules": Array [
@@ -9179,12 +6104,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 719,
+                  "line": 525,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 719,
+                  "line": 525,
                 },
               },
               "property": "font-size",
@@ -9195,12 +6120,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 720,
+                  "line": 526,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 720,
+                  "line": 526,
                 },
               },
               "property": "line-height",
@@ -9211,12 +6136,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 721,
+                  "line": 527,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 721,
+                  "line": 527,
                 },
               },
               "property": "letter-spacing",
@@ -9227,12 +6152,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 58,
-                  "line": 722,
+                  "line": 528,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 722,
+                  "line": 528,
                 },
               },
               "property": "font-size",
@@ -9243,12 +6168,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 723,
+              "line": 529,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 718,
+              "line": 524,
             },
           },
           "selectors": Array [
@@ -9264,12 +6189,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 732,
+          "line": 538,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 725,
+          "line": 531,
         },
       },
       "rules": Array [
@@ -9279,12 +6204,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 727,
+                  "line": 533,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 727,
+                  "line": 533,
                 },
               },
               "property": "font-size",
@@ -9295,12 +6220,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 728,
+                  "line": 534,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 728,
+                  "line": 534,
                 },
               },
               "property": "line-height",
@@ -9311,12 +6236,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 729,
+                  "line": 535,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 729,
+                  "line": 535,
                 },
               },
               "property": "letter-spacing",
@@ -9327,12 +6252,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 730,
+                  "line": 536,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 730,
+                  "line": 536,
                 },
               },
               "property": "font-size",
@@ -9343,12 +6268,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 731,
+              "line": 537,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 726,
+              "line": 532,
             },
           },
           "selectors": Array [
@@ -9365,12 +6290,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 22,
-              "line": 735,
+              "line": 541,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 735,
+              "line": 541,
             },
           },
           "property": "font-size",
@@ -9381,12 +6306,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 736,
+              "line": 542,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 736,
+              "line": 542,
             },
           },
           "property": "font-weight",
@@ -9397,12 +6322,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 737,
+              "line": 543,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 737,
+              "line": 543,
             },
           },
           "property": "line-height",
@@ -9413,12 +6338,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 738,
+              "line": 544,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 738,
+              "line": 544,
             },
           },
           "property": "letter-spacing",
@@ -9429,12 +6354,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 59,
-              "line": 739,
+              "line": 545,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 739,
+              "line": 545,
             },
           },
           "property": "font-size",
@@ -9445,12 +6370,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 740,
+          "line": 546,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 734,
+          "line": 540,
         },
       },
       "selectors": Array [
@@ -9463,12 +6388,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 747,
+          "line": 553,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 741,
+          "line": 547,
         },
       },
       "rules": Array [
@@ -9478,12 +6403,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 743,
+                  "line": 549,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 743,
+                  "line": 549,
                 },
               },
               "property": "font-size",
@@ -9494,12 +6419,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 744,
+                  "line": 550,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 744,
+                  "line": 550,
                 },
               },
               "property": "line-height",
@@ -9510,12 +6435,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 58,
-                  "line": 745,
+                  "line": 551,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 745,
+                  "line": 551,
                 },
               },
               "property": "font-size",
@@ -9526,12 +6451,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 746,
+              "line": 552,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 742,
+              "line": 548,
             },
           },
           "selectors": Array [
@@ -9547,12 +6472,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 755,
+          "line": 561,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 748,
+          "line": 554,
         },
       },
       "rules": Array [
@@ -9562,12 +6487,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 750,
+                  "line": 556,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 750,
+                  "line": 556,
                 },
               },
               "property": "font-size",
@@ -9578,12 +6503,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 751,
+                  "line": 557,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 751,
+                  "line": 557,
                 },
               },
               "property": "line-height",
@@ -9594,12 +6519,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 752,
+                  "line": 558,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 752,
+                  "line": 558,
                 },
               },
               "property": "letter-spacing",
@@ -9610,12 +6535,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 60,
-                  "line": 753,
+                  "line": 559,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 753,
+                  "line": 559,
                 },
               },
               "property": "font-size",
@@ -9626,12 +6551,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 754,
+              "line": 560,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 749,
+              "line": 555,
             },
           },
           "selectors": Array [
@@ -9647,12 +6572,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 763,
+          "line": 569,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 756,
+          "line": 562,
         },
       },
       "rules": Array [
@@ -9662,12 +6587,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 24,
-                  "line": 758,
+                  "line": 564,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 758,
+                  "line": 564,
                 },
               },
               "property": "font-size",
@@ -9678,12 +6603,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 759,
+                  "line": 565,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 759,
+                  "line": 565,
                 },
               },
               "property": "line-height",
@@ -9694,12 +6619,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 760,
+                  "line": 566,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 760,
+                  "line": 566,
                 },
               },
               "property": "letter-spacing",
@@ -9710,12 +6635,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 61,
-                  "line": 761,
+                  "line": 567,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 761,
+                  "line": 567,
                 },
               },
               "property": "font-size",
@@ -9726,12 +6651,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 762,
+              "line": 568,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 757,
+              "line": 563,
             },
           },
           "selectors": Array [
@@ -9747,12 +6672,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 771,
+          "line": 577,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 764,
+          "line": 570,
         },
       },
       "rules": Array [
@@ -9762,12 +6687,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 766,
+                  "line": 572,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 766,
+                  "line": 572,
                 },
               },
               "property": "font-size",
@@ -9778,12 +6703,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 767,
+                  "line": 573,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 767,
+                  "line": 573,
                 },
               },
               "property": "line-height",
@@ -9794,12 +6719,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 768,
+                  "line": 574,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 768,
+                  "line": 574,
                 },
               },
               "property": "letter-spacing",
@@ -9810,12 +6735,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 769,
+                  "line": 575,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 769,
+                  "line": 575,
                 },
               },
               "property": "font-size",
@@ -9826,12 +6751,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 770,
+              "line": 576,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 765,
+              "line": 571,
             },
           },
           "selectors": Array [
@@ -9848,12 +6773,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 774,
+              "line": 580,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 774,
+              "line": 580,
             },
           },
           "property": "font-size",
@@ -9864,12 +6789,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 775,
+              "line": 581,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 775,
+              "line": 581,
             },
           },
           "property": "font-weight",
@@ -9880,12 +6805,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 776,
+              "line": 582,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 776,
+              "line": 582,
             },
           },
           "property": "line-height",
@@ -9896,12 +6821,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 777,
+              "line": 583,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 777,
+              "line": 583,
             },
           },
           "property": "letter-spacing",
@@ -9912,12 +6837,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 778,
+          "line": 584,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 773,
+          "line": 579,
         },
       },
       "selectors": Array [
@@ -9931,12 +6856,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 53,
-              "line": 781,
+              "line": 587,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 781,
+              "line": 587,
             },
           },
           "property": "font-size",
@@ -9947,12 +6872,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 782,
+              "line": 588,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 782,
+              "line": 588,
             },
           },
           "property": "font-weight",
@@ -9963,12 +6888,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 783,
+              "line": 589,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 783,
+              "line": 589,
             },
           },
           "property": "line-height",
@@ -9979,12 +6904,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 784,
+              "line": 590,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 784,
+              "line": 590,
             },
           },
           "property": "letter-spacing",
@@ -9995,12 +6920,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 785,
+          "line": 591,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 780,
+          "line": 586,
         },
       },
       "selectors": Array [
@@ -10014,12 +6939,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 60,
-              "line": 788,
+              "line": 594,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 788,
+              "line": 594,
             },
           },
           "property": "font-size",
@@ -10030,12 +6955,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 59,
-              "line": 789,
+              "line": 595,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 789,
+              "line": 595,
             },
           },
           "property": "font-weight",
@@ -10046,12 +6971,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 63,
-              "line": 790,
+              "line": 596,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 790,
+              "line": 596,
             },
           },
           "property": "line-height",
@@ -10062,12 +6987,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 68,
-              "line": 791,
+              "line": 597,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 791,
+              "line": 597,
             },
           },
           "property": "letter-spacing",
@@ -10078,12 +7003,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 792,
+          "line": 598,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 787,
+          "line": 593,
         },
       },
       "selectors": Array [
@@ -10097,12 +7022,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 795,
+              "line": 601,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 795,
+              "line": 601,
             },
           },
           "property": "font-size",
@@ -10113,12 +7038,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 59,
-              "line": 796,
+              "line": 602,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 796,
+              "line": 602,
             },
           },
           "property": "font-weight",
@@ -10129,12 +7054,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 797,
+              "line": 603,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 797,
+              "line": 603,
             },
           },
           "property": "line-height",
@@ -10145,12 +7070,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 63,
-              "line": 798,
+              "line": 604,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 798,
+              "line": 604,
             },
           },
           "property": "letter-spacing",
@@ -10161,12 +7086,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 799,
+          "line": 605,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 794,
+          "line": 600,
         },
       },
       "selectors": Array [
@@ -10180,12 +7105,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 63,
-              "line": 802,
+              "line": 608,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 802,
+              "line": 608,
             },
           },
           "property": "font-size",
@@ -10196,12 +7121,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 803,
+              "line": 609,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 803,
+              "line": 609,
             },
           },
           "property": "font-weight",
@@ -10212,12 +7137,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 804,
+              "line": 610,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 804,
+              "line": 610,
             },
           },
           "property": "line-height",
@@ -10228,12 +7153,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 71,
-              "line": 805,
+              "line": 611,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 805,
+              "line": 611,
             },
           },
           "property": "letter-spacing",
@@ -10244,12 +7169,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 806,
+          "line": 612,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 801,
+          "line": 607,
         },
       },
       "selectors": Array [
@@ -10263,12 +7188,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 59,
-              "line": 809,
+              "line": 615,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 809,
+              "line": 615,
             },
           },
           "property": "font-size",
@@ -10279,12 +7204,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 62,
-              "line": 810,
+              "line": 616,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 810,
+              "line": 616,
             },
           },
           "property": "font-weight",
@@ -10295,12 +7220,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 64,
-              "line": 811,
+              "line": 617,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 811,
+              "line": 617,
             },
           },
           "property": "line-height",
@@ -10311,12 +7236,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 66,
-              "line": 812,
+              "line": 618,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 812,
+              "line": 618,
             },
           },
           "property": "letter-spacing",
@@ -10327,12 +7252,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 813,
+          "line": 619,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 808,
+          "line": 614,
         },
       },
       "selectors": Array [
@@ -10346,12 +7271,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 816,
+              "line": 622,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 816,
+              "line": 622,
             },
           },
           "property": "font-size",
@@ -10362,12 +7287,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 817,
+              "line": 623,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 817,
+              "line": 623,
             },
           },
           "property": "font-weight",
@@ -10378,12 +7303,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 818,
+              "line": 624,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 818,
+              "line": 624,
             },
           },
           "property": "line-height",
@@ -10394,12 +7319,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 60,
-              "line": 819,
+              "line": 625,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 819,
+              "line": 625,
             },
           },
           "property": "letter-spacing",
@@ -10410,12 +7335,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 820,
+          "line": 626,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 815,
+          "line": 621,
         },
       },
       "selectors": Array [
@@ -10429,12 +7354,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 48,
-              "line": 823,
+              "line": 629,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 823,
+              "line": 629,
             },
           },
           "property": "font-size",
@@ -10445,12 +7370,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 824,
+              "line": 630,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 824,
+              "line": 630,
             },
           },
           "property": "font-weight",
@@ -10461,12 +7386,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 825,
+              "line": 631,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 825,
+              "line": 631,
             },
           },
           "property": "line-height",
@@ -10477,12 +7402,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 826,
+              "line": 632,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 826,
+              "line": 632,
             },
           },
           "property": "letter-spacing",
@@ -10493,12 +7418,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 827,
+          "line": 633,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 822,
+          "line": 628,
         },
       },
       "selectors": Array [
@@ -10512,12 +7437,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 830,
+              "line": 636,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 830,
+              "line": 636,
             },
           },
           "property": "font-size",
@@ -10528,12 +7453,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 831,
+              "line": 637,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 831,
+              "line": 637,
             },
           },
           "property": "font-weight",
@@ -10544,12 +7469,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 832,
+              "line": 638,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 832,
+              "line": 638,
             },
           },
           "property": "line-height",
@@ -10560,12 +7485,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 833,
+              "line": 639,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 833,
+              "line": 639,
             },
           },
           "property": "letter-spacing",
@@ -10576,12 +7501,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 834,
+          "line": 640,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 829,
+          "line": 635,
         },
       },
       "selectors": Array [
@@ -10595,12 +7520,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 837,
+              "line": 643,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 837,
+              "line": 643,
             },
           },
           "property": "font-size",
@@ -10611,12 +7536,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 838,
+              "line": 644,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 838,
+              "line": 644,
             },
           },
           "property": "font-weight",
@@ -10627,12 +7552,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 839,
+              "line": 645,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 839,
+              "line": 645,
             },
           },
           "property": "line-height",
@@ -10643,12 +7568,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 840,
+              "line": 646,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 840,
+              "line": 646,
             },
           },
           "property": "letter-spacing",
@@ -10659,12 +7584,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 841,
+          "line": 647,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 836,
+          "line": 642,
         },
       },
       "selectors": Array [
@@ -10678,12 +7603,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 51,
-              "line": 844,
+              "line": 650,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 844,
+              "line": 650,
             },
           },
           "property": "font-size",
@@ -10694,12 +7619,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 845,
+              "line": 651,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 845,
+              "line": 651,
             },
           },
           "property": "font-weight",
@@ -10710,12 +7635,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 846,
+              "line": 652,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 846,
+              "line": 652,
             },
           },
           "property": "line-height",
@@ -10726,12 +7651,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 847,
+              "line": 653,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 847,
+              "line": 653,
             },
           },
           "property": "letter-spacing",
@@ -10742,12 +7667,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 848,
+          "line": 654,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 843,
+          "line": 649,
         },
       },
       "selectors": Array [
@@ -10761,12 +7686,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 851,
+              "line": 657,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 851,
+              "line": 657,
             },
           },
           "property": "font-size",
@@ -10777,12 +7702,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 852,
+              "line": 658,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 852,
+              "line": 658,
             },
           },
           "property": "font-weight",
@@ -10793,12 +7718,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 853,
+              "line": 659,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 853,
+              "line": 659,
             },
           },
           "property": "line-height",
@@ -10809,12 +7734,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 854,
+              "line": 660,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 854,
+              "line": 660,
             },
           },
           "property": "letter-spacing",
@@ -10825,12 +7750,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 855,
+          "line": 661,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 850,
+          "line": 656,
         },
       },
       "selectors": Array [
@@ -10844,12 +7769,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 858,
+              "line": 664,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 858,
+              "line": 664,
             },
           },
           "property": "font-size",
@@ -10860,12 +7785,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 859,
+              "line": 665,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 859,
+              "line": 665,
             },
           },
           "property": "font-weight",
@@ -10876,12 +7801,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 55,
-              "line": 860,
+              "line": 666,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 860,
+              "line": 666,
             },
           },
           "property": "line-height",
@@ -10892,12 +7817,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 58,
-              "line": 861,
+              "line": 667,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 861,
+              "line": 667,
             },
           },
           "property": "letter-spacing",
@@ -10908,12 +7833,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 862,
+          "line": 668,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 857,
+          "line": 663,
         },
       },
       "selectors": Array [
@@ -10927,12 +7852,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 21,
-              "line": 865,
+              "line": 671,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 865,
+              "line": 671,
             },
           },
           "property": "font-size",
@@ -10943,12 +7868,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 866,
+              "line": 672,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 866,
+              "line": 672,
             },
           },
           "property": "font-weight",
@@ -10959,12 +7884,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 867,
+              "line": 673,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 867,
+              "line": 673,
             },
           },
           "property": "line-height",
@@ -10975,12 +7900,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 868,
+              "line": 674,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 868,
+              "line": 674,
             },
           },
           "property": "letter-spacing",
@@ -10991,12 +7916,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 54,
-              "line": 869,
+              "line": 675,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 869,
+              "line": 675,
             },
           },
           "property": "font-size",
@@ -11007,12 +7932,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 870,
+          "line": 676,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 864,
+          "line": 670,
         },
       },
       "selectors": Array [
@@ -11025,12 +7950,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 877,
+          "line": 683,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 871,
+          "line": 677,
         },
       },
       "rules": Array [
@@ -11040,12 +7965,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 873,
+                  "line": 679,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 873,
+                  "line": 679,
                 },
               },
               "property": "font-size",
@@ -11056,12 +7981,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 21,
-                  "line": 874,
+                  "line": 680,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 874,
+                  "line": 680,
                 },
               },
               "property": "line-height",
@@ -11072,12 +7997,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 59,
-                  "line": 875,
+                  "line": 681,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 875,
+                  "line": 681,
                 },
               },
               "property": "font-size",
@@ -11088,12 +8013,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 876,
+              "line": 682,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 872,
+              "line": 678,
             },
           },
           "selectors": Array [
@@ -11109,12 +8034,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 884,
+          "line": 690,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 878,
+          "line": 684,
         },
       },
       "rules": Array [
@@ -11124,12 +8049,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 880,
+                  "line": 686,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 880,
+                  "line": 686,
                 },
               },
               "property": "font-size",
@@ -11140,12 +8065,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 881,
+                  "line": 687,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 881,
+                  "line": 687,
                 },
               },
               "property": "line-height",
@@ -11156,12 +8081,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 882,
+                  "line": 688,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 882,
+                  "line": 688,
                 },
               },
               "property": "font-size",
@@ -11172,12 +8097,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 883,
+              "line": 689,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 879,
+              "line": 685,
             },
           },
           "selectors": Array [
@@ -11194,12 +8119,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 21,
-              "line": 887,
+              "line": 693,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 887,
+              "line": 693,
             },
           },
           "property": "font-size",
@@ -11210,12 +8135,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 888,
+              "line": 694,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 888,
+              "line": 694,
             },
           },
           "property": "font-weight",
@@ -11226,12 +8151,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 23,
-              "line": 889,
+              "line": 695,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 889,
+              "line": 695,
             },
           },
           "property": "line-height",
@@ -11242,12 +8167,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 890,
+              "line": 696,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 890,
+              "line": 696,
             },
           },
           "property": "letter-spacing",
@@ -11258,12 +8183,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 57,
-              "line": 891,
+              "line": 697,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 891,
+              "line": 697,
             },
           },
           "property": "font-size",
@@ -11274,12 +8199,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 892,
+          "line": 698,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 886,
+          "line": 692,
         },
       },
       "selectors": Array [
@@ -11292,7 +8217,2349 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 900,
+          "line": 706,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 699,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 701,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 701,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 702,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 702,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.25",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 703,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 703,
+                },
+              },
+              "property": "font-weight",
+              "type": "declaration",
+              "value": "400",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 53,
+                  "line": 704,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 704,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2rem + 0 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 705,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 700,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-04",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 713,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 707,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 709,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 709,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 710,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 710,
+                },
+              },
+              "property": "font-weight",
+              "type": "declaration",
+              "value": "400",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 711,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 711,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 712,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 708,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-04",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 716,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 716,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 717,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 717,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "400",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 718,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 718,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.25",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 719,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 719,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 720,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 720,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 721,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 715,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-fluid-heading-05",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 729,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 722,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 724,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 724,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 21,
+                  "line": 725,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 725,
+                },
+              },
+              "property": "font-weight",
+              "type": "declaration",
+              "value": "300",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 726,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 726,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.22",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 727,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 727,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 728,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 723,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 736,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 730,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 732,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 732,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 733,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 733,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.19",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 734,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 734,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 735,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 731,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 743,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 737,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 739,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 739,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 740,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 740,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.17",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 741,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 741,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 742,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 738,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 749,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 744,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 746,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 746,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 747,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 747,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 748,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 745,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-05",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 752,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 752,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 753,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 753,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "600",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 754,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 754,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.25",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 755,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 755,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 756,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 756,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 757,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 751,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-fluid-heading-06",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 764,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 758,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 760,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 760,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 761,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 761,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.22",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 762,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 762,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 763,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 759,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 771,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 765,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 767,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 767,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 768,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 768,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.19",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 769,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 769,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 770,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 766,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 778,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 772,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 774,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 774,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 775,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 775,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.17",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 776,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 776,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 777,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 773,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 784,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 779,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 781,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 781,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 782,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 782,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 783,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 780,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-heading-06",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 787,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 787,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "1.5rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 788,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 788,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "300",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 21,
+              "line": 789,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 789,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.334",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 790,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 790,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 56,
+              "line": 791,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 791,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(1.5rem + 0.25 * (100vw - 20rem) / 46)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 792,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 786,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-fluid-paragraph-01",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 799,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 793,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 795,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 795,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 25,
+                  "line": 796,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 796,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.28572",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 59,
+                  "line": 797,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 797,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.75rem + 0.25 * (100vw - 66rem) / 33)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 798,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 794,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-paragraph-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 806,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 800,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 802,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 802,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 803,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 803,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.25",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 804,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 804,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 805,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 801,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-paragraph-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 106,
+              "line": 809,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 809,
+            },
+          },
+          "property": "font-family",
+          "type": "declaration",
+          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 21,
+              "line": 810,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 810,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "1.25rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 811,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 811,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "400",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 812,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 812,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.3",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 813,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 813,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 814,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 814,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(1.25rem + 0 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 815,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 808,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-fluid-quotation-01",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 821,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 816,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 818,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 818,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 59,
+                  "line": 819,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 819,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.25rem + 0.25 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 820,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 817,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 828,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 822,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 824,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 824,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.5rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 825,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 825,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.334",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 58,
+                  "line": 826,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 826,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.5rem + 0.25 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 827,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 823,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 835,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 829,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 831,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 831,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "1.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 25,
+                  "line": 832,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 832,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.28572",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 59,
+                  "line": 833,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 833,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(1.75rem + 0.25 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 834,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 830,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 842,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 836,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 838,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 838,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 839,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 839,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.25",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 840,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 840,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 841,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 837,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 106,
+              "line": 845,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 845,
+            },
+          },
+          "property": "font-family",
+          "type": "declaration",
+          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 846,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 846,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 847,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 847,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "300",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 848,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 848,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.25",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 849,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 849,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 54,
+              "line": 850,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 850,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 851,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 844,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-fluid-quotation-02",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 858,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 852,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 854,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 854,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 855,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 855,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.22",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 856,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 856,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 857,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 853,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 865,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 859,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 861,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 861,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 862,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 862,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.19",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 863,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 863,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 864,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 860,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 872,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 866,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 20,
+                  "line": 868,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 868,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 869,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 869,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.17",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 870,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 870,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 871,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 867,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 878,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 873,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 875,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 875,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 876,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 876,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 877,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 874,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-quotation-02",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 22,
+              "line": 881,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 881,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2.625rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 882,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 882,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "300",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 883,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 883,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.19",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 884,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 884,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 55,
+              "line": 885,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 885,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2.625rem + 0 * (100vw - 20rem) / 22)",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 886,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 880,
+        },
+      },
+      "selectors": Array [
+        ".cds--type-fluid-display-01",
+      ],
+      "type": "rule",
+    },
+    Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 892,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 887,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 889,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 889,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "2.625rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 60,
+                  "line": 890,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 890,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(2.625rem + 0.75 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 891,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 888,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-display-01",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 898,
         },
         "source": undefined,
         "start": Object {
@@ -11306,7 +10573,7 @@ Object {
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 20,
+                  "column": 24,
                   "line": 895,
                 },
                 "source": undefined,
@@ -11317,61 +10584,29 @@ Object {
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "2rem",
+              "value": "3.375rem",
             },
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 22,
+                  "column": 61,
                   "line": 896,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
                   "line": 896,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.25",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 897,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 897,
-                },
-              },
-              "property": "font-weight",
-              "type": "declaration",
-              "value": "400",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 53,
-                  "line": 898,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 898,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "calc(2rem + 0 * (100vw - 82rem) / 17)",
+              "value": "calc(3.375rem + 0.375 * (100vw - 66rem) / 16)",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 899,
+              "line": 897,
             },
             "source": undefined,
             "start": Object {
@@ -11380,374 +10615,7 @@ Object {
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-04",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 907,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 901,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 903,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 903,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 904,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 904,
-                },
-              },
-              "property": "font-weight",
-              "type": "declaration",
-              "value": "400",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 905,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 905,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 906,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 902,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-heading-04",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 910,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 910,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 911,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 911,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 912,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 912,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 913,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 913,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 914,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 914,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 915,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 909,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-heading-05",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 923,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 916,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 918,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 918,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 21,
-                  "line": 919,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 919,
-                },
-              },
-              "property": "font-weight",
-              "type": "declaration",
-              "value": "300",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 920,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 920,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.22",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 921,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 921,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 922,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 917,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-heading-05",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 930,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 924,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 926,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 926,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 927,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 927,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.19",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 928,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 928,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 929,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 925,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-heading-05",
+            ".cds--type-fluid-display-01",
           ],
           "type": "rule",
         },
@@ -11759,12 +10627,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 937,
+          "line": 905,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 931,
+          "line": 899,
         },
       },
       "rules": Array [
@@ -11773,29 +10641,29 @@ Object {
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 20,
-                  "line": 933,
+                  "column": 23,
+                  "line": 901,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 933,
+                  "line": 901,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "3rem",
+              "value": "3.75rem",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 934,
+                  "line": 902,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 934,
+                  "line": 902,
                 },
               },
               "property": "line-height",
@@ -11806,32 +10674,32 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 56,
-                  "line": 935,
+                  "line": 903,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 935,
+                  "line": 903,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+              "value": "calc(3.75rem + 1 * (100vw - 82rem) / 17)",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 936,
+              "line": 904,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 932,
+              "line": 900,
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-05",
+            ".cds--type-fluid-display-01",
           ],
           "type": "rule",
         },
@@ -11843,12 +10711,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 943,
+          "line": 912,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 938,
+          "line": 906,
         },
       },
       "rules": Array [
@@ -11858,48 +10726,64 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 940,
+                  "line": 908,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 940,
+                  "line": 908,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "3.75rem",
+              "value": "4.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 909,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 909,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.13",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 941,
+                  "line": 910,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 941,
+                  "line": 910,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "3.75rem",
+              "value": "4.75rem",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 942,
+              "line": 911,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 939,
+              "line": 907,
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-05",
+            ".cds--type-fluid-display-01",
           ],
           "type": "rule",
         },
@@ -11911,29 +10795,29 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 18,
-              "line": 946,
+              "column": 22,
+              "line": 915,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 946,
+              "line": 915,
             },
           },
           "property": "font-size",
           "type": "declaration",
-          "value": "2rem",
+          "value": "2.625rem",
         },
         Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 947,
+              "line": 916,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 947,
+              "line": 916,
             },
           },
           "property": "font-weight",
@@ -11944,28 +10828,28 @@ Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 948,
+              "line": 917,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 948,
+              "line": 917,
             },
           },
           "property": "line-height",
           "type": "declaration",
-          "value": "1.25",
+          "value": "1.19",
         },
         Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 949,
+              "line": 918,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 949,
+              "line": 918,
             },
           },
           "property": "letter-spacing",
@@ -11975,33 +10859,33 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 54,
-              "line": 950,
+              "column": 55,
+              "line": 919,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 950,
+              "line": 919,
             },
           },
           "property": "font-size",
           "type": "declaration",
-          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
+          "value": "calc(2.625rem + 0 * (100vw - 20rem) / 22)",
         },
       ],
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 951,
+          "line": 920,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 945,
+          "line": 914,
         },
       },
       "selectors": Array [
-        ".cds--type-fluid-heading-06",
+        ".cds--type-fluid-display-02",
       ],
       "type": "rule",
     },
@@ -12010,12 +10894,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 958,
+          "line": 926,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 952,
+          "line": 921,
         },
       },
       "rules": Array [
@@ -12024,65 +10908,49 @@ Object {
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 23,
-                  "line": 954,
+                  "column": 24,
+                  "line": 923,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 954,
+                  "line": 923,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "2.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 955,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 955,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.22",
+              "value": "2.625rem",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 60,
-                  "line": 956,
+                  "line": 924,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 956,
+                  "line": 924,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
+              "value": "calc(2.625rem + 0.75 * (100vw - 42rem) / 24)",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 957,
+              "line": 925,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 953,
+              "line": 922,
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-06",
+            ".cds--type-fluid-display-02",
           ],
           "type": "rule",
         },
@@ -12094,12 +10962,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 965,
+          "line": 932,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 959,
+          "line": 927,
         },
       },
       "rules": Array [
@@ -12109,64 +10977,48 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 24,
-                  "line": 961,
+                  "line": 929,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 961,
+                  "line": 929,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 962,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 962,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.19",
+              "value": "3.375rem",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 61,
-                  "line": 963,
+                  "line": 930,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 963,
+                  "line": 930,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
+              "value": "calc(3.375rem + 0.375 * (100vw - 66rem) / 16)",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 964,
+              "line": 931,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 960,
+              "line": 928,
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-06",
+            ".cds--type-fluid-display-02",
           ],
           "type": "rule",
         },
@@ -12178,12 +11030,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 972,
+          "line": 939,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 966,
+          "line": 933,
         },
       },
       "rules": Array [
@@ -12192,65 +11044,65 @@ Object {
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 20,
-                  "line": 968,
+                  "column": 23,
+                  "line": 935,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 968,
+                  "line": 935,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "3rem",
+              "value": "3.75rem",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 969,
+                  "line": 936,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 969,
+                  "line": 936,
                 },
               },
               "property": "line-height",
               "type": "declaration",
-              "value": "1.17",
+              "value": "1.16",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 56,
-                  "line": 970,
+                  "line": 937,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 970,
+                  "line": 937,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
+              "value": "calc(3.75rem + 1 * (100vw - 82rem) / 17)",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 971,
+              "line": 938,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 967,
+              "line": 934,
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-06",
+            ".cds--type-fluid-display-02",
           ],
           "type": "rule",
         },
@@ -12262,12 +11114,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 978,
+          "line": 946,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 973,
+          "line": 940,
         },
       },
       "rules": Array [
@@ -12277,48 +11129,64 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 975,
+                  "line": 942,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 975,
+                  "line": 942,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "3.75rem",
+              "value": "4.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 943,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 943,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.13",
             },
             Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 976,
+                  "line": 944,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 976,
+                  "line": 944,
                 },
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "3.75rem",
+              "value": "4.75rem",
             },
           ],
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 977,
+              "line": 945,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 974,
+              "line": 941,
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-heading-06",
+            ".cds--type-fluid-display-02",
           ],
           "type": "rule",
         },
@@ -12330,29 +11198,29 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 20,
-              "line": 981,
+              "column": 22,
+              "line": 949,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 981,
+              "line": 949,
             },
           },
           "property": "font-size",
           "type": "declaration",
-          "value": "1.5rem",
+          "value": "2.625rem",
         },
         Object {
           "position": Position {
             "end": Object {
               "column": 19,
-              "line": 982,
+              "line": 950,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 982,
+              "line": 950,
             },
           },
           "property": "font-weight",
@@ -12362,29 +11230,29 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 21,
-              "line": 983,
+              "column": 20,
+              "line": 951,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 983,
+              "line": 951,
             },
           },
           "property": "line-height",
           "type": "declaration",
-          "value": "1.334",
+          "value": "1.19",
         },
         Object {
           "position": Position {
             "end": Object {
               "column": 20,
-              "line": 984,
+              "line": 952,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 984,
+              "line": 952,
             },
           },
           "property": "letter-spacing",
@@ -12394,38 +11262,503 @@ Object {
         Object {
           "position": Position {
             "end": Object {
-              "column": 56,
-              "line": 985,
+              "column": 58,
+              "line": 953,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 985,
+              "line": 953,
             },
           },
           "property": "font-size",
           "type": "declaration",
-          "value": "calc(1.5rem + 0.25 * (100vw - 20rem) / 46)",
+          "value": "calc(2.625rem + 0.75 * (100vw - 20rem) / 22)",
         },
       ],
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 986,
+          "line": 954,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 980,
+          "line": 948,
         },
       },
       "selectors": Array [
-        ".cds--type-fluid-paragraph-01",
+        ".cds--type-fluid-display-03",
       ],
       "type": "rule",
     },
     Object {
+      "media": "(min-width: 42rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 961,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 955,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 24,
+                  "line": 957,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 957,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.375rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 958,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 958,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.18",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 61,
+                  "line": 959,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 959,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3.375rem + 0.375 * (100vw - 42rem) / 24)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 960,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 956,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-display-03",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
       "media": "(min-width: 66rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 969,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 962,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 964,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 964,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "3.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 965,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 965,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.16",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 28,
+                  "line": 966,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 966,
+                },
+              },
+              "property": "letter-spacing",
+              "type": "declaration",
+              "value": "-0.64px",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 56,
+                  "line": 967,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 967,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(3.75rem + 1 * (100vw - 66rem) / 16)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 968,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 963,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-display-03",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 82rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 977,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 970,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 972,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 972,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "4.75rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 973,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 973,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.13",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 28,
+                  "line": 974,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 974,
+                },
+              },
+              "property": "letter-spacing",
+              "type": "declaration",
+              "value": "-0.64px",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 58,
+                  "line": 975,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 975,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "calc(4.75rem + 0.5 * (100vw - 82rem) / 17)",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 976,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 971,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-display-03",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "media": "(min-width: 99rem)",
+      "position": Position {
+        "end": Object {
+          "column": 2,
+          "line": 985,
+        },
+        "source": undefined,
+        "start": Object {
+          "column": 1,
+          "line": 978,
+        },
+      },
+      "rules": Array [
+        Object {
+          "declarations": Array [
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 980,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 980,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "5.25rem",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 22,
+                  "line": 981,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 981,
+                },
+              },
+              "property": "line-height",
+              "type": "declaration",
+              "value": "1.11",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 28,
+                  "line": 982,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 982,
+                },
+              },
+              "property": "letter-spacing",
+              "type": "declaration",
+              "value": "-0.96px",
+            },
+            Object {
+              "position": Position {
+                "end": Object {
+                  "column": 23,
+                  "line": 983,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 5,
+                  "line": 983,
+                },
+              },
+              "property": "font-size",
+              "type": "declaration",
+              "value": "5.25rem",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 984,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 979,
+            },
+          },
+          "selectors": Array [
+            ".cds--type-fluid-display-03",
+          ],
+          "type": "rule",
+        },
+      ],
+      "type": "media",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 22,
+              "line": 988,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 988,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "2.625rem",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 19,
+              "line": 989,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 989,
+            },
+          },
+          "property": "font-weight",
+          "type": "declaration",
+          "value": "300",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 990,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 990,
+            },
+          },
+          "property": "line-height",
+          "type": "declaration",
+          "value": "1.19",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 20,
+              "line": 991,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 991,
+            },
+          },
+          "property": "letter-spacing",
+          "type": "declaration",
+          "value": "0",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 59,
+              "line": 992,
+            },
+            "source": undefined,
+            "start": Object {
+              "column": 3,
+              "line": 992,
+            },
+          },
+          "property": "font-size",
+          "type": "declaration",
+          "value": "calc(2.625rem + 1.625 * (100vw - 20rem) / 22)",
+        },
+      ],
       "position": Position {
         "end": Object {
           "column": 2,
@@ -12437,79 +11770,13 @@ Object {
           "line": 987,
         },
       },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 989,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 989,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 25,
-                  "line": 990,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 990,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.28572",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 59,
-                  "line": 991,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 991,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.75rem + 0.25 * (100vw - 66rem) / 33)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 992,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 988,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-paragraph-01",
-          ],
-          "type": "rule",
-        },
+      "selectors": Array [
+        ".cds--type-fluid-display-04",
       ],
-      "type": "media",
+      "type": "rule",
     },
     Object {
-      "media": "(min-width: 99rem)",
+      "media": "(min-width: 42rem)",
       "position": Position {
         "end": Object {
           "column": 2,
@@ -12527,7 +11794,7 @@ Object {
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 20,
+                  "column": 23,
                   "line": 996,
                 },
                 "source": undefined,
@@ -12538,7 +11805,7 @@ Object {
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "2rem",
+              "value": "4.25rem",
             },
             Object {
               "position": Position {
@@ -12554,12 +11821,12 @@ Object {
               },
               "property": "line-height",
               "type": "declaration",
-              "value": "1.25",
+              "value": "1.15",
             },
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 20,
+                  "column": 58,
                   "line": 998,
                 },
                 "source": undefined,
@@ -12570,7 +11837,7 @@ Object {
               },
               "property": "font-size",
               "type": "declaration",
-              "value": "2rem",
+              "value": "calc(4.25rem + 1.5 * (100vw - 42rem) / 24)",
             },
           ],
           "position": Position {
@@ -12585,2348 +11852,6 @@ Object {
             },
           },
           "selectors": Array [
-            ".cds--type-fluid-paragraph-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 106,
-              "line": 1003,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1003,
-            },
-          },
-          "property": "font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 21,
-              "line": 1004,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1004,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "1.25rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1005,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1005,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "400",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1006,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1006,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.3",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1007,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1007,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 1008,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1008,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(1.25rem + 0 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1009,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1002,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-quotation-01",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1015,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1010,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1012,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1012,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 59,
-                  "line": 1013,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1013,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.25rem + 0.25 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1014,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1011,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1022,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1016,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1018,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1018,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.5rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1019,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1019,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.334",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 58,
-                  "line": 1020,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1020,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.5rem + 0.25 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1021,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1017,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1029,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1023,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1025,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1025,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "1.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 25,
-                  "line": 1026,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1026,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.28572",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 59,
-                  "line": 1027,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1027,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(1.75rem + 0.25 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1028,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1024,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1036,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1030,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 1032,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1032,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1033,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1033,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.25",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 1034,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1034,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1035,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1031,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 106,
-              "line": 1039,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1039,
-            },
-          },
-          "property": "font-family",
-          "type": "declaration",
-          "value": "'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 18,
-              "line": 1040,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1040,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1041,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1041,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1042,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1042,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.25",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1043,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1043,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 54,
-              "line": 1044,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1044,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2rem + 0.25 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1045,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1038,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-quotation-02",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1052,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1046,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1048,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1048,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1049,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1049,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.22",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 1050,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1050,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.25rem + 0.375 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1051,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1047,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1059,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1053,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 1055,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1055,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1056,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1056,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.19",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 1057,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1057,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1058,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1054,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1066,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1060,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 20,
-                  "line": 1062,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1062,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1063,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1063,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.17",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 1064,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1064,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3rem + 0.75 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1065,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1061,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1072,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1067,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1069,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1069,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1070,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1070,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1071,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1068,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-quotation-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 22,
-              "line": 1075,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1075,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1076,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1076,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1077,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1077,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1078,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1078,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 55,
-              "line": 1079,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1079,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2.625rem + 0 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1080,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1074,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-display-01",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1086,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1081,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 1083,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1083,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 1084,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1084,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.75 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1085,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1082,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1092,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1087,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 1089,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1089,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.375rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 1090,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1090,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3.375rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1091,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1088,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1099,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1093,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1095,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1095,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1096,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1096,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.17",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 1097,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1097,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3.75rem + 1 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1098,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1094,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1106,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1100,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1102,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1102,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "4.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1103,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1103,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.13",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1104,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1104,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "4.75rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1105,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1101,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-01",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 22,
-              "line": 1109,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1109,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1110,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1110,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "600",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1111,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1111,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1112,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1112,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 55,
-              "line": 1113,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1113,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2.625rem + 0 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1114,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1108,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-display-02",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1120,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1115,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 1117,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1117,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "2.625rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 60,
-                  "line": 1118,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1118,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(2.625rem + 0.75 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1119,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1116,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1126,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1121,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 1123,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1123,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.375rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 1124,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1124,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3.375rem + 0.375 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1125,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1122,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1133,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1127,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1129,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1129,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1130,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1130,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.16",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 1131,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1131,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3.75rem + 1 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1132,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1128,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1140,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1134,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1136,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1136,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "4.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1137,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1137,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.13",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1138,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1138,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "4.75rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1139,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1135,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-02",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 22,
-              "line": 1143,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1143,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1144,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1144,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1145,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1145,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1146,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1146,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 58,
-              "line": 1147,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1147,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2.625rem + 0.75 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1148,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1142,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-display-03",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1155,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1149,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 24,
-                  "line": 1151,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1151,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.375rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1152,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1152,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.18",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 61,
-                  "line": 1153,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1153,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3.375rem + 0.375 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1154,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1150,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-03",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 66rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1163,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1156,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1158,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1158,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "3.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1159,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1159,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.16",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 28,
-                  "line": 1160,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1160,
-                },
-              },
-              "property": "letter-spacing",
-              "type": "declaration",
-              "value": "-0.64px",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 56,
-                  "line": 1161,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1161,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(3.75rem + 1 * (100vw - 66rem) / 16)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1162,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1157,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-03",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 82rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1171,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1164,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1166,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1166,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "4.75rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1167,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1167,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.13",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 28,
-                  "line": 1168,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1168,
-                },
-              },
-              "property": "letter-spacing",
-              "type": "declaration",
-              "value": "-0.64px",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 58,
-                  "line": 1169,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1169,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(4.75rem + 0.5 * (100vw - 82rem) / 17)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1170,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1165,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-03",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "media": "(min-width: 99rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1179,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1172,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1174,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1174,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "5.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1175,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1175,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.11",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 28,
-                  "line": 1176,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1176,
-                },
-              },
-              "property": "letter-spacing",
-              "type": "declaration",
-              "value": "-0.96px",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1177,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1177,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "5.25rem",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1178,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1173,
-            },
-          },
-          "selectors": Array [
-            ".cds--type-fluid-display-03",
-          ],
-          "type": "rule",
-        },
-      ],
-      "type": "media",
-    },
-    Object {
-      "declarations": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 22,
-              "line": 1182,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1182,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "2.625rem",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 19,
-              "line": 1183,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1183,
-            },
-          },
-          "property": "font-weight",
-          "type": "declaration",
-          "value": "300",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1184,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1184,
-            },
-          },
-          "property": "line-height",
-          "type": "declaration",
-          "value": "1.19",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 20,
-              "line": 1185,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1185,
-            },
-          },
-          "property": "letter-spacing",
-          "type": "declaration",
-          "value": "0",
-        },
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 59,
-              "line": 1186,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1186,
-            },
-          },
-          "property": "font-size",
-          "type": "declaration",
-          "value": "calc(2.625rem + 1.625 * (100vw - 20rem) / 22)",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1187,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1181,
-        },
-      },
-      "selectors": Array [
-        ".cds--type-fluid-display-04",
-      ],
-      "type": "rule",
-    },
-    Object {
-      "media": "(min-width: 42rem)",
-      "position": Position {
-        "end": Object {
-          "column": 2,
-          "line": 1194,
-        },
-        "source": undefined,
-        "start": Object {
-          "column": 1,
-          "line": 1188,
-        },
-      },
-      "rules": Array [
-        Object {
-          "declarations": Array [
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 23,
-                  "line": 1190,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1190,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "4.25rem",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 22,
-                  "line": 1191,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1191,
-                },
-              },
-              "property": "line-height",
-              "type": "declaration",
-              "value": "1.15",
-            },
-            Object {
-              "position": Position {
-                "end": Object {
-                  "column": 58,
-                  "line": 1192,
-                },
-                "source": undefined,
-                "start": Object {
-                  "column": 5,
-                  "line": 1192,
-                },
-              },
-              "property": "font-size",
-              "type": "declaration",
-              "value": "calc(4.25rem + 1.5 * (100vw - 42rem) / 24)",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 1193,
-            },
-            "source": undefined,
-            "start": Object {
-              "column": 3,
-              "line": 1189,
-            },
-          },
-          "selectors": Array [
             ".cds--type-fluid-display-04",
           ],
           "type": "rule",
@@ -14939,12 +11864,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 1202,
+          "line": 1008,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 1195,
+          "line": 1001,
         },
       },
       "rules": Array [
@@ -14954,12 +11879,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 1197,
+                  "line": 1003,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1197,
+                  "line": 1003,
                 },
               },
               "property": "font-size",
@@ -14970,12 +11895,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 1198,
+                  "line": 1004,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1198,
+                  "line": 1004,
                 },
               },
               "property": "line-height",
@@ -14986,12 +11911,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 1199,
+                  "line": 1005,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1199,
+                  "line": 1005,
                 },
               },
               "property": "letter-spacing",
@@ -15002,12 +11927,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 60,
-                  "line": 1200,
+                  "line": 1006,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1200,
+                  "line": 1006,
                 },
               },
               "property": "font-size",
@@ -15018,12 +11943,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 1201,
+              "line": 1007,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1196,
+              "line": 1002,
             },
           },
           "selectors": Array [
@@ -15039,12 +11964,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 1210,
+          "line": 1016,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 1203,
+          "line": 1009,
         },
       },
       "rules": Array [
@@ -15054,12 +11979,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 24,
-                  "line": 1205,
+                  "line": 1011,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1205,
+                  "line": 1011,
                 },
               },
               "property": "font-size",
@@ -15070,12 +11995,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 1206,
+                  "line": 1012,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1206,
+                  "line": 1012,
                 },
               },
               "property": "line-height",
@@ -15086,12 +12011,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 1207,
+                  "line": 1013,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1207,
+                  "line": 1013,
                 },
               },
               "property": "letter-spacing",
@@ -15102,12 +12027,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 61,
-                  "line": 1208,
+                  "line": 1014,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1208,
+                  "line": 1014,
                 },
               },
               "property": "font-size",
@@ -15118,12 +12043,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 1209,
+              "line": 1015,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1204,
+              "line": 1010,
             },
           },
           "selectors": Array [
@@ -15139,12 +12064,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 1218,
+          "line": 1024,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 1211,
+          "line": 1017,
         },
       },
       "rules": Array [
@@ -15154,12 +12079,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 1213,
+                  "line": 1019,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1213,
+                  "line": 1019,
                 },
               },
               "property": "font-size",
@@ -15170,12 +12095,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 22,
-                  "line": 1214,
+                  "line": 1020,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1214,
+                  "line": 1020,
                 },
               },
               "property": "line-height",
@@ -15186,12 +12111,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 28,
-                  "line": 1215,
+                  "line": 1021,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1215,
+                  "line": 1021,
                 },
               },
               "property": "letter-spacing",
@@ -15202,12 +12127,12 @@ Object {
               "position": Position {
                 "end": Object {
                   "column": 23,
-                  "line": 1216,
+                  "line": 1022,
                 },
                 "source": undefined,
                 "start": Object {
                   "column": 5,
-                  "line": 1216,
+                  "line": 1022,
                 },
               },
               "property": "font-size",
@@ -15218,12 +12143,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 4,
-              "line": 1217,
+              "line": 1023,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1212,
+              "line": 1018,
             },
           },
           "selectors": Array [
@@ -15240,12 +12165,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 1221,
+              "line": 1027,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1221,
+              "line": 1027,
             },
           },
           "property": "font-size",
@@ -15256,12 +12181,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 52,
-              "line": 1222,
+              "line": 1028,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1222,
+              "line": 1028,
             },
           },
           "property": "font-weight",
@@ -15272,12 +12197,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 56,
-              "line": 1223,
+              "line": 1029,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1223,
+              "line": 1029,
             },
           },
           "property": "line-height",
@@ -15288,12 +12213,12 @@ Object {
           "position": Position {
             "end": Object {
               "column": 61,
-              "line": 1224,
+              "line": 1030,
             },
             "source": undefined,
             "start": Object {
               "column": 3,
-              "line": 1224,
+              "line": 1030,
             },
           },
           "property": "letter-spacing",
@@ -15304,12 +12229,12 @@ Object {
       "position": Position {
         "end": Object {
           "column": 2,
-          "line": 1225,
+          "line": 1031,
         },
         "source": undefined,
         "start": Object {
           "column": 1,
-          "line": 1220,
+          "line": 1026,
         },
       },
       "selectors": Array [

--- a/packages/styles/scss/__tests__/type-test.js
+++ b/packages/styles/scss/__tests__/type-test.js
@@ -130,8 +130,8 @@ describe('@carbon/styles/scss/type', () => {
     const { stylesheet } = css.parse(result.css.toString());
     const [rule] = stylesheet.rules;
     for (const declaration of rule.declarations) {
-      expect(declaration.property).toEqual(
-        expect.stringContaining('--custom-')
+      expect(declaration.value).toEqual(
+        expect.stringContaining('var(--custom-')
       );
     }
   });

--- a/packages/styles/scss/_config.scss
+++ b/packages/styles/scss/_config.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2018, 2023
+// Copyright IBM Corp. 2018, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -18,11 +18,11 @@ $css--body: true !default;
 /// @group config
 $css--font-face: true !default;
 
-/// If true, emit the custom type properties in in :root
+/// If true, emit the custom type properties in :root
 /// @access public
 /// @type Bool
 /// @group config
-$css--emit-type-custom-props: true !default;
+$css--emit-type-custom-props: false !default;
 
 /// If true, include reset CSS
 /// @access public


### PR DESCRIPTION
Closes #18764

In https://github.com/carbon-design-system/carbon/pull/17198 I mentioned there was a chance emitting these by default could cause issues. This turns off the emitting of these custom properties by default to avoid the problems shown in the parent issue. 

#### Changelog

**Changed**

- set `$css--emit-type-custom-props: false` by default
- update snaps
- update tests

#### Testing / Reviewing

- scss tests should pass
- to fully validate the fix you have to spin up a new nextjs app using scss modules and try to import the type module directly, as shown in the parent issue. 
