### PR TITLE
fix(Slider): fix regression on Two Handle variant stories

### DIFF
--- a/packages/react/src/components/Slider/Slider.stories.js
+++ b/packages/react/src/components/Slider/Slider.stories.js
@@ -39,7 +39,7 @@ Default.argTypes = {
   ariaLabelInput: {
     control: { type: 'text' },
   },
-  preview_ariaLabelInputUpper: {
+  unstable_ariaLabelInputUpper: {
     control: { type: 'text' },
   },
   light: {
@@ -98,7 +98,7 @@ Default.argTypes = {
   name: {
     control: { type: 'text' },
   },
-  preview_nameUpper: {
+  unstable_nameUpper: {
     control: { type: 'text' },
   },
   readOnly: {
@@ -120,7 +120,7 @@ Default.argTypes = {
   value: {
     control: { type: 'number' },
   },
-  preview_valueUpper: {
+  unstable_valueUpper: {
     control: { type: 'number' },
   },
   onBlur: {
@@ -157,7 +157,7 @@ Default.argTypes = {
 
 Default.args = {
   ariaLabelInput: 'Lower bound',
-  preview_ariaLabelInputUpper: 'Upper bound',
+  unstable_ariaLabelInputUpper: 'Upper bound',
   disabled: false,
   hideTextInput: false,
   invalid: false,
@@ -169,7 +169,7 @@ Default.args = {
   step: 5,
   stepMultiplier: 5,
   value: 50,
-  preview_valueUpper: undefined,
+  unstable_valueUpper: undefined,
   warn: false,
   warnText: 'Warning message goes here',
 };
@@ -273,10 +273,10 @@ export const TwoHandleSlider = () => {
   return (
     <Slider
       ariaLabelInput="Lower bound"
-      preview_ariaLabelInputUpper="Upper bound"
+      unstable_ariaLabelInputUpper="Upper bound"
       labelText="Slider label"
       value={10}
-      preview_valueUpper={90}
+      unstable_valueUpper={90}
       min={0}
       max={100}
       step={1}
@@ -290,10 +290,10 @@ export const TwoHandleSliderWithHiddenInputs = () => {
   return (
     <Slider
       ariaLabelInput="Lower bound"
-      preview_ariaLabelInputUpper="Upper bound"
+      unstable_ariaLabelInputUpper="Upper bound"
       labelText="Slider label"
       value={10}
-      preview_valueUpper={90}
+      unstable_valueUpper={90}
       min={0}
       max={100}
       step={1}


### PR DESCRIPTION
Closes #20518

This PR renames the `preview__` props/controls in the Slider stories back to `unstable__` to fix a regression introduced [when unstable exports were aliased under preview 
](https://github.com/carbon-design-system/carbon/pull/20376)
### Changelog

**Changed**

- renamed `preview__` props/controls in the Slider storybook file back to `unstable__`


#### Testing / Reviewing

- In the React storybook, go to:
    - `Slider/Two Handle Slider`
    - `Slider/Two Handle Slider with Hidden Inputs`
- Both stories should render as expected
  
## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass
