### PR TITLE
refactor: rewrite `useOutsideClick` in typescript

### DIFF
--- a/packages/react/src/internal/useOutsideClick.ts
+++ b/packages/react/src/internal/useOutsideClick.ts
@@ -1,30 +1,39 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect, useRef } from 'react';
-import { useEvent } from './useEvent';
+import { useEffect, useRef, type RefObject } from 'react';
 import { canUseDOM } from './environment';
+import { useWindowEvent } from './useEvent';
 
-export function useOutsideClick(ref, callback) {
+export const useOutsideClick = <T extends HTMLElement>(
+  ref: RefObject<T>,
+  callback: (event: MouseEvent) => void
+) => {
   const savedCallback = useRef(callback);
 
   useEffect(() => {
     savedCallback.current = callback;
-  });
+  }, [callback]);
 
   // We conditionally guard the `useEvent` hook for SSR. `canUseDOM` can be
   // treated as a constant as it will be false when executed in a Node.js
   // environment and true when executed in the browser
   if (canUseDOM) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEvent(window, 'click', (event) => {
-      if (ref.current && !ref.current.contains(event.target)) {
+    useWindowEvent('click', (event) => {
+      const { target } = event;
+
+      if (
+        target instanceof Node &&
+        ref.current &&
+        !ref.current.contains(target)
+      ) {
         savedCallback.current(event);
       }
     });
   }
-}
+};


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18987

Rewrote `useOutsideClick` in TypeScript.

#### Changelog

**Changed**

- Rewrote `useOutsideClick` in TypeScript.

#### Testing / Reviewing

I changed the `useEvent` usage in the hook to `useWindowEvent`. I'm not sure why `useEvent` was used so if someone could clarify, that would be helpful.

```sh
yarn test packages/react
```
