### PR TITLE
chore(wtr): update wc test config

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -58,7 +58,7 @@
     "start": "yarn storybook",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "test": "web-test-runner \"src/components/**/__tests__/**/*.js\" --node-resolve",
+    "test": "web-test-runner \"src/components/**/__tests__/**/*.js\" --node-resolve --concurrency=1",
     "test:updateSnapshots": "yarn test --update-snapshots",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "visual-snapshot": "yarn percy storybook:start ./storybook-static",

--- a/packages/web-components/src/components/combo-button/__tests__/__snapshots__/combo-button-test.snap.js
+++ b/packages/web-components/src/components/combo-button/__tests__/__snapshots__/combo-button-test.snap.js
@@ -1167,3 +1167,35 @@ snapshots['Menu behavior should handle menu item clicks'] = `<cds-button
 </slot>
 `;
 /* end snapshot Menu behavior should handle menu item clicks */
+snapshots['cds-combo-button should support `tooltips-content` attribute'] =
+  `<cds-button
+  has-main-content=""
+  kind="primary"
+  size="lg"
+  tab-index="0"
+  tooltip-alignment=""
+  tooltip-position="top"
+  type="button"
+>
+  Primary action
+</cds-button>
+<cds-icon-button
+  align="top"
+  close-on-activation=""
+  kind="primary"
+  menu-alignment="top"
+  part="trigger"
+  size="lg"
+  tab-index="0"
+  tooltip-alignment=""
+  tooltip-position="top"
+  type="button"
+>
+  <span slot="tooltip-content">
+    Custom tooltip text
+  </span>
+</cds-icon-button>
+<slot>
+</slot>
+`;
+/* end snapshot cds-combo-button should support `tooltips-content` attribute */


### PR DESCRIPTION
Update `test` script in web components to limit concurrency to 1. The default concurrency of 2 can cause random timeout errors when tests would run in parallel.

### Changelog

**Changed**

- add `--concurrency=1` to web components `test` command


#### Testing / Reviewing

There should be no build errors and all tests should pass.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
