### PR TITLE
chore(merge-rate): change cron schedule to 13:00 UTC Tuesdays

### DIFF
--- a/.github/workflows/metrics-merge-rate.yml
+++ b/.github/workflows/metrics-merge-rate.yml
@@ -2,7 +2,7 @@ name: Calculate PR Merge Rate
 
 on:
   schedule:
-    - cron: '0 1 * * 3' # Runs at 1:00 AM UTC every Wednesday
+    - cron: '0 13 * * 2' # Runs before retro at 13:00 UTC (8AM EST/9AM EDT) every Tuesday
   workflow_dispatch: # Allows manual runs from the GitHub Actions tab
 
 jobs:


### PR DESCRIPTION
### Changelog

**Changed**

- Modify the metrics-merge-rate.yml scheduled run time to be before our team retrospective so we can view it during that meeting

#### Testing / Reviewing

- Double check the cron is correct. 
- Note: DST doesn't matter because it'll just run an extra hour earlier than retro for that part of the year

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
