### PR TITLE
feat: add `useRef` types

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -6,16 +6,11 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useRef } from 'react';
+import React from 'react';
 import { IconButton, IconButtonKind, IconButtonKinds } from '../IconButton';
-import { composeEventHandlers } from '../../tools/events';
-import { PolymorphicProps } from '../../types/common';
 import { PopoverAlignment } from '../Popover';
 import ButtonBase from './ButtonBase';
-import {
-  PolymorphicComponentPropWithRef,
-  PolymorphicRef,
-} from '../../internal/PolymorphicProps';
+import { PolymorphicComponentPropWithRef } from '../../internal/PolymorphicProps';
 
 export const ButtonKinds = [
   'primary',
@@ -150,7 +145,6 @@ const Button: ButtonComponent = React.forwardRef(
     props: ButtonProps<T>,
     ref: React.Ref<unknown>
   ) => {
-    const tooltipRef = useRef(null);
     const {
       as,
       autoAlign = false,
@@ -178,13 +172,6 @@ const Button: ButtonComponent = React.forwardRef(
           'This may impact accessibility for screen reader users.'
       );
     }
-
-    const handleClick = (evt: React.MouseEvent) => {
-      // Prevent clicks on the tooltip from triggering the button click event
-      if (evt.target === tooltipRef.current) {
-        evt.preventDefault();
-      }
-    };
 
     const iconOnlyImage = !ButtonImageElement ? null : <ButtonImageElement />;
 
@@ -235,7 +222,7 @@ const Button: ButtonComponent = React.forwardRef(
           onFocus={onFocus}
           onBlur={onBlur}
           autoAlign={autoAlign}
-          onClick={composeEventHandlers([onClick, handleClick])}
+          onClick={onClick}
           renderIcon={iconOnlyImage ? null : ButtonImageElement} // avoid doubling the icon.
         >
           {iconOnlyImage ?? children}

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -388,7 +388,7 @@ export interface DatePickerProps {
    * The value of the date value provided to flatpickr, could
    * be a date, a date number, a date string, an array of dates.
    */
-  value?: string | number | (string | number | object)[] | object | undefined;
+  value?: DateOption | DateOption[];
 
   /**
    * Specify whether the control is currently in warning state (Fluid only)
@@ -443,11 +443,12 @@ const DatePicker = React.forwardRef(function DatePicker(
   }, []);
 
   const lastStartValue = useRef('');
+  const calendarRef = useRef<Instance>(null);
 
   interface CalendarCloseEvent {
     selectedDates: Date[];
     dateStr: string;
-    instance: object; //This is `Intance` of flatpicker
+    instance: Instance;
   }
   const [calendarCloseEvent, setCalendarCloseEvent] =
     useState<CalendarCloseEvent | null>(null);
@@ -461,7 +462,7 @@ const DatePicker = React.forwardRef(function DatePicker(
         !startInputField.current.value
       ) {
         startInputField.current.value = lastStartValue.current;
-        calendarRef.current.setDate(
+        calendarRef.current?.setDate(
           [startInputField.current.value, endInputField?.current?.value],
           true,
           calendarRef.current.config.dateFormat
@@ -488,7 +489,6 @@ const DatePicker = React.forwardRef(function DatePicker(
   }, [calendarCloseEvent, handleCalendarClose]);
 
   const endInputField = useRef<HTMLTextAreaElement>(null);
-  const calendarRef: any | undefined = useRef(null);
   const savedOnChange = useSavedCallback(onChange);
 
   const savedOnOpen = useSavedCallback(onOpen);
@@ -623,7 +623,7 @@ const DatePicker = React.forwardRef(function DatePicker(
 
     const { current: start } = startInputField;
     const { current: end } = endInputField;
-    const flatpickerconfig: any = {
+    const flatpickerConfig: any = {
       inline: inline ?? false,
       onClose: onCalendarClose,
       disableMobile: true,
@@ -678,7 +678,7 @@ const DatePicker = React.forwardRef(function DatePicker(
       },
       onValueUpdate: onHook,
     };
-    const calendar = flatpickr(start, flatpickerconfig);
+    const calendar = flatpickr(start, flatpickerConfig);
 
     calendarRef.current = calendar;
 
@@ -694,12 +694,12 @@ const DatePicker = React.forwardRef(function DatePicker(
         const {
           calendarContainer,
           selectedDateElem: fpSelectedDateElem,
-          todayDateElem: fptodayDateElem,
+          todayDateElem: fpTodayDateElem,
         } = calendar;
         const selectedDateElem =
           calendarContainer.querySelector('.selected') && fpSelectedDateElem;
         const todayDateElem =
-          calendarContainer.querySelector('.today') && fptodayDateElem;
+          calendarContainer.querySelector('.today') && fpTodayDateElem;
         (
           (selectedDateElem ||
             todayDateElem ||
@@ -813,48 +813,48 @@ const DatePicker = React.forwardRef(function DatePicker(
   }));
 
   useEffect(() => {
-    if (calendarRef?.current?.set) {
+    if (calendarRef.current?.set) {
       calendarRef.current.set({ dateFormat });
     }
   }, [dateFormat]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set) {
+    if (calendarRef.current?.set) {
       calendarRef.current.set('minDate', minDate);
     }
   }, [minDate]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set) {
+    if (calendarRef.current?.set) {
       calendarRef.current.set('allowInput', allowInput);
     }
   }, [allowInput]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set) {
+    if (calendarRef.current?.set) {
       calendarRef.current.set('maxDate', maxDate);
     }
   }, [maxDate]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set && disable) {
+    if (calendarRef.current?.set && disable) {
       calendarRef.current.set('disable', disable);
     }
   }, [disable]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set && enable) {
+    if (calendarRef.current?.set && enable) {
       calendarRef.current.set('enable', enable);
     }
   }, [enable]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set && inline) {
+    if (calendarRef.current?.set && inline) {
       calendarRef.current.set('inline', inline);
     }
   }, [inline]);
   useEffect(() => {
-    //when value prop is set to empty, this clears the faltpicker's calendar instance and text input
+    //when value prop is set to empty, this clears the flatpicker's calendar instance and text input
     if (value === '') {
       calendarRef.current?.clear();
       if (startInputField.current) {
@@ -885,10 +885,10 @@ const DatePicker = React.forwardRef(function DatePicker(
     };
 
     const closeCalendar = (event) => {
-      calendarRef.current.close();
+      calendarRef.current?.close();
       // Remove focus from endDate calendar input
       onCalendarClose(
-        calendarRef.current.selectedDates,
+        calendarRef.current?.selectedDates,
         '',
         calendarRef.current,
         { type: 'clickOutside' }
@@ -902,7 +902,7 @@ const DatePicker = React.forwardRef(function DatePicker(
   }, [calendarRef, startInputField, endInputField, onCalendarClose]);
 
   useEffect(() => {
-    if (calendarRef?.current?.set) {
+    if (calendarRef.current?.set) {
       if (value !== undefined) {
         calendarRef.current.setDate(value);
       }
@@ -920,7 +920,7 @@ const DatePicker = React.forwardRef(function DatePicker(
         match(event, keys.Tab) &&
         !event.shiftKey &&
         document.activeElement === endInputField.current &&
-        calendarRef.current.isOpen
+        calendarRef.current?.isOpen
       ) {
         calendarRef.current.close();
         onCalendarClose(

--- a/packages/react/src/components/Dialog/index.tsx
+++ b/packages/react/src/components/Dialog/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2014, 2024
+ * Copyright IBM Corp. 2014, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -82,7 +82,7 @@ export const unstable__Dialog = React.forwardRef(
     // If the parent component has not passed a ref for forwardRef, forwardRef
     // will be null. A "backup" ref is needed to ensure the dialog's instance
     // methods can always be called within this component.
-    const backupRef = useRef(null);
+    const backupRef = useRef<HTMLDialogElement>(null);
     const ref = (forwardRef ??
       backupRef) as MutableRefObject<HTMLDialogElement>;
 

--- a/packages/react/src/components/Notification/Notification.tsx
+++ b/packages/react/src/components/Notification/Notification.tsx
@@ -416,7 +416,7 @@ export function ToastNotification({
     [`${prefix}--toast-notification--${kind}`]: kind,
   });
 
-  const contentRef = useRef(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   useNoInteractiveChildren(contentRef);
 
   const handleClose = (evt) => {
@@ -424,7 +424,7 @@ export function ToastNotification({
       setIsOpen(false);
     }
   };
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   function handleCloseButtonClick(event: MouseEvent) {
     onCloseButtonClick(event);
@@ -683,7 +683,7 @@ export function InlineNotification({
     [`${prefix}--inline-notification--hide-close-button`]: hideCloseButton,
   });
 
-  const contentRef = useRef(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   useNoInteractiveChildren(contentRef);
 
   const handleClose = (evt) => {
@@ -691,7 +691,7 @@ export function InlineNotification({
       setIsOpen(false);
     }
   };
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   function handleCloseButtonClick(event) {
     onCloseButtonClick(event);
@@ -1310,7 +1310,7 @@ export function Callout({
     [`${prefix}--actionable-notification--hide-close-button`]: true,
   });
 
-  const childrenContainer = useRef(null);
+  const childrenContainer = useRef<HTMLDivElement>(null);
   useInteractiveChildrenNeedDescription(
     childrenContainer,
     `interactive child node(s) should have an \`aria-describedby\` property with a value matching the value of \`titleId\``

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -427,7 +427,7 @@ const TextArea = forwardRef<TTextArea, TextAreaProps>((props, forwardRef) => {
     }
   }
 
-  const announcerRef = useRef(null);
+  const announcerRef = useRef<HTMLSpanElement>(null);
   const [prevAnnouncement, setPrevAnnouncement] = useState('');
   const ariaAnnouncement = useAnnouncer(
     textCount,

--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -322,7 +322,7 @@ const TextInput = React.forwardRef(function TextInput(
   );
 
   const { isFluid } = useContext(FormContext);
-  const announcerRef = useRef(null);
+  const announcerRef = useRef<HTMLSpanElement>(null);
   const [prevAnnouncement, setPrevAnnouncement] = useState('');
   const ariaAnnouncement = useAnnouncer(textCount, maxCount);
   useEffect(() => {


### PR DESCRIPTION
No issue.

Added `useRef` types.

#### Changelog

**New**

- Added `useRef` types.

**Changed**

- Fixed `DatePicker` types related to refs.

**Removed**

- Deleted `tooltipRef` and `handleClick` in the `Button` component since both are effectively dead code. `tooltipRef` is never set. Thus, `evt.target === tooltipRef.current` will always be `false`.

#### Testing / Reviewing

```sh
yarn test packages/react
```