### PR TITLE
MenuButton dropdown remains fixed when parent container scrolls, causing usability issues

### DIFF
--- a/packages/react/src/components/MenuButton/MenuButton.stories.js
+++ b/packages/react/src/components/MenuButton/MenuButton.stories.js
@@ -177,15 +177,38 @@ export const InScrollableContainer = () => {
   return (
     <div className="app">
       <div className="container">
-        <div className="scrollable-container" ref={containerRef} style={{height: "200px", overflowY: "auto", border: "1px solid #ddd", padding: "20px"}}>
+        <div
+          className="scrollable-container"
+          ref={containerRef}
+          style={{
+            height: '200px',
+            width: '8000px',
+            overflowY: 'auto',
+            overflowX: 'auto',
+            border: '1px solid #ddd',
+            padding: '20px',
+          }}>
           <p> This is the scrollable container</p>
-          <div style={{ height: "300px" }}></div>
-          <MenuButton label="MenuButton" menuTarget={target} boundary={containerRef.current}>
+          <div style={{ height: '300px' }}></div>
+          <MenuButton
+            label="Bottom"
+            menuTarget={target}
+            boundary={containerRef.current}>
             <MenuItem label="First action with a long label description" />
             <MenuItem label="Second action" />
             <MenuItem label="Third action" disabled />
           </MenuButton>
-          <div style={{ height: "200px" }}></div>
+          <div style={{ height: '100px' }}></div>
+          <MenuButton
+            label="Right"
+            menuTarget={target}
+            boundary={containerRef.current}
+            menuAlignment="right">
+            <MenuItem label="First action with a long label description" />
+            <MenuItem label="Second action" />
+            <MenuItem label="Third action" disabled />
+          </MenuButton>
+          <div style={{ height: '200px' }}></div>
         </div>
       </div>
     </div>

--- a/packages/react/src/components/MenuButton/MenuButton.stories.js
+++ b/packages/react/src/components/MenuButton/MenuButton.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { action } from 'storybook/actions';
 
 import { MenuItem, MenuItemDivider } from '../Menu';
@@ -162,5 +162,32 @@ export const WithMenuAlignment = () => {
         </MenuButton>
       </div>
     </>
+  );
+};
+
+export const InScrollableContainer = () => {
+  const containerRef = useRef(null);
+  const [target, setTarget] = useState(undefined);
+  useEffect(() => {
+    if (containerRef.current) {
+      setTarget(containerRef.current);
+    }
+  }, []);
+
+  return (
+    <div className="app">
+      <div className="container">
+        <div className="scrollable-container" ref={containerRef} style={{height: "200px", overflowY: "auto", border: "1px solid #ddd", padding: "20px"}}>
+          <p> This is the scrollable container</p>
+          <div style={{ height: "300px" }}></div>
+          <MenuButton label="MenuButton" menuTarget={target} boundary={containerRef.current}>
+            <MenuItem label="First action with a long label description" />
+            <MenuItem label="Second action" />
+            <MenuItem label="Third action" disabled />
+          </MenuButton>
+          <div style={{ height: "200px" }}></div>
+        </div>
+      </div>
+    </div>
   );
 };

--- a/packages/react/src/components/MenuButton/index.tsx
+++ b/packages/react/src/components/MenuButton/index.tsx
@@ -27,7 +27,6 @@ import {
   flip,
   size as floatingSize,
   autoUpdate,
-  type Boundary,
   type Placement,
   hide,
 } from '@floating-ui/react';
@@ -89,12 +88,6 @@ export interface MenuButtonProps extends ComponentProps<'div'> {
    * Specify a DOM node where the Menu should be rendered in. Defaults to document.body.
    */
   menuTarget?: Element;
-
-  /**
-   * Specify a bounding element to be used for calculating when to reflow and change alignment.
-   * The viewport is used by default. This allows the menu to stay within a scrollable container.
-   */
-  boundary?: Boundary;
 }
 
 // eslint-disable-next-line react/display-name -- https://github.com/carbon-design-system/carbon/issues/20452
@@ -110,7 +103,6 @@ const MenuButton = forwardRef<HTMLDivElement, MenuButtonProps>(
       menuAlignment = 'bottom',
       tabIndex = 0,
       menuTarget,
-      boundary,
       ...rest
     },
     forwardRef
@@ -145,12 +137,12 @@ const MenuButton = forwardRef<HTMLDivElement, MenuButtonProps>(
       fallbackPlacements: getFallbackPlacements(),
       fallbackStrategy: 'initialPlacement' as const,
       fallbackAxisSideDirection: 'start' as const,
-      boundary,
+      boundary: menuTarget,
       crossAxis,
     });
 
     if (!enableOnlyFloatingStyles) {
-      if (boundary) {
+      if (menuTarget) {
         middlewares.push(flip(getEnhancedFlipConfig(false)));
       } else {
         middlewares.push(
@@ -161,12 +153,12 @@ const MenuButton = forwardRef<HTMLDivElement, MenuButtonProps>(
       }
     }
 
-    if (boundary && enableOnlyFloatingStyles) {
+    if (menuTarget && enableOnlyFloatingStyles) {
       middlewares.push(flip(getEnhancedFlipConfig()));
     }
 
-    if (boundary) {
-      middlewares.push(hide({ boundary }));
+    if (menuTarget) {
+      middlewares.push(hide({ boundary: menuTarget }));
     }
 
     if (menuAlignment === 'bottom' || menuAlignment === 'top') {
@@ -381,22 +373,6 @@ MenuButton.propTypes = {
   menuTarget: PropTypes.instanceOf(
     typeof Element !== 'undefined' ? Element : Object
   ) as PropTypes.Validator<Element | null | undefined>,
-
-  /**
-   * Specify a bounding element to be used for calculating when to reflow and change alignment.
-   * The viewport is used by default. This allows the menu to stay within a scrollable container.
-   */
-  boundary: PropTypes.oneOfType([
-    PropTypes.oneOf(['clippingAncestors']),
-    PropTypes.elementType,
-    PropTypes.arrayOf(PropTypes.elementType),
-    PropTypes.exact({
-      x: PropTypes.number.isRequired,
-      y: PropTypes.number.isRequired,
-      width: PropTypes.number.isRequired,
-      height: PropTypes.number.isRequired,
-    }),
-  ]) as PropTypes.Validator<Boundary | null | undefined>,
 };
 
 export { MenuButton };


### PR DESCRIPTION
Closes #20693 

When a MenuButton is rendered inside a scrollable container, the menu items doesn't maintain proper positioning relative to the button during scrolling. This occurs because the menu uses fixed positioning which disconnects it from its parent's scroll context, causing the menu to remain in its original position while the button moves with the scroll.

Solution:
The solution makes use of floating-ui's flip and hide middlewares to handle positioning and visibility. When scrolling occurs, the menu now stays properly aligned with the button, flips to maintain visibility when approaching container edges, hides when it would be clipped by the container and updates CSS classes to reflect the current placement.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
