### PR TITLE
fix: update design office hours yl link

### DIFF
--- a/.github/workflows/slack-office-hours-design.yml
+++ b/.github/workflows/slack-office-hours-design.yml
@@ -72,7 +72,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/event/10463103",
+                    "url": "https://ec.yourlearning.ibm.com/w3/event/10522523",
                     "action_id": "button-action"
                   }
                 },


### PR DESCRIPTION

This PR updates the Slack Design Office hours workflow messaging to link out to our new [YL event link](https://ec.yourlearning.ibm.com/w3/event/10522523).

---

**Changed**

- Changed link out to new YL event.
