### PR TITLE
fix(fonts): unquote unicode-range and font-display values

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1902,6 +1902,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "petersandor",
+      "name": "Peter Šándor",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3933866?v=4",
+      "profile": "https://petersandor.name/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/mariyageorge01"><img src="https://avatars.githubusercontent.com/u/166684108?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mariya George</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=mariyageorge01" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/sojinantony01"><img src="https://avatars.githubusercontent.com/u/29255847?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sojin antony</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=sojinantony01" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Gopi-Agasthia-S-005CIU744"><img src="https://avatars.githubusercontent.com/u/196181829?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gopi-Agasthia-S-005CIU744</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Gopi-Agasthia-S-005CIU744" title="Code">💻</a></td>
+    <td align="center"><a href="https://petersandor.name/"><img src="https://avatars.githubusercontent.com/u/3933866?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Peter Šándor</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=petersandor" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/styles/scss/fonts/_mono.scss
+++ b/packages/styles/scss/fonts/_mono.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 @use './unicode';
@@ -20,7 +22,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 100;
@@ -42,7 +44,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 200;
@@ -64,7 +66,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 300;
@@ -86,7 +88,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 400;
@@ -108,7 +110,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 450;
@@ -130,7 +132,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 500;
@@ -152,7 +154,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 600;
@@ -174,7 +176,7 @@ $package-name: 'mono';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 700;

--- a/packages/styles/scss/fonts/_sans-arabic.scss
+++ b/packages/styles/scss/fonts/_sans-arabic.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 
@@ -16,7 +18,7 @@ $package-name: 'sans-arabic';
 
 @mixin thin() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 100;
@@ -32,7 +34,7 @@ $package-name: 'sans-arabic';
 
 @mixin extralight() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 200;
@@ -48,7 +50,7 @@ $package-name: 'sans-arabic';
 
 @mixin light() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 300;
@@ -64,7 +66,7 @@ $package-name: 'sans-arabic';
 
 @mixin regular() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 400;
@@ -80,7 +82,7 @@ $package-name: 'sans-arabic';
 
 @mixin text() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 450;
@@ -96,7 +98,7 @@ $package-name: 'sans-arabic';
 
 @mixin medium() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -112,7 +114,7 @@ $package-name: 'sans-arabic';
 
 @mixin semibold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -128,7 +130,7 @@ $package-name: 'sans-arabic';
 
 @mixin bold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;

--- a/packages/styles/scss/fonts/_sans-devanagari.scss
+++ b/packages/styles/scss/fonts/_sans-devanagari.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 
@@ -16,7 +18,7 @@ $package-name: 'sans-devanagari';
 
 @mixin thin() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 100;
@@ -32,7 +34,7 @@ $package-name: 'sans-devanagari';
 
 @mixin extralight() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 200;
@@ -48,7 +50,7 @@ $package-name: 'sans-devanagari';
 
 @mixin light() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 300;
@@ -64,7 +66,7 @@ $package-name: 'sans-devanagari';
 
 @mixin regular() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 400;
@@ -80,7 +82,7 @@ $package-name: 'sans-devanagari';
 
 @mixin text() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 450;
@@ -96,7 +98,7 @@ $package-name: 'sans-devanagari';
 
 @mixin medium() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -112,7 +114,7 @@ $package-name: 'sans-devanagari';
 
 @mixin semibold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -128,7 +130,7 @@ $package-name: 'sans-devanagari';
 
 @mixin bold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;

--- a/packages/styles/scss/fonts/_sans-hebrew.scss
+++ b/packages/styles/scss/fonts/_sans-hebrew.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 
@@ -16,7 +18,7 @@ $package-name: 'sans-hebrew';
 
 @mixin thin() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 100;
@@ -32,7 +34,7 @@ $package-name: 'sans-hebrew';
 
 @mixin extralight() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 200;
@@ -48,7 +50,7 @@ $package-name: 'sans-hebrew';
 
 @mixin light() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 300;
@@ -64,7 +66,7 @@ $package-name: 'sans-hebrew';
 
 @mixin regular() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 400;
@@ -80,7 +82,7 @@ $package-name: 'sans-hebrew';
 
 @mixin text() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 450;
@@ -96,7 +98,7 @@ $package-name: 'sans-hebrew';
 
 @mixin medium() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -112,7 +114,7 @@ $package-name: 'sans-hebrew';
 
 @mixin semibold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -128,7 +130,7 @@ $package-name: 'sans-hebrew';
 
 @mixin bold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;

