### PR TITLE
test(chromatic): enable turbosnap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,12 +436,15 @@ jobs:
           buildScriptName: storybook:build
           zip: true # Runs Chromatic with the option to compress the build output
           autoAcceptChanges: 'main' # Option to accept all changes on main
-          # TODO: set up TurboSnap via onlyChanged w/ externals
-          # https://www.chromatic.com/docs/github-actions/#enable-turbosnap
-          # onlyChanged: true # 👈 Required option to enable TurboSnap
-          # externals: |
-          #   packages/(colors|elements|feature-flags|grid|icons|icons-react|layout|motion|pictograms|pictograms-react|styles|themes|type|utilities|utilities-react)/**
-          #   *.sass
+          # 👇 Add debug: true and print dependency trace for changed files to help with debugging:
+          traceChanged: 'expanded'
+          debug: true
+          onlyChanged: true # 👈 Required option to enable TurboSnap
+          externals: |
+            packages/(colors|elements|feature-flags|grid|icons|icons-react|layout|motion|pictograms|pictograms-react|styles|themes|type|utilities|utilities-react)/**
+            *.sass
+          untraced: |
+            config/**
         env:
           # 👇 Set to the PR branch if it's a PR; otherwise, falls back to the pushed branch name
           CHROMATIC_BRANCH:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,7 @@ jobs:
       - name: Build project
         run: yarn build
       - name: Build storybook
-        run: yarn workspace @carbon/react storybook:build
+        run: yarn workspace @carbon/react storybook:build --stats-json
       - id: chromatic
         name: Run Chromatic
         uses: chromaui/action@4d8ebd13658d795114f8051e25c28d66f14886c6 # v13.1.2


### PR DESCRIPTION
Closes #19807

This enables TurboSnap on Chromatic.

### Changelog

**Changed**

- update ci.yml step with flags to enable turbosnap, trigger full rebuilds on changes to elements/styles, and ignoring changes to non-visual sections of the codebase like `/config/**`

#### Testing / Reviewing

- TBD, this may not work, https://www.chromatic.com/docs/turbosnap/setup/#github-pull_request-triggers

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
