### PR TITLE
fix: treeView story crashes on node click

### DIFF
--- a/packages/react/src/components/TreeView/TreeNode.tsx
+++ b/packages/react/src/components/TreeView/TreeNode.tsx
@@ -242,7 +242,7 @@ const TreeNode = React.forwardRef<HTMLElement, TreeNodeProps>(
     forwardedRef
   ) => {
     const depth = propDepth as number;
-    const selected = propSelected as (string | number)[];
+    const selected = (propSelected as (string | number)[]) || [];
 
     const detailsWrapperRef = useRef<HTMLElementOrAnchor>(null);
     const { labelTextRef, isEllipsisApplied, tooltipText } = useEllipsisCheck(


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19661

In TreeNode.tsx, the selected prop can be undefined at runtime when using the controllable state feature flag, but the code assumed it's always an array and crashed 

### Changelog

**New**

Added defensive null check for selected prop in TreeNode component

**Changed**

TreeNode now defaults to empty array when selected prop is undefined, preventing runtime crashes

#### Testing / Reviewing


Open Storybook and navigate to components-treeview-feature-flag--default story
Click any node in the TreeView - Verify the story no longer crashes with "Cannot read properties of undefined" error
Verify node selection still works correctly (nodes can be selected/deselected)
Test with both controlled and uncontrolled TreeView usage to ensure no regressions

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
