### PR TITLE
fix(link): handling disabled behavior of LinkComponent

### DIFF
--- a/packages/react/src/components/Link/Link-test.js
+++ b/packages/react/src/components/Link/Link-test.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import Link from '../Link';
+import { Link } from '../Link';
 
 const prefix = 'cds';
 
@@ -129,6 +129,31 @@ describe('Link', () => {
     expect(document.body).toHaveFocus();
     await userEvent.tab();
     expect(document.body).toHaveFocus();
+  });
+
+  // check for disabled onclick handler
+  it('should not call onClick when disabled', async () => {
+    const onClick = jest.fn();
+    render(
+      <Link href="/" disabled onClick={onClick} className="some-class">
+        A simple link
+      </Link>
+    );
+    const link = screen.getByText('A simple link');
+    await userEvent.click(link);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('should call onClick when not disabled', async () => {
+    const onClick = jest.fn();
+    render(
+      <Link href="/" onClick={onClick} className="some-class">
+        A simple link
+      </Link>
+    );
+    const link = screen.getByText('A simple link');
+    await userEvent.click(link);
+    expect(onClick).toHaveBeenCalled();
   });
 
   describe('automated verification testing', () => {

--- a/packages/react/src/components/Link/Link-test.js
+++ b/packages/react/src/components/Link/Link-test.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { Link } from '../Link';
+import Link from '../Link';
 
 const prefix = 'cds';
 

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -122,8 +122,25 @@ const LinkBase = React.forwardRef<
 
     const BaseComponentAsAny = (BaseComponent ?? 'a') as any;
 
+    const handleOnClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (disabled) {
+        event.preventDefault();
+        event.stopPropagation();
+      } else {
+        // If the link is not disabled, we allow the onClick event to propagate
+        // so that any parent handlers can also respond to the click.
+        if (rest.onClick) {
+          rest.onClick(event);
+        }
+      }
+    };
+
     return (
-      <BaseComponentAsAny ref={ref} {...linkProps} {...rest}>
+      <BaseComponentAsAny
+        ref={ref}
+        {...linkProps}
+        {...rest}
+        onClick={handleOnClick}>
         {children}
         {!inline && Icon && (
           <div className={`${prefix}--link__icon`}>

--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -47,7 +47,7 @@ $link-focus-text-color: custom-property.get-var(
       text-decoration: underline;
     }
 
-    &:active,
+    &:active:not(.#{$prefix}--link--disabled),
     &:active:visited,
     &:active:visited:hover {
       @include focus-outline;
@@ -57,7 +57,7 @@ $link-focus-text-color: custom-property.get-var(
       text-decoration: underline;
     }
 
-    &:focus {
+    &:focus:not(.#{$prefix}--link--disabled) {
       @include focus-outline;
 
       outline-color: $link-focus-text-color;


### PR DESCRIPTION
Closes #19729

### Changelog

**New**

- added event.preventDefault and event.stopPropagation for bubbling of the event for disabled state

**Changed**

- modified css behavior for disabled state.

#### Testing / Reviewing

in the disabled state, even if the DOM element is populated with href, the link will not navigate based on the target.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [X] Wrote passing tests that cover this change
- [ ] ~~Addressed any impact on accessibility (a11y)~~
- [ ] ~~Tested for cross-browser consistency~~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
