### PR TITLE
refactor: port `uniqueId` to typescript and fix tests

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import { ChevronDown } from '@carbon/icons-react';
 import Copy from '../Copy';
 import Button from '../Button';
 import CopyButton from '../CopyButton';
-import getUniqueId from '../../tools/uniqueId';
+import { uniqueId } from '../../tools/uniqueId';
 import copy from 'copy-to-clipboard';
 import deprecate from '../../prop-types/deprecate';
 import { usePrefix } from '../../internal/usePrefix';
@@ -214,7 +214,7 @@ function CodeSnippet({
 }: PropsWithChildren<CodeSnippetProps>) {
   const [expandedCode, setExpandedCode] = useState(false);
   const [shouldShowMoreLessBtn, setShouldShowMoreLessBtn] = useState(false);
-  const { current: uid } = useRef(getUniqueId());
+  const { current: uid } = useRef(uniqueId());
   const codeContentRef = useRef<HTMLPreElement>(null);
   const codeContainerRef = useRef<HTMLDivElement>(null);
   const innerCodeRef = useRef<HTMLElement>(null);

--- a/packages/react/src/components/FileUploader/FileUploaderButton.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { matches, keys } from '../../internal/keyboard';
 import { ButtonKinds } from '../../prop-types/types';
-import uid from '../../tools/uniqueId';
+import { uniqueId } from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 import deprecate from '../../prop-types/deprecate';
 import { ReactAttr } from '../../types/common';
@@ -123,7 +123,7 @@ function FileUploaderButton({
   const prefix = usePrefix();
   const [labelText, setLabelText] = useState(ownerLabelText);
   const [prevOwnerLabelText, setPrevOwnerLabelText] = useState(ownerLabelText);
-  const { current: inputId } = useRef(id || uid());
+  const { current: inputId } = useRef(id || uniqueId());
   const inputNode = useRef<HTMLInputElement>(null);
   const classes = cx(`${prefix}--btn`, className, {
     [`${prefix}--btn--${buttonKind}`]: buttonKind,

--- a/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderDropContainer.tsx
@@ -9,7 +9,7 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { keys, matches } from '../../internal/keyboard';
-import uniqueId from '../../tools/uniqueId';
+import { uniqueId } from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 import { composeEventHandlers } from '../../tools/events';
 import deprecate from '../../prop-types/deprecate';

--- a/packages/react/src/components/FileUploader/FileUploaderItem.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItem.tsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import Filename from './Filename';
 import { keys, matches } from '../../internal/keyboard';
-import uid from '../../tools/uniqueId';
+import { uniqueId } from '../../tools/uniqueId';
 import { usePrefix } from '../../internal/usePrefix';
 import { ReactAttr } from '../../types/common';
 import { noopFn } from '../../internal/noopFn';
@@ -89,7 +89,7 @@ function FileUploaderItem({
   const textRef = useRef<HTMLParagraphElement>(null);
   const [isEllipsisApplied, setIsEllipsisApplied] = useState(false);
   const prefix = usePrefix();
-  const { current: id } = useRef(uuid || uid());
+  const { current: id } = useRef(uuid || uniqueId());
   const classes = cx(`${prefix}--file__selected-file`, className, {
     [`${prefix}--file__selected-file--invalid`]: invalid,
     [`${prefix}--file__selected-file--md`]: size === 'md',

--- a/packages/react/src/components/FileUploader/stories/drag-and-drop-single.js
+++ b/packages/react/src/components/FileUploader/stories/drag-and-drop-single.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,16 +10,9 @@ import classnames from 'classnames';
 import FileUploaderItem from '../FileUploaderItem';
 import FileUploaderDropContainer from '../FileUploaderDropContainer';
 import FormItem from '../../FormItem';
+import { uniqueId } from '../../../tools/uniqueId';
 
 const prefix = 'cds';
-
-// -- copied from internal/tools/uniqueId.js
-let lastId = 0;
-function uid(prefix = 'id') {
-  lastId++;
-  return `${prefix}${lastId}`;
-}
-// -- end copied
 
 const ExampleDropContainerApp = (props) => {
   const [file, setFile] = useState();
@@ -97,7 +90,7 @@ const ExampleDropContainerApp = (props) => {
 
     const newFile = [
       {
-        uuid: uid(),
+        uuid: uniqueId(),
         name: file[0].name,
         filesize: file[0].size,
         status: 'uploading',
@@ -145,7 +138,7 @@ const ExampleDropContainerApp = (props) => {
         )}>
         {file !== undefined && (
           <FileUploaderItem
-            key={uid()}
+            key={uniqueId()}
             uuid={file.uuid}
             name={file.name}
             filesize={file.filesize}

--- a/packages/react/src/components/FileUploader/stories/drop-container.js
+++ b/packages/react/src/components/FileUploader/stories/drop-container.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,16 +10,9 @@ import classnames from 'classnames';
 import FileUploaderItem from '../FileUploaderItem';
 import FileUploaderDropContainer from '../FileUploaderDropContainer';
 import FormItem from '../../FormItem';
+import { uniqueId } from '../../../tools/uniqueId';
 
 const prefix = 'cds';
-
-// -- copied from internal/tools/uniqueId.js
-let lastId = 0;
-function uid(prefix = 'id') {
-  lastId++;
-  return `${prefix}${lastId}`;
-}
-// -- end copied
 
 const ExampleDropContainerApp = (props) => {
   const [files, setFiles] = useState([]);
@@ -112,7 +105,7 @@ const ExampleDropContainerApp = (props) => {
     (evt, { addedFiles }) => {
       evt.stopPropagation();
       const newFiles = addedFiles.map((file) => ({
-        uuid: uid(),
+        uuid: uniqueId(),
         name: file.name,
         filesize: file.size,
         status: 'uploading',
@@ -177,7 +170,7 @@ const ExampleDropContainerApp = (props) => {
             ...rest
           }) => (
             <FileUploaderItem
-              key={uid()}
+              key={uniqueId()}
               uuid={uuid}
               name={name}
               filesize={filesize}

--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -20,7 +20,7 @@ import React, {
 import { keys, match, matches } from '../../internal/keyboard';
 import { useControllableState } from '../../internal/useControllableState';
 import { usePrefix } from '../../internal/usePrefix';
-import uniqueId from '../../tools/uniqueId';
+import { uniqueId } from '../../tools/uniqueId';
 import { useFeatureFlag } from '../FeatureFlags';
 
 export type TreeNodeProps = {

--- a/packages/react/src/components/TreeView/TreeView.tsx
+++ b/packages/react/src/components/TreeView/TreeView.tsx
@@ -11,7 +11,7 @@ import React, { useEffect, useRef, useState, type SyntheticEvent } from 'react';
 import { keys, match, matches } from '../../internal/keyboard';
 import { useControllableState } from '../../internal/useControllableState';
 import { usePrefix } from '../../internal/usePrefix';
-import uniqueId from '../../tools/uniqueId';
+import { uniqueId } from '../../tools/uniqueId';
 import { useFeatureFlag } from '../FeatureFlags';
 import TreeNode, { TreeNodeProps } from './TreeNode';
 

--- a/packages/react/src/tools/__tests__/uniqueId-test.js
+++ b/packages/react/src/tools/__tests__/uniqueId-test.js
@@ -1,13 +1,18 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import uniqueId from '../uniqueId';
-
 describe('uniqueId', () => {
+  let uniqueId;
+
+  beforeEach(() => {
+    jest.resetModules();
+    uniqueId = require('../uniqueId').uniqueId;
+  });
+
   it('increments unique id as expected', () => {
     const uniqueIdOne = uniqueId();
     const uniqueIdTwo = uniqueId();
@@ -18,6 +23,27 @@ describe('uniqueId', () => {
 
   it('accepts a custom prefix', () => {
     const uniqueIdThree = uniqueId('customPrefix');
-    expect(uniqueIdThree).toEqual('customPrefix3');
+
+    expect(uniqueIdThree).toEqual('customPrefix1');
+  });
+
+  it('should return a numeric id when an empty prefix is provided', () => {
+    const result = uniqueId('');
+
+    expect(result).toEqual('1');
+  });
+
+  it('should fall back to default prefix when `undefined` is provided', () => {
+    const result = uniqueId(undefined);
+
+    expect(result.startsWith('id')).toBe(true);
+  });
+
+  it('should increment properly across multiple prefixes', () => {
+    const first = uniqueId('a');
+    const second = uniqueId('b');
+
+    expect(first).toEqual('a1');
+    expect(second).toEqual('b2');
   });
 });

--- a/packages/react/src/tools/uniqueId.ts
+++ b/packages/react/src/tools/uniqueId.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 let lastId = 0;
 
-export default function uniqueId(prefix = 'id') {
+export const uniqueId = (prefix = 'id') => {
   lastId++;
   return `${prefix}${lastId}`;
-}
+};


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19089

Ported `uniqueId` to TypeScript and fixed tests.

#### Changelog

**New**

- Added tests.

**Changed**

- Ported `uniqueId` to TypeScript.
- Fixed the `accepts a custom prefix` test. The old test was not independent. If you added an `only` limitter to the test, it would fail.

**Removed**

- Deleted copies of `uniqueId`. It wasn't clear to me why these copies were necessary when the function could be imported. Maybe someone knows?

#### Testing / Reviewing

```sh
yarn test packages/react
```