### PR TITLE
fix: fixed clickable issue on menu in safari

### DIFF
--- a/packages/web-components/src/components/ui-shell/side-nav-menu.ts
+++ b/packages/web-components/src/components/ui-shell/side-nav-menu.ts
@@ -69,7 +69,9 @@ class CDSSideNavMenu extends FocusMixin(LitElement) {
   /**
    * Handler for the `click` event on the expando button.
    */
-  private _handleClickExpando() {
+  private _handleClickExpando(e: Event) {
+    const target = e.currentTarget as HTMLButtonElement;
+    target.focus();
     this._handleUserInitiatedToggle();
   }
 

--- a/packages/web-components/src/components/ui-shell/side-nav.scss
+++ b/packages/web-components/src/components/ui-shell/side-nav.scss
@@ -141,11 +141,3 @@ $css--plex: true !default;
 :host(#{$prefix}-header-side-nav-items[has-divider]) {
   @extend .#{$prefix}--side-nav__header-divider;
 }
-
-:host(#{$prefix}-side-nav) {
-  @extend .#{$prefix}--side-nav;
-}
-
-:host(#{$prefix}-side-nav[expanded]) {
-  @extend .#{$prefix}--side-nav--expanded;
-}

--- a/packages/web-components/src/components/ui-shell/side-nav.scss
+++ b/packages/web-components/src/components/ui-shell/side-nav.scss
@@ -141,3 +141,11 @@ $css--plex: true !default;
 :host(#{$prefix}-header-side-nav-items[has-divider]) {
   @extend .#{$prefix}--side-nav__header-divider;
 }
+
+:host(#{$prefix}-side-nav) {
+  @extend .#{$prefix}--side-nav;
+}
+
+:host(#{$prefix}-side-nav[expanded]) {
+  @extend .#{$prefix}--side-nav--expanded;
+}

--- a/packages/web-components/src/components/ui-shell/side-nav.ts
+++ b/packages/web-components/src/components/ui-shell/side-nav.ts
@@ -140,17 +140,29 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
         forEach(headerItems, (item) => {
           item.setAttribute('tabindex', '-1');
         });
-        (
-          this.querySelector(
+
+        const currentFocus = document.activeElement;
+        const shouldAutoFocus =
+          !currentFocus ||
+          !this.contains(currentFocus) ||
+          currentFocus === document.body;
+
+        if (shouldAutoFocus) {
+          const firstNavItem = this.querySelector(
             (this.constructor as typeof CDSSideNav).selectorNavItems
-          ) as HTMLElement
-        )?.focus();
+          ) as HTMLElement;
+
+          if (firstNavItem) {
+            firstNavItem.focus();
+          }
+        }
       } else {
         forEach(headerItems, (item) => {
           item.removeAttribute('tabindex');
         });
       }
     }
+
     if (changedProperties.has('isNotChildOfHeader')) {
       forEach(
         doc.querySelectorAll(
@@ -175,7 +187,7 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
   private _handleFocusOut({ relatedTarget }: FocusEvent) {
     const { collapseMode } = this;
     if (collapseMode !== SIDE_NAV_COLLAPSE_MODE.FIXED) {
-      if (!this.contains(relatedTarget as Node)) {
+      if (relatedTarget && !this.contains(relatedTarget as Node)) {
         this.expanded = false;
       }
     }

--- a/packages/web-components/src/components/ui-shell/side-nav.ts
+++ b/packages/web-components/src/components/ui-shell/side-nav.ts
@@ -140,22 +140,6 @@ class CDSSideNav extends HostListenerMixin(LitElement) {
         forEach(headerItems, (item) => {
           item.setAttribute('tabindex', '-1');
         });
-
-        const currentFocus = document.activeElement;
-        const shouldAutoFocus =
-          !currentFocus ||
-          !this.contains(currentFocus) ||
-          currentFocus === document.body;
-
-        if (shouldAutoFocus) {
-          const firstNavItem = this.querySelector(
-            (this.constructor as typeof CDSSideNav).selectorNavItems
-          ) as HTMLElement;
-
-          if (firstNavItem) {
-            firstNavItem.focus();
-          }
-        }
       } else {
         forEach(headerItems, (item) => {
           item.removeAttribute('tabindex');


### PR DESCRIPTION
Closes #19294 

Fixed clickable issue on menu in safari

### Changelog

**New**

- Improved Safari compatibility for side navigation menu item clicks in rail mode

#### Testing / Reviewing

Open Safari browser and go to https://deploy-preview-19827--v11-carbon-web-components.netlify.app/?path=/story/components-ui-shell--side-nav-rail-w-header
Hover over the side Nav.
Now click anywhere in the "Category Title". The redirection to the underlying link should happen.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
