### PR TITLE
fix(invalid-text): fixed global styling for invalid-text

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -206,6 +206,7 @@ export const Default = (args) => {
         itemToString={(item) => (item ? item.text : '')}
         {...args}
       />
+      <Dropdown />
     </div>
   );
 };

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -258,7 +258,7 @@ export const Test19971 = (args) => {
         itemToString={(item) => (item ? item.text : '')}
         {...args}
       />
-      <Dropdown id="test-2" items={items} />
+      <Dropdown titleText="test title " id="test-2" items={items} />
     </div>
   );
 };

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -206,7 +206,7 @@ export const Default = (args) => {
         itemToString={(item) => (item ? item.text : '')}
         {...args}
       />
-      <Dropdown />
+      <Dropdown id="default-2" />
     </div>
   );
 };

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -206,12 +206,63 @@ export const Default = (args) => {
         itemToString={(item) => (item ? item.text : '')}
         {...args}
       />
-      <Dropdown id="default-2" />
     </div>
   );
 };
 
 Default.args = {
+  ...sharedArgs,
+};
+
+// Test story, remove before merging
+export const Test19971 = (args) => {
+  const items = [
+    {
+      text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+    },
+    {
+      text: 'Option 1',
+    },
+    {
+      text: 'Option 2',
+    },
+    {
+      text: 'Option 3 - a disabled item',
+      disabled: true,
+    },
+    {
+      text: 'Option 4',
+    },
+    {
+      text: 'Option 5',
+    },
+    {
+      text: 'Option 6',
+    },
+    {
+      text: 'Option 7',
+    },
+    {
+      text: 'Option 8',
+    },
+  ];
+
+  return (
+    <div style={{ width: 400 }}>
+      <Dropdown
+        id="test-1"
+        titleText="Dropdown label"
+        helperText="This is some helper text"
+        label="Choose an option"
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+        {...args}
+      />
+      <Dropdown id="test-2" items={items} />
+    </div>
+  );
+};
+Test19971.args = {
   ...sharedArgs,
 };
 

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -214,58 +214,6 @@ Default.args = {
   ...sharedArgs,
 };
 
-// Test story, remove before merging
-export const Test19971 = (args) => {
-  const items = [
-    {
-      text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
-    },
-    {
-      text: 'Option 1',
-    },
-    {
-      text: 'Option 2',
-    },
-    {
-      text: 'Option 3 - a disabled item',
-      disabled: true,
-    },
-    {
-      text: 'Option 4',
-    },
-    {
-      text: 'Option 5',
-    },
-    {
-      text: 'Option 6',
-    },
-    {
-      text: 'Option 7',
-    },
-    {
-      text: 'Option 8',
-    },
-  ];
-
-  return (
-    <div style={{ width: 400 }}>
-      <Dropdown
-        id="test-1"
-        titleText="Dropdown label"
-        helperText="This is some helper text"
-        label="Choose an option"
-        items={items}
-        itemToString={(item) => (item ? item.text : '')}
-        {...args}
-      />
-      <Dropdown titleText="test title " id="test-2" items={items} />
-    </div>
-  );
-};
-Test19971.args = {
-  ...sharedArgs,
-};
-
 Default.argTypes = {
   ...sharedArgTypes,
 };
@@ -545,3 +493,41 @@ export const withToggletipLabel = () => {
     </div>
   );
 };
