### PR TITLE
feat(button-set): add stacked property to web component `button-set`

### DIFF
--- a/packages/web-components/src/components/button/button-set.ts
+++ b/packages/web-components/src/components/button/button-set.ts
@@ -7,7 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { classMap } from 'lit/directives/class-map.js';
 import { html } from 'lit';
+import { property } from 'lit/decorators.js';
 import { BUTTON_KIND } from './defs';
 import styles from './button.scss?lit';
 import { prefix } from '../../globals/settings';
@@ -21,6 +23,12 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  */
 @customElement(`${prefix}-button-set`)
 class CDSButtonSet extends CDSButtonSetBase {
+  /**
+   * `true` if the button should have input focus when the page loads.
+   */
+  @property({ type: Boolean, reflect: true })
+  stacked = false;
+
   /**
    * Handler for @slotchange, set the first cds-button to kind secondary and primary for the remaining ones
    *
@@ -54,7 +62,13 @@ class CDSButtonSet extends CDSButtonSetBase {
   }
 
   render() {
-    return html` <slot @slotchange="${this._handleSlotChange}"></slot> `;
+    const { stacked } = this;
+    const defaultClasses = {
+      [`${prefix}--btn-set--stacked`]: stacked,
+    };
+    const classes = classMap(defaultClasses);
+
+    return html`<slot class="${classes} @slotchange="${this._handleSlotChange}"></slot>`;
   }
   /**
    * A selector that will return the child items.

--- a/packages/web-components/src/components/button/button-set.ts
+++ b/packages/web-components/src/components/button/button-set.ts
@@ -24,7 +24,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 @customElement(`${prefix}-button-set`)
 class CDSButtonSet extends CDSButtonSetBase {
   /**
-   * `true` if the button should have input focus when the page loads.
+   * `true` if the Button should be stacked, or not. Only applies to the button-set variant.
    */
   @property({ type: Boolean, reflect: true })
   stacked = false;

--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -33,6 +33,10 @@ $css--plex: true !default;
   .#{$prefix}--btn {
     flex-grow: 1;
     max-inline-size: 100%;
+
+    &:not(:focus) {
+      box-shadow: to-rem(-1px) to-rem(-1px) 0 0 $button-separator;
+    }
   }
 }
 

--- a/packages/web-components/src/components/button/button.stories.ts
+++ b/packages/web-components/src/components/button/button.stories.ts
@@ -111,6 +111,11 @@ const controls = {
       'Specify the size of the button, from the following list of sizes:',
     options: sizes,
   },
+  stacked: {
+    control: 'boolean',
+    description:
+      'Specify whether the Button should be stacked, or not. Only applies to the button-set variant.',
+  },
   tooltipAlignment: {
     control: 'radio',
     description:
@@ -372,11 +377,12 @@ export const SetOfButtons = {
     isSelected,
     linkRole,
     size,
+    stacked,
     tooltipAlignment,
     tooltipPosition,
     type,
   }) =>
-    html` <cds-button-set>
+    html` <cds-button-set .stacked="${stacked}">
       <cds-button
         button-class-name="${buttonClassName}"
         danger-description="${dangerDescription}"


### PR DESCRIPTION
Adds `stacked` feature to the `button-set` component.

#### Changelog

**New**

- add `stacked` property to `button-set` to allow vertical layout of buttons

#### Testing / Reviewing

Go to Button story in deploy preview, `Set of Buttons` variant and toggle `stacked` control.

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
