### PR TITLE
fix(DataTable): Use the right heading level in TableContainer.

### DIFF
--- a/packages/react/src/components/DataTable/TableContainer.tsx
+++ b/packages/react/src/components/DataTable/TableContainer.tsx
@@ -12,6 +12,7 @@ import { ReactAttr } from '../../types/common';
 import { usePrefix } from '../../internal/usePrefix';
 import { useId } from '../../internal/useId';
 import { TableContext } from './TableContext';
+import { Heading, Section } from '../Heading';
 
 export interface TableContainerProps
   extends Omit<ReactAttr<HTMLDivElement>, 'title'> {
@@ -63,15 +64,15 @@ const TableContainer = ({
 
   return (
     <TableContext.Provider value={value}>
-      <div {...rest} className={tableContainerClasses}>
+      <Section {...rest} className={tableContainerClasses}>
         {(title || description) && (
           <div className={`${prefix}--data-table-header`}>
             {title && (
-              <h4
+              <Heading
                 className={`${prefix}--data-table-header__title`}
                 id={titleId}>
                 {title}
-              </h4>
+              </Heading>
             )}
             {description && (
               <p
@@ -83,7 +84,7 @@ const TableContainer = ({
           </div>
         )}
         {children}
-      </div>
+      </Section>
     </TableContext.Provider>
   );
 };

--- a/packages/react/src/components/DataTable/__tests__/TableContainer-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableContainer-test.js
@@ -43,7 +43,7 @@ describe('TableContainer', () => {
       );
 
       const headerEl = container.querySelector('[class*="data-table-header"]');
-      const titleEl = headerEl.querySelector('h4');
+      const titleEl = headerEl.querySelector('h2');
       const descriptionEl = headerEl.querySelector('p');
 
       expect(headerEl).toBeInTheDocument();
@@ -82,7 +82,7 @@ describe('TableContainer', () => {
       );
 
       const headerEl = container.querySelector('[class*="data-table-header"]');
-      const titleEl = headerEl.querySelector('h4');
+      const titleEl = headerEl.querySelector('h2');
       const descriptionEl = headerEl.querySelector('p');
 
       expect(headerEl).toBeInTheDocument();

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`DataTable behaves as expected selection -- radio buttons should not have select-all checkbox 1`] = `
 <div>
-  <div
+  <section
     class="cds--data-table-container"
   >
     <div
       class="cds--data-table-header"
     >
-      <h4
+      <h2
         class="cds--data-table-header__title"
         id="tc-:r7g:-title"
       >
         DataTable with selection
-      </h4>
+      </h2>
     </div>
     <div
       class="cds--data-table-content"
@@ -170,24 +170,24 @@ exports[`DataTable behaves as expected selection -- radio buttons should not hav
         </tbody>
       </table>
     </div>
-  </div>
+  </section>
 </div>
 `;
 
 exports[`DataTable behaves as expected selection -- radio buttons should render 1`] = `
 <div>
-  <div
+  <section
     class="cds--data-table-container"
   >
     <div
       class="cds--data-table-header"
     >
-      <h4
+      <h2
         class="cds--data-table-header__title"
         id="tc-:r77:-title"
       >
         DataTable with selection
-      </h4>
+      </h2>
     </div>
     <div
       class="cds--data-table-content"
@@ -344,24 +344,24 @@ exports[`DataTable behaves as expected selection -- radio buttons should render 
         </tbody>
       </table>
     </div>
-  </div>
+  </section>
 </div>
 `;
 
 exports[`DataTable behaves as expected selection should render and match snapshot 1`] = `
 <div>
-  <div
+  <section
     class="cds--data-table-container"
   >
     <div
       class="cds--data-table-header"
     >
-      <h4
+      <h2
         class="cds--data-table-header__title"
         id="tc-:r2k:-title"
       >
         DataTable with selection
-      </h4>
+      </h2>
     </div>
     <section
       aria-label="data table toolbar"
@@ -788,25 +788,25 @@ exports[`DataTable behaves as expected selection should render and match snapsho
         </tbody>
       </table>
     </div>
-  </div>
+  </section>
 </div>
 `;
 
 exports[`DataTable renders as expected - Component API should render and match snapshot 1`] = `
 <div>
-  <div
+  <section
     class="cds--data-table-container"
     data-testid="test-id"
   >
     <div
       class="cds--data-table-header"
     >
-      <h4
+      <h2
         class="cds--data-table-header__title"
-        id="tc-:re:-title"
+        id="tc-:r0:-title"
       >
         DataTable with toolbar
-      </h4>
+      </h2>
     </div>
     <section
       aria-label="data table toolbar"
@@ -1004,7 +1004,7 @@ exports[`DataTable renders as expected - Component API should render and match s
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-labelledby="tooltip-:rm:"
+                aria-labelledby="tooltip-:r8:"
                 class="cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--ghost cds--btn--icon-only"
                 title="Settings"
                 type="button"
@@ -1033,7 +1033,7 @@ exports[`DataTable renders as expected - Component API should render and match s
             <span
               aria-hidden="true"
               class="cds--popover"
-              id="tooltip-:rm:"
+              id="tooltip-:r8:"
               role="tooltip"
             >
               <span
@@ -1059,7 +1059,7 @@ exports[`DataTable renders as expected - Component API should render and match s
       class="cds--data-table-content"
     >
       <table
-        aria-labelledby="tc-:re:-title"
+        aria-labelledby="tc-:r0:-title"
         class="cds--data-table cds--data-table--lg cds--data-table--visible-overflow-menu"
       >
         <thead>
@@ -1120,6 +1120,6 @@ exports[`DataTable renders as expected - Component API should render and match s
         </tbody>
       </table>
     </div>
-  </div>
+  </section>
 </div>
 `;

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -803,7 +803,7 @@ exports[`DataTable renders as expected - Component API should render and match s
     >
       <h2
         class="cds--data-table-header__title"
-        id="tc-:r0:-title"
+        id="tc-:re:-title"
       >
         DataTable with toolbar
       </h2>
@@ -1004,7 +1004,7 @@ exports[`DataTable renders as expected - Component API should render and match s
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-labelledby="tooltip-:r8:"
+                aria-labelledby="tooltip-:rm:"
                 class="cds--toolbar-action cds--overflow-menu cds--overflow-menu cds--overflow-menu--md cds--btn cds--btn--md cds--layout--size-md cds--btn--ghost cds--btn--icon-only"
                 title="Settings"
                 type="button"
@@ -1033,7 +1033,7 @@ exports[`DataTable renders as expected - Component API should render and match s
             <span
               aria-hidden="true"
               class="cds--popover"
-              id="tooltip-:r8:"
+              id="tooltip-:rm:"
               role="tooltip"
             >
               <span
@@ -1059,7 +1059,7 @@ exports[`DataTable renders as expected - Component API should render and match s
       class="cds--data-table-content"
     >
       <table
-        aria-labelledby="tc-:r0:-title"
+        aria-labelledby="tc-:re:-title"
         class="cds--data-table cds--data-table--lg cds--data-table--visible-overflow-menu"
       >
         <thead>


### PR DESCRIPTION
Closes #18835

Use the right heading level in TableContainer, rather than always using H4.

See https://www.w3.org/WAI/tutorials/page-structure/headings/.

#### Changelog

**Changed**

- TableContainer will pick its heading level based on the heading level of its parent, assuming that the parent is correctly using Section and Heading.

#### Testing / Reviewing

Tested locally via Jest test.
