### PR TITLE
fix: remove unexpected shadow from web-component button

### DIFF
--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -33,10 +33,6 @@ $css--plex: true !default;
   .#{$prefix}--btn {
     flex-grow: 1;
     max-inline-size: 100%;
-
-    &:not(:focus) {
-      box-shadow: to-rem(-1px) to-rem(-1px) 0 0 $button-separator;
-    }
   }
 }
 


### PR DESCRIPTION
**Closes** N/A

While working on the new `combo-button` in web-components, I noticed that a `box-shadow` was showing on buttons when they were not focused. This style doesn’t exist in the React version and caused a small but visible difference between the two. The shadow came from some unexpected `box-shadow` rules in the `button`, affecting other components like the new `combo-button` and `menu-button`.

### Changelog

**Removed**

- Removed box-shadow from .#{prefix}--btn:not(:focus) in `button.scss`

### Testing / Reviewing

- CI should pass

Visual test:
1. Go to `Web Components Deploy Preview` > `Button` > `Default`
2. Observe the button and confirm that it no longer has a box-shadow
3. Compare with the React version to ensure visual parity

before: 
![file-8ddhh4LyJvcWQGywtFet6Q](https://github.com/user-attachments/assets/2e852d0d-70f3-4769-b191-430d0da4cca4)

after: 
![Pasted Graphic 6](https://github.com/user-attachments/assets/e9385fd6-6559-4b49-82b2-75e4ae3c44bc)

---

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff  
- [N/A] Updated documentation and storybook examples
- [N/A] Wrote passing tests that cover this change 
- [N/A] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency 
- [x] Validated that this code is ready for review and status checks should pass  

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
