### PR TITLE
fix(themes): tokens preview app

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1517,6 +1517,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "didoo",
+      "name": "Cristiano Rastelli",
+      "avatar_url": "https://avatars.githubusercontent.com/u/686239?v=4",
+      "profile": "http://www.didoo.net/",
+      "contributions": [
+        "code",
+        "example"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/anjju"><img src="https://avatars.githubusercontent.com/u/20580246?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anju Shivan</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=anjju" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/seanhaug"><img src="https://avatars.githubusercontent.com/u/227620549?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sean Haughey</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=seanhaug" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Vignesh-Loganathan-IBM-1"><img src="https://avatars.githubusercontent.com/u/196759586?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vignesh-Loganathan-IBM-1</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Vignesh-Loganathan-IBM-1" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.didoo.net/"><img src="https://avatars.githubusercontent.com/u/686239?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cristiano Rastelli</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=didoo" title="Code">💻</a> <a href="#example-didoo" title="Examples">💡</a></td>
   </tr>
 </table>
 

--- a/packages/themes/examples/preview/src/pages/index.js
+++ b/packages/themes/examples/preview/src/pages/index.js
@@ -171,11 +171,11 @@ export default function IndexPage() {
             <tbody>
               {tokens
                 .filter((token) => {
-                  const group = token.groups.find((group) => {
-                    return group.name === activeGroup;
-                  });
-
-                  if (!group) {
+                  if (
+                    activeGroup !== 'All' &&
+                    token.groups &&
+                    !token.groups.includes(activeGroup)
+                  ) {
                     return false;
                   }
 


### PR DESCRIPTION
Closes #20443

This is a small fix to the tokens preview app, which was rendering an empty list of tokens even when the selectors were all set to `All`.

**Before:**
<img width="1778" height="949" alt="screenshot_5335" src="https://github.com/user-attachments/assets/71043991-a28a-4e05-aa7a-1cf14b60be2c" />

**After:**
<img width="1780" height="965" alt="screenshot_5336" src="https://github.com/user-attachments/assets/bf7433af-51a4-4ad8-a74e-6414c75259e4" />

### Changelog

**Changed**

- updated logic to filter by `group/activeGroup` in token preview app (now it's consistent with the other filters too)

#### Testing / Reviewing

Run the token preview app and check that the filters work as expected.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
