### PR TITLE
feat(date-picker): React|WC parity

### DIFF
--- a/packages/web-components/.storybook/templates/with-layer.ts
+++ b/packages/web-components/.storybook/templates/with-layer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,12 +38,12 @@ class CDSLayer extends LitElement {
 
   updated() {
     if (this.content) {
+      const layer1 = this.content.cloneNode(true) as HTMLElement;
       const layer2 = this.content.cloneNode(true) as HTMLElement;
-      const layer3 = this.content.cloneNode(true) as HTMLElement;
+      layer1.setAttribute('slot', 'layer-1');
       layer2.setAttribute('slot', 'layer-2');
-      layer3.setAttribute('slot', 'layer-3');
+      this.appendChild(layer1);
       this.appendChild(layer2);
-      this.appendChild(layer3);
     }
   }
 
@@ -60,17 +60,17 @@ class CDSLayer extends LitElement {
               <cds-layer with-background>
                 <div class="${prefix}--with-layer__layer">
                   <div class="${prefix}--with-layer__label">
-                    ${Layers()} $layer-02
+                    ${Layers()} $layer-01
                   </div>
                   <div class="${prefix}--with-layer__content">
-                    <slot name="layer-2"></slot>
+                    <slot name="layer-1"></slot>
                     <cds-layer with-background>
                       <div class="${prefix}--with-layer__layer">
                         <div class="${prefix}--with-layer__label">
-                          ${Layers()} $layer-03
+                          ${Layers()} $layer-02
                         </div>
                         <div class="${prefix}--with-layer__content">
-                          <slot name="layer-3"></slot>
+                          <slot name="layer-2"></slot>
                         </div>
                       </div>
                     </cds-layer>

--- a/packages/web-components/src/components/date-picker/date-picker-input-skeleton.ts
+++ b/packages/web-components/src/components/date-picker/date-picker-input-skeleton.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,15 +18,42 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 @customElement(`${prefix}-date-picker-input-skeleton`)
 class CDSDatePickerInputSkeleton extends LitElement {
   /**
+   * Specify whether the label should be hidden, or not
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'hide-label' })
+  hideLabel = false;
+
+  /**
+   * * @deprecated use `range` instead
    * Date picker input kind. Corresponds to the attribute with the same name.
    */
   @property({ reflect: true })
   kind = DATE_PICKER_INPUT_KIND.SIMPLE;
 
+  /**
+   * Specify whether the skeleton should be of range date picker.
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'range' })
+  range = false;
+
   render() {
+    const { hideLabel, range } = this;
     return html`
-      <span class="${prefix}--label"></span>
-      <div class="${prefix}--date-picker__input ${prefix}--skeleton"></div>
+      <div class="${prefix}--date-picker-input-skeleton-container">
+        ${!hideLabel ? html`<span class="${prefix}--label"></span>` : null}
+        <div class="${prefix}--date-picker__input ${prefix}--skeleton"></div>
+      </div>
+      ${range
+        ? html`
+            <div class="${prefix}--date-picker-input-skeleton-container">
+              ${!hideLabel
+                ? html`<span class="${prefix}--label"></span>`
+                : null}
+              <div
+                class="${prefix}--date-picker__input ${prefix}--skeleton"></div>
+            </div>
+          `
+        : null}
     `;
   }
 

--- a/packages/web-components/src/components/date-picker/date-picker-input.ts
+++ b/packages/web-components/src/components/date-picker/date-picker-input.ts
@@ -285,6 +285,7 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
       [`${prefix}--date-picker__input--invalid`]: normalizedProps.invalid,
       [`${prefix}--date-picker__input--warn`]: normalizedProps.warn,
       [`${prefix}--date-picker__input--${size}`]: size,
+      [`${prefix}--date-picker__input--decorator`]: hasAILabel,
     });
 
     const inputWrapperClasses = classMap({
@@ -292,7 +293,6 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
       [`${prefix}--date-picker-input__wrapper--invalid`]:
         normalizedProps.invalid,
       [`${prefix}--date-picker-input__wrapper--warn`]: normalizedProps.warn,
-      [`${prefix}--date-picker-input__wrapper--slug`]: hasAILabel,
     });
 
     const helperTextClasses = classMap({
@@ -340,6 +340,7 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
   }
 
   updated() {
+    this.toggleAttribute('ai-label', this._hasAILabel);
     const label = this.shadowRoot?.querySelector("slot[name='ai-label']");
 
     if (label) {

--- a/packages/web-components/src/components/date-picker/date-picker-input.ts
+++ b/packages/web-components/src/components/date-picker/date-picker-input.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -143,28 +143,16 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
   hideLabel = false;
 
   /**
-   * Specify whether the control is currently in warning state
+   * Controls the invalid state and visibility of the `validityMessage`.
    */
   @property({ type: Boolean, reflect: true })
-  warn = false;
-
-  /**
-   * Provide the text that is displayed when the control is in warning state
-   */
-  @property({ attribute: 'warn-text' })
-  warnText = '';
+  invalid = false;
 
   /**
    * Message which is displayed if the value is invalid.
    */
   @property({ attribute: 'invalid-text' })
   invalidText = '';
-
-  /**
-   * Controls the invalid state and visibility of the `validityMessage`.
-   */
-  @property({ type: Boolean, reflect: true })
-  invalid = false;
 
   /**
    * Date picker input kind.
@@ -203,16 +191,16 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
   required = false;
 
   /**
-   * Vertical size of this date picker input.
-   */
-  @property({ attribute: 'size', reflect: true })
-  size = INPUT_SIZE.MEDIUM;
-
-  /**
    * true to use the short version.
    */
   @property({ type: Boolean, reflect: true })
   short = false;
+
+  /**
+   * Vertical size of this date picker input.
+   */
+  @property({ attribute: 'size', reflect: true })
+  size = INPUT_SIZE.MEDIUM;
 
   /**
    * The `type` attribute for the `<input>` in the shadow DOM.
@@ -225,6 +213,18 @@ class CDSDatePickerInput extends FocusMixin(LitElement) {
    */
   @property()
   value!: string;
+
+  /**
+   * Specify whether the control is currently in warning state
+   */
+  @property({ type: Boolean, reflect: true })
+  warn = false;
+
+  /**
+   * Provide the text that is displayed when the control is in warning state
+   */
+  @property({ attribute: 'warn-text' })
+  warnText = '';
 
   render() {
     const constructor = this.constructor as typeof CDSDatePickerInput;

--- a/packages/web-components/src/components/date-picker/date-picker.mdx
+++ b/packages/web-components/src/components/date-picker/date-picker.mdx
@@ -71,7 +71,11 @@ in your date picker is being fetched from an external resource like an API.
 
 ## Component API
 
+## `cds-date-picker`
+
 <ArgTypes of="cds-date-picker" />
+
+## `cds-date-picker-input`
 
 <ArgTypes of="cds-date-picker-input" />
 

--- a/packages/web-components/src/components/date-picker/date-picker.scss
+++ b/packages/web-components/src/components/date-picker/date-picker.scss
@@ -14,6 +14,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/components/form';
 @use '@carbon/styles/scss/components/date-picker/date-picker' as *;
+@use '@carbon/styles/scss/utilities/ai-gradient' as *;
 
 // https://github.com/carbon-design-system/carbon/issues/11408
 @include date-picker;
@@ -162,4 +163,9 @@ $css--plex: true !default;
 
     inline-size: rem(75px);
   }
+}
+
+:host(#{$prefix}-date-picker-input[ai-label])
+  .#{$prefix}--date-picker__input--decorator {
+  @include ai-gradient;
 }

--- a/packages/web-components/src/components/date-picker/date-picker.scss
+++ b/packages/web-components/src/components/date-picker/date-picker.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2024
+// Copyright IBM Corp. 2019, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -162,6 +162,20 @@ $css--plex: true !default;
     block-size: rem(14px);
 
     inline-size: rem(75px);
+  }
+
+  .#{$prefix}--date-picker-input-skeleton-container {
+    display: inline-block;
+  }
+}
+
+:host(#{$prefix}-date-picker-input-skeleton[range]) {
+  .#{$prefix}--date-picker-input-skeleton-container {
+    inline-size: rem(143.5px);
+
+    .#{$prefix}--date-picker__input {
+      inline-size: rem(143.5px);
+    }
   }
 }
 

