### PR TITLE
fix: box sizing on the tag

### DIFF
--- a/packages/web-components/src/components/tag/tag.scss
+++ b/packages/web-components/src/components/tag/tag.scss
@@ -20,6 +20,8 @@ $css--plex: true !default;
 :host(#{$prefix}-tag),
 :host(#{$prefix}-dismissible-tag) {
   @extend .#{$prefix}--tag;
+
+  box-sizing: border-box;
 }
 
 :host(#{$prefix}-selectable-tag),


### PR DESCRIPTION
Contributes to #18774

the react version of tag returns a button, that inherits the user agent styles of button the browser provides (box-sizing included).
however wc tags (those having the border) being a custom element with role="button". doesn't get any user agent styles unless it extends `HTMLButtonElement`. they couldn't inherit as well due to shadow dom encapsulation. so manually adding box-sizing would fix this

| before | After |
| ------ | ------ |
| <img width="1202" alt="Screenshot 2025-04-28 at 1 38 54 PM" src="https://github.com/user-attachments/assets/39bd09c5-cabf-4f45-bf2c-ac3254b7f7f0" /> | <img width="1202" alt="Screenshot 2025-04-28 at 1 39 00 PM" src="https://github.com/user-attachments/assets/7bd54247-7698-41e9-b21c-b236d3d0c954" /> |

#### Changelog

**Changed**

- added box sizing to variants that has borders

#### Testing / Reviewing

visually through storybook
