### PR TITLE
fix(textarea&text-input): Error shown in console when typing in TextArea and Text-Input

### DIFF
--- a/packages/web-components/src/components/text-input/text-input.stories.ts
+++ b/packages/web-components/src/components/text-input/text-input.stories.ts
@@ -74,7 +74,7 @@ const args = {
   warnText:
     'Warning message that is really long can wrap to more lines but should not be excessively long.',
   value: '',
-  onInput: `${prefix}-select-selected`,
+  onInput: (e: Event) => {},
 };
 
 const argTypes = {

--- a/packages/web-components/src/components/textarea/textarea.stories.ts
+++ b/packages/web-components/src/components/textarea/textarea.stories.ts
@@ -58,7 +58,7 @@ const args = {
     'Error message that is really long can wrap to more lines but should not be excessively long.',
   label: 'TextArea label',
   maxCount: 500,
-  onInput: 'input',
+  onInput: (e: Event) => {},
   placeholder: '',
   readonly: false,
   rows: 4,


### PR DESCRIPTION
Closes #19830 

There was an issue discovered for `textarea` and `text-input` where typing in either one would result in an error printing in the console. 

This turned out to be due to the `onInput` arg in storybook being a string, which is what caused this issue and what is being fixed in this PR.
 
### Changelog

**New**

- Nothing new

**Changed**

- Changed `onInput` arg value from a string to a simple arrow function

**Removed**

- Nothing removed

#### Testing / Reviewing

- Go to `textarea` in deploy preview
- Make sure there is no error in console when typing
- Go to `text-input` in deploy preview
- Make sure there is no error in console when typing

