### PR TITLE
chore: remove test1 story from Column

### DIFF
--- a/packages/react/src/components/Grid/FlexGrid.stories.js
+++ b/packages/react/src/components/Grid/FlexGrid.stories.js
@@ -425,36 +425,6 @@ export const Default = (args) => {
   );
 };
 
-export const Test1 = (args) => {
-  // Grab the style from here to see the visual example
-  //https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/Grid/FlexGrid.stories.scss
-  function DemoContent({ children }) {
-    return (
-      <div className="outside">
-        <div className="inside">{children}</div>
-      </div>
-    );
-  }
-  return (
-    <FlexGrid {...args} as="section">
-      <Row>
-        <Column as="section">
-          <DemoContent>1/4</DemoContent>
-        </Column>
-        <Column>
-          <DemoContent>1/4</DemoContent>
-        </Column>
-        <Column>
-          <DemoContent>1/4</DemoContent>
-        </Column>
-        <Column>
-          <DemoContent>1/4</DemoContent>
-        </Column>
-      </Row>
-    </FlexGrid>
-  );
-};
-
 Default.args = {
   as: 'div',
   fullWidth: false,


### PR DESCRIPTION
Closes #19033

Removed an unintended test1 story that was accidentally included in the FlexGrid Storybook.

#### Changelog

**New**
Nothing new added

**Changed**
No changes to existing functionality

**Removed**
test1 story from Grid/FlexGrid.stories.js

Testing / Reviewing
- CI should pass
- Open Storybook and navigate to the FlexGrid stories
- Confirm that the test1 story is no longer listed
- No other stories or functionality should be affected
