### PR TITLE
fix(Textinput): character counter fix

### DIFF
--- a/packages/react/src/components/TextInput/TextInput.tsx
+++ b/packages/react/src/components/TextInput/TextInput.tsx
@@ -19,6 +19,7 @@ import { useNormalizedInputProps } from '../../internal/useNormalizedInputProps'
 import deprecate from '../../prop-types/deprecate';
 import { textInputProps } from './util';
 import { FormContext } from '../FluidForm';
+import { useMergedRefs } from '../../internal/useMergedRefs';
 import { usePrefix } from '../../internal/usePrefix';
 import { getAnnouncement } from '../../internal/getAnnouncement';
 import { Text } from '../Text';
@@ -191,9 +192,20 @@ const TextInput = React.forwardRef(function TextInput(
   const prefix = usePrefix();
 
   const { defaultValue, value } = rest;
-  const [textCount, setTextCount] = useState(
-    defaultValue?.toString().length || value?.toString().length || 0
-  );
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mergedRef = useMergedRefs([ref, inputRef]);
+
+  function getInitialTextCount(): number {
+    const targetValue = defaultValue || value || inputRef.current?.value || '';
+    return targetValue.toString().length;
+  }
+
+  const [textCount, setTextCount] = useState(getInitialTextCount());
+
+  useEffect(() => {
+    setTextCount(getInitialTextCount());
+  }, [value, defaultValue, enableCounter]);
 
   const normalizedProps = useNormalizedInputProps({
     id,
@@ -227,7 +239,7 @@ const TextInput = React.forwardRef(function TextInput(
     },
     placeholder,
     type,
-    ref,
+    ref: mergedRef,
     className: textInputClasses,
     title: placeholder,
     disabled: normalizedProps.disabled,

--- a/packages/react/src/components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react/src/components/TextInput/__tests__/TextInput-test.js
@@ -369,5 +369,43 @@ describe('TextInput', () => {
 
       expect(counter).toBeInTheDocument();
     });
+
+    it('should count ref value when enableCounter is toggled)', async () => {
+      // Test for issue #18520: TextInput missing ref check for initial value
+      const TestComponent = () => {
+        const [enableCounter, setEnableCounter] = React.useState(false);
+        const inputRef = React.useRef(null);
+
+        React.useEffect(() => {
+          if (inputRef.current) {
+            inputRef.current.value = 'FormValue';
+          }
+        }, []);
+
+        return (
+          <div>
+            <TextInput
+              ref={inputRef}
+              id="input-1"
+              labelText="TextInput label"
+              enableCounter={enableCounter}
+              maxCount={15}
+            />
+            <button onClick={() => setEnableCounter(true)}>
+              Enable Counter
+            </button>
+          </div>
+        );
+      };
+
+      render(<TestComponent />);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(screen.queryByText(/\/15/)).not.toBeInTheDocument();
+
+      // Enable counter
+      await userEvent.click(screen.getByText('Enable Counter'));
+      expect(screen.getByText('9/15')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18520

TextInput now checks ref values for initial character count, making it consistent with TextArea behavior. Previously, character counter would show "0/maxCount" when values were set via refs instead of props

**New**

Adds a test case

**Changed**

TextInput character counter now checks ref value as fallback when props are empty

#### Testing / Reviewing

CI should pass
verify existing functionality is intact  

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~ NA
- [x] Wrote passing tests that cover this change
~- [ ] Addressed any impact on accessibility (a11y)~ NA
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
