### PR TITLE
fix: remove invalid hook usage in `wrapFocus` utils

### DIFF
--- a/packages/react/src/internal/wrapFocus.ts
+++ b/packages/react/src/internal/wrapFocus.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect } from 'react';
 import { tabbable } from 'tabbable';
 import { selectorTabbable } from './keyboard/navigation';
 
@@ -143,16 +142,14 @@ export const wrapFocusWithoutSentinels = ({
 }) => {
   if (!containerNode) return;
 
-  useEffect(() => {
-    if (
-      ['blur', 'focusout', 'focusin', 'focus'].includes(event.type) &&
-      process.env.NODE_ENV !== 'production'
-    ) {
-      throw new Error(
-        `Error: wrapFocusWithoutSentinels(...) called in unsupported ${event.type} event.\n\nCall wrapFocusWithoutSentinels(...) from onKeyDown instead.`
-      );
-    }
-  }, []);
+  if (
+    ['blur', 'focusout', 'focusin', 'focus'].includes(event.type) &&
+    process.env.NODE_ENV !== 'production'
+  ) {
+    throw new Error(
+      `Error: wrapFocusWithoutSentinels(...) called in unsupported ${event.type} event.\n\nCall wrapFocusWithoutSentinels(...) from onKeyDown instead.`
+    );
+  }
 
   // Use `tabbable` to get the focusable elements in tab order.
   // `selectorTabbable` returns elements in DOM order which is why it's not


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19386

Removed the invalid hook usage in the `wrapFocus` utils.

### Changelog

**Removed**

- Removed the invalid hook usage in the `wrapFocus` utils.

#### Testing / Reviewing

Check stories mentioned in https://github.com/carbon-design-system/carbon/issues/19386.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
