### PR TITLE
fix: Tab tip popover alignment to follow spec

### DIFF
--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -277,35 +277,39 @@ export const Popover: PopoverComponent & {
             ),
             autoAlign &&
               flip({
-                fallbackPlacements: align.includes('bottom')
-                  ? [
-                      'bottom',
-                      'bottom-start',
-                      'bottom-end',
-                      'right',
-                      'right-start',
-                      'right-end',
-                      'left',
-                      'left-start',
-                      'left-end',
-                      'top',
-                      'top-start',
-                      'top-end',
-                    ]
-                  : [
-                      'top',
-                      'top-start',
-                      'top-end',
-                      'left',
-                      'left-start',
-                      'left-end',
-                      'right',
-                      'right-start',
-                      'right-end',
-                      'bottom',
-                      'bottom-start',
-                      'bottom-end',
-                    ],
+                fallbackPlacements: isTabTip
+                  ? align.includes('bottom')
+                    ? ['bottom-start', 'bottom-end', 'top-start', 'top-end']
+                    : ['top-start', 'top-end', 'bottom-start', 'bottom-end']
+                  : align.includes('bottom')
+                    ? [
+                        'bottom',
+                        'bottom-start',
+                        'bottom-end',
+                        'right',
+                        'right-start',
+                        'right-end',
+                        'left',
+                        'left-start',
+                        'left-end',
+                        'top',
+                        'top-start',
+                        'top-end',
+                      ]
+                    : [
+                        'top',
+                        'top-start',
+                        'top-end',
+                        'left',
+                        'left-start',
+                        'left-end',
+                        'right',
+                        'right-start',
+                        'right-end',
+                        'bottom',
+                        'bottom-start',
+                        'bottom-end',
+                      ],
 
                 fallbackStrategy: 'initialPlacement',
                 fallbackAxisSideDirection: 'start',


### PR DESCRIPTION
Closes #18379 

Fixing tab tip popover alignment to follow spec

#### Changelog

**Changed**

- Updated Popover component to restrict tab tip popover alignments to follow spec (only top-start, top-end, bottom-start, bottom-end)
- Fixed issue where tab tip popovers were using a centered alignment (off-spec)
- Prevented tab tip popovers from aligning to the sides of the trigger

#### Testing / Reviewing

- [ ]  Navigate to the tab tip popover story

- [ ] Scroll around and verify tab tip popovers only align in the four correct positions:
      Top-start (left)
      Top-end (right)
      Bottom-start (left)
      Bottom-end (right)


- [ ] Verify popover only flips vertically (top to bottom or bottom to top), not horizontally
- [ ] Ensure there's no "centered" alignment visible
- [ ] Compare behavior to OverflowMenu which was fixed in PR #17248
