### PR TITLE
fix(labels): update needs triage label automations

### DIFF
--- a/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
@@ -2,7 +2,8 @@ name: Accessibility Issue ♿
 description: Report an accessibility or usability issue.
 title: '[a11y]: '
 type: 'bug'
-labels: ['type: a11y ♿', 'type: bug 🐛', 'status: needs triage 🕵️‍♀️']
+labels:
+  ['type: a11y ♿', 'type: bug 🐛', 'status: needs triage :female_detective:']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -3,7 +3,7 @@ description:
   Something not working as expected? This is the place to report your issue.
 title: '[Bug]: '
 type: 'bug'
-labels: ['type: bug 🐛', 'status: needs triage 🕵️‍♀️']
+labels: ['type: bug 🐛', 'status: needs triage :female_detective:']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/DESIGN_DEFECT.yaml
+++ b/.github/ISSUE_TEMPLATE/DESIGN_DEFECT.yaml
@@ -2,7 +2,7 @@ name: Design defect 🎨
 description: Report a visual design issue
 title: '[Bug]: '
 type: 'bug'
-labels: ['type: bug 🐛', 'status: needs triage 🕵️‍♀️']
+labels: ['type: bug 🐛', 'status: needs triage :female_detective:']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_OR_ENHANCEMENT.yaml
@@ -2,7 +2,7 @@ name: Feature request or enhancement 💡
 description: Suggest an idea for this project.
 title: '[Feature Request]: '
 type: 'enhancement'
-labels: ['type: enhancement 💡', 'status: needs triage 🕵️‍♀️']
+labels: ['type: enhancement 💡', 'status: needs triage :female_detective:']
 body:
   - type: markdown
     attributes:
@@ -45,7 +45,9 @@ body:
     id: package
     attributes:
       label: Package
-      description: Which package(s) does this request apply to? You can select more than one.
+      description:
+        Which package(s) does this request apply to? You can select more than
+        one.
       multiple: true
       options:
         - '@carbon/react'

--- a/.github/ISSUE_TEMPLATE/QUESTION.yaml
+++ b/.github/ISSUE_TEMPLATE/QUESTION.yaml
@@ -1,7 +1,7 @@
 name: Question ❓
 description: Usage question or discussion about Carbon components.
 title: '[Question]: '
-labels: ['type: question ❓', 'status: needs triage 🕵️‍♀️']
+labels: ['type: question ❓', 'status: needs triage :female_detective:']
 body:
   - type: markdown
     attributes:

--- a/actions/issues/src/labels.js
+++ b/actions/issues/src/labels.js
@@ -16,7 +16,7 @@ module.exports = {
 
     // Triage
     needsMoreInfo: 'status: needs more info',
-    needsTriage: 'status: needs triage 🕵️‍♀️',
+    needsTriage: 'status: needs triage :female_detective:',
     waitingForAuthor: `status: waiting for author's response 💬`,
     waitingForMaintainer: 'status: waiting for maintainer response 💬',
 


### PR DESCRIPTION
This updates issue templates and triage automations to use the updated label value for the needs triage label to avoid duplicate labels being created.

<details><summary>Full context</summary>
<p>

I updated the label a couple weeks ago to use the "colon-notation" for the emoji instead of hardcoding the emoji in the label. I was having lots of issues trying to query the github api with the emoji and the "colon-notation" fixed it. 

The issue templates and workflow automations _create_ any label that doesn't exist, which caused a duplicate label to be made

![2025-03-24 at 15 08 23-MAIN-Google Chrome](https://github.com/user-attachments/assets/6f9b21ad-5c16-439f-afda-3e59df93e8c0)

by updating these files we shouldn't get a duplicate label created anymore.

</p>
</details> 




#### Changelog

**Changed**

- updated all usages of the needs triage label in the codebase

#### Testing / Reviewing

Once this is merged I'll clean up the old label and make sure issues with it are given the proper label

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
