### PR TITLE
fix(feature-flags): update cjs entrypoint

### DIFF
--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -3,8 +3,7 @@
   "description": "Build with feature flags in Carbon",
   "version": "0.28.0",
   "license": "Apache-2.0",
-  "type": "module",
-  "main": "es/index.js",
+  "main": "lib/index.js",
   "module": "es/index.js",
   "sass": "index.scss",
   "repository": {


### PR DESCRIPTION
Closes #19980 

Update entrypoint for CommonJS. This also reverts the change in https://github.com/carbon-design-system/carbon/pull/19883 making `@carbon/feature-flags` ESM by default. A better way to do this would be to update all packages to ESM at the same time.

### Changelog

**Changed**

- update CJS entrypoint for `@carbon/feature-flags`

#### Testing / Reviewing

Everything should build and all tests/CI should pass.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
