### PR TITLE
Update FilterableMultiSelect.tsx to fix ShadowDOM

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -677,6 +677,7 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
     isItemDisabled(item, _index) {
       return (item as any)?.disabled;
     },
+    ...downshiftProps,
   });
   function stateReducer(state, actionAndChanges) {
     const { type, props, changes } = actionAndChanges;


### PR DESCRIPTION
Closes #

{{short description}}

### Changelog

**New**

- Nothing new. This component previously worked in the shadowDOM. This PR is looking to reinstate that situation.

**Changed**

- FilterableMultiSelect component stopped working in ShadowDOM after v1.68.0. Since then I've been using 'patch-package' to manually update this file post installing of @carbon/react to add support for downshift props.

**Removed**

- Nothing removed. Support for downshift props re-instated

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
