### PR TITLE
feat(operational-tag): add parts to allow for external styling

### DIFF
--- a/packages/web-components/src/components/tag/__tests__/tag-test.js
+++ b/packages/web-components/src/components/tag/__tests__/tag-test.js
@@ -296,6 +296,14 @@ describe('cds-tag', function () {
 
       await expect(el).dom.to.equalSnapshot();
     });
+
+    it('should expose part on tag', async () => {
+      const operationalTag = html`<cds-operational-tag
+        text="Tag content"></cds-operational-tag>`;
+      const el = await fixture(operationalTag);
+
+      expect(el.shadowRoot.querySelector('[part="tag"]')).to.exist;
+    });
   });
 
   it('should render as a filter tag', async () => {

--- a/packages/web-components/src/components/tag/operational-tag.ts
+++ b/packages/web-components/src/components/tag/operational-tag.ts
@@ -152,6 +152,7 @@ class CDSOperationalTag extends HostListenerMixin(FocusMixin(LitElement)) {
           closeOnActivation
           leave-delay-ms=${0}>
           <cds-tag
+            part="tag"
             ?aria-pressed="${selected}"
             size="${size}"
             ?disabled="${disabled}"
@@ -166,6 +167,7 @@ class CDSOperationalTag extends HostListenerMixin(FocusMixin(LitElement)) {
         </cds-tooltip>`
       : html`
           <cds-tag
+            part="tag"
             ?aria-pressed="${selected}"
             size="${size}"
             ?disabled="${disabled}"


### PR DESCRIPTION
Closes #

Currently working on an AI Chat that leverages components from @carbon/web-components. This PR adds part attributes to the `cds-tag` inside `cds-operational-tag` to allow block size adjustments.

```
cds-operational-tag::part(tag) {
  block-size: 20px;
}
```

### Changelog

**New**

- add `part` to `tag` component inside `operational-tag`

#### Testing / Reviewing

we can verify this by adding above styles to operational tag story

packages/web-components/src/components/tag/tag.stories.ts

```
render: () => {
...
    return html`
    <style>
      cds-operational-tag::part(tag) {
        block-size: 20px;
      }
    </style>
...
  },
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
