### PR TITLE
fix(popover): alignment

### DIFF
--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -327,6 +327,7 @@ export const Popover: PopoverComponent & {
               }),
             arrow({
               element: caretRef,
+              padding: 16,
             }),
             autoAlign && hide(),
           ],

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.stories.js
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.stories.js
@@ -93,3 +93,72 @@ Default.argTypes = {
     },
   },
 };
+
+export const WithLargeText = (args) => {
+  const definition = 'Example definition';
+  return (
+    <p>
+      Custom domains direct requests for your apps in this Cloud Foundry
+      organization to a{' '}
+      <DefinitionTooltip openOnHover definition={definition} {...args}>
+        URL that you own. A custom domain can be a shared domain,
+      </DefinitionTooltip>{' '}
+      a shared subdomain, or a shared domain and host.
+    </p>
+  );
+};
+
+WithLargeText.args = {
+  align: 'bottom-left',
+  defaultOpen: false,
+  definition: 'Example definition',
+  openOnHover: true,
+};
+
+WithLargeText.argTypes = {
+  align: {
+    options: [
+      'top',
+      'top-left',
+      'top-right',
+
+      'bottom',
+      'bottom-left',
+      'bottom-right',
+
+      'left',
+      'left-bottom',
+      'left-top',
+
+      'right',
+      'right-bottom',
+      'right-top',
+    ],
+    control: {
+      type: 'select',
+    },
+  },
+  definition: {
+    control: {
+      type: 'text',
+    },
+  },
+  id: {
+    table: { disable: true },
+  },
+  openOnHover: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  tooltipText: {
+    table: {
+      disable: true,
+    },
+  },
+  triggerClassName: {
+    table: {
+      disable: true,
+    },
+  },
+};

--- a/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
+++ b/packages/react/src/components/UIShell/UIShell.HeaderBase.stories.js
@@ -320,7 +320,8 @@ export const HeaderWNavigationActionsAndSideNav = () => (
           <HeaderGlobalBar>
             <HeaderGlobalAction
               aria-label="Search"
-              onClick={action('search click')}>
+              onClick={action('search click')}
+              tooltipAlignment="start">
               <Search size={20} />
             </HeaderGlobalAction>
             <HeaderGlobalAction

--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -7,6 +7,7 @@
 
 @use '../../config' as *;
 @use '../../layer' as *;
+@use '../../spacing' as *;
 @use '../../theme';
 @use '../../utilities/box-shadow' as *;
 @use '../../utilities/button-reset';
@@ -47,7 +48,10 @@ $popover-background-color: custom-property.get-var(
 );
 
 // The drop shadow value used for the popover container
-$popover-drop-shadow: custom-property.get-var('popover-drop-shadow', 'none');
+$popover-drop-shadow: custom-property.get-var(
+  'popover-drop-shadow',
+  drop-shadow(0 $spacing-01 $spacing-01 rgba(0, 0, 0, 0.2))
+);
 
 // The border radius value for the popover container
 $popover-border-radius: custom-property.get-var('popover-border-radius', 2px);
@@ -103,10 +107,8 @@ $popover-caret-height: custom-property.get-var(
   }
 
   // Drop shadow modifier
-  .#{$prefix}--popover--drop-shadow
-    .#{$prefix}--popover
-    > .#{$prefix}--popover-content {
-    filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.2));
+  .#{$prefix}--popover--drop-shadow .#{$prefix}--popover {
+    filter: $popover-drop-shadow;
   }
 
   // Caret tip modifier
@@ -121,7 +123,6 @@ $popover-caret-height: custom-property.get-var(
   .#{$prefix}--popover {
     position: absolute;
     z-index: z('floating');
-    filter: $popover-drop-shadow;
     inset: 0;
     pointer-events: none;
   }

--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -901,6 +901,18 @@ $popover-caret-height: custom-property.get-var(
       .#{$prefix}--popover--auto-align
     )
     > .#{$prefix}--popover
+    > .#{$prefix}--popover-content,
+  [dir='rtl']
+    .#{$prefix}--popover--tab-tip.#{$prefix}--popover--top-end:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content,
+  [dir='rtl']
+    .#{$prefix}--popover--tab-tip.#{$prefix}--popover--bottom-end:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-inline-start: 0;
   }
@@ -914,8 +926,21 @@ $popover-caret-height: custom-property.get-var(
       .#{$prefix}--popover--auto-align
     )
     > .#{$prefix}--popover
+    > .#{$prefix}--popover-content,
+  [dir='rtl']
+    .#{$prefix}--popover--tab-tip.#{$prefix}--popover--top-start:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content,
+  [dir='rtl']
+    .#{$prefix}--popover--tab-tip.#{$prefix}--popover--bottom-start:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-inline-end: 0;
+    inset-inline-start: initial;
   }
 
   .#{$prefix}--popover--tab-tip .#{$prefix}--popover {

--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -235,7 +235,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-block-end: 0;
-    inset-inline-start: 0;
+    inset-inline-start: calc(50% - $popover-offset);
     transform: translate(
       calc(-1 * $popover-offset),
       calc(100% + $popover-offset)
@@ -250,7 +250,7 @@ $popover-caret-height: custom-property.get-var(
     .#{$prefix}--popover--bottom-start:not(.#{$prefix}--popover--auto-align)
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
-    inset-inline-end: 0;
+    inset-inline-end: calc(50% - $popover-offset);
     inset-inline-start: initial;
   }
 
@@ -261,7 +261,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-block-end: 0;
-    inset-inline-end: 0;
+    inset-inline-end: calc(50% - $popover-offset);
     transform: translate($popover-offset, calc(100% + $popover-offset));
   }
 
