### PR TITLE
fix: remove caption from dom when string is empty

### DIFF
--- a/packages/web-components/src/components/notification/toast-notification.ts
+++ b/packages/web-components/src/components/notification/toast-notification.ts
@@ -38,9 +38,13 @@ class CDSToastNotification extends CDSInlineNotification {
         <div class="${prefix}--${type}-notification__subtitle">
           ${subtitle}<slot name="subtitle"></slot>
         </div>
-        <div class="${prefix}--${type}-notification__caption">
-          ${caption}<slot name="caption"></slot>
-        </div>
+        ${caption || this.querySelector('[slot="caption"]')
+          ? html`
+              <div class="${prefix}--${type}-notification__caption">
+                ${caption}<slot name="caption"></slot>
+              </div>
+            `
+          : null}
         <slot></slot>
       </div>
     `;


### PR DESCRIPTION
Closes #20114

the toast notification in web component version, now hides the caption `<div>` element from the DOM when the caption is empty.

### Changelog

**Changed**

- the caption `<div>` is conditionally rendered according to the caption attribute, and support for the slot caption also.


#### Testing / Reviewing

- go to the toast notification story
- empty the caption control
- see that the caption element is not present in the DOM

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
