### PR TITLE
refactor: port `deprecateComponent` to typescript

### DIFF
--- a/packages/react/src/components/DataTable/TableSlugRow.tsx
+++ b/packages/react/src/components/DataTable/TableSlugRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, { ReactNode, useEffect } from 'react';
 import classNames from 'classnames';
 import { usePrefix } from '../../internal/usePrefix';
-import deprecateComponent from '../../prop-types/deprecateComponent';
+import { deprecateComponent } from '../../prop-types/deprecateComponent';
 
 export interface TableSlugRowProps {
   /**

--- a/packages/react/src/prop-types/deprecateComponent.ts
+++ b/packages/react/src/prop-types/deprecateComponent.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2023
+ * Copyright IBM Corp. 2016, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,9 +7,9 @@
 
 import { warning } from '../internal/warning';
 
-const didWarnAboutDeprecation = {};
+const didWarnAboutDeprecation: Record<string, boolean> = {};
 
-export default function deprecateComponent(componentName, message) {
+export const deprecateComponent = (componentName: string, message?: string) => {
   if (!componentName) {
     return;
   }
@@ -25,4 +25,4 @@ export default function deprecateComponent(componentName, message) {
   }
 
   return componentName;
-}
+};


### PR DESCRIPTION
Closes N/A

Ported `deprecateComponent` to TypeScript.

### Changelog

**Changed**

- Ported `deprecateComponent` to TypeScript.

#### Testing / Reviewing

Check for type errors.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Wrote passing tests that cover this change~~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
