### PR TITLE
fix(modal): adjust scroll to account for gradient

### DIFF
--- a/packages/web-components/src/components/modal/modal.ts
+++ b/packages/web-components/src/components/modal/modal.ts
@@ -154,6 +154,40 @@ class CDSModal extends HostListenerMixin(LitElement) {
         }
       }
     }
+
+    // Adjust scroll if needed so that element with focus is not obscured by gradient
+    const modal = document.querySelector(`${prefix}-modal`);
+    const modalContent = document.querySelector(`${prefix}-modal-body`);
+    if (
+      !modal ||
+      !modal.hasAttribute('has-scrolling-content') ||
+      !modalContent ||
+      !relatedTarget ||
+      !modalContent.contains(relatedTarget as Node)
+    ) {
+      return;
+    }
+
+    const lastContent = modalContent.children[modalContent.children.length - 1];
+    const gradientSpacing =
+      modalContent.scrollHeight -
+      (lastContent as HTMLElement).offsetTop -
+      (lastContent as HTMLElement).clientHeight;
+
+    for (let elem of modalContent.children) {
+      if (elem.contains(relatedTarget as Node)) {
+        const spaceBelow =
+          modalContent.clientHeight -
+          (elem as HTMLElement).offsetTop +
+          modalContent.scrollTop -
+          (elem as HTMLElement).clientHeight;
+        if (spaceBelow < gradientSpacing) {
+          modalContent.scrollTop =
+            modalContent.scrollTop + (gradientSpacing - spaceBelow);
+        }
+        break;
+      }
+    }
   };
 
   @HostListener('document:keydown')


### PR DESCRIPTION
Closes #19277

On a `blur` event when Modal has scrollable content, adjust scroll if needed to prevent element in focus from being obscured by the gradient styling.

Made changes to the following components:
- React:
`ComposedModal`
`Modal`

- Web Component
`Modal`

### Changelog

**New**

- In `onBlur` handler, calculate spacing needed and update `scrollTop` of Modal content

#### Testing / Reviewing

- CI tests should pass
- Go to Storybook and check that gradient styling does not obscure the focused element while navigating only using TAB through the scrollable Modal. Check the following:
React:
`Modal` w/ AI Label
`ComposedModal` w/ AI Label
`ComposedModal` w/ Scrolling Content
Web Component:
`Modal` w/ AI Label


## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
