### PR TITLE
fix(menu): prevent scroll when navigating with arrow keys

### DIFF
--- a/packages/web-components/src/components/menu/menu.ts
+++ b/packages/web-components/src/components/menu/menu.ts
@@ -209,6 +209,10 @@ class CDSMenu extends HostListenerMixin(LitElement) {
     if (e.key === 'Escape' || (!isRoot && e.key === 'ArrowLeft')) {
       this.dispatchCloseEvent(e);
     } else {
+      // Prevent scrolling when navigating menu items
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+      }
       this._focusItem(e);
     }
   };


### PR DESCRIPTION
Closes #19389

While working on the new Combo Button component for web-components #19218, @thyhmdo was reviewing the PR and noticed there was an unexpected scroll when navigating menu items using the up/down arrow keys. I investigated and found that the same behavior also occurs in the Menu Button. 

### Changelog

**New**

- Prevented unexpected scroll behavior when using ArrowUp or ArrowDown keys to navigate menu items by adding e.preventDefault() in the keyboard handler.

#### Testing / Reviewing

1. Go to Web Component `Deploy Preview` > `Menu Button` > `Experimental Auto Align`
2. Open the menu and use the up/down arrow keys to navigate through menu items
3. Expected: No scroll jump should occur during navigation

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [N/A] Updated documentation and storybook examples
- [N/A] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

<!--
❗ Make sure you've included everything from the PR guide:
https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
