### PR TITLE
fix(dropdown): close listbox when ai-label is focused

### DIFF
--- a/packages/web-components/src/components/ai-label/__tests__/ai-label-test.js
+++ b/packages/web-components/src/components/ai-label/__tests__/ai-label-test.js
@@ -263,14 +263,14 @@ describe('cds-ai-label', function () {
     document.body.removeChild(el);
   });
 
-  it('should remain open when focus stays inside', async () => {
+  // a11y
+  it('should remain open when focus stays inside, and retains focus', async () => {
     const el = await fixture(html`<cds-ai-label></cds-ai-label>`);
     const button = el.shadowRoot.querySelector('.cds--slug__button');
-    button.click();
-
     button.focus();
-
+    button.click();
     expect(el.open).to.be.true;
+    expect(document.activeElement).to.equal(el);
   });
 
   it('should close when Escape is pressed', async () => {

--- a/packages/web-components/src/components/ai-label/ai-label.stories.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.stories.ts
@@ -232,6 +232,54 @@ export const ExplainabilityPopover = {
   },
 };
 
+export const Test = {
+  render: () => {
+    class TestWrapper extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: 'open' });
+
+        const aiLabel = document.createElement('cds-ai-label');
+        aiLabel.setAttribute('autoalign', '');
+        aiLabel.setAttribute('alignment', 'bottom-left');
+        aiLabel.setAttribute('ai-text', 'AI');
+        aiLabel.setAttribute('size', 'xs');
+        // aiLabel.setAttribute('revert-active', "");
+
+        const bodyText = document.createElement('div');
+        bodyText.setAttribute('slot', 'body-text');
+
+        const slot = document.createElement('slot');
+        slot.setAttribute('name', 'content');
+
+        bodyText.appendChild(slot);
+        aiLabel.appendChild(bodyText);
+        shadow.appendChild(aiLabel);
+      }
+    }
+
+    if (!customElements.get('test-wrapper')) {
+      customElements.define('test-wrapper', TestWrapper);
+    }
+
+    return html`
+      <div style="padding: 2rem; display: flex; gap: 1rem;">
+        <test-wrapper>
+          <div slot="content">
+            <p>Interactive slotted content:</p>
+            <button>Click me</button>
+            <input type="text" placeholder="Type here" />
+            <a href="#">Link</a>
+            <p>now it should not close on click/typing</p>
+          </div>
+        </test-wrapper>
+        <cds-button size="xs">test</cds-button>
+        <cds-ai-label></cds-ai-label>
+      </div>
+    `;
+  },
+};
+
 const meta = {
   title: 'Components/AI Label',
 };

--- a/packages/web-components/src/components/ai-label/ai-label.ts
+++ b/packages/web-components/src/components/ai-label/ai-label.ts
@@ -74,59 +74,12 @@ class CDSAILabel extends CDSToggleTip {
   @property()
   previousValue;
 
-  connectedCallback() {
-    super.connectedCallback?.();
-    document.addEventListener('click', this._handleOutsideClick, true);
-    document.addEventListener('focusin', this._handleFocusChange, true);
-  }
-  disconnectedCallback() {
-    super.disconnectedCallback?.();
-    document.removeEventListener('click', this._handleOutsideClick, true);
-    document.removeEventListener('click', this._handleFocusChange, true);
-  }
-
-  private _handleOutsideClick = (event: MouseEvent) => {
-    const path = event.composedPath();
-    if (!path.includes(this)) {
-      this.open = false;
-      this.requestUpdate();
-    }
-  };
-
-  private _handleFocusChange = (event: FocusEvent) => {
-    if (
-      this.open &&
-      (!(event.target instanceof Node) || !this.contains(event.target))
-    ) {
-      this.open = false;
-      this.requestUpdate();
-    }
-  };
-
   protected _handleClick = () => {
-    const activeElement = document.activeElement;
-    if (activeElement instanceof HTMLElement) {
-      activeElement.blur();
-    }
-
     if (this.revertActive) {
       this.revertActive = false;
       this.removeAttribute('revert-active');
     } else {
-      this.open = !this.open;
-      this.requestUpdate();
-    }
-  };
-
-  protected _handleAIKeydown = (event: KeyboardEvent) => {
-    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Escape') {
-      event.stopPropagation();
-    }
-
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      this.open = false;
-      this.requestUpdate();
+      super._handleClick();
     }
   };
 
