### PR TITLE
refactor: port `isRequiredOneOf` to typescript

### DIFF
--- a/packages/react/src/prop-types/AriaPropTypes.js
+++ b/packages/react/src/prop-types/AriaPropTypes.js
@@ -6,7 +6,7 @@
  */
 
 import PropTypes from 'prop-types';
-import isRequiredOneOf from './isRequiredOneOf';
+import { isRequiredOneOf } from './isRequiredOneOf';
 
 export const AriaLabelPropType = isRequiredOneOf({
   'aria-label': PropTypes.string,

--- a/packages/react/src/prop-types/isRequiredOneOf.ts
+++ b/packages/react/src/prop-types/isRequiredOneOf.ts
@@ -1,20 +1,26 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { Validator, ValidationMap } from 'prop-types';
+
 /**
- * @param {[key: string]: Function)} propTypes The list of type checkers, keyed by prop names.
- * @returns {[key: string]: Function}
- *   The new prop type checkers that checks if one of the given props exist,
- *   in addition to the original type checkings.
+ * Returns a set of prop-type validators that enforce at least one of the
+ * specified props must be provided.
+ *
+ * @param propTypes - An object of prop-type validators. The keys of the object
+ *    are the names of the props, and the values are the prop-type validators.
+ * @returns A new object of wrapped prop-type validators.
  */
-export default function isRequiredOneOf(propTypes) {
+export const isRequiredOneOf = <T extends Record<string, Validator<any>>>(
+  propTypes: T
+): ValidationMap<any> => {
   const names = Object.keys(propTypes);
   const checker =
-    (propType) =>
+    (propType: Validator<any>): Validator<any> =>
     (props, propName, componentName, ...rest) => {
       if (
         process.env.NODE_ENV !== 'production' &&
@@ -29,10 +35,10 @@ export default function isRequiredOneOf(propTypes) {
       return propType(props, propName, componentName, ...rest);
     };
   return names.reduce(
-    (o, name) => ({
-      ...o,
+    (acc, name) => ({
+      ...acc,
       [name]: checker(propTypes[name]),
     }),
     {}
   );
-}
+};


### PR DESCRIPTION
No issue.

Ported `isRequiredOneOf` to TypeScript.

#### Changelog

**Changed**

- Ported `isRequiredOneOf` to TypeScript.

#### Testing / Reviewing

```sh
yarn test packages/react
```