### PR TITLE
fix: scope ai-label to the slot

### DIFF
--- a/packages/web-components/src/components/tile/tile.scss
+++ b/packages/web-components/src/components/tile/tile.scss
@@ -76,8 +76,8 @@ $css--plex: true !default;
     @extend .#{$prefix}--tile--icon;
   }
 
-  ::slotted(#{$prefix}-ai-label),
-  ::slotted(#{$prefix}-slug) {
+  ::slotted([slot='ai-label']),
+  ::slotted([slot='slug']) {
     pointer-events: none;
   }
 }
@@ -210,8 +210,8 @@ $css--plex: true !default;
 :host(#{$prefix}-selectable-tile),
 :host(#{$prefix}-radio-tile) {
   ::slotted([slot='decorator']),
-  ::slotted(#{$prefix}-ai-label),
-  ::slotted(#{$prefix}-slug) {
+  ::slotted([slot='ai-label']),
+  ::slotted([slot='slug']) {
     position: absolute;
     inset-block-start: $spacing-05;
     inset-inline-end: $spacing-05;
@@ -219,10 +219,10 @@ $css--plex: true !default;
 }
 
 :host(#{$prefix}-radio-tile[selected]) ::slotted([slot='decorator']),
-:host(#{$prefix}-radio-tile[selected]) ::slotted(#{$prefix}-ai-label),
+:host(#{$prefix}-radio-tile[selected]) ::slotted([slot='ai-label']),
 :host(#{$prefix}-selectable-tile) ::slotted([slot='decorator']),
-:host(#{$prefix}-selectable-tile) ::slotted(#{$prefix}-ai-label),
-:host(#{$prefix}-selectable-tile) ::slotted(#{$prefix}-slug) {
+:host(#{$prefix}-selectable-tile) ::slotted([slot='ai-label']),
+:host(#{$prefix}-selectable-tile) ::slotted([slot='slug']) {
   inset-inline-end: $spacing-08;
   transition: inset-inline-end $duration-fast-02 motion(standard, productive);
 }

--- a/packages/web-components/src/components/tile/tile.ts
+++ b/packages/web-components/src/components/tile/tile.ts
@@ -30,22 +30,19 @@ class CDSTile extends LitElement {
    * Handles `slotchange` event.
    */
   protected _handleSlotChange({ target }: Event) {
-    const hasContent = (target as HTMLSlotElement)
+    const hasSlottedAiLabel = (target as HTMLSlotElement)
       .assignedNodes()
-      .filter((elem) =>
-        (elem as HTMLElement).matches !== undefined
-          ? (elem as HTMLElement).matches(
-              (this.constructor as typeof CDSTile).aiLabelItem
-            ) ||
-            // remove reference of slug in v12
-            (elem as HTMLElement).matches(
-              (this.constructor as typeof CDSTile).slugItem
-            )
-          : false
-      );
-    if (hasContent.length > 0) {
-      this._hasAILabel = Boolean(hasContent);
-      (hasContent[0] as HTMLElement).setAttribute('size', 'xs');
+      .filter((elem) => {
+        if (!(elem instanceof HTMLElement)) {
+          return false;
+        }
+        const slot = elem.getAttribute('slot');
+        return slot === 'ai-label' || slot === 'slug';
+      });
+
+    if (hasSlottedAiLabel.length > 0) {
+      this._hasAILabel = Boolean(hasSlottedAiLabel);
+      (hasSlottedAiLabel[0] as HTMLElement).setAttribute('size', 'xs');
     }
     this.requestUpdate();
   }

--- a/packages/web-components/src/components/tile/tile.ts
+++ b/packages/web-components/src/components/tile/tile.ts
@@ -30,19 +30,22 @@ class CDSTile extends LitElement {
    * Handles `slotchange` event.
    */
   protected _handleSlotChange({ target }: Event) {
-    const hasSlottedAiLabel = (target as HTMLSlotElement)
+    const hasContent = (target as HTMLSlotElement)
       .assignedNodes()
-      .filter((elem) => {
-        if (!(elem instanceof HTMLElement)) {
-          return false;
-        }
-        const slot = elem.getAttribute('slot');
-        return slot === 'ai-label' || slot === 'slug';
-      });
-
-    if (hasSlottedAiLabel.length > 0) {
-      this._hasAILabel = Boolean(hasSlottedAiLabel);
-      (hasSlottedAiLabel[0] as HTMLElement).setAttribute('size', 'xs');
+      .filter((elem) =>
+        (elem as HTMLElement).matches !== undefined
+          ? (elem as HTMLElement).matches(
+              (this.constructor as typeof CDSTile).aiLabelItem
+            ) ||
+            // remove reference of slug in v12
+            (elem as HTMLElement).matches(
+              (this.constructor as typeof CDSTile).slugItem
+            )
+          : false
+      );
+    if (hasContent.length > 0) {
+      this._hasAILabel = Boolean(hasContent);
+      (hasContent[0] as HTMLElement).setAttribute('size', 'xs');
     }
     this.requestUpdate();
   }


### PR DESCRIPTION
Closes #

this pr scopes ai-label to the assigned slot
it was observed that the previous logic and css effects every `cds-ai-label` placed inside the tile and we lose the flexibility to detach the slot.

### Changelog

**Changed**

- update scopes of the logics and css

#### Testing / Reviewing

try to remove slot="ai-label" and notice you have freedom to use ai-label wherever in the tile. just like a regular element

and this is what this pr does

https://github.com/user-attachments/assets/9638f8aa-cd5f-4d3d-9661-4e49112efdb9

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
