### PR TITLE
fix(ModalWrapper): correct deprecation version from v12.x to v2.x

### DIFF
--- a/packages/react/src/components/ModalWrapper/ModalWrapper.tsx
+++ b/packages/react/src/components/ModalWrapper/ModalWrapper.tsx
@@ -54,7 +54,7 @@ export default class ModalWrapper extends React.Component<
   if(isDev) {
     warning(
       didWarnAboutDeprecation,
-      '`<ModalWrapper>` has been deprecated in favor of `<ComposedModal/>` and will be removed in the next major version, `@carbon/react@v12.x`'
+      '`<ModalWrapper>` has been deprecated in favor of `<ComposedModal/>` and will be removed in the next major version, `@carbon/react@v2.x`'
     );
     didWarnAboutDeprecation = true;
   }


### PR DESCRIPTION
Closes #19114
- Fixes incorrect deprecation version reference in ModalWrapper from this PR (19114)

#### Changelog
**Changed**
- Updated the deprecation message to correctly refer to removal in `@carbon/react@v2.x` instead of `v12.x`.

Testing / Reviewing
`yarn test packages/react`