### PR TITLE
chore(gh): update wc CDN publishing workflow

### DIFF
--- a/.github/workflows/publish-web-components-cdn-v2.yml
+++ b/.github/workflows/publish-web-components-cdn-v2.yml
@@ -1,0 +1,76 @@
+name: Publish Web Components CDN artifacts to Cloud Object Storage
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      # Matches tags that have the shape `vX.Y.Z` or `vX.Y.Z-rc.X` Reference:
+      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      - '!v10*'
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-cdn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: '0'
+
+      - name: Use Node.js version from .nvmrc
+        uses: actions/setup-node@7e24a656e1c7a0d6f3eaef8d8e84ae379a5b035b
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: |
+          yarn install
+          yarn build
+
+      - name: Check release type
+        if: contains(github.ref_name, '-rc.')
+        run: echo "PRE_RELEASE=true" >> $GITHUB_ENV
+
+      - name: Get version of web components from package.json
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+        with:
+          path: packages/web-components
+
+      - name: Configure IBM Cloud credentials
+        uses: aws-actions/configure-aws-credentials@v4.2.1
+        with:
+          aws-access-key-id: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.COMMON_COS_REGION }}
+
+      - name: Upload CDN artifacts
+        run: |
+          upload() {
+            local DEST=$1
+            echo "Uploading to $DEST"
+            aws s3 sync packages/web-components/dist \
+              s3://${{ secrets.COMMON_COS_BUCKET }}/$DEST \
+              --acl public-read \
+              --follow-symlinks \
+              --endpoint-url https://${{ secrets.COMMON_COS_ENDPOINT }}
+          }
+        
+          if [ "$PRE_RELEASE" = "true" ]; then
+            # If tag is a release candidate, upload the CDN artifacts to the `next` tag folder
+            # ie. https://1.www.s81c.com/common/carbon/web-components/tag/v2/next/breadcrumb.min.js
+            upload "common/carbon/web-components/tag/v2/next"
+          else
+            # If tag is a full release, upload the CDN artifacts to the `latest` tag folder
+            # ie. https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/breadcrumb.min.js
+            upload "common/carbon/web-components/tag/v2/latest"
+          fi
+
+          # Upload the CDN artifacts to versioned folder
+          # ie. https://1.www.s81c.com/common/carbon/web-components/version/v2.12.0/breadcrumb.min.js
+          upload "common/carbon/web-components/version/v${{ steps.package-version.outputs.current-version }}"


### PR DESCRIPTION
This tests a fix for https://github.com/carbon-design-system/carbon/issues/19985 with a test workflow file `publish-web-components-cdn-v2.yml`. The current workflow randomly adds subdirectories into the destination paths. This has even happened from an `rc` release to a full release, when no changes were made to the project. This may be related to a very outdated action being used to push artifacts.

This consolidates the workflow a bit, while also using a combination of an official AWS Github action and some manual CLI commands.

If this fixes the issue, it will replace the current [workflow](https://github.com/carbon-design-system/carbon/blob/main/.github/workflows/publish-web-components-cdn.yml).

### Changelog

**New**

- use `aws-actions/configure-aws-credentials` workflow for sync setup
- add manual `aws sync` command for pushing

**Changed**

- consolidate IBM COS credentials

**Removed**

- `jakejarvis/s3-sync-action` Github action

#### Testing / Reviewing

Once merged, a custom, test tag can be pushed to the repo to trigger [this job](https://github.com/carbon-design-system/carbon/actions/workflows/publish-web-components-cdn.yml). Artifact paths should be:

**next**
```bash
/common/carbon/web-components/tag/v2/next/accordion/index.min.js

# this is wrong
/common/carbon/web-components/tag/v2/next/components/accordion/index.min.js

```

**latest**
```bash
/common/carbon/web-components/tag/v2/latest/accordion/index.min.js

# this is wrong
/common/carbon/web-components/tag/v2/latest/components/accordion/index.min.js

```

**version**
```bash
common/carbon/web-components/version/v2.33.0/accordion.min.js

# this is wrong
/common/carbon/web-components/version/v2.33.0/components/accordion/index.min.js

```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
