### PR TITLE
test(checkbox): unit tests and snapshot for checkbox

### DIFF
--- a/packages/web-components/src/components/checkbox/__tests__/__snapshots__/checkbox-group-test.snap.js
+++ b/packages/web-components/src/components/checkbox/__tests__/__snapshots__/checkbox-group-test.snap.js
@@ -1,0 +1,11 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots['cds-checkbox-group should render'] = `<cds-checkbox-group
+  legend-text="Checkbox heading"
+  orientation="vertical"
+  warn-text=""
+>
+</cds-checkbox-group>
+`;
+/* end snapshot cds-checkbox-group should render */

--- a/packages/web-components/src/components/checkbox/__tests__/__snapshots__/checkbox-test.snap.js
+++ b/packages/web-components/src/components/checkbox/__tests__/__snapshots__/checkbox-test.snap.js
@@ -1,0 +1,8 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots['cds-checkbox should render'] = `<cds-checkbox id="checkbox">
+  Checkbox Label
+</cds-checkbox>
+`;
+/* end snapshot cds-checkbox should render */

--- a/packages/web-components/src/components/checkbox/__tests__/checkbox-group-test.js
+++ b/packages/web-components/src/components/checkbox/__tests__/checkbox-group-test.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/checkbox/index.js';
+
+describe('cds-checkbox-group', function () {
+  it('should render', async () => {
+    const group = html`<cds-checkbox-group
+      legend-text="Checkbox heading"></cds-checkbox-group>`;
+    const el = await fixture(group);
+    expect(el).dom.to.equalSnapshot();
+  });
+
+  it('should render helper-text', async () => {
+    const group = html`<cds-checkbox-group
+      legend-text="Checkbox heading"
+      helper-text="Helper text"></cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const helperText = el.shadowRoot.querySelector('.cds--form__helper-text');
+
+    expect(helperText).to.exist;
+    expect(helperText.textContent.trim()).to.equal('Helper text');
+  });
+
+  it('should set data-invalid when invalid attribute is true', async () => {
+    const group = html` <cds-checkbox-group
+      invalid
+      legend-text="Checkbox heading">
+      <cds-checkbox default-checked>Checkbox label</cds-checkbox>
+      <cds-checkbox>Checkbox label</cds-checkbox>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const fieldsetElement = el.shadowRoot.querySelector('fieldset');
+    expect(fieldsetElement.hasAttribute('data-invalid')).to.be.true;
+  });
+
+  it('should display invalid-text if invalid attribute is true', async () => {
+    const group = html` <cds-checkbox-group
+      invalid
+      invalid-text="Invalid text"
+      legend-text="Checkbox heading">
+      <cds-checkbox default-checked>Checkbox label</cds-checkbox>
+      <cds-checkbox>Checkbox label</cds-checkbox>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const invalidText = el.shadowRoot.querySelector('.cds--form-requirement');
+
+    expect(invalidText).to.exist;
+    expect(invalidText.textContent.trim()).to.equal('Invalid text');
+  });
+
+  it('should render legend-text', async () => {
+    const group = html`<cds-checkbox-group
+      legend-text="Checkbox heading"></cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const legend = el.shadowRoot.querySelector('legend');
+
+    expect(legend).to.exist;
+    expect(legend.textContent.trim()).to.equal('Checkbox heading');
+  });
+
+  it('should respect readOnly prop', async () => {
+    const group = html` <cds-checkbox-group
+      legend-text="Checkbox heading"
+      readOnly>
+      <cds-checkbox default-checked>Checkbox label</cds-checkbox>
+      <cds-checkbox>Checkbox label</cds-checkbox>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const fieldsetElement = el.shadowRoot.querySelector('fieldset');
+    expect(fieldsetElement.hasAttribute('aria-disabled')).to.be.true;
+  });
+
+  it('should respect warn prop', async () => {
+    const group = html` <cds-checkbox-group legend-text="Checkbox heading" warn>
+      <cds-checkbox default-checked>Checkbox label</cds-checkbox>
+      <cds-checkbox>Checkbox label</cds-checkbox>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const warnIcon = el.shadowRoot.querySelector(
+      '.cds--checkbox__invalid-icon--warning'
+    );
+    expect(warnIcon).to.exist;
+  });
+
+  it('should display warn-text if warn attribute is true', async () => {
+    const group = html` <cds-checkbox-group
+      legend-text="Checkbox heading"
+      warn
+      warn-text="Warn text">
+      <cds-checkbox default-checked>Checkbox label</cds-checkbox>
+      <cds-checkbox>Checkbox label</cds-checkbox>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const warnText = el.shadowRoot.querySelector('.cds--form-requirement');
+
+    expect(warnText).to.exist;
+    expect(warnText.textContent.trim()).to.equal('Warn text');
+  });
+
+  it('should respect deprecated slug prop', async () => {
+    const group = html` <cds-checkbox-group legend-text="Checkbox heading">
+      <cds-ai-label slot="slug" alignment="bottom-left">
+        <div slot="body-text">
+          <p class="secondary">AI Explained</p>
+          <h2 class="ai-label-heading">84%</h2>
+          <p class="secondary bold">Confidence score</p>
+          <p class="secondary">
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+          <hr />
+          <p class="secondary">Model type</p>
+          <p class="bold">Foundation model</p>
+        </div>
+      </cds-ai-label>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const slot = el.shadowRoot.querySelector('slot[name="slug"]');
+    const assigned = slot.assignedNodes({ flatten: true });
+
+    const aiLabel = assigned.find(
+      (node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.tagName.toLowerCase() === 'cds-ai-label'
+    );
+
+    expect(aiLabel).to.exist;
+  });
+
+  it('should respect decorator prop', async () => {
+    const group = html` <cds-checkbox-group legend-text="Checkbox heading">
+      <cds-ai-label slot="decorator" alignment="bottom-left">
+        <div slot="body-text">
+          <p class="secondary">AI Explained</p>
+          <h2 class="ai-label-heading">84%</h2>
+          <p class="secondary bold">Confidence score</p>
+          <p class="secondary">
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+          <hr />
+          <p class="secondary">Model type</p>
+          <p class="bold">Foundation model</p>
+        </div>
+      </cds-ai-label>
+    </cds-checkbox-group>`;
+    const el = await fixture(group);
+
+    const slot = el.shadowRoot.querySelector('slot[name="decorator"]');
+    const assigned = slot.assignedNodes({ flatten: true });
+
+    const aiLabel = assigned.find(
+      (node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.tagName.toLowerCase() === 'cds-ai-label'
+    );
+
+    expect(aiLabel).to.exist;
+  });
+
+  it('should render checkboxes horizontally', async () => {
+    const group = html` <cds-checkbox-group
+      orientation="horizontal"
+      legend-text="test-horizontal-prop">
+      <cds-checkbox>Checkbox label 1</cds-checkbox>
+      <cds-checkbox>Checkbox label 2</cds-checkbox>
+      <cds-checkbox>Checkbox label 3</cds-checkbox>
+    </cds-checkbox-group>`;
+
+    const el = await fixture(group);
+
+    const fieldsetElement = el.shadowRoot.querySelector('fieldset');
+    expect(
+      fieldsetElement.classList.contains('cds--checkbox-group--horizontal')
+    ).to.be.true;
+  });
+});

--- a/packages/web-components/src/components/checkbox/__tests__/checkbox-skeleton-test.js
+++ b/packages/web-components/src/components/checkbox/__tests__/checkbox-skeleton-test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/checkbox/index.js';
+
+describe('cds-checkbox-skeleton', function () {
+  it('should render', async () => {
+    const skeleton = html`<cds-checkbox-skeleton></cds-checkbox-skeleton>`;
+    const el = await fixture(skeleton);
+    expect(el).dom.to.equalSnapshot();
+  });
+});

--- a/packages/web-components/src/components/checkbox/__tests__/checkbox-test.js
+++ b/packages/web-components/src/components/checkbox/__tests__/checkbox-test.js
@@ -1,0 +1,273 @@
+/**
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import '@carbon/web-components/es/components/checkbox/index.js';
+
+describe('cds-checkbox', function () {
+  it('should render', async () => {
+    const checkbox = html`<cds-checkbox>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+    expect(el).dom.to.equalSnapshot();
+  });
+
+  it('should set the `id` on the <input> element', async () => {
+    const checkbox = html`<cds-checkbox id="test"></cds-checkbox>`;
+    const el = await fixture(checkbox);
+    const inputElement = el.shadowRoot.querySelector('input');
+
+    expect(inputElement.getAttribute('id')).to.equal('test');
+  });
+
+  it('should label the input by the given label-text', async () => {
+    const checkbox = html`<cds-checkbox>test label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    expect(el.textContent.trim()).to.equal('test label');
+  });
+
+  it('should use default-checked to set the default value of the <input> checkbox', async () => {
+    const checkbox = html`<cds-checkbox default-checked
+      >Checkbox Label</cds-checkbox
+    >`;
+    const el = await fixture(checkbox);
+
+    const inputElement = el.shadowRoot.querySelector('input');
+
+    expect(inputElement.hasAttribute('checked')).to.be.true;
+  });
+
+  it('should disable the <input> if disabled is provided as an attribute', async () => {
+    const checkbox = html`<cds-checkbox disabled>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const inputElement = el.shadowRoot.querySelector('input');
+    expect(inputElement.hasAttribute('disabled')).to.be.true;
+  });
+
+  it('should set checked on the <input> if checked is provided as a prop', async () => {
+    const checked = html`<cds-checkbox checked>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checked);
+
+    const inputElement = el.shadowRoot.querySelector('input');
+    expect(inputElement.hasAttribute('checked')).to.be.true;
+
+    const notChecked = html`<cds-checkbox>Checkbox Label</cds-checkbox>`;
+    const elem = await fixture(notChecked);
+
+    const inputElem = elem.shadowRoot.querySelector('input');
+    expect(inputElem.hasAttribute('checked')).to.be.false;
+  });
+
+  it('should hide the label if hide-label is provided as an attribute', async () => {
+    const checkbox = html`<cds-checkbox hide-label
+      >Checkbox Label</cds-checkbox
+    >`;
+    const el = await fixture(checkbox);
+
+    const labelSpanElement = el.shadowRoot.querySelector('label span');
+    expect(labelSpanElement.classList.contains('cds--visually-hidden')).to.be
+      .true;
+  });
+
+  it('should render helper-text', async () => {
+    const checkbox = html`<cds-checkbox helper-text="Helper text"
+      >Checkbox Label</cds-checkbox
+    >`;
+    const el = await fixture(checkbox);
+
+    const helper = el.shadowRoot.querySelector('.cds--form__helper-text');
+
+    expect(helper).to.exist;
+    expect(helper.textContent.trim()).to.equal('Helper text');
+  });
+
+  it('should set data-invalid when invalid attribute is true', async () => {
+    const checkbox = html`<cds-checkbox invalid>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const inputElement = el.shadowRoot.querySelector('input');
+    expect(inputElement.hasAttribute('data-invalid')).to.be.true;
+  });
+
+  it('should display invalid-text if invalid prop is true', async () => {
+    const checkbox = html`<cds-checkbox invalid invalid-text="Invalid text"
+      >Checkbox Label</cds-checkbox
+    >`;
+    const el = await fixture(checkbox);
+
+    const invalidText = el.shadowRoot.querySelector('.cds--form-requirement');
+
+    expect(invalidText).to.exist;
+    expect(invalidText.textContent.trim()).to.equal('Invalid text');
+  });
+
+  it('should respect readOnly prop', async () => {
+    const checkbox = html`<cds-checkbox readOnly>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const inputElement = el.shadowRoot.querySelector('input');
+    expect(inputElement.hasAttribute('aria-readonly')).to.be.true;
+  });
+
+  it('should respect warn prop', async () => {
+    const checkbox = html`<cds-checkbox warn>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const warnIcon = el.shadowRoot.querySelector(
+      '.cds--checkbox__invalid-icon--warning'
+    );
+    expect(warnIcon).to.exist;
+  });
+
+  it('should display warn-text if warn prop is true', async () => {
+    const checkbox = html`<cds-checkbox warn warn-text="Warn text"
+      >Checkbox Label</cds-checkbox
+    >`;
+    const el = await fixture(checkbox);
+
+    const warnText = el.shadowRoot.querySelector('.cds--form-requirement');
+
+    expect(warnText).to.exist;
+    expect(warnText.textContent.trim()).to.equal('Warn text');
+  });
+
+  it('should fire cds-checkbox-changed event when checkbox is changed', async () => {
+    const checkbox = html`<cds-checkbox>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    await el.updateComplete;
+
+    const inputElement = el.shadowRoot.querySelector('input');
+    const listener = oneEvent(el, 'cds-checkbox-changed');
+    inputElement.click();
+    const event = await listener;
+
+    expect(event).to.exist;
+    expect(event.detail).to.deep.equal({
+      checked: true,
+      indeterminate: false,
+    });
+  });
+
+  it('should NOT fire cds-checkbox-changed event when readonly', async () => {
+    const checkbox = html`<cds-checkbox readOnly>Checkbox Label</cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    await el.updateComplete;
+
+    const inputElement = el.shadowRoot.querySelector('input');
+
+    const eventPromise = oneEvent(el, 'cds-checkbox-changed');
+    inputElement.click();
+
+    // Resolves if no event is fired and rejects if event is fired to prevent
+    // the test from hanging.
+    const result = await Promise.race([
+      eventPromise.then(() => 'cds-checkbox-changed event fired'),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 100)),
+    ]);
+
+    expect(result).to.equal(
+      'timeout',
+      'cds-checkbox-changed event should not fire when readonly'
+    );
+  });
+
+  it('should respect deprecated slug prop', async () => {
+    const checkbox = html` <cds-checkbox>
+      <cds-ai-label slot="slug" alignment="bottom-left">
+        <div slot="body-text">
+          <p class="secondary">AI Explained</p>
+          <h2 class="ai-label-heading">84%</h2>
+          <p class="secondary bold">Confidence score</p>
+          <p class="secondary">
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+          <hr />
+          <p class="secondary">Model type</p>
+          <p class="bold">Foundation model</p>
+        </div>
+      </cds-ai-label>
+    </cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const slot = el.shadowRoot.querySelector('slot[name="slug"]');
+    const assigned = slot.assignedNodes({ flatten: true });
+
+    const aiLabel = assigned.find(
+      (node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.tagName.toLowerCase() === 'cds-ai-label'
+    );
+
+    expect(aiLabel).to.exist;
+  });
+
+  it('should respect decorator prop', async () => {
+    const checkbox = html` <cds-checkbox>
+      <cds-ai-label slot="decorator" alignment="bottom-left">
+        <div slot="body-text">
+          <p class="secondary">AI Explained</p>
+          <h2 class="ai-label-heading">84%</h2>
+          <p class="secondary bold">Confidence score</p>
+          <p class="secondary">
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+          <hr />
+          <p class="secondary">Model type</p>
+          <p class="bold">Foundation model</p>
+        </div>
+      </cds-ai-label>
+    </cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const slot = el.shadowRoot.querySelector('slot[name="decorator"]');
+    const assigned = slot.assignedNodes({ flatten: true });
+
+    const aiLabel = assigned.find(
+      (node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.tagName.toLowerCase() === 'cds-ai-label'
+    );
+
+    expect(aiLabel).to.exist;
+  });
+
+  it('should set size to "md" when decorator kind is "inline"', async () => {
+    const checkbox = html` <cds-checkbox>
+      <cds-ai-label slot="decorator" kind="inline" alignment="bottom-left">
+        <div slot="body-text">
+          <p class="secondary">AI Explained</p>
+          <h2 class="ai-label-heading">84%</h2>
+          <p class="secondary bold">Confidence score</p>
+          <p class="secondary">
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+          <hr />
+          <p class="secondary">Model type</p>
+          <p class="bold">Foundation model</p>
+        </div>
+      </cds-ai-label>
+    </cds-checkbox>`;
+    const el = await fixture(checkbox);
+
+    const slot = el.shadowRoot.querySelector('slot[name="decorator"]');
+    const assigned = slot.assignedNodes({ flatten: true });
+
+    const aiLabel = assigned.find(
+      (node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.tagName.toLowerCase() === 'cds-ai-label'
+    );
+
+    expect(aiLabel).to.exist;
+    expect(aiLabel.getAttribute('size')).to.equal('md');
+  });
+});

--- a/packages/web-components/src/components/checkbox/checkbox-group.ts
+++ b/packages/web-components/src/components/checkbox/checkbox-group.ts
@@ -200,6 +200,7 @@ class CDSCheckboxGroup extends LitElement {
         <legend class="${prefix}--label" id=${legendId || ariaLabelledBy}>
           ${legendText}
           <slot name="ai-label" @slotchange="${handleSlotChange}"></slot>
+          <slot name="decorator" @slotchange="${handleSlotChange}"></slot>
           <slot name="slug" @slotchange="${handleSlotChange}"></slot>
         </legend>
         <slot></slot>

--- a/packages/web-components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/web-components/src/components/checkbox/checkbox.stories.ts
@@ -122,7 +122,6 @@ export const Horizontal = {
     warnText,
   }) => html`
     <cds-checkbox-group
-      legend-text="Group label"
       helper-text="${helperText}"
       ?disabled="${disabled}"
       ?invalid="${invalid}"
@@ -209,6 +208,7 @@ export const WithAILabel = {
     readonly,
     onChange,
     helperText,
+    legendText,
     invalid,
     invalidText,
     orientation,
@@ -217,7 +217,7 @@ export const WithAILabel = {
   }) => html`
     <div style="width: 400px">
       <cds-checkbox-group
-      legend-text="Group label"
+      legend-text="${legendText}"
       helper-text="${helperText}"
       ?disabled="${disabled}"
       ?invalid="${invalid}"

--- a/packages/web-components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/web-components/src/components/checkbox/checkbox.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -68,19 +68,6 @@ const controls = {
     control: 'text',
     description:
       'Provide the text that is displayed when the form group is in warning state.',
-  },
-};
-
-const singleControls = {
-  ...controls,
-  indeterminate: {
-    control: 'boolean',
-    description: 'Specify whether the Checkbox is in an indeterminate state',
-  },
-  defaultChecked: {
-    control: 'boolean',
-    description:
-      'Specify whether the underlying input should be checked by default',
   },
 };
 
@@ -157,7 +144,6 @@ export const Horizontal = {
 
 export const Single = {
   args: defaultArgs,
-  argTypes: singleControls,
   render: () => html`
     <cds-checkbox helper-text="Helper text goes here"
       >${checkboxLabel}</cds-checkbox
@@ -177,7 +163,6 @@ export const Single = {
 
 export const Skeleton = {
   args: defaultArgs,
-  argTypes: singleControls,
   render: () => html`
     <fieldset class="${prefix}--fieldset">
       <cds-checkbox-skeleton></cds-checkbox-skeleton>
@@ -249,7 +234,7 @@ export const WithAILabel = {
         <cds-checkbox @cds-checkbox-changed="${onChange}">Checkbox label</cds-checkbox>
       </cds-checkbox-group>
       <br></br>
-      <cds-checkbox-group 
+      <cds-checkbox-group
       legend-text="Group label"
       helper-text="${helperText}"
       ?disabled="${disabled}"
@@ -274,7 +259,7 @@ export const WithAILabel = {
         <cds-checkbox @cds-checkbox-changed="${onChange}">Checkbox label</cds-checkbox>
       </cds-checkbox-group>
        <br></br>
-      <cds-checkbox-group 
+      <cds-checkbox-group
       legend-text="Group label"
       helper-text="${helperText}"
       ?disabled="${disabled}"

--- a/packages/web-components/src/components/checkbox/checkbox.ts
+++ b/packages/web-components/src/components/checkbox/checkbox.ts
@@ -174,7 +174,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
   /**
    * Specify whether the underlying input should be checked by default
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, attribute: 'default-checked' })
   defaultChecked;
 
   /**
@@ -210,10 +210,14 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
   protected _hasAILabel = false;
 
   updated() {
-    const { _hasAILabel: hasAILabel } = this;
+    const { _hasAILabel: hasAILabel, defaultChecked } = this;
     hasAILabel
       ? this.setAttribute('ai-label', '')
       : this.removeAttribute('ai-label');
+
+    if (defaultChecked) {
+      this.checked = defaultChecked;
+    }
   }
 
   render() {
@@ -259,8 +263,10 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         part="input"
         class="${`${prefix}--checkbox`}"
         aria-readonly="${String(Boolean(readonly))}"
-        .checked="${checked ? checked : defaultChecked}"
+        ?checked="${checked}"
+        ?data-invalid="${invalid}"
         ?disabled="${disabled}"
+        ?defaultChecked="${defaultChecked}"
         .indeterminate="${indeterminate}"
         name="${ifDefined(name)}"
         value="${ifDefined(value)}"
@@ -276,6 +282,7 @@ class CDSCheckbox extends FocusMixin(FormMixin(LitElement)) {
         >
       </label>
       <slot name="ai-label" @slotchange="${this._handleSlotChange}"></slot>
+      <slot name="decorator" @slotchange="${this._handleSlotChange}"></slot>
       <slot name="slug" @slotchange="${this._handleSlotChange}"></slot>
       <div class="${prefix}--checkbox__validation-msg">
         ${!readonly && invalid

--- a/packages/web-components/src/components/loading/__tests__/loading-test.js
+++ b/packages/web-components/src/components/loading/__tests__/loading-test.js
@@ -9,7 +9,7 @@ import '@carbon/web-components/es/components/loading/index.js';
 import { LOADING_TYPE } from '@carbon/web-components/es/components/loading/defs.js';
 
 describe('cds-loading', function () {
-  const loadling = html`<cds-loading></cds-loading>`;
+  const loading = html`<cds-loading></cds-loading>`;
   const loadingWithDescription = html`<cds-loading
     description="Custom loading text"></cds-loading>`;
   const loadingWithLabel = html`<cds-loading
@@ -19,13 +19,13 @@ describe('cds-loading', function () {
   const loadingActive = html`<cds-loading active></cds-loading>`;
 
   it('should render', async () => {
-    const el = await fixture(loadling);
+    const el = await fixture(loading);
     expect(el).dom.to.equalSnapshot();
   });
 
   describe('Component API', () => {
     it('should have default description text', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.description).to.equal('Loading');
     });
 
@@ -50,7 +50,7 @@ describe('cds-loading', function () {
     });
 
     it('should support type as alias for small property', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.type).to.equal(LOADING_TYPE.REGULAR);
 
       el.type = LOADING_TYPE.SMALL;
@@ -61,7 +61,7 @@ describe('cds-loading', function () {
 
   describe('Active state', () => {
     it('should support setting active state', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.active).to.be.false;
 
       el.active = true;
@@ -71,7 +71,7 @@ describe('cds-loading', function () {
     });
 
     it('should support inactive as inverse of active property', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.inactive).to.be.true;
       expect(el.active).to.be.false;
 
@@ -81,7 +81,7 @@ describe('cds-loading', function () {
     });
 
     it('should reflect active state to attribute', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.hasAttribute('active')).to.be.false;
       el.active = true;
       await el.updateComplete;
@@ -89,7 +89,7 @@ describe('cds-loading', function () {
     });
 
     it('should reflect inactive state to attribute', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.hasAttribute('inactive')).to.be.true;
       el.inactive = false;
       await el.updateComplete;
@@ -107,7 +107,7 @@ describe('cds-loading', function () {
     });
 
     it('should render without overlay when overlay attribute is not set', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       expect(el.overlay).to.be.false;
       const svgElement = el.shadowRoot.querySelector('svg');
       expect(svgElement).to.exist;
@@ -116,7 +116,7 @@ describe('cds-loading', function () {
 
   describe('SVG structure', () => {
     it('should have correct structure for default loading', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       const svg = el.shadowRoot.querySelector('svg');
       expect(svg).to.exist;
 
@@ -138,7 +138,7 @@ describe('cds-loading', function () {
 
   describe('automated verification testing', () => {
     it('should have no Axe violations', async () => {
-      const el = await fixture(loadling);
+      const el = await fixture(loading);
       await expect(el).to.be.accessible();
     });
 


### PR DESCRIPTION
Closes #18783 

This PR adds test cases for the Web Components `checkbox` component, aligning with the existing React test cases.

Some tweaks were made to the `checkbox` and `checkbox-group` components for parity.

#### Changelog

**New**

- snapshot and unit tests for `cds-checkbox` and `cds-checkbox-group`

**Changed**

- fix spelling in `loading` component tests
- adjust `defaultChecked` property to set the `checked` property
- set the `defaultChecked` and `data-invalid` attributes to the underlying `input` element of `checkbox`
- add `decorator` slot for `checkbox` and `checkbox-group`

**Removed**

- take out unused props from the checkbox story

#### Testing / Reviewing

Run `yarn test` within the `packages/web-components` folder