@@ -273,7 +273,6 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover-caret {
     inset-block-end: 0;
     inset-inline-end: 0;
-    inset-inline-start: auto;
   }
 
   .#{$prefix}--popover--bottom-start:not(.#{$prefix}--popover--auto-align)
@@ -281,17 +280,13 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover-caret {
     inset-block-end: 0;
     inset-inline-end: auto;
-    inset-inline-start: 0;
-    transform: translate(50%, calc($popover-offset));
   }
 
   .#{$prefix}--popover--top-start:not(.#{$prefix}--popover--auto-align)
     > .#{$prefix}--popover
     > .#{$prefix}--popover-caret {
     inset-block-end: 0;
-    inset-inline-end: auto;
-    inset-inline-start: 0;
-    transform: translate(50%, calc(-1 * $popover-offset));
+    inset-inline-end: 0;
   }
 
   [dir='rtl']
@@ -302,7 +297,7 @@ $popover-caret-height: custom-property.get-var(
     .#{$prefix}--popover--bottom-end:not(.#{$prefix}--popover--auto-align)
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
-    inset-inline-start: 0;
+    inset-inline-start: calc(50% - $popover-offset);
   }
 
   // Popover hover area placement
@@ -427,7 +422,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-block-start: 0;
-    inset-inline-start: 0;
+    inset-inline-start: calc(50% - $popover-offset);
     transform: translate(
       calc(-1 * $popover-offset),
       calc(-100% - $popover-offset)
@@ -442,7 +437,7 @@ $popover-caret-height: custom-property.get-var(
     .#{$prefix}--popover--top-start:not(.#{$prefix}--popover--auto-align)
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
-    inset-inline-end: 0;
+    inset-inline-end: calc(50% - $popover-offset);
     inset-inline-start: initial;
   }
 
@@ -453,7 +448,7 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     inset-block-start: 0;
-    inset-inline-end: 0;
+    inset-inline-end: calc(50% - $popover-offset);
     transform: translate($popover-offset, calc(-100% - $popover-offset));
   }
 
@@ -465,7 +460,7 @@ $popover-caret-height: custom-property.get-var(
     .#{$prefix}--popover--top-end:not(.#{$prefix}--popover--auto-align)
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
-    inset-inline-start: 0;
+    inset-inline-start: calc(50% - $popover-offset);
   }
 
   // Popover hover area placement
@@ -895,6 +890,32 @@ $popover-caret-height: custom-property.get-var(
     > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     border-radius: 0;
+  }
+
+  .#{$prefix}--popover--tab-tip.#{$prefix}--popover--top-start:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content,
+  .#{$prefix}--popover--tab-tip.#{$prefix}--popover--bottom-start:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content {
+    inset-inline-start: 0;
+  }
+
+  .#{$prefix}--popover--tab-tip.#{$prefix}--popover--top-end:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content,
+  .#{$prefix}--popover--tab-tip.#{$prefix}--popover--bottom-end:not(
+      .#{$prefix}--popover--auto-align
+    )
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content {
+    inset-inline-end: 0;
   }
 
   .#{$prefix}--popover--tab-tip .#{$prefix}--popover {

--- a/packages/styles/scss/components/ui-shell/header/_header.scss
+++ b/packages/styles/scss/components/ui-shell/header/_header.scss
@@ -57,26 +57,6 @@
     z-index: z('header') + 1;
   }
 
-  .#{$prefix}--header {
-    .#{$prefix}--popover--bottom-start:not(.#{$prefix}--popover--auto-align) {
-      > .#{$prefix}--popover {
-        > .#{$prefix}--popover-caret,
-        > .#{$prefix}--popover-content {
-          inset-inline-start: $spacing-05;
-        }
-      }
-    }
-
-    .#{$prefix}--popover--bottom-end:not(.#{$prefix}--popover--auto-align) {
-      > .#{$prefix}--popover {
-        > .#{$prefix}--popover-caret,
-        > .#{$prefix}--popover-content {
-          inset-inline-end: $spacing-05;
-        }
-      }
-    }
-  }
-
   .#{$prefix}--header__action > :first-child {
     margin-block-start: 0;
   }


### PR DESCRIPTION
Closes #N/A

in Carbon labs we noticed from #20322 was causing the popover  header to misaligned
<img width="479" height="376" alt="image" src="https://github.com/user-attachments/assets/829c7233-43fc-4bcd-887e-e270b6be4429" />

Then, after talking to @laurenmrice we were that none of the carets seemed to be centered, which partially came from here https://github.com/carbon-design-system/carbon/pull/17964

Now the popovers should be correctly aligned while still maintaining the above fixes, but not causing the misalignment

### Changelog

**New**

- {{new thing}}

**Changed**

- adjusted popover styles
- added back long text definitionTooltip temporarily to check styles
- added alignment in UIShell's HeaderGlobalActions temporarly to check styles

**Removed**

- header specific styles the popover should be able to handle the styles

#### Testing / Reviewing

- Check all Popover stories (ltr and rtl)
- Check DefinitionTooltip stories (ltr and rtl)
- check tooltip stories

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
