### PR TITLE
docs(Grid): update broken links

### DIFF
--- a/packages/react/src/components/Grid/Column.tsx
+++ b/packages/react/src/components/Grid/Column.tsx
@@ -48,7 +48,7 @@ export interface ColumnBaseProps {
    * Specify column span for the `lg` breakpoint (Default breakpoint up to 1312px)
    * This breakpoint supports 16 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   lg?: ColumnSpan;
 
@@ -56,7 +56,7 @@ export interface ColumnBaseProps {
    * Specify column span for the `max` breakpoint. This breakpoint supports 16
    * columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   max?: ColumnSpan;
 
@@ -64,7 +64,7 @@ export interface ColumnBaseProps {
    * Specify column span for the `md` breakpoint (Default breakpoint up to 1056px)
    * This breakpoint supports 8 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   md?: ColumnSpan;
 
@@ -72,7 +72,7 @@ export interface ColumnBaseProps {
    * Specify column span for the `sm` breakpoint (Default breakpoint up to 672px)
    * This breakpoint supports 4 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   sm?: ColumnSpan;
 
@@ -80,7 +80,7 @@ export interface ColumnBaseProps {
    * Specify column span for the `xlg` breakpoint (Default breakpoint up to
    * 1584px) This breakpoint supports 16 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   xlg?: ColumnSpan;
 
@@ -190,7 +190,7 @@ Column.propTypes = {
    * Specify column span for the `lg` breakpoint (Default breakpoint up to 1312px)
    * This breakpoint supports 16 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   lg: spanPropType,
 
@@ -198,7 +198,7 @@ Column.propTypes = {
    * Specify column span for the `max` breakpoint. This breakpoint supports 16
    * columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   max: spanPropType,
 
@@ -206,7 +206,7 @@ Column.propTypes = {
    * Specify column span for the `md` breakpoint (Default breakpoint up to 1056px)
    * This breakpoint supports 8 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   md: spanPropType,
 
@@ -214,7 +214,7 @@ Column.propTypes = {
    * Specify column span for the `sm` breakpoint (Default breakpoint up to 672px)
    * This breakpoint supports 4 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   sm: spanPropType,
 
@@ -228,7 +228,7 @@ Column.propTypes = {
    * Specify column span for the `xlg` breakpoint (Default breakpoint up to
    * 1584px) This breakpoint supports 16 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   xlg: spanPropType,
 };
@@ -282,7 +282,7 @@ CSSGridColumn.propTypes = {
    * Specify column span for the `lg` breakpoint (Default breakpoint up to 1312px)
    * This breakpoint supports 16 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   lg: spanPropType,
 
@@ -290,7 +290,7 @@ CSSGridColumn.propTypes = {
    * Specify column span for the `max` breakpoint. This breakpoint supports 16
    * columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   max: spanPropType,
 
@@ -298,7 +298,7 @@ CSSGridColumn.propTypes = {
    * Specify column span for the `md` breakpoint (Default breakpoint up to 1056px)
    * This breakpoint supports 8 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   md: spanPropType,
 
@@ -306,7 +306,7 @@ CSSGridColumn.propTypes = {
    * Specify column span for the `sm` breakpoint (Default breakpoint up to 672px)
    * This breakpoint supports 4 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   sm: spanPropType,
 
@@ -328,7 +328,7 @@ CSSGridColumn.propTypes = {
    * Specify column span for the `xlg` breakpoint (Default breakpoint up to
    * 1584px) This breakpoint supports 16 columns by default.
    *
-   * @see https://www.carbondesignsystem.com/guidelines/layout#breakpoints
+   * @see https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints
    */
   xlg: spanPropType,
 };

--- a/packages/react/src/components/Grid/Grid.mdx
+++ b/packages/react/src/components/Grid/Grid.mdx
@@ -69,7 +69,7 @@ don't span more columns than the total number of columns in the grid.
 To specify how many columns the `Column` component should span, you can use the
 `sm`, `md`, `lg`, `xlg`, or `max` props. These props are shorthand versions of
 the names given to each of the breakpoints defined by the
-[2x Grid](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation/#responsive-options).
+[2x Grid](https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints).
 In the example below, we will use the `lg` prop for the large breakpoint and the
 number `4` to specify that each `Column` component should span 4 columns at that
 breakpoint.
@@ -124,7 +124,7 @@ among others.
 ## Gutter modes
 
 There are several
-[gutter modes](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation/#gutter-modes)
+[gutter modes](https://carbondesignsystem.com/elements/2x-grid/overview/#gutters)
 that you can use depending on the layout effect you're looking to achieve. By
 default, `Grid` uses the wide gutter mode with a 32px gutter. However, you can
 use the `condensed` prop to enable the condensed gutter mode with a 1px gutter


### PR DESCRIPTION
Closes #19359

Fix broken documentation links in `Column.tsx` and `Grid overview page`. The previous URLs under `@see` tags were returning 404 errors. These have been updated to point to the correct layout breakpoints documentation in the Carbon Design System site.

### Changelog

**Changed**

- Updated outdated `@see` links in `Column.tsx` to use the correct URLs: `https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints`
- Updated corresponding links in `Grid.mdx`

#### Testing / Reviewing

To verify this PR:

1. Open the changed file `Column.tsx `and verify that the updated links are working correctly
2. Confirm that each link now points to a valid section on the Carbon Design System site (no more 404 errors)
3. Navigate to `Deploy Preview > Grid > Overview`
4. Check that the "2x Grid" and "Gutter" link directs to the correct page on the Carbon Design System site and no longer returns a 404 error.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff  
- [X] Updated documentation and storybook examples  
- [N/A] Wrote passing tests that cover this change  
- [N/A] Addressed any impact on accessibility (a11y)  
- [X] Tested for cross-browser consistency  
- [X] Validated that this code is ready for review and status checks should pass

<!--
❗ Make sure you've included everything from the PR guide:

https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
