### PR TITLE
chore: make babel-preset-carbon package public

### DIFF
--- a/config/babel-preset-carbon/package.json
+++ b/config/babel-preset-carbon/package.json
@@ -1,6 +1,5 @@
 {
   "name": "babel-preset-carbon",
-  "private": true,
   "version": "0.7.0",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
Currently the `eslint-config-carbon` package has a dev dependency on `babel-preset-carbon`. The last public release of [`babel-preset-carbon` was version 0.0.14](https://www.npmjs.com/package/babel-preset-carbon?activeTab=versions) and is marked as private in the monorepo. 

When installing `eslint-config-carbon`, will point to the 0.0.14 `babel-preset-carbon` version instead of the latest internal version within the monorepo. This PR removes the `private` field so that the `babel-preset-carbon` package can be published and `eslint-config-carbon` can point to the latest version.

### Changelog

**Removed**

- removed the `private` field from the `babel-preset-carbon` package.json file

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
