### PR TITLE
fix(layer): support generic polymorphic props

### DIFF
--- a/packages/react/src/components/Layer/index.tsx
+++ b/packages/react/src/components/Layer/index.tsx
@@ -55,23 +55,17 @@ export interface LayerBaseProps {
 export type LayerProps<T extends React.ElementType> =
   PolymorphicComponentPropWithRef<T, LayerBaseProps>;
 
-const Layer = React.forwardRef<
-  any,
-  LayerBaseProps & {
-    as?: React.ElementType;
-  } & React.HTMLAttributes<HTMLDivElement>
->(
-  (
-    {
+const Layer = React.forwardRef(
+  <T extends React.ElementType = 'div'>(props: LayerProps<T>, ref) => {
+    const {
       as,
       className: customClassName,
       children,
       level: overrideLevel,
       withBackground = false,
       ...rest
-    },
-    ref
-  ) => {
+    } = props;
+
     const contextLevel = React.useContext(LayerContext);
     const level = overrideLevel ?? contextLevel;
     const prefix = usePrefix();


### PR DESCRIPTION
Closes #19358 

Fix polymorphic props for `Layer` component.

### Changelog

**New**

- Fix type parameters in `Layer`’s `forwardRef` definition to improve TypeScript compatibility for polymorphic components.

**Changed**

- Refactored `Layer` to use a generic parameter in `forwardRef`, resolving a type mismatch that previously prevented Carbon upgrade.

**Removed**

- ~None~

#### Testing / Reviewing

To test this change:

- Use the `Layer` component in any component `.tsx` file. I just add my component in Accordion:
Example usage (e.g., in `Accordion.tsx`):

  ```tsx
  import { Grid, Column } from '../Grid';
  import { Layer } from '../Layer';

  function TestComponent() {
    return <div className="test-component">Test component</div>;
  }

  return (
    <AccordionProvider disabled={disabled}>
      <Grid>
        <TestComponent />
        <div className="color-layer">
          <TestComponent />
        </div>
        <Layer as={Column} className="color-layer" sm={1} md={2} lg={4}>
          <TestComponent />
          <Layer className="color-layer">
            <TestComponent />
          </Layer>
        </Layer>
      </Grid>
    </AccordionProvider>
  );

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
