### PR TITLE
feat(layer): web-component prop and stories update

### DIFF
--- a/packages/react/src/components/Layer/Layer.mdx
+++ b/packages/react/src/components/Layer/Layer.mdx
@@ -14,6 +14,7 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 - [Layer](#layer)
   - [Overview](#overview)
+  - [With background](#with-background)
   - [Setting a custom level](#setting-a-custom-level)
   - [Get the current layer](#get-the-current-layer)
 - [Component API](#component-api)

--- a/packages/web-components/.storybook/templates/with-layer.scss
+++ b/packages/web-components/.storybook/templates/with-layer.scss
@@ -16,10 +16,6 @@
 .#{$prefix}--with-layer__layer {
   position: relative;
   border: 1px dashed colors.$purple-50;
-}
-
-.#{$prefix}--with-layer__layer .#{$prefix}--with-layer__layer {
-  background-color: theme.$layer;
   margin-block-start: spacing.$spacing-07;
 }
 
@@ -31,6 +27,17 @@
   background-color: tag.$tag-background-purple;
   color: tag.$tag-color-purple;
   column-gap: spacing.$spacing-02;
+}
+
+.#{$prefix}--with-layer__background {
+  border: 1px dashed colors.$magenta-50;
+  margin: -42px;
+  min-block-size: 100vh;
+}
+
+.#{$prefix}--with-layer__background > .#{$prefix}--with-layer__label {
+  background-color: tag.$tag-background-magenta;
+  color: tag.$tag-color-magenta;
 }
 
 .#{$prefix}--with-layer__content {

--- a/packages/web-components/.storybook/templates/with-layer.ts
+++ b/packages/web-components/.storybook/templates/with-layer.ts
@@ -49,36 +49,38 @@ class CDSLayer extends LitElement {
 
   render() {
     return html`
-      <div class="${prefix}--with-layer">
-        <div class="${prefix}--with-layer__layer">
-          <div class="${prefix}--with-layer__label">${Layers()} Layer 1</div>
-          <div class="${prefix}--with-layer__content">
-            <cds-layer>
+      <cds-layer with-background>
+        <div class="${prefix}--with-layer">
+          <div class="${prefix}--with-layer__background">
+            <div class="${prefix}--with-layer__label">
+              ${Layers()} $background
+            </div>
+            <div class="${prefix}--with-layer__content">
               <slot @slotchange="${this._handleSlotChange}"></slot>
-              <div class="${prefix}--with-layer__layer">
-                <div class="${prefix}--with-layer__label">
-                  ${Layers()} Layer 2
-                </div>
-                <div class="${prefix}--with-layer__content">
-                  <cds-layer>
+              <cds-layer with-background>
+                <div class="${prefix}--with-layer__layer">
+                  <div class="${prefix}--with-layer__label">
+                    ${Layers()} $layer-02
+                  </div>
+                  <div class="${prefix}--with-layer__content">
                     <slot name="layer-2"></slot>
-                    <div class="${prefix}--with-layer__layer">
-                      <div class="${prefix}--with-layer__label">
-                        ${Layers()} Layer 3
-                      </div>
-                      <div class="${prefix}--with-layer__content">
-                        <cds-layer>
+                    <cds-layer with-background>
+                      <div class="${prefix}--with-layer__layer">
+                        <div class="${prefix}--with-layer__label">
+                          ${Layers()} $layer-03
+                        </div>
+                        <div class="${prefix}--with-layer__content">
                           <slot name="layer-3"></slot>
-                        </cds-layer>
+                        </div>
                       </div>
-                    </div>
-                  </cds-layer>
+                    </cds-layer>
+                  </div>
                 </div>
-              </div>
-            </cds-layer>
+              </cds-layer>
+            </div>
           </div>
         </div>
-      </div>
+      </cds-layer>
     `;
   }
 

--- a/packages/web-components/src/components/layer/layer-story.scss
+++ b/packages/web-components/src/components/layer/layer-story.scss
@@ -13,3 +13,8 @@
   background: $layer;
   color: $text-primary;
 }
+
+.example-layer-test-component-no-background {
+  padding: $spacing-05;
+  color: $text-primary;
+}

--- a/packages/web-components/src/components/layer/layer.mdx
+++ b/packages/web-components/src/components/layer/layer.mdx
@@ -12,6 +12,7 @@ import * as LayerStories from './layer.stories';
 
 - [Overview](#overview)
 - [Setting a custom level](#setting-a-custom-level)
+- [With background](#with-background)
 - [Get the current layer](#get-the-current-layer)
 - [Component API](#component-api)
 - [CDN](#cdn)
@@ -41,6 +42,15 @@ indefinitely, but the token sets typically end after 3 layers.
   </cds-layer>
 </cds-layer>
 ```
+
+## With Background
+
+The layer component updates layer tokens at each level and theme. When you add
+the `with-background` attribute, it automatically sets a background color using
+the `$layer-background` token. Without it, you can manually set the background
+with `background-color: $layer-background`.
+
+<Canvas of={LayerStories.withBackground} />
 
 ## Setting a custom level
 

--- a/packages/web-components/src/components/layer/layer.scss
+++ b/packages/web-components/src/components/layer/layer.scss
@@ -10,6 +10,10 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/layer' as *;
 @use '@carbon/styles/scss/config' as *;
 
+:host(#{$prefix}-layer) {
+  display: block;
+}
+
 :host(#{$prefix}-layer[level='0']) {
   @extend .#{$prefix}--layer-one;
 }
@@ -20,4 +24,8 @@ $css--plex: true !default;
 
 :host(#{$prefix}-layer[level='2']) {
   @extend .#{$prefix}--layer-three;
+}
+
+:host(#{$prefix}-layer[with-background]) {
+  @extend .#{$prefix}--layer__with-background;
 }

--- a/packages/web-components/src/components/layer/layer.stories.ts
+++ b/packages/web-components/src/components/layer/layer.stories.ts
@@ -39,6 +39,29 @@ export const Default = {
   `,
 };
 
+export const withBackground = {
+  render: () => html`
+    <cds-layer with-background>
+      <div class="example-layer-test-component-no-background">
+        Test component
+      </div>
+      <cds-layer with-background>
+        <div class="example-layer-test-component-no-background">
+          Test component
+        </div>
+        <cds-layer with-background>
+          <div class="example-layer-test-component-no-background">
+            Test component
+          </div>
+        </cds-layer>
+      </cds-layer>
+    </cds-layer>
+    <style>
+      ${styles}
+    </style>
+  `,
+};
+
 export const CustomLevel = {
   name: 'Custom level',
   args: {
@@ -49,6 +72,9 @@ export const CustomLevel = {
     <cds-layer level="${level}">
       <div class="example-layer-test-component">Test component</div>
     </cds-layer>
+    <style>
+      ${styles}
+    </style>
   `,
 };
 

--- a/packages/web-components/src/components/layer/layer.ts
+++ b/packages/web-components/src/components/layer/layer.ts
@@ -38,6 +38,9 @@ class CDSLayer extends LitElement {
   @property()
   layers;
 
+  @property({ type: Boolean, attribute: 'with-background' })
+  withBackground;
+
   updated() {
     if (!this.layers) {
       this.layers = this.querySelectorAll(


### PR DESCRIPTION
Closes #19426 

Update `cds-layer` web component to add `with-background` prop and update with-layer stories


### Changelog

**Changed**

- add a with-background prop
- updated with-layer stories to use the `with-background`
- update mdx files

#### Testing / Reviewing

with layer stories should now match react
Layer with background story should match react

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
