### PR TITLE
fix(toggle): align readonly small toggle to design spec

### DIFF
--- a/packages/react/src/components/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Toggle/Toggle.tsx
@@ -203,7 +203,7 @@ export function Toggle({
         {labelText && <Text className={labelTextClasses}>{labelText}</Text>}
         <div className={appearanceClasses}>
           <div className={switchClasses}>
-            {isSm && (
+            {isSm && !readOnly && (
               <svg
                 aria-hidden="true"
                 focusable="false"

--- a/packages/styles/scss/components/toggle/_toggle.scss
+++ b/packages/styles/scss/components/toggle/_toggle.scss
@@ -176,7 +176,7 @@
     background-color: transparent;
 
     &::before {
-      background-color: $text-primary;
+      background-color: $icon-primary;
       inset-block-start: convert.to-rem(2px);
       inset-inline-start: convert.to-rem(2px);
     }

--- a/packages/web-components/src/components/toggle/toggle.ts
+++ b/packages/web-components/src/components/toggle/toggle.ts
@@ -54,7 +54,7 @@ class CDSToggle extends HostListenerMixin(CDSCheckbox) {
   }
 
   protected _renderCheckmark() {
-    if (this.size !== TOGGLE_SIZE.SMALL) {
+    if (this.size !== TOGGLE_SIZE.SMALL || this.readOnly == true) {
       return undefined;
     }
     return html`


### PR DESCRIPTION
Closes #20367

This PR aligns the readonly small toggle to the design spec by removing the checkmark when it is in a `toggled` state.

### Changelog

**New**

- Added conditions to conditionally render the checkmark only if the toggle is not small and readonly

**Changed**

- Changed the toggle switch colour token from `$text-primary` to `$icon-primary`
    - This should not result in any visual changes since both tokens carry the same colour value. This is purely just for nomenclature consistency with the design spec


#### Testing / Reviewing

- Go to `Toggle/Default` in deploy preview for both React and Web Components
- In the controls set `size = small` and `readOnly=true`
    - [React link](https://deploy-preview-20505--v11-carbon-react.netlify.app/?path=/story/components-toggle--default&args=size:sm;readOnly:!true)
    - [WC link](https://deploy-preview-20505--v11-carbon-web-components.netlify.app/?path=/story/components-toggle--default&args=readOnly:!true;size:sm)
- There should be no checkmark visible inside of the toggle switch
- There should be no regression on the colour of the toggle switch, the token change should result in no visual changes

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~~[ ] Updated documentation and storybook examples~~
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass