### PR TITLE
fix: null text counter

### DIFF
--- a/packages/web-components/src/components/textarea/textarea.ts
+++ b/packages/web-components/src/components/textarea/textarea.ts
@@ -77,7 +77,7 @@ class CDSTextarea extends CDSTextInput {
   render() {
     const { enableCounter, maxCount } = this;
 
-    const textCount = this.value?.length;
+    const textCount = this.value?.length ?? 0;
 
     const invalidIcon = WarningFilled16({
       class: `${prefix}--text-area__invalid-icon`,


### PR DESCRIPTION
Closes #18844 

Fixes the textarea counter to display "0/maxCount" instead of "undefined/maxCount" when value is null or undefined

#### Changelog

**Changed**

```
const textCount = this.value?.length;
```
 to 

```
const textCount = this.value?.length ?? 0;
```
#### Testing / Reviewing

Test setting the textarea to empty string, null, and undefined values to ensure the counter works properly in all cases

