### PR TITLE
fix(ai-label): wc closing when interacting with content

### DIFF
--- a/packages/web-components/src/components/ai-label/ai-label.stories.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.stories.ts
@@ -231,6 +231,45 @@ export const ExplainabilityPopover = {
     `;
   },
 };
+class WrappingComponent extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const wrapper = document.createElement('cds-ai-label');
+    wrapper.setAttribute('autoalign', '');
+    wrapper.setAttribute('ai-text', 'IA');
+
+    const bodyText = document.createElement('div');
+    bodyText.setAttribute('slot', 'body-text');
+
+    const slot = document.createElement('slot');
+    slot.setAttribute('name', 'custom-content');
+
+    bodyText.appendChild(slot);
+    wrapper.appendChild(bodyText);
+    shadow.appendChild(wrapper);
+  }
+}
+
+customElements.define('wrapping-component', WrappingComponent);
+
+export const Nested = {
+  render: () => {
+    return html`
+      <style>
+        ${styles}
+      </style>
+      <div class="ai-label-container">
+        <wrapping-component>
+          <div slot="custom-content">
+            <a href="http://google.com" target="_blank">google.com</a>
+          </div>
+        </wrapping-component>
+      </div>
+    `;
+  },
+};
 
 const meta = {
   title: 'Components/AI Label',

--- a/packages/web-components/src/components/ai-label/ai-label.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.ts
@@ -79,7 +79,7 @@ class CDSAILabel extends HostListenerMixin(CDSToggleTip) {
   @HostListener('parentRoot:click')
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
-  private _handleOutsideClick = (event: Event) => {
+  private _handleOutsideClick = (event: MouseEvent) => {
     const path = event.composedPath();
     if (!path.includes(this)) {
       this.open = false;
@@ -90,7 +90,7 @@ class CDSAILabel extends HostListenerMixin(CDSToggleTip) {
   @HostListener('parentRoot:focusin')
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
-  private _handleFocusChange = (event: Event) => {
+  private _handleFocusChange = (event: FocusEvent) => {
     if (
       this.open &&
       (!(event.target instanceof Node) || !this.contains(event.target))

--- a/packages/web-components/src/components/ai-label/ai-label.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.ts
@@ -15,6 +15,8 @@ import Undo16 from '@carbon/icons/es/undo/16.js';
 import { AI_LABEL_SIZE, AI_LABEL_KIND } from './defs';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 import { iconLoader } from '../../globals/internal/icon-loader';
+import HostListener from '../../globals/decorators/host-listener';
+import HostListenerMixin from '../../globals/mixins/host-listener';
 
 /**
  * Basic AI Label.
@@ -22,7 +24,7 @@ import { iconLoader } from '../../globals/internal/icon-loader';
  * @element cds-ai-label
  */
 @customElement(`${prefix}-ai-label`)
-class CDSAILabel extends CDSToggleTip {
+class CDSAILabel extends HostListenerMixin(CDSToggleTip) {
   /**
    * @deprecated the slot string will be renamed to "decorator"
    */
@@ -74,18 +76,10 @@ class CDSAILabel extends CDSToggleTip {
   @property()
   previousValue;
 
-  connectedCallback() {
-    super.connectedCallback?.();
-    document.addEventListener('click', this._handleOutsideClick, true);
-    document.addEventListener('focusin', this._handleFocusChange, true);
-  }
-  disconnectedCallback() {
-    super.disconnectedCallback?.();
-    document.removeEventListener('click', this._handleOutsideClick, true);
-    document.removeEventListener('click', this._handleFocusChange, true);
-  }
-
-  private _handleOutsideClick = (event: MouseEvent) => {
+  @HostListener('parentRoot:click')
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleOutsideClick = (event: Event) => {
     const path = event.composedPath();
     if (!path.includes(this)) {
       this.open = false;
@@ -93,7 +87,10 @@ class CDSAILabel extends CDSToggleTip {
     }
   };
 
-  private _handleFocusChange = (event: FocusEvent) => {
+  @HostListener('parentRoot:focusin')
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20452
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleFocusChange = (event: Event) => {
     if (
       this.open &&
       (!(event.target instanceof Node) || !this.contains(event.target))


### PR DESCRIPTION
Closes [#179](https://github.com/carbon-design-system/carbon-ai-chat/issues/179) in C4AI
Closes #19982 at Root cause

the previous pr #20094 didn't fix our issue, after testing in [this](https://stackblitz.com/edit/github-4mlsa6rw-59ybtxm4?file=package.json%3AL16) stackblitz, and the root cause was explained [here](https://github.com/carbon-design-system/carbon-ai-chat/issues/179#issuecomment-3285693272).

### Changelog

**Changed**

- Refactored the code as per [conventions](https://github.com/carbon-design-system/carbon/blob/main/packages/web-components/src/coding-conventions.md#lifecycle-management)
- The event listener is attached to `parentRoot`, making it more robust and reliable in the context of web components.

#### Testing / Reviewing

This change was tested side by side with the `Carbon AI Chat` repo by building and pulling the builds locally, and it works as expected.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
