### PR TITLE
fix(DataTable): use `getTablePrefix` for fully unique expansion row ids

### DIFF
--- a/e2e/components/DataTable/DataTable-test.avt.e2e.js
+++ b/e2e/components/DataTable/DataTable-test.avt.e2e.js
@@ -200,6 +200,20 @@ test.describe('@avt DataTable', () => {
         'components-datatable-expansion--batch-expansion'
       );
     });
+    test('@avt-advanced-states batch expansion with multiple tables', async ({
+      page,
+    }) => {
+      await visitStory(page, {
+        component: 'DataTable',
+        id: 'components-datatable-expansion--batch-expansion-multiple-tables',
+        globals: {
+          theme: 'white',
+        },
+      });
+      await expect(page).toHaveNoACViolations(
+        'components-datatable-expansion--batch-expansion-multiple-tables'
+      );
+    });
   });
 
   test.describe('@avt filtering', () => {

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -160,6 +160,7 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
     isExpanded: boolean;
     onExpand: (event: MouseEvent<HTMLButtonElement>) => void;
     [key: string]: unknown;
+    id: string;
   };
 
   getRowProps: (options: {
@@ -174,6 +175,7 @@ export interface DataTableRenderProps<RowType, ColTypes extends any[]> {
     key: string;
     onExpand: (event: MouseEvent<HTMLButtonElement>) => void;
     [key: string]: unknown;
+    expandHeader: string;
   };
 
   getExpandedRowProps: (options: {
@@ -443,9 +445,12 @@ export const DataTable = <RowType, ColTypes extends any[]>(
       ...rest,
       'aria-label': t(translationKey),
       // Provide a string of all expanded row IDs, separated by a space.
-      'aria-controls': rowIds.map((id) => `expanded-row-${id}`).join(' '),
+      'aria-controls': rowIds
+        .map((id) => `${getTablePrefix()}-expanded-row-${id}`)
+        .join(' '),
       isExpanded,
       onExpand: composeEventHandlers(handlers),
+      id: `${getTablePrefix()}-expand`,
     };
   };
 
@@ -493,9 +498,10 @@ export const DataTable = <RowType, ColTypes extends any[]>(
       onExpand: composeEventHandlers([handleOnExpandRow(row.id), onClick]),
       isExpanded: row.isExpanded,
       'aria-label': t(translationKey),
-      'aria-controls': `expanded-row-${row.id}`,
+      'aria-controls': `${getTablePrefix()}-expanded-row-${row.id}`,
       isSelected: row.isSelected,
       disabled: row.disabled,
+      expandHeader: `${getTablePrefix()}-expand`,
     };
   };
 
@@ -505,7 +511,7 @@ export const DataTable = <RowType, ColTypes extends any[]>(
   }) => {
     return {
       ...rest,
-      id: `expanded-row-${row.id}`,
+      id: `${getTablePrefix()}-expanded-row-${row.id}`,
     };
   };
 

--- a/packages/react/src/components/DataTable/TableExpandRow.tsx
+++ b/packages/react/src/components/DataTable/TableExpandRow.tsx
@@ -50,6 +50,10 @@ export interface TableRowExpandInteropProps {
    * Specify if the row is selected.
    */
   isSelected?: boolean;
+  /**
+   * The id of the matching th node in the table head. Addresses a11y concerns outlined here: https://www.ibm.com/able/guidelines/ci162/info_and_relationships.html and https://www.w3.org/TR/WCAG20-TECHS/H43
+   */
+  expandHeader?: string;
 }
 
 export interface TableExpandRowProps

--- a/packages/react/src/components/DataTable/TableRow.tsx
+++ b/packages/react/src/components/DataTable/TableRow.tsx
@@ -36,6 +36,7 @@ const TableRow = frFn((props, ref) => {
     onExpand, // eslint-disable-line @typescript-eslint/no-unused-vars -- https://github.com/carbon-design-system/carbon/issues/20452
     isExpanded, // eslint-disable-line @typescript-eslint/no-unused-vars -- https://github.com/carbon-design-system/carbon/issues/20452
     isSelected,
+    expandHeader, // eslint-disable-line @typescript-eslint/no-unused-vars
     ...cleanProps
   } = props;
 

--- a/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content.stories.js
+++ b/packages/react/src/components/DataTable/stories/dynamic-content/DataTable-dynamic-content.stories.js
@@ -166,6 +166,7 @@ export const Default = (args) => {
           {({
             rows,
             headers,
+            getExpandHeaderProps,
             getHeaderProps,
             getSelectionProps,
             getToolbarProps,
@@ -238,7 +239,10 @@ export const Default = (args) => {
                 <Table {...getTableProps()} aria-label="sample table">
                   <TableHead>
                     <TableRow>
-                      <TableExpandHeader aria-label="expand row" />
+                      <TableExpandHeader
+                        aria-label="expand row"
+                        {...getExpandHeaderProps()}
+                      />
                       {args.radio ? (
                         <th scope="col" />
                       ) : (

--- a/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion.stories.js
+++ b/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion.stories.js
@@ -51,6 +51,7 @@ export const Default = (args) => (
       rows,
       headers,
       getHeaderProps,
+      getExpandHeaderProps,
       getRowProps,
       getExpandedRowProps,
       getTableProps,

--- a/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion.stories.js
+++ b/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion.stories.js
@@ -156,3 +156,123 @@ export const BatchExpansion = (args) => (
     )}
   </DataTable>
 );
+
+export const BatchExpansionMultipleTables = (args) => (
+  <>
+    <DataTable {...args} rows={rows} headers={headers}>
+      {({
+        rows,
+        headers,
+        getHeaderProps,
+        getExpandHeaderProps,
+        getRowProps,
+        getExpandedRowProps,
+        getTableProps,
+        getTableContainerProps,
+        getCellProps,
+      }) => (
+        <TableContainer
+          title="DataTable"
+          description="With batch expansion"
+          {...getTableContainerProps()}>
+          <Table {...getTableProps()} aria-label="sample table">
+            <TableHead>
+              <TableRow>
+                <TableExpandHeader
+                  enableToggle={true}
+                  {...getExpandHeaderProps()}
+                />
+                {headers.map((header, i) => (
+                  <TableHeader key={i} {...getHeaderProps({ header })}>
+                    {header.header}
+                  </TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <React.Fragment key={row.id}>
+                  <TableExpandRow {...getRowProps({ row })}>
+                    {row.cells.map((cell) => (
+                      <TableCell {...getCellProps({ cell })}>
+                        {cell.value}
+                      </TableCell>
+                    ))}
+                  </TableExpandRow>
+                  <TableExpandedRow
+                    colSpan={headers.length + 1}
+                    className="demo-expanded-td"
+                    {...getExpandedRowProps({ row })}>
+                    <h6>Expandable row content</h6>
+                    <div>Description here</div>
+                  </TableExpandedRow>
+                </React.Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </DataTable>
+    <DataTable {...args} rows={rows} headers={headers}>
+      {({
+        rows,
+        headers,
+        getHeaderProps,
+        getExpandHeaderProps,
+        getRowProps,
+        getExpandedRowProps,
+        getTableProps,
+        getTableContainerProps,
+        getCellProps,
+      }) => (
+        <TableContainer
+          title="DataTable"
+          description="With batch expansion"
+          {...getTableContainerProps()}>
+          <Table {...getTableProps()} aria-label="sample table">
+            <TableHead>
+              <TableRow>
+                <TableExpandHeader
+                  enableToggle={true}
+                  {...getExpandHeaderProps()}
+                />
+                {headers.map((header, i) => (
+                  <TableHeader key={i} {...getHeaderProps({ header })}>
+                    {header.header}
+                  </TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <React.Fragment key={row.id}>
+                  <TableExpandRow {...getRowProps({ row })}>
+                    {row.cells.map((cell) => (
+                      <TableCell {...getCellProps({ cell })}>
+                        {cell.value}
+                      </TableCell>
+                    ))}
+                  </TableExpandRow>
+                  <TableExpandedRow
+                    colSpan={headers.length + 1}
+                    className="demo-expanded-td"
+                    {...getExpandedRowProps({ row })}>
+                    <h6>Expandable row content</h6>
+                    <div>Description here</div>
+                  </TableExpandedRow>
+                </React.Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </DataTable>
+  </>
+);
+/*
+ * This story will:
+ * - Be excluded from the docs page
+ * - Removed from the sidebar navigation
+ * - Still be a tested variant and available at direct url
+ */
+BatchExpansionMultipleTables.tags = ['!dev', '!autodocs'];

--- a/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion.stories.js
+++ b/packages/react/src/components/DataTable/stories/expansion/DataTable-expansion.stories.js
@@ -64,7 +64,10 @@ export const Default = (args) => (
         <Table {...getTableProps()} aria-label="sample table">
           <TableHead>
             <TableRow>
-              <TableExpandHeader aria-label="expand row" />
+              <TableExpandHeader
+                aria-label="expand row"
+                {...getExpandHeaderProps()}
+              />
               {headers.map((header, i) => (
                 <TableHeader key={i} {...getHeaderProps({ header })}>
                   {header.header}


### PR DESCRIPTION
Closes #19133
Closes #20616

This incorporates `getTablePrefix()` into the unique values generated for row `id`s and `aria-controls` relating to table row expansion. This makes it so that multiple tables can be rendered on the same page and not have any conflicting id's or attribute values.

### Changelog

**Changed**

- update various get*Props getters to use getTablePrefix
- add a new hidden story that has two tables on the same page
- add a new avt test that runs against the new "two tables" story

#### Testing / Reviewing

1. Go to the ?path=/story/components-datatable-expansion--batch-expansion story
2. Run the accessibility-checker plugin, observe there are:
   1. No errors of `The 'headers' attribute value "expand" does not refer to a cell in the same table`
   1. No warnings of `The <th> element has the id "expand" that is already in use`
   1. No warnings of `The <tr> element has the id "expanded-row-d" that is already in use`
3. In both tables expand all rows by clicking the "expand all" chevron in the headers
4. Repeat step 2 - run ac, make sure none of the applicable errors/warnings are present 

This is the path for the hidden story: `components-datatable-expansion--batch-expansion-multiple-tables`

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
