### PR TITLE
fix(utilities/react): don't replace process.env.NODE_ENV during build

### DIFF
--- a/packages/utilities-react/package.json
+++ b/packages/utilities-react/package.json
@@ -30,8 +30,8 @@
     "provenance": true
   },
   "scripts": {
-    "build:es": "esbuild ./src/**/!(*-test).{js,ts,jsx,tsx} --minify --outdir=es --target=es2020 --format=esm",
-    "build:cjs": "esbuild ./src/**/!(*-test).{js,ts,jsx,tsx} --minify --outdir=lib --target=es2020 --format=cjs",
+    "build:es": "esbuild ./src/**/!(*-test).{js,ts,jsx,tsx} --minify --outdir=es --target=es2020 --format=esm --define:process=process",
+    "build:cjs": "esbuild ./src/**/!(*-test).{js,ts,jsx,tsx} --minify --outdir=lib --target=es2020 --format=cjs --define:process=process",
     "build:types": "tsc",
     "build": "yarn build:es & yarn build:cjs & yarn build:types",
     "watch": "yarn build:es --watch & yarn build:cjs --watch",


### PR DESCRIPTION
By default, esbuild resolves `process.env.NODE_ENV` during build time. This caused the `@carbon/utilities-react` package to not emit critical code for the `useNoInteractiveChildren` hook. By manually defining `process`, `process.env` or `process.env.NODE_ENV`, esbuild will not try resolve it. This PR therefore defines `process` as `process` in the build scripts for the `@carbon/utilities-react` package.

#### Testing / Reviewing

1. Build `@carbon/utilities-react` from `main`
2. Inspect `packages/utilities-react/es/useNoInteractiveChildren/index.js`
3. It should have generated an empty function for `useNoInteractiveChildren`
  3.1 `function u(e,t="component should have no interactive child nodes"){}`
4. Build `@carbon/utilities-react` from this PR's branch
5. Inspect `packages/utilities-react/es/useNoInteractiveChildren/index.js`
6. The function generated for `useNoInteractiveChildren` should now contain logic including the `process.env.NODE_ENV !== 'production'` condition
  6.1 `function s(r,t="component should have no interactive child nodes"){process.env.NODE_ENV!=="production"&&…}`