### PR TITLE
High Contrast Mode style fix for PasswordInput

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1866,6 +1866,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "mariyageorge01",
+      "name": "Mariya George",
+      "avatar_url": "https://avatars.githubusercontent.com/u/166684108?v=4",
+      "profile": "https://github.com/mariyageorge01",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/vcherneny"><img src="https://avatars.githubusercontent.com/u/11604315?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vlad Cherneny</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=vcherneny" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/murito"><img src="https://avatars.githubusercontent.com/u/2628140?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Francisco Alcalá</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=murito" title="Code">💻</a></td>
     <td align="center"><a href="https://www.linkedin.com/in/sujithcs"><img src="https://avatars.githubusercontent.com/u/43125517?v=4?s=100" width="100px;" alt=""/><br /><sub><b>SUJITH C S</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Code-Suji" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/mariyageorge01"><img src="https://avatars.githubusercontent.com/u/166684108?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mariya George</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mariyageorge01" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -172,6 +172,8 @@
   .#{$prefix}--btn.#{$prefix}--text-input--password__visibility__toggle.#{$prefix}--tooltip__trigger:focus
     svg {
     fill: $icon-primary;
+
+    @include high-contrast-mode('icon-fill');
   }
 
   .#{$prefix}--text-input--invalid,


### PR DESCRIPTION
Closes #https://github.com/carbon-design-system/carbon/issues/19183

This PR fixes a style issue when Windows High Contrast Mode is enabled in PasswordInput.

#### Changelog

**New**

- Show/Hide Password toggle is now visible when hovered in HCM.

**Changed**

- Added a style so that PasswordInput works fine in HCM.
 
**Removed**

- Nothing

#### Testing / Reviewing

Pull the branch locally and check that PasswordInput works well in HCM

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
