### PR TITLE
fix(accordion): add aria-label support to Accordion component buttons

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -247,6 +247,9 @@ Map {
   },
   "AccordionItem" => {
     "propTypes": {
+      "aria-label": {
+        "type": "string",
+      },
       "children": {
         "type": "node",
       },

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -40,6 +40,12 @@ export interface AccordionItemProps {
   disabled?: boolean;
 
   /**
+   * Specify a custom label for the accordion button.
+   * This is important for accessibility when the accordion has no visible title.
+   */
+  'aria-label'?: AriaAttributes['aria-label'];
+
+  /**
    * The handler of the massaged `click` event.
    */
   onClick?: MouseEventHandler<HTMLLIElement>;
@@ -95,6 +101,7 @@ export interface AccordionItemProps {
 export interface AccordionToggleProps {
   'aria-controls'?: AriaAttributes['aria-controls'];
   'aria-expanded'?: AriaAttributes['aria-expanded'];
+  'aria-label'?: AriaAttributes['aria-label'];
   className?: string;
   disabled?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -116,6 +123,7 @@ function AccordionItem({
   title = 'title',
   disabled: controlledDisabled,
   handleAnimationEnd,
+  'aria-label': ariaLabel,
   ...rest
 }: PropsWithChildren<AccordionItemProps>) {
   const [isOpen, setIsOpen] = useState(open);
@@ -187,6 +195,7 @@ function AccordionItem({
         disabled={disabled}
         aria-controls={id}
         aria-expanded={isOpen}
+        aria-label={ariaLabel}
         className={`${prefix}--accordion__heading`}
         onClick={onClick}
         onKeyDown={onKeyDown}
@@ -223,6 +232,12 @@ AccordionItem.propTypes = {
    * Specify whether an individual AccordionItem should be disabled
    */
   disabled: PropTypes.bool,
+
+  /**
+   * Specify a custom label for the accordion button.
+   * This is important for accessibility when the accordion has no visible title.
+   */
+  'aria-label': PropTypes.string,
 
   /**
    * The handler of the massaged `click` event.

--- a/packages/react/src/components/Accordion/__tests__/AccordionItem-test.js
+++ b/packages/react/src/components/Accordion/__tests__/AccordionItem-test.js
@@ -85,6 +85,17 @@ describe('AccordionItem', () => {
 
       expect(screen.getByText('Test title')).toBeInTheDocument();
     });
+
+    it('should respect aria-label prop', () => {
+      render(
+        <AccordionItem title="Test title" aria-label="Custom accordion label" />
+      );
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'Custom accordion label'
+      );
+    });
   });
 
   describe('behaves as expected', () => {


### PR DESCRIPTION
Closes #19314

This commit adds support for the aria-label attribute on AccordionItem buttons to improve accessibility when accordion items contain only icons without text.

### Changelog

**Changed**

- Added aria-label property to AccordionItemProps interface
- Added aria-label property to AccordionToggleProps interface
- Modified AccordionItem component to pass aria-label to the button element
- Added test case to verify aria-label functionality


#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
