### PR TITLE
fix: toggletip content being read only first time

### DIFF
--- a/packages/react/src/components/Toggletip/index.tsx
+++ b/packages/react/src/components/Toggletip/index.tsx
@@ -131,6 +131,7 @@ export function Toggletip<E extends ElementType = 'span'>({
     buttonProps: {
       'aria-expanded': open,
       'aria-controls': id,
+      'aria-describedby': open ? id : undefined,
       onClick: actions.toggle,
     },
     contentProps: {
@@ -354,8 +355,7 @@ const ToggletipContent = React.forwardRef<
     <PopoverContent
       className={customClassName}
       {...toggletip?.contentProps}
-      ref={ref}
-      aria-live="polite">
+      ref={ref}>
       <div className={`${prefix}--toggletip-content`}>{children}</div>
     </PopoverContent>
   );


### PR DESCRIPTION
Closes #19338 

Toggletip content was only announced once. fixed the issue.
### Changelog

**Changed**

Added aria-describedby to button

#### Testing / Reviewing

1. Go to Storybook > Toggletip > Default 
2. Open the toggletip 2-3 times. It should announce the content everytime.

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] <s>Updated documentation and storybook examples</s>
- [ ] <s>Wrote passing tests that cover this change</s>
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
