### PR TITLE
fix(OverflowMenu): prevent onOpen infinite loop

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-test.js
@@ -438,4 +438,21 @@ describe('OverflowMenu', () => {
       expect(standardRef.current).toBe(innerRef.current);
     });
   });
+  it('should call onOpen', async () => {
+    const onOpen = jest.fn();
+    render(
+      <OverflowMenu
+        aria-label="Overflow menu"
+        className="extra-class"
+        onOpen={onOpen}>
+        <OverflowMenuItem className="test-child" itemText="one" />
+        <OverflowMenuItem className="test-child" itemText="two" />
+      </OverflowMenu>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -32,25 +32,6 @@ export const RenderCustomIcon = () => {
     </OverflowMenu>
   );
 };
-export const Test = () => {
-  const [loading, setLoading] = React.useState(false);
-
-  const onOpen = () => {
-    console.log('onOpen called');
-    setLoading(true);
-
-    setTimeout(() => {
-      console.log('loading done');
-      setLoading(false);
-    }, 1000);
-  };
-
-  return (
-    <OverflowMenu aria-label="overflow menu" align="bottom" onOpen={onOpen}>
-      <OverflowMenuItem itemText={loading ? 'Loading…' : 'Open'} />
-    </OverflowMenu>
-  );
-};
 export const Default = (args) => (
   <OverflowMenu aria-label="overflow-menu" {...args}>
     <OverflowMenuItem itemText="Stop app" />

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -32,7 +32,25 @@ export const RenderCustomIcon = () => {
     </OverflowMenu>
   );
 };
+export const Test = () => {
+  const [loading, setLoading] = React.useState(false);
 
+  const onOpen = () => {
+    console.log('onOpen called');
+    setLoading(true);
+
+    setTimeout(() => {
+      console.log('loading done');
+      setLoading(false);
+    }, 1000);
+  };
+
+  return (
+    <OverflowMenu aria-label="overflow menu" align="bottom" onOpen={onOpen}>
+      <OverflowMenuItem itemText={loading ? 'Loading…' : 'Open'} />
+    </OverflowMenu>
+  );
+};
 export const Default = (args) => (
   <OverflowMenu aria-label="overflow-menu" {...args}>
     <OverflowMenuItem itemText="Stop app" />

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -308,9 +308,7 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
     useEffect(() => {
       if (open && !prevOpenState.current) {
         onOpen();
-      }
-
-      if (!open && prevOpenState.current) {
+      } else if (!open && prevOpenState.current) {
         onClose();
       }
 

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.tsx
@@ -305,13 +305,17 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
       }
     }, []);
 
-    // Call `onClose` when menu closes.
     useEffect(() => {
+      if (open && !prevOpenState.current) {
+        onOpen();
+      }
+
       if (!open && prevOpenState.current) {
         onClose();
       }
+
       prevOpenState.current = open;
-    }, [open, onClose]);
+    }, [open, onClose, onOpen]);
 
     useOutsideClick(wrapperRef, ({ target }) => {
       if (
@@ -475,7 +479,6 @@ export const OverflowMenu = forwardRef<HTMLButtonElement, OverflowMenuProps>(
         },
         !hasFocusin
       );
-      onOpen();
     };
 
     const getTarget = () => {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19153

Fixes infinite loop bug where onOpen callback would trigger repeatedly when it caused content changes that affected menu positioning. 

### Changelog

**New**

Moved onOpen from positioning callback (handlePlace) to state change effect to ensure it's called exactly once per menu opening.

**Changed**

OverflowMenu onOpen callback now triggers on state change instead of positioning events
**Removed**


#### Testing / Reviewing
Open deploy preview - and go to "Test" story 
Verify onOpen is called exactly once when menu opens
Verify menu still opens/closes normally
Verify content changes don't trigger additional onOpen calls

- [x] ⚠️ BEFORE MERGE ⚠️  the test story needs to be removed 

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~ N/A
- [x] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~ N/A
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)

