### PR TITLE
feat(PageHeader): expand/collapse functionality, title animation into breadcrumb bar

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -11756,11 +11756,19 @@ Map {
         },
       },
     },
+    "PageHeaderScrollButton": Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "render": [Function],
+    },
     "PageHeaderTabBar": Object {
       "$$typeof": Symbol(react.forward_ref),
       "render": [Function],
     },
     "Root": Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "render": [Function],
+    },
+    "ScrollButton": Object {
       "$$typeof": Symbol(react.forward_ref),
       "render": [Function],
     },

--- a/packages/react/src/components/PageHeader/PageHeader-test.js
+++ b/packages/react/src/components/PageHeader/PageHeader-test.js
@@ -38,7 +38,6 @@ jest.mock('@carbon/utilities', () => ({
 }));
 
 describe('PageHeader', () => {
-  let consoleErrorSpy;
   beforeEach(() => {
     mockUseOverflowItems.mockReset();
     mockUseOverflowItems.mockReturnValue({
@@ -46,17 +45,6 @@ describe('PageHeader', () => {
       hiddenItems: [],
       itemRefHandler: jest.fn(),
     });
-    consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation((message) => {
-        expect(message).toBe(
-          'Page header context was not provided or hook was used outside of the Page header component.'
-        );
-      });
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
   });
 
   describe('export configuration', () => {
@@ -178,9 +166,9 @@ describe('PageHeader', () => {
   describe('PageHeader.Content component api', () => {
     it('should render', () => {
       const { container } = render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content title="title" />
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
       expect(container.firstChild).toBeInTheDocument();
     });
@@ -188,13 +176,13 @@ describe('PageHeader', () => {
     it('should place className on the outermost element', () => {
       const contentRef = React.createRef();
       const { container } = render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content
             ref={contentRef}
             className="custom-class"
             title="title"
           />
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
       expect(contentRef.current).toHaveClass(`${prefix}--page-header__content`);
       expect(contentRef.current).toHaveClass('custom-class');
@@ -202,9 +190,9 @@ describe('PageHeader', () => {
 
     it('should render a title', () => {
       render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content title="Page header content title" />
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
 
       expect(screen.getByText('Page header content title')).toBeInTheDocument();
@@ -212,13 +200,13 @@ describe('PageHeader', () => {
 
     it('should render an icon', () => {
       const { container } = render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content
             title="title"
             renderIcon={() => {
               return <Bee size={32} />;
             }}></PageHeader.Content>
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
 
       const icon = container.querySelector(
@@ -229,11 +217,11 @@ describe('PageHeader', () => {
 
     it('should render children', () => {
       render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content title="title">
             Children content
           </PageHeader.Content>
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
 
       expect(screen.getByText('Children content')).toBeInTheDocument();
@@ -241,7 +229,7 @@ describe('PageHeader', () => {
 
     it('should render contextual actions', () => {
       const { container } = render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content
             title="title"
             contextualActions={
@@ -251,7 +239,7 @@ describe('PageHeader', () => {
                 <div>action 3</div>
               </>
             }></PageHeader.Content>
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
 
       const pageActions = container.querySelector(
@@ -262,11 +250,11 @@ describe('PageHeader', () => {
 
     it('should render page actions', () => {
       const { container } = render(
-        <PageHeaderDirect>
+        <PageHeader.Root>
           <PageHeader.Content
             title="title"
             pageActions={<button>page actions</button>}></PageHeader.Content>
-        </PageHeaderDirect>
+        </PageHeader.Root>
       );
 
       const buttonElement = screen.getByText(/page actions/i);
@@ -792,7 +780,7 @@ describe('PageHeader', () => {
         unobserve: () => null,
       }));
     });
-    it('should render a tab bar with the expand/collapse button', () => {
+    it('should render a tab bar with scroller button and tags', () => {
       render(
         <PageHeader.Root>
           <PageHeader.Content>Hello</PageHeader.Content>
@@ -800,6 +788,15 @@ describe('PageHeader', () => {
             tags={mockTags}
             scroller={<PageHeader.ScrollButton />}
           />
+        </PageHeader.Root>
+      );
+      expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
+    });
+    it('should render a tab bar with scroller button and without passing tags', () => {
+      render(
+        <PageHeader.Root>
+          <PageHeader.Content>Hello</PageHeader.Content>
+          <PageHeaderTabBarDirect scroller={<PageHeader.ScrollButton />} />
         </PageHeader.Root>
       );
       expect(screen.getByLabelText('Collapse')).toBeInTheDocument();

--- a/packages/react/src/components/PageHeader/PageHeader-test.js
+++ b/packages/react/src/components/PageHeader/PageHeader-test.js
@@ -801,5 +801,21 @@ describe('PageHeader', () => {
       );
       expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
     });
+    it('should render call function passed to scroller', async () => {
+      const scrollerOnClick = jest.fn();
+      render(
+        <PageHeader.Root>
+          <PageHeader.Content>Hello</PageHeader.Content>
+          <PageHeaderTabBarDirect
+            scroller={<PageHeader.ScrollButton onClick={scrollerOnClick} />}
+          />
+        </PageHeader.Root>
+      );
+      const scrollerButton = screen.getByLabelText('Collapse');
+      expect(scrollerButton).toBeInTheDocument();
+
+      await userEvent.click(scrollerButton);
+      expect(scrollerOnClick).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react/src/components/PageHeader/PageHeader-test.js
+++ b/packages/react/src/components/PageHeader/PageHeader-test.js
@@ -801,7 +801,7 @@ describe('PageHeader', () => {
       );
       expect(screen.getByLabelText('Collapse')).toBeInTheDocument();
     });
-    it('should render call function passed to scroller', async () => {
+    it('should call onClick function passed to scroller', async () => {
       const scrollerOnClick = jest.fn();
       render(
         <PageHeader.Root>

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -8,7 +8,6 @@ import React from 'react';
 import { Add } from '@carbon/icons-react';
 import { unstable__PageHeader as PageHeader } from '../../';
 import {
-  PageHeader,
   PageHeaderBreadcrumbBar,
   PageHeaderContent,
   PageHeaderTabBar,

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -523,9 +523,9 @@ export const CollapseAndExpand = (args) => {
           isFixedNav>
           <SideNavItems>
             <SideNavLink
-              href="https://pages.github.ibm.com/carbon/ibm-products/"
+              href="https://www.carbondesignsystem.com"
               target="_blank">
-              Sample link: Carbon for IBM Products
+              Carbon Design System
             </SideNavLink>
           </SideNavItems>
         </SideNav>

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -20,9 +20,18 @@ import { Tag } from '../Tag';
 import { Button } from '../Button';
 import { Grid, Column } from '../Grid';
 import { Breadcrumb, BreadcrumbItem } from '../Breadcrumb';
+import {
+  Header,
+  HeaderName,
+  HeaderMenuButton,
+  SideNav,
+  SideNavItems,
+  SideNavLink,
+} from '../UIShell';
 import { breakpoints } from '@carbon/layout';
 import image1 from './_story-assets/2x1.jpg';
 import image2 from './_story-assets/3x2.jpg';
+import './_story-styles.scss';
 
 import { Bee, AiGenerate, CloudFoundry_1, Activity } from '@carbon/icons-react';
 import mdx from './PageHeader.mdx';
@@ -491,3 +500,81 @@ export const TabBarWithTabsAndTags = (args) => (
     </TabPanels>
   </Tabs>
 );
+
+export const CollapseAndExpand = (args) => {
+  const [isSideNavExpanded, setIsSideNavExpanded] = React.useState(false);
+  return (
+    <div className="page-header-story-wrapper">
+      <Header aria-label="IBM Platform Name">
+        <HeaderMenuButton
+          aria-label="Open menu"
+          isCollapsible
+          onClick={() => {
+            setIsSideNavExpanded((prev) => !prev);
+          }}
+          isActive={isSideNavExpanded}
+        />
+        <HeaderName href="#" prefix="IBM">
+          Software application
+        </HeaderName>
+        <SideNav
+          aria-label="Side navigation"
+          expanded={isSideNavExpanded}
+          isFixedNav>
+          <SideNavItems>
+            <SideNavLink
+              href="https://pages.github.ibm.com/carbon/ibm-products/"
+              target="_blank">
+              Sample link: Carbon for IBM Products
+            </SideNavLink>
+          </SideNavItems>
+        </SideNav>
+      </Header>
+      <Tabs className>
+        <PageHeader.Root>
+          <PageHeader.BreadcrumbBar
+            border={args.border}
+            pageActionsFlush={args.pageActionsFlush}
+            contentActionsFlush={args.contentActionsFlush}
+            renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
+            pageActions={breadcrumbPageActions}>
+            <Breadcrumb>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+            </Breadcrumb>
+          </PageHeader.BreadcrumbBar>
+          <PageHeader.Content
+            title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
+            {...args}>
+            <PageHeader.ContentText subtitle="Subtitle">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex.
+            </PageHeader.ContentText>
+          </PageHeader.Content>
+          <PageHeader.TabBar tags={tags} scroller={<PageHeader.ScrollButton />}>
+            <TabList>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+              <Tab>Tab 4</Tab>
+              <Tab>Tab 5</Tab>
+              <Tab>Tab 6</Tab>
+              <Tab>Tab 7</Tab>
+            </TabList>
+          </PageHeader.TabBar>
+        </PageHeader.Root>
+        <TabPanels>
+          <TabPanel style={{ height: '200vh' }}>Tab Panel 1</TabPanel>
+          <TabPanel>Tab Panel 2</TabPanel>
+          <TabPanel>Tab Panel 3</TabPanel>
+          <TabPanel>Tab Panel 4</TabPanel>
+          <TabPanel>Tab Panel 5</TabPanel>
+          <TabPanel>Tab Panel 6</TabPanel>
+          <TabPanel>Tab Panel 7</TabPanel>
+        </TabPanels>
+      </Tabs>
+    </div>
+  );
+};

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { Add } from '@carbon/icons-react';
 import { unstable__PageHeader as PageHeader } from '../../';
 import {
-  PageHeader as PageHeaderDirect,
+  PageHeader,
   PageHeaderBreadcrumbBar,
   PageHeaderContent,
   PageHeaderTabBar,
@@ -538,7 +538,7 @@ export const CollapseAndExpand = (args) => {
             contentActionsFlush={args.contentActionsFlush}
             renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
             renderTitleBreadcrumb={() => (
-              <BreadcrumbItem href="#" isCurrentPage>
+              <BreadcrumbItem href="#">
                 Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long
               </BreadcrumbItem>
             )}

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -537,9 +537,14 @@ export const CollapseAndExpand = (args) => {
             pageActionsFlush={args.pageActionsFlush}
             contentActionsFlush={args.contentActionsFlush}
             renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
+            renderTitleBreadcrumb={() => (
+              <BreadcrumbItem href="#" isCurrentPage>
+                Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long
+              </BreadcrumbItem>
+            )}
             pageActions={breadcrumbPageActions}>
             <Breadcrumb>
-              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
               <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
             </Breadcrumb>
           </PageHeader.BreadcrumbBar>

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -566,13 +566,27 @@ export const CollapseAndExpand = (args) => {
           </PageHeader.TabBar>
         </PageHeader.Root>
         <TabPanels>
-          <TabPanel style={{ height: '200vh' }}>Tab Panel 1</TabPanel>
-          <TabPanel>Tab Panel 2</TabPanel>
-          <TabPanel>Tab Panel 3</TabPanel>
-          <TabPanel>Tab Panel 4</TabPanel>
-          <TabPanel>Tab Panel 5</TabPanel>
-          <TabPanel>Tab Panel 6</TabPanel>
-          <TabPanel>Tab Panel 7</TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 1
+          </TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 2
+          </TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 3
+          </TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 4
+          </TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 5
+          </TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 6
+          </TabPanel>
+          <TabPanel className="page-header-story--tall-tab-panel">
+            Tab Panel 7
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </div>

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -37,7 +37,9 @@ import { Grid, Column } from '../Grid';
 import { IconButton, IconButtonProps } from '../IconButton';
 import { ChevronUp } from '@carbon/react/icons';
 import Breadcrumb from '../Breadcrumb';
-import { BreadcrumbItemProps } from '../Breadcrumb/BreadcrumbItem';
+import BreadcrumbItem, {
+  BreadcrumbItemProps,
+} from '../Breadcrumb/BreadcrumbItem';
 
 /**
  * ----------
@@ -342,7 +344,7 @@ const PageHeaderBreadcrumbBar = React.forwardRef<
           [`${prefix}--page-header-title-breadcrumb-show`]: titleClipped,
         }),
         key: 'cloned title breadcrumb',
-        isCurrentPage: true,
+        ...(element.type === BreadcrumbItem && { isCurrentPage: true }),
       });
       const finalBreadcrumbs = React.cloneElement(
         foundBreadcrumb,

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -37,6 +37,7 @@ import { Grid, Column } from '../Grid';
 import { IconButton, IconButtonProps } from '../IconButton';
 import { ChevronUp } from '@carbon/react/icons';
 import Breadcrumb from '../Breadcrumb';
+import { BreadcrumbItemProps } from '../Breadcrumb/BreadcrumbItem';
 
 /**
  * ----------
@@ -281,7 +282,7 @@ interface PageHeaderBreadcrumbBarProps {
   /**
    * Text for the title breadcrumb, ie current page
    */
-  renderTitleBreadcrumb?: () => React.ReactElement;
+  renderTitleBreadcrumb?: () => React.ReactElement<BreadcrumbItemProps>;
 }
 const PageHeaderBreadcrumbBar = React.forwardRef<
   HTMLDivElement,
@@ -319,12 +320,24 @@ const PageHeaderBreadcrumbBar = React.forwardRef<
 
   const renderChildren = () => {
     const filteredBreadcrumbs = React.Children.toArray(children).filter(
-      (child) => child.type === Breadcrumb
+      (child) => {
+        if (React.isValidElement(child)) {
+          return child.type === Breadcrumb;
+        }
+      }
     );
     if (filteredBreadcrumbs) {
       const foundBreadcrumb = filteredBreadcrumbs[0];
+      if (!React.isValidElement(foundBreadcrumb)) return;
       const element = renderTitleBreadcrumb?.();
-      const clonedElement = React.cloneElement(element!, {
+
+      // If there isn't a title breadcrumb stop here
+      // and just return the children
+      if (!element) {
+        return children;
+      }
+
+      const clonedElement = React.cloneElement(element, {
         className: classnames(`${prefix}--page-header-title-breadcrumb`, {
           [`${prefix}--page-header-title-breadcrumb-show`]: titleClipped,
         }),
@@ -332,12 +345,17 @@ const PageHeaderBreadcrumbBar = React.forwardRef<
         isCurrentPage: true,
       });
       const finalBreadcrumbs = React.cloneElement(
-        foundBreadcrumb as React.ReactElement,
+        foundBreadcrumb,
         {},
+        // @ts-expect-error Revisit
         [...foundBreadcrumb.props.children.flat(), clonedElement]
       );
       const foundBreadcrumbIndex = React.Children.toArray(children).findIndex(
-        (child) => child.type === Breadcrumb
+        (child) => {
+          if (React.isValidElement(child)) {
+            return child.type === Breadcrumb;
+          }
+        }
       );
       const childrenArray = (React.Children.toArray(children)[
         foundBreadcrumbIndex

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -899,13 +899,13 @@ const PageHeaderScrollButton = React.forwardRef<
     // Page header content is not fully collapsed
     if (!isFullyCollapsed) {
       const pageHeaderContentHeight = refs?.contentRef.current.offsetHeight;
-      scrollableTarget.scrollTo({
+      scrollableTarget?.scrollTo({
         top: pageHeaderContentHeight, // headerTopValue, check if breadcrumb bar is included
         behavior: 'smooth',
       });
     } else {
       // Page header content is fully collapsed
-      scrollableTarget.scrollTo({ top: 0, behavior: 'smooth' });
+      scrollableTarget?.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -35,7 +35,7 @@ import { Popover, PopoverContent } from '../Popover';
 import { useId } from '../../internal/useId';
 import { Grid, Column } from '../Grid';
 import { IconButton, IconButtonProps } from '../IconButton';
-import { ChevronUp } from '@carbon/react/icons';
+import { ChevronUp } from '@carbon/icons-react';
 import Breadcrumb from '../Breadcrumb';
 import BreadcrumbItem, {
   BreadcrumbItemProps,

--- a/packages/react/src/components/PageHeader/PageHeader.tsx
+++ b/packages/react/src/components/PageHeader/PageHeader.tsx
@@ -102,6 +102,12 @@ const scrollableAncestor = (target: HTMLElement) => {
   return scrollableAncestorInner(target);
 };
 
+/**
+ * -------------
+ * Context setup
+ * -------------
+ */
+
 type PageHeaderRefs = {
   contentRef?: RefObject<HTMLDivElement>;
   baseRef?: RefObject<HTMLDivElement>;
@@ -706,6 +712,17 @@ const PageHeaderTabBar = React.forwardRef<
     },
     className
   );
+
+  const renderScroller = () => (
+    <>
+      {scroller && (
+        <div className={`${prefix}--page-header--scroller-button-container`}>
+          {scroller}
+        </div>
+      )}
+    </>
+  );
+
   // Early return if no tags are provided
   if (!tags.length) {
     return (
@@ -713,6 +730,7 @@ const PageHeaderTabBar = React.forwardRef<
         <Grid>
           <Column lg={16} md={8} sm={4}>
             {children}
+            {renderScroller()}
           </Column>
         </Grid>
       </div>
@@ -729,7 +747,6 @@ const PageHeaderTabBar = React.forwardRef<
   }, [tags]);
 
   const tagsContainerRef = useRef<HTMLDivElement>(null);
-  const tagsAndScrollerRef = useRef<HTMLDivElement>(null);
   const offsetRef = useRef<HTMLDivElement>(null);
   // To close popover when window resizes
   useEffect(() => {
@@ -751,7 +768,7 @@ const PageHeaderTabBar = React.forwardRef<
     itemRefHandler = () => {},
   } = useOverflowItems<TagItem>(
     tagsWithIds,
-    tagsAndScrollerRef as React.RefObject<HTMLDivElement>,
+    tagsContainerRef as React.RefObject<HTMLDivElement>,
     offsetRef as React.RefObject<HTMLDivElement>
   ) || {
     visibleItems: [],
@@ -808,12 +825,8 @@ const PageHeaderTabBar = React.forwardRef<
         <Column lg={16} md={8} sm={4}>
           <div className={`${prefix}--page-header__tab-bar--tablist`}>
             {children}
-            <div
-              ref={tagsAndScrollerRef}
-              className={`${prefix}--page-header__tab-bar--tag-scroller-wrapper`}>
-              {tags.length > 0 && renderTags()}
-              {scroller}
-            </div>
+            {tags.length > 0 && renderTags()}
+            {renderScroller()}
           </div>
         </Column>
       </Grid>
@@ -845,7 +858,7 @@ const PageHeaderScrollButton = React.forwardRef<
   const { refs } = usePageHeader();
   const [fullyCollapsed, setFullyCollapsed] = useState(false);
 
-  // Intersection Observer to track if PageHeaderContent is visible on page
+  // Intersection Observer to track if the PageHeaderContent is visible on page.
   // If it is not visible, we should set fully collapsed to true so that the
   // scroller button will know if it is clicked to expand rather than
   // collapse the header
@@ -877,7 +890,7 @@ const PageHeaderScrollButton = React.forwardRef<
     };
   }, [refs]);
 
-  const handleScroller = (event, isFullyCollapsed: boolean) => {
+  const handleScroller = (isFullyCollapsed: boolean) => {
     if (!refs?.contentRef?.current) return;
     const scrollableTarget = scrollableAncestor(
       refs?.contentRef.current
@@ -899,33 +912,28 @@ const PageHeaderScrollButton = React.forwardRef<
   const prefix = usePrefix();
 
   return (
-    <div className={`${prefix}--page-header--scroller-button-container`}>
-      <IconButton
-        ref={ref}
-        label={fullyCollapsed ? expandText : collapseText}
-        size="md"
-        kind="ghost"
-        autoAlign
-        {...other}
-        onClick={(event) => {
-          onClick?.(event);
-          handleScroller(event, fullyCollapsed);
-        }}
-        className={classnames(
-          className,
-          `${prefix}--page-header--scroller-button`
-        )}>
-        <ChevronUp
-          className={classnames(
-            `${prefix}--page-header--scroller-button-icon`,
-            {
-              [`${prefix}--page-header--scroller-button-icon-collapsed`]:
-                fullyCollapsed,
-            }
-          )}
-        />
-      </IconButton>
-    </div>
+    <IconButton
+      ref={ref}
+      label={fullyCollapsed ? expandText : collapseText}
+      size="md"
+      kind="ghost"
+      autoAlign
+      {...other}
+      onClick={(event) => {
+        onClick?.(event);
+        handleScroller(fullyCollapsed);
+      }}
+      className={classnames(
+        className,
+        `${prefix}--page-header--scroller-button`
+      )}>
+      <ChevronUp
+        className={classnames(`${prefix}--page-header--scroller-button-icon`, {
+          [`${prefix}--page-header--scroller-button-icon-collapsed`]:
+            fullyCollapsed,
+        })}
+      />
+    </IconButton>
   );
 });
 

--- a/packages/react/src/components/PageHeader/_story-styles.scss
+++ b/packages/react/src/components/PageHeader/_story-styles.scss
@@ -3,3 +3,7 @@
 .page-header-story-wrapper {
   margin-top: spacing.$spacing-09;
 }
+
+.page-header-story--tall-tab-panel {
+  height: 200vh;
+}

--- a/packages/react/src/components/PageHeader/_story-styles.scss
+++ b/packages/react/src/components/PageHeader/_story-styles.scss
@@ -1,0 +1,5 @@
+@use '../../../../styles/scss/spacing';
+
+.page-header-story-wrapper {
+  margin-top: spacing.$spacing-09;
+}

--- a/packages/react/src/components/PageHeader/index.tsx
+++ b/packages/react/src/components/PageHeader/index.tsx
@@ -12,6 +12,7 @@ export {
   PageHeaderContentText,
   PageHeaderTabBar,
   PageHeaderHeroImage,
+  PageHeaderScrollButton,
   //
   Root,
   BreadcrumbBar,
@@ -20,6 +21,7 @@ export {
   ContentText,
   TabBar,
   HeroImage,
+  ScrollButton,
 } from './PageHeader';
 export type {
   PageHeaderProps,
@@ -29,4 +31,5 @@ export type {
   PageHeaderContentTextProps,
   PageHeaderTabBarProps,
   PageHeaderHeroImageProps,
+  PageHeaderScrollButtonProps,
 } from './PageHeader';

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -11,6 +11,7 @@
 @use '../../spacing' as *;
 @use '../../theme' as *;
 @use '../../type' as *;
+@use '../../motion' as *;
 @use '../../utilities/convert';
 
 /// Page header styles
@@ -18,12 +19,18 @@
 /// @group page-header
 @mixin page-header {
   .#{$prefix}--page-header {
+    position: sticky;
     background-color: $layer-01;
     border-block-end: 1px solid $border-subtle-01;
+    inset-block-start: var(--#{$prefix}-page-header-header-top);
   }
 
   .#{$prefix}--page-header__breadcrumb-bar {
+    position: sticky;
+    z-index: 1;
+    background-color: $layer;
     block-size: convert.to-rem(40px);
+    inset-block-start: var(--#{$prefix}-page-header-breadcrumb-top);
   }
 
   .#{$prefix}--page-header__breadcrumb-bar .#{$prefix}--subgrid {
@@ -195,5 +202,27 @@
 
   .#{$prefix}--page-header__tag-item {
     flex-shrink: 0;
+  }
+
+  .#{$prefix}--page-header__tab-bar--tag-scroller-wrapper {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .#{$prefix}--page-header--scroller-button-icon {
+    transition: transform $transition-expansion;
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  .#{$prefix}--page-header--scroller-button-icon-collapsed {
+    transform: rotate(180deg);
+  }
+
+  .#{$prefix}--page-header--scroller-button-container {
+    position: absolute;
+    inset-block-end: 0;
+    inset-inline-end: 0;
   }
 }

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -238,6 +238,20 @@
     }
   }
 
+  @keyframes page-header-title-breadcrumb-animation-reduced-motion {
+    0% {
+      opacity: 0;
+    }
+
+    5% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+
   .#{$prefix}--page-header-title-breadcrumb {
     opacity: 0;
     transform: translateY($spacing-05);
@@ -250,6 +264,10 @@
         opacity: 1;
         transform: translateY(0);
       }
+      @media (prefers-reduced-motion: reduce) {
+        transform: translateY(0);
+        transition: opacity motion(standard, productive) $duration-moderate-01;
+      }
     }
     // `animation-timeline: scroll()` only currently supported in Chromium based browsers
     @supports (animation-timeline: scroll()) {
@@ -259,7 +277,8 @@
       animation-timeline: scroll(block nearest);
 
       @media (prefers-reduced-motion: reduce) {
-        transition: none;
+        animation-name: page-header-title-breadcrumb-animation-reduced-motion;
+        transform: translateY(0);
       }
     }
   }

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -220,4 +220,42 @@
     inset-block-end: 0;
     inset-inline-end: 0;
   }
+
+  @keyframes page-header-title-breadcrumb-animation {
+    0% {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+
+    5% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .#{$prefix}--page-header-title-breadcrumb {
+    opacity: 0;
+    transform: translateY($spacing-05);
+    transition:
+      transform motion(standard, productive) $duration-moderate-01,
+      opacity motion(standard, productive) $duration-moderate-01;
+    // Target browsers that do not yet support timeline scrolling
+    @supports not (animation-timeline: scroll()) {
+      &.#{$prefix}--page-header-title-breadcrumb-show {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+    // scroll() only currently supported in Chromium based browsers
+    @supports (animation-timeline: scroll()) {
+      animation-direction: alternate;
+      animation-duration: 1ms; /* Firefox requires this to apply the animation */
+      animation-name: page-header-title-breadcrumb-animation;
+      animation-timeline: scroll(block nearest);
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
+    }
+  }
 }

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -231,6 +231,11 @@
       opacity: 1;
       transform: translateY(0);
     }
+
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 
   .#{$prefix}--page-header-title-breadcrumb {
@@ -239,14 +244,14 @@
     transition:
       transform motion(standard, productive) $duration-moderate-01,
       opacity motion(standard, productive) $duration-moderate-01;
-    // Target browsers that do not yet support timeline scrolling
+    // Target browsers that do not yet support animation-timeline: scroll()
     @supports not (animation-timeline: scroll()) {
       &.#{$prefix}--page-header-title-breadcrumb-show {
         opacity: 1;
         transform: translateY(0);
       }
     }
-    // scroll() only currently supported in Chromium based browsers
+    // `animation-timeline: scroll()` only currently supported in Chromium based browsers
     @supports (animation-timeline: scroll()) {
       animation-direction: alternate;
       animation-duration: 1ms; /* Firefox requires this to apply the animation */

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -192,6 +192,14 @@
     display: flex;
     align-items: center;
     justify-content: right;
+    padding-inline-end: 0;
+
+    @include breakpoint(md) {
+      padding-inline-end: $spacing-03;
+    }
+    @include breakpoint(max) {
+      padding-inline-end: $spacing-05;
+    }
   }
 
   .#{$prefix}--page-header__tags-popover-list {

--- a/packages/styles/scss/components/page-header/_page-header.scss
+++ b/packages/styles/scss/components/page-header/_page-header.scss
@@ -204,11 +204,6 @@
     flex-shrink: 0;
   }
 
-  .#{$prefix}--page-header__tab-bar--tag-scroller-wrapper {
-    display: flex;
-    justify-content: flex-end;
-  }
-
   .#{$prefix}--page-header--scroller-button-icon {
     transition: transform $transition-expansion;
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Closes carbon-design-system/ibm-products#7800 

Adds `PageHeader.ScrollButton` component to be used with new `scroller` prop on the `PageHeader.TabBar`. Basic API usage would looks like the following:
```jsx
<PageHeader.TabBar tags={tags} scroller={<PageHeader.ScrollButton />}>
  <TabList>
    <Tab>1</Tab>
    <Tab>2</Tab>
    <Tab>3</Tab>
  </TabList>
</PageHeader.TabBar>
```

This will result in the collapse/expand button as seen in the screenshot below:
<img width="1401" alt="Screenshot 2025-06-13 at 3 49 20 PM" src="https://github.com/user-attachments/assets/05f83f51-64ad-4334-9c44-3ca8b2a4eaef" />



I also added a context to the root `PageHeader` and an accompanying custom hook (`usePageHeader`) to access the context from the sub-components in order to get everything working together.

To support the title breadcrumb, I added a new prop to `PageHeader.BreadcrumbBar` called `renderTitleBreadcrumb`. This render prop should return a `BreadcrumbItem` for the title, but is flexible enough to return anything.

<img width="1399" alt="Screenshot 2025-06-13 at 3 59 55 PM" src="https://github.com/user-attachments/assets/a408f421-0a06-46e5-a356-00d6b5f2254a" />


### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
