### PR TITLE
select all checkbox bug in data-table's radio selection version

### DIFF
--- a/packages/web-components/src/components/data-table/stories/data-table-selection.stories.ts
+++ b/packages/web-components/src/components/data-table/stories/data-table-selection.stories.ts
@@ -56,8 +56,23 @@ const controls = {
 };
 
 export const Default = {
-  render: () => html`
-    <cds-table>
+  args: defaultArgs,
+  argTypes: controls,
+  render: ({
+    isSortable,
+    locale,
+    radio,
+    size,
+    useStaticWidth,
+    useZebraStyles,
+  }) => html`
+    <cds-table
+      ?is-sortable=${isSortable}
+      locale="${locale}"
+      ?radio=${radio}
+      size="${size}"
+      ?use-static-width="${useStaticWidth}"
+      ?use-zebra-styles="${useZebraStyles}">
       <cds-table-header-title slot="title">DataTable</cds-table-header-title>
       <cds-table-header-description slot="description"
         >With selection</cds-table-header-description
@@ -210,97 +225,6 @@ export const WithRadioSelection = {
 export const WithSelectionAndSorting = {
   render: () => html`
     <cds-table is-sortable>
-      <cds-table-header-title slot="title">DataTable</cds-table-header-title>
-      <cds-table-header-description slot="description"
-        >With selection</cds-table-header-description
-      >
-
-      <cds-table-head>
-        <cds-table-header-row selection-name="header">
-          <cds-table-header-cell>Name</cds-table-header-cell>
-          <cds-table-header-cell>Protocol</cds-table-header-cell>
-          <cds-table-header-cell>Port</cds-table-header-cell>
-          <cds-table-header-cell>Rule</cds-table-header-cell>
-          <cds-table-header-cell>Attached groups</cds-table-header-cell>
-          <cds-table-header-cell>Status</cds-table-header-cell>
-        </cds-table-header-row>
-      </cds-table-head>
-      <cds-table-body>
-        <cds-table-row selection-name="0">
-          <cds-table-cell>Load Balancer 3</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>3000</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Kevin's VM Groups</cds-table-cell>
-          <cds-table-cell
-            ><cds-link disabled>Disabled</cds-link></cds-table-cell
-          >
-        </cds-table-row>
-        <cds-table-row selection-name="1">
-          <cds-table-cell>Load Balancer 1</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>443</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Maureen's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-row selection-name="2">
-          <cds-table-cell>Load Balancer 2</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>80</cds-table-cell>
-          <cds-table-cell>DNS delegation</cds-table-cell>
-          <cds-table-cell>Andrew's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-row selection-name="3">
-          <cds-table-cell>Load Balancer 6</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>3000</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Marc's VM Groups</cds-table-cell>
-          <cds-table-cell
-            ><cds-link disabled>Disabled</cds-link></cds-table-cell
-          >
-        </cds-table-row>
-        <cds-table-row selection-name="4">
-          <cds-table-cell>Load Balancer 4</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>443</cds-table-cell>
-          <cds-table-cell>Round robin</cds-table-cell>
-          <cds-table-cell>Mel's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Starting</cds-link></cds-table-cell>
-        </cds-table-row>
-        <cds-table-row selection-name="5">
-          <cds-table-cell>Load Balancer 5</cds-table-cell>
-          <cds-table-cell>HTTP</cds-table-cell>
-          <cds-table-cell>80</cds-table-cell>
-          <cds-table-cell>DNS delegation</cds-table-cell>
-          <cds-table-cell>Ronja's VM Groups</cds-table-cell>
-          <cds-table-cell><cds-link>Active</cds-link></cds-table-cell>
-        </cds-table-row>
-      </cds-table-body>
-    </cds-table>
-  `,
-};
-
-export const Playground = {
-  args: defaultArgs,
-  argTypes: controls,
-  render: ({
-    isSortable,
-    locale,
-    radio,
-    size,
-    useStaticWidth,
-    useZebraStyles,
-  }) => html`
-    <cds-table
-      ?is-sortable=${isSortable}
-      locale="${locale}"
-      ?radio=${radio}
-      size="${size}"
-      ?use-static-width="${useStaticWidth}"
-      ?use-zebra-styles="${useZebraStyles}">
       <cds-table-header-title slot="title">DataTable</cds-table-header-title>
       <cds-table-header-description slot="description"
         >With selection</cds-table-header-description

--- a/packages/web-components/src/components/data-table/table.ts
+++ b/packages/web-components/src/components/data-table/table.ts
@@ -755,6 +755,9 @@ class CDSTable extends HostListenerMixin(LitElement) {
           (elem as CDSTableRow).radio = this.radio;
         }
       );
+      if (this._tableHeaderRow) {
+        this._tableHeaderRow.hideCheckbox = this.radio;
+      }
     }
 
     if (changedProperties.has('size')) {


### PR DESCRIPTION
Closes #19846 

Fixes the select all checkbox appearing in the radio selection.

### Changelog

**New**

- included this condition when the radio selection gets rendered
```
      if (this._tableHeaderRow) {
        this._tableHeaderRow.hideCheckbox = this.radio;
      }
``` 
- added controls to the data-table selection variant's default story 

**Removed**

- removed the playground story

#### Testing / Reviewing


- open the default story of the data-table selection variant
- in the controls, change to the radio selection.
- now you can verify that the select-all checkbox isn't appearing


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
