### PR TITLE
fix(MultiSelect): update types

### DIFF
--- a/packages/react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.tsx
@@ -914,7 +914,7 @@ export const MultiSelect = React.forwardRef(
       </div>
     );
   }
-);
+) as MultiSelectComponent;
 
 type MultiSelectComponentProps<ItemType> = React.PropsWithChildren<
   MultiSelectProps<ItemType>
@@ -922,6 +922,8 @@ type MultiSelectComponentProps<ItemType> = React.PropsWithChildren<
   React.RefAttributes<HTMLButtonElement>;
 
 interface MultiSelectComponent {
+  propTypes: Record<string, any>;
+  displayName: string;
   <ItemType>(
     props: MultiSelectComponentProps<ItemType>
   ): React.ReactElement<any> | null;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19242

Fixed `MultiSelect` types.

#### Changelog

**New**

- Added types for `displayName` and `propTypes` to the component interface.

**Changed**

- Fixed `MultiSelect` types.

#### Testing / Reviewing

Paste the following code in packages/react/src/components/MultiSelect/index.tsx or any typescript file in the project and check that there are no errors.

```tsx
import { MultiSelect } from './MultiSelect';

const Component = () => {
  return (
    <MultiSelect
      id={''}
      items={[
        { name: 'one', value: 'one' },
        { name: 'two', value: 'two' },
        { name: 'three', value: 'three' },
      ]}
      selectedItems={[{ name: 'one', value: 'one' }]}
      itemToString={(item) => (item ? item.name : '')}
      itemToElement={({ name, value }) => (
        <div>
          {name} {value}
        </div>
      )}
      label={''}
    />
  );
};

```