### PR TITLE
fix: update outside click behavior for modals

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -5206,9 +5206,7 @@ Map {
       "passiveModal": Object {
         "type": "bool",
       },
-      "preventCloseOnClickOutside": Object {
-        "type": "bool",
-      },
+      "preventCloseOnClickOutside": [Function],
       "primaryButtonDisabled": Object {
         "type": "bool",
       },

--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -373,7 +373,9 @@ describe('ComposedModal', () => {
               open={open}
               launcherButtonRef={focusRef}
               onClick={() => setOpen(false)}>
-              <button data-testid="close" onClick={() => setOpen(false)} />
+              <button data-testid="close" onClick={() => setOpen(false)}>
+                Close
+              </button>
             </ComposedModal>
             <button data-testid="focusElem" ref={focusRef}>
               focus after close
@@ -430,7 +432,7 @@ describe('ComposedModal', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  it('should close when clicked on outside background layer', async () => {
+  it('should close when clicking outside passive composed modal', async () => {
     const onClose = jest.fn();
     render(
       <ComposedModal open onClose={onClose}>
@@ -440,6 +442,26 @@ describe('ComposedModal', () => {
     const backgroundLayer = screen.getByRole('presentation');
     await userEvent.click(backgroundLayer);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should not close when clicking outside non-passive composed modal', async () => {
+    const onClose = jest.fn();
+    render(
+      <>
+        <button data-testid="outside-button">☀️</button>
+        <ComposedModal open onClose={onClose}>
+          <ModalHeader>Header</ModalHeader>
+          <ModalBody>Body</ModalBody>
+          <ModalFooter
+            primaryButtonText="Confirm"
+            secondaryButtonText="Cancel"
+          />
+        </ComposedModal>
+      </>
+    );
+
+    await userEvent.click(screen.getByTestId('outside-button'));
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('should NOT close when clicked inside dialog window, dragged outside and released mouse button', async () => {
@@ -471,7 +493,9 @@ describe('ComposedModal', () => {
             open={open}
             launcherButtonRef={focusRef}
             onClick={() => setOpen(false)}>
-            <button data-testid="close" onClick={() => setOpen(false)} />
+            <button data-testid="close" onClick={() => setOpen(false)}>
+              Close
+            </button>
           </ComposedModal>
           <button data-testid="focusElem" ref={focusRef}>
             focus after close

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -1,4 +1,10 @@
-import { Story, ArgTypes, Canvas, Unstyled, Meta } from '@storybook/addon-docs/blocks';
+import {
+  Story,
+  ArgTypes,
+  Canvas,
+  Unstyled,
+  Meta,
+} from '@storybook/addon-docs/blocks';
 import ComposedModal from '../ComposedModal';
 import { InlineNotification } from '../Notification';
 import CodeSnippet from '../CodeSnippet';
@@ -120,9 +126,23 @@ const ModalStateManager = ({
     and
     <CodeSnippet type="inline" hideCopyButton>ComposedModal</CodeSnippet>
     have to be put at the top level in a React tree. The easiest way to ensure
-    that is using React portal as shown in above example.
+    that is using a React portal, as shown in the example above.
   </InlineNotification>
 </Unstyled>
+<br />
+<Unstyled>
+  <InlineNotification
+    kind="info"
+    title="Outside click behavior"
+    className="sb-notification">
+    Passive modals can be closed by clicking outside by default. Non-passive
+    modals cannot be dismissed this way, even if{' '}
+    <CodeSnippet type="inline" hideCopyButton>preventCloseOnClickOutside</CodeSnippet>{' '}
+    is set to{' '}
+    <CodeSnippet type="inline" hideCopyButton>false</CodeSnippet>.
+  </InlineNotification>
+</Unstyled>
+
 {/* <!-- prettier-ignore-end --> */}
 
 ## Modal sizes
@@ -231,15 +251,15 @@ With `<ComposedModal>`, you can control the buttons with the following code.
     kind="warning"
     title="Warning"
     className="sb-notification">
-    As the instruction for the three buttons implies,
+    As the instructions for the three buttons imply,
     <CodeSnippet type="inline" hideCopyButton>ModalFooter</CodeSnippet>
-    is flexible on the buttons as you render
+    is flexible with the buttons you render using
     <CodeSnippet type="inline" hideCopyButton>Button</CodeSnippet>
-    's by yourself, as shown below. In this case, the application code
-    needs to take care of running actions upon clicking those buttons, e.g. closing
-    the modal
+    components. In this case, your application code is responsible for handling
+    button actions, such as closing the modal.
   </InlineNotification>
 </Unstyled>
+
 {/* <!-- prettier-ignore-end --> */}
 
 ```jsx

--- a/packages/react/src/components/ComposedModal/ComposedModal.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.mdx
@@ -1,10 +1,4 @@
-import {
-  Story,
-  ArgTypes,
-  Canvas,
-  Unstyled,
-  Meta,
-} from '@storybook/addon-docs/blocks';
+import { Story, ArgTypes, Canvas, Unstyled, Meta } from '@storybook/addon-docs/blocks';
 import ComposedModal from '../ComposedModal';
 import { InlineNotification } from '../Notification';
 import CodeSnippet from '../CodeSnippet';

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, {
+  Children,
   cloneElement,
   useEffect,
   useRef,
@@ -335,8 +336,16 @@ const ComposedModal = React.forwardRef<HTMLDivElement, ComposedModalProps>(
       const { target } = evt;
       const mouseDownTarget = onMouseDownTarget.current;
       evt.stopPropagation();
+      const containsModalFooter = Children.toArray(childrenWithProps).some(
+        (child) => isComponentElement(child, ModalFooter)
+      );
+      const isPassive = !containsModalFooter;
+      const shouldCloseOnOutsideClick =
+        (isPassive && preventCloseOnClickOutside !== false) ||
+        (!isPassive && preventCloseOnClickOutside === true);
+
       if (
-        !preventCloseOnClickOutside &&
+        shouldCloseOnOutsideClick &&
         target instanceof Node &&
         !elementOrParentIsFloatingMenu(target, selectorsFloatingMenus) &&
         innerModal.current &&

--- a/packages/react/src/components/ComposedModal/ComposedModal.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.tsx
@@ -340,9 +340,9 @@ const ComposedModal = React.forwardRef<HTMLDivElement, ComposedModalProps>(
         (child) => isComponentElement(child, ModalFooter)
       );
       const isPassive = !containsModalFooter;
-      const shouldCloseOnOutsideClick =
-        (isPassive && preventCloseOnClickOutside !== false) ||
-        (!isPassive && preventCloseOnClickOutside === true);
+      const shouldCloseOnOutsideClick = isPassive
+        ? preventCloseOnClickOutside !== false
+        : preventCloseOnClickOutside === true;
 
       if (
         shouldCloseOnOutsideClick &&

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -519,7 +519,9 @@ describe('Modal', () => {
               open={open}
               launcherButtonRef={focusRef}
               onClick={() => setOpen(false)}>
-              <button data-testid="close" onClick={() => setOpen(false)} />
+              <button data-testid="close" onClick={() => setOpen(false)}>
+                Close
+              </button>
             </Modal>
             <button data-testid="focusElem" ref={focusRef}>
               focus after close
@@ -565,7 +567,7 @@ describe('events', () => {
     expect(screen.getByTestId('modal-6')).toHaveClass('is-visible');
   });
 
-  it('should handle close when outside of modal is clicked', async () => {
+  it('should not close when clicking outside non-passive modal', async () => {
     const onRequestClose = jest.fn();
     render(
       <Modal
@@ -589,6 +591,23 @@ describe('events', () => {
 
     const outerModal = screen.getByTestId('modal-7');
     await userEvent.click(outerModal);
+    expect(onRequestClose).not.toHaveBeenCalled();
+  });
+
+  it('should close when clicking outside passive modal', async () => {
+    const onRequestClose = jest.fn();
+    render(
+      <Modal
+        open
+        passiveModal
+        onRequestClose={onRequestClose}
+        data-testid="modal-passive">
+        <p>This is a passive modal</p>
+      </Modal>
+    );
+
+    const backgroundLayer = screen.getByRole('presentation');
+    await userEvent.click(backgroundLayer);
     expect(onRequestClose).toHaveBeenCalled();
   });
 

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -541,6 +541,67 @@ describe('Modal', () => {
       });
     });
   });
+
+  describe('preventCloseOnClickOutside prop validation', () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+      consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should throw a prop-type warning when passiveModal=false and preventCloseOnClickOutside=false', () => {
+      render(
+        <Modal
+          open
+          passiveModal={false}
+          preventCloseOnClickOutside={false}
+          primaryButtonText="Submit"
+          secondaryButtonText="Cancel">
+          <p>Test content</p>
+        </Modal>
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '`Modal`: `preventCloseOnClickOutside` should not be `false` when `passiveModal` is `false`. Non-passive `Modal`s should not be dismissible by clicking outside.'
+      );
+    });
+
+    it('should not throw a warning when passiveModal=true and preventCloseOnClickOutside=false', () => {
+      render(
+        <Modal
+          open
+          passiveModal
+          preventCloseOnClickOutside={false}
+          primaryButtonText="Submit"
+          secondaryButtonText="Cancel">
+          <p>Test content</p>
+        </Modal>
+      );
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not throw a warning when passiveModal=false and preventCloseOnClickOutside=true', () => {
+      render(
+        <Modal
+          open
+          passiveModal={false}
+          preventCloseOnClickOutside={true}
+          primaryButtonText="Submit"
+          secondaryButtonText="Cancel">
+          <p>Test content</p>
+        </Modal>
+      );
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('events', () => {

--- a/packages/react/src/components/Modal/Modal.mdx
+++ b/packages/react/src/components/Modal/Modal.mdx
@@ -1,4 +1,10 @@
-import { Story, ArgTypes, Canvas, Unstyled, Meta } from '@storybook/addon-docs/blocks';
+import {
+  Story,
+  ArgTypes,
+  Canvas,
+  Unstyled,
+  Meta,
+} from '@storybook/addon-docs/blocks';
 import Modal from '../Modal';
 import { InlineNotification } from '../Notification';
 import CodeSnippet from '../CodeSnippet';
@@ -58,6 +64,17 @@ text.
 
 <ArgTypes />
 
+{/* <!-- prettier-ignore-start --> */}
+
+{/*
+TODO: Why are there `ComposedModal` docs in the `Modal` docs?
+The documentation is being duplicated between this file and
+`packages/react/src/components/ComposedModal/ComposedModal.mdx`.
+Currently, there are differences between the `ComposedModal` docs in these two files.
+*/}
+
+{/* <!-- prettier-ignore-end --> */}
+
 ## Opening/closing modal
 
 For both modal variants, you can open/close the modal by changing the `open`
@@ -107,17 +124,39 @@ const ModalStateManager = ({
 };
 ```
 
+{/* <!-- prettier-ignore-start --> */}
+
 <Unstyled>
   <InlineNotification
-    title="Warning"
     kind="warning"
+    title="Warning"
     className="sb-notification">
-    <CodeSnippet type="inline" hideCopyButton>{'<Modal>'}</CodeSnippet>
-    <CodeSnippet type="inline" hideCopyButton>{`<ComposedModal>`}</CodeSnippet>{' '}
-    has to be put at the top level in a React tree. The easiest way to ensure
-    that is using React portal as shown in above example.
+    <CodeSnippet type="inline" hideCopyButton>Modal</CodeSnippet>
+    and
+    <CodeSnippet type="inline" hideCopyButton>ComposedModal</CodeSnippet>
+    have to be put at the top level in a React tree. The easiest way to ensure
+    that is using a React portal, as shown in the example above.
   </InlineNotification>
 </Unstyled>
+<br />
+<Unstyled>
+  <InlineNotification
+    kind="info"
+    title="Outside click behavior"
+    className="sb-notification">
+    Passive modals can be closed by clicking outside by default. Non-passive
+    modals cannot be dismissed this way, even if{' '}
+    <CodeSnippet type="inline" hideCopyButton>
+      preventCloseOnClickOutside
+    </CodeSnippet>{' '}
+    is set to{' '}
+    <CodeSnippet type="inline" hideCopyButton>
+      false
+    </CodeSnippet>
+    .
+  </InlineNotification>
+</Unstyled>
+
 {/* <!-- prettier-ignore-end --> */}
 
 ## Modal sizes
@@ -223,18 +262,18 @@ With `<ComposedModal>`, you can control the buttons with the following code.
 
 <Unstyled>
   <InlineNotification
-    title="Warning"
     kind="warning"
+    title="Warning"
     className="sb-notification">
-    As the instruction for the three buttons implies,{' '}
-    <CodeSnippet type="inline" hideCopyButton>{'<ModalFooter>'}</CodeSnippet>
-    is flexible on the buttons as you render
-    <CodeSnippet type="inline" hideCopyButton>{'<Button>'}</CodeSnippet>
-    s by yourself, as shown below. In this case, the application code
-    needs to take care of running actions upon clicking those buttons, e.g. closing
-    the modal:
+    As the instructions for the three buttons imply,
+    <CodeSnippet type="inline" hideCopyButton>ModalFooter</CodeSnippet>
+    is flexible with the buttons you render using
+    <CodeSnippet type="inline" hideCopyButton>Button</CodeSnippet>
+    components. In this case, your application code is responsible for handling
+    button actions, such as closing the modal.
   </InlineNotification>
 </Unstyled>
+
 {/* <!-- prettier-ignore-end --> */}
 
 ```jsx

--- a/packages/react/src/components/Modal/Modal.mdx
+++ b/packages/react/src/components/Modal/Modal.mdx
@@ -1,10 +1,4 @@
-import {
-  Story,
-  ArgTypes,
-  Canvas,
-  Unstyled,
-  Meta,
-} from '@storybook/addon-docs/blocks';
+import { Story, ArgTypes, Canvas, Unstyled, Meta } from '@storybook/addon-docs/blocks';
 import Modal from '../Modal';
 import { InlineNotification } from '../Notification';
 import CodeSnippet from '../CodeSnippet';
@@ -64,16 +58,7 @@ text.
 
 <ArgTypes />
 
-{/* <!-- prettier-ignore-start --> */}
-
-{/*
-TODO: Why are there `ComposedModal` docs in the `Modal` docs?
-The documentation is being duplicated between this file and
-`packages/react/src/components/ComposedModal/ComposedModal.mdx`.
-Currently, there are differences between the `ComposedModal` docs in these two files.
-*/}
-
-{/* <!-- prettier-ignore-end --> */}
+{/* TODO: https://github.com/carbon-design-system/carbon/issues/19624 */}
 
 ## Opening/closing modal
 

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -47,6 +47,8 @@ import { isComponentElement } from '../../internal';
 import { warning } from '../../internal/warning';
 
 export const ModalSizes = ['xs', 'sm', 'md', 'lg'] as const;
+const invalidOutsideClickMessage =
+  '`Modal`: `preventCloseOnClickOutside` should not be `false` when `passiveModal` is `false`. Non-passive `Modal`s should not be dismissible by clicking outside.';
 
 export type ModalSize = (typeof ModalSizes)[number];
 
@@ -305,6 +307,10 @@ const Modal = React.forwardRef(function Modal(
       'element handles focus, so `enableDialogElement` must be off for ' +
       '`focusTrapWithoutSentinels` to have any effect.'
   );
+
+  if (!passiveModal && preventCloseOnClickOutside === false) {
+    console.error(invalidOutsideClickMessage);
+  }
 
   function isCloseButton(element: Element) {
     return (
@@ -959,15 +965,9 @@ Modal.propTypes = {
   /**
    * Prevent closing on click outside of modal
    */
-  preventCloseOnClickOutside: (
-    props: ModalProps,
-    propName: string,
-    componentName: string
-  ) => {
+  preventCloseOnClickOutside: (props: ModalProps, propName: string) => {
     if (!props.passiveModal && props[propName] === false) {
-      return new Error(
-        `${componentName}: \`${propName}\` should not be \`false\` when \`passiveModal\` is \`false\`. Non-passive ${componentName}s should not be dismissible by clicking outside.`
-      );
+      return new Error(invalidOutsideClickMessage);
     }
 
     return null;

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -263,7 +263,7 @@ const Modal = React.forwardRef(function Modal(
     size,
     hasScrollingContent = false,
     closeButtonLabel = 'Close',
-    preventCloseOnClickOutside = false,
+    preventCloseOnClickOutside = !passiveModal,
     isFullWidth,
     launcherButtonRef,
     loadingStatus = 'inactive',
@@ -959,7 +959,19 @@ Modal.propTypes = {
   /**
    * Prevent closing on click outside of modal
    */
-  preventCloseOnClickOutside: PropTypes.bool,
+  preventCloseOnClickOutside: (
+    props: ModalProps,
+    propName: string,
+    componentName: string
+  ) => {
+    if (!props.passiveModal && props[propName] === false) {
+      return new Error(
+        `${componentName}: \`${propName}\` should not be \`false\` when \`passiveModal\` is \`false\`. Non-passive ${componentName}s should not be dismissible by clicking outside.`
+      );
+    }
+
+    return null;
+  },
 
   /**
    * Specify whether the Button should be disabled, or not


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/13712

Updated outside click behavior for modals.

### Changelog

**New**

- Added documentation regarding passive modals.

**Changed**

- Updated outside click behavior for modals.
- Fixed accessibility issues in tests.
- Fixed discrepencies in modal docs.

#### Testing / Reviewing

I left a `TODO` with a question that hopefully someone can answer.

```sh
yarn test packages/react
```

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
