### PR TITLE
fix(Dropdown): fix type declarations to include ref

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -284,7 +284,7 @@ function stateReducer(state, actionAndChanges) {
   }
 }
 
-const Dropdown = React.forwardRef<HTMLButtonElement, DropdownProps<any>>(
+const Dropdown = React.forwardRef(
   <ItemType,>(
     {
       autoAlign = false,

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -11,6 +11,7 @@ import React, {
   isValidElement,
   MouseEvent,
   ReactNode,
+  Ref,
   useCallback,
   useContext,
   useEffect,
@@ -84,8 +85,7 @@ export interface OnChangeData<ItemType> {
 
 export interface DropdownProps<ItemType>
   extends Omit<ReactAttr<HTMLDivElement>, ExcludedAttributes>,
-    TranslateWithId<ListBoxMenuIconTranslationKey>,
-    React.RefAttributes<HTMLDivElement> {
+    TranslateWithId<ListBoxMenuIconTranslationKey> {
   /**
    * Specify a label to be read by screen readers on the container node
    * 'aria-label' of the ListBox component.
@@ -284,7 +284,7 @@ function stateReducer(state, actionAndChanges) {
   }
 }
 
-const Dropdown = React.forwardRef(
+const Dropdown = React.forwardRef<HTMLButtonElement, DropdownProps<any>>(
   <ItemType,>(
     {
       autoAlign = false,
@@ -726,14 +726,11 @@ const Dropdown = React.forwardRef(
   }
 );
 
-type DropdownComponentProps<ItemType> = React.PropsWithoutRef<
-  React.PropsWithChildren<DropdownProps<ItemType>> &
-    React.RefAttributes<HTMLButtonElement>
->;
-
-export interface DropdownComponent {
+// Workaround problems with forwardRef() and generics.  In the long term, should stop using forwardRef().
+// See https://stackoverflow.com/questions/58469229/react-with-typescript-generics-while-using-react-forwardref.
+interface DropdownComponent {
   <ItemType>(
-    props: DropdownComponentProps<ItemType>
+    props: DropdownProps<ItemType> & { ref?: Ref<HTMLButtonElement> }
   ): React.ReactElement<any> | null;
 }
 


### PR DESCRIPTION
Refs #13022.

Like most Carbon components, `Dropdown` can take a `ref`, but for some reason that was hidden in its public type.

Also cleared up some contradicting code: The `ref` is on an `HTMLButtonElement` not an `HTMLDivElement`.


#### Changelog

**Changed**

- Exported type of Dropdown now includes `ref`.

#### Testing / Reviewing

Ran lint and build, and then tested against my own to confirm that it let me get rid of the `@ts-expect-error` directives when passing `ref` to a `Dropdown`.

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
