### PR TITLE
fix(styles): use valid media query

### DIFF
--- a/packages/styles/scss/components/code-snippet/_code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet/_code-snippet.scss
@@ -508,15 +508,14 @@ $copy-btn-feedback: $background-inverse !default;
   // Safari-only media query
   // since fades won't appear correctly with CSS custom properties
   // see: tabs, code snippet, and modal overflow indicators
-  @media not all and (min-resolution >= 0.001dpcm) {
-    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-      .#{$prefix}--snippet__overflow-indicator--left {
-        background-image: linear-gradient(to left, rgba($layer, 0), $layer);
-      }
+  @supports (hanging-punctuation: first) and (font: -apple-system-body) and
+    (-webkit-appearance: none) {
+    .#{$prefix}--snippet__overflow-indicator--left {
+      background-image: linear-gradient(to left, rgba($layer, 0), $layer);
+    }
 
-      .#{$prefix}--snippet__overflow-indicator--right {
-        background-image: linear-gradient(to right, rgba($layer, 0), $layer);
-      }
+    .#{$prefix}--snippet__overflow-indicator--right {
+      background-image: linear-gradient(to right, rgba($layer, 0), $layer);
     }
   }
 

--- a/packages/styles/scss/components/loading/_loading.scss
+++ b/packages/styles/scss/components/loading/_loading.scss
@@ -76,12 +76,11 @@
   }
 
   // Negative values for `stroke-dashoffset` are not supported in Safari
-  @media not all and (resolution >= 0.001dpcm) {
-    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-      circle.#{$prefix}--loading__background {
-        stroke-dasharray: 265;
-        stroke-dashoffset: 0;
-      }
+  @supports (hanging-punctuation: first) and (font: -apple-system-body) and
+    (-webkit-appearance: none) {
+    circle.#{$prefix}--loading__background {
+      stroke-dasharray: 265;
+      stroke-dashoffset: 0;
     }
   }
 

--- a/packages/styles/scss/components/tabs/_tabs.scss
+++ b/packages/styles/scss/components/tabs/_tabs.scss
@@ -258,41 +258,40 @@
     // Safari-only media query
     // won't appear correctly with CSS custom properties
     // see: code snippet and modal overflow indicators
-    @media not all and (resolution >= 0.001dpcm) {
-      @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    @supports (hanging-punctuation: first) and (font: -apple-system-body) and
+      (-webkit-appearance: none) {
+      .#{$prefix}--tabs__overflow-indicator--left {
+        background-image: linear-gradient(
+          to left,
+          rgba($background, 0),
+          $background
+        );
+      }
+
+      .#{$prefix}--tabs__overflow-indicator--right {
+        background-image: linear-gradient(
+          to right,
+          rgba($background, 0),
+          $background
+        );
+      }
+
+      &.#{$prefix}--tabs--contained
         .#{$prefix}--tabs__overflow-indicator--left {
-          background-image: linear-gradient(
-            to left,
-            rgba($background, 0),
-            $background
-          );
-        }
+        background-image: linear-gradient(
+          to left,
+          rgba($layer-accent, 0),
+          $layer-accent
+        );
+      }
 
+      &.#{$prefix}--tabs--contained
         .#{$prefix}--tabs__overflow-indicator--right {
-          background-image: linear-gradient(
-            to right,
-            rgba($background, 0),
-            $background
-          );
-        }
-
-        &.#{$prefix}--tabs--contained
-          .#{$prefix}--tabs__overflow-indicator--left {
-          background-image: linear-gradient(
-            to left,
-            rgba($layer-accent, 0),
-            $layer-accent
-          );
-        }
-
-        &.#{$prefix}--tabs--contained
-          .#{$prefix}--tabs__overflow-indicator--right {
-          background-image: linear-gradient(
-            to right,
-            rgba($layer-accent, 0),
-            $layer-accent
-          );
-        }
+        background-image: linear-gradient(
+          to right,
+          rgba($layer-accent, 0),
+          $layer-accent
+        );
       }
     }
 

--- a/packages/styles/scss/components/tag/_tag.scss
+++ b/packages/styles/scss/components/tag/_tag.scss
@@ -381,10 +381,9 @@
     inline-size: convert.to-rem(60px);
 
     // Safari specific bug (#7672)
-    @media not all and (min-resolution >= 0.001dpcm) {
-      @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-        transform: translateZ(0);
-      }
+    @supports (hanging-punctuation: first) and (font: -apple-system-body) and
+      (-webkit-appearance: none) {
+      transform: translateZ(0);
     }
   }
 

--- a/packages/styles/scss/components/tile/_tile.scss
+++ b/packages/styles/scss/components/tile/_tile.scss
@@ -316,10 +316,9 @@ $-icon-container-size: calc(#{layout.density('padding-inline')} * 2 + 1rem);
       // Safari-only media query
       // Fixes an issue with scrolling
       // and absolutely positioned elements (#8119)
-      @media not all and (resolution >= 0.001dpcm) {
-        @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-          overflow-y: auto;
-        }
+      @supports (hanging-punctuation: first) and (font: -apple-system-body) and
+        (-webkit-appearance: none) {
+        overflow-y: auto;
       }
     }
   }


### PR DESCRIPTION
Closes #17337 

I was also hitting this issue that was originally documented by @kubijo after attempting to use `rolldown-vite` (which uses `lightningcss`) in `@carbon/ibm-products`. I just refactored the invalid media query with an alternative approach using `@supports` to only target Safari.

### Changelog

**Changed**

- `packages/styles/scss/components/code-snippet/_code-snippet.scss`
- `packages/styles/scss/components/loading/_loading.scss`
- `packages/styles/scss/components/tabs/_tabs.scss`
- `packages/styles/scss/components/tag/_tag.scss`
- `packages/styles/scss/components/tile/_tile.scss`

#### Testing / Reviewing

Verified across browsers that these components still render the same

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
