### PR TITLE
docs(indicators): fix switched up import statements

### DIFF
--- a/packages/react/src/components/IconIndicator/IconIndicator.mdx
+++ b/packages/react/src/components/IconIndicator/IconIndicator.mdx
@@ -30,7 +30,7 @@ information to users. The shapes and colors, communicate severity that enables
 users to quickly assess and identify status and respond accordingly.
 
 ```jsx
-import { IconIndicator as unstable__IconIndicator } from '@carbon/react';
+import { unstable__IconIndicator as IconIndicator } from '@carbon/react';
 
 function ExampleComponent() {
   return (

--- a/packages/react/src/components/ShapeIndicator/ShapeIndicator.mdx
+++ b/packages/react/src/components/ShapeIndicator/ShapeIndicator.mdx
@@ -22,7 +22,7 @@ import { ArgTypes, Meta } from '@storybook/blocks';
 `ShapeIndicator`
 
 ```jsx
-import { ShapeIndicator as unstable__ShapeIndicator } from '@carbon/react';
+import { unstable__ShapeIndicator as ShapeIndicator } from '@carbon/react';
 
 function ExampleComponent() {
   return (


### PR DESCRIPTION
Reported on Slack: https://ibm-analytics.slack.com/archives/C2K6RFJ1G/p1744263095108549

Fixes switched up import statements in the IconIndicator and ShapeIndicator documentation.