### PR TITLE
Fix checked attribute not updating on TileGroup selection

### DIFF
--- a/packages/react/src/components/RadioTile/RadioTile-test.js
+++ b/packages/react/src/components/RadioTile/RadioTile-test.js
@@ -126,6 +126,7 @@ describe('RadioTile', () => {
       expect(ref.current.type).toEqual('radio');
       expect(ref.current.value).toEqual('some test value');
     });
+
     it('should pass "required" prop to the input element', () => {
       render(
         <RadioTile required value="some test value">
@@ -133,6 +134,52 @@ describe('RadioTile', () => {
         </RadioTile>
       );
       expect(screen.getByRole('radio')).toHaveAttribute('required');
+    });
+
+    it('should set the checked attribute on the DOM element when checked prop is true', () => {
+      render(
+        <RadioTile value="standard" checked>
+          Option 1
+        </RadioTile>
+      );
+
+      const radioInput = screen.getByRole('radio');
+      expect(radioInput).toBeChecked();
+      expect(radioInput.hasAttribute('checked')).toBe(true);
+    });
+
+    it('should remove the checked attribute on the DOM element when checked prop is false', () => {
+      render(
+        <RadioTile value="standard" checked={false}>
+          Option 1
+        </RadioTile>
+      );
+
+      const radioInput = screen.getByRole('radio');
+      expect(radioInput).not.toBeChecked();
+      expect(radioInput.hasAttribute('checked')).toBe(false);
+    });
+
+    it('should update the checked attribute when the checked prop changes', () => {
+      const { rerender } = render(
+        <RadioTile value="standard" checked={false}>
+          Option 1
+        </RadioTile>
+      );
+
+      const radioInput = screen.getByRole('radio');
+      expect(radioInput).not.toBeChecked();
+      expect(radioInput.hasAttribute('checked')).toBe(false);
+
+      // Update with checked=true
+      rerender(
+        <RadioTile value="standard" checked>
+          Option 1
+        </RadioTile>
+      );
+
+      expect(radioInput).toBeChecked();
+      expect(radioInput.hasAttribute('checked')).toBe(true);
     });
   });
 

--- a/packages/react/src/components/RadioTile/RadioTile.tsx
+++ b/packages/react/src/components/RadioTile/RadioTile.tsx
@@ -193,7 +193,27 @@ const RadioTile = React.forwardRef(
           tabIndex={!disabled ? tabIndex : undefined}
           type="radio"
           value={value}
-          ref={ref}
+          ref={(el) => {
+            // Set the checked attribute directly on the DOM element for assistive technologies
+            if (el) {
+              if (checked) {
+                el.setAttribute('checked', '');
+              } else {
+                el.removeAttribute('checked');
+              }
+            }
+
+            // Forward the ref
+            if (ref) {
+              if (typeof ref === 'function') {
+                ref(el);
+              } else {
+                (
+                  ref as React.MutableRefObject<HTMLInputElement | null>
+                ).current = el;
+              }
+            }
+          }}
           required={required}
         />
         <label {...rest} htmlFor={inputId} className={className}>


### PR DESCRIPTION
Closes #19738

This PR resolves an accessibility issue where the checked attribute on input elements within the TileGroup component did not update when selecting a different tile. The attribute remained on the initially selected tile, potentially causing issues for assistive technologies that rely on accurate state representation.


**Changed**

- the RadioTile component correctly manages the `checked` attribute on the DOM element for better accessibility support. The implementation explicitly sets or removes the attribute using `setAttribute` and `removeAttribute`, which is important for assistive technologies to properly recognize the checked state of the radio button.


#### Testing / Reviewing

The tests verify that:

When checked={true}, the DOM element has the checked attribute set
When checked={false}, the DOM element does not have the checked attribute
The checked attribute updates correctly when the prop changes

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
