### PR TITLE
fix(ui-shell): prevent premature switcher close on Safari

### DIFF
--- a/packages/react/src/components/UIShell/HeaderPanel.tsx
+++ b/packages/react/src/components/UIShell/HeaderPanel.tsx
@@ -114,10 +114,10 @@ const HeaderPanel: React.FC<HeaderPanelProps> = React.forwardRef(
       };
     }
 
-    useWindowEvent('click', () => {
-      const { activeElement } = document;
-      if (!(activeElement instanceof HTMLElement)) return;
-      setLastClickedElement(activeElement);
+    useWindowEvent('click', (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!(target instanceof HTMLElement)) return;
+      setLastClickedElement(target);
 
       const isChildASwitcher =
         isValidElement(children) &&
@@ -126,8 +126,8 @@ const HeaderPanel: React.FC<HeaderPanelProps> = React.forwardRef(
 
       if (
         isChildASwitcher &&
-        !activeElement.closest(`.${prefix}--header-panel--expanded`) &&
-        !activeElement.closest(`.${prefix}--header__action`) &&
+        !target.closest(`.${prefix}--header-panel--expanded`) &&
+        !target.closest(`.${prefix}--header__action`) &&
         !headerPanelReference?.current?.classList.contains(
           `${prefix}--switcher`
         ) &&


### PR DESCRIPTION
Closes #19747

Fixes inconsistent `HeaderPanel` behavior in Safari by replacing `document.activeElement` with `event.target` to ensure reliable detection of click origin.

### Changelog

**Changed**

- Replaced use of `document.activeElement` with `event.target` in `HeaderPanel`'s `useWindowEvent('click')` to ensure consistent behavior across browsers (notably Safari).

**Removed**

- ~None~

#### Testing / Reviewing

- Open `React Deploy Preview in Safari`> `UI Shell` > `Header` > `Header w/ Actions and Switcher`
- Verify that it opens and closes properly when clicked

> [!WARNING]  
> The keyboard navigation isn’t working in Safari. I'll open an issue so we can get that fixed.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
