### PR TITLE
feat(selectall): Update selectAll behaviours for filterable-multiselect

### DIFF
--- a/packages/web-components/src/components/multi-select/__tests__/multi-select-test.js
+++ b/packages/web-components/src/components/multi-select/__tests__/multi-select-test.js
@@ -1669,6 +1669,10 @@ describe('cds-multi-select', function () {
         'cds-multi-select-item[is-select-all]'
       );
 
+      // no items are selected
+      expect(selectAllItem.hasAttribute('selected')).to.be.false;
+      expect(selectAllItem.hasAttribute('indeterminate')).to.be.false;
+
       // filter to “foo”
       input.value = 'foo';
       input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/packages/web-components/src/components/multi-select/__tests__/multi-select-test.js
+++ b/packages/web-components/src/components/multi-select/__tests__/multi-select-test.js
@@ -1047,56 +1047,6 @@ describe('cds-multi-select', function () {
       expect(items[0].hasAttribute('is-select-all')).to.be.true;
     });
 
-    it('should handle select-all with filterable multiselect', async () => {
-      const el = await fixture(html`
-        <cds-multi-select label="test-label" select-all filterable>
-          <cds-multi-select-item is-select-all
-            >Select All</cds-multi-select-item
-          >
-          <cds-multi-select-item value="apple">Apple</cds-multi-select-item>
-          <cds-multi-select-item value="banana">Banana</cds-multi-select-item>
-          <cds-multi-select-item value="cherry">Cherry</cds-multi-select-item>
-        </cds-multi-select>
-      `);
-
-      const trigger = el.shadowRoot.querySelector('.cds--list-box__field');
-      trigger.click();
-      await el.updateComplete;
-
-      const filterInput = el.shadowRoot.querySelector('input');
-      const selectAllItem = el.querySelector(
-        'cds-multi-select-item[is-select-all]'
-      );
-
-      filterInput.value = 'a';
-      filterInput.dispatchEvent(new Event('input', { bubbles: true }));
-      await el.updateComplete;
-
-      expect(selectAllItem.hasAttribute('filtered')).to.be.false;
-
-      const visibleItems = el.querySelectorAll(
-        'cds-multi-select-item:not([filtered])'
-      );
-      expect(visibleItems.length).to.equal(3);
-
-      selectAllItem.click();
-      await el.updateComplete;
-
-      const appleItem = el.querySelector(
-        'cds-multi-select-item[value="apple"]'
-      );
-      const bananaItem = el.querySelector(
-        'cds-multi-select-item[value="banana"]'
-      );
-      const cherryItem = el.querySelector(
-        'cds-multi-select-item[value="cherry"]'
-      );
-
-      expect(appleItem.hasAttribute('selected')).to.be.true;
-      expect(bananaItem.hasAttribute('selected')).to.be.true;
-      expect(cherryItem.hasAttribute('selected')).to.be.true;
-    });
-
     it('should clear all selections when select-all is clicked in indeterminate state', async () => {
       const el = await fixture(html`
         <cds-multi-select label="test-label" select-all>
@@ -1593,6 +1543,162 @@ describe('cds-multi-select', function () {
         'cds-multi-select-item:not([filtered])'
       );
       expect(visibleItems.length).to.equal(1);
+    });
+  });
+
+  describe('Select All Behaviours with Filterable MultiSelect', () => {
+    it('should only select visible item when filtering', async () => {
+      const el = await fixture(html`
+        <cds-multi-select select-all filterable>
+          <cds-multi-select-item is-select-all
+            >Select All</cds-multi-select-item
+          >
+          <cds-multi-select-item value="apple">Apple</cds-multi-select-item>
+          <cds-multi-select-item value="banana">Banana</cds-multi-select-item>
+          <cds-multi-select-item value="cherry">Cherry</cds-multi-select-item>
+        </cds-multi-select>
+      `);
+
+      const trigger = el.shadowRoot.querySelector('.cds--list-box__field');
+      trigger.click();
+      await el.updateComplete;
+
+      const filterInput = el.shadowRoot.querySelector('input');
+      const selectAllItem = el.querySelector(
+        'cds-multi-select-item[is-select-all]'
+      );
+
+      filterInput.value = 'a';
+      filterInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      selectAllItem.click();
+      await el.updateComplete;
+
+      const appleItem = el.querySelector(
+        'cds-multi-select-item[value="apple"]'
+      );
+      const bananaItem = el.querySelector(
+        'cds-multi-select-item[value="banana"]'
+      );
+      const cherryItem = el.querySelector(
+        'cds-multi-select-item[value="cherry"]'
+      );
+
+      expect(selectAllItem.hasAttribute('selected')).to.be.true;
+      expect(appleItem.hasAttribute('selected')).to.be.true;
+      expect(bananaItem.hasAttribute('selected')).to.be.true;
+      expect(cherryItem.hasAttribute('selected')).to.be.false;
+    });
+    it('should hide the select-all item when there are no items visible', async () => {
+      const el = await fixture(html`
+        <cds-multi-select filterable select-all>
+          <cds-multi-select-item is-select-all>All</cds-multi-select-item>
+          <cds-multi-select-item value="enabled">Enabled</cds-multi-select-item>
+          <cds-multi-select-item value="disabled-a" disabled
+            >Disabled A</cds-multi-select-item
+          >
+          <cds-multi-select-item value="disabled-b" disabled
+            >Disabled B</cds-multi-select-item
+          >
+        </cds-multi-select>
+      `);
+
+      const trigger = el.shadowRoot.querySelector('.cds--list-box__field');
+      trigger.click();
+      await el.updateComplete;
+      const selectAll = el.querySelector(
+        'cds-multi-select-item[is-select-all]'
+      );
+      expect(selectAll.hasAttribute('filtered')).to.be.false;
+
+      // filter that matches nothing
+      const input = el.shadowRoot.querySelector('input');
+      input.value = 'xyz';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      expect(selectAll.hasAttribute('filtered')).to.be.true;
+    });
+
+    it('should hide the select-all item when there are only disabled items visible', async () => {
+      const el = await fixture(html`
+        <cds-multi-select filterable select-all>
+          <cds-multi-select-item is-select-all>All</cds-multi-select-item>
+          <cds-multi-select-item value="enabled">Enabled</cds-multi-select-item>
+          <cds-multi-select-item value="disabled-a" disabled
+            >Disabled A</cds-multi-select-item
+          >
+          <cds-multi-select-item value="disabled-b" disabled
+            >Disabled B</cds-multi-select-item
+          >
+        </cds-multi-select>
+      `);
+
+      const trigger = el.shadowRoot.querySelector('.cds--list-box__field');
+      trigger.click();
+      await el.updateComplete;
+      const selectAll = el.querySelector(
+        'cds-multi-select-item[is-select-all]'
+      );
+      expect(selectAll.hasAttribute('filtered')).to.be.false;
+
+      // filter that matches disabled items
+      const input = el.shadowRoot.querySelector('input');
+      input.value = 'Disabled';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      expect(selectAll.hasAttribute('filtered')).to.be.true;
+    });
+
+    it('should correctly compute checked/indeterminate state depending on filter ', async () => {
+      const el = await fixture(html`
+        <cds-multi-select filterable select-all>
+          <cds-multi-select-item is-select-all>All</cds-multi-select-item>
+          <cds-multi-select-item value="foo">foo</cds-multi-select-item>
+          <cds-multi-select-item value="bar">bar</cds-multi-select-item>
+        </cds-multi-select>
+      `);
+
+      const trigger = el.shadowRoot.querySelector('.cds--list-box__field');
+      trigger.click();
+      await el.updateComplete;
+      const input = el.shadowRoot.querySelector('input');
+      const selectAllItem = el.querySelector(
+        'cds-multi-select-item[is-select-all]'
+      );
+
+      // filter to “foo”
+      input.value = 'foo';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      // no selected items visible: neither
+      expect(selectAllItem.hasAttribute('selected')).to.be.false;
+      expect(selectAllItem.hasAttribute('indeterminate')).to.be.false;
+
+      // click select all
+      selectAllItem.click();
+      await el.updateComplete;
+      // all visible items (foo) are selected: selected
+      expect(selectAllItem.hasAttribute('selected')).to.be.true;
+      expect(selectAllItem.hasAttribute('indeterminate')).to.be.false;
+
+      // filter to “bar”
+      input.value = 'bar';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      // no selected items visible: neither
+      expect(selectAllItem.hasAttribute('selected')).to.be.false;
+      expect(selectAllItem.hasAttribute('indeterminate')).to.be.false;
+
+      // Remove filter
+      input.value = '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      // only some visible items are selected: indeterminate
+      expect(selectAllItem.hasAttribute('selected')).to.be.false;
+      expect(selectAllItem.hasAttribute('indeterminate')).to.be.true;
     });
   });
 });

--- a/packages/web-components/src/components/multi-select/multi-select.stories.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.stories.ts
@@ -341,6 +341,28 @@ export const Filterable = {
   },
 };
 
+export const FilterableWithSelectAll = {
+  decorators: [(story) => html` <div style="width:300px">${story()}</div> `],
+  render: () => {
+    return html`
+      <cds-multi-select
+        filterable="true"
+        title-text="FilterableMultiselect title"
+        helper-text="This is helper text"
+        select-all>
+        <cds-multi-select-item is-select-all>All roles</cds-multi-select-item>
+
+        <cds-multi-select-item value="editor">Editor</cds-multi-select-item>
+        <cds-multi-select-item value="owner">Owner</cds-multi-select-item>
+        <cds-multi-select-item disabled value="staging"
+          >Reader - a disabled itme</cds-multi-select-item
+        >
+        <cds-multi-select-item value="uploader">Uploader</cds-multi-select-item>
+      </cds-multi-select>
+    `;
+  },
+};
+
 export const FilterableWithAILabel = {
   render: () => {
     return html`

--- a/packages/web-components/src/components/multi-select/multi-select.stories.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.stories.ts
@@ -23,6 +23,7 @@ import '../button';
 import '../toggle-tip';
 import '../icon-button';
 import '../../../.storybook/templates/with-layer';
+import '../link';
 
 const content = html`
   <div slot="body-text">
@@ -613,7 +614,7 @@ export const WithToggletipLabel = {
                 sed do eiusmod tempor incididunt ut fsil labore et dolore magna
                 aliqua.
               </p>
-              <cds-link slot="actions">Test</cds-link>
+              <cds-link href="#" slot="actions">Test</cds-link>
               <cds-button slot="actions">Button</cds-button>
             </cds-toggletip>
           </span>

--- a/packages/web-components/src/components/multi-select/multi-select.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.ts
@@ -105,11 +105,21 @@ class CDSMultiSelect extends CDSDropdown {
     if (itemToSelect) {
       // clicked select all
       if (itemToSelect.isSelectAll) {
-        allItems.forEach((i) => {
-          if (!i.isSelectAll && !i.disabled) {
-            i.selected = !itemToSelect.selected;
+        const items = this.filterable
+          ? Array.from(
+              this.querySelectorAll(
+                (this.constructor as typeof CDSMultiSelect).selectorItemResults
+              )
+            )
+          : allItems;
+        items.forEach((i) => {
+          if (
+            !(i as CDSMultiSelectItem).isSelectAll &&
+            !(i as CDSMultiSelectItem).disabled
+          ) {
+            (i as CDSMultiSelectItem).selected = !itemToSelect.selected;
           }
-          i.indeterminate = false;
+          (i as CDSMultiSelectItem).indeterminate = false;
         });
         itemToSelect.selected = !itemToSelect.selected;
         // clicked regular item
@@ -402,6 +412,27 @@ class CDSMultiSelect extends CDSDropdown {
     });
 
     this.requestUpdate();
+
+    if (this.selectAll) {
+      this._computeSelectAllState();
+
+      const selectAllItem = this.querySelector(
+        `${prefix}-multi-select-item[is-select-all]`
+      ) as CDSMultiSelectItem;
+      if (selectAllItem) {
+        const visible = Array.from(
+          this.querySelectorAll(
+            (this.constructor as typeof CDSMultiSelect).selectorItemResults
+          )
+        ) as CDSMultiSelectItem[];
+        const actionable = visible.filter((i) => !i.isSelectAll && !i.disabled);
+        if (actionable.length === 0) {
+          selectAllItem.setAttribute('filtered', '');
+        } else {
+          selectAllItem.removeAttribute('filtered');
+        }
+      }
+    }
 
     const constructor = this.constructor as typeof CDSMultiSelect;
     const visibleItems = Array.from(
@@ -728,7 +759,10 @@ class CDSMultiSelect extends CDSDropdown {
     if (!selectAllItem) {
       return;
     }
-    const enabledItems = allItems.filter((i) => !i.isSelectAll && !i.disabled);
+
+    const enabledItems = allItems
+      .filter((i) => !i.isSelectAll && !i.disabled)
+      .filter((i) => !this.filterable || !i.hasAttribute('filtered'));
     const selectedCount = enabledItems.filter((i) => i.selected).length;
     const allSelected = selectedCount === enabledItems.length;
 

--- a/packages/web-components/src/components/multi-select/multi-select.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.ts
@@ -414,8 +414,6 @@ class CDSMultiSelect extends CDSDropdown {
     this.requestUpdate();
 
     if (this.selectAll) {
-      this._computeSelectAllState();
-
       const selectAllItem = this.querySelector(
         `${prefix}-multi-select-item[is-select-all]`
       ) as CDSMultiSelectItem;
@@ -430,6 +428,7 @@ class CDSMultiSelect extends CDSDropdown {
           selectAllItem.setAttribute('filtered', '');
         } else {
           selectAllItem.removeAttribute('filtered');
+          this._computeSelectAllState();
         }
       }
     }

--- a/packages/web-components/src/components/multi-select/multi-select.ts
+++ b/packages/web-components/src/components/multi-select/multi-select.ts
@@ -755,7 +755,7 @@ class CDSMultiSelect extends CDSDropdown {
       )
     ) as CDSMultiSelectItem[];
     const selectAllItem = allItems.find((i) => i.isSelectAll);
-    if (!selectAllItem) {
+    if (!selectAllItem || selectAllItem.hasAttribute('filtered')) {
       return;
     }
 


### PR DESCRIPTION
Closes #19941

Following up on #19884, this PR updates the selectAll behaviour for the `multiselect[filterable]` component in Web Components to also have the following behaviours:

- When the selectAll item is clicked, all filtered items are selected, this means that when items = {one, two, three}. Filtering for "three" and clicking selectAll only selects three, since it is the only filtered item present. Deselections also behave in this manner with filters.

- The checked/indeterminate/empty state of the selectAll item changes dynamically based on the filter. If only half of the filtered items are selected it'll be indeterminate. But, if the text input changes to filter just one, already selected item, it will be checked.

- The selectAll item is only present if it is usable. Meaning, if there are no filtered items (i.e. the dropdown is empty), there will be no selectAll item, since it has nothing to select. The same behaviour applies for if the only selectable item(s) are disabled.

- The selectAll item is always at the top of the list for usability, no matter what the filter is.

- The selectAll item is not included in the count of selected items in the tag on the left-hand-side of the text-input.

 
### Changelog

**New**

- Added `FilterableWithSelectAll` story to showcase the new feature
- Fixed an issue where the link for `WithToggleTipLabel` wasn't showing the correct styles in storybook

**Changed**

- Modified `_selectDidChange()` to account for when `select-all` and `filterable` are both used so that only filtered items are selected/de-selected
- Modified `_handleInput()` to hide select-all item when there are no selectable items
- Modified `_computeSelectAllState()` so that the indeterminate/checked state is determined based on the filtered items

#### Testing / Reviewing

- Go to the new "Filterable with Select All" story in the deploy preview
- Behaviours listed above should work as expected
- CI should pass


## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
