### PR TITLE
fix(`Tooltip`): prevent unbroken text from overflowing

### DIFF
--- a/packages/react/src/components/Tooltip/story.scss
+++ b/packages/react/src/components/Tooltip/story.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2023
+// Copyright IBM Corp. 2016, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -46,8 +46,4 @@
 
 .sb-definition-tooltip p {
   @include type.type-style('body-short-02');
-}
-
-.cds--tooltip-content {
-  overflow-wrap: break-word;
 }

--- a/packages/styles/scss/components/tooltip/_tooltip.scss
+++ b/packages/styles/scss/components/tooltip/_tooltip.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2023
+// Copyright IBM Corp. 2016, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -36,6 +36,7 @@ $tooltip-padding-inline: custom-property.get-var(
 
     padding: $tooltip-padding-block $tooltip-padding-inline;
     max-inline-size: convert.to-rem(288px);
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19402

Added component styles to Prevent unbroken `Tooltip` text from overflowing.

### Changelog

**New**

- Added component styles to Prevent unbroken `Tooltip` text from overflowing.

**Removed**

- Removed Storybook styles.

#### Testing / Reviewing

Follow the same steps listed in https://github.com/carbon-design-system/carbon/pull/19058#issue-2979591070.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~~Wrote passing tests that cover this change~~ - There was no testing added in https://github.com/carbon-design-system/carbon/pull/19058 so I assumed no testing was necessary with these changes.
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass


More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
