### PR TITLE
fix: header's right panel storybook (19363)

### DIFF
--- a/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
@@ -534,16 +534,16 @@ export const HeaderWActionsAndRightPanel = (args) => {
           <HeaderGlobalAction
             aria-label="Notifications"
             badgeCount={args.badgeCount}
-            isActive
-            onClick={action('notification click')}>
+            isActive={isPanelExpanded}
+            onClick={togglePanel}
+            tooltipAlignment="center"
+            id="notification-button">
             <Notification size={20} />
           </HeaderGlobalAction>
           <HeaderGlobalAction
-            aria-label={isPanelExpanded ? 'Close panel' : 'Open panel'}
-            isActive={isPanelExpanded}
-            onClick={togglePanel}
-            tooltipAlignment="end"
-            id="switcher-button">
+            aria-label="App Switcher"
+            onClick={action('app-switcher click')}
+            tooltipAlignment="end">
             <SwitcherIcon size={20} />
           </HeaderGlobalAction>
         </HeaderGlobalBar>
@@ -551,20 +551,8 @@ export const HeaderWActionsAndRightPanel = (args) => {
           expanded={isPanelExpanded}
           onHeaderPanelFocus={closePanel}
           addFocusListeners={true}
-          href="#switcher-button">
-          {/* Add panel content here */}
-          <Switcher aria-label="Switcher Container" expanded={isPanelExpanded}>
-            <SwitcherItem aria-label="Link 1" href="#">
-              Link 1
-            </SwitcherItem>
-            <SwitcherDivider />
-            <SwitcherItem href="#" aria-label="Link 2">
-              Link 2
-            </SwitcherItem>
-            <SwitcherItem href="#" aria-label="Link 3">
-              Link 3
-            </SwitcherItem>
-          </Switcher>
+          href="#notification-button">
+          {/* Notification panel content here */}
         </HeaderPanel>
       </Header>
       <StoryContent />

--- a/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
@@ -509,14 +509,21 @@ export const HeaderWActionsAndRightPanel = (args) => {
   // Add state to control panel expansion
   const [isPanelExpanded, setIsPanelExpanded] = useState(false);
 
-  // Function to toggle panel
+  // Toggle the notification panel when the icon is clicked
   const togglePanel = () => {
-    setIsPanelExpanded(!isPanelExpanded);
+    setIsPanelExpanded((prev) => !prev);
   };
 
   // Function to close panel specifically
   const closePanel = () => {
     setIsPanelExpanded(false);
+  };
+
+  // Close the panel when Escape key is pressed
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      closePanel();
+    }
   };
 
   return (
@@ -536,6 +543,8 @@ export const HeaderWActionsAndRightPanel = (args) => {
             badgeCount={args.badgeCount}
             isActive={isPanelExpanded}
             onClick={togglePanel}
+            onBlur={closePanel}
+            onKeyDown={handleKeyDown}
             tooltipAlignment="center"
             id="notification-button">
             <Notification size={20} />
@@ -547,11 +556,7 @@ export const HeaderWActionsAndRightPanel = (args) => {
             <SwitcherIcon size={20} />
           </HeaderGlobalAction>
         </HeaderGlobalBar>
-        <HeaderPanel
-          expanded={isPanelExpanded}
-          onHeaderPanelFocus={closePanel}
-          addFocusListeners={true}
-          href="#notification-button">
+        <HeaderPanel expanded={isPanelExpanded} href="#notification-button">
           {/* Notification panel content here */}
         </HeaderPanel>
       </Header>


### PR DESCRIPTION
Closes #19363

Fixed implementation of the header's right panel toggle behavior in Storybook. Focus and panel state logic were mistakenly applied to the App Switcher button instead of the Notifications button.

### Changelog

**Changed**

- Moved `isPanelExpanded` state and handlers from the App Switcher to the Notifications button.
- Updated Storybook story to reflect correct accessibility labels and behavior.

#### Testing / Reviewing

1. Go to React `Deploy Preview` > `UIShell` > `Header w/ Actions and Right Panel`
2. Click on the `Bell icon (notification)`, check if open and close
3. After you tested the open and close, tab away from it, make sure it closes after the loss of focuss

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [N/A] Updated documentation and storybook examples
- [N/A] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

<!--
❗ Make sure you've included everything from the PR guide:
https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md
-->
