### PR TITLE
fix(dropdown): allow for browser native tooltip to appear for overflow text in dropdown and combobox

### DIFF
--- a/packages/web-components/src/components/combo-box/combo-box.scss
+++ b/packages/web-components/src/components/combo-box/combo-box.scss
@@ -85,6 +85,7 @@ $css--plex: true !default;
 :host(#{$prefix}-combo-box-item[disabled]) {
   .#{$prefix}--list-box__menu-item__option {
     color: $text-disabled;
+    cursor: not-allowed;
     text-decoration: none;
   }
 }

--- a/packages/web-components/src/components/dropdown/dropdown-item.ts
+++ b/packages/web-components/src/components/dropdown/dropdown-item.ts
@@ -6,7 +6,7 @@
  */
 
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import Checkmark16 from '@carbon/icons/lib/checkmark/16.js';
 import { prefix } from '../../globals/settings';
 import { DROPDOWN_SIZE } from './dropdown';
@@ -51,16 +51,13 @@ class CDSDropdownItem extends LitElement {
   size = DROPDOWN_SIZE.MEDIUM;
 
   /**
-   * title
-   */
-  @property({ type: String, reflect: true })
-  title = '';
-
-  /**
    * The `value` attribute that is set to the parent `<cds-dropdown>` when this dropdown item is selected.
    */
   @property()
   value = '';
+
+  @state()
+  _hasEllipsisApplied = false;
 
   connectedCallback() {
     super.connectedCallback();
@@ -90,8 +87,22 @@ class CDSDropdownItem extends LitElement {
         (node) => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim()
       );
 
-    this.title = text[0].textContent ?? '';
-    this.requestUpdate();
+    const textContainer = this.shadowRoot?.querySelector(
+      `.${prefix}--list-box__menu-item__option`
+    );
+
+    if (!textContainer || this._hasEllipsisApplied === true) return;
+
+    const observer = new ResizeObserver(() => {
+      this._hasEllipsisApplied =
+        textContainer.scrollWidth > textContainer.clientWidth;
+
+      if (this._hasEllipsisApplied) {
+        textContainer.setAttribute('title', text[0].textContent ?? '');
+      }
+    });
+
+    observer.observe(textContainer);
   }
 
   render() {

--- a/packages/web-components/src/components/dropdown/dropdown-item.ts
+++ b/packages/web-components/src/components/dropdown/dropdown-item.ts
@@ -56,6 +56,9 @@ class CDSDropdownItem extends LitElement {
   @property()
   value = '';
 
+  /**
+   * true if menu item has ellipsis applied
+   */
   @state()
   _hasEllipsisApplied = false;
 

--- a/packages/web-components/src/components/dropdown/dropdown-item.ts
+++ b/packages/web-components/src/components/dropdown/dropdown-item.ts
@@ -51,6 +51,12 @@ class CDSDropdownItem extends LitElement {
   size = DROPDOWN_SIZE.MEDIUM;
 
   /**
+   * title
+   */
+  @property({ type: String, reflect: true })
+  title = '';
+
+  /**
    * The `value` attribute that is set to the parent `<cds-dropdown>` when this dropdown item is selected.
    */
   @property()
@@ -71,11 +77,28 @@ class CDSDropdownItem extends LitElement {
     this.setAttribute('aria-selected', String(this.selected));
   }
 
+  /**
+   * Handles `slotchange` event.
+   *
+   * Adds the `title` property to its parent element so the native
+   * browser tooltip appears for menu items that result in ellipsis
+   */
+  protected _handleSlotChange({ target }: Event) {
+    const text = (target as HTMLSlotElement)
+      .assignedNodes()
+      .filter(
+        (node) => node.nodeType !== Node.TEXT_NODE || node!.textContent!.trim()
+      );
+
+    this.title = text[0].textContent ?? '';
+    this.requestUpdate();
+  }
+
   render() {
-    const { selected } = this;
+    const { selected, _handleSlotChange: handleSlotChange } = this;
     return html`
       <div class="${prefix}--list-box__menu-item__option">
-        <slot></slot>
+        <slot @slotchange=${handleSlotChange}></slot>
         ${!selected
           ? undefined
           : Checkmark16({

--- a/packages/web-components/src/components/dropdown/dropdown-item.ts
+++ b/packages/web-components/src/components/dropdown/dropdown-item.ts
@@ -111,7 +111,7 @@ class CDSDropdownItem extends LitElement {
   render() {
     const { selected, _handleSlotChange: handleSlotChange } = this;
     return html`
-      <div class="${prefix}--list-box__menu-item__option">
+      <div class="${prefix}--list-box__menu-item__option" part="menu-item">
         <slot @slotchange=${handleSlotChange}></slot>
         ${!selected
           ? undefined

--- a/packages/web-components/src/components/dropdown/dropdown.scss
+++ b/packages/web-components/src/components/dropdown/dropdown.scss
@@ -122,6 +122,7 @@ $css--plex: true !default;
 :host(#{$prefix}-dropdown-item[disabled])
   .#{$prefix}--list-box__menu-item__option {
   color: $text-disabled;
+  cursor: not-allowed;
   text-decoration: none;
 }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19727

In React `Dropdown` and `ComboBox`, when menu item has text overflow and has ellipsis applied the browser native tooltip appears on hover to show the full text. This does not happen in Web Components `cds-dropdown` and `cds-combo-box`. This PR detects when ellipsis is applied and sets the `title` property in the wrapper div so that it can be picked up by browser native tooltip.


https://github.com/user-attachments/assets/f4cc1a71-c52f-4a8c-8122-beb1fc181f5d



### Changelog

**New**

- detect on slot change whether ellipsis is applied and set the `title` property
- added `menu-item` part property to wrapper div

**Changed**

- apply cursor styles when `cds-combo-box` and `cds-dropdown` menu items are disabled

#### Testing / Reviewing

Go to WC deploy preview and checkout `cds-dropdown` and `cds-combo-box` default stories

1. Open dropdown / combo-box menu items
2. hover on the ellipsis applied menu item
3. see that the native tooltip appears with the full text


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
