### PR TITLE
docs(layer): update usage example in docs and StackBlitz

### DIFF
--- a/packages/web-components/examples/components/layer/index.html
+++ b/packages/web-components/examples/components/layer/index.html
@@ -9,13 +9,8 @@ LICENSE file in the root directory of this source tree.
   <head>
     <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
-
+    
     <link rel="stylesheet" href="src/styles.scss" />
-    <style>
-      .example-layer-test-component {
-        padding: 1rem;
-      }
-    </style>
     <script type="module" src="src/index.js"></script>
   </head>
   <body>

--- a/packages/web-components/examples/components/layer/src/styles.scss
+++ b/packages/web-components/examples/components/layer/src/styles.scss
@@ -1,9 +1,15 @@
 @use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/theme';
 @use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/spacing';
 
 :root {
   @include theme.theme(themes.$white);
   background-color: var(--cds-background);
   color: var(--cds-text-primary);
+}
+
+.example-layer-test-component {
+  padding: spacing.$spacing-05;
+  background: theme.$layer;
 }

--- a/packages/web-components/src/components/layer/layer.mdx
+++ b/packages/web-components/src/components/layer/layer.mdx
@@ -36,11 +36,15 @@ import '@carbon/web-components/es/components/layer/index.js';
 
 ### HTML
 
-Here we define a custom test class to define a custom padding.
+Here we define a custom test class to define a custom padding and background using tokens, which must be imported via Sass.
 
 ```css
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/theme';
+
 .example-layer-test-component {
-  padding: 1rem;
+  padding: spacing.$spacing-05;
+  background: theme.$layer;
 }
 ```
 


### PR DESCRIPTION
Closes #17757

Improves the Layer component usage example by adding tokens ($layer, $spacing-05) via Sass.
This helps users better understand how layers behave, with clearer visual output and improved documentation and StackBlitz.

#### Changelog

**Changed**
- Updated styles.scss and index.html in examples/components/layer to use spacing and background tokens
- Updated layer.mdx with the corrected usage example

**Removed**
- Removed hardcoded `padding: 1rem` previously defined in the HTML example

**Testing / Reviewing**
- CI should pass
- Not possible to test directly on StackBlitz as it pulls from the main branch
- Verify that the updated is clear and matches the expected visual output

Screenshot to illustrate the final result in StackBlitz: 
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/fdfb930d-b2dd-4cfb-827e-bcb4fe5482d3" />

