### PR TITLE
feat: WC datatable batch actions select all button

### DIFF
--- a/packages/react/src/components/DataTable/TableBatchActions.tsx
+++ b/packages/react/src/components/DataTable/TableBatchActions.tsx
@@ -141,14 +141,12 @@ const TableBatchActions: TableBatchActionsComponent = ({
           </Text>
         </p>
         {onSelectAll && (
-          <>
-            <span className={`${prefix}--batch-summary__divider`}>&#x7c;</span>
-            <Button
-              onClick={onSelectAll}
-              tabIndex={shouldShowBatchActions ? 0 : -1}>
-              {t('carbon.table.batch.selectAll', { totalCount })}
-            </Button>
-          </>
+          <Button
+            onClick={onSelectAll}
+            className={`${prefix}--batch-summary__select-all`}
+            tabIndex={shouldShowBatchActions ? 0 : -1}>
+            {t('carbon.table.batch.selectAll', { totalCount })}
+          </Button>
         )}
       </div>
       <TableActionList>

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -383,13 +383,8 @@ exports[`DataTable behaves as expected selection should render and match snapsho
               0 items selected
             </span>
           </p>
-          <span
-            class="cds--batch-summary__divider"
-          >
-            |
-          </span>
           <button
-            class="cds--btn cds--btn--primary"
+            class="cds--batch-summary__select-all cds--btn cds--btn--primary"
             tabindex="-1"
             type="button"
           >

--- a/packages/styles/scss/components/data-table/action/_data-table-action.scss
+++ b/packages/styles/scss/components/data-table/action/_data-table-action.scss
@@ -469,32 +469,52 @@
 
   // cancel btn pseudo element
   .#{$prefix}--action-list
-    .#{$prefix}--btn--primary:nth-child(3):hover
+    .#{$prefix}--btn--primary:nth-last-child(2):hover
     + .#{$prefix}--btn--primary.#{$prefix}--batch-summary__cancel::before,
   .#{$prefix}--action-list
-    .#{$prefix}--btn--primary:nth-child(3):focus
+    .#{$prefix}--btn--primary:nth-last-child(2):focus
     + .#{$prefix}--btn--primary.#{$prefix}--batch-summary__cancel::before {
     opacity: 0;
   }
 
-  .#{$prefix}--btn--primary.#{$prefix}--batch-summary__cancel::before {
-    position: absolute;
-    display: block;
-    border: none;
-    background-color: $text-on-color;
-    block-size: $spacing-05;
-    content: '';
-    inline-size: convert.to-rem(1px);
-    //visually 16px spacing is 1px too low
-    inset-block-start: convert.to-rem(15px);
-    inset-inline-start: 0;
-    opacity: 1;
-    transition: opacity $duration-fast-02 motion(standard, productive);
+  .#{$prefix}--btn--primary.#{$prefix}--batch-summary {
+    &__select-all {
+      margin-inline-start: $spacing-03;
+    }
+
+    &__cancel,
+    &__select-all {
+      @media (prefers-reduced-motion: no-preference) {
+        &::before {
+          position: absolute;
+          display: block;
+          border: none;
+          background-color: $text-on-color;
+          block-size: $spacing-05;
+          content: '';
+          inline-size: convert.to-rem(1px);
+          //visually 16px spacing is 1px too low
+          inset-block-start: convert.to-rem(15px);
+          inset-inline-start: 0;
+          opacity: 1;
+          transition: opacity $duration-fast-02 motion(standard, productive);
+        }
+      }
+    }
   }
 
-  .#{$prefix}--btn--primary.#{$prefix}--batch-summary__cancel:hover::before {
-    opacity: 0;
-    transition: opacity $transition-base $standard-easing;
+  .#{$prefix}--btn--primary.#{$prefix}--batch-summary {
+    &__cancel:hover::before,
+    &__select-all:hover::before {
+      opacity: 0;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      &__cancel:hover::before,
+      &__select-all:hover::before {
+        transition: opacity $transition-base $standard-easing;
+      }
+    }
   }
 
   // items selected text
@@ -517,10 +537,6 @@
 
   .#{$prefix}--batch-summary__para {
     @include type-style('body-compact-01');
-  }
-
-  .#{$prefix}--batch-summary__divider {
-    padding-inline-start: $spacing-03;
   }
 
   //-------------------------------------------------

--- a/packages/web-components/src/components/data-table/_table-action.scss
+++ b/packages/web-components/src/components/data-table/_table-action.scss
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/components/button';
 @use '@carbon/styles/scss/components/search';
 @use '@carbon/styles/scss/components/data-table/action';
+@use '@carbon/styles/scss/layout' as *;
 
 //
 // Table toolbar
@@ -20,6 +21,7 @@
 
 :host(#{$prefix}-table-toolbar) {
   @extend .#{$prefix}--table-toolbar;
+  @include emit-layout-tokens();
 
   z-index: 1;
 }

--- a/packages/web-components/src/components/data-table/table-batch-actions.ts
+++ b/packages/web-components/src/components/data-table/table-batch-actions.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import styles from './data-table.scss?lit';
@@ -31,6 +31,17 @@ class CDSTableBatchActions extends LitElement {
   }
 
   /**
+   * Handles `click` event on the Select all button.
+   */
+  private _handleSelectAll() {
+    const { eventClickSelectAll } = this
+      .constructor as typeof CDSTableBatchActions;
+    this.dispatchEvent(
+      new CustomEvent(eventClickSelectAll, { bubbles: true, composed: true })
+    );
+  }
+
+  /**
    * `true` if this batch actions bar should be active.
    */
   @property({ type: Boolean, reflect: true })
@@ -50,6 +61,12 @@ class CDSTableBatchActions extends LitElement {
   @property({ type: Number, attribute: 'selected-rows-count' })
   selectedRowsCount = 0;
 
+  /**
+   * Numeric representation of the total number of items present in a table.
+   */
+  @property({ type: Number, attribute: 'total-rows-count' })
+  totalRowsCount = 0;
+
   firstUpdated() {
     this.querySelectorAll(
       (this.constructor as typeof CDSTableBatchActions).selectorButtons
@@ -68,13 +85,26 @@ class CDSTableBatchActions extends LitElement {
     const {
       formatSelectedItemsCount,
       selectedRowsCount,
+      totalRowsCount,
       _handleCancel: handleCancel,
+      _handleSelectAll: handleSelectAll,
     } = this;
     return html`
       <div class="${prefix}--batch-summary">
         <p class="${prefix}--batch-summary__para">
           ${formatSelectedItemsCount({ count: selectedRowsCount })}
         </p>
+        ${totalRowsCount > 0
+          ? html`
+              <button
+                class="${prefix}--btn ${prefix}--btn--primary ${prefix}--batch-summary__select-all"
+                @click=${handleSelectAll}>
+                <slot name="select-all-button-content"
+                  >Select all ${totalRowsCount}</slot
+                >
+              </button>
+            `
+          : nothing}
       </div>
       <div class="${prefix}--action-list">
         <slot></slot>
@@ -99,6 +129,13 @@ class CDSTableBatchActions extends LitElement {
    */
   static get eventClickCancel() {
     return `${prefix}-table-batch-actions-cancel-clicked`;
+  }
+
+  /**
+   * The name of the custom event fired after the Select all button is clicked.
+   */
+  static get eventClickSelectAll() {
+    return `${prefix}-table-batch-actions-select-all-clicked`;
   }
 
   static styles = styles;


### PR DESCRIPTION
Closes #19543 

Adds select all button on datatable batch actions toolbar, in web components

### Changelog

**New**
adds additional button `Select all n` where n being a number property `totalRowsCount` on `cds-table-batch-actions`, and exposed an event on it
`cds-table-batch-actions-select-all-clicked`

**Changed**
- changes global styles for cancel and select all button to work for both react and web components consistently.
- also fixes cancel button by emitting layout tokens to batch actions toolbar
- fixes or made the behavior stable with tiny divider between cancel and action buttons disappear on hover, by targetting css from the end where placement of cancel button remains constant while custom actions varies
nth-last-child(2) always targets the button before cancel, making it more stable.

#### Testing / Reviewing

verified in storybook by adding
```
<cds-table-batch-actions
  ?active="true"
  total-rows-count=${10}
  @cds-table-batch-actions-select-all-clicked=${()=>{console.log("select all clicked")}}
>
```
https://github.com/user-attachments/assets/2b13091d-9326-47bf-a664-b9e3e84c5158

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~ (if i have to be consistent with React WC parity, i'm not sure if i have to do this.)
- [ ] ~Wrote passing tests that cover this change~ (test suit not found for WC data-table, or am i missing something?)
- [x] Addressed any impact on accessibility (a11y) (tested with IBM EAC, no new violations found)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
