### PR TITLE
fix(notification): align toast notification details spacing with design spec

### DIFF
--- a/packages/web-components/src/components/notification/toast-notification.ts
+++ b/packages/web-components/src/components/notification/toast-notification.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,22 +31,20 @@ class CDSToastNotification extends CDSInlineNotification {
   protected _renderText() {
     const { caption, subtitle, title, _type: type } = this;
     return html`
-      <div class="${prefix}--${type}-notification__details">
-        <div class="${prefix}--${type}-notification__title">
-          ${title}<slot name="title"></slot>
-        </div>
-        <div class="${prefix}--${type}-notification__subtitle">
-          ${subtitle}<slot name="subtitle"></slot>
-        </div>
-        ${caption || this.querySelector('[slot="caption"]')
-          ? html`
-              <div class="${prefix}--${type}-notification__caption">
-                ${caption}<slot name="caption"></slot>
-              </div>
-            `
-          : null}
-        <slot></slot>
+      <div class="${prefix}--${type}-notification__title">
+        ${title}<slot name="title"></slot>
       </div>
+      <div class="${prefix}--${type}-notification__subtitle">
+        ${subtitle}<slot name="subtitle"></slot>
+      </div>
+      ${caption || this.querySelector('[slot="caption"]')
+        ? html`
+            <div class="${prefix}--${type}-notification__caption">
+              ${caption}<slot name="caption"></slot>
+            </div>
+          `
+        : null}
+      <slot></slot>
     `;
   }
 


### PR DESCRIPTION
Closes #20570 

Fixed a bug with the toast notification spacing in web components to match the design spec.

### Changelog

**Removed**

- Removed an extra div in the component's render that resulted in the `${prefix}--${type}-notification__details` class being applied twice

#### Testing / Reviewing

- Go to `Notifications/Toast/Default` in WC Deploy Preview
- The bottom spacing should be 16px/1rem to match React and the Design spec


## PR Checklist
As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~~[ ] Wrote passing tests that cover this change~~
- ~~[ ] Addressed any impact on accessibility (a11y)~~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass