### PR TITLE
feat(data-table): parity - make data-table header sticky

### DIFF
--- a/packages/web-components/src/components/data-table/_table-action.scss
+++ b/packages/web-components/src/components/data-table/_table-action.scss
@@ -149,6 +149,7 @@
   @extend .#{$prefix}--batch-actions;
 
   box-sizing: border-box;
+  overflow-x: auto;
 }
 
 :host(#{$prefix}-table-batch-actions[active]) {

--- a/packages/web-components/src/components/data-table/_table-core.scss
+++ b/packages/web-components/src/components/data-table/_table-core.scss
@@ -12,8 +12,6 @@
 :host(#{$prefix}-table) {
   @extend .#{$prefix}--data-table;
 
-  display: table;
-
   ::slotted(#{$prefix}-table-head) {
     @include type-style('heading-01');
 
@@ -36,6 +34,11 @@
   inline-size: auto;
 }
 
+.#{$prefix}--data-table-content {
+  display: table;
+  inline-size: 100%;
+}
+
 :host(#{$prefix}-table[sticky-header]) {
   ::slotted(#{$prefix}-table-head),
   ::slotted(#{$prefix}-table-body) {
@@ -50,14 +53,12 @@
   }
 }
 
-:host(#{$prefix}-table[with-header]) {
-  .#{$prefix}--data-table-header-container {
-    display: table-caption;
-  }
+.#{$prefix}--data-table_inner-container {
+  display: block;
+  inline-size: 100%;
+  overflow-x: auto;
 }
-.#{$prefix}--data-table-header-container {
-  display: table-caption;
-}
+
 :host(#{$prefix}-table-head[sticky-header]) {
   position: sticky;
   z-index: 1;

--- a/packages/web-components/src/components/data-table/table.ts
+++ b/packages/web-components/src/components/data-table/table.ts
@@ -893,7 +893,6 @@ class CDSTable extends HostListenerMixin(LitElement) {
     });
   }
 
-   
   render() {
     return html` <div class="${prefix}--data-table-header-container">
         <div ?hidden="${!this.withHeader}" class="${prefix}--data-table-header">
@@ -948,8 +947,6 @@ class CDSTable extends HostListenerMixin(LitElement) {
     });
     this._handleSortAction(columnIndex, sortDirection);
   }
-
-   
 
   /**
    * The name of the custom event fired before a new sort direction is set upon a user gesture.

--- a/packages/web-components/src/components/data-table/table.ts
+++ b/packages/web-components/src/components/data-table/table.ts
@@ -893,10 +893,9 @@ class CDSTable extends HostListenerMixin(LitElement) {
     });
   }
 
-  /* eslint-disable no-constant-condition */
+   
   render() {
-    return html`
-      <div class="${prefix}--data-table-header-container">
+    return html` <div class="${prefix}--data-table-header-container">
         <div ?hidden="${!this.withHeader}" class="${prefix}--data-table-header">
           <slot @slotchange="${this._handleSlotChange}" name="title"></slot>
           <slot
@@ -906,18 +905,13 @@ class CDSTable extends HostListenerMixin(LitElement) {
         <slot name="toolbar"></slot>
       </div>
 
-      ${false // TODO: replace with this.stickyHeader when feature is fully implemented
-        ? html` <div class="${prefix}--data-table_inner-container">
-            <div class="${prefix}--data-table-content">
-              <slot
-                @cds-table-body-content-change="${this
-                  ._handleTableBodyChange}"></slot>
-            </div>
-          </div>`
-        : html`<slot
+      <div class="${prefix}--data-table_inner-container">
+        <div class="${prefix}--data-table-content">
+          <slot
             @cds-table-body-content-change="${this
-              ._handleTableBodyChange}"></slot>`}
-    `;
+              ._handleTableBodyChange}"></slot>
+        </div>
+      </div>`;
   }
 
   /**
@@ -955,7 +949,7 @@ class CDSTable extends HostListenerMixin(LitElement) {
     this._handleSortAction(columnIndex, sortDirection);
   }
 
-  /* eslint-enable no-constant-condition */
+   
 
   /**
    * The name of the custom event fired before a new sort direction is set upon a user gesture.


### PR DESCRIPTION
Closes #17735 

This PR aligns the Web Component `cds-data-table` with the React version default behavior where the table header respects the parent width and remains sticky. The current implementation overflows out of the parent width and requires the table header to be scrolled to view the batch actions when in smaller viewport.

https://github.com/user-attachments/assets/2bf465b9-0daf-4d35-82fc-a5b1c7011d65


### Changelog

**Changed**

- switch the `display: table` attribute to the `data-table-content` element instead this is in-line with what is done in React
- ensure that the slotted `cds-table-head` and `cds-table-body` components are wrapped in parent divs to allow for the styling needed

#### Testing / Reviewing

Compare the current WC vs. React data table in small view port, then check the deploy preview - the header behavior should align 

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
