### PR TITLE
docs(flexgrid): update heading and links in documentation

### DIFF
--- a/packages/react/src/components/Grid/FlexGrid.mdx
+++ b/packages/react/src/components/Grid/FlexGrid.mdx
@@ -4,7 +4,7 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
 <Meta isTemplate />
 
-# Grid
+# FlexGrid
 
 [Source code](https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Grid)
 &nbsp;|&nbsp;
@@ -78,7 +78,7 @@ they don't span more columns than the total number of columns in the grid.
 To specify how many columns the `Column` component should span, you can use the
 `sm`, `md`, `lg`, `xlg`, or `max` props. These props are shorthand versions of
 the names given to each of the breakpoints defined by the
-[2x Grid](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation/#responsive-options).
+[2x Grid](https://carbondesignsystem.com/elements/2x-grid/overview/#breakpoints).
 In the example below, we will use the `lg` prop for the large breakpoint and the
 number `4` to specify that each `Column` component should span 4 columns at that
 breakpoint.
@@ -118,7 +118,7 @@ we will use the `sm`, `md`, and `lg` prop to specify how many columns the
 ## Gutter modes
 
 There are several
-[gutter modes](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation/#gutter-modes)
+[gutter modes](https://carbondesignsystem.com/elements/2x-grid/overview/#gutters)
 that you can use depending on the layout effect you're looking to achieve. By
 default, `FlexGrid` uses the wide gutter mode with a 32px gutter. However, you
 can use the `narrow` or `condensed` props to enable the narrow and condensed


### PR DESCRIPTION
Closes #16558

Update FlexGrid documentation heading and links

### Changelog

**New**

- N/A

**Changed**

- Renamed "Grid" section to "FlexGrid".
- Updated links.

**Removed**

- N/A

#### Testing / Reviewing

- Open the FlexGrid documentation page  
- Verify the main heading shows "FlexGrid" instead of "Grid"  
- Check if the links open the correct Carbon documentation pages

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
