### PR TITLE
fix(date-picker): fix focus management and calendar closing

### DIFF
--- a/e2e/components/DatePicker/DatePicker-test.avt.e2e.js
+++ b/e2e/components/DatePicker/DatePicker-test.avt.e2e.js
@@ -97,7 +97,7 @@ test.describe('@avt DatePicker', () => {
     // avoid flaky test failures from the keyboard press happening too quickly
     // this retries the keypress along with the focus assertion until it passes
     await expect(async () => {
-      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Tab');
       const today = await page.locator('span.today');
       await expect(today).toBeVisible();
       await expect(today).toBeFocused();
@@ -128,7 +128,7 @@ test.describe('@avt DatePicker', () => {
       page.locator('input#date-picker-input-id-start')
     ).toBeFocused();
     await expect(page.locator('div.flatpickr-calendar')).toHaveClass(/open/);
-    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Tab');
     await expect(page.locator('span.today')).toBeFocused();
     await page.keyboard.press('Enter');
     await expect(page.locator('span.today')).toBeFocused();

--- a/e2e/components/FluidDatePicker/FluidDatePicker-test.avt.e2e.js
+++ b/e2e/components/FluidDatePicker/FluidDatePicker-test.avt.e2e.js
@@ -76,7 +76,7 @@ test.describe('@avt FluidDatePicker', () => {
     // avoid flaky test failures from the keyboard press happening too quickly
     // this retries the keypress along with the focus assertion until it passes
     await expect(async () => {
-      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Tab');
       await expect(today).toBeVisible();
       await expect(today).toBeFocused();
     }).toPass();
@@ -105,7 +105,7 @@ test.describe('@avt FluidDatePicker', () => {
       page.locator('input#date-picker-input-id-start')
     ).toBeFocused();
     await expect(page.locator('div.flatpickr-calendar')).toHaveClass(/open/);
-    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Tab');
     await expect(page.locator('span.today')).toBeFocused();
     await page.keyboard.press('Enter');
     await expect(page.locator('span.today')).toBeFocused();

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -565,6 +565,10 @@ describe('Single date picker', () => {
     // close on pressing SHIFT+TAB from date input
     await userEvent.tab();
     expect(dateInput).toHaveFocus();
+    await userEvent.tab();
+    expect(document.activeElement).toHaveClass(`flatpickr-day`);
+    await userEvent.tab({ shift: true });
+    expect(dateInput).toHaveFocus();
     await userEvent.tab({ shift: true });
     expect(document.body).toHaveFocus();
     expect(onClose).toHaveBeenCalledTimes(2);
@@ -837,6 +841,10 @@ describe('Range date picker', () => {
 
     // close on pressing SHIFT+TAB from start date input
     await userEvent.tab();
+    expect(startInput).toHaveFocus();
+    await userEvent.tab();
+    expect(document.activeElement).toHaveClass(`flatpickr-day`);
+    await userEvent.tab({ shift: true });
     expect(startInput).toHaveFocus();
     await userEvent.tab({ shift: true });
     expect(document.body).toHaveFocus();

--- a/packages/react/src/components/DatePicker/DatePicker-test.js
+++ b/packages/react/src/components/DatePicker/DatePicker-test.js
@@ -100,57 +100,6 @@ describe('DatePicker', () => {
     ).toBeInTheDocument();
   });
 
-  it('should not fire onChange handler when clicking outside the datepicker in range mode', () => {
-    const handleChange = jest.fn();
-    const { getByLabelText, getByText } = render(
-      <DatePicker
-        onChange={handleChange}
-        dateFormat="m/d/Y"
-        datePickerType="range">
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          placeholder="mm/dd/yyyy"
-          labelText="Start date"
-        />
-        <DatePickerInput
-          id="date-picker-input-id-finish"
-          placeholder="mm/dd/yyyy"
-          labelText="End date"
-        />
-      </DatePicker>
-    );
-    const startDateInput = getByLabelText('Start date');
-    const endDateInput = getByLabelText('End date');
-    // Change the dates
-    fireEvent.change(startDateInput, { target: { value: '01/01/2023' } });
-    fireEvent.change(endDateInput, { target: { value: '01/07/2023' } });
-    // Simulate a click event outside the datepicker
-    fireEvent.click(document.body);
-    fireEvent.focus(startDateInput);
-    fireEvent.click(document.body);
-    expect(handleChange).not.toHaveBeenCalled();
-  });
-
-  it('should render the children as expected', () => {
-    render(
-      <DatePicker onChange={() => {}} dateFormat="m/d/Y" datePickerType="range">
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          placeholder="mm/dd/yyyy"
-          labelText="Start date"
-        />
-        <DatePickerInput
-          id="date-picker-input-id-finish"
-          placeholder="mm/dd/yyyy"
-          labelText="End date"
-        />
-      </DatePicker>
-    );
-
-    expect(screen.getByLabelText('Start date')).toBeInTheDocument();
-    expect(screen.getByLabelText('End date')).toBeInTheDocument();
-  });
-
   it('should add the date format as expected', () => {
     render(
       <DatePicker
@@ -349,66 +298,6 @@ describe('DatePicker', () => {
     expect(warn).toHaveBeenCalled();
     expect(screen.getByLabelText('Date Picker label')).toHaveValue('');
     warn.mockRestore();
-  });
-
-  it('end date in range mode should not retain old value after setting to null', async () => {
-    const DatePickerExample = () => {
-      const resetValues = { fromDate: null, toDate: null };
-      const [dateRange, setDateRange] = useState(resetValues);
-      const onChange = ({ fromDate, toDate }) => {
-        setDateRange({ fromDate, toDate });
-      };
-      return (
-        <>
-          <DatePicker
-            datePickerType="range"
-            onChange={(dates) => {
-              const [start, end] = dates;
-              onChange({ fromDate: start, toDate: end });
-            }}
-            value={
-              dateRange ? [dateRange.fromDate, dateRange.toDate] : [null, null]
-            }>
-            <DatePickerInput
-              id="fromDate"
-              placeholder="mm/dd/yyyy"
-              labelText="FromDate"
-            />
-            <DatePickerInput
-              id="toDate"
-              placeholder="mm/dd/yyyy"
-              labelText="ToDate"
-            />
-          </DatePicker>
-          <button type="button" onClick={() => setDateRange(resetValues)}>
-            reset
-          </button>
-        </>
-      );
-    };
-    render(<DatePickerExample />);
-
-    // populate fromDate and toDate values
-    await userEvent.type(
-      screen.getByLabelText('FromDate'),
-      '01/14/2025{enter}'
-    );
-    await userEvent.type(screen.getByLabelText('ToDate'), '02/10/2025{enter}');
-
-    // reset both values
-    await userEvent.click(screen.getByText('reset'));
-
-    // assert that toDate is empty
-    expect(screen.getByLabelText('ToDate')).toHaveValue('');
-
-    // populate fromDate
-    await userEvent.type(
-      screen.getByLabelText('FromDate'),
-      '01/14/2025{enter}'
-    );
-
-    // assert that toDate is still empty
-    expect(screen.getByLabelText('ToDate')).toHaveValue('');
   });
 });
 
@@ -652,6 +541,307 @@ describe('Single date picker', () => {
     );
     expect(screen.getByRole('application')).toHaveClass('open');
   });
+
+  it('should close calendar with single type on focus loss', async () => {
+    const onClose = jest.fn();
+    render(
+      <DatePicker datePickerType="single" onClose={onClose}>
+        <DatePickerInput id="input-id" labelText="Date input" />
+      </DatePicker>
+    );
+
+    const dateInput = screen.getByLabelText('Date input');
+
+    // close on pressing TAB from calendar
+    expect(document.body).toHaveFocus();
+    await userEvent.tab();
+    expect(dateInput).toHaveFocus();
+    await userEvent.tab();
+    expect(document.activeElement).toHaveClass(`flatpickr-day`);
+    await userEvent.tab();
+    expect(document.body).toHaveFocus();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // close on pressing SHIFT+TAB from date input
+    await userEvent.tab();
+    expect(dateInput).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(document.body).toHaveFocus();
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Range date picker', () => {
+  it('should not fire onChange handler when clicking outside the datepicker in range mode', () => {
+    const handleChange = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <DatePicker
+        onChange={handleChange}
+        dateFormat="m/d/Y"
+        datePickerType="range">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          placeholder="mm/dd/yyyy"
+          labelText="Start date"
+        />
+        <DatePickerInput
+          id="date-picker-input-id-finish"
+          placeholder="mm/dd/yyyy"
+          labelText="End date"
+        />
+      </DatePicker>
+    );
+    const startDateInput = getByLabelText('Start date');
+    const endDateInput = getByLabelText('End date');
+    // Change the dates
+    fireEvent.change(startDateInput, { target: { value: '01/01/2023' } });
+    fireEvent.change(endDateInput, { target: { value: '01/07/2023' } });
+    // Simulate a click event outside the datepicker
+    fireEvent.click(document.body);
+    fireEvent.focus(startDateInput);
+    fireEvent.click(document.body);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('should render the children as expected', () => {
+    render(
+      <DatePicker onChange={() => {}} dateFormat="m/d/Y" datePickerType="range">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          placeholder="mm/dd/yyyy"
+          labelText="Start date"
+        />
+        <DatePickerInput
+          id="date-picker-input-id-finish"
+          placeholder="mm/dd/yyyy"
+          labelText="End date"
+        />
+      </DatePicker>
+    );
+
+    expect(screen.getByLabelText('Start date')).toBeInTheDocument();
+    expect(screen.getByLabelText('End date')).toBeInTheDocument();
+  });
+
+  it('should respect readOnly prop', async () => {
+    const onChange = jest.fn();
+    const onClick = jest.fn();
+
+    render(
+      <DatePicker
+        dateFormat="m/d/Y"
+        onClick={onClick}
+        onChange={onChange}
+        datePickerType="range"
+        readOnly={true}>
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          labelText="Start date"
+        />
+        <DatePickerInput
+          id="date-picker-input-id-finish"
+          labelText="End date"
+        />
+      </DatePicker>
+    );
+
+    // Click events should fire
+    const theStart = screen.getByLabelText('Start date');
+    await userEvent.click(theStart);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    const theEnd = screen.getByLabelText('End date');
+    await userEvent.click(theEnd);
+    expect(onClick).toHaveBeenCalledTimes(2);
+
+    await userEvent.type(theStart, '01/01/2018{tab}'); // should not be possible to type
+    await userEvent.type(theEnd, '02/02/2018{enter}'); // should not be possible to type
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('should work with ISO 8601 format or others', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <DatePicker dateFormat="Y-m-d" onChange={onChange} datePickerType="range">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          labelText="Start date"
+        />
+        <DatePickerInput
+          id="date-picker-input-id-finish"
+          labelText="End date"
+        />
+      </DatePicker>
+    );
+    const theStart = screen.getByLabelText('Start date');
+    const theEnd = screen.getByLabelText('End date');
+
+    await userEvent.type(theStart, '2023-01-05{enter}');
+    await userEvent.type(theEnd, '2023-01-19{enter}');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('application')).toHaveClass('open');
+    await userEvent.keyboard('{escape}');
+    expect(screen.getByRole('application')).not.toHaveClass('open');
+  });
+
+  it('clearing end date should not cause console warnings', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <DatePicker onChange={() => {}} datePickerType="range" dateFormat="m/d/Y">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          placeholder="mm/dd/yyyy"
+          labelText="Start Date"
+          data-testid="input-value-start"
+        />
+        <DatePickerInput
+          id="date-picker-input-id-end"
+          placeholder="mm/dd/yyyy"
+          labelText="End Date"
+          data-testid="input-value-end"
+        />
+      </DatePicker>
+    );
+    await userEvent.type(
+      screen.getByLabelText('Start Date'),
+      '01/01/2024{enter}'
+    );
+    await userEvent.type(
+      screen.getByLabelText('End Date'),
+      '01/15/2024{enter}'
+    );
+
+    // Ensure the dates are correctly populated
+    expect(screen.getByLabelText('Start Date')).toHaveValue('01/01/2024');
+    expect(screen.getByLabelText('End Date')).toHaveValue('01/15/2024');
+
+    // Clear the end date
+    await userEvent.clear(screen.getByLabelText('End Date'));
+    expect(screen.getByLabelText('End Date')).toHaveValue('');
+
+    // Click on the start date input after clearing the end date
+    await userEvent.click(screen.getByLabelText('Start Date'));
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('should add the calendar if changed from simple type to range', () => {
+    const { rerender } = render(
+      <DatePicker datePickerType="simple">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          labelText="Start date"
+        />
+      </DatePicker>
+    );
+    expect(screen.queryByRole('application')).not.toBeInTheDocument();
+    rerender(
+      <DatePicker datePickerType="range">
+        <DatePickerInput
+          id="date-picker-input-id-start"
+          labelText="Start date"
+        />
+        <DatePickerInput id="date-picker-input-id-end" labelText="End date" />
+      </DatePicker>
+    );
+    expect(screen.getByRole('application')).toBeInTheDocument();
+  });
+
+  it('end date in range mode should not retain old value after setting to null', async () => {
+    const DatePickerExample = () => {
+      const resetValues = { fromDate: null, toDate: null };
+      const [dateRange, setDateRange] = useState(resetValues);
+      const onChange = ({ fromDate, toDate }) => {
+        setDateRange({ fromDate, toDate });
+      };
+      return (
+        <>
+          <DatePicker
+            datePickerType="range"
+            onChange={(dates) => {
+              const [start, end] = dates;
+              onChange({ fromDate: start, toDate: end });
+            }}
+            value={
+              dateRange ? [dateRange.fromDate, dateRange.toDate] : [null, null]
+            }>
+            <DatePickerInput
+              id="fromDate"
+              placeholder="mm/dd/yyyy"
+              labelText="FromDate"
+            />
+            <DatePickerInput
+              id="toDate"
+              placeholder="mm/dd/yyyy"
+              labelText="ToDate"
+            />
+          </DatePicker>
+          <button type="button" onClick={() => setDateRange(resetValues)}>
+            reset
+          </button>
+        </>
+      );
+    };
+    render(<DatePickerExample />);
+
+    // populate fromDate and toDate values
+    await userEvent.type(
+      screen.getByLabelText('FromDate'),
+      '01/14/2025{enter}'
+    );
+    await userEvent.type(screen.getByLabelText('ToDate'), '02/10/2025{enter}');
+
+    // reset both values
+    await userEvent.click(screen.getByText('reset'));
+
+    // assert that toDate is empty
+    expect(screen.getByLabelText('ToDate')).toHaveValue('');
+
+    // populate fromDate
+    await userEvent.type(
+      screen.getByLabelText('FromDate'),
+      '01/14/2025{enter}'
+    );
+
+    // assert that toDate is still empty
+    expect(screen.getByLabelText('ToDate')).toHaveValue('');
+  });
+
+  it('should close calendar with range type on focus loss', async () => {
+    const onClose = jest.fn();
+    render(
+      <DatePicker datePickerType="range" onClose={onClose}>
+        <DatePickerInput id="start-input-id" labelText="Start input" />
+        <DatePickerInput id="end-input-id" labelText="End input" />
+      </DatePicker>
+    );
+
+    const startInput = screen.getByLabelText('Start input');
+    const endInput = screen.getByLabelText('End input');
+
+    // close on pressing TAB from calendar after navigating past end date input
+    expect(document.body).toHaveFocus();
+    await userEvent.tab();
+    expect(startInput).toHaveFocus();
+    await userEvent.tab();
+    expect(document.activeElement).toHaveClass(`flatpickr-day`);
+    await userEvent.tab();
+    expect(endInput).toHaveFocus();
+    await userEvent.tab();
+    expect(document.activeElement).toHaveClass(`flatpickr-day`);
+    await userEvent.tab();
+    expect(document.body).toHaveFocus();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // close on pressing SHIFT+TAB from start date input
+    await userEvent.tab();
+    expect(startInput).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(document.body).toHaveFocus();
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('Date picker with locale', () => {
@@ -769,199 +959,5 @@ describe('Date picker with minDate and maxDate', () => {
 
     expect(mockConsoleError).not.toHaveBeenCalled();
     jest.restoreAllMocks();
-  });
-
-  it('should respect readOnly prop', async () => {
-    const onChange = jest.fn();
-    const onClick = jest.fn();
-
-    render(
-      <DatePicker
-        dateFormat="m/d/Y"
-        onClick={onClick}
-        onChange={onChange}
-        datePickerType="range"
-        readOnly={true}>
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          labelText="Start date"
-        />
-        <DatePickerInput
-          id="date-picker-input-id-finish"
-          labelText="End date"
-        />
-      </DatePicker>
-    );
-
-    // Click events should fire
-    const theStart = screen.getByLabelText('Start date');
-    await userEvent.click(theStart);
-    expect(onClick).toHaveBeenCalledTimes(1);
-    const theEnd = screen.getByLabelText('End date');
-    await userEvent.click(theEnd);
-    expect(onClick).toHaveBeenCalledTimes(2);
-
-    await userEvent.type(theStart, '01/01/2018{tab}'); // should not be possible to type
-    await userEvent.type(theEnd, '02/02/2018{enter}'); // should not be possible to type
-
-    expect(onChange).toHaveBeenCalledTimes(0);
-  });
-
-  it('should work with ISO 8601 format or others', async () => {
-    const onChange = jest.fn();
-
-    render(
-      <DatePicker dateFormat="Y-m-d" onChange={onChange} datePickerType="range">
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          labelText="Start date"
-        />
-        <DatePickerInput
-          id="date-picker-input-id-finish"
-          labelText="End date"
-        />
-      </DatePicker>
-    );
-    const theStart = screen.getByLabelText('Start date');
-    const theEnd = screen.getByLabelText('End date');
-
-    await userEvent.type(theStart, '2023-01-05{tab}');
-    await userEvent.type(theEnd, '2023-01-19{enter}');
-    expect(onChange).toHaveBeenCalledTimes(2);
-    expect(screen.getByRole('application')).toHaveClass('open');
-    await userEvent.keyboard('{escape}');
-    expect(screen.getByRole('application')).not.toHaveClass('open');
-  });
-  it('clearing end date should not cause console warnings', async () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    render(
-      <DatePicker onChange={() => {}} datePickerType="range" dateFormat="m/d/Y">
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          placeholder="mm/dd/yyyy"
-          labelText="Start Date"
-          data-testid="input-value-start"
-        />
-        <DatePickerInput
-          id="date-picker-input-id-end"
-          placeholder="mm/dd/yyyy"
-          labelText="End Date"
-          data-testid="input-value-end"
-        />
-      </DatePicker>
-    );
-    await userEvent.type(
-      screen.getByLabelText('Start Date'),
-      '01/01/2024{enter}'
-    );
-    await userEvent.type(
-      screen.getByLabelText('End Date'),
-      '01/15/2024{enter}'
-    );
-
-    // Ensure the dates are correctly populated
-    expect(screen.getByLabelText('Start Date')).toHaveValue('01/01/2024');
-    expect(screen.getByLabelText('End Date')).toHaveValue('01/15/2024');
-
-    // Clear the end date
-    await userEvent.clear(screen.getByLabelText('End Date'));
-    expect(screen.getByLabelText('End Date')).toHaveValue('');
-
-    // Click on the start date input after clearing the end date
-    await userEvent.click(screen.getByLabelText('Start Date'));
-    expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
-  });
-
-  it('should add the calendar if changed from simple type to range', () => {
-    const { rerender } = render(
-      <DatePicker datePickerType="simple">
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          labelText="Start date"
-        />
-      </DatePicker>
-    );
-    expect(screen.queryByRole('application')).not.toBeInTheDocument();
-    rerender(
-      <DatePicker datePickerType="range">
-        <DatePickerInput
-          id="date-picker-input-id-start"
-          labelText="Start date"
-        />
-        <DatePickerInput id="date-picker-input-id-end" labelText="End date" />
-      </DatePicker>
-    );
-    expect(screen.getByRole('application')).toBeInTheDocument();
-  });
-  it('should close calendar when moving focus outside of the DatePicker by pressing TAB', async () => {
-    const onClose = jest.fn();
-    render(
-      <div className="wrapper">
-        <DatePicker datePickerType="range" onClose={onClose}>
-          <DatePickerInput id="input-id-start" labelText="Start date" />
-          <DatePickerInput id="input-id-end" labelText="End date" />
-        </DatePicker>
-        <DatePicker datePickerType="range">
-          <DatePickerInput
-            id="next-input-id-start"
-            labelText="Next start date"
-          />
-          <DatePickerInput id="next-input-id-end" labelText="Next end date" />
-        </DatePicker>
-      </div>
-    );
-
-    const startInput = screen.getByLabelText('Start date');
-    const endInput = screen.getByLabelText('End date');
-    const nextInput = screen.getByLabelText('Next start date');
-
-    expect(document.body).toHaveFocus();
-    await userEvent.tab();
-    expect(startInput).toHaveFocus();
-    await userEvent.tab();
-    expect(endInput).toHaveFocus();
-    expect(onClose).not.toHaveBeenCalled();
-    await userEvent.tab();
-    expect(nextInput).toHaveFocus();
-    expect(onClose).toHaveBeenCalled();
-  });
-  it('should close calendar when moving focus outside of the DatePicker by pressing SHIFT+TAB', async () => {
-    const onClose = jest.fn();
-    render(
-      <div className="wrapper">
-        <DatePicker datePickerType="range">
-          <DatePickerInput
-            id="prev-input-id-start"
-            labelText="Previous start date"
-          />
-          <DatePickerInput
-            id="prev-input-id-end"
-            labelText="Previous end date"
-          />
-        </DatePicker>
-        <DatePicker datePickerType="range" onClose={onClose}>
-          <DatePickerInput id="input-id-start" labelText="Start date" />
-          <DatePickerInput id="input-id-end" labelText="End date" />
-        </DatePicker>
-      </div>
-    );
-
-    const prevStartInput = screen.getByLabelText('Previous start date');
-    const prevEndInput = screen.getByLabelText('Previous end date');
-    const startInput = screen.getByLabelText('Start date');
-
-    expect(document.body).toHaveFocus();
-    await userEvent.tab();
-    expect(prevStartInput).toHaveFocus();
-    await userEvent.tab();
-    expect(prevEndInput).toHaveFocus();
-    await userEvent.tab();
-    await expect(startInput).toHaveFocus();
-    expect(onClose).not.toHaveBeenCalled();
-    await userEvent.tab({ shift: true });
-    expect(prevEndInput).toHaveFocus();
-    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -489,6 +489,7 @@ const DatePicker = React.forwardRef(function DatePicker(
   }, [calendarCloseEvent, handleCalendarClose]);
 
   const endInputField = useRef<HTMLTextAreaElement>(null);
+  const lastFocusedField = useRef<HTMLTextAreaElement>(null);
   const savedOnChange = useSavedCallback(onChange);
 
   const savedOnOpen = useSavedCallback(onOpen);
@@ -682,32 +683,79 @@ const DatePicker = React.forwardRef(function DatePicker(
 
     calendarRef.current = calendar;
 
-    function handleArrowDown(event) {
+    const handleInputFieldKeyDown = (event: KeyboardEvent) => {
+      const {
+        calendarContainer,
+        selectedDateElem: fpSelectedDateElem,
+        todayDateElem: fpTodayDateElem,
+      } = calendar;
+
       if (match(event, keys.Escape)) {
-        calendar?.calendarContainer?.classList.remove('open');
+        calendarContainer.classList.remove('open');
       }
 
-      if (match(event, keys.ArrowDown)) {
-        if (event.target == endInputField.current) {
-          calendar?.calendarContainer?.classList.add('open');
+      if (match(event, keys.Tab)) {
+        if (!event.shiftKey) {
+          event.preventDefault();
+          calendarContainer.classList.add('open');
+          const selectedDateElem =
+            calendarContainer.querySelector('.selected') && fpSelectedDateElem;
+          const todayDateElem =
+            calendarContainer.querySelector('.today') && fpTodayDateElem;
+          (
+            (selectedDateElem ||
+              todayDateElem ||
+              calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
+              calendarContainer) as HTMLElement
+          ).focus();
+
+          if (event.target === startInputField.current) {
+            lastFocusedField.current = startInputField.current;
+          } else if (event.target === endInputField.current) {
+            lastFocusedField.current = endInputField.current;
+          }
+        } else if (
+          calendarRef.current?.isOpen &&
+          event.target === startInputField.current
+        ) {
+          calendarRef.current.close();
+          onCalendarClose(
+            calendarRef.current.selectedDates,
+            '',
+            calendarRef.current,
+            event
+          );
         }
-        const {
-          calendarContainer,
-          selectedDateElem: fpSelectedDateElem,
-          todayDateElem: fpTodayDateElem,
-        } = calendar;
-        const selectedDateElem =
-          calendarContainer.querySelector('.selected') && fpSelectedDateElem;
-        const todayDateElem =
-          calendarContainer.querySelector('.today') && fpTodayDateElem;
-        (
-          (selectedDateElem ||
-            todayDateElem ||
-            calendarContainer.querySelector('.flatpickr-day[tabindex]') ||
-            calendarContainer) as HTMLElement
-        ).focus();
       }
-    }
+    };
+
+    const handleCalendarKeyDown = (event: KeyboardEvent) => {
+      if (!calendarRef.current || !startInputField.current) return;
+      const lastInputField =
+        datePickerType == 'range'
+          ? endInputField.current
+          : startInputField.current;
+      if (match(event, keys.Tab)) {
+        if (!event.shiftKey) {
+          if (lastFocusedField.current === lastInputField) {
+            lastInputField.focus();
+            calendarRef.current.close();
+            onCalendarClose(
+              calendarRef.current.selectedDates,
+              '',
+              calendarRef.current,
+              event
+            );
+          } else {
+            event.preventDefault();
+            lastInputField.focus();
+          }
+        } else {
+          event.preventDefault();
+          (lastFocusedField.current || startInputField.current).focus();
+        }
+      }
+    };
 
     function handleOnChange(event) {
       const { target } = event;
@@ -739,7 +787,7 @@ const DatePicker = React.forwardRef(function DatePicker(
     }
 
     if (start) {
-      start.addEventListener('keydown', handleArrowDown);
+      start.addEventListener('keydown', handleInputFieldKeyDown);
       start.addEventListener('change', handleOnChange);
       start.addEventListener('keypress', handleKeyPress);
 
@@ -757,9 +805,16 @@ const DatePicker = React.forwardRef(function DatePicker(
     }
 
     if (end) {
-      end.addEventListener('keydown', handleArrowDown);
+      end.addEventListener('keydown', handleInputFieldKeyDown);
       end.addEventListener('change', handleOnChange);
       end.addEventListener('keypress', handleKeyPress);
+    }
+
+    if (calendar.calendarContainer) {
+      calendar.calendarContainer.addEventListener(
+        'keydown',
+        handleCalendarKeyDown
+      );
     }
 
     //component did unmount equivalent
@@ -782,15 +837,22 @@ const DatePicker = React.forwardRef(function DatePicker(
       }
 
       if (start) {
-        start.removeEventListener('keydown', handleArrowDown);
+        start.removeEventListener('keydown', handleInputFieldKeyDown);
         start.removeEventListener('change', handleOnChange);
         start.removeEventListener('keypress', handleKeyPress);
       }
 
       if (end) {
-        end.removeEventListener('keydown', handleArrowDown);
+        end.removeEventListener('keydown', handleInputFieldKeyDown);
         end.removeEventListener('change', handleOnChange);
-        end.removeEventListener('change', handleKeyPress);
+        end.removeEventListener('keypress', handleKeyPress);
+      }
+
+      if (calendar.calendarContainer) {
+        calendar.calendarContainer.removeEventListener(
+          'keydown',
+          handleCalendarKeyDown
+        );
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -920,32 +982,6 @@ const DatePicker = React.forwardRef(function DatePicker(
       startInputField.current.value = value;
     }
   }, [value, prefix]); //eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (!calendarRef.current || !startInputField.current) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        calendarRef.current?.isOpen &&
-        ((match(event, keys.Tab) &&
-          !event.shiftKey &&
-          document.activeElement === endInputField.current) ||
-          (match(event, keys.Tab) &&
-            event.shiftKey &&
-            document.activeElement === startInputField.current))
-      ) {
-        calendarRef.current.close();
-        onCalendarClose(
-          calendarRef.current.selectedDates,
-          '',
-          calendarRef.current,
-          event
-        );
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown, true);
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
-  }, [calendarRef, startInputField, endInputField, onCalendarClose]);
 
   let fluidError;
   if (isFluid) {


### PR DESCRIPTION
Closes #12594

Closes calendar on loss of focus via both Tab and Shift+Tab. Also makes Tab the key to move focus to calendar instead of Down Arrow (this makes pressing Shift+Tab to return to the date input field more intuitive). Confirmed that Escape works to close calendar from both the calendar and input field.

### Changelog

**New**
-  Listeners calling `handleInputFieldKeyDown` and `handleCalendarKeyDown` to handle focus navigation and calendar closing on `keydown ` events

**Changed**

- Keyboard focus navigation to calendar (and reopening it) by pressing Tab instead of ArrowDown
- Updated existing tests for calendar closing on loss of focus to include additional cases
- Updated ISO 8601 format test to account for changes in keyboard navigation
- Organized existing unit tests with `datePickerType="range"` into a new test group (some were organized under `minDate` and `maxDate` group)
- Updated existing playwright tests with keyboard nav changes

**Removed**
- `handleArrowDown` function
- `useEffect` containing `handleKeyDown`

#### Testing / Reviewing

- New focus management and calendar closing tests should pass
- Verify that keyboard navigation functions as expected for all DatePicker variants in storybook

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [N/A] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
