### PR TITLE
fix(Button): adjust padding for icon-only buttons

### DIFF
--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -150,17 +150,15 @@
   }
 
   .#{$prefix}--btn--icon-only {
+    align-items: center;
     justify-content: center;
+
     padding: 0;
+
     block-size: layout.size('height');
     inline-size: layout.size('height');
-    // -1px to compensate for border width
-    padding-block-start: min(
-      calc(
-        (layout.size('height') - convert.to-rem(16px)) / 2 - convert.to-rem(1px)
-      ),
-      var(--temp-padding-block-max)
-    );
+
+    padding-block-start: 0;
 
     > :first-child {
       min-inline-size: convert.to-rem(16px);

--- a/packages/styles/scss/components/button/_button.scss
+++ b/packages/styles/scss/components/button/_button.scss
@@ -152,12 +152,9 @@
   .#{$prefix}--btn--icon-only {
     align-items: center;
     justify-content: center;
-
     padding: 0;
-
     block-size: layout.size('height');
     inline-size: layout.size('height');
-
     padding-block-start: 0;
 
     > :first-child {

--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -100,20 +100,23 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-button) {
+  .#{$prefix}--btn--icon-only {
+    align-items: center;
+    padding-block-start: 0;
+
+    &.#{$prefix}--btn--selected,
+    &.#{$prefix}--btn--expressive {
+      padding: $spacing-03;
+    }
+  }
+}
+
 :host(#{$prefix}-button[kind='ghost']) {
   .#{$prefix}--btn--ghost {
     &:hover,
     &:active {
       outline: none;
-    }
-
-    &.#{$prefix}--btn--icon-only {
-      padding-block-start: 0;
-
-      &.#{$prefix}--btn--selected,
-      &.#{$prefix}--btn--expressive {
-        padding: $spacing-03;
-      }
     }
 
     &:not(:focus) {


### PR DESCRIPTION
Closes #18561 

- Fixed icon button centering of the icon
- [WebComponents] Also fixes a bug where isExpressive = true also had alignment issues (it was fixed only for ghost now fixed for all icon buttons)

### Changelog

**Changed**

- fixed icon button styling for icon alignment by setting `padding-block-start` to 0 and using `align-items: center`
  - web-components
  - react

#### Testing / Reviewing

Go to [Icon Button](https://deploy-preview-19991--v11-carbon-web-components.netlify.app/?path=/story/components-button--icon-button&args=type:button;size:xl;isExpressive:!true)
Verify that:
Icon is properly centered in the various buttons (primary, ghost, etc..)
Hover and active states work correctly
Other button variants (primary, secondary, danger) maintain their correct alignment
Selected state of ghost button maintains proper icon alignment

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
