### PR TITLE
wc: fix(tag): align tooltip logic and a11y with React

### DIFF
--- a/packages/web-components/src/components/tag/dismissible-tag.ts
+++ b/packages/web-components/src/components/tag/dismissible-tag.ts
@@ -100,16 +100,16 @@ class CDSDismissibleTag extends HostListenerMixin(FocusMixin(CDSTag)) {
   };
 
   /**
-   * Text to show on tag "close" buttons
-   */
-  @property({ type: String, reflect: true })
-  title = 'Dismiss';
-
-  /**
    * `true` if the tag should be disabled
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
+
+  /**
+   * Provide a custom tooltip label for the dismiss button
+   */
+  @property({ type: String, attribute: 'dismiss-tooltip-label', reflect: true })
+  dismissTooltipLabel?: string;
 
   /**
    * `true` if the tag should be open.
@@ -149,10 +149,12 @@ class CDSDismissibleTag extends HostListenerMixin(FocusMixin(CDSTag)) {
       _hasEllipsisApplied: hasEllipsisApplied,
       tagTitle,
       text,
-      title,
+      dismissTooltipLabel,
     } = this;
 
     const dismissLabel = `Dismiss "${text}"`;
+    const dismissActionLabel =
+      dismissTooltipLabel || (hasEllipsisApplied ? dismissLabel : 'Dismiss');
 
     return html`
       <slot name="icon" @slotchange="${handleIconSlotChange}"></slot>
@@ -169,13 +171,13 @@ class CDSDismissibleTag extends HostListenerMixin(FocusMixin(CDSTag)) {
           <button
             class="sb-tooltip-trigger"
             role="button"
-            aria-labelledby="content"
+            aria-label="${dismissActionLabel}"
             class="${prefix}--tag__close-icon"
             ?disabled=${disabled}>
             ${Close16()}
           </button>
           <cds-tooltip-content id="content">
-            ${hasEllipsisApplied ? dismissLabel : title}
+            ${dismissActionLabel}
           </cds-tooltip-content>
         </cds-tooltip>
       </div>

--- a/packages/web-components/src/components/tag/dismissible-tag.ts
+++ b/packages/web-components/src/components/tag/dismissible-tag.ts
@@ -171,7 +171,7 @@ class CDSDismissibleTag extends HostListenerMixin(FocusMixin(CDSTag)) {
           <button
             class="sb-tooltip-trigger"
             role="button"
-            aria-label="${dismissActionLabel}"
+            aria-labelledby="content"
             class="${prefix}--tag__close-icon"
             ?disabled=${disabled}>
             ${Close16()}


### PR DESCRIPTION
Closes #18517

Fixes the tooltip behavior on `<cds-dismissible-tag>` to match the logic in the React implementation.

> [!NOTE]  
> I created a separate [PR](https://github.com/carbon-design-system/carbon/pull/19106) for React.

#### Changelog

**New**
- Added `dismissTooltipLabel` property

**Changed**
- Updated `dismissActionLabel` logic in `<cds-dismissible-tag>` to show:
  - `Dismiss "Label"` when ellipsis/truncation is applied
  - `Dismiss` when not
- Removed native `title` attribute from close button to avoid tooltip overlap
<img width="370" alt="image" src="https://github.com/user-attachments/assets/29933d6e-7f75-4baa-b827-a757f91077c0" />

#### Testing / Reviewing
- CI should pass

To test this in Storybook (Deploy Preview):

1. Go to Tag > Dismissible story.
2. Set a long text value (so it's truncated).
3. Hover over the close button (×) and check:
   - The tooltip shows your custom message.
<img width="774" alt="image" src="https://github.com/user-attachments/assets/0e89d3e8-2ae5-4ef1-8140-726c440f8680" />