@@ -149,7 +102,6 @@ class CDSAILabel extends CDSToggleTip {
       <button
         aria-controls="${this.id}"
         @click="${this._handleClick}"
-        @keydown="${this._handleAIKeydown}"
         class=${classes}
         aria-label="${ariaLabel}">
         <span class="${prefix}--slug__text">${aiText}</span>
@@ -173,8 +125,7 @@ class CDSAILabel extends CDSToggleTip {
               ?autoalign=${autoalign}
               kind="ghost"
               size="sm"
-              @click="${this._handleClick}"
-              @keydown="${this._handleAIKeydown}">
+              @click="${this._handleClick}">
               <span slot="tooltip-content"> ${revertLabel} </span>
               ${iconLoader(Undo16, { slot: 'icon' })}
             </cds-icon-button>

--- a/packages/web-components/src/components/combo-box/combo-box.scss
+++ b/packages/web-components/src/components/combo-box/combo-box.scss
@@ -16,6 +16,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/components/combo-box' as *;
 @use '@carbon/styles/scss/components/form';
 @use '@carbon/styles/scss/components/text-input/text-input';
+@use '@carbon/styles/scss/utilities/convert';
 @use '../dropdown/dropdown';
 
 :host(#{$prefix}-combo-box) {
@@ -76,10 +77,19 @@ $css--plex: true !default;
   .#{$prefix}--list-box__menu-item__option {
     block-size: auto;
   }
+}
 
-  &:hover {
-    background-color: $layer-hover;
-  }
+:host(#{$prefix}-combo-box-item:hover:not([disabled])) {
+  background-color: $layer-hover;
+}
+
+:host(#{$prefix}-combo-box-item:active:not([disabled])) {
+  background-color: $layer-selected;
+}
+
+:host(#{$prefix}-combo-box-item:hover[disabled])
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: $border-subtle-01;
 }
 
 :host(#{$prefix}-combo-box-item[disabled]) {
@@ -96,7 +106,6 @@ $css--plex: true !default;
 
 :host(#{$prefix}-combo-box-item[selected]) {
   @extend .#{$prefix}--list-box__menu-item--active;
-  @extend .#{$prefix}--list-box__menu-item--highlighted;
 
   .#{$prefix}--list-box__menu-item__option {
     color: $text-primary;
@@ -134,7 +143,7 @@ $css--plex: true !default;
   ::slotted(#{$prefix}-slug) {
     position: absolute;
     inset-block-start: 50%;
-    inset-inline-end: $spacing-08;
+    inset-inline-end: calc($spacing-08 + 9px);
   }
 
   ::slotted(#{$prefix}-ai-label:not([revert-active])),
@@ -143,11 +152,29 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-combo-box[ai-label])
+  .#{$prefix}--list-box__wrapper--decorator {
+  @include ai-gradient;
+}
+
 :host(#{$prefix}-combo-box[ai-label][isclosable]) {
+  padding-inline-end: $spacing-06;
+
   ::slotted(#{$prefix}-ai-label),
   ::slotted(#{$prefix}-slug) {
-    inset-inline-end: $spacing-10;
+    inset-inline-end: calc($spacing-10 + 18px);
   }
+}
+
+:host(#{$prefix}-combo-box[ai-label]) ::slotted(#{$prefix}-ai-label)::after {
+  position: absolute;
+  display: block;
+  background-color: $border-subtle-01;
+  block-size: $spacing-05;
+  content: '';
+  inline-size: convert.to-rem(1px);
+  inset-block-start: 0;
+  inset-inline-end: convert.to-rem(-9px);
 }
 
 :host(#{$prefix}-combo-box[warn]),

--- a/packages/web-components/src/components/combo-box/combo-box.ts
+++ b/packages/web-components/src/components/combo-box/combo-box.ts
@@ -159,6 +159,7 @@ class CDSComboBox extends CDSDropdown {
     ) {
       this._handleUserInitiatedClearInput();
     } else {
+      this.open = false;
       super._handleKeypressInner(event);
     }
   }

--- a/packages/web-components/src/components/combo-box/combo-box.ts
+++ b/packages/web-components/src/components/combo-box/combo-box.ts
@@ -102,9 +102,15 @@ class CDSComboBox extends CDSDropdown {
     const items = this.querySelectorAll(
       (this.constructor as typeof CDSComboBox).selectorItem
     );
-    const index = !this._filterInputNode.value
+    let index = !this._filterInputNode.value
       ? -1
       : findIndex(items, this._testItemWithQueryText, this);
+
+    // clear the index if the found item is disabled
+    if (items[index]?.hasAttribute('disabled')) {
+      index = -1;
+    }
+
     forEach(items, (item, i) => {
       if (i === index) {
         const menuRect = this._itemMenu?.getBoundingClientRect();
@@ -138,7 +144,7 @@ class CDSComboBox extends CDSDropdown {
     this.requestUpdate(); // If the only change is to `_filterInputValue`, auto-update doesn't happen
   }
 
-  protected _handleClickInner(event: MouseEvent) {
+  protected _handleClickInner(event: PointerEvent) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/carbon-design-system/carbon/issues/20071
     const { target } = event as any;
     if (this._selectionButtonNode?.contains(target)) {
@@ -159,7 +165,6 @@ class CDSComboBox extends CDSDropdown {
     ) {
       this._handleUserInitiatedClearInput();
     } else {
-      this.open = false;
       super._handleKeypressInner(event);
     }
   }
@@ -231,7 +236,7 @@ class CDSComboBox extends CDSDropdown {
 
     const inputClasses = classMap({
       [`${prefix}--text-input`]: true,
-      [`${prefix}--text-input--empty`]: !value,
+      [`${prefix}--text-input--empty`]: !value && !filterInputValue,
     });
 
     let activeDescendantFallback: string | undefined;

--- a/packages/web-components/src/components/dropdown/dropdown.scss
+++ b/packages/web-components/src/components/dropdown/dropdown.scss
@@ -46,6 +46,7 @@ $css--plex: true !default;
     outline: none;
   }
 }
+
 :host(#{$prefix}-dropdown[ai-label]) .#{$prefix}--list-box__wrapper--decorator {
   @include ai-gradient;
 }
@@ -111,12 +112,21 @@ $css--plex: true !default;
   }
 }
 
-:host(#{$prefix}-dropdown-item:hover) {
+:host(#{$prefix}-dropdown-item:hover:not([disabled])) {
   background-color: $layer-hover;
+}
+
+:host(#{$prefix}-dropdown-item:active:not([disabled])) {
+  background-color: $layer-selected;
 }
 
 :host(#{$prefix}-dropdown-item[highlighted]) {
   @extend .#{$prefix}--list-box__menu-item--highlighted;
+}
+
+:host(#{$prefix}-dropdown-item:hover[disabled])
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: $border-subtle-01;
 }
 
 :host(#{$prefix}-dropdown-item[disabled])
@@ -128,7 +138,6 @@ $css--plex: true !default;
 
 :host(#{$prefix}-dropdown-item[selected]) {
   @extend .#{$prefix}--list-box__menu-item--active;
-  @extend .#{$prefix}--list-box__menu-item--highlighted;
 
   .#{$prefix}--list-box__menu-item__option {
     color: $text-primary;

--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -143,18 +143,13 @@ class CDSDropdown extends ValidityMixin(
    * @param event The event.
    */
   protected _handleClickInner(event: PointerEvent) {
-    const { pointerType, target } = event;
+    const { target } = event;
     const constructor = this.constructor as typeof CDSDropdown;
     const clickedItem = (target as Element).closest(
       constructor.selectorItem
     ) as CDSDropdownItem | null;
 
-    if (!this.shadowRoot || this.readOnly) {
-      return;
-    }
-
-    // Only handle pointer types: mouse, pen, or touch.
-    if (!['mouse', 'pen', 'touch'].includes(pointerType)) {
+    if (this.readOnly) {
       return;
     }
 
@@ -165,7 +160,7 @@ class CDSDropdown extends ValidityMixin(
     }
 
     // If trigger inside the shadow root is clicked, toggle open/close.
-    if (this.shadowRoot.contains(target as Node)) {
+    if (this.shadowRoot && this.shadowRoot.contains(target as Node)) {
       this._handleUserInitiatedToggle();
       return;
     }
@@ -357,15 +352,13 @@ class CDSDropdown extends ValidityMixin(
     if (!disabled) {
       if (this.dispatchEvent(new CustomEvent(eventBeforeToggle, init))) {
         this.open = force;
-        if (!this.open) {
-          forEach(
-            this.querySelectorAll(constructor.selectorItemHighlighted),
-            (item) => {
-              (item as CDSDropdownItem).highlighted = false;
-            }
-          );
-        }
-        this.requestUpdate();
+        this._clearHighlight();
+        const itemToHighlight = this.querySelector(
+          constructor.selectorItemSelected
+        );
+
+        itemToHighlight?.setAttribute('highlighted', '');
+
         this.dispatchEvent(new CustomEvent(eventToggle, init));
       }
     }

--- a/packages/web-components/src/components/dropdown/dropdown.ts
+++ b/packages/web-components/src/components/dropdown/dropdown.ts
@@ -32,6 +32,7 @@ import {
   NAVIGATION_DIRECTION,
 } from './defs';
 import CDSDropdownItem from './dropdown-item';
+import CDSAILabel from '../ai-label/ai-label';
 import styles from './dropdown.scss?lit';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
 
@@ -199,7 +200,10 @@ class CDSDropdown extends ValidityMixin(
     if (!this.open) {
       switch (action) {
         case DROPDOWN_KEYBOARD_ACTION.TRIGGERING:
-          this._handleUserInitiatedToggle(true);
+          // Only toggle if the event target is not a CDSAILabel
+          if (!(event.target instanceof CDSAILabel)) {
+            this._handleUserInitiatedToggle(true);
+          }
           break;
         default:
           break;

--- a/packages/web-components/src/components/multi-select/multi-select.scss
+++ b/packages/web-components/src/components/multi-select/multi-select.scss
@@ -39,11 +39,8 @@ $css--plex: true !default;
 
   .#{$prefix}--text-input {
     border: none;
+    outline: none;
     padding-inline-start: 0;
-
-    &:focus {
-      outline: none;
-    }
   }
 
   .#{$prefix}--tag--disabled {

--- a/packages/web-components/src/components/toggle-tip/__tests__/toggle-tip-test.js
+++ b/packages/web-components/src/components/toggle-tip/__tests__/toggle-tip-test.js
@@ -64,26 +64,16 @@ describe('cds-toggletip', function () {
     expect(el.open).to.be.false;
   });
 
-  it('should stay open on focus out (as per spec)', async () => {
+  // https://carbondesignsystem.com/components/toggletip/accessibility/#keyboard-interactions
+  it('should close on focus out', async () => {
     const el = await fixture(html`<cds-toggletip open></cds-toggletip>`);
-
-    const outsideElement = document.createElement('button');
-    document.body.appendChild(outsideElement);
-
-    const button = el.shadowRoot.querySelector('.cds--toggletip-button');
-    button.focus();
-
     const event = new FocusEvent('focusout', {
-      relatedTarget: outsideElement,
-      bubbles: true,
-      composed: true,
+      relatedTarget: document.body,
     });
     el.dispatchEvent(event);
-
     await el.updateComplete;
 
-    expect(el.open).to.be.true;
-    document.body.removeChild(outsideElement);
+    expect(el.open).to.be.false;
   });
 
   it('should render body text when provided via slot', async () => {

--- a/packages/web-components/src/components/toggle-tip/toggletip.stories.ts
+++ b/packages/web-components/src/components/toggle-tip/toggletip.stories.ts
@@ -74,6 +74,7 @@ export const Default = {
         <cds-link href="#" slot="actions">Link action</cds-link>
         <cds-button size="sm" slot="actions">Button</cds-button>
       </cds-toggletip>
+      <cds-button size="xs">test</cds-button>
     </div>
   `,
 };

--- a/packages/web-components/src/components/toggle-tip/toggletip.ts
+++ b/packages/web-components/src/components/toggle-tip/toggletip.ts
@@ -85,9 +85,9 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
       : this.removeAttribute('has-actions');
   }
 
-  protected _handleClick = () => {
+  protected _handleClick() {
     this.open = !this.open;
-  };
+  }
 
   /**
    * Handles `keydown` event on this element.
@@ -110,11 +110,31 @@ class CDSToggletip extends HostListenerMixin(FocusMixin(LitElement)) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- https://github.com/carbon-design-system/carbon/issues/20071
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleFocusOut(event: FocusEvent) {
-    const path = event.composedPath();
-    if (path.includes(this as unknown as EventTarget)) {
+    if (this.contains(event.relatedTarget as Node)) {
+      return;
+    }
+
+    if (this._deepShadowContains(this, event.relatedTarget)) {
       return;
     }
     this.open = false;
+  }
+
+  private _deepShadowContains(root: Node, el: EventTarget | null): boolean {
+    if (!(el instanceof Node)) {
+      return false;
+    }
+    if (el === root) {
+      return true;
+    }
+
+    return this._deepShadowContains(
+      root,
+      (el as HTMLElement).assignedSlot ||
+        el.parentNode ||
+        (el.getRootNode() as ShadowRoot).host ||
+        null
+    );
   }
 
   protected _renderToggleTipLabel = () => {


### PR DESCRIPTION
Exploration to fix #19274

> [!CAUTION]
> Do not merge 

Notes from #20552 that spawned this PR:

> (this should) handle ai-lable interaction on cds-dropdown, to check if the target is an instance of ai-label and call the necessary methods. and the dropdown inheritance on combo-box and multi-select must automatically fix them by delegating the parent behaviors after component specific behaviors in the respective components.
> ...
> everything works fine except multi select which is updating twice for some reason and due to 2 updates the ai-label closes. dropdown and combo-box works as expected