### PR TITLE
[a11y] ContentSwitcher - High Contrast Mode 

### DIFF
--- a/packages/styles/scss/components/content-switcher/_content-switcher.scss
+++ b/packages/styles/scss/components/content-switcher/_content-switcher.scss
@@ -147,6 +147,8 @@
   .#{$prefix}--content-switcher
     .#{$prefix}--content-switcher-btn.#{$prefix}--content-switcher--selected:last-child {
     border: 0;
+
+    @include high-contrast-mode('bold-border');
   }
 
   .#{$prefix}--content-switcher-btn::before {
@@ -291,6 +293,8 @@
     .#{$prefix}--content-switcher-btn
     svg {
     fill: $icon-primary;
+
+    @include high-contrast-mode('icon-fill');
   }
 
   .#{$prefix}--content-switcher--icon-only

--- a/packages/styles/scss/components/content-switcher/_content-switcher.scss
+++ b/packages/styles/scss/components/content-switcher/_content-switcher.scss
@@ -63,6 +63,8 @@
       @media (prefers-reduced-motion: reduce) {
         transition: none;
       }
+
+      @include high-contrast-mode('selected');
     }
 
     &:disabled::after {
@@ -302,6 +304,8 @@
     svg {
     z-index: 1;
     fill: $icon-inverse;
+
+    @include high-contrast-mode('icon-fill-selected');
   }
 
   .#{$prefix}--content-switcher--icon-only.#{$prefix}--content-switcher--sm

--- a/packages/styles/scss/utilities/_high-contrast-mode.scss
+++ b/packages/styles/scss/utilities/_high-contrast-mode.scss
@@ -25,6 +25,10 @@
       outline: 1px solid transparent;
     }
 
+    @if ($type == 'bold-border') {
+      border: 2px solid Highlight;
+    }
+
     @if ($type == 'disabled') {
       color: GrayText;
       fill: GrayText;

--- a/packages/styles/scss/utilities/_high-contrast-mode.scss
+++ b/packages/styles/scss/utilities/_high-contrast-mode.scss
@@ -16,6 +16,10 @@
       fill: ButtonText;
     }
 
+    @if ($type == 'icon-fill-selected') {
+      fill: HighlightText;
+    }
+
     @if ($type == 'focus') {
       color: Highlight;
       outline: 1px solid Highlight;
@@ -26,7 +30,11 @@
     }
 
     @if ($type == 'bold-border') {
-      border: 2px solid Highlight;
+      border: 2px solid ButtonBorder;
+    }
+
+    @if ($type == 'selected') {
+      background-color: SelectedItem;
     }
 
     @if ($type == 'disabled') {


### PR DESCRIPTION
Closes #19140 

Fixed the ContentSwitcher Windows High Contrast mode style issues.

### Changelog

**New**

- Added styles to fix issues in HCM.

**Changed**

- NA

**Removed**

- NA

#### Testing / Reviewing

- Pull the branch locally and ensure that ContentSwitcher works fine in HCM.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples - NA
- [ ] Wrote passing tests that cover this change - NA
- [x] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
