### PR TITLE
Fix WC data-table ai label column cells

### DIFF
--- a/packages/web-components/src/components/data-table/_table-core.scss
+++ b/packages/web-components/src/components/data-table/_table-core.scss
@@ -269,7 +269,7 @@
   }
 }
 
-:host(#{$prefix}-table-cell[slug-in-header]) {
+:host(#{$prefix}-table-cell[ai-label-in-header]) {
   @include ai-table-gradient;
 }
 


### PR DESCRIPTION
Contributes to #17739

renames slug to ai-label in a css selector, bringing back the missing gradient styles in column ai label stories

#### Changelog

**Changed**
changed a css selector from slug to ai-label

#### Testing / Reviewing

visually through storybook, in all column ai label variants
| before | after |
| - | - |
|<img width="761" alt="Screenshot 2025-05-05 at 3 25 02 PM" src="https://github.com/user-attachments/assets/f978ea95-8eac-45b8-9649-afb42d6f0754" />|<img width="761" alt="Screenshot 2025-05-05 at 3 25 13 PM" src="https://github.com/user-attachments/assets/650efa11-8fea-4684-a548-029bd91c715b" />|
