### PR TITLE
fix(form): change helper text color to $text-helper

### DIFF
--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -233,7 +233,7 @@ $input-label-weight: 400 !default;
     @include type-style('helper-text-01');
 
     z-index: 0;
-    color: $text-secondary;
+    color: $text-helper;
     // Added to prevent error text from displaying under helper text in Safari (#6392)
     inline-size: 100%;
     margin-block-start: $spacing-02;


### PR DESCRIPTION
Currently, all helper texts are using `$text-secondary` as their text color despite the specifications stating it should be `$text-helper`.

Example: [TextInput](https://carbondesignsystem.com/components/text-input/style/#text-input-color)
<img width="810" height="442" alt="image" src="https://github.com/user-attachments/assets/251a37ab-6216-4f10-b4b4-526feec4cbd6" />
<img width="473" height="154" alt="image" src="https://github.com/user-attachments/assets/ff3e83eb-0ddc-4ae7-976f-293b16e50917" />


### Changelog

**Changed**

- Update `$text-secondary` to `$text-helper` for helper texts in `form.scss`

#### Testing / Reviewing

- Review deployed storybook preview for the following components:
  - Checkbox
  - ComboBox
  - DatePicker
  - Dropdown
  - MultiSelect
  - NumberInput
  - PasswordInput
  - RadioButton
  - Select
  - TextArea
  - TextInput

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass
