### PR TITLE
fix: extend SkeletonPlaceholder props with HTMLAttributes

### DIFF
--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.tsx
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.tsx
@@ -1,16 +1,17 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { type HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
 
-export interface SkeletonPlaceholderProps {
+export interface SkeletonPlaceholderProps
+  extends HTMLAttributes<HTMLDivElement> {
   /**
    * Add a custom class to the component to set the height and width
    */
@@ -34,8 +35,7 @@ const SkeletonPlaceholder = ({
 
 SkeletonPlaceholder.propTypes = {
   /**
-   * Add a custom class to the component
-   * to set the height and width
+   * Add a custom class to the component to set the height and width
    */
   className: PropTypes.string,
 };


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19243

Extended `SkeletonPlaceholder` props with `HTMLAttributes`

### Changelog

**Changed**

- Extended `SkeletonPlaceholder` props with `HTMLAttributes`

#### Testing / Reviewing

Find a TypeScript file with a `SkeletonPlaceholder` component, add a `style` attribute to it, and check for any type errors.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Wrote passing tests that cover this change~~
- [ ] ~~Addressed any impact on accessibility (a11y)~~
- [ ] ~~Tested for cross-browser consistency~~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
