### PR TITLE
Make aria-label and aria-labelledby optional in UIShell's Header

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4201,8 +4201,12 @@ Map {
   },
   "Header" => Object {
     "propTypes": Object {
-      "aria-label": [Function],
-      "aria-labelledby": [Function],
+      "aria-label": Object {
+        "type": "string",
+      },
+      "aria-labelledby": Object {
+        "type": "string",
+      },
       "className": Object {
         "type": "string",
       },

--- a/packages/react/src/components/UIShell/Header.tsx
+++ b/packages/react/src/components/UIShell/Header.tsx
@@ -8,17 +8,16 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';
-import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
 import { usePrefix } from '../../internal/usePrefix';
 
 export interface HeaderProps {
   children?: ReactNode;
   /**
-   * Required props for the accessibility label of the header
+   * Specify aria-label
    */
   'aria-label'?: string;
   /**
-   * Required props for the accessibility label of the header
+   * Specify aria-labelledby
    */
   'aria-labelledby'?: string;
   /**
@@ -44,9 +43,14 @@ const Header: React.FC<HeaderProps> = ({
 
 Header.propTypes = {
   /**
-   * Required props for the accessibility label of the header
+   * Specify aria-label
    */
-  ...AriaLabelPropType,
+  'aria-label': PropTypes.string,
+
+  /**
+   * Specify aria-labelledby
+   */
+  'aria-labelledby': PropTypes.string,
 
   /**
    * Optionally provide a custom class name that is applied to the underlying <header>

--- a/packages/react/src/components/UIShell/Header.tsx
+++ b/packages/react/src/components/UIShell/Header.tsx
@@ -12,16 +12,19 @@ import { usePrefix } from '../../internal/usePrefix';
 
 export interface HeaderProps {
   children?: ReactNode;
+
   /**
-   * Specify aria-label
+   * Optionally provide aria-label
    */
   'aria-label'?: string;
+
   /**
-   * Specify aria-labelledby
+   * Optionally provide aria-labelledby
    */
   'aria-labelledby'?: string;
+
   /**
-   * Optionally provide a custom class name that is applied to the underlying <header>
+   * Optionally provide a custom class name that is applied to the underlying header
    */
   className?: string;
 }
@@ -43,17 +46,17 @@ const Header: React.FC<HeaderProps> = ({
 
 Header.propTypes = {
   /**
-   * Specify aria-label
+   * Optionally provide aria-label
    */
   'aria-label': PropTypes.string,
 
   /**
-   * Specify aria-labelledby
+   * Optionally provide aria-labelledby
    */
   'aria-labelledby': PropTypes.string,
 
   /**
-   * Optionally provide a custom class name that is applied to the underlying <header>
+   * Optionally provide a custom class name that is applied to the underlying header
    */
   className: PropTypes.string,
 };

--- a/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
@@ -164,13 +164,6 @@ export default {
       hideNoControlsWarning: true,
     },
   },
-  argTypes: {
-    className: {
-      table: {
-        disable: true,
-      },
-    },
-  },
 };
 
 export const HeaderWNavigation = () => (

--- a/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
@@ -164,6 +164,13 @@ export default {
       hideNoControlsWarning: true,
     },
   },
+  argTypes: {
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const HeaderWNavigation = () => (


### PR DESCRIPTION
Closes #19725

This PR makes `aria-label` and `aria-labelledby` optional in UIShell's `Header`.

### Changelog

**New**

- The props: aria-label and aria-labelledby are now optional in UIShell - Header component

**Changed**

- Before this PR, UIShell Header needed either aria-label or aria-labelledby. With the changes in this PR, you can exclude aria-label and aria-labelledby. Excluding them will not emit any console warnings.

**Removed**

- NA

#### Testing / Reviewing

The error in dev console cannot be reproduced in storybook by default. I tested this in my application by updating the node_modules with the changes in this PR and it fixed the issue I was experiencing in https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1750333381614129.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change - updated existing test
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
