### PR TITLE
fix(number-input): unable to type decimal

### DIFF
--- a/packages/web-components/src/components/number-input/number-input.ts
+++ b/packages/web-components/src/components/number-input/number-input.ts
@@ -55,7 +55,7 @@ class CDSNumberInput extends CDSTextInput {
         },
       })
     );
-    super._handleInput(event);
+    this._value = value;
   }
 
   /**
@@ -251,18 +251,44 @@ class CDSNumberInput extends CDSTextInput {
   @property({ reflect: true })
   size = INPUT_SIZE.MEDIUM;
 
+  getDecimalPlaces = (num: number) => {
+    const parts = num.toString().split('.');
+
+    return parts[1] ? parts[1].length : 0;
+  };
+
   /**
    * Handles incrementing the value in the input
    */
   stepUp() {
-    this._input.stepUp();
+    const currentValue = Number(this._input.value);
+    const rawValue = currentValue + Number(this.step);
+
+    const precision = Math.max(
+      this.getDecimalPlaces(currentValue),
+      this.getDecimalPlaces(Number(this.step))
+    );
+
+    const floatValue = parseFloat(rawValue.toFixed(precision));
+    this._value = String(floatValue);
+    this.value = this._value;
   }
 
   /**
    * Handles decrementing the value in the input
    */
   stepDown() {
-    this._input.stepDown();
+    const currentValue = Number(this._input.value);
+    const rawValue = currentValue - Number(this.step);
+
+    const precision = Math.max(
+      this.getDecimalPlaces(currentValue),
+      this.getDecimalPlaces(Number(this.step))
+    );
+
+    const floatValue = parseFloat(rawValue.toFixed(precision));
+    this._value = String(floatValue);
+    this.value = this._value;
   }
 
   render() {


### PR DESCRIPTION
Closes #20132 

Previously when typing a decimal (.) the cursor would jump to the beginning of the number input. Now when typing a decimal the cursor should stay and the steppers should accuretly change the value
### Changelog


**Changed**

- the handleInput was causing the cursor to jump when the value changed
- update stepUp  and stepDown so when given a decimal the correct output appear


#### Testing / Reviewing

got to the web components
- number input playground 
- type 50.3
- change step in control to (.4) then increase and decrease
- play with other numbers too
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~ ( tests are already written to check if decimals work)
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
