### PR TITLE
fix: containedList TS warning with moduleResolution nodenext

### DIFF
--- a/packages/react/src/components/ContainedList/ContainedList.tsx
+++ b/packages/react/src/components/ContainedList/ContainedList.tsx
@@ -16,9 +16,9 @@ import { Search } from '../Search';
 
 const variants = ['on-page', 'disclosed'] as const;
 
-export interface ContainedListType extends React.FC<ContainedListProps> {
+export type ContainedListType = React.FC<ContainedListProps> & {
   ContainedListItem: typeof ContainedListItem;
-}
+};
 
 export type Variants = (typeof variants)[number];
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19451

This PR should fix TypeScript compilation errors when using `ContainedList` with moduleResolution: "nodenext"

`ContainedListType` interface uses inheritance ([extends React.FC](https://github.com/carbon-design-system/carbon/blob/b56c1b874c065ec947ada06d78ed88d22ae53261/packages/react/src/components/ContainedList/ContainedList.tsx#L19)) to combine function component behavior with static properties. 
I suspect when TypeScript's strict module resolution ("nodenext") tries to validate this inheritance pattern for JSX usage, it gets confused by the complex type hierarchy and can't figure out if it's a valid JSX component type.

Intersection types should be better handled by TypeScript's strict module resolution than interface extension.

### Changelog


**Changed**

Changed `ContainedListType` from interface inheritance to intersection type to fix TypeScript errors with moduleResolution: "nodenext"



#### Testing / Reviewing

1. Set up a TypeScript project with moduleResolution: "nodenext" in tsconfig -> i have this [stackblitz](https://stackblitz.com/edit/github-1u9du64p-3crisxqb?file=tsconfig.app.json,src%2FApp.tsx&preset=node=) 
2.  Verify no TypeScript error
3.  confirm ContainedListType export still works
4.  Verify no breakiing changes 

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
