### PR TITLE
feat(skeleton-placeholder): add parts to allow for external styling

### DIFF
--- a/packages/web-components/src/components/ai-skeleton/ai-skeleton-placeholder.ts
+++ b/packages/web-components/src/components/ai-skeleton/ai-skeleton-placeholder.ts
@@ -20,6 +20,7 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
 class CDSAISkeletonPlaceholder extends LitElement {
   render() {
     return html`<cds-skeleton-placeholder
+      exportparts="placeholder:skeleton-placeholder"
       optional-classes="${prefix}--skeleton__placeholder--ai"></cds-skeleton-placeholder>`;
   }
 

--- a/packages/web-components/src/components/skeleton-placeholder/skeleton-placeholder.ts
+++ b/packages/web-components/src/components/skeleton-placeholder/skeleton-placeholder.ts
@@ -39,7 +39,7 @@ class CDSSkeletonPlaceholder extends LitElement {
     }
     const classes = classMap(defaultClasses);
 
-    return html` <div class="${classes}"></div> `;
+    return html` <div part="placeholder" class="${classes}"></div> `;
   }
 
   static styles = styles;


### PR DESCRIPTION
Closes #

Currently working on AI Chat which leverages components from `@carbon/web-components`. For the chat, the `cds-ai-skeleton-placeholder` component width needs to be adjusted. This PR adds `part`s to the skeleton-placeholder components to allow for that flexibility.

```
cds-ai-skeleton-placeholder::part(skeleton-placeholder) {
    inline-size: 100%;
}
```

### Changelog

**New**

- add `part` to `skeleton-placeholder` component
- add `exportparts` to the `skeleton-placeholder` from within `ai-skeleton-placeholder` to reach further into the shadowDOM

#### Testing / Reviewing

You can add the above styles to the `ai-skeleton-placeholder` story to see that it works

ai-skeleton-placeholder.stories.ts
```
render: () => {
    return html`
    <style>
      cds-ai-skeleton-placeholder::part(skeleton-placeholder) {
        inline-size: 100%;
      }
    </style>
    <cds-ai-skeleton-placeholder
      class="test"></cds-ai-skeleton-placeholder>`;
  },
  ```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
