### PR TITLE
fix(styles): use map.get in place of map-get

### DIFF
--- a/packages/grid/scss/_flex-grid.scss
+++ b/packages/grid/scss/_flex-grid.scss
@@ -270,7 +270,7 @@
 /// @group @carbon/layout
 @function -last-map-item($map) {
   $total-length: list.length($map);
-  @return map-get($map, -key-by-index($map, $total-length));
+  @return map.get($map, -key-by-index($map, $total-length));
 }
 
 /// Provide a map and index, and get back the relevant key value

--- a/packages/layout/scss/_utilities.scss
+++ b/packages/layout/scss/_utilities.scss
@@ -4,6 +4,7 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
+@use 'sass:map';
 
 /// Map deep get
 /// @author Hugo Giraudel
@@ -37,5 +38,5 @@
 /// @group @carbon/layout
 @function last-map-item($map) {
   $total-length: list.length($map);
-  @return map-get($map, carbon--key-by-index($map, $total-length));
+  @return map.get($map, carbon--key-by-index($map, $total-length));
 }

--- a/packages/type/scss/_font-family.scss
+++ b/packages/type/scss/_font-family.scss
@@ -6,6 +6,7 @@
 //
 
 @use 'sass:string';
+@use 'sass:map';
 
 /// Font family fallbacks for: IBM Plex Mono, IBM Plex Sans, IBM Plex Sans
 /// Condensed, IBM Plex Sans Hebrew, and IBM Plex Serif
@@ -65,7 +66,7 @@ $font-families: (
 /// @access public
 /// @group @carbon/type
 @function font-family($name) {
-  @return map-get($font-families, $name);
+  @return map.get($font-families, $name);
 }
 
 /// Include the `font-family` definition for the given name in your selector
@@ -92,7 +93,7 @@ $font-weights: (
 /// @access public
 /// @group @carbon/type
 @function font-weight($weight) {
-  @return map-get($font-weights, $weight);
+  @return map.get($font-weights, $weight);
 }
 
 /// Set the `font-weight` property with the value for a given name


### PR DESCRIPTION
[Reported on slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1741772474570139)

#### Changelog

**Changed**

- updated usages of map-get to map.get
