### PR TITLE
fix(PageHeader): address bug with exported subcomponent display names

### DIFF
--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -697,10 +697,10 @@ const Content = PageHeaderContent;
 Content.displayName = 'PageHeaderContent';
 
 const ContentPageActions = PageHeaderContentPageActions;
-Content.displayName = 'PageHeaderContentPageActions';
+ContentPageActions.displayName = 'PageHeaderContentPageActions';
 
 const ContentText = PageHeaderContentText;
-Content.displayName = 'PageHeaderContentText';
+ContentText.displayName = 'PageHeaderContentText';
 
 const HeroImage = PageHeaderHeroImage;
 HeroImage.displayName = 'PageHeaderHeroImage';


### PR DESCRIPTION
Closes #19608 

Some of the page header sub components were mistakenly assigned incorrect display name values. I only noticed this because I was taking a closer look at it within React dev tools and noticed multiple `PageHeaderContentText` components nested within each other. This was happening because `Content` display name was being set multiple times, the last of which being `PageHeaderContentText`.

### Changelog

**Changed**

- `packages/react/src/components/PageHeader/PageHeader.tsx`

#### Testing / Reviewing

N/A

## PR Checklist

<!-- 
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~ 
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
