### PR TITLE
fix(select): use aria-describedby and visually hide label

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1527,6 +1527,16 @@
         "code",
         "example"
       ]
+    },
+    {
+      "login": "olihf-dematic",
+      "name": "olihf-dematic",
+      "avatar_url": "https://avatars.githubusercontent.com/u/225178617?v=4",
+      "profile": "https://github.com/olihf-dematic",
+      "contributions": [
+        "code",
+        "a11y"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
     <td align="center"><a href="https://github.com/seanhaug"><img src="https://avatars.githubusercontent.com/u/227620549?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sean Haughey</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=seanhaug" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Vignesh-Loganathan-IBM-1"><img src="https://avatars.githubusercontent.com/u/196759586?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vignesh-Loganathan-IBM-1</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=Vignesh-Loganathan-IBM-1" title="Code">💻</a></td>
     <td align="center"><a href="http://www.didoo.net/"><img src="https://avatars.githubusercontent.com/u/686239?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cristiano Rastelli</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=didoo" title="Code">💻</a> <a href="#example-didoo" title="Examples">💡</a></td>
+    <td align="center"><a href="https://github.com/olihf-dematic"><img src="https://avatars.githubusercontent.com/u/225178617?v=4?s=100" width="100px;" alt=""/><br /><sub><b>olihf-dematic</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=olihf-dematic" title="Code">💻</a> <a href="#a11y-olihf-dematic" title="Accessibility">️️️️♿️</a></td>
   </tr>
 </table>
 

--- a/packages/web-components/src/components/select/__tests__/select-test.js
+++ b/packages/web-components/src/components/select/__tests__/select-test.js
@@ -58,7 +58,8 @@ describe('cds-select', () => {
       </cds-select>
     `);
     const label = el.shadowRoot.querySelector('label');
-    expect(label).to.be.null;
+    expect(label).to.exist;
+    expect(label.classList.contains('cds--visually-hidden')).to.be.true;
   });
 
   it('should render invalid text when invalid attribute is set', async () => {

--- a/packages/web-components/src/components/select/select.scss
+++ b/packages/web-components/src/components/select/select.scss
@@ -13,6 +13,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/components/select';
 @use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/utilities/convert' as *;
+@use '@carbon/styles/scss/utilities/visually-hidden' as *;
 
 $divider-width: 1px;
 

--- a/packages/web-components/src/components/select/select.ts
+++ b/packages/web-components/src/components/select/select.ts
@@ -448,6 +448,7 @@ class CDSSelect extends FormMixin(LitElement) {
         id="input"
         class="${inputClasses}"
         ?disabled="${disabled}"
+        aria-label="${ifDefined(hideLabel ? labelText : undefined)}"
         aria-readonly="${String(Boolean(readonly))}"
         aria-invalid="${String(Boolean(invalid))}"
         aria-describedby="${ifDefined(!invalid ? undefined : 'invalid-text')}"

--- a/packages/web-components/src/components/select/select.ts
+++ b/packages/web-components/src/components/select/select.ts
@@ -421,6 +421,7 @@ class CDSSelect extends FormMixin(LitElement) {
     const labelClasses = classMap({
       [`${prefix}--label`]: true,
       [`${prefix}--label--disabled`]: disabled,
+      [`${prefix}--visually-hidden`]: hideLabel,
     });
 
     const helperTextClasses = classMap({
@@ -448,7 +449,6 @@ class CDSSelect extends FormMixin(LitElement) {
         id="input"
         class="${inputClasses}"
         ?disabled="${disabled}"
-        aria-label="${ifDefined(hideLabel ? labelText : undefined)}"
         aria-readonly="${String(Boolean(readonly))}"
         aria-invalid="${String(Boolean(invalid))}"
         aria-describedby="${ifDefined(!invalid ? undefined : 'invalid-text')}"
@@ -488,11 +488,10 @@ class CDSSelect extends FormMixin(LitElement) {
     `;
 
     return html`
-      ${!hideLabel
-        ? html`<label class="${labelClasses}" for="input">
-            <slot name="label-text"> ${labelText} </slot>
-          </label>`
-        : null}
+      <label class="${labelClasses}" for="input">
+        <slot name="label-text"> ${labelText} </slot>
+      </label>
+
       ${inline
         ? html`<div
             class="${prefix}--select-input--inline__wrapper"

--- a/packages/web-components/src/components/select/select.ts
+++ b/packages/web-components/src/components/select/select.ts
@@ -431,7 +431,7 @@ class CDSSelect extends FormMixin(LitElement) {
 
     const supplementalText = helperText
       ? html`
-          <div class="${helperTextClasses}">
+          <div id="helper-text" class="${helperTextClasses}">
             <slot name="helper-text"> ${helperText} </slot>
           </div>
         `
@@ -439,10 +439,17 @@ class CDSSelect extends FormMixin(LitElement) {
 
     const errorText =
       invalid || warn
-        ? html` <div class="${prefix}--form-requirement">
+        ? html` <div id="error-text" class="${prefix}--form-requirement">
             ${invalid ? invalidText : warnText}
           </div>`
         : null;
+
+    let describedBy: string | undefined;
+    if (invalid || warn) {
+      describedBy = 'error-text';
+    } else if (helperText) {
+      describedBy = 'helper-text';
+    }
 
     const input = html`
       <select
@@ -451,7 +458,7 @@ class CDSSelect extends FormMixin(LitElement) {
         ?disabled="${disabled}"
         aria-readonly="${String(Boolean(readonly))}"
         aria-invalid="${String(Boolean(invalid))}"
-        aria-describedby="${ifDefined(!invalid ? undefined : 'invalid-text')}"
+        aria-describedby="${ifDefined(describedBy)}"
         @input="${handleInput}">
         ${!placeholder || value
           ? undefined


### PR DESCRIPTION
Closes #20649

Fixes the HTML select element in CDS-Select never having a defined `aria-label` even when `label-text` is provided

### Changelog

**New**

- `select`: Apply `aria-label` when `hide-label` is true, and `label-text` is defined

**Changed**

- N/A

**Removed**

- N/A

#### Testing / Reviewing

- On the storybook playground for CDS-Select (:
 - Ensure `label-text` is defined
 - Set `hide-label` to true
 - Verify an aria-label, with content `label-text` is applied to the html select element

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
