### PR TITLE
chore(pageheader): organize stories in storybook and add documentation in overview

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -11609,16 +11609,7 @@ Map {
     "ContentPageActions": Object {
       "displayName": "PageHeaderContentPageActions",
       "propTypes": Object {
-        "children": Object {
-          "type": "node",
-        },
-        "className": Object {
-          "type": "string",
-        },
-        "menuButtonLabel": Object {
-          "type": "string",
-        },
-        "pageActions": Object {
+        "actions": Object {
           "args": Array [
             Array [
               Object {
@@ -11630,6 +11621,15 @@ Map {
             ],
           ],
           "type": "oneOfType",
+        },
+        "children": Object {
+          "type": "node",
+        },
+        "className": Object {
+          "type": "string",
+        },
+        "menuButtonLabel": Object {
+          "type": "string",
         },
       },
     },
@@ -11707,16 +11707,7 @@ Map {
     "PageHeaderContentPageActions": Object {
       "displayName": "PageHeaderContentPageActions",
       "propTypes": Object {
-        "children": Object {
-          "type": "node",
-        },
-        "className": Object {
-          "type": "string",
-        },
-        "menuButtonLabel": Object {
-          "type": "string",
-        },
-        "pageActions": Object {
+        "actions": Object {
           "args": Array [
             Array [
               Object {
@@ -11728,6 +11719,15 @@ Map {
             ],
           ],
           "type": "oneOfType",
+        },
+        "children": Object {
+          "type": "node",
+        },
+        "className": Object {
+          "type": "string",
+        },
+        "menuButtonLabel": Object {
+          "type": "string",
         },
       },
     },

--- a/packages/react/src/components/PageHeader/PageHeader-test.js
+++ b/packages/react/src/components/PageHeader/PageHeader-test.js
@@ -245,7 +245,7 @@ describe('PageHeader', () => {
     it('should not show MenuButton when there are no hidden elements', async () => {
       // Render the component with the mock page actions
       const { container } = render(
-        <PageHeader.ContentPageActions pageActions={mockPageActions} />
+        <PageHeader.ContentPageActions actions={mockPageActions} />
       );
 
       act(() => {
@@ -267,7 +267,7 @@ describe('PageHeader', () => {
     });
 
     it('should render MenuButton with hidden actions when overflow occurs', async () => {
-      render(<PageHeader.ContentPageActions pageActions={mockPageActions} />);
+      render(<PageHeader.ContentPageActions actions={mockPageActions} />);
 
       act(() => {
         mockOverflowOnChange(
@@ -297,7 +297,7 @@ describe('PageHeader', () => {
       const { container } = render(
         <PageHeader.ContentPageActions
           className="custom-class"
-          pageActions={mockPageActions}
+          actions={mockPageActions}
         />
       );
       expect(container.firstChild).toHaveClass('custom-class');
@@ -306,7 +306,7 @@ describe('PageHeader', () => {
     it('should use a custom menuButtonLabel if provided', () => {
       render(
         <PageHeader.ContentPageActions
-          pageActions={mockPageActions}
+          actions={mockPageActions}
           menuButtonLabel="Options"
         />
       );
@@ -314,7 +314,7 @@ describe('PageHeader', () => {
     });
 
     it('should call onClick of hidden action when MenuItem is clicked', async () => {
-      render(<PageHeader.ContentPageActions pageActions={mockPageActions} />);
+      render(<PageHeader.ContentPageActions actions={mockPageActions} />);
 
       act(() => {
         mockOverflowOnChange(

--- a/packages/react/src/components/PageHeader/PageHeader.mdx
+++ b/packages/react/src/components/PageHeader/PageHeader.mdx
@@ -155,43 +155,43 @@ return (
   ]}
 />
 
-When including a hero image within the `PageHeader`, the `Grid` and `Column` components will need to be utilized in order
+When including a hero image within the `PageHeader`:
+
+1. The `Grid` and `Column` components will need to be utilized in order
 to define the layout correctly.
+2. The `withHeroImage` prop needs to be passed in to the `PageHeader.Root`
 
 ```jsx
 import { Grid, Column } from '@carbon/react';
 
 return (
-  <Grid>
-    <Column lg={16} md={8} sm={4}>
-      <PageHeader.Root>
-        <Grid>
-          <Column lg={8} md={4} sm={4}>
-            <PageHeader.Content .... />
-          </Column>
-          <Column lg={8} md={4} sm={0}>
-            <PageHeader.HeroImage>
-              <picture>
-                <source
-                  srcset={image1}
-                  media={`(min-width: ${breakpoints.lg.width})`}
-                />
-                <source
-                  srcset={image2}
-                  media={`(max-width: ${breakpoints.lg.width})`}
-                />
-                <img
-                  src={image1}
-                  alt="a default image"
-                  style={{ maxWidth: '100%', height: 'auto' }}
-                />
-              </picture>
-            </PageHeader.HeroImage>
-          </Column>
-        </Grid>
-      </PageHeader.Root>
-    </Column>
-  </Grid>
+  <PageHeader.Root withHeroImage>
+    <Grid>
+      <Column lg={8} md={4} sm={4}>
+        <PageHeader.BreadcrumbBar ... />
+        <PageHeader.Content ... />
+      </Column>
+      <Column lg={8} md={4} sm={0}>
+        <PageHeader.HeroImage>
+          <picture>
+            <source
+              srcset={image1}
+              media={`(min-width: ${breakpoints.lg.width})`}
+            />
+            <source
+              srcset={image2}
+              media={`(max-width: ${breakpoints.lg.width})`}
+            />
+            <img
+              src={image1}
+              alt="a default image"
+              style={{ maxWidth: '100%', height: 'auto' }}
+            />
+          </picture>
+        </PageHeader.HeroImage>
+      </Column>
+    </Grid>
+  </PageHeader.Root>
 )
 
 ```

--- a/packages/react/src/components/PageHeader/PageHeader.mdx
+++ b/packages/react/src/components/PageHeader/PageHeader.mdx
@@ -116,22 +116,7 @@ const actionItems = [
       label: 'action 1',
     },
   },
-  {
-    id: 'action2',
-    onClick: () => console.log(`Action 2`),
-    body: (
-      <Button
-        renderIcon={Activity}
-        iconDescription="Icon Description 2"
-        hasIconOnly
-        size="md"
-        kind="ghost"
-      />
-    ),
-    menuItem: {
-      label: 'action 2',
-    },
-  }
+  ...
 ];
 
 return (
@@ -182,16 +167,7 @@ return (
       <PageHeader.Root>
         <Grid>
           <Column lg={8} md={4} sm={4}>
-            <PageHeader.Content
-              title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-              {...args}>
-              <PageHeader.ContentText subtitle="Subtitle">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-                enim ad minim veniam, quis nostrud exercitation ullamco laboris
-                nisi ut aliquip ex.
-              </PageHeader.ContentText>
-            </PageHeader.Content>
+            <PageHeader.Content .... />
           </Column>
           <Column lg={8} md={4} sm={0}>
             <PageHeader.HeroImage>

--- a/packages/react/src/components/PageHeader/PageHeader.mdx
+++ b/packages/react/src/components/PageHeader/PageHeader.mdx
@@ -14,9 +14,15 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 ## Table of Contents
 
+- [Overview](#overview)
+- [PageHeader.BreadcrumbBar](#pageheaderbreadcrumbbar)
+- [PageHeader.Content](#pageheadercontent)
+  - [PageHeader.Content with hero image](#pageheadercontent-with-hero-image)
+- [PageHeader.TabsBar](#pageheadertabsbar)
+
 ## Overview
 
-The page header is a large family of components.
+The `PageHeader` is a large family of components, composed of three zones; the Breadcrumb, Content, and Tabs.
 
 <Canvas
   of={PageHeaderStories.Default}
@@ -27,6 +33,197 @@ The page header is a large family of components.
     },
   ]}
 />
+
+## PageHeader.BreadcrumbBar
+
+The `PageHeader.BreadcrumbBar` component is used to render the breadcrumb navigation area within the `PageHeader`.
+It accepts `Breadcrumb` and `BreadcrumbItem` components as children to define the breadcrumb trail.Additionally, it accepts
+`contentActions` and` pageActions` props, allowing for actions, such as `Button` or `IconButton` — alongside
+the breadcrumb content.
+
+```jsx
+import { Bee } from '@carbon/icons-react';
+
+const BeeIcon = () => <Bee size={16} />;
+
+const pageActions = (
+  <Button
+    renderIcon={Activity}
+    iconDescription="Icon Description 1"
+    hasIconOnly
+    size="md"
+    kind="ghost"
+  />
+);
+
+const contentActions = (
+  <Button size="md">Button</Button>
+)
+
+return (
+  <PageHeader.BreadcrumbBar
+    renderIcon={BeeIcon}
+    contentActions={contentActions}
+    pageActions={pageActions}>
+    <Breadcrumb>
+      <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+      <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+    </Breadcrumb>
+  </PageHeader.BreadcrumbBar>
+)
+```
+
+## PageHeader.Content
+
+<Canvas
+  of={PageHeaderStories.ContentWithContextualActionsAndPageActions}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(PageHeaderStories.ContentWithContextualActionsAndPageActions),
+    },
+  ]}
+/>
+
+The `PageHeader.Content` component defines the primary content area of the `PageHeader`, including the title, subtitle, and
+any supporting text or contextual actions. It accepts a `title` prop to display the main heading and can optionally include a `renderIcon` prop
+to show an icon adjacent to the title. Child components such as `PageHeader.ContentText` can be used to provide additional descriptive text.
+To support use cases such as tags, `contextualActions` can be passed as a prop to render components beside the content.
+`pageActions` allows integration of action buttons aligned with the content section.
+
+The `PageHeader.ContentPageActions` component provides responsive behavior by collapsing actions into a `MenuButto`n when the viewport
+width is reduced. To enable this functionality, it expects an array of action objects with a specific API shape, as demonstrated below:
+
+```jsx
+
+const actionItems = [
+  {
+    // props used for both collapse menu item and non-collapsed action form
+    id: 'action1',
+    onClick: () => console.log(`Action 1`),
+    // component to render when non-collapsed
+    body: (
+      <Button
+        renderIcon={AiGenerate}
+        iconDescription="Icon Description 1"
+        hasIconOnly
+        size="md"
+        kind="ghost"
+      />
+    ),
+    // props to pass to the corresponding collapsed menu item
+    menuItem: {
+      label: 'action 1',
+    },
+  },
+  {
+    id: 'action2',
+    onClick: () => console.log(`Action 2`),
+    body: (
+      <Button
+        renderIcon={Activity}
+        iconDescription="Icon Description 2"
+        hasIconOnly
+        size="md"
+        kind="ghost"
+      />
+    ),
+    menuItem: {
+      label: 'action 2',
+    },
+  }
+];
+
+return (
+   <PageHeader.Content
+      title="Title text"
+      contextualActions={
+        <>
+          <Tag className="tag" type="blue" size="lg">
+            Moop
+          </Tag>
+        </>
+      }
+      pageActions={
+        <PageHeader.ContentPageActions
+          menuButtonLabel="Actions"
+          actions={actionItems}></PageHeader.ContentPageActions>
+      }>
+      <PageHeader.ContentText subtitle="Subtitle">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex.
+      </PageHeader.ContentText>
+    </PageHeader.Content>
+)
+```
+
+## PageHeader.Content With Hero Image
+
+<Canvas
+  of={PageHeaderStories.ContentWithHeroImage}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () => stackblitzPrefillConfig(PageHeaderStories.ContentWithHeroImage),
+    },
+  ]}
+/>
+
+When including a hero image within the `PageHeader`, the `Grid` and `Column` components will need to be utilized in order
+to define the layout correctly.
+
+```jsx
+import { Grid, Column } from '@carbon/react';
+
+return (
+  <Grid>
+    <Column lg={16} md={8} sm={4}>
+      <PageHeader.Root>
+        <Grid>
+          <Column lg={8} md={4} sm={4}>
+            <PageHeader.Content
+              title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
+              {...args}>
+              <PageHeader.ContentText subtitle="Subtitle">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex.
+              </PageHeader.ContentText>
+            </PageHeader.Content>
+          </Column>
+          <Column lg={8} md={4} sm={0}>
+            <PageHeader.HeroImage>
+              <picture>
+                <source
+                  srcset={image1}
+                  media={`(min-width: ${breakpoints.lg.width})`}
+                />
+                <source
+                  srcset={image2}
+                  media={`(max-width: ${breakpoints.lg.width})`}
+                />
+                <img
+                  src={image1}
+                  alt="a default image"
+                  style={{ maxWidth: '100%', height: 'auto' }}
+                />
+              </picture>
+            </PageHeader.HeroImage>
+          </Column>
+        </Grid>
+      </PageHeader.Root>
+    </Column>
+  </Grid>
+)
+
+```
+
+
+
+## PageHeader.TabsBar
+
 
 ## Component API
 

--- a/packages/react/src/components/PageHeader/PageHeader.mdx
+++ b/packages/react/src/components/PageHeader/PageHeader.mdx
@@ -61,15 +61,18 @@ const contentActions = (
 )
 
 return (
-  <PageHeader.BreadcrumbBar
-    renderIcon={BeeIcon}
-    contentActions={contentActions}
-    pageActions={pageActions}>
-    <Breadcrumb>
-      <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
-      <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-    </Breadcrumb>
-  </PageHeader.BreadcrumbBar>
+  <PageHeader.Root>
+    <PageHeader.BreadcrumbBar
+      renderIcon={BeeIcon}
+      contentActions={contentActions}
+      pageActions={pageActions}>
+      <Breadcrumb>
+        <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+      </Breadcrumb>
+    </PageHeader.BreadcrumbBar>
+    ...
+  </PageHeader.Root>
 )
 ```
 
@@ -91,7 +94,7 @@ to show an icon adjacent to the title. Child components such as `PageHeader.Cont
 To support use cases such as tags, `contextualActions` can be passed as a prop to render components beside the content.
 `pageActions` allows integration of action buttons aligned with the content section.
 
-The `PageHeader.ContentPageActions` component provides responsive behavior by collapsing actions into a `MenuButto`n when the viewport
+The `PageHeader.ContentPageActions` component provides responsive behavior by collapsing actions into a `MenuButton` when the viewport
 width is reduced. To enable this functionality, it expects an array of action objects with a specific API shape, as demonstrated below:
 
 ```jsx
@@ -120,7 +123,9 @@ const actionItems = [
 ];
 
 return (
-   <PageHeader.Content
+  <PageHeader.Root>
+   ...
+    <PageHeader.Content
       title="Title text"
       contextualActions={
         <>
@@ -140,6 +145,7 @@ return (
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex.
       </PageHeader.ContentText>
     </PageHeader.Content>
+  </PageHeader.Root>
 )
 ```
 
@@ -197,6 +203,32 @@ return (
 ```
 
 ## PageHeader.TabsBar
+
+To render the Tabs zone simply utilitize the `PageHeader.TabBar` and `PageHeader.Tabs` components, passing in
+the `Tab` components as children.
+
+
+```jsx
+  <PageHeader.Root>
+    ...
+    <PageHeader.TabBar>
+      <PageHeader.Tabs>
+        <TabList>
+          <Tab>Dashboard</Tab>
+          <Tab>Monitoring</Tab>
+          <Tab>Activity</Tab>
+          <Tab>Settings</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Dashboard Tab Panel</TabPanel>
+          <TabPanel>Monitoring Tab Panel</TabPanel>
+          <TabPanel>Activity Tab Panel</TabPanel>
+          <TabPanel>Settings Tab Panel</TabPanel>
+        </TabPanels>
+      </PageHeader.Tabs>
+    </PageHeader.TabBar>
+  </PageHeader.Root>
+```
 
 
 ## Component API

--- a/packages/react/src/components/PageHeader/PageHeader.mdx
+++ b/packages/react/src/components/PageHeader/PageHeader.mdx
@@ -161,17 +161,14 @@ return (
   ]}
 />
 
-When including a hero image within the `PageHeader`:
-
-1. The `Grid` and `Column` components will need to be utilized in order
+When including a hero image within the `PageHeader`, the `Grid` and `Column` components will need to be utilized in order
 to define the layout correctly.
-2. The `withHeroImage` prop needs to be passed in to the `PageHeader.Root`
 
 ```jsx
 import { Grid, Column } from '@carbon/react';
 
 return (
-  <PageHeader.Root withHeroImage>
+  <PageHeader.Root>
     <Grid>
       <Column lg={8} md={4} sm={4}>
         <PageHeader.BreadcrumbBar ... />

--- a/packages/react/src/components/PageHeader/PageHeader.mdx
+++ b/packages/react/src/components/PageHeader/PageHeader.mdx
@@ -37,12 +37,12 @@ The `PageHeader` is a large family of components, composed of three zones; the B
 ## PageHeader.BreadcrumbBar
 
 The `PageHeader.BreadcrumbBar` component is used to render the breadcrumb navigation area within the `PageHeader`.
-It accepts `Breadcrumb` and `BreadcrumbItem` components as children to define the breadcrumb trail.Additionally, it accepts
+It accepts `Breadcrumb` and `BreadcrumbItem` components as children to define the breadcrumb trail. Additionally, it accepts
 `contentActions` and` pageActions` props, allowing for actions, such as `Button` or `IconButton` — alongside
 the breadcrumb content.
 
 ```jsx
-import { Bee } from '@carbon/icons-react';
+import { Bee, Activity } from '@carbon/icons-react';
 
 const BeeIcon = () => <Bee size={16} />;
 
@@ -195,8 +195,6 @@ return (
 )
 
 ```
-
-
 
 ## PageHeader.TabsBar
 

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -398,7 +398,7 @@ export const ContentWithContextualActionsAndPageActions = (args) => (
       pageActions={
         <PageHeader.ContentPageActions
           menuButtonLabel="Actions"
-          pageActions={pageActionButtonItems}></PageHeader.ContentPageActions>
+          actions={pageActionButtonItems}></PageHeader.ContentPageActions>
       }
       {...args}>
       <PageHeader.ContentText subtitle="Subtitle">
@@ -408,54 +408,4 @@ export const ContentWithContextualActionsAndPageActions = (args) => (
       </PageHeader.ContentText>
     </PageHeader.Content>
   </PageHeader.Root>
-);
-
-export const DirectExports = (args) => (
-  <PageHeaderDirect {...args}>
-    <PageHeaderBreadcrumbBar
-      renderIcon={BreadcrumbBeeIcon}
-      pageActions={breadcrumbPageActions}>
-      <Breadcrumb>
-        <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
-        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-      </Breadcrumb>
-    </PageHeaderBreadcrumbBar>
-    <PageHeaderContent
-      title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-      contextualActions={
-        <>
-          <Tag className="tag" type="blue" size="lg">
-            Moop
-          </Tag>
-        </>
-      }
-      pageActions={
-        <PageHeaderContentPageActions
-          menuButtonLabel="Actions"
-          pageActions={pageActionButtonItems}></PageHeaderContentPageActions>
-      }
-      {...args}>
-      <PageHeaderContentText subtitle="Subtitle">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex.
-      </PageHeaderContentText>
-    </PageHeaderContent>
-    <PageHeaderTabBar>
-      <PageHeaderTabs>
-        <TabList>
-          <Tab>Dashboard</Tab>
-          <Tab>Monitoring</Tab>
-          <Tab>Activity</Tab>
-          <Tab>Settings</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>Dashboard Tab Panel</TabPanel>
-          <TabPanel>Monitoring Tab Panel</TabPanel>
-          <TabPanel>Activity Tab Panel</TabPanel>
-          <TabPanel>Settings Tab Panel</TabPanel>
-        </TabPanels>
-      </PageHeaderTabs>
-    </PageHeaderTabBar>
-  </PageHeaderDirect>
 );

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -38,6 +38,8 @@ export default {
     PageHeaderHeroImage,
     PageHeaderTabBar,
     PageHeaderTabs,
+    PageHeaderContentText,
+    PageHeaderContentPageActions,
   },
   argTypes: {
     children: {

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -245,55 +245,49 @@ export const ContentWithContextualActions = (args) => (
 );
 
 export const ContentWithHeroImage = (args) => (
-  <Grid>
-    <Column lg={16} md={8} sm={4}>
-      <PageHeader.Root>
-        <Grid>
-          <Column lg={8} md={4} sm={4}>
-            <PageHeader.BreadcrumbBar
-              border={false}
-              renderIcon={BreadcrumbBeeIcon}>
-              <Breadcrumb>
-                <BreadcrumbItem>
-                  <a href="/#">Breadcrumb 1</a>
-                </BreadcrumbItem>
-                <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-              </Breadcrumb>
-            </PageHeader.BreadcrumbBar>
-            <PageHeader.Content
-              title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-              {...args}>
-              <PageHeader.ContentText subtitle="Subtitle">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-                enim ad minim veniam, quis nostrud exercitation ullamco laboris
-                nisi ut aliquip ex.
-              </PageHeader.ContentText>
-            </PageHeader.Content>
-          </Column>
-          <Column lg={8} md={4} sm={0}>
-            <PageHeader.HeroImage>
-              <picture>
-                <source
-                  srcset={image1}
-                  media={`(min-width: ${breakpoints.lg.width})`}
-                />
-                <source
-                  srcset={image2}
-                  media={`(max-width: ${breakpoints.lg.width})`}
-                />
-                <img
-                  src={image1}
-                  alt="a default image"
-                  style={{ maxWidth: '100%', height: 'auto' }}
-                />
-              </picture>
-            </PageHeader.HeroImage>
-          </Column>
-        </Grid>
-      </PageHeader.Root>
-    </Column>
-  </Grid>
+  <PageHeader.Root withHeroImage>
+    <Grid>
+      <Column lg={8} md={4} sm={4}>
+        <PageHeader.BreadcrumbBar border={false} renderIcon={BreadcrumbBeeIcon}>
+          <Breadcrumb>
+            <BreadcrumbItem>
+              <a href="/#">Breadcrumb 1</a>
+            </BreadcrumbItem>
+            <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+          </Breadcrumb>
+        </PageHeader.BreadcrumbBar>
+        <PageHeader.Content
+          title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
+          {...args}>
+          <PageHeader.ContentText subtitle="Subtitle">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex.
+          </PageHeader.ContentText>
+        </PageHeader.Content>
+      </Column>
+      <Column lg={8} md={4} sm={0}>
+        <PageHeader.HeroImage>
+          <picture>
+            <source
+              srcset={image1}
+              media={`(min-width: ${breakpoints.lg.width})`}
+            />
+            <source
+              srcset={image2}
+              media={`(max-width: ${breakpoints.lg.width})`}
+            />
+            <img
+              src={image1}
+              alt="a default image"
+              style={{ maxWidth: '100%', height: 'auto' }}
+            />
+          </picture>
+        </PageHeader.HeroImage>
+      </Column>
+    </Grid>
+  </PageHeader.Root>
 );
 
 const pageActionButtonItems = [

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -29,6 +29,44 @@ import { Bee, AiGenerate, CloudFoundry_1, Activity } from '@carbon/icons-react';
 import mdx from './PageHeader.mdx';
 import { TabList, Tab, TabPanels, TabPanel } from '../Tabs/Tabs';
 
+export default {
+  title: 'Patterns/unstable__PageHeader',
+  component: PageHeader,
+  subcomponents: {
+    PageHeaderBreadcrumbBar,
+    PageHeaderContent,
+    PageHeaderHeroImage,
+    PageHeaderTabBar,
+    PageHeaderTabs,
+  },
+  argTypes: {
+    children: {
+      control: false, // ReactNode props don't work in the controls pane
+    },
+  },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <>
+        <style>
+          {`
+          .sb-show-main.sb-main-padded {
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+          }
+        `}
+        </style>
+        <Story />
+      </>
+    ),
+  ],
+};
+
 const BeeIcon = () => <Bee size={32} />;
 
 const BreadcrumbBeeIcon = () => <Bee size={16} />;
@@ -65,50 +103,13 @@ const breadcrumbContentActions = (
   </>
 );
 
-export default {
-  title: 'Patterns/unstable__PageHeader',
-  component: PageHeader,
-  subcomponents: {
-    PageHeaderBreadcrumbBar,
-    PageHeaderContent,
-    PageHeaderHeroImage,
-    PageHeaderTabBar,
-    PageHeaderTabs,
-  },
-  argTypes: {
-    children: {
-      control: false, // ReactNode props don't work in the controls pane
-    },
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  decorators: [
-    (Story) => (
-      <>
-        <style>
-          {`
-          .sb-show-main.sb-main-padded {
-            padding-left: 0;
-            padding-right: 0;
-          }
-        `}
-        </style>
-        <Story />
-      </>
-    ),
-  ],
-};
-
 export const Default = (args) => (
   <PageHeader.Root>
     <PageHeader.BreadcrumbBar
       border={args.border}
       pageActionsFlush={args.pageActionsFlush}
       contentActionsFlush={args.contentActionsFlush}
-      renderIcon={BreadcrumbBeeIcon}
+      renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
       contentActions={breadcrumbContentActions}
       pageActions={breadcrumbPageActions}>
       <Breadcrumb>
@@ -149,6 +150,7 @@ Default.args = {
   contentActionsFlush: false,
   title:
     'Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long',
+  renderBreadcrumbIcon: true,
 };
 
 Default.argTypes = {
@@ -179,13 +181,18 @@ Default.argTypes = {
       type: 'text',
     },
   },
+  renderBreadcrumbIcon: {
+    description:
+      'Specify whether to render the BreadcrumbBar icon (storybook control only)',
+    control: {
+      type: 'boolean',
+    },
+  },
 };
 
 export const ContentWithIcon = (args) => (
   <PageHeader.Root>
-    <PageHeader.BreadcrumbBar
-      renderIcon={BreadcrumbBeeIcon}
-      pageActions={breadcrumbPageActions}>
+    <PageHeader.BreadcrumbBar pageActions={breadcrumbPageActions}>
       <Breadcrumb>
         <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
         <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -229,7 +229,7 @@ export const ContentWithContextualActions = (args) => (
       contextualActions={
         <>
           <Tag className="tag" type="blue" size="lg">
-            Moop
+            Tag
           </Tag>
         </>
       }
@@ -387,7 +387,7 @@ export const ContentWithContextualActionsAndPageActions = (args) => (
       contextualActions={
         <>
           <Tag className="tag" type="blue" size="lg">
-            Moop
+            Tag
           </Tag>
         </>
       }

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -13,13 +13,11 @@ import {
   PageHeaderContent,
   PageHeaderTabBar,
   PageHeaderContentText,
+  PageHeaderContentPageActions,
   PageHeaderHeroImage,
   PageHeaderTabs,
 } from '../PageHeader';
-import { Dropdown } from '../Dropdown';
 import { Tag } from '../Tag';
-import { ContentSwitcher } from '../ContentSwitcher';
-import { IconSwitch } from '../Switch';
 import { Button } from '../Button';
 import { Grid, Column } from '../Grid';
 import { Breadcrumb, BreadcrumbItem } from '../Breadcrumb';
@@ -27,54 +25,13 @@ import { breakpoints } from '@carbon/layout';
 import image1 from './_story-assets/2x1.jpg';
 import image2 from './_story-assets/3x2.jpg';
 
-import {
-  Bee,
-  AiGenerate,
-  CloudFoundry_1,
-  Activity,
-  PartitionAuto,
-  TaskAdd,
-  TableOfContents,
-  Workspace,
-  ViewMode_2,
-} from '@carbon/icons-react';
+import { Bee, AiGenerate, CloudFoundry_1, Activity } from '@carbon/icons-react';
 import mdx from './PageHeader.mdx';
 import { TabList, Tab, TabPanels, TabPanel } from '../Tabs/Tabs';
 
 const BeeIcon = () => <Bee size={32} />;
 
 const BreadcrumbBeeIcon = () => <Bee size={16} />;
-
-const dropdownItems = [
-  {
-    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
-  },
-  {
-    text: 'Option 1',
-  },
-  {
-    text: 'Option 2',
-  },
-  {
-    disabled: true,
-    text: 'Option 3 - a disabled item',
-  },
-  {
-    text: 'Option 4',
-  },
-  {
-    text: 'Option 5',
-  },
-  {
-    text: 'Option 6',
-  },
-  {
-    text: 'Option 7',
-  },
-  {
-    text: 'Option 8',
-  },
-];
 
 const breadcrumbPageActions = (
   <>
@@ -86,14 +43,14 @@ const breadcrumbPageActions = (
       kind="ghost"
     />
     <Button
-      renderIcon={Activity}
+      renderIcon={AiGenerate}
       iconDescription="Icon Description 2"
       hasIconOnly
       size="md"
       kind="ghost"
     />
     <Button
-      renderIcon={Activity}
+      renderIcon={CloudFoundry_1}
       iconDescription="Icon Description 3"
       hasIconOnly
       size="md"
@@ -118,8 +75,6 @@ export default {
     PageHeaderTabBar,
     PageHeaderTabs,
   },
-  // uncomment includeStories before merging so the stories aren't visible in prod
-  includeStories: [],
   argTypes: {
     children: {
       control: false, // ReactNode props don't work in the controls pane
@@ -184,42 +139,6 @@ export const Default = (args) => (
         </TabPanels>
       </PageHeader.Tabs>
     </PageHeader.TabBar>
-  </PageHeader.Root>
-);
-
-export const BreadcrumbBar = (args) => (
-  <PageHeader.Root>
-    <PageHeader.BreadcrumbBar
-      renderIcon={BreadcrumbBeeIcon}
-      pageActions={breadcrumbPageActions}>
-      <Breadcrumb>
-        <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
-        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-      </Breadcrumb>
-    </PageHeader.BreadcrumbBar>
-  </PageHeader.Root>
-);
-
-export const Content = (args) => (
-  <PageHeader.Root>
-    <PageHeader.BreadcrumbBar
-      renderIcon={BreadcrumbBeeIcon}
-      pageActions={breadcrumbPageActions}>
-      <Breadcrumb>
-        <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
-        <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-      </Breadcrumb>
-    </PageHeader.BreadcrumbBar>
-    <PageHeader.Content
-      title="Page header content title with an extra long title that turns into a definition tooltip that creates a title with an ellipsis."
-      {...args}>
-      <PageHeader.ContentText subtitle="Subtitle">
-        Neque massa fames auctor maecenas leo. Mollis vehicula per, est justo.
-        Massa elementum class enim malesuada lacinia hendrerit enim erat
-        pellentesque. Sapien arcu lobortis est erat arcu nibh vehicula congue.
-        Nisi molestie primis lorem nascetur sem metus mattis etiam scelerisque.
-      </PageHeader.ContentText>
-    </PageHeader.Content>
   </PageHeader.Root>
 );
 
@@ -445,41 +364,37 @@ export const ContentWithContextualActionsAndPageActions = (args) => (
   </PageHeader.Root>
 );
 
-export const TabBar = (args) => {
-  return (
-    <PageHeader.Root>
-      <PageHeader.TabBar {...args}>
-        <PageHeader.Tabs>
-          <TabList>
-            <Tab>Dashboard</Tab>
-            <Tab>Monitoring</Tab>
-            <Tab>Activity</Tab>
-            <Tab>Settings</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel key={0}>Dashboard Tab Panel</TabPanel>
-            <TabPanel>Monitoring Tab Panel</TabPanel>
-            <TabPanel>Activity Tab Panel</TabPanel>
-            <TabPanel>Settings Tab Panel</TabPanel>
-          </TabPanels>
-        </PageHeader.Tabs>
-      </PageHeader.TabBar>
-    </PageHeader.Root>
-  );
-};
-
 export const DirectExports = (args) => (
   <PageHeaderDirect {...args}>
     <PageHeaderBreadcrumbBar
       renderIcon={BreadcrumbBeeIcon}
-      contentActions={breadcrumbContentActions}
       pageActions={breadcrumbPageActions}>
       <Breadcrumb>
         <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
         <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
       </Breadcrumb>
     </PageHeaderBreadcrumbBar>
-    <PageHeaderContent />
+    <PageHeaderContent
+      title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
+      contextualActions={
+        <>
+          <Tag className="tag" type="blue" size="lg">
+            Moop
+          </Tag>
+        </>
+      }
+      pageActions={
+        <PageHeaderContentPageActions
+          menuButtonLabel="Actions"
+          pageActions={pageActionButtonItems}></PageHeaderContentPageActions>
+      }
+      {...args}>
+      <PageHeaderContentText subtitle="Subtitle">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex.
+      </PageHeaderContentText>
+    </PageHeaderContent>
     <PageHeaderTabBar>
       <PageHeaderTabs>
         <TabList>

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -103,8 +103,11 @@ export default {
 };
 
 export const Default = (args) => (
-  <PageHeader.Root {...args}>
+  <PageHeader.Root>
     <PageHeader.BreadcrumbBar
+      border={args.border}
+      pageActionsFlush={args.pageActionsFlush}
+      contentActionsFlush={args.contentActionsFlush}
       renderIcon={BreadcrumbBeeIcon}
       contentActions={breadcrumbContentActions}
       pageActions={breadcrumbPageActions}>
@@ -113,9 +116,7 @@ export const Default = (args) => (
         <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
       </Breadcrumb>
     </PageHeader.BreadcrumbBar>
-    <PageHeader.Content
-      title="Page header content title with an extra long title that turns into a definition tooltip that creates a title with an ellipsis."
-      {...args}>
+    <PageHeader.Content title={args.title}>
       <PageHeader.ContentText subtitle="Subtitle">
         Neque massa fames auctor maecenas leo. Mollis vehicula per, est justo.
         Massa elementum class enim malesuada lacinia hendrerit enim erat
@@ -141,6 +142,44 @@ export const Default = (args) => (
     </PageHeader.TabBar>
   </PageHeader.Root>
 );
+
+Default.args = {
+  border: true,
+  pageActionsFlush: false,
+  contentActionsFlush: false,
+  title:
+    'Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long',
+};
+
+Default.argTypes = {
+  border: {
+    description: 'Specify whether to render BreadcrumbBar border',
+    control: {
+      type: 'boolean',
+    },
+  },
+  pageActionsFlush: {
+    description:
+      'Specify whether the page actions within BreadcrumbBar should be flush',
+    control: {
+      type: 'boolean',
+    },
+  },
+  contentActionsFlush: {
+    description:
+      'Specify whether the content actions within BreadcrumbBar should be flush with the page actions',
+    control: {
+      type: 'boolean',
+    },
+  },
+  title: {
+    description:
+      'Provide the title text to be rendered within  PageHeaderContent',
+    control: {
+      type: 'text',
+    },
+  },
+};
 
 export const ContentWithIcon = (args) => (
   <PageHeader.Root>

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -35,13 +35,21 @@ import { Grid, Column } from '../Grid';
 interface PageHeaderProps {
   children?: React.ReactNode;
   className?: string;
+  /**
+   * Specify if using Hero Image layout.
+   */
+  withHeroImage?: Boolean;
 }
 const PageHeader = React.forwardRef<HTMLDivElement, PageHeaderProps>(
-  function PageHeader({ className, children, ...other }: PageHeaderProps, ref) {
+  function PageHeader(
+    { className, children, withHeroImage, ...other }: PageHeaderProps,
+    ref
+  ) {
     const prefix = usePrefix();
     const classNames = classnames(
       {
         [`${prefix}--page-header`]: true,
+        [`${prefix}--page-header-with-hero-image`]: withHeroImage,
       },
       className
     );
@@ -60,6 +68,9 @@ PageHeader.displayName = 'PageHeader';
  * -----------------------
  */
 interface PageHeaderBreadcrumbBarProps {
+  /**
+   * `true` by default to render BreadcrumbBar bottom border.
+   */
   border?: Boolean;
   children?: React.ReactNode;
   className?: string;
@@ -556,13 +567,7 @@ const PageHeaderTabBar = React.forwardRef<
   );
   return (
     <div className={classNames} ref={ref} {...other}>
-      <Grid>
-        <Column lg={16} md={8} sm={4}>
-          <div className={`${prefix}--page-header__tab-bar-container`}>
-            {children}
-          </div>
-        </Column>
-      </Grid>
+      {children}
     </div>
   );
 });
@@ -578,7 +583,39 @@ const PageHeaderTabs = React.forwardRef<HTMLDivElement, PageHeaderTabsProps>(
     { className, children, ...other }: PageHeaderTabsProps,
     ref
   ) {
-    return <BaseTabs {...other}>{children}</BaseTabs>;
+    const prefix = usePrefix();
+
+    const childrenArray = React.Children.toArray(children);
+    let tabListElement: React.ReactNode = null;
+    const otherChildren: React.ReactNode[] = [];
+
+    // extract the TabList component so we can wrap a needed div around for
+    // layout purposes
+    childrenArray.forEach((child: any) => {
+      if (
+        child?.type?.displayName === 'TabList' ||
+        child?.type?.name === 'TabList'
+      ) {
+        tabListElement = child;
+      } else {
+        otherChildren.push(child);
+      }
+    });
+
+    return (
+      <BaseTabs {...other}>
+        {tabListElement && (
+          <div className={`${prefix}--page-header__tablist-wrapper`}>
+            <Grid>
+              <Column lg={16} md={8} sm={4}>
+                {tabListElement}
+              </Column>
+            </Grid>
+          </div>
+        )}
+        {otherChildren}
+      </BaseTabs>
+    );
   }
 );
 PageHeaderTabs.displayName = 'PageHeaderTabs';

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -308,13 +308,13 @@ interface PageHeaderContentPageActionsProps {
   /**
    * The PageHeaderContent's page actions
    */
-  pageActions?: React.ReactNode;
+  actions?: React.ReactNode;
 }
 const PageHeaderContentPageActions = ({
   className,
   children,
   menuButtonLabel = 'Actions',
-  pageActions,
+  actions,
   ...other
 }: PageHeaderContentPageActionsProps) => {
   const prefix = usePrefix();
@@ -325,7 +325,7 @@ const PageHeaderContentPageActions = ({
     className
   );
 
-  type pageAction = {
+  type action = {
     id: string;
     onClick?: () => void;
     body: React.ReactNode;
@@ -335,7 +335,7 @@ const PageHeaderContentPageActions = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const offsetRef = useRef<HTMLDivElement>(null);
   const [menuButtonVisibility, setMenuButtonVisibility] = useState(false);
-  const [hiddenItems, setHiddenItems] = useState<pageAction[]>([]);
+  const [hiddenItems, setHiddenItems] = useState<action[]>([]);
 
   // need to set the grid columns width based on the menu button's width
   // to avoid overlapping when resizing
@@ -350,13 +350,13 @@ const PageHeaderContentPageActions = ({
   }, [menuButtonVisibility]);
 
   useEffect(() => {
-    if (!containerRef.current || !Array.isArray(pageActions)) return;
+    if (!containerRef.current || !Array.isArray(actions)) return;
     createOverflowHandler({
       container: containerRef.current,
       // exclude the hidden menu button from children
       maxVisibleItems: containerRef.current.children.length - 1,
       onChange: (visible, hidden) => {
-        setHiddenItems(pageActions?.slice(visible.length));
+        setHiddenItems(actions?.slice(visible.length));
 
         if (hidden.length > 0) {
           setMenuButtonVisibility(true);
@@ -367,11 +367,11 @@ const PageHeaderContentPageActions = ({
 
   return (
     <div className={classNames} ref={containerRef} {...other}>
-      {pageActions && (
+      {actions && (
         <>
-          {Array.isArray(pageActions) && (
+          {Array.isArray(actions) && (
             <>
-              {pageActions.map((action) => (
+              {actions.map((action) => (
                 <div key={action.id}>
                   {React.cloneElement(action.body, {
                     ...action.body.props,
@@ -418,7 +418,7 @@ PageHeaderContentPageActions.propTypes = {
   /**
    * The PageHeaderContent's page actions
    */
-  pageActions: PropTypes.oneOfType([PropTypes.node, PropTypes.array]),
+  actions: PropTypes.oneOfType([PropTypes.node, PropTypes.array]),
 };
 
 /**

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -35,21 +35,13 @@ import { Grid, Column } from '../Grid';
 interface PageHeaderProps {
   children?: React.ReactNode;
   className?: string;
-  /**
-   * Specify if using Hero Image layout.
-   */
-  withHeroImage?: Boolean;
 }
 const PageHeader = React.forwardRef<HTMLDivElement, PageHeaderProps>(
-  function PageHeader(
-    { className, children, withHeroImage, ...other }: PageHeaderProps,
-    ref
-  ) {
+  function PageHeader({ className, children, ...other }: PageHeaderProps, ref) {
     const prefix = usePrefix();
     const classNames = classnames(
       {
         [`${prefix}--page-header`]: true,
-        [`${prefix}--page-header-with-hero-image`]: withHeroImage,
       },
       className
     );

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -17,10 +17,7 @@
 /// @access public
 /// @group page-header
 @mixin page-header {
-  .#{$prefix}--page-header__breadcrumb-bar,
-  .#{$prefix}--page-header__content,
-  .#{$prefix}--page-header__tablist-wrapper,
-  .#{$prefix}--page-header-with-hero-image {
+  .#{$prefix}--page-header {
     background-color: $layer-01;
   }
 
@@ -186,5 +183,9 @@
 
   .#{$prefix}--page-header__tab-bar .#{$prefix}--tabs {
     margin-inline-start: -$spacing-05;
+  }
+
+  .#{$prefix}--tab-content {
+    background: $background;
   }
 }

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -164,7 +164,7 @@
     display: flex;
     overflow: hidden;
     align-items: center;
-    justify-content: end;
+    justify-content: flex-end;
     block-size: 100%;
   }
 

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -17,14 +17,26 @@
 /// @access public
 /// @group page-header
 @mixin page-header {
+  .#{$prefix}--page-header__breadcrumb-bar,
+  .#{$prefix}--page-header__content,
+  .#{$prefix}--page-header__tablist-wrapper,
+  .#{$prefix}--page-header-with-hero-image {
+    background-color: $layer-01;
+  }
+
   .#{$prefix}--page-header__breadcrumb-bar {
     block-size: convert.to-rem(40px);
+  }
+
+  .#{$prefix}--page-header__breadcrumb-bar .#{$prefix}--subgrid {
+    block-size: 100%;
   }
 
   .#{$prefix}--page-header__breadcrumb-container {
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
+    block-size: 100%;
     inline-size: 100%;
   }
 
@@ -39,7 +51,7 @@
   }
 
   .#{$prefix}--page-header__breadcrumb-bar-border {
-    border-block-end: 1px solid $border-subtle-01;
+    border-block-end: 1px solid $border-subtle-00;
   }
 
   .#{$prefix}--page-header__breadcrumb__icon {
@@ -59,7 +71,7 @@
   }
 
   .#{$prefix}--page-header__content {
-    margin: $spacing-06 0;
+    padding: $spacing-06 0;
   }
 
   .#{$prefix}--page-header__content__title-wrapper {
@@ -168,7 +180,11 @@
     block-size: 100%;
   }
 
-  .#{$prefix}--page-header__tab-bar-container {
+  .#{$prefix}--page-header__tablist-wrapper {
+    border-block-end: 1px solid $border-subtle-00;
+  }
+
+  .#{$prefix}--page-header__tab-bar .#{$prefix}--tabs {
     margin-inline-start: -$spacing-05;
   }
 }

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -51,7 +51,7 @@
   }
 
   .#{$prefix}--page-header__breadcrumb-bar-border {
-    border-block-end: 1px solid $border-subtle-00;
+    border-block-end: 1px solid $border-subtle-01;
   }
 
   .#{$prefix}--page-header__breadcrumb__icon {
@@ -181,7 +181,7 @@
   }
 
   .#{$prefix}--page-header__tablist-wrapper {
-    border-block-end: 1px solid $border-subtle-00;
+    border-block-end: 1px solid $border-subtle-01;
   }
 
   .#{$prefix}--page-header__tab-bar .#{$prefix}--tabs {


### PR DESCRIPTION
Closes #19493

This PR exposes the `PageHeader` stories as experimental under the "Patterns" section of Storybook and adds technical documentation

### Changelog

**New**

- added some controls to the Default story

**Changed**

- change the `pageActions` prop name in `PageHeader.ContentPageActions` to `actions` to make it less repetitive 
- use `justify-content: flex-end` as `justify-content: end` has been deprecated

**Removed**

- remove unused components and imports
- remove the `Content`, `BreadcrumbBar`, and `TabBar` stories in favor of variations of the `PageHeader` with some/all of zones together

#### Testing / Reviewing

Review the stories and let me know if I should remove/add any stories or controls

Review the [documentation in the `Overview` section](https://deploy-preview-19520--v11-carbon-react.netlify.app/?path=/docs/patterns-unstable-pageheader--overview).

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
