### PR TITLE
chore: fix 'previ' to 'preview' in stickyHeader prop description

### DIFF
--- a/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-batch-actions.stories.js
@@ -195,7 +195,7 @@ Default.argTypes = {
   stickyHeader: {
     control: 'boolean',
     description:
-      'Specify whether the header should be sticky. Still in previ: may not work with every combination of table props',
+      'Specify whether the header should be sticky. Still in preview: may not work with every combination of table props',
   },
   useStaticWidth: {
     control: 'boolean',


### PR DESCRIPTION
Closes: N/A

Fixes typo in `stickyHeader` prop description. Just a documentation fix.

### Changelog

**New**

- ~None.~

**Changed**

- Corrected `'previ'` to `'preview'` in the `stickyHeader` prop description in `DataTable-batch-actions.stories.`

**Removed**

- ~None.~

#### Testing / Reviewing

- Verify that the `stickyHeader` in  DataTable > Batch Actions, description now reads:  
  'Specify whether the header should be sticky. Still in preview: may not work with every combination of table props'

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
