### PR TITLE
fix: pageheader content and tab bar style fixes

### DIFF
--- a/packages/web-components/src/components/combo-button/__tests__/__snapshots__/combo-button-test.snap.js
+++ b/packages/web-components/src/components/combo-button/__tests__/__snapshots__/combo-button-test.snap.js
@@ -1167,3 +1167,35 @@ snapshots['Menu behavior should handle menu item clicks'] = `<cds-button
 </slot>
 `;
 /* end snapshot Menu behavior should handle menu item clicks */
+snapshots['cds-combo-button should support `tooltips-content` attribute'] =
+  `<cds-button
+  has-main-content=""
+  kind="primary"
+  size="lg"
+  tab-index="0"
+  tooltip-alignment=""
+  tooltip-position="top"
+  type="button"
+>
+  Primary action
+</cds-button>
+<cds-icon-button
+  align="top"
+  close-on-activation=""
+  kind="primary"
+  menu-alignment="top"
+  part="trigger"
+  size="lg"
+  tab-index="0"
+  tooltip-alignment=""
+  tooltip-position="top"
+  type="button"
+>
+  <span slot="tooltip-content">
+    Custom tooltip text
+  </span>
+</cds-icon-button>
+<slot>
+</slot>
+`;
+/* end snapshot cds-combo-button should support `tooltips-content` attribute */

--- a/packages/web-components/src/components/page-header/__tests__/__snapshots__/page-header-test.snap.js
+++ b/packages/web-components/src/components/page-header/__tests__/__snapshots__/page-header-test.snap.js
@@ -44,3 +44,24 @@ snapshots['cds-page-header cds-page-header-tabs should render'] =
 </cds-page-header-tabs>
 `;
 /* end snapshot cds-page-header cds-page-header-tabs should render */
+snapshots['cds-page-header cds-page-header-tabs should render'] =
+  `<cds-page-header-tabs>
+  <cds-tabs value="tab-1">
+    <cds-tab
+      id="tab-1"
+      target="tab-panel-1"
+      value="tab-1"
+    >
+      Tab 1
+    </cds-tab>
+    <cds-tab
+      id="tab-2"
+      target="tab-panel-2"
+      value="tab-2"
+    >
+      Tab 2
+    </cds-tab>
+  </cds-tabs>
+</cds-page-header-tabs>
+`;
+/* end snapshot cds-page-header cds-page-header-tabs should render */

--- a/packages/web-components/src/components/page-header/__tests__/page-header-test.js
+++ b/packages/web-components/src/components/page-header/__tests__/page-header-test.js
@@ -155,7 +155,7 @@ describe('cds-page-header', function () {
     it('should render', async () => {
       const el = await fixture(
         html` <cds-page-header-tabs>
-          <cds-tabs slot="tabs" value="tab-1">
+          <cds-tabs value="tab-1">
             <cds-tab id="tab-1" target="tab-panel-1" value="tab-1"
               >Tab 1</cds-tab
             >
