### PR TITLE
ci: address circular dependency warnings

### DIFF
--- a/packages/react/src/components/ListBox/ListBox.tsx
+++ b/packages/react/src/components/ListBox/ListBox.tsx
@@ -20,7 +20,7 @@ import {
   ListBoxTypePropType,
   type ListBoxSize,
   type ListBoxType,
-} from '.';
+} from './ListBoxPropTypes';
 import { usePrefix } from '../../internal/usePrefix';
 import { FormContext } from '../FluidForm';
 

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -1015,7 +1015,7 @@ NumberInput.propTypes = {
   warnText: PropTypes.node,
 };
 
-export interface LabelProps {
+interface LabelProps {
   disabled?: boolean;
   hideLabel?: boolean;
   id?: string;
@@ -1040,21 +1040,13 @@ const Label = ({ disabled, id, hideLabel, label }: LabelProps) => {
   return null;
 };
 
-// TODO: `Label` isn't exported. Why does it have `propTypes`? I have the same
-// question for the `HelperText` component too.
-Label.propTypes = {
-  disabled: PropTypes.bool,
-  hideLabel: PropTypes.bool,
-  id: PropTypes.string,
-  label: PropTypes.node,
-};
-
-export interface HelperTextProps {
+interface HelperTextProps {
   id?: string;
   description?: ReactNode;
   disabled?: boolean;
 }
-function HelperText({ disabled, description, id }: HelperTextProps) {
+
+const HelperText = ({ disabled, description, id }: HelperTextProps) => {
   const prefix = usePrefix();
   const className = cx(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: disabled,
@@ -1068,12 +1060,6 @@ function HelperText({ disabled, description, id }: HelperTextProps) {
     );
   }
   return null;
-}
-
-HelperText.propTypes = {
-  description: PropTypes.node,
-  disabled: PropTypes.bool,
-  id: PropTypes.string,
 };
 
 /**

--- a/packages/react/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react/src/components/NumberInput/NumberInput.tsx
@@ -16,7 +16,6 @@ import React, {
   useMemo,
   useRef,
   useState,
-  type FC,
   type MouseEvent,
   type ReactNode,
 } from 'react';
@@ -1016,13 +1015,14 @@ NumberInput.propTypes = {
   warnText: PropTypes.node,
 };
 
-export interface Label {
+export interface LabelProps {
   disabled?: boolean;
   hideLabel?: boolean;
   id?: string;
   label?: ReactNode;
 }
-const Label: FC<Label> = ({ disabled, id, hideLabel, label }) => {
+
+const Label = ({ disabled, id, hideLabel, label }: LabelProps) => {
   const prefix = usePrefix();
   const className = cx({
     [`${prefix}--label`]: true,
@@ -1040,6 +1040,8 @@ const Label: FC<Label> = ({ disabled, id, hideLabel, label }) => {
   return null;
 };
 
+// TODO: `Label` isn't exported. Why does it have `propTypes`? I have the same
+// question for the `HelperText` component too.
 Label.propTypes = {
   disabled: PropTypes.bool,
   hideLabel: PropTypes.bool,

--- a/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -16,7 +16,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import type { RadioButtonProps } from '../RadioButton';
-import { Legend } from '../Text';
+import { Legend } from '../Text/createTextComponent';
 import { usePrefix } from '../../internal/usePrefix';
 import { WarningFilled, WarningAltFilled } from '@carbon/icons-react';
 import { deprecate } from '../../prop-types/deprecate';

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -18,7 +18,7 @@ import {
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
 } from '../../internal/PolymorphicProps';
-import { TextDirectionContext, type TextDir } from '.';
+import { TextDirectionContext, type TextDir } from './TextDirectionContext';
 
 export interface TextBaseProps {
   dir?: TextDir;

--- a/packages/react/src/components/Text/TextDirection.tsx
+++ b/packages/react/src/components/Text/TextDirection.tsx
@@ -12,7 +12,7 @@ import {
   type GetTextDirection,
   type TextDir,
   type TextDirectionContextType,
-} from '.';
+} from './TextDirectionContext';
 
 export interface TextDirectionProps {
   children: ReactNode;

--- a/packages/react/src/components/Text/createTextComponent.tsx
+++ b/packages/react/src/components/Text/createTextComponent.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { type ElementType } from 'react';
-import { Text, TextProps } from '.';
+import { Text, TextProps } from './Text';
 
 /**
  * Create a text component wrapper for a given text node type. Useful for
@@ -14,10 +14,7 @@ import { Text, TextProps } from '.';
  * @param {string} element
  * @param {string} displayName
  */
-export const createTextComponent = (
-  element: ElementType,
-  displayName: string
-) => {
+const createTextComponent = (element: ElementType, displayName: string) => {
   const TextWrapper = (props: TextProps<ElementType>) => {
     return <Text as={element} {...props} />;
   };
@@ -28,3 +25,5 @@ export const createTextComponent = (
 
   return TextWrapper;
 };
+
+export const Legend = createTextComponent('legend', 'Legend');

--- a/packages/react/src/components/Text/index.ts
+++ b/packages/react/src/components/Text/index.ts
@@ -5,11 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createTextComponent } from './createTextComponent';
-
 export * from './Text';
 export * from './TextDirection';
 export * from './TextDirectionContext';
-
-export const Label = createTextComponent('label', 'Label');
-export const Legend = createTextComponent('legend', 'Legend');

--- a/packages/react/src/components/UIShell/Switcher.tsx
+++ b/packages/react/src/components/UIShell/Switcher.tsx
@@ -19,7 +19,8 @@ import { usePrefix } from '../../internal/usePrefix';
 import { useMergedRefs } from '../../internal/useMergedRefs';
 import PropTypes from 'prop-types';
 import { AriaLabelPropType } from '../../prop-types/AriaPropTypes';
-import { SwitcherDivider, SwitcherItem } from '.';
+import SwitcherItem from './SwitcherItem';
+import SwitcherDivider from './SwitcherDivider';
 
 export interface BaseSwitcherProps {
   /**


### PR DESCRIPTION
Closes N/A

Refactored imports and export to prevent circular dependency warnings in CI.

### Changelog

**Changed**

- Refactored imports and export to prevent circular dependency warnings in CI.
- Updated the `Label` interface in `NumberInput.tsx` so that it no longer matches the component name.
- Moved the `Legend` component to `packages/react/src/components/Text/createTextComponent.tsx` to prevent a circular dependency

**Removed**

- Removed an unused `Label` text component.

#### Testing / Reviewing

https://github.com/carbon-design-system/carbon/pull/19666#issuecomment-3218212128

I’m not sure why the `LabelProps` (previously `Label`) interface is exported, as it isn’t used outside that file.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Wrote passing tests that cover this change~~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
