### PR TITLE
feat(file-uploader): add render props for file item name and actions

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -3470,6 +3470,12 @@ Map {
       "onDelete": Object {
         "type": "func",
       },
+      "renderFileActions": Object {
+        "type": "func",
+      },
+      "renderFileName": Object {
+        "type": "func",
+      },
       "size": Object {
         "args": Array [
           Array [
@@ -3613,6 +3619,12 @@ Map {
       "onDelete": Object {
         "type": "func",
       },
+      "renderActions": Object {
+        "type": "func",
+      },
+      "renderName": Object {
+        "type": "func",
+      },
       "size": Object {
         "args": Array [
           Array [
@@ -3656,9 +3668,6 @@ Map {
       "invalid": Object {
         "type": "bool",
       },
-      "name": Object {
-        "type": "string",
-      },
       "status": Object {
         "args": Array [
           Array [
@@ -3668,9 +3677,6 @@ Map {
           ],
         ],
         "type": "oneOf",
-      },
-      "tabIndex": Object {
-        "type": "number",
       },
     },
   },

--- a/packages/react/src/components/FileUploader/FileUploader.stories.js
+++ b/packages/react/src/components/FileUploader/FileUploader.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 /* eslint-disable no-console */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import ExampleDropContainerApp from './stories/drop-container';
 import ExampleDropContainerAppSingle from './stories/drag-and-drop-single';
 import mdx from './FileUploader.mdx';
@@ -19,6 +19,11 @@ import {
   FileUploaderItem,
   FileUploaderSkeleton,
 } from './';
+import Link from '../Link';
+import { Download, TrashCan } from '@carbon/icons-react';
+import { usePrefix } from '../../internal/usePrefix';
+import { IconButton } from '../IconButton';
+import { Tooltip } from '../Tooltip';
 
 const filenameStatuses = ['edit', 'complete', 'uploading'];
 
@@ -173,6 +178,97 @@ export const Default = (args) => {
       <FileUploader {...args} />
     </div>
   );
+};
+
+export const WithCustomFileItems = (args) => {
+  return (
+    <div className="cds--file__container">
+      <FileUploader {...args} />
+    </div>
+  );
+};
+
+WithCustomFileItems.args = {
+  labelTitle: 'Upload files',
+  labelDescription: 'Max file size is 500 MB. Only .jpg files are supported.',
+  buttonLabel: 'Add file',
+  buttonKind: 'primary',
+  size: 'md',
+  filenameStatus: 'edit',
+  accept: ['.jpg', '.png'],
+  multiple: true,
+  disabled: false,
+  iconDescription: 'Delete file',
+  name: '',
+  renderFileActions: () => {
+    return (
+      <>
+        <IconButton autoAlign="true" kind="ghost" size="sm" label="Download">
+          <Download />
+        </IconButton>
+        <IconButton autoAlign="true" kind="ghost" size="sm" label="Remove">
+          <TrashCan />
+        </IconButton>
+      </>
+    );
+  },
+  renderFileName: ({ name }) => {
+    const prefix = usePrefix();
+    const linkRef = useRef(null);
+
+    return (
+      <Tooltip
+        align="bottom"
+        className={`${prefix}--file-filename-tooltip`}
+        label={name}
+        style={{ minWidth: '0', width: '100%' }}>
+        <button className={`${prefix}--file-filename-button`} type="button">
+          <Link
+            style={{ display: 'inline' }}
+            ref={linkRef}
+            className={` ${prefix}--file-filename`}
+            title={name}
+            href="#">
+            {name}
+          </Link>
+        </button>
+      </Tooltip>
+    );
+  },
+};
+
+WithCustomFileItems.argTypes = {
+  onChange: { action: 'onChange' },
+  onClick: { action: 'onClick' },
+  onDelete: { action: 'onDelete' },
+  buttonKind: {
+    control: { type: 'select' },
+    options: [
+      'primary',
+      'secondary',
+      'danger',
+      'ghost',
+      'danger--primary',
+      'tertiary',
+    ],
+  },
+  filenameStatus: {
+    control: { type: 'select' },
+    options: filenameStatuses,
+  },
+  size: {
+    control: { type: 'select' },
+    options: ['sm', 'md', 'lg'],
+  },
+  accept: {
+    table: { disable: true },
+  },
+  className: {
+    table: { disable: true },
+  },
+  role: {
+    table: { disable: true },
+  },
 };
 
 Default.args = {

--- a/packages/react/src/components/FileUploader/FileUploaderItemBase.tsx
+++ b/packages/react/src/components/FileUploader/FileUploaderItemBase.tsx
@@ -1,0 +1,175 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React, { type HTMLAttributes } from 'react';
+
+import { usePrefix } from '../../internal/usePrefix';
+import { Text } from '../Text';
+import Filename from './Filename';
+
+export interface FileUploaderItemProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Error message body for an invalid file upload
+   */
+  errorBody?: string;
+
+  /**
+   * Error message subject for an invalid file upload
+   */
+  errorSubject?: string;
+
+  /**
+   * Description of status icon (displayed in native tooltip)
+   */
+  iconDescription?: string;
+
+  /**
+   * Specify if the currently uploaded file is invalid
+   */
+  invalid?: boolean;
+
+  /**
+   * Name of the uploaded file
+   */
+  name?: string;
+
+  /**
+   * Specify the size of the FileUploaderButton, from a list of available
+   * sizes.
+   */
+  size?: 'sm' | 'md' | 'lg';
+
+  /**
+   * Status of the file upload
+   */
+  status?: 'uploading' | 'edit' | 'complete';
+
+  /**
+   * A function used to render a custom name for the file object.
+   */
+  renderName?: (props: { name: string | undefined }) => React.ReactNode;
+
+  /**
+   * A function used to render a custom actions for the file object.
+   */
+  renderActions?: (props: {
+    name: string | undefined;
+    status: string;
+  }) => React.ReactNode;
+}
+function FileUploaderItemBase({
+  name,
+  status = 'uploading',
+  iconDescription,
+  invalid,
+  errorSubject,
+  errorBody,
+  size,
+  className,
+  renderName,
+  renderActions,
+  ...other
+}: FileUploaderItemProps) {
+  const prefix = usePrefix();
+  const classes = cx(`${prefix}--file__selected-file`, className, {
+    [`${prefix}--file__selected-file--invalid`]: invalid,
+    [`${prefix}--file__selected-file--md`]: size === 'md',
+    [`${prefix}--file__selected-file--sm`]: size === 'sm',
+  });
+
+  const filterSpaceName = (name: string | undefined) => {
+    return name?.replace(/\s+/g, '');
+  };
+
+  return (
+    <span className={classes} {...other}>
+      {renderName?.({ name })}
+      <div className={`${prefix}--file-container-item`}>
+        <span className={`${prefix}--file__state-container`}>
+          <Filename
+            iconDescription={iconDescription}
+            status={status}
+            invalid={invalid}
+            aria-describedby={
+              invalid && errorSubject
+                ? `${filterSpaceName(name)}-id-error`
+                : undefined
+            }
+          />
+          {renderActions?.({ name, status })}
+        </span>
+      </div>
+      {invalid && errorSubject && (
+        <div
+          className={`${prefix}--form-requirement`}
+          role="alert"
+          id={`${filterSpaceName(name)}-id-error`}>
+          <Text as="div" className={`${prefix}--form-requirement__title`}>
+            {errorSubject}
+          </Text>
+          {errorBody && (
+            <Text as="p" className={`${prefix}--form-requirement__supplement`}>
+              {errorBody}
+            </Text>
+          )}
+        </div>
+      )}
+    </span>
+  );
+}
+
+FileUploaderItemBase.propTypes = {
+  /**
+   * Error message body for an invalid file upload
+   */
+  errorBody: PropTypes.string,
+
+  /**
+   * Error message subject for an invalid file upload
+   */
+  errorSubject: PropTypes.string,
+
+  /**
+   * Description of status icon (displayed in native tooltip)
+   */
+  iconDescription: PropTypes.string,
+
+  /**
+   * Specify if the currently uploaded file is invalid
+   */
+  invalid: PropTypes.bool,
+
+  /**
+   * Name of the uploaded file
+   */
+  name: PropTypes.string,
+
+  /**
+   * Specify the size of the FileUploaderButton, from a list of available
+   * sizes.
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+
+  /**
+   * Status of the file upload
+   */
+  status: PropTypes.oneOf(['uploading', 'edit', 'complete']),
+
+  /**
+   * A function used to render a custom name for the file object.
+   */
+  renderName: PropTypes.func,
+
+  /**
+   * A function used to render a custom actions for the file object.
+   */
+  renderActions: PropTypes.func,
+};
+
+export default FileUploaderItemBase;

--- a/packages/react/src/components/FileUploader/Filename.tsx
+++ b/packages/react/src/components/FileUploader/Filename.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Close, WarningFilled, CheckmarkFilled } from '@carbon/icons-react';
+import { WarningFilled, CheckmarkFilled } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import React, { type HTMLAttributes } from 'react';
 import Loading from '../Loading';
@@ -33,27 +33,15 @@ export interface FilenameProps
   invalid?: boolean;
 
   /**
-   * Name of the uploaded file
-   */
-  name?: string;
-
-  /**
    * Status of the file upload
    */
   status?: FilenameStatus;
-
-  /**
-   * Provide a custom tabIndex value for the `<Filename>`
-   */
-  tabIndex?: number;
 }
 
 function Filename({
   iconDescription = 'Uploading file',
   status = 'uploading',
   invalid,
-  name,
-  tabIndex = 0,
   ['aria-describedby']: ariaDescribedBy,
   ...rest
 }: FilenameProps) {
@@ -72,15 +60,6 @@ function Filename({
       return (
         <>
           {invalid && <WarningFilled className={`${prefix}--file-invalid`} />}
-          <button
-            aria-label={`${iconDescription} - ${name}`}
-            className={`${prefix}--file-close`}
-            type="button"
-            tabIndex={tabIndex}
-            {...rest}
-            aria-describedby={invalid ? ariaDescribedBy : undefined}>
-            <Close />
-          </button>
         </>
       );
     case 'complete':
@@ -115,19 +94,9 @@ Filename.propTypes = {
   invalid: PropTypes.bool,
 
   /**
-   * Name of the uploaded file
-   */
-  name: PropTypes.string,
-
-  /**
    * Status of the file upload
    */
   status: PropTypes.oneOf(['edit', 'complete', 'uploading']),
-
-  /**
-   * Provide a custom tabIndex value for the `<Filename>`
-   */
-  tabIndex: PropTypes.number,
 };
 
 export default Filename;

--- a/packages/react/src/components/FileUploader/__tests__/FileUploader-test.js
+++ b/packages/react/src/components/FileUploader/__tests__/FileUploader-test.js
@@ -1,16 +1,18 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { render, act, screen } from '@testing-library/react';
+import { Download, TrashCan } from '@carbon/icons-react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import FileUploader from '../';
 import React from 'react';
-import { uploadFiles } from '../test-helpers';
+import FileUploader from '../';
+import { IconButton } from '../../IconButton';
+import Link from '../../Link';
 
 const iconDescription = 'test description';
 const requiredProps = {
@@ -21,6 +23,11 @@ const requiredProps = {
 };
 
 describe('FileUploader', () => {
+  it('should have no aXe violations', async () => {
+    const { container } = render(<FileUploader />);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
   it('should support a custom class name on the root element', () => {
     const { container } = render(
       <FileUploader {...requiredProps} className="test" />
@@ -81,6 +88,7 @@ describe('FileUploader', () => {
     const complete = screen.getByLabelText(iconDescription);
     expect(edit).not.toEqual(complete);
   });
+
   it('should disable file input when `disabled` prop is true', () => {
     const { container } = render(
       <FileUploader {...requiredProps} disabled buttonLabel="disabled upload" />
@@ -88,6 +96,7 @@ describe('FileUploader', () => {
     const input = container.querySelector('input');
     expect(input).toBeDisabled();
   });
+
   it('should render with different button kinds', () => {
     const buttonKinds = ['primary', 'secondary', 'danger', 'ghost'];
     buttonKinds.forEach((kind) => {
@@ -98,6 +107,7 @@ describe('FileUploader', () => {
       expect(button).toHaveClass(`cds--btn--${kind}`);
     });
   });
+
   it('should trigger `onDelete` when a file is removed', async () => {
     const onDelete = jest.fn();
     const { container } = render(
@@ -121,6 +131,7 @@ describe('FileUploader', () => {
 
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
+
   it('should trigger `onChange` when files are selected', async () => {
     const onChange = jest.fn();
     const { container } = render(
@@ -133,5 +144,42 @@ describe('FileUploader', () => {
     await userEvent.upload(input, file);
 
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render custom file name and actions when provided via `renderFileName` and `renderFileActions`', async () => {
+    const renderFileActions = () => (
+      <>
+        <IconButton autoAlign="true" kind="ghost" size="sm" label="Download">
+          <Download data-testid="Node 1" />
+        </IconButton>
+        <IconButton autoAlign="true" kind="ghost" size="sm" label="Remove">
+          <TrashCan data-testid="Node 2" />
+        </IconButton>
+      </>
+    );
+
+    const renderFileName = (name) => (
+      <Link data-testid="Node 3" title={name} href="#">
+        {JSON.stringify(name)}
+      </Link>
+    );
+
+    const { container } = render(
+      <FileUploader
+        {...requiredProps}
+        renderFileName={renderFileName}
+        renderFileActions={renderFileActions}
+      />
+    );
+
+    const input = container.querySelector('input');
+    const filename = 'test.png';
+    const file = new File(['test'], filename, { type: 'image/png' });
+
+    await userEvent.upload(input, file);
+
+    expect(screen.getByTestId('Node 1')).toBeInTheDocument();
+    expect(screen.getByTestId('Node 2')).toBeInTheDocument();
+    expect(screen.getByTestId('Node 3')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/FileUploader/__tests__/Filename-test.js
+++ b/packages/react/src/components/FileUploader/__tests__/Filename-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,51 +33,5 @@ describe('Filename', () => {
         await expect(container).toHaveNoACViolations(`Filename-${status}`);
       }
     );
-  });
-
-  it('should support events on interactive icons when `edit` or `complete` is the status', () => {
-    const onClick = jest.fn();
-    const { container: edit } = render(
-      <Filename
-        name="File 1"
-        iconDescription="test description"
-        status="edit"
-        onClick={onClick}
-      />
-    );
-
-    fireEvent.click(
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-      edit.querySelector(`[aria-label="test description - File 1"]`)
-    );
-    expect(onClick).toHaveBeenCalledTimes(1);
-
-    onClick.mockReset();
-
-    const { container: complete } = render(
-      <Filename
-        iconDescription="test description"
-        status="complete"
-        onClick={onClick}
-      />
-    );
-
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    fireEvent.click(complete.querySelector(`[aria-label="test description"]`));
-    expect(onClick).toHaveBeenCalledTimes(1);
-
-    const { container: uploading } = render(
-      <Filename
-        iconDescription="test description"
-        status="uploading"
-        onClick={onClick}
-      />
-    );
-
-    onClick.mockReset();
-
-    // eslint-disable-next-line testing-library/prefer-screen-queries
-    fireEvent.click(getByText(uploading, 'test description'));
-    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/styles/scss/components/file-uploader/_file-uploader.scss
+++ b/packages/styles/scss/components/file-uploader/_file-uploader.scss
@@ -177,7 +177,7 @@
     .#{$prefix}--file-filename-container-wrap {
       margin-block-start: 1px;
       max-inline-size: 17.5rem;
-      padding-inline-start: $spacing-05;
+
       @include breakpoint-down(410px) {
         max-inline-size: 13.5rem;
       }
@@ -188,7 +188,6 @@
 
       .#{$prefix}--file-filename-tooltip {
         inline-size: -webkit-fill-available;
-        padding-inline-start: $spacing-05;
 
         /* This is for targeting styles specific to firefox */
         /* https://sass-lang.com/documentation/breaking-changes/moz-document/ */


### PR DESCRIPTION
Closes #19643 

Updates the file uploader component to accept render props for custom rendering of each uploaded file's name and available actions.

The purpose of this change is to accommodate file uploader designs which require different actions to be taken on a file item such as downloading or viewing a file.

> 1. Changing the delete icon from a cross to a trash can for each file item,
> 2. Adding a download icon action to each file item to download the file,
> 
> ![Image](https://github.com/user-attachments/assets/2d9577b1-0d89-4b98-a554-96cb94fcca41)
> 
> 3. Adding a view icon action to each file item to view the file,
> 
> <img alt="Image" src="https://github.com/user-attachments/assets/1ecd3b9c-ef95-428a-8626-57b3df49a19c" />
> 
> 4. Changing file item text to a link to view attachment in new tab.
> 
> <img alt="Image" src="https://github.com/user-attachments/assets/3e435a87-c68f-45a5-9e42-6545f312def1" />
> 
> <img alt="Image" src="https://github.com/user-attachments/assets/5a434e53-18e7-42c3-8f92-a189942626cf" />

Some areas where I'm looking for feedback:

- Is the "render props" pattern the correct approach to enable consumers to provide customizations to file items
- Should the customization of a file item come in 2 properties (as is the current approach) vs a single property.
- Providing `renderFileActions` causes the `onDelete` prop to be unnecessary since the default delete action will no longer be displayed when `renderFileActions` is provided; is it okay for certain props to be mutually exclusive?
- I've been hung up on one use case where a consumer may simply want to swap the default delete icon (x) with a trash can icon. With the render props approach, the consumer has to provide the trash can icon via `renderFileActions` and write the logic to delete the file manually as oppose to using the internal logic of the `FileUploaderComponent`; is there a way to connect an icon which is provided via render props to utilize internal functions or is it expected that the consumer now has to handle that additional work?
- In the storybook `With Custom File Actions`, the icons provided via `renderFileActions` currently don't do anything; Ideally, the example would showcase how to hook up the trash can icon such that it mimics the functionality of the default delete icon (x). Looking for guidance on how to write that within the storybook example.
- When trying to enable a11y tests for the FileUploaderButton/FileUploader components, there was an error: `Message: Form control element <input> has no associated label`, which seemed to refer to the hidden input within the `FileUploaderButton`; this input does have a label so if there is a way to associate the label to the input other including `htmlFor` on the `label` and `id` on the `input` some guidance would be appreciated.


### Changelog

**New**

- create file uploader item base component which supports render props for its name and actions

**Changed**

- update file uploader item component to incorporate new render props when provided and fallback to default name and action templates otherwise
- update file uploader component to include render props to use for each file name and file actions

**Removed**

- remove the delete button the filename class

#### Testing / Reviewing

Use `yarn storybook` and view `With Custom File Items` example within the File Uploader component story. Use other examples within the File Uploader component story to verify backwards compatibility. 

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