+
+// Hidden Test-Only Story. This story tests for a bug where the invalid-text would overlap with components below it. #19960
+export const TestInvalidTextNoOverlap = () => {
+  const items = [
+    {
+      text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+    },
+  ];
+
+  return (
+    <div style={{ width: 400 }}>
+      <Dropdown
+        id="test-1"
+        titleText="test invalid text, the invalid text should not overlap"
+        helperText="This is some helper text"
+        label="Choose an option"
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+        invalid
+        invalidText="invalid text, this should not overlap with the component below"
+      />
+      <Dropdown
+        titleText="test title"
+        label="Choose an option"
+        itemToString={(item) => (item ? item.text : '')}
+        id="test-2"
+        items={items}
+      />
+    </div>
+  );
+};
+/*
+ * This story will:
+ * - Be excluded from the docs page
+ * - Removed from the sidebar navigation
+ * - Still be a tested variant
+ */
+TestInvalidTextNoOverlap.tags = ['!dev', '!autodocs'];

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -198,7 +198,12 @@ const TextArea = frFn((props, forwardRef) => {
 
   const textAreaInstanceId = useId();
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const helperTextRef = useRef<HTMLDivElement>(null);
+  const errorTextRef = useRef<HTMLDivElement>(null);
+  const warnTextRef = useRef<HTMLDivElement>(null);
+
   const ref = useMergedRefs([forwardRef, textareaRef]);
 
   function getInitialTextCount(): number {
@@ -221,13 +226,20 @@ const TextArea = frFn((props, forwardRef) => {
   }, [value, defaultValue, counterMode]);
 
   useIsomorphicEffect(() => {
+    const measuredWidth = wrapperRef.current?.scrollWidth;
     if (other.cols && textareaRef.current) {
       textareaRef.current.style.width = '';
       textareaRef.current.style.resize = 'none';
     } else if (textareaRef.current) {
       textareaRef.current.style.width = `100%`;
     }
-  }, [other.cols]);
+    [helperTextRef, errorTextRef, warnTextRef].forEach((r) => {
+      if (r.current) {
+        r.current.style.maxWidth = `${measuredWidth}px`;
+        r.current.style.overflowWrap = 'break-word';
+      }
+    });
+  }, [other.cols, invalid, warn]);
 
   const textareaProps: {
     id: TextAreaProps['id'];
@@ -383,7 +395,11 @@ const TextArea = frFn((props, forwardRef) => {
     : `text-area-helper-text-${textAreaInstanceId}`;
 
   const helper = helperText ? (
-    <Text as="div" id={helperId} className={helperTextClasses}>
+    <Text
+      as="div"
+      id={helperId}
+      className={helperTextClasses}
+      ref={helperTextRef}>
       {helperText}
     </Text>
   ) : null;
@@ -395,7 +411,8 @@ const TextArea = frFn((props, forwardRef) => {
       as="div"
       role="alert"
       className={`${prefix}--form-requirement`}
-      id={errorId}>
+      id={errorId}
+      ref={errorTextRef}>
       {invalidText}
       {isFluid && (
         <WarningFilled className={`${prefix}--text-area__invalid-icon`} />
@@ -403,8 +420,15 @@ const TextArea = frFn((props, forwardRef) => {
     </Text>
   ) : null;
 
+  const warnId = id + '-warn-msg';
+
   const warning = warn ? (
-    <Text as="div" role="alert" className={`${prefix}--form-requirement`}>
+    <Text
+      as="div"
+      role="alert"
+      className={`${prefix}--form-requirement`}
+      id={warnId}
+      ref={warnTextRef}>
       {warnText}
       {isFluid && (
         <WarningAltFilled
@@ -493,7 +517,10 @@ const TextArea = frFn((props, forwardRef) => {
         {label}
         {counter}
       </div>
-      <div className={textAreaWrapperClasses} data-invalid={invalid || null}>
+      <div
+        ref={wrapperRef}
+        className={textAreaWrapperClasses}
+        data-invalid={invalid || null}>
         {invalid && !isFluid && (
           <WarningFilled className={`${prefix}--text-area__invalid-icon`} />
         )}

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -143,7 +143,7 @@ export const Test19971 = (args) => {
   return (
     <div style={{ width: args.defaultWidth }}>
       <TextInput {...args} id="text-input-1" type="text" />
-      <TextInput id="text-input-2" type="text" />
+      <TextInput labelText="test label" id="text-input-2" type="text" />
     </div>
   );
 };

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -126,7 +126,7 @@ export const Default = (args) => {
           id="text-input-2"
           type="text"
         />
-        <TextInput labelText="labelText" id="text-input-2" type="text" />
+        <TextInput labelText="labelText" id="text-input-3" type="text" />
       </div>
     </div>
   );

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -117,8 +117,17 @@ const sharedArgTypes = {
 
 export const Default = (args) => {
   return (
-    <div style={{ width: args.defaultWidth }}>
-      <TextInput {...args} id="text-input-1" type="text" />
+    <div>
+      <div style={{ width: args.defaultWidth }}>
+        <TextInput {...args} id="text-input-1" type="text" />
+        <TextInput
+          invalid
+          invalidText="this is invalid"
+          id="text-input-2"
+          type="text"
+        />
+        <TextInput labelText="labelText" id="text-input-2" type="text" />
+      </div>
     </div>
   );
 };

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -117,22 +117,38 @@ const sharedArgTypes = {
 
 export const Default = (args) => {
   return (
-    <div>
-      <div style={{ width: args.defaultWidth }}>
-        <TextInput {...args} id="text-input-1" type="text" />
-        <TextInput
-          invalid
-          invalidText="this is invalid"
-          id="text-input-2"
-          type="text"
-        />
-        <TextInput labelText="labelText" id="text-input-3" type="text" />
-      </div>
+    <div style={{ width: args.defaultWidth }}>
+      <TextInput {...args} id="text-input-1" type="text" />
     </div>
   );
 };
 
 Default.args = {
+  defaultWidth: 300,
+  className: 'input-test-class',
+  placeholder: 'Placeholder text',
+  invalid: false,
+  invalidText: 'Error message goes here',
+  disabled: false,
+  labelText: 'Label text',
+  helperText: 'Helper text',
+  warn: false,
+  warnText:
+    'Warning message that is really long can wrap to more lines but should not be excessively long.',
+  size: 'md',
+};
+
+// Test story, remove before merging
+export const Test19971 = (args) => {
+  return (
+    <div style={{ width: args.defaultWidth }}>
+      <TextInput {...args} id="text-input-1" type="text" />
+      <TextInput id="text-input-2" type="text" />
+    </div>
+  );
+};
+
+Test19971.args = {
   defaultWidth: 300,
   className: 'input-test-class',
   placeholder: 'Placeholder text',

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -138,31 +138,6 @@ Default.args = {
   size: 'md',
 };
 
-// Test story, remove before merging
-export const Test19971 = (args) => {
-  return (
-    <div style={{ width: args.defaultWidth }}>
-      <TextInput {...args} id="text-input-1" type="text" />
-      <TextInput labelText="test label" id="text-input-2" type="text" />
-    </div>
-  );
-};
-
-Test19971.args = {
-  defaultWidth: 300,
-  className: 'input-test-class',
-  placeholder: 'Placeholder text',
-  invalid: false,
-  invalidText: 'Error message goes here',
-  disabled: false,
-  labelText: 'Label text',
-  helperText: 'Helper text',
-  warn: false,
-  warnText:
-    'Warning message that is really long can wrap to more lines but should not be excessively long.',
-  size: 'md',
-};
-
 Default.argTypes = {
   ...sharedArgTypes,
 };
@@ -250,3 +225,27 @@ withAILabel.argTypes = {
 export const Skeleton = () => {
   return <TextInputSkeleton />;
 };
+
+// Hidden Test-Only Story. This story tests for a bug where the invalid-text would overlap with components below it. #19960
+export const TestInvalidTextNoOverlap = (args) => {
+  return (
+    <div style={{ width: args.defaultWidth }}>
+      <TextInput
+        labelText="test invalid text, the invalid text should not overlap"
+        invalid
+        invalidText="invalid text, this should not overlap with the component below"
+        id="text-input-1"
+        type="text"
+      />
+      <TextInput labelText="test label" id="text-input-2" type="text" />
+    </div>
+  );
+};
+
+/*
+ * This story will:
+ * - Be excluded from the docs page
+ * - Removed from the sidebar navigation
+ * - Still be a tested variant
+ */
+TestInvalidTextNoOverlap.tags = ['!dev', '!autodocs'];

--- a/packages/styles/scss/components/text-area/_text-area.scss
+++ b/packages/styles/scss/components/text-area/_text-area.scss
@@ -61,10 +61,6 @@
     background-color: $field-02;
   }
 
-  .#{$prefix}--text-area--invalid {
-    padding-inline-end: $spacing-08;
-  }
-
   .#{$prefix}--text-area__wrapper {
     @include layout.use('density', $default: 'normal');
 
@@ -246,13 +242,5 @@
     display: flex;
     justify-content: space-between;
     inline-size: 100%;
-  }
-
-  .#{$prefix}--form-item:has(.#{$prefix}--text-area) {
-    position: relative;
-    .#{$prefix}--form-requirement {
-      position: absolute;
-      inset-block-start: 100%;
-    }
   }
 }

--- a/packages/styles/scss/components/text-area/_text-area.scss
+++ b/packages/styles/scss/components/text-area/_text-area.scss
@@ -106,7 +106,6 @@
   }
 
   .#{$prefix}--form-item {
-    position: relative;
     &:has(.#{$prefix}--text-area__wrapper--cols) {
       inline-size: fit-content;
     }
@@ -248,7 +247,12 @@
     justify-content: space-between;
     inline-size: 100%;
   }
-  .#{$prefix}--form-requirement {
+
+  .#{$prefix}--form-item:has(.#{$prefix}--text-area) {
+    position: relative;
+  }
+
+  .#{$prefix}--text-area__wrapper + .#{$prefix}--form-requirement {
     position: absolute;
     inset-block-start: 100%;
   }

--- a/packages/styles/scss/components/text-area/_text-area.scss
+++ b/packages/styles/scss/components/text-area/_text-area.scss
@@ -250,10 +250,9 @@
 
   .#{$prefix}--form-item:has(.#{$prefix}--text-area) {
     position: relative;
-  }
-
-  .#{$prefix}--text-area__wrapper + .#{$prefix}--form-requirement {
-    position: absolute;
-    inset-block-start: 100%;
+    .#{$prefix}--form-requirement {
+      position: absolute;
+      inset-block-start: 100%;
+    }
   }
 }

--- a/packages/web-components/src/components/textarea/textarea.scss
+++ b/packages/web-components/src/components/textarea/textarea.scss
@@ -42,6 +42,7 @@ $css--plex: true !default;
 :host(#{$prefix}-textarea[warn]),
 :host(#{$prefix}-textarea[invalid]) {
   .#{$prefix}--form-requirement {
+    position: absolute;
     inset-block-start: auto;
   }
   .#{$prefix}--text-area__wrapper--decorator {

--- a/packages/web-components/src/components/textarea/textarea.scss
+++ b/packages/web-components/src/components/textarea/textarea.scss
@@ -13,7 +13,6 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/utilities/ai-gradient' as *;
 
 :host(#{$prefix}-textarea) {
-  position: relative;
   @include emit-layout-tokens();
 
   outline: none;
@@ -41,10 +40,6 @@ $css--plex: true !default;
 
 :host(#{$prefix}-textarea[warn]),
 :host(#{$prefix}-textarea[invalid]) {
-  .#{$prefix}--form-requirement {
-    position: absolute;
-    inset-block-start: auto;
-  }
   .#{$prefix}--text-area__wrapper--decorator {
     .#{$prefix}--text-area {
       padding-inline-end: $spacing-10;

--- a/packages/web-components/src/components/textarea/textarea.ts
+++ b/packages/web-components/src/components/textarea/textarea.ts
@@ -154,6 +154,12 @@ class CDSTextarea extends CDSTextInput {
    */
   private _prevCounterMode: 'character' | 'word' = this.counterMode;
 
+  /**
+   * The previous cols value. This lets updated() conditionally call _measureWrapper()
+   * if the cols value has changed.
+   */
+  private _prevCols?: number;
+
   render() {
     const { enableCounter, maxCount } = this;
 
@@ -265,6 +271,10 @@ class CDSTextarea extends CDSTextInput {
   }
   updated(): void {
     super.updated?.();
+    if (this.cols !== this._prevCols) {
+      this._prevCols = this.cols;
+      this._measureWrapper();
+    }
     if (this.counterMode !== this._prevCounterMode) {
       const textarea = this._textarea;
       if (textarea) {
@@ -276,6 +286,31 @@ class CDSTextarea extends CDSTextInput {
       }
       this._prevCounterMode = this.counterMode;
     }
+  }
+
+  /**
+   * Measures the width of the wrapper and applies that to the max-width of the
+   * helper-text and invalid/warn-text
+   */
+  private _measureWrapper() {
+    const wrapper = this.shadowRoot?.querySelector<HTMLElement>(
+      `.${prefix}--text-area__wrapper`
+    );
+
+    const wrapperWidth = wrapper?.scrollWidth;
+
+    const helper = this.shadowRoot?.querySelector<HTMLElement>(
+      `.${prefix}--form__helper-text`
+    );
+    const requirement = this.shadowRoot?.querySelector<HTMLElement>(
+      `.${prefix}--form-requirement`
+    );
+    [helper, requirement].forEach((el) => {
+      if (el) {
+        el.style.maxWidth = `${wrapperWidth}px`;
+        el.style.overflowWrap = 'break-word';
+      }
+    });
   }
 
   static shadowRootOptions = {


### PR DESCRIPTION
Closes #19960 
Closes #19967

There was a styling bug where invalidText would have the incorrect behaviour. For `TextInput` it would overlap with components below it, for `Dropdown` it would not show up at all when there are components below it, for `Checkbox` there would be alignment issues, etc.

This PR fixes this bug and re-implements the invalid-text overflow functionality when `cols` is used for `TextArea` for both React and Web Components since the original implementation was problematic.

### Changelog

**New**

- Added hidden test-only story for Dropdown: `?path=/story/components-textinput--test-invalid-text-no-overlap`
- Added hidden test-only story for TextInput: `?path=/story/components-textinput--test-invalid-text-no-overlap`

- Added `warnId` to the warn text in `TextArea` in React since it was missing

**Changed**

- Changed the implementation of the helper/invalid/warn-text overflow when the `cols` attribute was used in `TextArea` for React and WC:
    - _React_: Added refs for helper, invalid and warn texts and the wrapper which is then used to update their max-width accordingly in `useIsomorphicEffect` when the `cols` prop changes.
    - _WC_: Added a private `_measureWrapper()` function which, when `cols` is changed, measures the width of the wrapper and applies the appropriate styles to the helper/invalid/warn text.

**Removed**

- Removed `position: absolute` and `position: relative` styling that was used to implement text-overflow from React and WC `TextArea` since it was problematic
- Removed `.#{$prefix}--text-area--invalid {padding-inline-end: $spacing-08;}` from `_text-area.scss` since this was causing `TextArea` to increase its width past the set `cols` width when `invalid='true'`


#### Testing / Reviewing

- Go to https://deploy-preview-19971--v11-carbon-react.netlify.app/?path=/story/components-dropdown--test-invalid-text-no-overlap
    - Invalid text should not overlap with component below and should be visible
- Go to https://deploy-preview-19971--v11-carbon-react.netlify.app/?path=/story/components-textinput--test-invalid-text-no-overlap
    - Invalid text should not overlap with component below and should be visible
- Go to `Checkbox` in React storybook
    - Go to Single story
    - Invalid text should be aligned
- Go to `TextArea` in React storybook
    - Set `cols=2` and `invalid='true'`
    - Invalid text should wrap
- Go to `TextArea` in Web Components storybook
    - Set `cols=2` and `invalid='true'`
    - Invalid text should wrap
- Can also test with helper text and warn text to make sure they work as well

- There should be no regression