### PR TITLE
refactor: port `usePressable` to typescript and add tests

### DIFF
--- a/packages/react/src/components/Tabs/__tests__/usePressable-tests.js
+++ b/packages/react/src/components/Tabs/__tests__/usePressable-tests.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useRef } from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { usePressable } from '../usePressable';
+
+jest.useFakeTimers();
+
+const TestComponent = (props) => {
+  const ref = useRef(null);
+
+  usePressable(ref, props);
+
+  return <button ref={ref}>Press me</button>;
+};
+
+describe('usePressable', () => {
+  it('should call `onPressIn` on pointer down', () => {
+    const onPressIn = jest.fn();
+    const { getByText } = render(<TestComponent onPressIn={onPressIn} />);
+
+    fireEvent.pointerDown(getByText('Press me'));
+    expect(onPressIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `onPressOut` on pointer up', () => {
+    const onPressOut = jest.fn();
+    const { getByText } = render(<TestComponent onPressOut={onPressOut} />);
+
+    fireEvent.pointerDown(getByText('Press me'));
+    fireEvent.pointerUp(getByText('Press me'));
+    expect(onPressOut).toHaveBeenCalledWith({ longPress: false });
+  });
+
+  it('should call `onPress` on click', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<TestComponent onPress={onPress} />);
+
+    fireEvent.click(getByText('Press me'));
+    expect(onPress).toHaveBeenCalledWith({ longPress: false });
+  });
+
+  it('should call `onLongPress` after delay', () => {
+    const onLongPress = jest.fn();
+    const { getByText } = render(<TestComponent onLongPress={onLongPress} />);
+    fireEvent.pointerDown(getByText('Press me'));
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call `onLongPress` if released early', () => {
+    const onLongPress = jest.fn();
+    const { getByText } = render(<TestComponent onLongPress={onLongPress} />);
+
+    fireEvent.pointerDown(getByText('Press me'));
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+      fireEvent.pointerUp(getByText('Press me'));
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const { unmount, getByText } = render(<TestComponent />);
+    const button = getByText('Press me');
+    const removeEventListenerSpy = jest.spyOn(button, 'removeEventListener');
+
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalled();
+  });
+
+  it('should prevent default context menu', () => {
+    const { getByText } = render(<TestComponent />);
+    const button = getByText('Press me');
+    const event = new MouseEvent('contextmenu', { bubbles: true });
+    const preventDefault = jest.spyOn(event, 'preventDefault');
+
+    button.dispatchEvent(event);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
No issue.

Ported `usePressable` to TypeScript and added tests.

### Changelog

**New**

- Added `usePressable` tests.

**Changed**

- Ported `usePressable` to TypeScript.

#### Testing / Reviewing

```sh
yarn test packages/react
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
