### PR TITLE
feat: add prop-types to `TableCell`

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -1972,6 +1972,23 @@ Map {
     },
     "TableCell": Object {
       "$$typeof": Symbol(react.forward_ref),
+      "propTypes": Object {
+        "children": Object {
+          "type": "node",
+        },
+        "className": Object {
+          "type": "string",
+        },
+        "colSpan": Object {
+          "type": "number",
+        },
+        "hasAILabelHeader": Object {
+          "type": "bool",
+        },
+        "headers": Object {
+          "type": "string",
+        },
+      },
       "render": [Function],
     },
     "TableContainer": Object {
@@ -7888,6 +7905,23 @@ Map {
   },
   "TableCell" => Object {
     "$$typeof": Symbol(react.forward_ref),
+    "propTypes": Object {
+      "children": Object {
+        "type": "node",
+      },
+      "className": Object {
+        "type": "string",
+      },
+      "colSpan": Object {
+        "type": "number",
+      },
+      "hasAILabelHeader": Object {
+        "type": "bool",
+      },
+      "headers": Object {
+        "type": "string",
+      },
+    },
     "render": [Function],
   },
   "TableContainer" => Object {

--- a/packages/react/src/components/DataTable/TableCell.tsx
+++ b/packages/react/src/components/DataTable/TableCell.tsx
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 import { ReactAttr } from '../../types/common';
+import PropTypes from 'prop-types';
 
 export interface TableCellProps extends ReactAttr<HTMLTableCellElement> {
   /**
@@ -37,24 +38,48 @@ export interface TableCellProps extends ReactAttr<HTMLTableCellElement> {
   headers?: string;
 }
 
-const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
-  ({ children, className, hasAILabelHeader, colSpan, ...rest }, ref) => {
-    const prefix = usePrefix();
+const frFn = forwardRef<HTMLTableCellElement, TableCellProps>;
 
-    const tableCellClassNames = classNames(className, {
-      [`${prefix}--table-cell--column-slug`]: hasAILabelHeader,
-    });
-    return (
-      <td
-        className={tableCellClassNames ? tableCellClassNames : undefined}
-        ref={ref}
-        colSpan={colSpan}
-        {...rest}>
-        {children}
-      </td>
-    );
-  }
-);
+const TableCell = frFn((props, ref) => {
+  const { children, className, hasAILabelHeader, colSpan, ...rest } = props;
+  const prefix = usePrefix();
+
+  const tableCellClassNames = classNames(className, {
+    [`${prefix}--table-cell--column-slug`]: hasAILabelHeader,
+  });
+  return (
+    <td
+      className={tableCellClassNames ? tableCellClassNames : undefined}
+      ref={ref}
+      colSpan={colSpan}
+      {...rest}>
+      {children}
+    </td>
+  );
+});
 
 TableCell.displayName = 'TableCell';
+TableCell.propTypes = {
+  /**
+   * Pass in children that will be embedded in the table header label
+   */
+  children: PropTypes.node,
+  /**
+   * Specify an optional className to be applied to the container node
+   */
+  className: PropTypes.string,
+  /**
+   * The width of the expanded row's internal cell
+   */
+  colSpan: PropTypes.number,
+  /**
+   * Specify if the table cell is in an AI column
+   */
+  hasAILabelHeader: PropTypes.bool,
+  /**
+   * The id of the matching th node in the table head. Addresses a11y concerns outlined here: https://www.ibm.com/able/guidelines/ci162/info_and_relationships.html and https://www.w3.org/TR/WCAG20-TECHS/H43
+   */
+  headers: PropTypes.string,
+};
+
 export default TableCell;


### PR DESCRIPTION
Partially addresses https://github.com/carbon-design-system/carbon/issues/19144

Added prop-types to `TableCell`.

#### Changelog

**New**

- Added prop-types to `TableCell`.

#### Testing / Reviewing

```sh
yarn test packages/react
```