### PR TITLE
fix(ailabel): removing z-index from AI label

### DIFF
--- a/packages/styles/scss/components/slug/_slug.scss
+++ b/packages/styles/scss/components/slug/_slug.scss
@@ -150,7 +150,6 @@ $sizes: (
   .#{$prefix}--ai-label__text,
   .#{$prefix}--slug__text {
     position: relative;
-    z-index: 1;
   }
 
   // Inline slug


### PR DESCRIPTION
Closes #19876

Removing redundant z-index from cds--ai-label__text & cds--slug__text elements

### Changelog

**Removed**

- Removing z-index from cds--ai-label__text and cds--slug__text elements that had a value of 1, which was causing bleed-through issues when the AI column slid underneath the pinned column

#### Testing / Reviewing

https://github.com/user-attachments/assets/98c06081-cd85-4de4-8ed6-45128b3cb38f


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
