### PR TITLE
fix: move rest prop from button to th

### DIFF
--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -234,6 +234,7 @@ const TableHeader = React.forwardRef(function TableHeader(
 
   return (
     <th
+      {...rest}
       id={id}
       aria-sort={ariaSort}
       className={headerClasses}
@@ -247,8 +248,7 @@ const TableHeader = React.forwardRef(function TableHeader(
         type="button"
         aria-describedby={uniqueId}
         className={className}
-        onClick={handleClick}
-        {...rest}>
+        onClick={handleClick}>
         <span className={`${prefix}--table-sort__flex`}>
           <div className={`${prefix}--table-header-label`}>{children}</div>
           <Arrow size={20} className={`${prefix}--table-sort__icon`} />

--- a/packages/react/src/components/DataTable/TableHeader.tsx
+++ b/packages/react/src/components/DataTable/TableHeader.tsx
@@ -248,7 +248,8 @@ const TableHeader = React.forwardRef(function TableHeader(
         type="button"
         aria-describedby={uniqueId}
         className={className}
-        onClick={handleClick}>
+        onClick={handleClick}
+        {...rest}>
         <span className={`${prefix}--table-sort__flex`}>
           <div className={`${prefix}--table-header-label`}>{children}</div>
           <Arrow size={20} className={`${prefix}--table-sort__icon`} />


### PR DESCRIPTION
Closes #20460


### Changelog

**Changed**

- Move {..rest} spread from button to <th>


#### Testing / Reviewing

pass some attributes like `width` to the `<TableHeader>`, and inspect that it get's applied to `<th>` 

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
