### PR TITLE
feat(overflow-menu): add custom event to item click

### DIFF
--- a/packages/web-components/src/components/overflow-menu/overflow-menu-item.ts
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu-item.ts
@@ -19,9 +19,28 @@ import styles from './overflow-menu.scss?lit';
  * Overflow menu item.
  *
  * @element cds-overflow-menu-item
+ * @fires cds-overflow-menu-item-clicked - The custom event fired when an overflow menu item is clicked.
  */
 @customElement(`${prefix}-overflow-menu-item`)
 class CDSOverflowMenuItem extends FocusMixin(LitElement) {
+  /**
+   * Handles `click` event on this element.
+   */
+  private _handleClick(event: Event) {
+    this.dispatchEvent(
+      new CustomEvent(
+        (this.constructor as typeof CDSOverflowMenuItem).itemClicked,
+        {
+          bubbles: true,
+          composed: true,
+          detail: {
+            evt: event,
+          },
+        }
+      )
+    );
+  }
+
   /**
    * `true` if the action is danger.
    */
@@ -60,13 +79,15 @@ class CDSOverflowMenuItem extends FocusMixin(LitElement) {
   }
 
   render() {
+    const { _handleClick: handleClick } = this;
     return this.href
       ? html`
           <a
             class="${prefix}--overflow-menu-options__btn"
             ?disabled=${this.disabled}
             href="${this.href}"
-            tabindex="-1">
+            tabindex="-1"
+            @click="${handleClick}">
             <div class="${prefix}--overflow-menu-options__option-content">
               <slot></slot>
             </div>
@@ -76,12 +97,20 @@ class CDSOverflowMenuItem extends FocusMixin(LitElement) {
           <button
             class="${prefix}--overflow-menu-options__btn"
             ?disabled=${this.disabled}
-            tabindex="-1">
+            tabindex="-1"
+            @click="${handleClick}">
             <div class="${prefix}--overflow-menu-options__option-content">
               <slot></slot>
             </div>
           </button>
         `;
+  }
+
+  /**
+   * The name of the custom event fired when the item is clicked.
+   */
+  static get itemClicked() {
+    return `${prefix}-overflow-menu-item-clicked`;
   }
 
   static shadowRootOptions = {

--- a/packages/web-components/src/components/overflow-menu/overflow-menu.mdx
+++ b/packages/web-components/src/components/overflow-menu/overflow-menu.mdx
@@ -59,7 +59,7 @@ Note: For `boolean` attributes, `true` means simply setting the attribute (e.g.
 
 <ArgTypes of="cds-overflow-menu-body" />
 
-## `<cds-overflow-menu-item>` attributes and properties
+## `<cds-overflow-menu-item>` attributes, properties, and events
 
 Note: For `boolean` attributes, `true` means simply setting the attribute (e.g.
 `<cds-overflow-menu-item disabled>`) and `false` means not setting the attribute

--- a/packages/web-components/src/components/tag/tag.ts
+++ b/packages/web-components/src/components/tag/tag.ts
@@ -22,7 +22,7 @@ export { TAG_SIZE, TAG_TYPE };
 
 /**
  * Tag.
- *
+ * @element cds-tag
  * @fires cds-tag-beingclosed - The custom event fired as the element is being closed
  * @fires cds-tag-closed - The custom event fired after the element has been closed
  */


### PR DESCRIPTION
Closes #18487 

Adds custom event when overflow menu item is clicked.

#### Changelog

**New**

- add `cds-overflow-menu-item-clicked` custom event to overflow menu item click event.

**Changed**

- add `@element` JSDoc to `cds-tag`


#### Testing / Reviewing

Add a simple code snippet to `overflow-menu.stories.ts` to see the click event fire.
```javascript
document.addEventListener('cds-overflow-menu-item-clicked', (event) => {
  const { currentTarget } = event;
  const { detail } = event as CustomEvent;
  const { evt } = detail;
  console.log('item clicked', currentTarget, evt);
});
```

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
