### PR TITLE
fix(toggle): wc mis aligned focus ring

### DIFF
--- a/packages/styles/scss/components/toggle/_toggle.scss
+++ b/packages/styles/scss/components/toggle/_toggle.scss
@@ -81,13 +81,11 @@
     .#{$prefix}--toggle__switch {
     &::after {
       display: block;
-      border: 2px solid $focus;
       border-radius: convert.to-rem(16px);
-      block-size: calc(100% + convert.to-rem(6px));
+      block-size: 100%;
       content: '';
-      inline-size: calc(100% + convert.to-rem(6px));
-      margin-block-start: convert.to-rem(-3px);
-      margin-inline-start: convert.to-rem(-3px);
+      outline: 2px solid $focus;
+      outline-offset: 1px;
     }
   }
 


### PR DESCRIPTION
contributes to #17626 

this pr fixes misaligned focus ring on web component toggle, while still showing properly on high contrast mode as per #17626
<img width="204" alt="Screenshot 2025-04-09 at 5 30 34 PM" src="https://github.com/user-attachments/assets/7713d4ff-b57b-4677-8deb-11496b839c73" />

#### Changelog

**Changed**

- changed common styles (changed border to outline and removed some unwanted styles) for wc and react toggle component

#### Testing / Reviewing

verified in storybook, both react and web component, and with high contrast mode
