### PR TITLE
fix: added ref to css grid mode

### DIFF
--- a/packages/react/src/components/Grid/Column.tsx
+++ b/packages/react/src/components/Grid/Column.tsx
@@ -122,6 +122,7 @@ const Column = React.forwardRef<
           className={customClassName}
           sm={sm}
           md={md}
+          ref={ref}
           lg={lg}
           xlg={xlg}
           max={max}
@@ -233,34 +234,45 @@ Column.propTypes = {
   xlg: spanPropType,
 };
 
-function CSSGridColumn({
-  as: BaseComponent = 'div',
-  children,
-  className: containerClassName,
-  sm,
-  md,
-  lg,
-  xlg,
-  max,
-  span,
-  ...rest
-}: ColumnProps<any>) {
-  const prefix = usePrefix();
-  const breakpointClassName = getClassNameForBreakpoints(
-    [sm, md, lg, xlg, max],
-    prefix
-  );
-  const spanClassName = getClassNameForSpan(span, prefix);
-  const className = cx(containerClassName, breakpointClassName, spanClassName, {
-    [`${prefix}--css-grid-column`]: true,
-  });
+const CSSGridColumn = React.forwardRef<any, ColumnProps<any>>(
+  (
+    {
+      as: BaseComponent = 'div',
+      children,
+      className: containerClassName,
+      sm,
+      md,
+      lg,
+      xlg,
+      max,
+      span,
+      ...rest
+    },
+    ref
+  ) => {
+    // Add ref parameter
+    const prefix = usePrefix();
+    const breakpointClassName = getClassNameForBreakpoints(
+      [sm, md, lg, xlg, max],
+      prefix
+    );
+    const spanClassName = getClassNameForSpan(span, prefix);
+    const className = cx(
+      containerClassName,
+      breakpointClassName,
+      spanClassName,
+      {
+        [`${prefix}--css-grid-column`]: true,
+      }
+    );
 
-  return (
-    <BaseComponent className={className} {...rest}>
-      {children}
-    </BaseComponent>
-  );
-}
+    return (
+      <BaseComponent className={className} ref={ref} {...rest}>
+        {children}
+      </BaseComponent>
+    );
+  }
+);
 
 CSSGridColumn.propTypes = {
   /**

--- a/packages/react/src/components/Grid/__tests__/Column-test.js
+++ b/packages/react/src/components/Grid/__tests__/Column-test.js
@@ -12,6 +12,13 @@ import { Column } from '../';
 const prefix = 'cds';
 
 describe('Column', () => {
+  // Add this test case inside the main describe('Column', () => {}) block
+  it('should forward ref to the underlying DOM element', () => {
+    const ref = React.createRef();
+    const { container } = render(<Column ref={ref} />);
+    expect(ref.current).toBe(container.firstChild);
+  });
+
   it('should support a custom element as the root node', () => {
     const { container } = render(<Column as="section" />);
     expect(container.firstChild.tagName).toBe('SECTION');
@@ -123,6 +130,17 @@ describe('Column', () => {
 
     afterEach(() => {
       cleanup();
+    });
+
+    it('should forward ref in CSS Grid mode', () => {
+      const ref = React.createRef();
+      render(
+        <Grid>
+          <Column ref={ref} lg={4} />
+        </Grid>
+      );
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+      expect(ref.current).toHaveClass('cds--css-grid-column');
     });
 
     describe.each(['sm', 'md', 'lg', 'xlg', 'max'])('%s', (breakpoint) => {


### PR DESCRIPTION
Closes #19353 

added ref support to the css grid mode to the Grid component.

### Changelog

**New**

- added ref prop in column component

**Changed**

- converted the `CSSGridColumn` component to support ForwardRef.

**Removed**


#### Testing / Reviewing

- make sure the tests are passed
- pull down the code to local
- revert my changes
- see that one of my test case that checks for ref in `CSSGridColumn` fails

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
