### PR TITLE
fix(multi-select): adjust AI label spacing when clear button appears

### DIFF
--- a/packages/web-components/src/components/multi-select/multi-select.scss
+++ b/packages/web-components/src/components/multi-select/multi-select.scss
@@ -16,6 +16,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/components/form';
 @use '@carbon/styles/scss/components/checkbox';
 @use '@carbon/styles/scss/components/tag';
+@use '@carbon/styles/scss/utilities/convert';
 
 :host(#{$prefix}-multi-select) {
   outline: none;
@@ -57,6 +58,12 @@ $css--plex: true !default;
   .#{$prefix}--list-box__field:focus-within {
   outline: $spacing-01 solid $focus;
   outline-offset: -#{$spacing-01};
+}
+
+:host(#{$prefix}-multi-select[filterable])
+  .#{$prefix}--list-box__field:has(.#{$prefix}--list-box__selection)
+  ~ ::slotted(#{$prefix}-ai-label) {
+  inset-inline-end: calc($spacing-10 + 18px);
 }
 
 :host(#{$prefix}-multi-select[direction='top']) {
@@ -169,13 +176,25 @@ $css--plex: true !default;
   ::slotted(#{$prefix}-slug) {
     position: absolute;
     inset-block-start: 50%;
-    inset-inline-end: $spacing-08;
+    inset-inline-end: calc($spacing-08 + 9px);
+    margin-block-start: convert.to-rem(0.5px);
   }
 
   ::slotted(#{$prefix}-ai-label:not([revert-active])),
   ::slotted(#{$prefix}-slug:not([revert-active])) {
     transform: translateY(-50%);
   }
+}
+
+:host(#{$prefix}-multi-select[ai-label]) ::slotted(#{$prefix}-ai-label)::after {
+  position: absolute;
+  display: block;
+  background-color: $border-subtle-01;
+  block-size: convert.to-rem(16px);
+  content: '';
+  inline-size: convert.to-rem(1px);
+  inset-block-start: 0;
+  inset-inline-end: convert.to-rem(-9px);
 }
 
 :host(#{$prefix}-multi-select[ai-label][warn]),

--- a/packages/web-components/src/components/multi-select/multi-select.scss
+++ b/packages/web-components/src/components/multi-select/multi-select.scss
@@ -190,7 +190,7 @@ $css--plex: true !default;
   position: absolute;
   display: block;
   background-color: $border-subtle-01;
-  block-size: convert.to-rem(16px);
+  block-size: $spacing-05;
   content: '';
   inline-size: convert.to-rem(1px);
   inset-block-start: 0;


### PR DESCRIPTION
Closes #19297

Fixes overlapping buttons WCAG 2.5.8 issue in Multi Select filterable with AI label variation. Added styling on AI label that creates spacing  and vertical divider matching the React version when clear button is present

New spacing:
<img width="772" alt="Screenshot 2025-05-20 at 5 06 21 PM" src="https://github.com/user-attachments/assets/2182eb4e-8270-44e9-a691-ea458f103aa2" />

### Changelog

**New**

- Styling for spacing and adding vertical divider when clear button is present

#### Testing / Reviewing

- Check that button spacing matches React version when typing into input field of Multi Select with AI label and `filterable="true"`

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
