### PR TITLE
refactor: port useIsomorphicEffect to typescript

### DIFF
--- a/packages/react/src/internal/useIsomorphicEffect.js
+++ b/packages/react/src/internal/useIsomorphicEffect.js
@@ -1,7 +1,0 @@
-import { useEffect, useLayoutEffect } from 'react';
-
-// useLayoutEffect on the client, useEffect on the server
-const useIsomorphicEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
-
-export default useIsomorphicEffect;

--- a/packages/react/src/internal/useIsomorphicEffect.ts
+++ b/packages/react/src/internal/useIsomorphicEffect.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect, useLayoutEffect } from 'react';
+
+/** `useLayoutEffect` on the client, `useEffect` on the server */
+const useIsomorphicEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default useIsomorphicEffect;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18887

Ported `useIsomorphicEffect` to TypeScript.

#### Changelog

**Changed**

- Ported `useIsomorphicEffect` to TypeScript.

#### Testing / Reviewing

```sh
yarn test packages/react
```