### PR TITLE
fix(`react`): declare `DefinitionTooltip`'s `children` prop as required in TypeScript

### DIFF
--- a/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.tsx
@@ -32,7 +32,7 @@ export interface DefinitionTooltipProps
   /**
    * The `children` prop will be used as the value that is being defined
    */
-  children?: React.ReactNode;
+  children: React.ReactNode;
 
   /**
    * Specify an optional className to be applied to the container node


### PR DESCRIPTION
Closes #19834.

Declare `DefinitionTooltip`'s `children` prop as non-nullable in TypeScript to match the PropTypes `isRequired` definition, which is the correct one [per Nikhil Tomar](https://github.com/carbon-design-system/carbon/issues/19834#issuecomment-3045439129).

### Changelog

**Changed**

- Declare `DefinitionTooltip`'s `children` prop as required in TypeScript to match the PropTypes `isRequired` definition.

#### Testing / Reviewing

In a TypeScript-enabled project, place a childless `DefinitionTooltip` and expect this error:

<img width="689" height="170" alt="image" src="https://github.com/user-attachments/assets/cc620f60-d104-4b5e-b969-19150cf21491" />

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Wrote passing tests that cover this change~~
- [ ] ~~Addressed any impact on accessibility (a11y)~~
- [ ] ~~Tested for cross-browser consistency~~
- [x] Validated that this code is ready for review and status checks should pass