### PR TITLE
19857-header action focus

### DIFF
--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -403,6 +403,7 @@
     flex: 1 1 0%;
     justify-content: flex-end;
     block-size: 100%;
+    margin-block-start: 1rem;
   }
 
   //--------------------------------------------------------------------------

--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -401,9 +401,11 @@
   .#{$prefix}--header__global {
     display: flex;
     flex: 1 1 0%;
+    align-items: center;
     justify-content: flex-end;
     block-size: 100%;
-    margin-block-start: 1rem;
+    margin-block-start: 0.25rem;
+    margin-inline: 0.25rem;
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
Closes #19857 

{{short description}}

### Changelog


**Changed**
- Added margin-block-start to header CSS.

#### Testing / Reviewing

- Click header menu and navigate using the Tab key, you'll notice the border should not  slightly off.



## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
