### PR TITLE
fix(layout): ensure locally defined layout definition has precedence

### DIFF
--- a/packages/react/src/components/Layout/Layout.stories.js
+++ b/packages/react/src/components/Layout/Layout.stories.js
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { Accordion, AccordionItem } from '../Accordion';
 import Button from '../Button';
+import Tag from '../Tag';
 import { HStack, VStack } from '../Stack';
 import { TextInput } from '../TextInput';
 
@@ -35,6 +36,9 @@ const Demo = () => (
       <div style={{ display: 'flex', alignItems: 'flex-end' }}>
         <Button>&lt;Button /&gt;</Button>
       </div>
+      <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+        <Tag>&lt;Tag /&gt;</Tag>
+      </div>
       <TextInput
         labelText='<TextInput size="sm" />'
         size="sm"
@@ -42,6 +46,9 @@ const Demo = () => (
       />
       <div style={{ display: 'flex', alignItems: 'flex-end' }}>
         <Button size="sm">&lt;Button size=&quot;sm&quot; /&gt;</Button>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+        <Tag size="sm">&lt;Tag size&quot;sm&quot; /&gt;</Tag>
       </div>
     </HStack>
     <Accordion>

--- a/packages/styles/scss/utilities/_layout.scss
+++ b/packages/styles/scss/utilities/_layout.scss
@@ -72,7 +72,7 @@
         );
 
         &.#{config.$prefix}--layout--#{$group}-#{$step},
-        .#{config.$prefix}--layout--#{$group}-#{$step} & {
+        .#{config.$prefix}--layout--#{$group}-#{$step} :where(&) {
           $token: custom-property.get-var(
             'layout-#{$group}-#{$property}-#{$step}'
           );

--- a/packages/styles/scss/utilities/_layout.scss
+++ b/packages/styles/scss/utilities/_layout.scss
@@ -71,6 +71,7 @@
           $value
         );
 
+        &.#{config.$prefix}--layout--#{$group}-#{$step},
         .#{config.$prefix}--layout--#{$group}-#{$step} & {
           $token: custom-property.get-var(
             'layout-#{$group}-#{$property}-#{$step}'


### PR DESCRIPTION
Closes #19388 

When a component redefines layout tokens (such as size), the selector `.cds--layout--{group}-{step} .{component}` is created.

As outlined in the linked issue, if a `<Button>`'s `props.size` is set to `lg`, it emits the class name `.cds--layout--size-lg`. If you were to place a `<Tag>` (which redefines layout tokens) inside of the button, the selector `.cds--layout--size-lg .cds--tag` would be matched and receive precedence over the locally defined size.

This PR adds a second selector that is being emitted: `.{component}.cds--layout--{group}-{step}` which takes precedence in this case (`.cds--tag.cds--layout--group-sm` would be matched) as the specificity of the original selector has been lowered (`.cds--layout--{group}-{step} :where(.{component})`).

### Changelog

**Changed**

- Updated the styles emitted by `layout.redefine-tokens` as described above.

#### Testing / Reviewing

- Verify the following scenario:
```jsx
{/* The button should be displayed as lg (48px) while the tag should be displayed at 18px height. */}
<Button size="lg">
  <Tag size="sm">SM tag</Tag>
</Button>
```
- Verify the ContainedList -> With title decorators story remains unchanged
- Verify the popover in the OperationalTag story remains unchanged
- Verify the functionality of unstable_Layout story
  - A tag has been added to the demo

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples~
- ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
