### PR TITLE
fix(menu): close on loss of focus

### DIFF
--- a/packages/web-components/src/components/menu/menu.ts
+++ b/packages/web-components/src/components/menu/menu.ts
@@ -10,6 +10,7 @@ import { prefix } from '../../globals/settings';
 import { property, state } from 'lit/decorators.js';
 import styles from './menu.scss?lit';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
+import HostListener from '../../globals/decorators/host-listener';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import { classMap } from 'lit/directives/class-map.js';
 import { MenuContext, menuDefaultState } from './menu-context';
@@ -133,6 +134,19 @@ class CDSMenu extends HostListenerMixin(LitElement) {
    */
   @property()
   y: number | number[] = 0;
+
+  @HostListener('focusout')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleBlur = (e: FocusEvent) => {
+    const { isRoot } = this.context;
+    // Close the menu if all of the following are met:
+    // * The menu is open
+    // * The focusout event is on the root menu
+    // * Focus is moving outside the menu
+    if (this.open && isRoot && !this.contains(e.relatedTarget as Node)) {
+      this.dispatchCloseEvent(e);
+    }
+  };
 
   /**
    * The name of the custom event fired when the the Menu should be closed.


### PR DESCRIPTION
Closes #19300

Added a listener to the `Menu` Web Component to call `dispatchCloseEvent` when the menu loses focus. Logic matches React component implementation and prevents potential WCAG 2.4.11 violations.

### Changelog

**New**

- `HostListener` that closes Menu on loss of focus

#### Testing / Reviewing

- Check that `dispatchCloseEvent` is called when the Menu is open and loses focus
- Check for parity between this implementation and React version

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
