### PR TITLE
fix: resolve StackBlitz preview links for preview components

### DIFF
--- a/packages/react/previewer/codePreviewer.tsx
+++ b/packages/react/previewer/codePreviewer.tsx
@@ -55,12 +55,15 @@ export const stackblitzPrefillConfig = (
     componentNames: Array<string>,
     storyCode: string
   ) => {
-    return componentNames.filter((componentName) => {
-      // Grab the component and add the "<" resulting in"`<ComponentName`
-      const regex = new RegExp(`<${componentName}\\b`, 'g');
-      // Check if the component exists in the `storyCode`
-      return regex.test(storyCode);
-    });
+    return componentNames
+      .filter((componentName) => {
+        const regex = new RegExp(`<${componentName}\\b`, 'g');
+        return regex.test(storyCode);
+      })
+      .map((componentName) => {
+        const previewVersion = `preview__${componentName}`;
+        return carbonComponents[previewVersion] ? previewVersion : componentName;
+      });
   };
 
   // Get all matched components


### PR DESCRIPTION
**Changed**

- Modified `findComponentImports` function in `packages/react/previewer/codePreviewer.tsx` to correctly map component names to their preview exports when generating StackBlitz previews

fixes: #20599

**Removed**

- Removed unnecessary inline comments from the fix for cleaner code
The fix ensures that when stories use component names like `<IconIndicator>`, the generated StackBlitz code correctly imports `preview__IconIndicator` from `@carbon/react`.

### Problem
- StackBlitz preview links were failing for preview components because the code was trying to import components like `IconIndicator` when it should have been importing `preview__IconIndicator`.

### Solution  
- Updated the component matching logic to check for preview versions of components and use the correct export names (e.g., `preview__IconIndicator`, `preview_Layout`) when generating StackBlitz import statements.

### Components Fixed
- This fix applies to all preview components including IconIndicator, ShapeIndicator, Layout, Dialog, and all fluid components that use the `preview__` export prefix.