--- a/packages/web-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.stories.ts
@@ -23,14 +23,14 @@ const sizes = {
   [`Large (${INPUT_SIZE.LARGE})`]: INPUT_SIZE.LARGE,
 };
 
-const defaultArgs = {
+const args = {
   dateFormat: 'm/d/Y',
   disabled: false,
   allowInput: true,
   closeOnSelect: true,
   minDate: '',
   maxDate: '',
-  datePickerType: 'single',
+  kind: 'single',
   readonly: false,
   short: false,
   helperText: '',
@@ -57,7 +57,7 @@ const argTypes = {
     control: 'text',
     description: 'The date format.',
   },
-  datePickerType: {
+  kind: {
     control: 'radio',
     options: { Single: 'single', Simple: 'simple', Range: 'range' },
     description: `The type of the date picker:
@@ -121,59 +121,20 @@ const argTypes = {
   },
 };
 
-export const Simple = {
-  render: () => {
+export const Default = {
+  args,
+  argTypes,
+  render: (args) => {
+    const { dateFormat, kind, placeholder, size } = args ?? {};
     return html`
-      <cds-date-picker>
+      <cds-date-picker dateFormat="${dateFormat}">
         <cds-date-picker-input
+          kind="${kind}"
           label-text="Date Picker label"
-          placeholder="mm/dd/yyyy">
+          placeholder="${placeholder}"
+          size="${size}">
         </cds-date-picker-input>
       </cds-date-picker>
-    `;
-  },
-};
-
-export const SimpleWithLayer = {
-  render: () => {
-    return html`
-  <sb-template-layers>
-    <cds-date-picker>
-    <cds-date-picker-input
-      label-text="Date Picker label"
-      placeholder="mm/dd/yyyy">
-    </cds-date-picker-input>
-  </sb-template-layers>
-  `;
-  },
-};
-
-export const SingleWithCalendar = {
-  render: () => {
-    return html`
-      <cds-date-picker>
-        <cds-date-picker-input
-          kind="single"
-          label-text="Date Picker label"
-          placeholder="mm/dd/yyyy">
-        </cds-date-picker-input>
-      </cds-date-picker>
-    `;
-  },
-};
-
-export const SingleWithCalendarWithLayer = {
-  render: () => {
-    return html`
-      <sb-template-layers>
-        <cds-date-picker>
-          <cds-date-picker-input
-            kind="single"
-            label-text="Date Picker label"
-            placeholder="mm/dd/yyyy">
-          </cds-date-picker-input>
-        </cds-date-picker>
-      </sb-template-layers>
     `;
   },
 };
@@ -246,6 +207,63 @@ export const RangeWithCalendarWithLayer = {
   },
 };
 
+export const Simple = {
+  render: () => {
+    return html`
+      <cds-date-picker>
+        <cds-date-picker-input
+          label-text="Date Picker label"
+          placeholder="mm/dd/yyyy">
+        </cds-date-picker-input>
+      </cds-date-picker>
+    `;
+  },
+};
+
+export const SimpleWithLayer = {
+  render: () => {
+    return html`
+  <sb-template-layers>
+    <cds-date-picker>
+    <cds-date-picker-input
+      label-text="Date Picker label"
+      placeholder="mm/dd/yyyy">
+    </cds-date-picker-input>
+  </sb-template-layers>
+  `;
+  },
+};
+
+export const SingleWithCalendar = {
+  render: () => {
+    return html`
+      <cds-date-picker>
+        <cds-date-picker-input
+          kind="single"
+          label-text="Date Picker label"
+          placeholder="mm/dd/yyyy">
+        </cds-date-picker-input>
+      </cds-date-picker>
+    `;
+  },
+};
+
+export const SingleWithCalendarWithLayer = {
+  render: () => {
+    return html`
+      <sb-template-layers>
+        <cds-date-picker>
+          <cds-date-picker-input
+            kind="single"
+            label-text="Date Picker label"
+            placeholder="mm/dd/yyyy">
+          </cds-date-picker-input>
+        </cds-date-picker>
+      </sb-template-layers>
+    `;
+  },
+};
+
 export const Skeleton = {
   render: () => html`
     <cds-date-picker-input-skeleton
@@ -303,93 +321,6 @@ export const WithAILabel = {
             ${content}${actions}</cds-ai-label
           >
         </cds-date-picker-input>
-      </cds-date-picker>
-    `;
-  },
-};
-
-export const Playground = {
-  decorators: [(story) => html` <div>${story()}</div> `],
-  argTypes,
-  args: defaultArgs,
-  render: (args) => {
-    const {
-      disabled,
-      dateFormat,
-      onChange,
-      minDate,
-      maxDate,
-      size,
-      helperText,
-      placeholder,
-      invalid,
-      invalidText,
-      warning,
-      warningText,
-      short,
-      datePickerType,
-      readonly,
-      onInput,
-    } = args || {};
-
-    return html`
-      <cds-date-picker
-        ?disabled="${disabled}"
-        date-format="${dateFormat}"
-        ?readonly="${readonly}"
-        min-date="${minDate}"
-        max-date="${maxDate}"
-        @cds-date-picker-changed="${onChange}">
-        ${datePickerType === 'range'
-          ? html`
-              <cds-date-picker-input
-                kind="from"
-                label-text="Date Picker label"
-                size="${size}"
-                placeholder="${placeholder}"
-                ?invalid="${invalid}"
-                invalid-text="${invalidText}"
-                ?short="${short}"
-                ?warn="${warning}"
-                warn-text="${warningText}"
-                @input="${onInput}">
-                ${helperText
-                  ? html`<span slot="helper-text">${helperText}</span>`
-                  : html``}
-              </cds-date-picker-input>
-              <cds-date-picker-input
-                kind="to"
-                label-text="Date Picker label"
-                size="${size}"
-                placeholder="${placeholder}"
-                ?invalid="${invalid}"
-                invalid-text="${invalidText}"
-                ?short="${short}"
-                ?warn="${warning}"
-                warn-text="${warningText}"
-                @input="${onInput}">
-                ${helperText
-                  ? html`<span slot="helper-text">${helperText}</span>`
-                  : html``}
-              </cds-date-picker-input>
-            `
-          : html`
-              <cds-date-picker-input
-                kind="${datePickerType}"
-                label-text="Date Picker label"
-                size="${size}"
-                placeholder="${placeholder}"
-                ?invalid="${invalid}"
-                invalid-text="${invalidText}"
-                ?short="${short}"
-                ?warn="${warning}"
-                warn-text="${warningText}"
-                @input="${onInput}">
-                ${helperText
-                  ? html`<span slot="helper-text">${helperText}</span>`
-                  : html``}
-              </cds-date-picker-input>
-            `}
       </cds-date-picker>
     `;
   },

--- a/packages/web-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.stories.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -161,7 +161,7 @@ export const RangeWithCalendar = {
 export const RangeWithCalendarWithLayer = {
   render: () => {
     return html`
-      <cds-layer>
+      <sb-template-layers>
         <cds-date-picker>
           <cds-date-picker-input
             kind="from"
@@ -174,35 +174,7 @@ export const RangeWithCalendarWithLayer = {
             placeholder="mm/dd/yyyy">
           </cds-date-picker-input>
         </cds-date-picker>
-        <cds-layer>
-          <cds-date-picker>
-            <cds-date-picker-input
-              kind="from"
-              label-text="Start date"
-              placeholder="mm/dd/yyyy">
-            </cds-date-picker-input>
-            <cds-date-picker-input
-              kind="to"
-              label-text="End date"
-              placeholder="mm/dd/yyyy">
-            </cds-date-picker-input>
-          </cds-date-picker>
-          <cds-layer>
-            <cds-date-picker>
-              <cds-date-picker-input
-                kind="from"
-                label-text="Start date"
-                placeholder="mm/dd/yyyy">
-              </cds-date-picker-input>
-              <cds-date-picker-input
-                kind="to"
-                label-text="End date"
-                placeholder="mm/dd/yyyy">
-              </cds-date-picker-input>
-            </cds-date-picker>
-          </cds-layer>
-        </cds-layer>
-      </cds-layer>
+      </sb-template-layers>
     `;
   },
 };

--- a/packages/web-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.stories.ts
@@ -23,14 +23,13 @@ const sizes = {
   [`Large (${INPUT_SIZE.LARGE})`]: INPUT_SIZE.LARGE,
 };
 
-const args = {
+const defaultArgs = {
   dateFormat: 'm/d/Y',
   disabled: false,
   allowInput: true,
   closeOnSelect: true,
   minDate: '',
   maxDate: '',
-  kind: 'single',
   readonly: false,
   short: false,
   helperText: '',
@@ -42,7 +41,7 @@ const args = {
   size: INPUT_SIZE.MEDIUM,
 };
 
-const argTypes = {
+const controls = {
   allowInput: {
     control: 'boolean',
     description:
@@ -56,22 +55,6 @@ const argTypes = {
   dateFormat: {
     control: 'text',
     description: 'The date format.',
-  },
-  kind: {
-    control: 'radio',
-    options: { Single: 'single', Simple: 'simple', Range: 'range' },
-    description: `The type of the date picker:
-    <ul>
-      <li><code>simple</code>
-        <ul><li>Without calendar dropdown.</li></ul>
-      </li>
-      <li><code>single</code>
-        <ul><li>With calendar dropdown and single date.</li></ul>
-      </li>
-      <li><code>range</code>
-        <ul><li>With calendar dropdown and a date range.</li></ul>
-      </li>
-    </ul>`,
   },
   disabled: { control: 'boolean' },
   helperText: { control: 'text' },
@@ -122,14 +105,158 @@ const argTypes = {
 };
 
 export const Default = {
-  args,
-  argTypes,
-  render: (args) => {
-    const { dateFormat, kind, placeholder, size } = args ?? {};
+  args: { ...defaultArgs, kind: 'single' },
+  argTypes: {
+    ...controls,
+    kind: {
+      control: 'radio',
+      options: { Single: 'single', Simple: 'simple', Range: 'range' },
+      description: `The type of the date picker:
+    <ul>
+      <li><code>simple</code>
+        <ul><li>Without calendar dropdown.</li></ul>
+      </li>
+      <li><code>single</code>
+        <ul><li>With calendar dropdown and single date.</li></ul>
+      </li>
+      <li><code>range</code>
+        <ul><li>With calendar dropdown and a date range.</li></ul>
+      </li>
+    </ul>`,
+    },
+  },
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    kind,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
     return html`
-      <cds-date-picker dateFormat="${dateFormat}">
+      <cds-date-picker
+        allow-input="${allowInput}"
+        close-on-select="${closeOnSelect}"
+        date-format="${dateFormat}"
+        max-date="${maxDate}"
+        min-date="${minDate}">
         <cds-date-picker-input
           kind="${kind}"
+          label-text="Date Picker label"
+          placeholder="${placeholder}"
+          size="${size}">
+        </cds-date-picker-input>
+        ${kind === 'range'
+          ? html`
+              <cds-date-picker-input
+                kind="${kind}"
+                label-text="End date"
+                placeholder="${placeholder}"
+                size="${size}">
+              </cds-date-picker-input>
+            `
+          : null}
+      </cds-date-picker>
+    `;
+  },
+};
+
+export const RangeWithCalendar = {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
+    return html`
+      <cds-date-picker
+        allow-input="${allowInput}"
+        close-on-select="${closeOnSelect}"
+        date-format="${dateFormat}"
+        max-date="${maxDate}"
+        min-date="${minDate}">
+        <cds-date-picker-input
+          kind="from"
+          label-text="Start date"
+          placeholder="${placeholder}"
+          size="${size}">
+        </cds-date-picker-input>
+        <cds-date-picker-input
+          kind="to"
+          label-text="End date"
+          placeholder="${placeholder}"
+          size="${size}">
+        </cds-date-picker-input>
+      </cds-date-picker>
+    `;
+  },
+};
+
+export const RangeWithCalendarWithLayer = {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
+    return html`
+      <sb-template-layers>
+        <cds-date-picker
+          allow-input="${allowInput}"
+          close-on-select="${closeOnSelect}"
+          date-format="${dateFormat}"
+          max-date="${maxDate}"
+          min-date="${minDate}">
+          <cds-date-picker-input
+            kind="from"
+            label-text="Start date"
+            placeholder="${placeholder}"
+            size="${size}">
+          </cds-date-picker-input>
+          <cds-date-picker-input
+            kind="to"
+            label-text="End date"
+            placeholder="${placeholder}"
+            size="${size}">
+          </cds-date-picker-input>
+        </cds-date-picker>
+      </sb-template-layers>
+    `;
+  },
+};
+
+export const Simple = {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
+    return html`
+      <cds-date-picker
+        allow-input="${allowInput}"
+        close-on-select="${closeOnSelect}"
+        date-format="${dateFormat}"
+        max-date="${maxDate}"
+        min-date="${minDate}">
+        <cds-date-picker-input
           label-text="Date Picker label"
           placeholder="${placeholder}"
           size="${size}">
@@ -139,81 +266,60 @@ export const Default = {
   },
 };
 
-export const RangeWithCalendar = {
-  render: () => {
-    return html`
-      <cds-date-picker>
-        <cds-date-picker-input
-          kind="from"
-          label-text="Start date"
-          placeholder="mm/dd/yyyy">
-        </cds-date-picker-input>
-        <cds-date-picker-input
-          kind="to"
-          label-text="End date"
-          placeholder="mm/dd/yyyy">
-        </cds-date-picker-input>
-      </cds-date-picker>
-    `;
-  },
-};
-
-export const RangeWithCalendarWithLayer = {
-  render: () => {
+export const SimpleWithLayer = {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
     return html`
       <sb-template-layers>
-        <cds-date-picker>
-          <cds-date-picker-input
-            kind="from"
-            label-text="Start date"
-            placeholder="mm/dd/yyyy">
-          </cds-date-picker-input>
-          <cds-date-picker-input
-            kind="to"
-            label-text="End date"
-            placeholder="mm/dd/yyyy">
-          </cds-date-picker-input>
-        </cds-date-picker>
-      </sb-template-layers>
-    `;
-  },
-};
-
-export const Simple = {
-  render: () => {
-    return html`
-      <cds-date-picker>
+        <cds-date-picker
+          allow-input="${allowInput}"
+          close-on-select="${closeOnSelect}"
+          date-format="${dateFormat}"
+          max-date="${maxDate}"
+          min-date="${minDate}">
         <cds-date-picker-input
           label-text="Date Picker label"
-          placeholder="mm/dd/yyyy">
+          placeholder="${placeholder}"
+          size="${size}">
         </cds-date-picker-input>
-      </cds-date-picker>
-    `;
-  },
-};
-
-export const SimpleWithLayer = {
-  render: () => {
-    return html`
-  <sb-template-layers>
-    <cds-date-picker>
-    <cds-date-picker-input
-      label-text="Date Picker label"
-      placeholder="mm/dd/yyyy">
-    </cds-date-picker-input>
-  </sb-template-layers>
+      </sb-template-layers>
   `;
   },
 };
 
 export const SingleWithCalendar = {
-  render: () => {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
     return html`
-      <cds-date-picker>
+      <cds-date-picker
+        allow-input="${allowInput}"
+        close-on-select="${closeOnSelect}"
+        date-format="${dateFormat}"
+        max-date="${maxDate}"
+        min-date="${minDate}">
         <cds-date-picker-input
           kind="single"
           label-text="Date Picker label"
-          placeholder="mm/dd/yyyy">
+          placeholder="${placeholder}"
+          size="${size}">
         </cds-date-picker-input>
       </cds-date-picker>
     `;
@@ -221,14 +327,30 @@ export const SingleWithCalendar = {
 };
 
 export const SingleWithCalendarWithLayer = {
-  render: () => {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
     return html`
       <sb-template-layers>
-        <cds-date-picker>
+        <cds-date-picker
+          allow-input="${allowInput}"
+          close-on-select="${closeOnSelect}"
+          date-format="${dateFormat}"
+          max-date="${maxDate}"
+          min-date="${minDate}">
           <cds-date-picker-input
             kind="single"
             label-text="Date Picker label"
-            placeholder="mm/dd/yyyy">
+            placeholder="${placeholder}"
+            size="${size}">
           </cds-date-picker-input>
         </cds-date-picker>
       </sb-template-layers>
@@ -236,11 +358,23 @@ export const SingleWithCalendarWithLayer = {
   },
 };
 
+const skeletonControls = {
+  hideLabel: {
+    control: 'boolean',
+    description: 'Specify whether the label should be hidden, or not',
+  },
+  range: {
+    control: 'boolean',
+    description: 'Specify whether the skeleton should be of range date picker.',
+  },
+};
+
 export const Skeleton = {
-  render: () => html`
-    <cds-date-picker-input-skeleton
-      kind="from"></cds-date-picker-input-skeleton>
-    <cds-date-picker-input-skeleton kind="to"></cds-date-picker-input-skeleton>
+  args: { hideLabel: false, range: true },
+  argTypes: skeletonControls,
+  render: ({ range }) => html`
+    <cds-date-picker-input-skeleton range=${range}>
+    </cds-date-picker-input-skeleton>
   `,
   decorators: [(story) => html` <div>${story()}</div> `],
   parameters: {
@@ -282,13 +416,29 @@ const actions = html`
 `;
 
 export const WithAILabel = {
-  render: () => {
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    allowInput,
+    closeOnSelect,
+    dateFormat,
+    maxDate,
+    minDate,
+    placeholder,
+    size,
+  }) => {
     return html`
-      <cds-date-picker>
+      <cds-date-picker
+        allow-input="${allowInput}"
+        close-on-select="${closeOnSelect}"
+        date-format="${dateFormat}"
+        max-date="${maxDate}"
+        min-date="${minDate}">
         <cds-date-picker-input
           kind="single"
           label-text="Date Picker label"
-          placeholder="mm/dd/yyyy">
+          placeholder="${placeholder}"
+          size="${size}">
           <cds-ai-label alignment="bottom-left">
             ${content}${actions}</cds-ai-label
           >
@@ -300,6 +450,11 @@ export const WithAILabel = {
 
 const meta = {
   title: 'Components/Date picker',
+  parameters: {
+    docs: {
+      controls: { exclude: ['calendar'] },
+    },
+  },
 };
 
 export default meta;

--- a/packages/web-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.stories.ts
@@ -33,10 +33,8 @@ const defaultArgs = {
   readonly: false,
   short: false,
   helperText: '',
-  warning: false,
-  warningText: '',
-  invalid: false,
-  invalidText: '',
+  warn: false,
+  warnText: '',
   placeholder: 'mm/dd/yyyy',
   size: INPUT_SIZE.MEDIUM,
 };
@@ -58,15 +56,6 @@ const controls = {
   },
   disabled: { control: 'boolean' },
   helperText: { control: 'text' },
-  invalid: {
-    control: 'boolean',
-    description: 'Specify whether or not the control is invalid (Fluid only).',
-  },
-  invalidText: {
-    control: 'text',
-    description:
-      'Provide the text that is displayed when the control is in error state (Fluid Only).',
-  },
   maxDate: {
     control: 'text',
     description: 'The maximum date that a user can pick to.',
@@ -86,15 +75,14 @@ const controls = {
     description: '<code>true</code> to use the short version.',
   },
   size: { control: 'select', options: sizes },
-  warning: {
+  warn: {
     control: 'boolean',
-    description:
-      'Specify whether the control is currently in warning state (Fluid only).',
+    description: 'Specify whether the control is currently in warning state.',
   },
-  warningText: {
+  warnText: {
     control: 'text',
     description:
-      'Provide the text that is displayed when the control is in warning state (Fluid only).',
+      'Provide the text that is displayed when the control is in warning state.',
   },
   onChange: {
     action: `${prefix}-date-picker-changed`,
@@ -129,32 +117,42 @@ export const Default = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     kind,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <cds-date-picker
         allow-input="${allowInput}"
         close-on-select="${closeOnSelect}"
         date-format="${dateFormat}"
+        ?disabled="${disabled}"
         max-date="${maxDate}"
-        min-date="${minDate}">
+        min-date="${minDate}"
+        ?readonly="${readonly}">
         <cds-date-picker-input
-          kind="${kind}"
+          kind="${kind === 'range' ? 'from' : kind}"
           label-text="Date Picker label"
           placeholder="${placeholder}"
-          size="${size}">
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
         </cds-date-picker-input>
         ${kind === 'range'
           ? html`
               <cds-date-picker-input
-                kind="${kind}"
+                kind="to"
                 label-text="End date"
                 placeholder="${placeholder}"
-                size="${size}">
+                size="${size}"
+                ?warn="${warn}"
+                warn-text="${warnText}">
               </cds-date-picker-input>
             `
           : null}
@@ -170,29 +168,39 @@ export const RangeWithCalendar = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <cds-date-picker
         allow-input="${allowInput}"
         close-on-select="${closeOnSelect}"
         date-format="${dateFormat}"
+        ?disabled="${disabled}"
         max-date="${maxDate}"
-        min-date="${minDate}">
+        min-date="${minDate}"
+        ?readonly="${readonly}">
         <cds-date-picker-input
           kind="from"
           label-text="Start date"
           placeholder="${placeholder}"
-          size="${size}">
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
         </cds-date-picker-input>
         <cds-date-picker-input
           kind="to"
           label-text="End date"
           placeholder="${placeholder}"
-          size="${size}">
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
         </cds-date-picker-input>
       </cds-date-picker>
     `;
@@ -206,10 +214,14 @@ export const RangeWithCalendarWithLayer = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <sb-template-layers>
@@ -217,19 +229,25 @@ export const RangeWithCalendarWithLayer = {
           allow-input="${allowInput}"
           close-on-select="${closeOnSelect}"
           date-format="${dateFormat}"
+          ?disabled="${disabled}"
           max-date="${maxDate}"
-          min-date="${minDate}">
+          min-date="${minDate}"
+          ?readonly="${readonly}">
           <cds-date-picker-input
             kind="from"
             label-text="Start date"
             placeholder="${placeholder}"
-            size="${size}">
+            size="${size}"
+            ?warn="${warn}"
+            warn-text="${warnText}">
           </cds-date-picker-input>
           <cds-date-picker-input
             kind="to"
             label-text="End date"
             placeholder="${placeholder}"
-            size="${size}">
+            size="${size}"
+            ?warn="${warn}"
+            warn-text="${warnText}">
           </cds-date-picker-input>
         </cds-date-picker>
       </sb-template-layers>
@@ -244,10 +262,14 @@ export const Simple = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <cds-date-picker
@@ -257,9 +279,13 @@ export const Simple = {
         max-date="${maxDate}"
         min-date="${minDate}">
         <cds-date-picker-input
+          ?disabled="${disabled}"
           label-text="Date Picker label"
           placeholder="${placeholder}"
-          size="${size}">
+          ?readonly="${readonly}"
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
         </cds-date-picker-input>
       </cds-date-picker>
     `;
@@ -273,10 +299,14 @@ export const SimpleWithLayer = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <sb-template-layers>
@@ -287,9 +317,13 @@ export const SimpleWithLayer = {
           max-date="${maxDate}"
           min-date="${minDate}">
         <cds-date-picker-input
+          ?disabled="${disabled}"
           label-text="Date Picker label"
           placeholder="${placeholder}"
-          size="${size}">
+          ?readonly="${readonly}"
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
         </cds-date-picker-input>
       </sb-template-layers>
   `;
@@ -303,23 +337,31 @@ export const SingleWithCalendar = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <cds-date-picker
         allow-input="${allowInput}"
         close-on-select="${closeOnSelect}"
         date-format="${dateFormat}"
+        ?disabled="${disabled}"
         max-date="${maxDate}"
-        min-date="${minDate}">
+        min-date="${minDate}"
+        ?readonly="${readonly}">
         <cds-date-picker-input
           kind="single"
           label-text="Date Picker label"
           placeholder="${placeholder}"
-          size="${size}">
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
         </cds-date-picker-input>
       </cds-date-picker>
     `;
@@ -332,11 +374,15 @@ export const SingleWithCalendarWithLayer = {
   render: ({
     allowInput,
     closeOnSelect,
+    disabled,
     dateFormat,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <sb-template-layers>
@@ -344,13 +390,17 @@ export const SingleWithCalendarWithLayer = {
           allow-input="${allowInput}"
           close-on-select="${closeOnSelect}"
           date-format="${dateFormat}"
+          ?disabled="${disabled}"
           max-date="${maxDate}"
-          min-date="${minDate}">
+          min-date="${minDate}"
+          ?readonly="${readonly}">
           <cds-date-picker-input
             kind="single"
             label-text="Date Picker label"
             placeholder="${placeholder}"
-            size="${size}">
+            size="${size}"
+            ?warn="${warn}"
+            warn-text="${warnText}">
           </cds-date-picker-input>
         </cds-date-picker>
       </sb-template-layers>
@@ -372,8 +422,10 @@ const skeletonControls = {
 export const Skeleton = {
   args: { hideLabel: false, range: true },
   argTypes: skeletonControls,
-  render: ({ range }) => html`
-    <cds-date-picker-input-skeleton range=${range}>
+  render: ({ hideLabel, range }) => html`
+    <cds-date-picker-input-skeleton
+      ?hide-label="${hideLabel}"
+      ?range="${range}">
     </cds-date-picker-input-skeleton>
   `,
   decorators: [(story) => html` <div>${story()}</div> `],
@@ -422,23 +474,31 @@ export const WithAILabel = {
     allowInput,
     closeOnSelect,
     dateFormat,
+    disabled,
     maxDate,
     minDate,
     placeholder,
+    readonly,
     size,
+    warn,
+    warnText,
   }) => {
     return html`
       <cds-date-picker
         allow-input="${allowInput}"
         close-on-select="${closeOnSelect}"
         date-format="${dateFormat}"
+        ?disabled="${disabled}"
         max-date="${maxDate}"
-        min-date="${minDate}">
+        min-date="${minDate}"
+        ?readonly="${readonly}">
         <cds-date-picker-input
           kind="single"
           label-text="Date Picker label"
           placeholder="${placeholder}"
-          size="${size}">
+          size="${size}"
+          ?warn="${warn}"
+          warn-text="${warnText}">
           <cds-ai-label alignment="bottom-left">
             ${content}${actions}</cds-ai-label
           >

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -92,12 +92,11 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
    * @returns The effective date picker mode, determined by the child `<cds-date-picker-input>`.
    */
   private get _mode() {
-    const { selectorInputFrom, selectorInputTo } = this
-      .constructor as typeof CDSDatePicker;
+    const { selectorInputTo } = this.constructor as typeof CDSDatePicker;
     if (this.querySelector(selectorInputTo)) {
       return DATE_PICKER_MODE.RANGE;
     }
-    if (this.querySelector(selectorInputFrom)) {
+    if (this.querySelector(`${prefix}-date-picker-input[kind="single"]`)) {
       return DATE_PICKER_MODE.SINGLE;
     }
     return DATE_PICKER_MODE.SIMPLE;
@@ -367,9 +366,8 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
   private _instantiateDatePicker() {
     this._releaseDatePicker();
     const { _dateInteractNode: dateInteractNode } = this;
-    // `this._dateInteractNode` won't be there unless there is a slotted `<cds-date-input type="from">`,
-    // which means Flatpickr will never be instantiated in "simple" mode.
-    if (dateInteractNode && dateInteractNode.input) {
+    // do not instantiate Flatpickr in "simple" mode
+    if (dateInteractNode && dateInteractNode.input && this._mode !== 'simple') {
       this.calendar = flatpickr(
         dateInteractNode.input as any,
         this._datePickerOptions

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -550,13 +550,15 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
       <a
         class="${prefix}--visually-hidden"
         href="javascript:void 0"
-        role="navigation"></a>
+        role="navigation"
+        tabindex="-1"></a>
       <slot @slotchange="${handleSlotChange}"></slot>
       <div id="floating-menu-container"></div>
       <a
         class="${prefix}--visually-hidden"
         href="javascript:void 0"
-        role="navigation"></a>
+        role="navigation"
+        tabindex="-1"></a>
     `;
   }
 

--- a/packages/web-components/src/components/date-picker/date-picker.ts
+++ b/packages/web-components/src/components/date-picker/date-picker.ts
@@ -449,28 +449,28 @@ class CDSDatePicker extends HostListenerMixin(FormMixin(LitElement)) {
   disabled = false;
 
   /**
-   * The localization data.
-   */
-  @property({ attribute: false })
-  locale!: FlatpickrLocale;
-
-  /**
    * The date range that a user can pick in calendar dropdown.
    */
   @property({ attribute: 'enabled-range' })
   enabledRange!: string;
 
   /**
-   * The minimum date that a user can start picking from.
+   * The localization data.
    */
-  @property({ attribute: 'min-date' })
-  minDate!: string;
+  @property({ attribute: false })
+  locale!: FlatpickrLocale;
 
   /**
    * The maximum date that a user can start picking from.
    */
   @property({ attribute: 'max-date' })
   maxDate!: string;
+
+  /**
+   * The minimum date that a user can start picking from.
+   */
+  @property({ attribute: 'min-date' })
+  minDate!: string;
 
   /**
    * Name for the input in the `FormData`

--- a/packages/web-components/src/components/date-picker/focus-plugin.ts
+++ b/packages/web-components/src/components/date-picker/focus-plugin.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2024
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/web-components/src/components/date-picker/focus-plugin.ts
+++ b/packages/web-components/src/components/date-picker/focus-plugin.ts
@@ -59,7 +59,7 @@ export interface ExtendedFlatpickrInstanceFocusPlugin
   /**
    * Lastly focused `<input>` for starting/end date.
    */
-  _lastFocusInput?: HTMLInputElement;
+  _lastFocusInput?: CDSDatePickerInput;
 }
 
 /**
@@ -77,53 +77,46 @@ export default (config: DatePickerFocusPluginConfig): Plugin =>
     };
 
     /**
-     * Handles `blur` event to move the focus back to the `<input>`.
+     * Handles `keydown` event for date picker input field
      */
-    const handleBlur = ({ target, relatedTarget }: FocusEvent) => {
-      // Obtains `beingUpdated` up-front because it'll be flushed out shortly
-      const { calendarContainer, isOpen } = fp;
-      if (
-        isOpen &&
-        calendarContainer.contains(target as Node) &&
-        !calendarContainer.contains(relatedTarget as Node) &&
-        relatedTarget !== config.inputFrom &&
-        relatedTarget !== config.inputTo
-      ) {
-        Promise.resolve().then(() => {
-          const rootNode = (target as Node).getRootNode();
-          // This `blur` event handler can be called from Flatpickr's code,
-          // cleaning up the calendar dropdowns DOM. Changing focus in such
-          // condition causes removing an orphaned DOM node, because Flatpickr
-          // redraws the calendar dropdown when the `<input>` gets focus.
-          if (
-            rootNode.nodeType === Node.DOCUMENT_NODE ||
-            rootNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE
-          ) {
-            if (fp._lastFocusInput === config.inputTo) {
-              config.inputTo!.focus();
-            } else {
-              config.inputFrom.focus();
-            }
-            // Closing after moving focus. Reversing the order will cause re-opening calendar dropdown upon focusing
-            fp.close();
-          }
-        });
+    const handleInputKeydown = (event: KeyboardEvent) => {
+      if (!(event.target instanceof CDSDatePickerInput)) return;
+
+      const { key } = event;
+
+      if (key === 'Escape') {
+        fp.close();
+      }
+      if (key === 'Tab') {
+        if (!event.shiftKey) {
+          event.preventDefault();
+          fp.open();
+          focusCalendar();
+        } else if (fp.isOpen && event.target === config.inputFrom) {
+          fp.close();
+        }
       }
     };
 
     /**
-     * Handles `keydown` event to move focus on calendar dropdown.
+     * Handles `keydown` event for calendar dropdown
      */
-    const handleInputKeydown = (event: KeyboardEvent) => {
+    const handleCalendarKeydown = (event: KeyboardEvent) => {
+      const endInput = config.inputTo ? config.inputTo : config.inputFrom;
       const { key } = event;
-      if (key === 'ArrowDown' || key === 'Down' || key === 'Enter') {
-        event.preventDefault();
-        fp.open();
-        if (key !== 'Enter') {
-          focusCalendar();
-        } else {
-          // Hitting Enter key blurs the `<input>`, causing any element to lose focus
-          setTimeout(focusCalendar, 0);
+
+      if (key === 'Tab') {
+        if (!event.shiftKey) {
+          if (fp._lastFocusInput === endInput) {
+            endInput.focus();
+            fp.close();
+          } else {
+            event.preventDefault();
+            endInput.focus();
+          }
+        } else if (fp._lastFocusInput === endInput) {
+          event.preventDefault();
+          setTimeout(() => endInput.focus(), 0);
         }
       }
     };
@@ -132,7 +125,7 @@ export default (config: DatePickerFocusPluginConfig): Plugin =>
      * Handles `focus` event on `<input>` for starting/end date to track the lastly focused one.
      */
     const handleInputFocus = ({ target }: FocusEvent) => {
-      fp._lastFocusInput = target as HTMLInputElement;
+      fp._lastFocusInput = target as CDSDatePickerInput;
     };
 
     /**
@@ -169,8 +162,8 @@ export default (config: DatePickerFocusPluginConfig): Plugin =>
       const { inputFrom, inputTo } = config;
       fp._hCDSCEDatePickerFocusPluginBlur = on(
         fp.calendarContainer,
-        'blur',
-        handleBlur,
+        'keydown',
+        handleCalendarKeydown,
         true
       );
       fp._hCDSCEDatePickerFocusPluginKeydownFrom = on(


### PR DESCRIPTION
Closes #19477 

Matches `date-picker` functionality with React version.

- [x] Missing "Default" story
- [x] AI Label gradient is missing
- [x] Move focus to calendar by pressing Tab. See https://github.com/carbon-design-system/carbon/pull/19504
- [x] Esc key should close calendar from input field
- [x] Layer styling is missing in Range With Calendar With Layer
- [x] See parent issue for more.

### Changelog

**New**

- "Default" story
- AI label gradient
- `Escape` key closes calendar from input field
- Keyboard navigation matches React (press `Tab` to focus on calendar dropdown)
- Layer styling for Range with Calendar with Layer story
- `hideLabel` and `range` properties in `cds-date-picker-skeleton` matching React version
- Added controls to WC storybook

**Changed**

- Order and titles of stories matches React
- Calendar dropdown removed from "simple" mode
- Layer names in storybook match React

**Removed**

- "Playground" story

#### Testing / Reviewing

- UX and visual review from the design team to ensure consistency
- CI tests should pass
- Ensure functionality matches React version (keyboard nav, simple/single/range modes)

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
