### PR TITLE
fix(modal): move initial focus to whole modal for passive modal

### DIFF
--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -893,4 +893,19 @@ describe('events', () => {
     await keyboard('{Enter}');
     expect(onRequestSubmit).toHaveBeenCalledTimes(1);
   });
+
+  it('should set focus on the modal container when the modal is passive', async () => {
+    render(
+      <Modal data-testid="modal-10" passiveModal open>
+        <p>
+          Custom domains direct requests for your apps in this Cloud Foundry
+          organization to a URL that you own. A custom domain can be a shared
+          domain, a shared subdomain, or a shared domain and host.
+        </p>
+      </Modal>
+    );
+
+    const modal = screen.getByRole('dialog');
+    expect(modal).toHaveFocus();
+  });
 });

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -527,6 +527,10 @@ const Modal = React.forwardRef(function Modal(
           return primaryFocusElement;
         }
 
+        if (passiveModal) {
+          return innerModal.current;
+        }
+
         return button && button.current;
       };
 


### PR DESCRIPTION
Avoids opening close button tooltip on passive modal open

Closes https://github.com/carbon-design-system/carbon/issues/16880

The only button in the passive modal is the close button. Once we open it the close button gets focused and we can see the "Close" tooltip open. We don't want to focus on close button in this case, so I moved the focus to modal container. After pressing the tab once the close button gets highlighted, which is expected behaviour.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
