### PR TITLE
chore(storybook): fix web component storybook icon imports

### DIFF
--- a/packages/web-components/.storybook/main.ts
+++ b/packages/web-components/.storybook/main.ts
@@ -68,7 +68,16 @@ const config: StorybookConfig = {
         exclude: ['lit', 'lit-html'],
       },
       define: {
-        'process.env': process.env,
+        'process.env.NODE_ENV': JSON.stringify(
+          process.env.NODE_ENV || 'development'
+        ),
+        'process.env.STORYBOOK_USE_RTL': JSON.stringify(
+          process.env.STORYBOOK_USE_RTL
+        ),
+        'process.env.CDS_FLAGS_ALL': JSON.stringify(process.env.CDS_FLAGS_ALL),
+        'process.env.CDS_EXPERIEMENTAL_COMPONENT_NAME': JSON.stringify(
+          process.env.CDS_EXPERIEMENTAL_COMPONENT_NAME
+        ),
       },
       sourcemap: true,
     });

--- a/packages/web-components/src/components/form/form.stories.ts
+++ b/packages/web-components/src/components/form/form.stories.ts
@@ -6,9 +6,9 @@
  */
 
 import { html } from 'lit';
-import View16 from '@carbon/icons/lib/view/16.js';
-import FolderOpen16 from '@carbon/icons/lib/folder--open/16.js';
-import Folders16 from '@carbon/icons/lib/folders/16.js';
+import View16 from '@carbon/icons/es/view/16.js';
+import FolderOpen16 from '@carbon/icons/es/folder--open/16.js';
+import Folders16 from '@carbon/icons/es/folders/16.js';
 import './index';
 import '../stack/index';
 import '../ai-label/index';

--- a/packages/web-components/src/components/form/form.stories.ts
+++ b/packages/web-components/src/components/form/form.stories.ts
@@ -6,6 +6,7 @@
  */
 
 import { html } from 'lit';
+import { iconLoader } from '../../globals/internal/icon-loader';
 import View16 from '@carbon/icons/es/view/16.js';
 import FolderOpen16 from '@carbon/icons/es/folder--open/16.js';
 import Folders16 from '@carbon/icons/es/folders/16.js';
@@ -44,15 +45,15 @@ const content = html`
 
 const actions = html`
   <cds-icon-button kind="ghost" slot="actions" size="lg">
-    ${View16({ slot: 'icon' })}
+    ${iconLoader(View16, { slot: 'icon' })}
     <span slot="tooltip-content"> View </span>
   </cds-icon-button>
   <cds-icon-button kind="ghost" slot="actions" size="lg">
-    ${FolderOpen16({ slot: 'icon' })}
+    ${iconLoader(FolderOpen16, { slot: 'icon' })}
     <span slot="tooltip-content"> Open folder</span>
   </cds-icon-button>
   <cds-icon-button kind="ghost" slot="actions" size="lg">
-    ${Folders16({ slot: 'icon' })}
+    ${iconLoader(Folders16, { slot: 'icon' })}
     <span slot="tooltip-content"> Folders </span>
   </cds-icon-button>
   <cds-ai-label-action-button>View details</cds-ai-label-action-button>


### PR DESCRIPTION
Fixes icon import paths in web components Storybook

### Changelog

**Changed**

- update icon import path in `form` story
- update Storybook config to use targeted `process.env` variables instead of the kitchen sink

#### Testing / Reviewing

Storybook should build in web components
```bash
# packages/web-components
yarn storybook:build
```

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
