### PR TITLE
docs(tooltip): clarify props must be spread onto child components

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -18,6 +18,7 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 - [Tooltip](#Tooltip)
 - [Overview](#overview)
+  - [Usage](#usage)
   - [Toggletips vs Tooltips](#toggletips-vs-tooltips)
   - [Customizing the content of a tooltip](#customizing-the-content-of-a-tooltip)
   - [Tooltip alignment](#tooltip-alignment)
@@ -31,8 +32,12 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 You can use the `Tooltip` component as a wrapper to display a popup for an
 interactive element that you provide. If you are trying to place interactive
-content inside of the `Tooltip` itself, consider using `Toggletip` instead. You
-can provide the interactive element as a child to `Tooltip`, for example:
+content inside of the `Tooltip` itself, consider using `Toggletip` instead.
+
+### Usage
+
+`Tooltip` accepts a single child for its `children` prop. It is important that
+the child is an interactive element, for example:
 
 ```jsx
 <Tooltip label="Close">
@@ -40,9 +45,28 @@ can provide the interactive element as a child to `Tooltip`, for example:
 </Tooltip>
 ```
 
-`Tooltip` accepts a single child for its `children` prop. It is important that
-the component you provide renders an interactive element. In addition, you can
-specify the contents of the popup through the `label` or `description` prop.
+When used with a component, props need to be spread on the child component.
+
+```jsx
+export default function App() {
+  return (
+    <Tooltip label="Close">
+      <CustomTrigger />
+    </Tooltip>
+  );
+}
+
+function CustomTrigger(props) {
+  return (
+    <button type="button" {...props}>
+      X
+    </button>
+  );
+}
+```
+
+You can specify the contents of the popup through the `label` or `description`
+prop.
 
 <Canvas
   of={TooltipStories.Default}


### PR DESCRIPTION
Thanks for pointing out this was missing @AlexanderMelox! 

### Changelog

**Changed**

- Updated react storybook tooltip overview docs

#### Testing / Reviewing

- Check my spelling, grammar, clarity

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
