### PR TITLE
fix(numberinput): display decimal inputMode keyboard by default

### DIFF
--- a/packages/react/src/components/FluidNumberInput/FluidNumberInput.tsx
+++ b/packages/react/src/components/FluidNumberInput/FluidNumberInput.tsx
@@ -59,8 +59,9 @@ export interface FluidNumberInputProps {
   id: string;
 
   /**
-   * Instruct the browser which keyboard to display on mobile devices. Note that
-   * standard numeric keyboards vary across devices and operating systems.
+   * Instruct the browser which keyboard to display on mobile devices. Defaults
+   * to `decimal`, but note that standard numeric keyboards vary across devices
+   * and operating systems.
    * @see https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/
    */
   inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
@@ -230,8 +231,9 @@ FluidNumberInput.propTypes = {
   id: PropTypes.string.isRequired,
 
   /**
-   * Instruct the browser which keyboard to display on mobile devices. Note that
-   * standard numeric keyboards vary across devices and operating systems.
+   * Instruct the browser which keyboard to display on mobile devices. Defaults
+   * to `decimal`, but note that standard numeric keyboards vary across devices
+   * and operating systems.
    * @see https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/
    */
   inputMode: PropTypes.oneOf([

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -135,8 +135,9 @@ export interface NumberInputProps
   id: string;
 
   /**
-   * Instruct the browser which keyboard to display on mobile devices. Note that
-   * standard numeric keyboards vary across devices and operating systems.
+   * Instruct the browser which keyboard to display on mobile devices. Defaults
+   * to `decimal`, but note that standard numeric keyboards vary across devices
+   * and operating systems.
    * @see https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/
    */
   inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
@@ -286,7 +287,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
       hideSteppers,
       iconDescription,
       id,
-      inputMode,
+      inputMode = 'decimal',
       invalid = false,
       invalidText,
       label,
@@ -850,8 +851,9 @@ NumberInput.propTypes = {
   id: PropTypes.string.isRequired,
 
   /**
-   * Instruct the browser which keyboard to display on mobile devices. Note that
-   * standard numeric keyboards vary across devices and operating systems.
+   * Instruct the browser which keyboard to display on mobile devices. Defaults
+   * to `decimal`, but note that standard numeric keyboards vary across devices
+   * and operating systems.
    * @see https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/
    */
   inputMode: PropTypes.oneOf([


### PR DESCRIPTION
This adds `decimal` as the default for `inputMode`.

[Surfaced in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1751376250332799?thread_ts=1749648029.085619&cid=C2K6RFJ1G), the recent change to `type="text"` caused browsers to infer/display the wrong (alphanumeric) keyboard on mobile devices. `inputMode` has always been configurable, but it was formally added to the prop API as part of #19471. `decimal` [looks like](https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/) the best default to use here. 

### Changelog

**Changed**

- Modify NumberInput to specify `decimal` as the default for `inputMode`

#### Testing / Reviewing

- View the NumberInput stories on a mobile device
- Ensure the keyboard that comes up is suited to inputting decimal numbers `.` with thousandths separators `,`
- This new default should be reflected in the storybook api/prop tables

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~ 
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
