### PR TITLE
fix(popover): remove default open from TabTip story

### DIFF
--- a/packages/web-components/src/components/popover/popover.stories.ts
+++ b/packages/web-components/src/components/popover/popover.stories.ts
@@ -108,7 +108,7 @@ export const TabTip = {
         ${styles}
       </style>
       <div class="popover-tabtip-story" style="display: 'flex'">
-        <cds-popover open tabTip id="popover-one">
+        <cds-popover tabTip id="popover-one">
           <button
             aria-label="Settings"
             type="button"


### PR DESCRIPTION
Closes #19610 

remove default `open` attribute from TabTip story

> [!IMPORTANT]  
> This PR fixes the bug where the popover overlapped content in the TabTip story.  
> Issue #19837 has been opened to add full parity with the React behavior.

### Changelog

**New**

- ~None~

**Changed**

- TabTip story for `<cds-popover>` no longer includes the `open` attribute by default

**Removed**

- Default `open` attribute on the first `<cds-popover>` in TabTip story

#### Testing / Reviewing

1. Go to `Web components Deploy Preview` > `Popover` > `Overview` and `Tab Tip`
3. Verify that the popover is **closed** on load  in 
4. Click the settings button to open and close the popover  
5. Ensure no content is overlapped by the popover on initial render  

Before:
<img width="310" alt="image" src="https://github.com/user-attachments/assets/11bc469d-6b0d-41fe-a23c-ae1b981fa3f0" />

After:
<img width="276" alt="image" src="https://github.com/user-attachments/assets/19fa451e-c3b7-4b2d-b320-552db0e3b9a1" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
