### PR TITLE
fix(DataTable): add support for onClick passed to getRowProps

### DIFF
--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -480,6 +480,7 @@ class DataTable<RowType, ColTypes extends any[]> extends Component<
     return {
       ...rest,
       key: row.id,
+      onClick,
       // Compose the event handlers so we don't overwrite a consumer's `onClick`
       // handler
       onExpand: composeEventHandlers([this.handleOnExpandRow(row.id), onClick]),
@@ -611,6 +612,8 @@ class DataTable<RowType, ColTypes extends any[]> extends Component<
     };
   };
 
+  // TODO: `getHeaderProps` and `getRowProps` return `key` props. Would it be
+  // beneficial for this function to also return a `key` prop?
   /**
    * Get the props associated with the given table cell.
    */

--- a/packages/react/src/components/DataTable/__tests__/DataTable-test.js
+++ b/packages/react/src/components/DataTable/__tests__/DataTable-test.js
@@ -118,6 +118,11 @@ describe('DataTable', () => {
               <TableHead>
                 <TableRow>
                   {headers.map((header, i) => (
+                    // TODO: `getHeaderProps` returns a `key`. Using it instead
+                    // of overwriting it with the `key` prop may improve test
+                    // coverage.
+                    //
+                    // This comment applies here and elsewhere.
                     <TableHeader key={i} {...getHeaderProps({ header })}>
                       {header.header}
                     </TableHeader>
@@ -126,6 +131,10 @@ describe('DataTable', () => {
               </TableHead>
               <TableBody>
                 {rows.map((row) => (
+                  // TODO: `getRowProps` returns a `key`. Using it may improve
+                  // test coverage.
+                  //
+                  // This comment applies here and elsewhere.
                   <TableRow key={row.id}>
                     {row.cells.map((cell) => (
                       <TableCell key={cell.id}>{cell.value}</TableCell>
@@ -981,6 +990,49 @@ describe('DataTable', () => {
           'Field 1:A!',
           'Field 3:A!',
         ]);
+      });
+    });
+
+    describe('row click behavior', () => {
+      it('should call onClick handler passed via getRowProps when row is clicked', async () => {
+        const handleClick = jest.fn();
+
+        render(
+          <DataTable
+            {...mockProps}
+            render={({ rows, headers, getRowProps, getHeaderProps }) => (
+              <TableContainer title="Test table">
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      {headers.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })}>
+                          {header.header}
+                        </TableHeader>
+                      ))}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {rows.map((row) => (
+                      <TableRow
+                        {...getRowProps({ row, onClick: handleClick })}
+                        data-testid={`row-${row.id}`}>
+                        {row.cells.map((cell) => (
+                          <TableCell key={cell.id}>{cell.value}</TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+          />
+        );
+
+        const firstRow = screen.getByTestId('row-b');
+        await userEvent.click(firstRow);
+
+        expect(handleClick).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/18173

Added support for `onClick` passed to `getRowProps`.

### Changelog

**New**

- Added support for `onClick` passed to `getRowProps`.

#### Testing / Reviewing

```sh
yarn test packages/react
```

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
