### PR TITLE
Fix: [a11y] Fixed how TextInput and TextArea handle hideLabel prop to correctly apply cds--visually-hidden class

### DIFF
--- a/packages/styles/scss/components/text-area/_text-area.scss
+++ b/packages/styles/scss/components/text-area/_text-area.scss
@@ -19,6 +19,7 @@
 @use '../../utilities/placeholder-colors' as *;
 @use '../../utilities/skeleton' as *;
 @use '../../utilities/layout';
+@use '../../utilities/visually-hidden' as *;
 
 /// Text area styles
 /// @access public

--- a/packages/styles/scss/components/text-input/_text-input.scss
+++ b/packages/styles/scss/components/text-input/_text-input.scss
@@ -25,6 +25,7 @@
 @use '../../utilities/layout';
 @use '../../utilities/focus-outline' as *;
 @use '../../utilities/button-reset';
+@use '../../utilities/visually-hidden' as *;
 
 /// Text input styles
 /// @access public

--- a/packages/web-components/src/components/text-input/text-input.ts
+++ b/packages/web-components/src/components/text-input/text-input.ts
@@ -441,13 +441,8 @@ class CDSTextInput extends ValidityMixin(FormMixin(LitElement)) {
           </label>`
         : null;
 
-    const labelText =
-      label && !hideLabel
-        ? html`<label class="${labelClasses}"> ${label} </label>`
-        : null;
-
     const labelWrapper = html`<div class="${prefix}--text-input__label-wrapper">
-      ${labelText} ${counter}
+      <label class="${labelClasses}"> ${label} </label> ${counter}
     </div>`;
 
     const helper = helperText

--- a/packages/web-components/src/components/textarea/textarea.ts
+++ b/packages/web-components/src/components/textarea/textarea.ts
@@ -102,6 +102,12 @@ class CDSTextarea extends CDSTextInput {
 
     const labelClasses = classMap({
       [`${prefix}--label`]: true,
+      [`${prefix}--visually-hidden`]: this.hideLabel,
+      [`${prefix}--label--disabled`]: this.disabled,
+    });
+
+    const counterClasses = classMap({
+      [`${prefix}--label`]: true,
       [`${prefix}--label--disabled`]: this.disabled,
     });
 
@@ -112,7 +118,7 @@ class CDSTextarea extends CDSTextInput {
 
     const counter =
       enableCounter && maxCount
-        ? html` <label class="${labelClasses}">
+        ? html` <label class="${counterClasses}">
             <slot name="label-text">${textCount}/${maxCount}</slot>
           </label>`
         : null;
@@ -128,13 +134,9 @@ class CDSTextarea extends CDSTextInput {
 
     return html`
       <div class="${prefix}--text-area__label-wrapper">
-        ${this.hideLabel
-          ? html``
-          : html`
-              <label class="${labelClasses}" for="input">
-                <slot name="label-text"> ${this.label} </slot>
-              </label>
-            `}
+        <label class="${labelClasses}" for="input">
+          <slot name="label-text"> ${this.label} </slot>
+        </label>
         ${counter}
       </div>
       <div class="${textareaWrapperClasses}" ?data-invalid="${this.invalid}">


### PR DESCRIPTION
Closes #19385

Fixed an issue where TextInput and TextArea were using the hideLabel prop to conditionally render the label of the component, instead of applying the cds--visually-hidden class, resulting in accessibility issues.

### Changelog

**New**

- Added `@use '../../utilities/visually-hidden' as *;` to both respective files

**Changed**

- Made it so hideLabel toggles the cds--visually-hidden class instead of conditionally rendering the label

**Removed**

- Nothing removed

#### Testing / Reviewing

- Go to https://deploy-preview-19399--v11-carbon-web-components.netlify.app/?path=/story/components-text-input--playground
- Use inspect element to view the label
- Set hideLabel to true
- Notice that cds--visually-hidden is applied, the label is still rendered, but is visually hidden


- Go to https://deploy-preview-19399--v11-carbon-web-components.netlify.app/?path=/story/components-text-area--playground
- Use inspect element to view the label
- Set hideLabel to true
- Notice that cds--visually-hidden is applied, the label is still rendered, but is visually hidden
