### PR TITLE
chore(codeowners): update to remove monorepo-lead-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,24 @@
 # Each line is a file pattern followed by one or more owners.
+# Order is important; the last matching pattern takes the most
+# precedence.
 
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, this team will
 # be requested for review when someone opens a pull request.
-* @carbon-design-system/monorepo-reviewers @carbon-design-system/monorepo-lead-reviewers
+* @carbon-design-system/monorepo-reviewers
 
 
 # Core icons and pictograms
-/packages/icons/src/svg/        @laurenmrice @carbon-design-system/brand-icons @carbon-design-system/monorepo-reviewers @carbon-design-system/monorepo-lead-reviewers
-/packages/pictograms/src/svg/   @laurenmrice @carbon-design-system/brand-pictograms @carbon-design-system/monorepo-reviewers @carbon-design-system/monorepo-lead-reviewers
+/packages/icons/src/svg/        @laurenmrice @carbon-design-system/brand-icons @carbon-design-system/monorepo-reviewers
+/packages/pictograms/src/svg/   @laurenmrice @carbon-design-system/brand-pictograms @carbon-design-system/monorepo-reviewers
 
-# Order is important; the last matching pattern takes the most
-# precedence. When someone opens a pull request that modifies
-# public api snapshot files, only this team and not the global
-# owner(s) will be requested for a review.
 # Admins and leads should be notified of Public API changes in
 # the system
-**/PublicAPI-test.js        @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
-**/PublicAPI-test.js.snap   @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
-
+**/PublicAPI-test.js        @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-reviewers
+**/PublicAPI-test.js.snap   @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-reviewers
 
 # Admins and leads should be notified of changes to CI/CD workflows
 # codeowners, and any other config present in .github.
 # This should always be the last entry in this file.
-/.github/           @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
-/.github/CODEOWNERS @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-lead-reviewers
+/.github/           @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-reviewers
+/.github/CODEOWNERS @carbon-design-system/developers-system-admins @carbon-design-system/monorepo-reviewers


### PR DESCRIPTION
This updates codeowners so that PR reviews are primarily gathered from one team. Two from the team will be assigned to a PR. If the PR contains changes to `.github` or the public API snapshots, system admins will be requested as well. 

### Changelog


**Changed**

- updated codeowners to remove monorepo-lead-reviewers

#### Testing / Reviewing

- The diff should show no issues with the syntax

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
