### PR TITLE
fix: remove invalid aria role section for toolbar

### DIFF
--- a/packages/web-components/src/components/data-table/table-toolbar.ts
+++ b/packages/web-components/src/components/data-table/table-toolbar.ts
@@ -27,7 +27,7 @@ class CDSTableToolbar extends LitElement {
 
   connectedCallback() {
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'section');
+      this.setAttribute('role', 'toolbar');
     }
     super.connectedCallback();
   }


### PR DESCRIPTION
Closes # https://github.com/carbon-design-system/carbon/issues/19888

This PR addresses an accessibility violation in the table-toolbar component.
Per the ARIA specification, the role section is not a valid widget role.

Fix:
Replaced role="section" with role="toolbar", which is the appropriate role for the table-toolbar container to indicate a grouping of interactive controls.

BEFORE : 
<img width="1705" height="970" alt="toolbar-issue BEFORE" src="https://github.com/user-attachments/assets/cbd30d87-7d45-493e-b441-99dbc70a29ec" />


AFTER:
<img width="1705" height="970" alt="toolbar-issue AFTER" src="https://github.com/user-attachments/assets/54f8c070-da49-4c75-bbc3-4f8cd38ee410" />

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
