### PR TITLE
chore(release): v11.82.1

### DIFF
--- a/examples/class-prefix/package.json
+++ b/examples/class-prefix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "class-prefix",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/custom-theme/package.json
+++ b/examples/custom-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "custom-theme",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/id-prefix/package.json
+++ b/examples/id-prefix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "id-prefix",
   "private": true,
-  "version": "0.79.0",
+  "version": "0.79.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/light-dark-mode/package.json
+++ b/examples/light-dark-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples-light-dark",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev",
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "next": "14.2.25",
     "react": "19.0.0",
     "react-dom": "19.0.0"

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples-nextjs",
   "private": true,
-  "version": "0.82.0",
+  "version": "0.82.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev",
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "next": "14.2.26",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/v10-token-compat-in-v11/package.json
+++ b/examples/v10-token-compat-in-v11/package.json
@@ -1,7 +1,7 @@
 {
   "name": "v10-token-compat-in-v11",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite",
   "private": true,
-  "version": "0.80.0",
+  "version": "0.80.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/carbon-components-react/package.json
+++ b/packages/carbon-components-react/package.json
@@ -2,7 +2,7 @@
   "name": "carbon-components-react",
   "private": true,
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences. This package reached end of support on September 30, 2024 and will not receive any more updates.",
-  "version": "8.82.0",
+  "version": "8.82.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -43,7 +43,7 @@
     "sass": "^1.33.0"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "@carbon/styles": "^1.81.0",
     "@ibm/telemetry-js": "^1.5.0",
     "chalk": "1.1.3"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/react",
   "description": "React components for the Carbon Design System",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -56,7 +56,7 @@
     "@carbon/icons-react": "^11.60.0",
     "@carbon/layout": "^11.34.0",
     "@carbon/styles": "^1.81.0",
-    "@carbon/utilities": "^0.5.0",
+    "@carbon/utilities": "^0.5.1",
     "@floating-ui/react": "^0.27.4",
     "@ibm/telemetry-js": "^1.5.0",
     "classnames": "2.5.1",

--- a/packages/utilities-react/package.json
+++ b/packages/utilities-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/utilities-react",
   "description": "Utilities and helpers to drive consistency across software products using the Carbon Design System with React",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -48,7 +48,7 @@
     "typescript-config-carbon": "^0.5.0"
   },
   "dependencies": {
-    "@carbon/utilities": "^0.5.0",
+    "@carbon/utilities": "^0.5.1",
     "@ibm/telemetry-js": "^1.6.1"
   }
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/utilities",
   "description": "Utilities and helpers to drive consistency across software products using the Carbon Design System",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/www/package.json
+++ b/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "www",
   "private": true,
-  "version": "0.91.0",
+  "version": "0.91.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@carbon/react": "^1.82.0",
+    "@carbon/react": "^1.82.1",
     "@octokit/core": "^4.0.0",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,7 +1955,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/react@npm:^1.82.0, @carbon/react@workspace:packages/react":
+"@carbon/react@npm:^1.82.1, @carbon/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@carbon/react@workspace:packages/react"
   dependencies:
@@ -1974,7 +1974,7 @@ __metadata:
     "@carbon/styles": "npm:^1.81.0"
     "@carbon/test-utils": "npm:^10.36.0"
     "@carbon/themes": "npm:^11.52.0"
-    "@carbon/utilities": "npm:^0.5.0"
+    "@carbon/utilities": "npm:^0.5.1"
     "@figma/code-connect": "npm:^1.3.2"
     "@floating-ui/react": "npm:^0.27.4"
     "@ibm/telemetry-js": "npm:^1.5.0"
@@ -2178,7 +2178,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/utilities-react@workspace:packages/utilities-react"
   dependencies:
-    "@carbon/utilities": "npm:^0.5.0"
+    "@carbon/utilities": "npm:^0.5.1"
     "@ibm/telemetry-js": "npm:^1.6.1"
     esbuild: "npm:^0.25.0"
     rimraf: "npm:^6.0.0"
@@ -2189,7 +2189,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/utilities@npm:^0.5.0, @carbon/utilities@workspace:packages/utilities":
+"@carbon/utilities@npm:^0.5.1, @carbon/utilities@workspace:packages/utilities":
   version: 0.0.0-use.local
   resolution: "@carbon/utilities@workspace:packages/utilities"
   dependencies:
@@ -10008,7 +10008,7 @@ __metadata:
     "@babel/plugin-transform-react-constant-elements": "npm:^7.24.7"
     "@babel/preset-env": "npm:^7.24.7"
     "@babel/preset-react": "npm:^7.24.7"
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@carbon/styles": "npm:^1.81.0"
     "@carbon/test-utils": "npm:^10.36.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
@@ -10491,7 +10491,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "class-prefix@workspace:examples/class-prefix"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@vitejs/plugin-react": "npm:4.0.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -11888,7 +11888,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "custom-theme@workspace:examples/custom-theme"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@vitejs/plugin-react": "npm:4.0.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -14078,7 +14078,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "examples-light-dark@workspace:examples/light-dark-mode"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     eslint: "npm:8.40.0"
     next: "npm:14.2.25"
     react: "npm:19.0.0"
@@ -14091,7 +14091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "examples-nextjs@workspace:examples/nextjs"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     eslint: "npm:8.40.0"
     eslint-config-next: "npm:13.4.7"
     next: "npm:14.2.26"
@@ -16352,7 +16352,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "id-prefix@workspace:examples/id-prefix"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@vitejs/plugin-react": "npm:4.0.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -28358,7 +28358,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "v10-token-compat-in-v11@workspace:examples/v10-token-compat-in-v11"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@vitejs/plugin-react": "npm:4.0.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -28668,7 +28668,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vite@workspace:examples/vite"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@vitejs/plugin-react": "npm:4.0.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -29338,7 +29338,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "www@workspace:www"
   dependencies:
-    "@carbon/react": "npm:^1.82.0"
+    "@carbon/react": "npm:^1.82.1"
     "@octokit/core": "npm:^4.0.0"
     "@octokit/plugin-retry": "npm:^3.0.9"
     "@octokit/plugin-throttling": "npm:^4.0.0"


### PR DESCRIPTION
Release PR for v11.82.1, which bumps up the version of `@carbon/utilities` package and the versions of the packages depending on it as well

