### PR TITLE
fix(date-picker): range mode close calendar on focus loss

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -895,4 +895,73 @@ describe('Date picker with minDate and maxDate', () => {
     );
     expect(screen.getByRole('application')).toBeInTheDocument();
   });
+  it('should close calendar when moving focus outside of the DatePicker by pressing TAB', async () => {
+    const onClose = jest.fn();
+    render(
+      <div className="wrapper">
+        <DatePicker datePickerType="range" onClose={onClose}>
+          <DatePickerInput id="input-id-start" labelText="Start date" />
+          <DatePickerInput id="input-id-end" labelText="End date" />
+        </DatePicker>
+        <DatePicker datePickerType="range">
+          <DatePickerInput
+            id="next-input-id-start"
+            labelText="Next start date"
+          />
+          <DatePickerInput id="next-input-id-end" labelText="Next end date" />
+        </DatePicker>
+      </div>
+    );
+
+    const startInput = screen.getByLabelText('Start date');
+    const endInput = screen.getByLabelText('End date');
+    const nextInput = screen.getByLabelText('Next start date');
+
+    expect(document.body).toHaveFocus();
+    await userEvent.tab();
+    expect(startInput).toHaveFocus();
+    await userEvent.tab();
+    expect(endInput).toHaveFocus();
+    expect(onClose).not.toHaveBeenCalled();
+    await userEvent.tab();
+    expect(nextInput).toHaveFocus();
+    expect(onClose).toHaveBeenCalled();
+  });
+  it('should close calendar when moving focus outside of the DatePicker by pressing SHIFT+TAB', async () => {
+    const onClose = jest.fn();
+    render(
+      <div className="wrapper">
+        <DatePicker datePickerType="range">
+          <DatePickerInput
+            id="prev-input-id-start"
+            labelText="Previous start date"
+          />
+          <DatePickerInput
+            id="prev-input-id-end"
+            labelText="Previous end date"
+          />
+        </DatePicker>
+        <DatePicker datePickerType="range" onClose={onClose}>
+          <DatePickerInput id="input-id-start" labelText="Start date" />
+          <DatePickerInput id="input-id-end" labelText="End date" />
+        </DatePicker>
+      </div>
+    );
+
+    const prevStartInput = screen.getByLabelText('Previous start date');
+    const prevEndInput = screen.getByLabelText('Previous end date');
+    const startInput = screen.getByLabelText('Start date');
+
+    expect(document.body).toHaveFocus();
+    await userEvent.tab();
+    expect(prevStartInput).toHaveFocus();
+    await userEvent.tab();
+    expect(prevEndInput).toHaveFocus();
+    await userEvent.tab();
+    await expect(startInput).toHaveFocus();
+    expect(onClose).not.toHaveBeenCalled();
+    await userEvent.tab({ shift: true });
+    expect(prevEndInput).toHaveFocus();
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -925,10 +925,13 @@ const DatePicker = React.forwardRef(function DatePicker(
     if (!calendarRef.current || !startInputField.current) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
-        match(event, keys.Tab) &&
-        !event.shiftKey &&
-        document.activeElement === endInputField.current &&
-        calendarRef.current?.isOpen
+        calendarRef.current?.isOpen &&
+        ((match(event, keys.Tab) &&
+          !event.shiftKey &&
+          document.activeElement === endInputField.current) ||
+          (match(event, keys.Tab) &&
+            event.shiftKey &&
+            document.activeElement === startInputField.current))
       ) {
         calendarRef.current.close();
         onCalendarClose(


### PR DESCRIPTION
Closes #19284

Fixes calendar not closing in range mode when pressing SHIFT+TAB to move focus outside of the DatePicker

### Changelog

**New**

- `onCalendarClose` is called when user presses SHIFT+TAB from start date input field
- Tests for `onCalendarClose` being called while moving focus

#### Testing / Reviewing

- Added `DatePicker` tests should pass 
- Verify that calendar closes when pressing SHIFT+TAB to move focus outside DatePicker

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
