### PR TITLE
fix(status-codemod): keep already updated component imports

### DIFF
--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.input.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.input.js
@@ -1,2 +1,6 @@
 // eslint-disable-next-line no-unused-vars
-import { Tearsheet, SearchBar, InlineTip } from '@carbon/ibm-products';
+import {
+  Tearsheet,
+  InlineTip,
+  previewCandidate__SearchBar as SearchBar,
+} from '@carbon/ibm-products';

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.input.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.input.js
@@ -1,4 +1,5 @@
-// eslint-disable-next-line no-unused-vars
+// prettier-ignore
+// eslint-disable no-unused-vars
 import {
   Tearsheet,
   InlineTip,

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
@@ -3,5 +3,5 @@
 import { 
   Tearsheet,
   previewCandidate__InlineTip as InlineTip,
-  previewCandidate__SearchBar as SearchBar
+  previewCandidate__SearchBar as SearchBar,
 } from '@carbon/ibm-products';

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
@@ -1,2 +1,7 @@
-// eslint-disable-next-line no-unused-vars
-import { Tearsheet, previewCandidate__InlineTip as InlineTip, previewCandidate__SearchBar as SearchBar } from '@carbon/ibm-products';
+// prettier-ignore
+// eslint-disable no-unused-vars
+import { 
+  Tearsheet,
+  previewCandidate__InlineTip as InlineTip,
+  previewCandidate__SearchBar as SearchBar
+} from '@carbon/ibm-products';

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
@@ -1,5 +1,2 @@
-import {
-  Tearsheet,
-  previewCandidate__SearchBar as SearchBar,
-  previewCandidate__InlineTip as InlineTip,
-} from '@carbon/ibm-products';
+// eslint-disable-next-line no-unused-vars
+import { Tearsheet, previewCandidate__InlineTip as InlineTip, previewCandidate__SearchBar as SearchBar } from '@carbon/ibm-products';

--- a/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
+++ b/packages/upgrade/transforms/__testfixtures__/ibm-products-update-pdlc-status.output.js
@@ -1,6 +1,6 @@
 // prettier-ignore
 // eslint-disable no-unused-vars
-import { 
+import {
   Tearsheet,
   previewCandidate__InlineTip as InlineTip,
   previewCandidate__SearchBar as SearchBar,

--- a/packages/upgrade/transforms/ibm-products-update-pdlc-status.js
+++ b/packages/upgrade/transforms/ibm-products-update-pdlc-status.js
@@ -30,55 +30,63 @@ function transformer(file, api) {
       },
     })
     .forEach((path) => {
-      const uniqueSpecifiers = new Set();
+      const seen = new Set();
       const newSpecifiers = [];
+
       path.node.specifiers.forEach((specifier) => {
         if (specifier.type === 'ImportSpecifier') {
-          nonStableComponentKeys.forEach((c) => {
-            const importedName = specifier.imported.name;
-            const localName = specifier.local
-              ? specifier.local.name
-              : importedName;
-            let transformedImportedName = importedName;
-            if (importedName === c) {
-              transformedImportedName = productsPreviewMap[c];
-              specifier.imported.name = transformedImportedName;
-              // Build new import specifier so that
-              // products components changing exports
-              // are aliased to their original name.
-              // This will help to avoid additional changes
-              // within jsx.
+          const importedName = specifier.imported.name;
+          const localName = specifier.local
+            ? specifier.local.name
+            : importedName;
+
+          const isAlreadyUpdated = nonStableComponentKeys.some(
+            (key) => importedName === productsPreviewMap[key]
+          );
+
+          const needsUpdate = nonStableComponentKeys.includes(importedName);
+
+          if (isAlreadyUpdated) {
+            // Already has prefix, ensure it has an alias to the base component name
+            // Find the base component name by looking up which key maps to this prefixed name
+            const baseComponentName = nonStableComponentKeys.find(
+              (key) => productsPreviewMap[key] === importedName
+            );
+
+            if (baseComponentName && !seen.has(importedName)) {
+              seen.add(importedName);
               const importSpecifier = j.importSpecifier(
-                j.identifier(transformedImportedName),
-                // Use the already specified alias if there is one
+                j.identifier(importedName),
                 j.identifier(localName)
               );
-              j(path).replaceWith(
-                j.importDeclaration(
-                  [...path.node.specifiers, importSpecifier],
-                  path.node.source
-                )
-              );
-
-              if (specifier.type === 'ImportSpecifier') {
-                if (!uniqueSpecifiers.has(importedName)) {
-                  uniqueSpecifiers.add(importedName);
-                  newSpecifiers.push(importSpecifier);
-                }
-              } else {
-                newSpecifiers.push(specifier);
-              }
+              newSpecifiers.push(importSpecifier);
+            } else if (!seen.has(importedName)) {
+              seen.add(importedName);
+              newSpecifiers.push(specifier);
             }
-          });
-          // Replace the original specifiers with the new aliased ones
-          // to prevent further changes needed in jsx for products components
-          // and keep already updated imports if there are any
-          const others = path.node.specifiers.filter(
-            (c) => !nonStableComponentKeys.includes(c.imported.name)
-          );
-          path.node.specifiers = [...others, ...newSpecifiers];
+          } else if (needsUpdate) {
+            const transformedImportedName = productsPreviewMap[importedName];
+
+            if (!seen.has(transformedImportedName)) {
+              seen.add(transformedImportedName);
+              const importSpecifier = j.importSpecifier(
+                j.identifier(transformedImportedName),
+                j.identifier(localName)
+              );
+              newSpecifiers.push(importSpecifier);
+            }
+          } else {
+            // Keep other imports unchanged
+            if (!seen.has(importedName)) {
+              seen.add(importedName);
+              newSpecifiers.push(specifier);
+            }
+          }
+        } else {
+          newSpecifiers.push(specifier);
         }
       });
+      path.node.specifiers = newSpecifiers;
     })
     .toSource();
 }

--- a/packages/upgrade/transforms/ibm-products-update-pdlc-status.js
+++ b/packages/upgrade/transforms/ibm-products-update-pdlc-status.js
@@ -72,8 +72,9 @@ function transformer(file, api) {
           });
           // Replace the original specifiers with the new aliased ones
           // to prevent further changes needed in jsx for products components
