### PR TITLE
feat(pageheader): restructure props for content page actions

### DIFF
--- a/packages/react/src/components/PageHeader/PageHeader-test.js
+++ b/packages/react/src/components/PageHeader/PageHeader-test.js
@@ -161,15 +161,19 @@ describe('PageHeader', () => {
     const mockPageActions = [
       {
         id: 'action1',
-        label: 'Action 1',
         onClick: jest.fn(),
         body: <button>Visible Action</button>,
+        menuItem: {
+          label: 'Action 1',
+        },
       },
       {
         id: 'action2',
-        label: 'Action 2',
         onClick: onClickMock,
         body: <button>Hidden Action</button>,
+        menuItem: {
+          label: 'Action 2',
+        },
       },
     ];
 

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -84,7 +84,7 @@ export default {
     PageHeaderTabs,
   },
   // uncomment includeStories before merging so the stories aren't visible in prod
-  includeStories: [],
+  // includeStories: [],
   argTypes: {
     children: {
       control: false, // ReactNode props don't work in the controls pane
@@ -262,9 +262,10 @@ const pageActionItems = (
 
 const pageActionButtonItems = [
   {
+    // props used for both collapse menu item and non-collapsed action form
     id: 'action1',
-    label: 'action 1',
     onClick: () => console.log(`Action 1`),
+    // component to render when non-collapsed
     body: (
       <Button
         renderIcon={AiGenerate}
@@ -274,10 +275,13 @@ const pageActionButtonItems = [
         kind="ghost"
       />
     ),
+    // props to pass to the corresponding collapsed menu item
+    menuItem: {
+      label: 'action 1',
+    },
   },
   {
     id: 'action2',
-    label: 'action 2',
     onClick: () => console.log(`Action 2`),
     body: (
       <Button
@@ -288,10 +292,12 @@ const pageActionButtonItems = [
         kind="ghost"
       />
     ),
+    menuItem: {
+      label: 'action 2',
+    },
   },
   {
     id: 'action3',
-    label: 'action 3',
     onClick: () => console.log(`Action 3`),
     body: (
       <Button
@@ -302,10 +308,12 @@ const pageActionButtonItems = [
         kind="ghost"
       />
     ),
+    menuItem: {
+      label: 'action 3',
+    },
   },
   {
     id: 'action4',
-    label: 'action 4',
     onClick: () => console.log(`Action 4`),
     body: (
       <Button
@@ -316,16 +324,21 @@ const pageActionButtonItems = [
         kind="ghost"
       />
     ),
+    menuItem: {
+      label: 'action 4',
+    },
   },
   {
     id: 'primary-action',
-    label: 'Primary action',
     onClick: () => console.log(`Primary action`),
     body: (
       <Button kind="primary" renderIcon={Add} size="md">
         Primary action
       </Button>
     ),
+    menuItem: {
+      label: 'Primary action',
+    },
   },
 ];
 

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -84,7 +84,7 @@ export default {
     PageHeaderTabs,
   },
   // uncomment includeStories before merging so the stories aren't visible in prod
-  // includeStories: [],
+  includeStories: [],
   argTypes: {
     children: {
       control: false, // ReactNode props don't work in the controls pane

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -19,6 +19,7 @@ import { breakpoints } from '@carbon/layout';
 import { useMatchMedia } from '../../internal/useMatchMedia';
 import { Text } from '../Text';
 import { MenuButton } from '../MenuButton';
+import { MenuItemProps } from '../Menu/MenuItem';
 import { MenuItem } from '../Menu';
 import { DefinitionTooltip } from '../Tooltip';
 import { AspectRatio } from '../AspectRatio';
@@ -265,9 +266,9 @@ const PageHeaderContentPageActions = ({
 
   type pageAction = {
     id: string;
-    label: string;
     onClick: () => void;
     body: React.ReactNode;
+    menuItem: MenuItemProps;
   };
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -310,8 +311,11 @@ const PageHeaderContentPageActions = ({
           {Array.isArray(pageActions) && (
             <>
               {pageActions.map((action) => (
-                <div key={action.id} className="action">
-                  {action.body}
+                <div key={action.id}>
+                  {React.cloneElement(action.body, {
+                    ...action.body.props,
+                    onClick: action.onClick,
+                  })}
                 </div>
               ))}
               <span data-offset data-hidden ref={offsetRef}>
@@ -322,8 +326,8 @@ const PageHeaderContentPageActions = ({
                   {[...hiddenItems].reverse().map((item) => (
                     <MenuItem
                       key={item.id}
-                      label={item.label}
                       onClick={item.onClick}
+                      {...item.menuItem}
                     />
                   ))}
                 </MenuButton>

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -266,7 +266,7 @@ const PageHeaderContentPageActions = ({
 
   type pageAction = {
     id: string;
-    onClick: () => void;
+    onClick?: () => void;
     body: React.ReactNode;
     menuItem: MenuItemProps;
   };


### PR DESCRIPTION
Closes #18903

Restructures the prop object needed to render the `PageHeader`'s content page actions and its collapsible behavior

https://github.com/user-attachments/assets/ce3fc39a-3c0e-4fd2-a33d-3512f84c94e3


Separates the object to common attributes need for rendering both forms (when not collapsed and when collapsed into a menu item)

Then within the `PageHeaderContentPageActions` we can then spread the props to allow for more flexibility for authoring

```
[
  {
    // props used for both collapse menu item and non-collapsed action form
    id: 'action1',
    onClick: () => console.log(`Action 1`),
    // component to render when non-collapsed
    body: (
      <Button
        renderIcon={AiGenerate}
        iconDescription="Icon Description 1"
        hasIconOnly
        size="md"
        kind="ghost"
      />
    ),
    // props to pass to the corresponding collapsed menu item
    menuItem: {
      label: 'action 1',
    },
  },

  ...
]
```

### Changelog

**Changed**

- Change the expected object structure needed for the `PageHeaderContentPageActions` component
- clone the given action component and add the `onClick` property if it is provided by user

#### Testing / Reviewing

Should render the [story](https://deploy-preview-19503--v11-carbon-react.netlify.app/?path=/story/patterns-unstable-pageheader--content-with-contextual-actions-and-page-actions) and collapse into the menu item when minimizing the browser width 

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
