### PR TITLE
fix(accordion): provide part attribute to the wrapper div

### DIFF
--- a/packages/web-components/src/components/accordion/accordion-item.ts
+++ b/packages/web-components/src/components/accordion/accordion-item.ts
@@ -209,7 +209,7 @@ class CDSAccordionItem extends FocusMixin(LitElement) {
           <slot name="title">${title}</slot>
         </div>
       </button>
-      <div class="${prefix}--accordion__wrapper">
+      <div class="${prefix}--accordion__wrapper" part="wrapper">
         <div id="content" part="content" class="${contentClasses}">
           <slot></slot>
         </div>


### PR DESCRIPTION
Closes #19794 

{{short description}}

### Changelog

**New**

- Provided a `part` attribute to the wrapper div

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
