### PR TITLE
ci(labeler): correct severity label definition to match the actual label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -139,11 +139,11 @@
   - '/(windows)/i'
 
 # Severity labels
-severity 1:
+'severity: 1':
   - '(Severity 1 = Must be fixed ASAP)'
-severity 2:
+'severity: 2':
   - '(Severity 2 = User cannot complete task)'
-severity 3:
+'severity: 3':
   - '(Severity 3 = User can complete task)'
-severity 4:
+'severity: 4':
   - '(Severity 4 = Unrelated to a user task)'


### PR DESCRIPTION
In testing #20228 I found that the severity labels were wrong, I missed the colon.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
