### PR TITLE
fix(ui-shell): improve header global action a11y

### DIFF
--- a/packages/web-components/src/components/ui-shell/header-global-action.ts
+++ b/packages/web-components/src/components/ui-shell/header-global-action.ts
@@ -128,6 +128,12 @@ class CDSHeaderGlobalAction extends CDSButton {
     if (key === 'Enter' || key === ' ') {
       event.preventDefault();
       this._handleClick(event);
+    } else if (key === 'Escape') {
+      const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
+      if (panel) {
+        panel.removeAttribute('expanded');
+      }
+      this.active = false;
     }
   }
 

--- a/packages/web-components/src/components/ui-shell/header-global-action.ts
+++ b/packages/web-components/src/components/ui-shell/header-global-action.ts
@@ -71,16 +71,6 @@ class CDSHeaderGlobalAction extends CDSButton {
   }
 
   private _handleFocusOut = (event: FocusEvent) => {
-    // Double-check:
-    // I use this `ownerDocument` instead of the global `document` to ensure the query
-    // works correctly even if this component is rendered inside a Shadow DOM or
-    // different document context (like an iframe).
-    //
-    // I found more info in:
-    // https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument
-    // https://lit.dev/docs/components/shadow-dom/
-    // const panel = document.querySelector(`#${this.panelId}`);
-    // const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
     const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
     const relatedTarget = event.relatedTarget as HTMLElement;
 

--- a/packages/web-components/src/components/ui-shell/header-global-action.ts
+++ b/packages/web-components/src/components/ui-shell/header-global-action.ts
@@ -60,17 +60,27 @@ class CDSHeaderGlobalAction extends CDSButton {
   }
 
   firstUpdated() {
-    this._buttonNode?.addEventListener('focusout', this._handleFocusOut);
     document.addEventListener('click', this._handleDocumentClick, true);
   }
 
   disconnectedCallback() {
-    this._buttonNode?.removeEventListener('focusout', this._handleFocusOut);
     document.removeEventListener('click', this._handleDocumentClick, true);
     super.disconnectedCallback();
   }
 
-  private _handleFocusOut = (event: FocusEvent) => {
+  private _handleDocumentClick = (event: MouseEvent) => {
+    const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
+    const target = event.composedPath()[0] as HTMLElement;
+
+    if (panel && !this.contains(target) && !panel.contains(target)) {
+      panel.removeAttribute('expanded');
+      this.active = false;
+    }
+  };
+
+  @HostListener('focusout')
+  // @ts-ignore
+  private _handleFocusOut(event: FocusEvent) {
     const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
     const relatedTarget = event.relatedTarget as HTMLElement;
 
@@ -83,17 +93,7 @@ class CDSHeaderGlobalAction extends CDSButton {
       panel.removeAttribute('expanded');
       this.active = false;
     }
-  };
-
-  private _handleDocumentClick = (event: MouseEvent) => {
-    const panel = this.ownerDocument?.querySelector(`#${this.panelId}`);
-    const target = event.composedPath()[0] as HTMLElement;
-
-    if (panel && !this.contains(target) && !panel.contains(target)) {
-      panel.removeAttribute('expanded');
-      this.active = false;
-    }
-  };
+  }
 
   @HostListener('click', { capture: true })
   // @ts-ignore

--- a/packages/web-components/src/components/ui-shell/ui-shell.stories.ts
+++ b/packages/web-components/src/components/ui-shell/ui-shell.stories.ts
@@ -398,7 +398,6 @@ export const HeaderBaseWActionsRightPanel = {
         </div>
         <cds-header-panel
           id="notification-panel"
-          expanded
           aria-label="Header Panel"></cds-header-panel>
       </cds-header>`,
 };


### PR DESCRIPTION
Closes #19374  

Continuation of #19289, that improves the behavior of `header-global-action` so the right panel now closes when focus is lost, and can also be toggled using Enter or Space. It also brings it in line with how the React version works.

### Changelog

**New**

- Added support for toggling the panel using `Enter` and `Space` keys.
- Added `focusout` and `document.click` handlers to close the panel when focus is lost or the user clicks outside.

**Changed**

- Used `@HostListener` for `keydown` to match the keyboard interaction.
- Used `ownerDocument` instead of `document` to make sure the panel is found even inside Shadow DOM. 

#### Testing / Reviewing

- Go to `Web Components Deploy Preview` > `Header w/ Actions and Right Panel`.
- Click or press `**Enter or Space**` on the `**Notifications**` button:
  - It should open the right panel.
  - Press `**Enter or Space**` again to close it.
- Click or tab away from the button/panel:
  - The panel should close automatically.

I used this as reference:
- https://lit.dev/docs/components/shadow-dom/
- https://web.dev/articles/shadowdom-v1
- https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff  
- ~[N/A] Updated documentation and storybook examples~
- ~[N/A] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)  
- [x] Tested for cross-browser consistency  
- [x] Validated that this code is ready for review and status checks should pass  

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)