### PR TITLE
fix(useOverflowItems): fix `useResizeObserver` import

### DIFF
--- a/packages/react/src/internal/__tests__/useOverflowItems-test.js
+++ b/packages/react/src/internal/__tests__/useOverflowItems-test.js
@@ -7,8 +7,6 @@
 
 import { renderHook, act } from '@testing-library/react';
 import useOverflowItems from '../useOverflowItems';
-import { useRef } from 'react';
-import React from 'react';
 
 // Mock ResizeObserver
 const mockResizeObserver = jest.fn(() => ({
@@ -17,10 +15,9 @@ const mockResizeObserver = jest.fn(() => ({
   disconnect: jest.fn(),
 }));
 
-// Mock use-resize-observer
-jest.mock('use-resize-observer', () => ({
-  __esModule: true,
-  default: jest.fn(({ onResize }) => {
+// Mock useResizeObserver
+jest.mock('../../internal/useResizeObserver', () => ({
+  useResizeObserver: jest.fn(({ onResize }) => {
     // Simulate resize behavior
     if (onResize) {
       setTimeout(() => onResize(), 0);

--- a/packages/react/src/internal/useOverflowItems.ts
+++ b/packages/react/src/internal/useOverflowItems.ts
@@ -13,7 +13,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import useResizeObserver from 'use-resize-observer';
+import { useResizeObserver } from './useResizeObserver';
 import { usePreviousValue } from './usePreviousValue';
 
 type Item = {


### PR DESCRIPTION
Fixes resize observer import in `useOverflowItems` to use internal hook.

### Changelog

**Changed**

- use internal `useResizeObserver` rather than external package
- update `useResizeObserver` tests

#### Testing / Reviewing

Everything should build and all CI flows should pass.

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
