### PR TITLE
chore: add Sass entry point for @carbon/colors

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "sass": "index.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/carbon-design-system/carbon.git",


### PR DESCRIPTION
This is a follow-up for #18955 which just adds a Sass entry point for one library I missed, `@carbon/colors`.

#### Changelog

**New**

- Add sass entrypoint to the `@carbon/colors` package

#### Testing / Reviewing

#### Other

I missed this because the `index.scss` file is generated as part of the build step
