### PR TITLE
Revert "fix(19982): fix toggletip-clickhandler"

### DIFF
--- a/packages/web-components/src/components/toggle-tip/__tests__/toggle-tip-test.js
+++ b/packages/web-components/src/components/toggle-tip/__tests__/toggle-tip-test.js
@@ -64,26 +64,15 @@ describe('cds-toggletip', function () {
     expect(el.open).to.be.false;
   });
 
-  it('should stay open on focus out (as per spec)', async () => {
+  it('should close on focus out', async () => {
     const el = await fixture(html`<cds-toggletip open></cds-toggletip>`);
-
-    const outsideElement = document.createElement('button');
-    document.body.appendChild(outsideElement);
-
-    const button = el.shadowRoot.querySelector('.cds--toggletip-button');
-    button.focus();
-
     const event = new FocusEvent('focusout', {
-      relatedTarget: outsideElement,
-      bubbles: true,
-      composed: true,
+      relatedTarget: document.body,
     });
     el.dispatchEvent(event);
-
     await el.updateComplete;
 
-    expect(el.open).to.be.true;
-    document.body.removeChild(outsideElement);
+    expect(el.open).to.be.false;
   });
 
   it('should render body text when provided via slot', async () => {

--- a/packages/web-components/src/components/toggle-tip/toggletip.ts
+++ b/packages/web-components/src/components/toggle-tip/toggletip.ts
@@ -110,11 +110,9 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20071
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleFocusOut(event: FocusEvent) {
-    const path = event.composedPath();
-    if (path.includes(this as unknown as EventTarget)) {
-      return;
+    if (!this.contains(event.relatedTarget as Node)) {
+      this.open = false;
     }
-    this.open = false;
   }
 
   protected _renderToggleTipLabel = () => {


### PR DESCRIPTION
Reverts carbon-design-system/carbon#20094

@devadula-nandan can you provide the issue or context you mentioned why this needs to be reverted?

If reverted we'll need to issue a patch that includes this and https://github.com/carbon-design-system/carbon/pull/20548