### PR TITLE
docs(release-schedule): mark v12 preview and TBD, update images and dates

### DIFF
--- a/docs/experimental-code.md
+++ b/docs/experimental-code.md
@@ -101,8 +101,8 @@ All breaking changes will be shipped as `enable-v12-*` flags within the current
 major release (v11). This enables projects to opt-in to breaking changes earlier
 and at their own pace avoiding one huge changeset when upgrading to the next
 major release. In theory, if all `enable-v12-*` flags are enabled within your
-project before the v12 release, no changes should need to be made to the affected
-components when updating to v12.
+project before the v12 release, no changes should need to be made to the
+affected components when updating to v12.
 
 For a flag to be committed to a release and renamed to `enable-v#-*` it must:
 

--- a/docs/experimental-code.md
+++ b/docs/experimental-code.md
@@ -101,8 +101,8 @@ All breaking changes will be shipped as `enable-v12-*` flags within the current
 major release (v11). This enables projects to opt-in to breaking changes earlier
 and at their own pace avoiding one huge changeset when upgrading to the next
 major release. In theory, if all `enable-v12-*` flags are enabled within your
-project before the v12 release, no changes should need to be made when updating
-to v12.
+project before the v12 release, no changes should need to be made the effected
+components when updating to v12.
 
 For a flag to be committed to a release and renamed to `enable-v#-*` it must:
 

--- a/docs/experimental-code.md
+++ b/docs/experimental-code.md
@@ -101,7 +101,7 @@ All breaking changes will be shipped as `enable-v12-*` flags within the current
 major release (v11). This enables projects to opt-in to breaking changes earlier
 and at their own pace avoiding one huge changeset when upgrading to the next
 major release. In theory, if all `enable-v12-*` flags are enabled within your
-project before the v12 release, no changes should need to be made the effected
+project before the v12 release, no changes should need to be made to the affected
 components when updating to v12.
 
 For a flag to be committed to a release and renamed to `enable-v#-*` it must:

--- a/docs/release-schedule.md
+++ b/docs/release-schedule.md
@@ -7,15 +7,32 @@ major versions of the Carbon Design System.
 | ------- | ----------- | --------------- | ------------ | ----------------- | ----------- |
 | `main`  | unstable    | unstable        | unstable     | unstable          | unstable    |
 | v9      | End of life | 2018-06-04      | 2018-06-04   | 2019-03-29        | 2022-03-31  |
-| v10     | Maintenance | 2019-03-29      | 2019-03-29   | 2022-03-31        | 2024-09-30  |
-| v11     | Active      | 2021-08-06      | 2022-03-31   | 2026-03-31        | 2028-03-31  |
-| v12     | Unreleased  | 2025-08-01      | 2026-03-31   | 2028-03-31        | 2029-03-31  |
+| v10     | End of life | 2019-03-29      | 2019-03-29   | 2022-03-31        | 2024-09-30  |
+| v11     | Active      | 2021-08-06      | 2022-03-31   | TBD               | TBD         |
+| v12     | Preview     | 2023-05-25      | TBD          | TBD               | TBD         |
 
 > Dates are subject to change
 
-![schedule](https://github.com/carbon-design-system/carbon/assets/3360588/b8014b83-a743-4ace-83a3-ff1c96eef194)
+![schedule](https://github.com/user-attachments/assets/bc5ccd5a-8781-4ba5-9024-2aaaf0a53121)
 
 ## Release phases
+
+### Preview
+
+The preview phase allows consumers to incrementally opt in to changes that will
+be present in the next major, but through the current active release. This phase
+begins when the first feature flag is "committed" to be on-by-default in a
+future major version.
+
+Once committed, flag names contain the version they've been committed to with
+the prefix `enable-v#-*`. At this point the API or functionality behind this
+flag is now fixed and won't change. We intend to ship this flag as "on by
+default" in the major version indicated in the name. e.g.
+`enable-v12-tile-default-icons`
+
+In theory, if all `enable-v12-*` flags are enabled within your project before
+the v12 release, no changes should need to be made the effected components when
+updating to v12.
 
 ### Prerelease
 

--- a/docs/release-schedule.md
+++ b/docs/release-schedule.md
@@ -31,8 +31,8 @@ default" in the major version indicated in the name. e.g.
 `enable-v12-tile-default-icons`
 
 In theory, if all `enable-v12-*` flags are enabled within your project before
-the v12 release, no changes should need to be made to the affected components when
-updating to v12.
+the v12 release, no changes should need to be made to the affected components
+when updating to v12.
 
 ### Prerelease
 

--- a/docs/release-schedule.md
+++ b/docs/release-schedule.md
@@ -31,7 +31,7 @@ default" in the major version indicated in the name. e.g.
 `enable-v12-tile-default-icons`
 
 In theory, if all `enable-v12-*` flags are enabled within your project before
-the v12 release, no changes should need to be made the effected components when
+the v12 release, no changes should need to be made to the affected components when
 updating to v12.
 
 ### Prerelease


### PR DESCRIPTION

#### Changelog

**Changed**

- This updates the v12 release timeline and moves relevant dates to be explicitly marked as TBD
- The v12 initial release date has been updated to 2023-05-25 because that's when we shipped the first v12 feature flag. 
  - May 25th 2023 in `v11.30.0` we introduced `enable-v12-tile-default-icons` https://github.com/carbon-design-system/carbon/pull/13382

#### Testing / Reviewing

- Double check the dates
- Double check the image
- Review the new preview release phase information
- I generated the image from our nodejs lts repo fork, in this commit: https://github.com/nodejs/lts-schedule/commit/3814bcacefc1a37bf9dd5f643cfe4dba3a071e84
