### PR TITLE
fix(storybook): removing overflow visible for WC container

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2006,6 +2006,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "F4isalSH",
+      "name": "Faisal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/88539362?v=4",
+      "profile": "https://github.com/F4isalSH",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/anuanto966"><img src="https://avatars.githubusercontent.com/u/216390110?v=4?s=100" width="100px;" alt=""/><br /><sub><b>anuanto966</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=anuanto966" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/F4isalSH"><img src="https://avatars.githubusercontent.com/u/88539362?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Faisal</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=F4isalSH" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/web-components/.storybook/_container.scss
+++ b/packages/web-components/.storybook/_container.scss
@@ -71,14 +71,3 @@ body {
 .docs-story div div {
   transform: none;
 }
-
-// Disable stylelint max-nesting-depth
-/* stylelint-disable */
-.sbdocs {
-  &.sbdocs-preview,
-  .docs-story,
-  .docs-story div {
-    overflow: visible;
-  }
-}
-/* stylelint-enable */


### PR DESCRIPTION
Closes #20111

In comparison to the React storybook:
<img width="1152" height="462" alt="image" src="https://github.com/user-attachments/assets/e3b63018-117f-4572-ade4-4dafd5aecd15" />

Any component in WC **with layers** is showing overlap as seen here:
<img width="1167" height="470" alt="image" src="https://github.com/user-attachments/assets/83883340-5e58-4c9e-845b-efa4047d5fea" />

### Changelog

**New**

- none

**Changed**

- `overflow: visible` attribute in `_container.scss` (Found sb-docs overflow in WC it is set as visible)

**Removed**

- none

#### Testing / Reviewing

**Before**:
<img width="1179" height="472" alt="image" src="https://github.com/user-attachments/assets/eea47c06-7b8e-47fd-8c17-8c1a5591fc06" />

**After**:
<img width="1152" height="462" alt="image" src="https://github.com/user-attachments/assets/e3b63018-117f-4572-ade4-4dafd5aecd15" />

Tested components that have withLayer in the storybook, on chrome and firefox.


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
