### PR TITLE
fix(header): adjust edge-aligned popover positioning

### DIFF
--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -369,68 +369,6 @@ export const ExperimentalAutoAlignBoundary = () => {
           }}
         />
       </div>
-    </div>
-  );
-};
-
-export const Test = () => {
-  const [open, setOpen] = useState();
-  const align = document?.dir === 'rtl' ? 'bottom-right' : 'bottom-left';
-  const alignTwo = document?.dir === 'rtl' ? 'bottom-left' : 'bottom-right';
-  return (
-    <div style={{ display: 'flex', gap: '8rem' }}>
-      <OverflowMenu
-        flipped={document?.dir === 'rtl'}
-        aria-label="overflow-menu">
-        <OverflowMenuItem itemText="Stop app" />
-        <OverflowMenuItem itemText="Restart app" />
-        <OverflowMenuItem itemText="Rename app" />
-        <OverflowMenuItem itemText="Clone and move app" disabled requireTitle />
-        <OverflowMenuItem itemText="Edit routes and access" requireTitle />
-        <OverflowMenuItem hasDivider isDelete itemText="Delete app" />
-      </OverflowMenu>
-
-      <Popover
-        align={align}
-        open={open}
-        onKeyDown={(evt) => {
-          if (match(evt, keys.Escape)) {
-            setOpen(false);
-          }
-        }}
-        isTabTip
-        onRequestClose={() => setOpen(false)}>
-        <button
-          aria-label="Settings"
-          type="button"
-          aria-expanded={open}
-          onClick={() => {
-            setOpen(!open);
-          }}>
-          <Settings />
-        </button>
-        <PopoverContent className="p-3">
-          <RadioButtonGroup
-            style={{ alignItems: 'flex-start', flexDirection: 'column' }}
-            legendText="Row height"
-            name="radio-button-group"
-            defaultSelected="small">
-            <RadioButton labelText="Small" value="small" id="radio-small" />
-            <RadioButton labelText="Large" value="large" id="radio-large" />
-          </RadioButtonGroup>
-          <hr />
-          <fieldset className={`cds--fieldset`}>
-            <legend className={`cds--label`}>Edit columns</legend>
-            <Checkbox defaultChecked labelText="Name" id="checkbox-label-1" />
-            <Checkbox defaultChecked labelText="Type" id="checkbox-label-2" />
-            <Checkbox
-              defaultChecked
-              labelText="Location"
-              id="checkbox-label-3"
-            />
-          </fieldset>
-        </PopoverContent>
-      </Popover>
     </div>
   );
 };

--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2016, 2023
+// Copyright IBM Corp. 2016, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -55,6 +55,26 @@
 
   .#{$prefix}--header__global .#{$prefix}--popover {
     z-index: z('header') + 1;
+  }
+
+  .#{$prefix}--header {
+    .#{$prefix}--popover--bottom-start:not(.#{$prefix}--popover--auto-align) {
+      > .#{$prefix}--popover {
+        > .#{$prefix}--popover-caret,
+        > .#{$prefix}--popover-content {
+          inset-inline-start: $spacing-05;
+        }
+      }
+    }
+
+    .#{$prefix}--popover--bottom-end:not(.#{$prefix}--popover--auto-align) {
+      > .#{$prefix}--popover {
+        > .#{$prefix}--popover-caret,
+        > .#{$prefix}--popover-content {
+          inset-inline-end: $spacing-05;
+        }
+      }
+    }
   }
 
   .#{$prefix}--header__action > :first-child {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19240

Adjusted edge-aligned `Popover` positioning in the `Header`.

### Changelog

**Changed**

- Adjusted edge-aligned `Popover` positioning in the `Header`.

**Removed**

- Deleted a `Test` story that was seemingly overlooked during a previous pull request merge.

#### Testing / Reviewing

How to test: Check out my branch and set up a test story using the code from the issue.

I'm not sure how to add testing for this fix. Any help with that would be appreciated since I'm fixing a regression.

![start](https://github.com/user-attachments/assets/1e42ef7e-ba12-4960-bd6e-1485a2a5c2c4)

![undefined](https://github.com/user-attachments/assets/c788281b-92e3-4854-924e-339ac2e61adb)

![end](https://github.com/user-attachments/assets/22e7031d-36e5-4554-b458-005236b450a5)

These changes also addressed the issue but they broke styling for other components.

```diff
diff --git a/packages/styles/scss/components/popover/_popover.scss b/packages/styles/scss/components/popover/_popover.scss
index ce5b361f1..477023493 100644
--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -235,7 +235,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-block-end: 0;
-    inset-inline-start: 0;
+    inset-inline-start: 1rem;
     transform: translate(
       calc(-1 * $popover-offset),
       calc(100% + $popover-offset)
@@ -261,7 +261,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-block-end: 0;
-    inset-inline-end: 0;
+    inset-inline-end: 1rem;
     transform: translate($popover-offset, calc(100% + $popover-offset));
   }

@@ -272,7 +272,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-caret {
     inset-block-end: 0;
-    inset-inline-end: 0;
+    inset-inline-end: 1rem;
     inset-inline-start: auto;
   }

@@ -281,7 +281,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover-caret {
     inset-block-end: 0;
     inset-inline-end: auto;
-    inset-inline-start: 0;
+    inset-inline-start: 1rem;
     transform: translate(50%, calc($popover-offset));
   }
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~~Wrote passing tests that cover this change~~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
