### PR TITLE
test(storybook): add test-only stories and hide them from the sidebar

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -79,6 +79,43 @@ BreadcrumbWithOverflowMenu.argTypes = {
   ...sharedArgTypes,
 };
 
+export const BreadcrumbWithOverflowMenuSizeSmall = (args) => {
+  console.log(process.env.IS_PRODUCTION);
+
+  return (
+    <Breadcrumb noTrailingSlash {...args}>
+      <BreadcrumbItem>
+        <a href="/#">Breadcrumb 1</a>
+      </BreadcrumbItem>
+      <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+      <BreadcrumbItem data-floating-menu-container>
+        <OverflowMenu align="bottom" aria-label="Overflow menu in a breadcrumb">
+          <OverflowMenuItem itemText="Breadcrumb 3" />
+          <OverflowMenuItem itemText="Breadcrumb 4" />
+        </OverflowMenu>
+      </BreadcrumbItem>
+      <BreadcrumbItem href="#">Breadcrumb 5</BreadcrumbItem>
+      <BreadcrumbItem isCurrentPage>Breadcrumb 6</BreadcrumbItem>
+    </Breadcrumb>
+  );
+};
+
+BreadcrumbWithOverflowMenuSizeSmall.argTypes = {
+  ...sharedArgTypes,
+};
+
+/*
+ * This story will:
+ * - Be excluded from the docs page
+ * - Removed from the sidebar navigation
+ * - Still be a tested variant
+ */
+BreadcrumbWithOverflowMenuSizeSmall.tags = ['!dev', '!autodocs'];
+
+BreadcrumbWithOverflowMenuSizeSmall.args = {
+  size: 'sm',
+};
+
 export const Skeleton = () => {
   return <BreadcrumbSkeleton />;
 };

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -79,26 +79,22 @@ BreadcrumbWithOverflowMenu.argTypes = {
   ...sharedArgTypes,
 };
 
-export const BreadcrumbWithOverflowMenuSizeSmall = (args) => {
-  console.log(process.env.IS_PRODUCTION);
-
-  return (
-    <Breadcrumb noTrailingSlash {...args}>
-      <BreadcrumbItem>
-        <a href="/#">Breadcrumb 1</a>
-      </BreadcrumbItem>
-      <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-      <BreadcrumbItem data-floating-menu-container>
-        <OverflowMenu align="bottom" aria-label="Overflow menu in a breadcrumb">
-          <OverflowMenuItem itemText="Breadcrumb 3" />
-          <OverflowMenuItem itemText="Breadcrumb 4" />
-        </OverflowMenu>
-      </BreadcrumbItem>
-      <BreadcrumbItem href="#">Breadcrumb 5</BreadcrumbItem>
-      <BreadcrumbItem isCurrentPage>Breadcrumb 6</BreadcrumbItem>
-    </Breadcrumb>
-  );
-};
+export const BreadcrumbWithOverflowMenuSizeSmall = (args) => (
+  <Breadcrumb noTrailingSlash {...args}>
+    <BreadcrumbItem>
+      <a href="/#">Breadcrumb 1</a>
+    </BreadcrumbItem>
+    <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+    <BreadcrumbItem data-floating-menu-container>
+      <OverflowMenu align="bottom" aria-label="Overflow menu in a breadcrumb">
+        <OverflowMenuItem itemText="Breadcrumb 3" />
+        <OverflowMenuItem itemText="Breadcrumb 4" />
+      </OverflowMenu>
+    </BreadcrumbItem>
+    <BreadcrumbItem href="#">Breadcrumb 5</BreadcrumbItem>
+    <BreadcrumbItem isCurrentPage>Breadcrumb 6</BreadcrumbItem>
+  </Breadcrumb>
+);
 
 BreadcrumbWithOverflowMenuSizeSmall.argTypes = {
   ...sharedArgTypes,

--- a/packages/react/src/components/IconIndicator/IconIndicator.stories.js
+++ b/packages/react/src/components/IconIndicator/IconIndicator.stories.js
@@ -20,6 +20,23 @@ export default {
   },
 };
 
+const sharedArgTypes = {
+  label: {
+    control: {
+      type: 'text',
+    },
+  },
+  kind: {
+    control: false,
+  },
+  size: {
+    control: {
+      type: 'select',
+    },
+    options: [16, 20],
+  },
+};
+
 export const Default = (props) => {
   return (
     <div
@@ -48,19 +65,42 @@ Default.args = {
   size: 16,
 };
 
-Default.argTypes = {
-  label: {
-    control: {
-      type: 'text',
-    },
-  },
-  kind: {
-    control: false,
-  },
-  size: {
-    control: {
-      type: 'select',
-    },
-    options: [16, 20],
-  },
+Default.argTypes = sharedArgTypes;
+
+export const DefaultWithSize24 = (props) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexFlow: 'column',
+        rowGap: '.5rem',
+      }}>
+      <IconIndicator kind="failed" label="Failed" {...props} />
+      <IconIndicator kind="caution-major" label="Caution major" {...props} />
+      <IconIndicator kind="caution-minor" label="Caution minor" {...props} />
+      <IconIndicator kind="undefined" label="Undefined" {...props} />
+      <IconIndicator kind="succeeded" label="Succeeded" {...props} />
+      <IconIndicator kind="normal" label="Normal" {...props} />
+      <IconIndicator kind="in-progress" label="In progress" {...props} />
+      <IconIndicator kind="incomplete" label="Incomplete" {...props} />
+      <IconIndicator kind="not-started" label="Not started" {...props} />
+      <IconIndicator kind="pending" label="Pending" {...props} />
+      <IconIndicator kind="unknown" label="Unknown" {...props} />
+      <IconIndicator kind="informative" label="Informative" {...props} />
+    </div>
+  );
 };
