### PR TITLE
fix(button): parity issue in icon button

### DIFF
--- a/packages/web-components/src/components/button/button.scss
+++ b/packages/web-components/src/components/button/button.scss
@@ -111,6 +111,9 @@ $css--plex: true !default;
       padding: $spacing-03;
     }
   }
+  .#{$prefix}--btn--ghost:not([disabled]) ::slotted([slot='icon']) {
+    fill: $icon-primary;
+  }
 }
 
 :host(#{$prefix}-button[kind='ghost']) {


### PR DESCRIPTION
Closes #20307

For Icon Button varient in Button component in WC package, the color of the icon varies from that of the color in React Component

### Changelog

**New**

- Updated the button styling to include style change for the icon


#### Testing / Reviewing

In `Icon Button` varient in the storybook, choose `kind` as `Ghost Button(ghost)` and the icon color would match the react version now.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
