### PR TITLE
fix(styles): replace `@document` at-rule with `@-moz-document`

### DIFF
--- a/packages/styles/scss/components/data-table/_data-table.scss
+++ b/packages/styles/scss/components/data-table/_data-table.scss
@@ -837,8 +837,11 @@
       display: none;
     }
 
-    //hides ff scrollbar
-    @document url-prefix() {
+    /* This is for targeting styles specific to firefox */
+    /* To hide the firefox scrollbar */
+    /* https://sass-lang.com/documentation/breaking-changes/moz-document/ */
+    /* stylelint-disable-next-line at-rule-no-vendor-prefix */
+    @-moz-document url-prefix() {
       thead,
       tbody {
         scrollbar-width: none;

--- a/packages/styles/scss/components/pagination-nav/_pagination-nav.scss
+++ b/packages/styles/scss/components/pagination-nav/_pagination-nav.scss
@@ -141,8 +141,10 @@
     appearance: none;
     max-block-size: layout.size('height');
     text-indent: calc(50% - 4.5px);
-    // Override some Firefox user-agent styles
-    @document url-prefix() {
+    /* This is for targeting styles specific to firefox */
+    /* https://sass-lang.com/documentation/breaking-changes/moz-document/ */
+    /* stylelint-disable-next-line at-rule-no-vendor-prefix */
+    @-moz-document url-prefix() {
       text-indent: 0;
     }
   }

--- a/packages/styles/scss/components/select/_select.scss
+++ b/packages/styles/scss/components/select/_select.scss
@@ -73,9 +73,12 @@
       display: none;
     }
 
-    // Select text renders a little high on Firefox
-    @document url-prefix() {
-      // Removes dotted inner focus
+    //
+    /* This is for targeting styles specific to firefox */
+    /* Removes dotted inner focus */
+    /* https://sass-lang.com/documentation/breaking-changes/moz-document/ */
+    /* stylelint-disable-next-line at-rule-no-vendor-prefix */
+    @-moz-document url-prefix() {
       &:-moz-focusring,
       &::-moz-focus-inner {
         background-image: none;


### PR DESCRIPTION
Closes #19227

Related #19305

When Stylelint was upgraded these were incorrectly updated to `@document` when they should've stayed as `@-moz-document`

### Changelog

**Changed**

- update datatable styles
- update pagination-nav styles
- update select styles

#### Testing / Reviewing

- View the stories for each effected component and ensure the related styles are present in firefox

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