@@ -172,7 +172,7 @@ describe('cds-page-header', function () {
     it('should render tabs', async () => {
       const el = await fixture(
         html` <cds-page-header-tabs>
-          <cds-tabs slot="tabs" value="tab-1">
+          <cds-tabs value="tab-1">
             <cds-tab id="tab-1" target="tab-panel-1" value="tab-1"
               >Tab 1</cds-tab
             >
@@ -183,21 +183,15 @@ describe('cds-page-header', function () {
         </cds-page-header-tabs>`
       );
 
-      const slot = el.shadowRoot.querySelector('slot[name="tabs"]');
-      const assigned = slot.assignedNodes({ flatten: true });
+      const tabs = el.querySelector('cds-tabs');
+      expect(tabs).to.exist;
 
-      const tabsComponent = assigned.find(
-        (node) =>
-          node.nodeType === Node.ELEMENT_NODE &&
-          node.tagName.toLowerCase() === 'cds-tabs'
-      );
+      await tabs.updateComplete;
 
-      expect(tabsComponent).to.exist;
-
-      const tabs = tabsComponent.querySelectorAll('cds-tab');
-      expect(tabs.length).to.equal(2);
-      expect(tabs[0].textContent).to.include('Tab 1');
-      expect(tabs[1].textContent).to.include('Tab 2');
+      const tab = tabs.querySelectorAll('cds-tab');
+      expect(tab.length).to.equal(2);
+      expect(tab[0].textContent).to.include('Tab 1');
+      expect(tab[1].textContent).to.include('Tab 2');
     });
 
     it('should render tags', async () => {

--- a/packages/web-components/src/components/page-header/page-header-tabs.ts
+++ b/packages/web-components/src/components/page-header/page-header-tabs.ts
@@ -24,10 +24,8 @@ class CDSPageHeaderTabs extends LitElement {
       <div
         class="${prefix}--sm:col-span-4 ${prefix}--md:col-span-8 ${prefix}--lg:col-span-16 ${prefix}--css-grid-column">
         <div class="${prefix}--page-header__tab-bar--tablist">
-          <slot name="tabs"></slot>
-          <div class="${prefix}--page-header__tags">
-            <slot name="tags"></slot>
-          </div>
+          <slot></slot>
+          <slot name="tags"></slot>
         </div>
       </div>
     </div>`;

--- a/packages/web-components/src/components/page-header/page-header.scss
+++ b/packages/web-components/src/components/page-header/page-header.scss
@@ -10,6 +10,7 @@
 $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/grid';
@@ -119,7 +120,7 @@ $css--plex: true !default;
   inline-size: 100%;
 }
 
-:host(#{$prefix}-page-header-tabs) .#{$prefix}--page-header__tags {
+:host(#{$prefix}-page-header-tabs) ::slotted([slot='tags']) {
   @extend .#{$prefix}--page-header__tags;
 
   inline-size: 100%;
@@ -134,4 +135,8 @@ $css--plex: true !default;
 
 #{$prefix}-definition-tooltip::part(definition-term) {
   border: none;
+}
+
+:host(#{$prefix}-page-header-tabs) ::slotted(cds-tabs) {
+  --tabs-overflow-button-background: $layer-01;
 }

--- a/packages/web-components/src/components/page-header/page-header.scss
+++ b/packages/web-components/src/components/page-header/page-header.scss
@@ -13,6 +13,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/grid';
 @use '@carbon/styles/scss/components/page-header/index' as *;
 
@@ -118,12 +119,23 @@ $css--plex: true !default;
   display: flex;
   justify-content: space-between;
   inline-size: 100%;
+
+  // TODO: remove once responsive logic for tags is implemented
+  @include breakpoint-down(md) {
+    flex-direction: column-reverse;
+    grid-gap: $spacing-05;
+  }
 }
 
 :host(#{$prefix}-page-header-tabs) ::slotted([slot='tags']) {
   @extend .#{$prefix}--page-header__tags;
 
   inline-size: 100%;
+
+  // TODO: remove once responsive logic for tags is implemented
+  @include breakpoint-down(md) {
+    justify-content: left;
+  }
 }
 
 :host(#{$prefix}-page-header-content),

--- a/packages/web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/web-components/src/components/page-header/page-header.stories.ts
@@ -70,7 +70,7 @@ export const Default = {
         </cds-page-header-content-text>
       </cds-page-header-content>
       <cds-page-header-tabs>
-        <cds-tabs slot="tabs" value="tab-1">
+        <cds-tabs value="tab-1">
           <cds-tab id="tab-1" target="tab-panel-1" value="tab-1">Tab 1</cds-tab>
           <cds-tab id="tab-2" target="tab-panel-2" value="tab-2">Tab 2</cds-tab>
           <cds-tab id="tab-3" target="tab-panel-3" value="tab-3">Tab 3</cds-tab>
@@ -228,7 +228,7 @@ export const TabBarWithTabsAndTags = {
           </cds-page-header-content-text>
         </cds-page-header-content>
         <cds-page-header-tabs>
-          <cds-tabs slot="tabs" value="tab-1">
+          <cds-tabs value="tab-1">
             <cds-tab id="tab-1" target="tab-panel-1" value="tab-1"
               >Tab 1</cds-tab
             >
@@ -289,7 +289,7 @@ export const TabBarWithTabsAndTags = {
 const meta = {
   title: 'Patterns/unstable__PageHeader',
   // comment below line to see the pageheader story
-  includeStories: [],
+  // includeStories: [],
   decorators: [
     (story) =>
       html` <style>

--- a/packages/web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/web-components/src/components/page-header/page-header.stories.ts
@@ -289,7 +289,7 @@ export const TabBarWithTabsAndTags = {
 const meta = {
   title: 'Patterns/unstable__PageHeader',
   // comment below line to see the pageheader story
-  // includeStories: [],
+  includeStories: [],
   decorators: [
     (story) =>
       html` <style>

--- a/packages/web-components/src/components/tabs/tabs.scss
+++ b/packages/web-components/src/components/tabs/tabs.scss
@@ -52,6 +52,10 @@ $inset-transition: inset 110ms motion(standard, productive);
   .#{$prefix}--tab--overflow-nav-button {
     z-index: 1;
   }
+
+  .#{$prefix}--tab--overflow-nav-button {
+    background-color: var(--tabs-overflow-button-background, $background);
+  }
 }
 
 :host(#{$prefix}-tabs) {


### PR DESCRIPTION
Closes #19546
Closes #19547

⚠️ Before merging ⚠️  the stories need `includeStories: []` uncommented so they don't show up in the storybook

This PR fixes some layout and style bugs around the page-header content and tabs bar zones 

Specifically the tabs overflow button backgrounds, setting them to use `$layer-01` instead of `$background` and adjusts / removes the spacing in the tab bar zone when there are no tags provided.

### Changelog

**Changed**

- set background color for tabs overflow button using variable so that the background can be adjusted in the `page-header-tabs` component styles
- fix tests for the tab zone and regenerate snapshots

**Removed**

- removed the slot name for `tabs`, it should be assumed that the open slot is for the tabs components - one less step for adopter when authoring
- remove div wrapper around tag slotted content, was adding styles that was interfering with layout in tab bar

#### Testing / Reviewing

ci-checks pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
