### PR TITLE
fix: migrate viewport definitions to storybook 9

### DIFF
--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -207,7 +207,7 @@ const parameters = {
   // X-Large (1312 - 1584px)
   // Max (>1584)
   viewport: {
-    viewports: {
+    options: {
       sm: {
         name: 'Small',
         styles: {

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -137,7 +137,7 @@ export const parameters = {
     },
   },
   viewport: {
-    viewports: {
+    options: {
       sm: {
         name: 'Small',
         styles: {


### PR DESCRIPTION
Closes #19808

### Changelog

**Changed**

- Renamed `parameters.viewport.viewports` to `parameters.viewport.options` in `preview.js` for both, react and web components storybook

#### Testing / Reviewing

- Run local storybooks (react and web components), or visit the deploy preview
  - Verify the viewport options are back as shown in the linked issue and they work as expected

## PR Checklist

- [x] Reviewed every line of the diff
~Updated documentation and storybook examples~
~Wrote passing tests that cover this change~
~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass
