### PR TITLE
fix(checkbox): add id to checkbox label

### DIFF
--- a/packages/web-components/src/components/checkbox/checkbox.ts
+++ b/packages/web-components/src/components/checkbox/checkbox.ts
@@ -108,7 +108,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
    * Specify a custom id for the checkbox
    */
   @property({ reflect: true })
-  id = '';
+  id = 'checkbox';
 
   /**
    * Specify whether the Checkbox is in an indeterminate state
@@ -267,7 +267,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         @change="${handleChange}"
         @click="${handleClick}" />
       <label
-        for="checkbox"
+        for="${ifDefined(id)}"
         part="label"
         class="${labelClasses}"
         title="${ifDefined(title)}">


### PR DESCRIPTION
Closes #19095 

The checkbox recently had an `id` attribute added as it was previously hardcoded, the `id` was passed into the checkbox `input` element. The corresponding `label` element also has to be updated to take the same `id` attribute in order for the checkbox status to update.

#### Changelog

**Changed**

- add `label`'s `for` attribute to take the `id` passed from user
- set default value for `id` to "checkbox"

#### Testing / Reviewing

Go to WC deploy preview and confirm you are able to check / uncheck the checkbox

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
