### PR TITLE
chore: ignore cds variables when outputting es-custom build

### DIFF
--- a/packages/web-components/tasks/build.js
+++ b/packages/web-components/tasks/build.js
@@ -185,7 +185,7 @@ async function postBuild() {
     await Promise.all(
       files.map(async (file) => {
         const content = await fs.promises.readFile(file, 'utf8');
-        const updatedContent = content.replace(/cds/g, 'cds-custom');
+        const updatedContent = content.replace(/(?<!--)cds/g, 'cds-custom');
         await fs.promises.writeFile(file, updatedContent);
       })
     );


### PR DESCRIPTION
When using the `es-custom` build output, some of the custom variables are not being defined as the variable prefix names are also being changed from `--cds-*` to `--cds-custom-*`

This PR adjusts the `es-custom` build to not replace the custom variable prefixes.

### Changelog

**Changed**

- change regex to ignore instances where `cds` is preceded by `--`

#### Testing / Reviewing

build locally and see that within the `es-custom` folder output, the variable names are not being replaced with `--cds-custom` - they should remain as `--cds`

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