+
+DefaultWithSize24.args = {
+  size: 24,
+};
+
+/*
+ * This story will:
+ * - Be excluded from the docs page
+ * - Removed from the sidebar navigation
+ * - Still be a tested variant
+ */
+DefaultWithSize24.tags = ['!dev', '!autodocs'];
+
+DefaultWithSize24.argTypes = sharedArgTypes;

--- a/packages/react/src/components/IconIndicator/IconIndicator.stories.js
+++ b/packages/react/src/components/IconIndicator/IconIndicator.stories.js
@@ -64,10 +64,9 @@ export const Default = (props) => {
 Default.args = {
   size: 16,
 };
-
 Default.argTypes = sharedArgTypes;
 
-export const DefaultWithSize24 = (props) => {
+export const DefaultWithSize20 = (props) => {
   return (
     <div
       style={{
@@ -91,8 +90,8 @@ export const DefaultWithSize24 = (props) => {
   );
 };
 
-DefaultWithSize24.args = {
-  size: 24,
+DefaultWithSize20.args = {
+  size: 20,
 };
 
 /*
@@ -101,6 +100,5 @@ DefaultWithSize24.args = {
  * - Removed from the sidebar navigation
  * - Still be a tested variant
  */
-DefaultWithSize24.tags = ['!dev', '!autodocs'];
-
-DefaultWithSize24.argTypes = sharedArgTypes;
+DefaultWithSize20.tags = ['!dev', '!autodocs'];
+DefaultWithSize20.argTypes = sharedArgTypes;

--- a/packages/react/src/components/ShapeIndicator/ShapeIndicator.stories.js
+++ b/packages/react/src/components/ShapeIndicator/ShapeIndicator.stories.js
@@ -19,6 +19,23 @@ export default {
   },
 };
 
+const sharedArgTypes = {
+  label: {
+    control: {
+      type: 'text',
+    },
+  },
+  kind: {
+    control: false,
+  },
+  textSize: {
+    control: {
+      type: 'select',
+    },
+    options: [12, 14],
+  },
+};
+
 export const Default = (props) => {
   return (
     <div
@@ -46,19 +63,41 @@ Default.args = {
   textSize: 12,
 };
 
-Default.argTypes = {
-  label: {
-    control: {
-      type: 'text',
-    },
-  },
-  kind: {
-    control: false,
-  },
-  textSize: {
-    control: {
-      type: 'select',
-    },
-    options: [12, 14],
-  },
+Default.argTypes = sharedArgTypes;
+
+export const DefaultWithTextSize14 = (props) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexFlow: 'column',
+        rowGap: '.5rem',
+      }}>
+      <ShapeIndicator kind="failed" label="Failed" {...props} />
+      <ShapeIndicator kind="critical" label="Critical" {...props} />
+      <ShapeIndicator kind="high" label="High" {...props} />
+      <ShapeIndicator kind="medium" label="Medium" {...props} />
+      <ShapeIndicator kind="low" label="Low" {...props} />
+      <ShapeIndicator kind="cautious" label="Cautious" {...props} />
+      <ShapeIndicator kind="undefined" label="Undefined" {...props} />
+      <ShapeIndicator kind="stable" label="Stable" {...props} />
+      <ShapeIndicator kind="informative" label="Informative" {...props} />
+      <ShapeIndicator kind="incomplete" label="Incomplete" {...props} />
+      <ShapeIndicator kind="draft" label="Draft" {...props} />
+    </div>
+  );
 };
+
+DefaultWithTextSize14.args = {
+  textSize: 14,
+};
+
+/*
+ * This story will:
+ * - Be excluded from the docs page
+ * - Removed from the sidebar navigation
+ * - Still be a tested variant
+ */
+DefaultWithTextSize14.tags = ['!dev', '!autodocs'];
+
+DefaultWithTextSize14.argTypes = sharedArgTypes;


### PR DESCRIPTION
Closes #19805

This adds three new stories that configure components with specific args for testing. These stories will be visually tested with Chromatic, while being hidden from the navigational sidebar. 

> [!IMPORTANT]  
> These stories are still included in the build, meaning they can be accessed by URL even when hidden from the sidebar.
>
> Additionally we discovered that there is no way to conditionally hide stories based on environment (production vs dev, for instance), so to debug vrt failures of these stories we'll have to either
> 1. Hit them by url directly
> 2. Temporarily reconfigure the tags from `['!dev', '!autodocs']` to `['dev', 'autodocs']`, and then switch it back before merging

### Changelog

**Changed**

- add stories to existing story files for 3 components that use args for vrt

#### Testing / Reviewing

- Go to the deploy preview, validate that these stories are not shown in the sidebar.
- Go to each story directly by url on the deploy preview
  - {storybookDeployBaseURL}/?path=/story/components-breadcrumb--breadcrumb-with-overflow-menu-size-small
  - {storybookDeployBaseURL}/?path=/story/experimental-statusindicators-unstable-iconindicator--default-with-size-20
  - {storybookDeployBaseURL}/?path=/story/experimental-statusindicators-unstable-shapeindicator--default-with-text-size-14
  - Ensure each of these bear the visual change present in the args (size difference, text size difference)
- In the chromatic status/ci check, review to make sure these stories are included and snapshotted. If they're not listed we'll need to debug why.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