+          // and keep already updated imports if there are any
           const others = path.node.specifiers.filter(
-            (c) => !Object.values(productsPreviewMap).includes(c.imported.name)
+            (c) => !nonStableComponentKeys.includes(c.imported.name)
           );
           path.node.specifiers = [...others, ...newSpecifiers];
         }

--- a/packages/upgrade/transforms/rename-imports-to-preview-core-and-products.js
+++ b/packages/upgrade/transforms/rename-imports-to-preview-core-and-products.js
@@ -37,60 +37,49 @@ function transformer(file, api) {
         },
       })
       .forEach((path) => {
-        const uniqueSpecifiers = new Set();
         const newSpecifiers = [];
+        const seen = new Set();
+
         path.node.specifiers.forEach((specifier) => {
           if (specifier.type === 'ImportSpecifier') {
-            nonStableKeys.forEach((c) => {
-              const importedName = specifier.imported.name;
-              const localName = specifier.local
-                ? specifier.local.name
-                : importedName;
-              let transformedImportedName = importedName;
-              if (importedName === c) {
-                transformedImportedName = allPreviews[c];
-                specifier.imported.name = transformedImportedName;
+            const importedName = specifier.imported.name;
+            const localName = specifier.local
+              ? specifier.local.name
+              : importedName;
+
+            if (nonStableKeys.includes(importedName)) {
+              const transformedImportedName = allPreviews[importedName];
+
+              if (!seen.has(importedName)) {
+                seen.add(importedName);
+
                 if (p === '@carbon/ibm-products') {
-                  // Build new import specifier so that
-                  // products components changing exports
-                  // are aliased to their original name.
-                  // This will help to avoid additional changes
-                  // within jsx.
+                  // Create aliased import for products components
                   const importSpecifier = j.importSpecifier(
                     j.identifier(transformedImportedName),
-                    // Use the already specified alias if there is one
                     j.identifier(localName)
                   );
-                  j(path).replaceWith(
-                    j.importDeclaration(
-                      [...path.node.specifiers, importSpecifier],
-                      path.node.source
-                    )
-                  );
-                  if (specifier.type === 'ImportSpecifier') {
-                    if (!uniqueSpecifiers.has(importedName)) {
-                      uniqueSpecifiers.add(importedName);
-                      newSpecifiers.push(importSpecifier);
-                    }
-                  } else {
-                    newSpecifiers.push(specifier);
-                  }
+                  newSpecifiers.push(importSpecifier);
+                } else {
+                  // For @carbon/react, just update the name
+                  specifier.imported.name = transformedImportedName;
+                  newSpecifiers.push(specifier);
                 }
               }
-            });
-            if (p === '@carbon/ibm-products') {
-              // Replace the original specifiers with the new aliased ones
-              // to prevent further changes needed in jsx for products components
-              // and keep already updated imports if there are any
-              const others = path.node.specifiers.filter(
-                (c) => !nonStableKeys.includes(c.imported.name)
-              );
-              path.node.specifiers = [...others, ...newSpecifiers];
+            } else {
+              // Keep non-transformed imports as-is
+              newSpecifiers.push(specifier);
             }
+          } else {
+            // Keep non-ImportSpecifier types (like ImportDefaultSpecifier)
+            newSpecifiers.push(specifier);
           }
         });
+
+        path.node.specifiers = newSpecifiers;
       });
   });
+
   return root.toSource();
 }
 

--- a/packages/upgrade/transforms/rename-imports-to-preview-core-and-products.js
+++ b/packages/upgrade/transforms/rename-imports-to-preview-core-and-products.js
@@ -78,12 +78,12 @@ function transformer(file, api) {
                 }
               }
             });
-            // Replace the original specifiers with the new aliased ones
-            // to prevent further changes needed in jsx for products components
             if (p === '@carbon/ibm-products') {
+              // Replace the original specifiers with the new aliased ones
+              // to prevent further changes needed in jsx for products components
+              // and keep already updated imports if there are any
               const others = path.node.specifiers.filter(
-                (c) =>
-                  !Object.values(productsPreviewMap).includes(c.imported.name)
+                (c) => !nonStableKeys.includes(c.imported.name)
               );
               path.node.specifiers = [...others, ...newSpecifiers];
             }


### PR DESCRIPTION
A bug was reported with the status codemod where component's that already updated their naming were being removed after the codemod was run. This PR should resolve that issue.

### Changelog

**Changed**

- `packages/upgrade/transforms/ibm-products-update-pdlc-status.js`
- `packages/upgrade/transforms/rename-imports-to-preview-core-and-products.js`

#### Testing / Reviewing

Verify tests still pass

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
