### PR TITLE
fix: overflow order stability, and better hidden-items calculation

### DIFF
--- a/packages/utilities/src/overflowHandler/overflowHandler-test.js
+++ b/packages/utilities/src/overflowHandler/overflowHandler-test.js
@@ -101,7 +101,7 @@ describe('createOverflowHandler (width)', () => {
       [500, 10, 0], // All items fit
       [400, 8, 2], // Fits first 7 items
       [200, 4, 6], // Fits first 3 items
-      [80, 2, 8],
+      [90, 2, 8],
       [0, 0, 10],
     ])(
       'When container width is %ipx, expect %i visible and %i hidden',
@@ -166,7 +166,7 @@ describe('createOverflowHandler (height)', () => {
       [500, 10, 0],
       [400, 8, 2],
       [200, 4, 6],
-      [80, 2, 8],
+      [90, 2, 8],
       [0, 0, 10],
     ])(
       'When container height is %ipx, expect %i visible and %i hidden',

--- a/packages/utilities/src/overflowHandler/overflowHandler.ts
+++ b/packages/utilities/src/overflowHandler/overflowHandler.ts
@@ -122,7 +122,7 @@ export function updateOverflowHandler({
     }
   }
 
-  onChange(visibleItems, hiddenItems);
+  hiddenItems.length && onChange(visibleItems, hiddenItems);
   return hiddenItems;
 }
 


### PR DESCRIPTION
Contributes to #18644 

made the calculation stable by adding break index, 

| before | after |
| - | - |
| <video src="https://github.com/user-attachments/assets/9f5229a2-3b09-4bd7-8429-2e24bda99017" controls></video> | <video src="https://github.com/user-attachments/assets/c6e7237d-19b3-484e-885c-9c29a9b98d79" controls></video> |

fixes hidden tag issues where we dismiss tags (either from popover or outside) , and the offset still shows up.

| before | after |
| - | - |
| <video src="https://github.com/user-attachments/assets/659e4318-4614-4863-96c9-19d406feba43" controls></video> | <video src="https://github.com/user-attachments/assets/f795066d-2274-4945-863d-cd3bc3aa311e" controls></video> |

#### Changelog

**Changed**

- refacors and handles cases with overflow order stability and hidden item calculation when dismissed

#### Testing / Reviewing
manually
https://stackblitz.com/edit/vitejs-vite-k37jbujd?file=index.html
used the new version of the utility in previous [examples](https://github.com/carbon-design-system/carbon/pull/18644) (iteration 2), and no regression was observed.
automated tests updated
