### PR TITLE
fix: Focus management in filterable multiselect

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -539,6 +539,32 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
     }
   }, [isOpen, onMenuChange, open]);
 
+  useEffect(() => {
+    const handleClickOutside = (event: Event) => {
+      const target = event.target as HTMLElement;
+      const wrapper = document
+        .getElementById(id)
+        ?.closest(`.${prefix}--multi-select__wrapper`);
+
+      // If click is outside our component and menu is open or input is focused
+      if (wrapper && !wrapper.contains(target)) {
+        if (isOpen || inputFocused) {
+          setIsOpen(false);
+          setInputFocused(false);
+          setInputValue('');
+        }
+      }
+    };
+
+    if (inputFocused || isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, inputFocused]);
+
   const {
     getToggleButtonProps,
     getLabelProps,

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -25,6 +25,7 @@ import {
   ToggletipLabel,
 } from '../Toggletip';
 import Link from '../Link';
+import TextInput from '../TextInput';
 
 export default {
   title: 'Components/MultiSelect',
@@ -392,6 +393,62 @@ export const WithLayerMultiSelect = (args) => (
   </WithLayer>
 );
 
+export const Test = () => {
+  const [selectedItems, setSelectedItems] = useState([]);
+  const items = [
+    {
+      id: 'downshift-1-item-0',
+      text: 'Option 1',
+    },
+    {
+      id: 'downshift-1-item-1',
+      text: 'Option 2',
+    },
+    {
+      id: 'downshift-1-item-2',
+      text: 'Option 3 - a disabled item',
+      disabled: true,
+    },
+    {
+      id: 'downshift-1-item-3',
+      text: 'Option 4',
+    },
+    {
+      id: 'downshift-1-item-4',
+      text: 'An example option that is really long to show what should be done to handle long text',
+    },
+    {
+      id: 'downshift-1-item-5',
+      text: 'Option 5',
+    },
+  ];
+  return (
+    <div style={{ width: 600, margin: 20 }}>
+      <p style={{ marginBottom: 20 }}>
+        <strong>Issue:</strong> click on the "FilterableMultiSelect Sample" and
+        edit. Then click to select the "TextInput Sample". Note that the browser
+        focus automatically switches back to the FilterableMultiSelect.
+        <strong>Expected Behavior:</strong> When a user interacts with
+        FilterableMultiSelect and then clicks on TextInput, the focus should
+        immediately and permanently move to TextInput without automatically
+        returning to FilterableMultiSelect.
+      </p>
+      <div style={{ width: 600, display: 'flex', alignItems: 'center' }}>
+        <div style={{ marginRight: 20 }}>
+          <FilterableMultiSelect
+            id="carbon-multiselect-example-3"
+            titleText="FilterableMultiselect Sample"
+            items={items}
+            onChange={(data) => setSelectedItems(data.selectedItems)}
+            itemToString={(item) => (item ? item.text : '')}
+            selectionFeedback="top-after-reopen"
+          />
+        </div>
+        <TextInput className="text-input" labelText="TextInput Sample" />
+      </div>
+    </div>
+  );
+};
 export const _FilterableWithLayer = (args) => (
   <WithLayer>
     {(layer) => (


### PR DESCRIPTION
Closes #17416 
Closes #16877 

Fix focus management when clicking outside FilterableMultiSelect
Fix FilterableMultiSelect focus management to prevent stealing focus from TextInput components

### Changelog

- Fixed FilterableMultiSelect focus behavior to properly lose focus when clicking outside after menu interactions
- Improved outside-click detection to prevent focus stealing from other components
- Added test coverage for focus management between FilterableMultiSelect and other components

#### Testing / Reviewing

- [x]  Open FilterableMultiSelect Test Story , interact with menu (select items)
- [x]  Click on a TextInput or click outside the component
- [x]  Verify: Focus moves properly and doesn't return to FilterableMultiSelect
- [x]  Verify: Can type in TextInput without focus jumping back

**NOTE** 
Test story is for reviewing purpose only. It will be removed before merging. Please do not merge before it is removed.

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
