### PR TITLE
fix: popover closing when clicking interactive elements inside floating content

### DIFF
--- a/packages/react/src/components/Popover/__tests__/Popover-test.js
+++ b/packages/react/src/components/Popover/__tests__/Popover-test.js
@@ -309,4 +309,25 @@ describe('Popover', () => {
       expect(onRequestClose).toHaveBeenCalled();
     });
   });
+
+  it('should NOT call onRequestClose when clicking inside the popover content', async () => {
+    const onRequestClose = jest.fn();
+    render(
+      <Popover open onRequestClose={onRequestClose}>
+        <button type="button">Settings</button>
+        <PopoverContent data-testid="popover-content">
+          <button data-testid="inside-button">Inside Button</button>
+          <input data-testid="inside-input" placeholder="Inside Input" />
+        </PopoverContent>
+      </Popover>
+    );
+
+    // Click on button inside popover - should NOT close
+    await userEvent.click(screen.getByTestId('inside-button'));
+    expect(onRequestClose).not.toHaveBeenCalled();
+
+    // Click on input inside popover - should NOT close
+    await userEvent.click(screen.getByTestId('inside-input'));
+    expect(onRequestClose).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -182,8 +182,17 @@ export const Popover: PopoverComponent & {
   // The `Popover` should close whenever it and its children loses focus
   useEvent(popover, 'focusout', (event) => {
     const relatedTarget = (event as FocusEvent).relatedTarget as Node | null;
+    if (!relatedTarget) {
+      return;
+    }
+    const isOutsideMainContainer = !popover.current?.contains(relatedTarget);
+    const isOutsideFloating =
+      enableFloatingStyles && refs.floating.current
+        ? !refs.floating.current.contains(relatedTarget)
+        : true;
 
-    if (!popover.current?.contains(relatedTarget)) {
+    // Only close if focus moved outside both containers
+    if (isOutsideMainContainer && isOutsideFloating) {
       onRequestClose?.();
     }
   });


### PR DESCRIPTION
Closes #19952 

Fix popover closing when clicking interactive elements inside floating content

### Changelog

**New**

-  Fixed focusout event handler to properly detect focus changes within floating popover content when autoAlign is enabled
- Updated click detection logic to account for floating-ui positioned elements when enableFloatingStyles is true

#### Testing / Reviewing

- [ ] Visit Tab Tip story in Popover
- [ ] Open Popover and click on any interactive element, Lets say radio-button. Popover should not close.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
