### PR TITLE
fix(FilterableMultiSelect): fix extra colon

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -861,16 +861,9 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
     : {};
 
   const clearSelectionContent =
-    controlledSelectedItems.length > 0 ? (
-      <span className={`${prefix}--visually-hidden`}>
-        {clearSelectionDescription} {controlledSelectedItems.length},
-        {clearSelectionText}
-      </span>
-    ) : (
-      <span className={`${prefix}--visually-hidden`}>
-        {clearSelectionDescription} 0
-      </span>
-    );
+    controlledSelectedItems.length > 0
+      ? `${clearSelectionDescription} ${controlledSelectedItems.length}. ${clearSelectionText}.`
+      : `${clearSelectionDescription} 0.`;
 
   return (
     <div className={wrapperClasses}>

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -868,7 +868,7 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
       </span>
     ) : (
       <span className={`${prefix}--visually-hidden`}>
-        {clearSelectionDescription}: 0
+        {clearSelectionDescription} 0
       </span>
     );
 


### PR DESCRIPTION
Closes #19424.

Fix extra colon in hidden "Total items selected: : 0" message.  Note that it already worked correctly when one or more items were selected.

Also get rid of duplicate (nested) `<span class="cds--visually-hidden">`.

I don't like the way FilterableMultiSelect adds hidden text to the label, but `aria-describedby` is already being used to point to the (visible) helper text.


### Changelog

**Changed**

- Removed extra colon in FilterableMultiSelect's hidden message for screen reader users.

#### Testing / Reviewing

Test on Storybook with JAWS.

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
