### PR TITLE
fix: `SelectableTile` onChange firing twice in react strict mode

### DIFF
--- a/packages/react/src/components/Tile/Tile.stories.js
+++ b/packages/react/src/components/Tile/Tile.stories.js
@@ -160,6 +160,14 @@ export const Selectable = (args) => {
   );
 };
 
+export const SelectableOnChangeTest = () => {
+  return (
+    <SelectableTile onChange={() => console.log('onChange')}>
+      Selectable
+    </SelectableTile>
+  );
+};
+
 Selectable.args = {
   disabled: false,
 };

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -7,6 +7,7 @@
 
 import React, {
   cloneElement,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -480,7 +481,11 @@ export const SelectableTile = React.forwardRef<
   const keyDownHandler = onKeyDown;
 
   const [isSelected, setIsSelected] = useState<boolean>(selected);
-  const [prevSelected, setPrevSelected] = useState<boolean>(selected);
+
+  // Use useEffect to sync with prop changes instead of render-time logic
+  useEffect(() => {
+    setIsSelected(selected);
+  }, [selected]);
 
   const classes = cx(
     `${prefix}--tile`,
@@ -497,46 +502,39 @@ export const SelectableTile = React.forwardRef<
     className
   );
 
-  function handleClick(evt) {
+  // Single function to handle selection changes
+  const handleSelectionChange = useCallback(
+    (evt: React.SyntheticEvent, newSelected: boolean) => {
+      setIsSelected(newSelected);
+      onChange(evt as React.ChangeEvent<HTMLDivElement>, newSelected, id);
+    },
+    [onChange, id]
+  );
+
+  function handleClick(evt: React.MouseEvent<HTMLDivElement>) {
     evt.preventDefault();
     evt?.persist?.();
     if (
       normalizedDecorator &&
       decoratorRef.current &&
-      decoratorRef.current.contains(evt.target)
+      decoratorRef.current.contains(evt.target as Node)
     ) {
       return;
     }
-    setIsSelected((prevSelected) => {
-      const newSelected = !prevSelected;
-      onChange(evt, newSelected, id);
-      return newSelected;
-    });
+
+    const newSelected = !isSelected;
+    handleSelectionChange(evt, newSelected);
     clickHandler(evt);
   }
 
-  function handleKeyDown(evt) {
+  function handleKeyDown(evt: React.KeyboardEvent<HTMLDivElement>) {
     evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
       evt.preventDefault();
-      setIsSelected((prevSelected) => {
-        const newSelected = !prevSelected;
-        onChange(evt, newSelected, id);
-        return newSelected;
-      });
+      const newSelected = !isSelected;
+      handleSelectionChange(evt, newSelected);
     }
     keyDownHandler(evt);
-  }
-
-  function handleChange(event) {
-    const newSelected = event.target.checked;
-    setIsSelected(newSelected);
-    onChange(event, newSelected, id);
-  }
-
-  if (selected !== prevSelected) {
-    setIsSelected(selected);
-    setPrevSelected(selected);
   }
 
   // AILabel is always size `xs`
@@ -559,7 +557,6 @@ export const SelectableTile = React.forwardRef<
       tabIndex={!disabled ? tabIndex : undefined}
       ref={ref}
       id={id}
-      onChange={!disabled ? handleChange : undefined}
       title={title}
       {...rest}>
       <span

--- a/packages/react/src/components/Tile/Tile.tsx
+++ b/packages/react/src/components/Tile/Tile.tsx
@@ -409,7 +409,7 @@ export interface SelectableTileProps extends HTMLAttributes<HTMLDivElement> {
    * The empty handler of the `<input>`.
    */
   onChange?(
-    event: ChangeEvent<HTMLDivElement>,
+    event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>,
     selected?: boolean,
     id?: string
   ): void;
@@ -504,20 +504,24 @@ export const SelectableTile = React.forwardRef<
 
   // Single function to handle selection changes
   const handleSelectionChange = useCallback(
-    (evt: React.SyntheticEvent, newSelected: boolean) => {
+    (
+      evt: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>,
+      newSelected: boolean
+    ) => {
       setIsSelected(newSelected);
-      onChange(evt as React.ChangeEvent<HTMLDivElement>, newSelected, id);
+      onChange(evt, newSelected, id);
     },
     [onChange, id]
   );
 
-  function handleClick(evt: React.MouseEvent<HTMLDivElement>) {
+  function handleClick(evt: MouseEvent<HTMLDivElement>) {
     evt.preventDefault();
     evt?.persist?.();
     if (
       normalizedDecorator &&
       decoratorRef.current &&
-      decoratorRef.current.contains(evt.target as Node)
+      evt.target instanceof Node &&
+      decoratorRef.current.contains(evt.target)
     ) {
       return;
     }
@@ -527,7 +531,7 @@ export const SelectableTile = React.forwardRef<
     clickHandler(evt);
   }
 
-  function handleKeyDown(evt: React.KeyboardEvent<HTMLDivElement>) {
+  function handleKeyDown(evt: KeyboardEvent<HTMLDivElement>) {
     evt?.persist?.();
     if (matches(evt, [keys.Enter, keys.Space])) {
       evt.preventDefault();


### PR DESCRIPTION
Closes #19521 

Fixed the onChange handler in the SelectableTile fires twice under React's strict mode by replacing render-time state sync with useEffect and centralizing selection logic

### Changelog

**New**

- Added useEffect to handle state sync with selected prop instead of doing it during render
- Added centralized handleSelectionChange function to manage all selection updates

**Changed**

- Moved state synchronization from render phase to useEffect to fix strict mode issues
- Updated event handlers to use proper TypeScript types
- Combined duplicate selection logic into single reusable function

**Removed**

- Removed render-time state sync logic that was causing double firing
- Removed unnecessary onChange handler from div element
- Removed prevSelected state that was used for render-time comparisons

#### Testing / Reviewing

To test the bug first, as we can't reproduce this in local directly
- providing the [stackblitz](https://stackblitz.com/edit/github-fdjpjsn2?file=src%2FApp.tsx,package.json,src%2Fmain.tsx&preset=node=) with the bug here to understand how `onChange` is fired twice
- in the main.tsx, remove the `<React.StrictMode>` tag, and test it again.
- see that `onChange` handler fires only once.

To test the fix:
- pull this PR down on local, and build the application.
- add this line in decorators array inside the `packages/react/.storybook/preview.js` file 

```
(Story) => (

<React.StrictMode>

<Story />

</React.StrictMode>

),

```

Image provided for the exact line and place to add this
![image](https://github.com/user-attachments/assets/6af2fc65-2cf5-43d2-ad74-09009c8926f5)
- open the test story "Selectable on change test" and keep the console open.
- click on the tile to make sure that the `onChange` handler is fired once.


## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
