### PR TITLE
feat(layer): add polymorphic props in Layer component

### DIFF
--- a/packages/react/src/components/Layer/Layer.stories.js
+++ b/packages/react/src/components/Layer/Layer.stories.js
@@ -97,6 +97,26 @@ export const UseLayer = () => {
   );
 };
 
+export const Test1 = () => {
+  function ExampleComponent() {
+    const { level } = useLayer();
+    return (
+      <div style={{ padding: '1rem', background: 'var(--cds-layer)' }}>
+        The current layer level is: {level}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ExampleComponent />
+      <Layer as="section">
+        <ExampleComponent />
+      </Layer>
+    </>
+  );
+};
+
 UseLayer.story = {
   name: 'useLayer',
 };

--- a/packages/react/src/components/Layer/Layer.stories.js
+++ b/packages/react/src/components/Layer/Layer.stories.js
@@ -97,26 +97,6 @@ export const UseLayer = () => {
   );
 };
 
-export const Test1 = () => {
-  function ExampleComponent() {
-    const { level } = useLayer();
-    return (
-      <div style={{ padding: '1rem', background: 'var(--cds-layer)' }}>
-        The current layer level is: {level}
-      </div>
-    );
-  }
-
-  return (
-    <>
-      <ExampleComponent />
-      <Layer as="section">
-        <ExampleComponent />
-      </Layer>
-    </>
-  );
-};
-
 UseLayer.story = {
   name: 'useLayer',
 };


### PR DESCRIPTION
Closes #18427 

Implementing polymorphic support for the `Layer` component.

**Changelog**

**New**  
- Added support for rendering `Layer` as different elements using the `as` prop.  
- Now `Layer` supports refs properly with `React.forwardRef`.  

**Changed**  
- Updated `Layer` to use `PolymorphicComponentPropWithRef`.  
- Refactored it to use a dynamic `BaseComponent` instead of a fixed element.  

#### Testing / Reviewing  

- CI should pass.  
- Make sure `Layer` still works as expected.  
<details open>
<summary>Test polymorphic capabilities:</summary>
<img width="1692" alt="image" src="https://github.com/user-attachments/assets/a706d0a0-b280-4265-83ea-5fc8bc6f55d5" />
</details>

>[!Note]
>Test if they can render as different elements using the as prop. A test story was added just for review purposes and will be removed after the PR is reviewed.