### PR TITLE
fix(code-snippet): fix disabled not working for Code Snippet type="inline"

### DIFF
--- a/packages/react/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.tsx
@@ -337,6 +337,7 @@ function CodeSnippet({
         aria-label={deprecatedAriaLabel || ariaLabel}
         aria-describedby={uid}
         className={codeSnippetClasses}
+        disabled={disabled}
         feedback={feedback}
         feedbackTimeout={feedbackTimeout}>
         <code id={uid} ref={innerCodeRef}>

--- a/packages/web-components/src/components/code-snippet/code-snippet.scss
+++ b/packages/web-components/src/components/code-snippet/code-snippet.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019, 2024
+// Copyright IBM Corp. 2019, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -25,8 +25,15 @@ $css--plex: true !default;
   }
 }
 
-:host(#{$prefix}-code-snippet[disabled]) {
+:host(#{$prefix}-code-snippet[disabled]:not([type='inline'])) {
   @extend .#{$prefix}--snippet--disabled;
+}
+:host(#{$prefix}-code-snippet[type='inline'][disabled]) {
+  cursor: not-allowed;
+
+  ::part(button) {
+    pointer-events: none;
+  }
 }
 
 :host(#{$prefix}-code-snippet[wrap-text]) {

--- a/packages/web-components/src/components/code-snippet/code-snippet.ts
+++ b/packages/web-components/src/components/code-snippet/code-snippet.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -363,7 +363,7 @@ class CDSCodeSnippet extends FocusMixin(LitElement) {
       // Ensures no extra whitespace text node
       // prettier-ignore
       return html`
-        <cds-copy button-class-name="${classes}" @click="${handleCopyClick}">
+        <cds-copy ?disabled=${disabled} button-class-name="${classes}" @click="${handleCopyClick}">
           <code slot="icon"><slot></slot></code>
           <span slot="tooltip-content">${tooltipContent}</span>
         </cds-copy>


### PR DESCRIPTION
Closes #19832

The React and WC versions of CodeSnippet had an issue with `disabled` not doing anything when set to true when the type was `inline`. This PR fixes this for both React and WC versions of the component

### Changelog

**New**

- Added `disabled` prop to type="inline" for the CodeSnippet React version since it was missing
- Added `disabled` attribute to type="inline" for the code-snippet WC version since it was missing
- Added disabled styling for the WC version of code-snippet

**Changed**

- Excluded inline code-snippet (WC version) from extending .#{$prefix}--snippet--disabled; in its disabled styling.

**Removed**

- Nothing removed

#### Testing / Reviewing

- Go to React deployed preview
- Go to the "Inline" story for CodeSnippet
- Set `disabled` to true
- Component should be disabled
- Go to WC deployed preview
- Go to the "Inline" story for CodeSnippet
- Set `disabled` to true
- Component should be disabled
