### PR TITLE
fix: selectable tile onChange method gives old value on keyboard sleect

### DIFF
--- a/packages/react/src/components/Tile/Tile-test.js
+++ b/packages/react/src/components/Tile/Tile-test.js
@@ -499,6 +499,17 @@ describe('Tile', () => {
       true,
       'selectable-tile-1'
     );
+    // should de-select when user press enter key on selected tile.
+    tile.focus();
+    await userEvent.keyboard('[Enter]');
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'keydown',
+      }),
+      false,
+      'selectable-tile-1'
+    );
   });
 
   it('should call onKeyDown', async () => {

--- a/packages/react/src/components/Tile/Tile.stories.js
+++ b/packages/react/src/components/Tile/Tile.stories.js
@@ -154,7 +154,10 @@ export const ClickableWithLayer = () => (
 
 export const Selectable = (args) => {
   return (
-    <SelectableTile id="selectable-tile-1" {...args}>
+    <SelectableTile
+      id="selectable-tile-1"
+      {...args}
+      onChange={(e, selected, aa) => console.log(selected)}>
       Selectable
     </SelectableTile>
   );

--- a/packages/react/src/components/Tile/Tile.stories.js
+++ b/packages/react/src/components/Tile/Tile.stories.js
@@ -154,10 +154,7 @@ export const ClickableWithLayer = () => (
 
 export const Selectable = (args) => {
   return (
-    <SelectableTile
-      id="selectable-tile-1"
-      {...args}
-      onChange={(e, selected, aa) => console.log(selected)}>
+    <SelectableTile id="selectable-tile-1" {...args}>
       Selectable
     </SelectableTile>
   );

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -515,15 +515,19 @@ export const SelectableTile = React.forwardRef<
     evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
       evt.preventDefault();
-      setIsSelected(!isSelected);
-      onChange(evt, isSelected, id);
+      setIsSelected((prevSelected) => {
+        const newSelected = !prevSelected;
+        onChange(evt, newSelected, id);
+        return newSelected;
+      });
     }
     keyDownHandler(evt);
   }
 
   function handleChange(event) {
-    setIsSelected(event.target.checked);
-    onChange(event, isSelected, id);
+    const newSelected = event.target.checked;
+    setIsSelected(newSelected);
+    onChange(event, newSelected, id);
   }
 
   if (selected !== prevSelected) {


### PR DESCRIPTION
Closes #18478 

SelectableTile onChange method was not giving latest selected value on keyboard select.

#### Testing / Reviewing
Go to Storybook > Tile > SelectableTile
select/deselect the tile from keyboard. 
It should display correct value in console.

Note: I have added the console in storybook for testing purpose only, will remove it before merge.