### PR TITLE
fix(toggle): use logical property for label spacing

### DIFF
--- a/packages/styles/scss/components/toggle/_toggle.scss
+++ b/packages/styles/scss/components/toggle/_toggle.scss
@@ -112,6 +112,10 @@
       inline-size: convert.to-rem(10px);
     }
   }
+  // Adjust label spacing for small toggle
+  .#{$prefix}--toggle--small .#{$prefix}--toggle__label {
+    margin-block-start: $spacing-03;
+  }
 
   .#{$prefix}--toggle__appearance--sm
     .#{$prefix}--toggle__switch--checked::before {


### PR DESCRIPTION
Closes #19147

This PR resolves the issue where the spacing between the toggle and its label was not using logical properties, and ensures proper alignment and spacing for small toggles. This improves visual consistency, accessibility, and compliance with stylelint rules.

### Changelog

**Changed**

- Updated styling logic in the `Toggle` component to use `margin-block-start` instead of `margin-top` for label spacing in small toggles.

#### Testing / Reviewing

- Verify that the small `Toggle` renders with correct spacing between the toggle and its label.
- Check that stylelint passes with no errors.
- Confirm changes do not break layout in existing stories/examples.
- Test in RTL and different zoom levels for a11y impact.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples (if applicable)
- [x] Wrote passing tests that cover this change (or confirmed existing tests pass)
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)