### PR TITLE
chore(web-components): update build-dist

### DIFF
--- a/packages/web-components/tasks/build-dist.js
+++ b/packages/web-components/tasks/build-dist.js
@@ -61,20 +61,19 @@ async function buildDist() {
     }
   }
 
-  // Generates the multi-input for the rollup config
-  const inputs = folders.reduce((acc, folder) => {
-    acc[`components/${folder}/index`] = `src/components/${folder}/index.ts`;
-    return acc;
-  }, {});
+  // Generate inputs with flat file names
+  const inputs = {};
+  folders.forEach((folder) => {
+    inputs[`${folder}.min`] = `src/components/${folder}/index.ts`;
+  });
 
   return rollup(getRollupConfig({ inputs }))
     .then((bundle) => {
       bundle.write({
         format: 'es',
         dir: 'dist',
-        preserveModules: true,
-        preserveModulesRoot: 'src',
-        entryFileNames: '[name].min.js',
+        // This ensures output files are named based on input keys
+        entryFileNames: '[name].js',
         banner: 'let process = { env: {} };',
       });
     })


### PR DESCRIPTION
Closes #19985 

Fixes the output paths for web component CDN artifacts to no longer include subdirectories (components, packages, etc). The current build adds subdirectories and includes them in the upload to the CDN server, breaking the CDN links.

### Changelog

**Changed**

- update `build-dist.js` to output CDN artifacts with no subdirectories

#### Testing / Reviewing

After building `packages/web-components` the `dist` directory should contain artifacts only, no subdirectories.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
