### PR TITLE
fix(DefinitionTooltip): make screen reader announce definition on hover

### DIFF
--- a/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
@@ -119,6 +119,7 @@ const DefinitionTooltip: React.FC<DefinitionTooltipProps> = ({
         {...rest}
         className={cx(`${prefix}--definition-term`, triggerClassName)}
         aria-controls={tooltipId}
+        aria-describedby={tooltipId}
         aria-expanded={isOpen}
         onBlur={() => {
           setOpen(false);


### PR DESCRIPTION
Closes #19285

Make  `DefinitionTooltip` link the term to its definition via `aria-describedby`, just like `Tooltip` does.

Addresses the problem that JAWS doesn't announce the definition when the tooltip is opened, at least when opened by hover (`openOnHover === true`) rather than clicking.

### Changelog

**New**

- Add `aria-describedby` attribute for `DefinitionTooltip`, to link the term to its definition.


#### Testing / Reviewing

Storybook under JAWS.  Tested [DefinitionTooltip story in main/](https://react.carbondesignsystem.com/iframe.html?id=components-definitiontooltip--default&viewMode=story) vs. [DefinitionTooltip story in this PR](https://deploy-preview-19482--v11-carbon-react.netlify.app/iframe.html?globals=&args=&id=components-definitiontooltip--default&viewMode=story).

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
