### PR TITLE
fix: header's right panel storybook fix (React version)

### DIFF
--- a/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
@@ -505,37 +505,72 @@ export const HeaderWSideNav = () => (
 
 HeaderWSideNav.storyName = 'Header w/ SideNav';
 
-export const HeaderWActionsAndRightPanel = (args) => (
-  <>
-    <Header aria-label="IBM Platform Name">
-      <HeaderName href="#" prefix="IBM">
-        [Platform]
-      </HeaderName>
-      <HeaderGlobalBar>
-        <HeaderGlobalAction
-          aria-label="Search"
-          onClick={action('search click')}>
-          <Search size={20} />
-        </HeaderGlobalAction>
-        <HeaderGlobalAction
-          aria-label="Notifications"
-          badgeCount={args.badgeCount}
-          isActive
-          onClick={action('notification click')}>
-          <Notification size={20} />
-        </HeaderGlobalAction>
-        <HeaderGlobalAction
-          aria-label="App Switcher"
-          onClick={action('app-switcher click')}
-          tooltipAlignment="end">
-          <SwitcherIcon size={20} />
-        </HeaderGlobalAction>
-      </HeaderGlobalBar>
-      <HeaderPanel expanded />
-    </Header>
-    <StoryContent />
-  </>
-);
+export const HeaderWActionsAndRightPanel = (args) => {
+  // Add state to control panel expansion
+  const [isPanelExpanded, setIsPanelExpanded] = useState(false);
+
+  // Function to toggle panel
+  const togglePanel = () => {
+    setIsPanelExpanded(!isPanelExpanded);
+  };
+
+  // Function to close panel specifically
+  const closePanel = () => {
+    setIsPanelExpanded(false);
+  };
+
+  return (
+    <>
+      <Header aria-label="IBM Platform Name">
+        <HeaderName href="#" prefix="IBM">
+          [Platform]
+        </HeaderName>
+        <HeaderGlobalBar>
+          <HeaderGlobalAction
+            aria-label="Search"
+            onClick={action('search click')}>
+            <Search size={20} />
+          </HeaderGlobalAction>
+          <HeaderGlobalAction
+            aria-label="Notifications"
+            badgeCount={args.badgeCount}
+            isActive
+            onClick={action('notification click')}>
+            <Notification size={20} />
+          </HeaderGlobalAction>
+          <HeaderGlobalAction
+            aria-label={isPanelExpanded ? 'Close panel' : 'Open panel'}
+            isActive={isPanelExpanded}
+            onClick={togglePanel}
+            tooltipAlignment="end"
+            id="switcher-button">
+            <SwitcherIcon size={20} />
+          </HeaderGlobalAction>
+        </HeaderGlobalBar>
+        <HeaderPanel
+          expanded={isPanelExpanded}
+          onHeaderPanelFocus={closePanel}
+          addFocusListeners={true}
+          href="#switcher-button">
+          {/* Add panel content here */}
+          <Switcher aria-label="Switcher Container" expanded={isPanelExpanded}>
+            <SwitcherItem aria-label="Link 1" href="#">
+              Link 1
+            </SwitcherItem>
+            <SwitcherDivider />
+            <SwitcherItem href="#" aria-label="Link 2">
+              Link 2
+            </SwitcherItem>
+            <SwitcherItem href="#" aria-label="Link 3">
+              Link 3
+            </SwitcherItem>
+          </Switcher>
+        </HeaderPanel>
+      </Header>
+      <StoryContent />
+    </>
+  );
+};
 
 HeaderWActionsAndRightPanel.storyName = 'Header w/ Actions and Right Panel';
 


### PR DESCRIPTION
Closes #19289 

Right panel's close on loss of focus is fixed, this is for React version, and only a storybook change.

### Changelog

**New**

- added a new state to track the panel's toggle, and close on focus
- added the `aria-label` switch up to work for accessibility


#### Testing / Reviewing

- in the deploy preview, go to the ui-shell's header story, Header w/ Actions and Right Panel.
- click on the header, and tab towards the right panel, and open it
- after you tested the open and close toggle, tab away from it, make sure it closes after the loss of focuss

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
