### PR TITLE
fix(data-table): missing first divider on select all

### DIFF
--- a/packages/web-components/src/components/data-table/_table-selection.scss
+++ b/packages/web-components/src/components/data-table/_table-selection.scss
@@ -22,11 +22,18 @@
 }
 
 :host(#{$prefix}-table-header-row[selected]) {
-  .#{$prefix}--table-column-checkbox,
   ::slotted(#{$prefix}-table-header-cell),
   .#{$prefix}--table-expand,
   .#{$prefix}--table-column-checkbox {
     border-block-end: 1px solid $layer-active;
+  }
+}
+
+:host(#{$prefix}-table-row[selected]:first-of-type) {
+  ::slotted(#{$prefix}-table-cell),
+  .#{$prefix}--table-expand,
+  .#{$prefix}--table-column-checkbox {
+    border-block-start: 1px solid var(--cds-border-subtle-selected);
   }
 }
 
@@ -50,7 +57,6 @@
 }
 
 :host(#{$prefix}-table-row[selected]) {
-  .#{$prefix}--table-column-checkbox,
   ::slotted(#{$prefix}-table-cell),
   .#{$prefix}--table-expand,
   .#{$prefix}--table-column-checkbox {
@@ -61,7 +67,6 @@
   }
 
   &:hover {
-    .#{$prefix}--table-column-checkbox,
     ::slotted(#{$prefix}-table-cell),
     .#{$prefix}--table-expand,
     .#{$prefix}--table-column-checkbox {
@@ -90,7 +95,6 @@
 
     background-attachment: fixed;
 
-    .#{$prefix}--table-column-checkbox,
     ::slotted(#{$prefix}-table-cell),
     .#{$prefix}--table-expand,
     .#{$prefix}--table-column-checkbox {
@@ -98,7 +102,6 @@
     }
   }
 
-  .#{$prefix}--table-column-checkbox,
   ::slotted(#{$prefix}-table-cell),
   .#{$prefix}--table-expand,
   .#{$prefix}--table-column-checkbox {

--- a/packages/web-components/src/components/data-table/_table-selection.scss
+++ b/packages/web-components/src/components/data-table/_table-selection.scss
@@ -33,7 +33,7 @@
   ::slotted(#{$prefix}-table-cell),
   .#{$prefix}--table-expand,
   .#{$prefix}--table-column-checkbox {
-    border-block-start: 1px solid var(--cds-border-subtle-selected);
+    border-block-start: 1px solid $border-subtle-selected;
   }
 }
 

--- a/packages/web-components/src/components/data-table/_table-selection.scss
+++ b/packages/web-components/src/components/data-table/_table-selection.scss
@@ -21,6 +21,15 @@
   }
 }
 
+:host(#{$prefix}-table-header-row[selected]) {
+  .#{$prefix}--table-column-checkbox,
+  ::slotted(#{$prefix}-table-header-cell),
+  .#{$prefix}--table-expand,
+  .#{$prefix}--table-column-checkbox {
+    border-block-end: 1px solid $layer-active;
+  }
+}
+
 :host(#{$prefix}-table-row) {
   .#{$prefix}--table-column-checkbox {
     border-block-end: 1px solid $border-subtle;


### PR DESCRIPTION
Closes n/a

data table web components missing divider on select all
<img width="2756" height="1022" alt="image" src="https://github.com/user-attachments/assets/b294cbf8-6e1a-443b-93b5-c096e893cf03" />### Changelog

**New**

- added divider styles

#### Testing / Reviewing

- confirm divider is there when doing select all and it's not there when not selected
- also check when selecting just the first item that the divider still shows
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
