### PR TITLE
fix(progress-bar): use $text-error as error validation text color

### DIFF
--- a/packages/styles/scss/components/progress-bar/_progress-bar.scss
+++ b/packages/styles/scss/components/progress-bar/_progress-bar.scss
@@ -114,9 +114,12 @@
   }
 
   .#{$prefix}--progress-bar--error .#{$prefix}--progress-bar__bar,
-  .#{$prefix}--progress-bar--error .#{$prefix}--progress-bar__status-icon,
-  .#{$prefix}--progress-bar--error .#{$prefix}--progress-bar__helper-text {
+  .#{$prefix}--progress-bar--error .#{$prefix}--progress-bar__status-icon {
     color: $support-error;
+  }
+
+  .#{$prefix}--progress-bar--error .#{$prefix}--progress-bar__helper-text {
+    color: $text-error;
   }
 
   .#{$prefix}--progress-bar--finished .#{$prefix}--progress-bar__bar,


### PR DESCRIPTION
Closes #20309

### Changelog

**Changed**

- Changed the error validation text color of ProgressBar from `$support-error` to `$text-error` for better contrast in g90 & g100 themes

#### Testing / Reviewing

1. Open storybook preview
2. Navigate to "Default" story of "ProgressBar"
3. Set "status" to "error"
4. Ensure the helper text color is using `$text-error` instead of `$support-error`

<img width="458" height="106" alt="image" src="https://github.com/user-attachments/assets/0de8741b-7193-4376-a80a-c22b5c3b72fb" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
