### PR TITLE
feat(web-components): enable accurate TypeScript code coverage reporting

### DIFF
--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -14,6 +14,8 @@
     "rootDir": ".",
     "skipLibCheck": true,
     "sourceMap": true,
+    "inlineSourceMap": false,
+    "inlineSources": true,
     "stripInternal": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/web-components/web-test-runner.config.mjs
+++ b/packages/web-components/web-test-runner.config.mjs
@@ -40,7 +40,7 @@ export default {
     sourceMap: true,
     all: true,
 
-    // thresholds can be modified once all componets have unit tests
+    // thresholds can be modified once all components have unit tests
     threshold: {
       statements: 60,
       branches: 60,

--- a/packages/web-components/web-test-runner.config.mjs
+++ b/packages/web-components/web-test-runner.config.mjs
@@ -24,15 +24,15 @@ export default {
 
     include: [
       'es/components/**/*.js',
-      '!es/components/**/*.scss.js',
       '!es/components/**/index.js',
-      '!es/components/**/*.stories.js',
       '!es/components/**/__tests__/**/*',
     ],
 
     exclude: [
       'node_modules/**/*',
       'coverage/**/*',
+      '**/*.stories.js',
+      '**/*.scss',
       'tests/**/*',
       '.storybook/**/*',
     ],

--- a/packages/web-components/web-test-runner.config.mjs
+++ b/packages/web-components/web-test-runner.config.mjs
@@ -1,16 +1,80 @@
+import { fromRollup } from '@web/dev-server-rollup';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+
+const resolve = fromRollup(nodeResolve);
+
 export default {
   files: 'src/components/**/__tests__/**/*.js',
   nodeResolve: true,
   concurrency: 1,
+
+  plugins: [
+    resolve({
+      extensions: ['.js', '.ts'],
+    }),
+  ],
+
+  rootDir: '.',
+
+  coverage: true,
   coverageConfig: {
     report: true,
     reportDir: 'coverage',
-    reporters: ['lcov', 'text-summary'],
-    include: ['es/components/**/*.js'],
-    exclude: [
-      'es/components/**/__tests__/**/*',
-      'es/components/**/*.stories.js',
-      'es/components/**/*.scss.js',
+    reporters: ['lcov', 'text-summary', 'html'],
+
+    include: [
+      'es/components/**/*.js',
+      '!es/components/**/*.scss.js',
+      '!es/components/**/index.js',
+      '!es/components/**/*.stories.js',
+      '!es/components/**/__tests__/**/*',
     ],
+
+    exclude: [
+      'node_modules/**/*',
+      'coverage/**/*',
+      'tests/**/*',
+      '.storybook/**/*',
+    ],
+
+    sourceMap: true,
+    all: true,
+
+    // thresholds can be modified once all componets have unit tests
+    threshold: {
+      statements: 60,
+      branches: 60,
+      functions: 60,
+      lines: 60,
+    },
+  },
+
+  middleware: [
+    (context, next) => {
+      const url = context.url;
+
+      // Serve source maps with correct headers
+      if (url.endsWith('.js.map')) {
+        context.type = 'application/json';
+        context.set('Access-Control-Allow-Origin', '*');
+      }
+
+      // Add source map headers for component JS files
+      if (
+        url.endsWith('.js') &&
+        url.includes('/components/') &&
+        !url.includes('__tests__')
+      ) {
+        context.set('SourceMap', url + '.map');
+      }
+
+      return next();
+    },
+  ],
+
+  testFramework: {
+    config: {
+      timeout: 5000,
+    },
   },
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19825

Post investigation, I identified that source maps were missing embedded TypeScript source content (`sourcesContent`), preventing the coverage tool from mapping JavaScript execution back to TypeScript source lines. Coverage reports consistently showed only `1/1 statements` per file despite substantial codebases containing hundreds of lines.

**Context**
- TypeScript compiler generated source maps with file references but no embedded source content
- V8 coverage collector could map execution to TypeScript line numbers but couldn't display actual code
- This resulted in only module-level statements (imports/exports) being counted



### Changelog

**New**

Enhanced source map middleware with proper headers for coverage mapping
- added coverage thresholds (60% baseline) aligned with current test state (can be changed later)


**Changed**

- Added `"inlineSources": true` in `tsconfig.json` to embed TypeScript source in maps
- Simplified Web Test Runner configuration to remove conflicting instrumentation
- Streamlined coverage configuration to focus on essential settings



#### Testing / Reviewing

verify coverage on [codecov](https://app.codecov.io/gh/carbon-design-system/carbon/tree/codecov-configs/packages) 
Run coverage locally and verify realistic metrics

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