--- a/packages/styles/scss/fonts/_sans-thai-looped.scss
+++ b/packages/styles/scss/fonts/_sans-thai-looped.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 
@@ -16,7 +18,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin thin() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 100;
@@ -32,7 +34,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin extralight() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 200;
@@ -48,7 +50,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin light() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 300;
@@ -64,7 +66,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin regular() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 400;
@@ -80,7 +82,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin text() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 450;
@@ -96,7 +98,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin medium() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -112,7 +114,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin semibold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -128,7 +130,7 @@ $package-name: 'sans-thai-looped';
 
 @mixin bold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;

--- a/packages/styles/scss/fonts/_sans-thai.scss
+++ b/packages/styles/scss/fonts/_sans-thai.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 
@@ -16,7 +18,7 @@ $package-name: 'sans-thai';
 
 @mixin thin() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 100;
@@ -32,7 +34,7 @@ $package-name: 'sans-thai';
 
 @mixin extralight() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 200;
@@ -48,7 +50,7 @@ $package-name: 'sans-thai';
 
 @mixin light() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 300;
@@ -64,7 +66,7 @@ $package-name: 'sans-thai';
 
 @mixin regular() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 400;
@@ -80,7 +82,7 @@ $package-name: 'sans-thai';
 
 @mixin text() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 450;
@@ -96,7 +98,7 @@ $package-name: 'sans-thai';
 
 @mixin medium() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -112,7 +114,7 @@ $package-name: 'sans-thai';
 
 @mixin semibold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;
@@ -128,7 +130,7 @@ $package-name: 'sans-thai';
 
 @mixin bold() {
   @font-face {
-    font-display: config.$font-display;
+    font-display: string.unquote(config.$font-display);
     font-family: $font-family;
     font-style: normal;
     font-weight: 500;

--- a/packages/styles/scss/fonts/_sans.scss
+++ b/packages/styles/scss/fonts/_sans.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 @use './unicode';
@@ -20,7 +22,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 100;
@@ -42,7 +44,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 200;
@@ -64,7 +66,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 300;
@@ -86,7 +88,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 400;
@@ -108,7 +110,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 450;
@@ -130,7 +132,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 500;
@@ -152,7 +154,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 600;
@@ -174,7 +176,7 @@ $package-name: 'sans';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 700;

--- a/packages/styles/scss/fonts/_serif.scss
+++ b/packages/styles/scss/fonts/_serif.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use 'sass:string';
+
 @use '../config';
 @use './src';
 @use './unicode';
@@ -20,7 +22,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 100;
@@ -42,7 +44,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 200;
@@ -64,7 +66,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 300;
@@ -86,7 +88,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 400;
@@ -108,7 +110,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 450;
@@ -130,7 +132,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 500;
@@ -152,7 +154,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 600;
@@ -174,7 +176,7 @@ $package-name: 'serif';
   @each $style in $styles {
     @each $unicode-range in $unicode-ranges {
       @font-face {
-        font-display: config.$font-display;
+        font-display: string.unquote(config.$font-display);
         font-family: $font-family;
         font-style: $style;
         font-weight: 700;

--- a/packages/styles/scss/fonts/unicode/_index.scss
+++ b/packages/styles/scss/fonts/unicode/_index.scss
@@ -6,6 +6,8 @@
 //
 
 @use 'sass:map';
+@use 'sass:list';
+@use 'sass:string';
 
 /// All available unicode ranges where the keys are unicode range names and the
 /// value is the list of unicode ranges that are applicable
@@ -118,7 +120,16 @@ $ranges: (
 /// @returns {List}
 @function get-range($name) {
   @if map.has-key($ranges, $name) {
-    @return map.get($ranges, $name);
+    $items: map.get($ranges, $name);
+    $count: list.length($items);
+    $result: '';
+
+    @for $i from 1 through $count {
+      $result: if($i == 1, '', $result + ', ') + list.nth($items, $i);
+    }
+
+    @return string.unquote($result);
   }
+
   @error 'Unable to find range with the name: #{$name}';
 }


### PR DESCRIPTION
Closes #19298
Closes #19324

### Changelog

**Changed**

- `unicode-range` and `font-display` values are now without quotes

#### Testing / Reviewing

1. Start any Carbon sample page with the styles loaded (fonts included) in Firefox
2. Open developer tools and toggle CSS logging
3. Check for console messages mentioning unknown descriptor in `unicode-range` and `font-display` 

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
