### PR TITLE
fix(slider): correct keyboard arrow navigation for decimal steps

### DIFF
--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -1077,7 +1077,7 @@ export const Slider = (props: SliderProps) => {
    */
   const calcValueForDelta = (currentValue: number, delta: number, step = 1) => {
     const base =
-      delta > 0 ? Math.floor(currentValue / step) * step : currentValue;
+      delta > 0 ? Math.round(currentValue / step) * step : currentValue;
     const newValue = base + delta;
     // TODO: Why is the logical OR needed here?
     const decimals = (step.toString().split('.')[1] || '').length;

--- a/packages/react/src/components/Slider/__test__/Slider-test.js
+++ b/packages/react/src/components/Slider/__test__/Slider-test.js
@@ -1240,13 +1240,14 @@ describe('Slider', () => {
         await keyboard('{ArrowRight}');
         await keyboard('{ArrowRight}');
         await keyboard('{ArrowRight}');
+        await keyboard('{ArrowRight}');
 
         // Retrieve the last call to `onChange`.
         const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
 
         // Assert that the value was updated correctly (i.e., not
         // 0.30000000000000004).
-        expect(lastCall.value).toBe(0.3);
+        expect(lastCall.value).toBe(0.4);
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/20036

Fixed carbon slider issue for decimal steps for keyboard navigation.
root cause:  This is due to how Math.floor works with floating-point division. In calcValueForDelta function, for 0.3/0.1, JavaScript produce 2.9999999999999996, and Math.floor rounds it down to 2 resulting in 0.2 after multiplying by 0.1.
### Changelog


**Changed**

replaced Math.floor with Math.round in calcValueForDelta function. 
Updated the existing test case to validate this scenario.


#### Testing / Reviewing

CI should pass.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
