### PR TITLE
feat(code-connect): connect low contrast ContentSwitcher

### DIFF
--- a/packages/react/code-connect/ContentSwitcher/ContentSwitcher.figma.tsx
+++ b/packages/react/code-connect/ContentSwitcher/ContentSwitcher.figma.tsx
@@ -15,14 +15,18 @@ figma.connect(
   {
     props: {
       children: figma.children(['_Content switcher text item']),
+      lowContrast: figma.boolean('Low contrast'),
       size: figma.enum('Size', {
         Large: 'lg',
         Medium: 'md',
         Small: 'sm',
       }),
     },
-    example: ({ size, children }) => (
-      <ContentSwitcher onChange={function noRefCheck() {}} size={size}>
+    example: ({ size, children, lowContrast }) => (
+      <ContentSwitcher
+        onChange={function noRefCheck() {}}
+        size={size}
+        lowContrast={lowContrast}>
         {children}
       </ContentSwitcher>
     ),
@@ -36,14 +40,18 @@ figma.connect(
     variant: { Type: 'Icon only' },
     props: {
       children: figma.children(['_Content switcher icon item']),
+      lowContrast: figma.boolean('Low contrast'),
       size: figma.enum('Size', {
         Large: 'lg',
         Medium: 'md',
         Small: 'sm',
       }),
     },
-    example: ({ size, children }) => (
-      <ContentSwitcher onChange={function noRefCheck() {}} size={size}>
+    example: ({ size, children, lowContrast }) => (
+      <ContentSwitcher
+        onChange={function noRefCheck() {}}
+        size={size}
+        lowContrast={lowContrast}>
         {children}
       </ContentSwitcher>
     ),

--- a/packages/react/code-connect/MultiSelect/FluidFilterableMultiSelect.figma.tsx
+++ b/packages/react/code-connect/MultiSelect/FluidFilterableMultiSelect.figma.tsx
@@ -12,7 +12,7 @@ import { FluidMultiSelect, FluidDropdownSkeleton } from '@carbon/react';
 import figma from '@figma/code-connect';
 
 figma.connect(
-  FluidFilterableMultiSelect,
+  FluidMultiSelect,
   'https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/(v11)-All-themes---Carbon-Design-System?node-id=45988-11486&t=aG4cJRjteQHcd71k-4',
   {
     props: {


### PR DESCRIPTION
Closes #19318



### Changelog


**Changed**

- add lowContrast prop to Code Connect for ContentSwitcher
- fix component name for FluidMultiSelect in Code Connect file


#### Testing / Reviewing

<img width="1195" height="339" alt="Screenshot 2025-09-29 at 8 53 43 AM" src="https://github.com/user-attachments/assets/0032246b-98db-4716-86ad-590f1b7b95fc" />
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~[x] Updated documentation and storybook examples~
~[x] Wrote passing tests that cover this change~
~[x] Addressed any impact on accessibility (a11y)~
~[x] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)

