### PR TITLE
fix(DataTable): fix duplicate expanded row id for multiple tables

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -610,9 +610,10 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
     row: DataTableRow<ColTypes>;
     [key: string]: unknown;
   }) => {
+    const expandedRowId = `expanded-row-${row.id}-${this.instanceId}`;
     return {
       ...rest,
-      id: `expanded-row-${row.id}-${this.instanceId}`,
+      id: expandedRowId,
     };
   };
 

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -590,7 +590,7 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
       onExpand: composeEventHandlers([this.handleOnExpandRow(row.id), onClick]),
       isExpanded: row.isExpanded,
       'aria-label': t(translationKey),
-      'aria-controls': `expanded-row-${row.id}`,
+      'aria-controls': `expanded-row-${row.id}-${this.instanceId}`,
       isSelected: row.isSelected,
       disabled: row.disabled,
     };
@@ -612,7 +612,7 @@ class DataTable<RowType, ColTypes extends any[]> extends React.Component<
   }) => {
     return {
       ...rest,
-      id: `expanded-row-${row.id}`,
+      id: `expanded-row-${row.id}-${this.instanceId}`,
     };
   };
 


### PR DESCRIPTION
### Issue:
- Partially Addresses: https://github.com/carbon-design-system/carbon/issues/19366

### Changelog

**Changed**

- Refactored the way the `id` and `aria-controls` attributes are set for expanded rows when multiple tables with expandable rows are present.
- Appended the `instanceId` to each row’s `id` to ensure uniqueness within the DOM.
- Appended the `instanceId` to the `aria-controls` attribute to correctly associate it with the corresponding row `id`.

#### Testing / Reviewing
#### Before making changes:
- Use multiple tables with row expansion.
- Inspect the elements and search for `expanded-row-a`. You’ll notice that multiple rows have the same `id` value.
#### After making changes:
- You’ll notice that appending the `instanceId` makes each `id` unique.

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
