### PR TITLE
fix(slider): Disallow invalid & warn when readonly or disabled

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1546,6 +1546,13 @@
      "contributions": [
        "code"
      ]
+    },
+    {
+      "login": "BiaBiruka",
+      "name": "Beatriz Parolin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/128196689?v=4",
+      "profile": "https://github.com/BiaBiruka",
+      "contributions": ["code"]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ check out our [Contributing Guide](/.github/CONTRIBUTING.md) and our
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/vidhyarbiji"><img src="https://avatars.githubusercontent.com/u/11348409?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vidhya Ravikumar</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=vidhyarbiji" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/BiaBiruka"><img src="https://avatars.githubusercontent.com/u/128196689?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Beatriz Parolin</b></sub></a><br /><a href="https://github.com/carbon-design-system/carbon/commits?author=BiaBiruka" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/react/src/components/Slider/Slider.tsx
+++ b/packages/react/src/components/Slider/Slider.tsx
@@ -1321,15 +1321,17 @@ export const Slider = (props: SliderProps) => {
       isRtl,
     } = state;
 
+    const isCurrentlyEditable = !readOnly && !disabled;
+
     const showWarning =
-      (!readOnly && warn) ||
+      (isCurrentlyEditable && warn) ||
       // TODO: https://github.com/carbon-design-system/carbon/issues/18991#issuecomment-2795709637
       // eslint-disable-next-line valid-typeof , no-constant-binary-expression -- https://github.com/carbon-design-system/carbon/issues/20452
       (typeof correctedValue !== null &&
         correctedPosition === HandlePosition.LOWER &&
         isValid);
     const showWarningUpper =
-      (!readOnly && warn) ||
+      (isCurrentlyEditable && warn) ||
       // TODO: https://github.com/carbon-design-system/carbon/issues/18991#issuecomment-2795709637
       // eslint-disable-next-line valid-typeof, no-constant-binary-expression -- https://github.com/carbon-design-system/carbon/issues/20452
       (typeof correctedValue !== null &&
@@ -1369,7 +1371,8 @@ export const Slider = (props: SliderProps) => {
             `${prefix}--slider-text-input--lower`,
             conditionalInputClasses,
             {
-              [`${prefix}--text-input--invalid`]: !readOnly && !isValid,
+              [`${prefix}--text-input--invalid`]:
+                isCurrentlyEditable && !isValid,
               [`${prefix}--slider-text-input--warn`]: showWarning,
             },
           ]);
@@ -1379,7 +1382,7 @@ export const Slider = (props: SliderProps) => {
             conditionalInputClasses,
             {
               [`${prefix}--text-input--invalid`]:
-                !readOnly && (twoHandles ? !isValidUpper : !isValid),
+                isCurrentlyEditable && (twoHandles ? !isValidUpper : !isValid),
               [`${prefix}--slider-text-input--warn`]: showWarningUpper,
             },
           ]);
@@ -1458,12 +1461,16 @@ export const Slider = (props: SliderProps) => {
                       onBlur={onBlurInput}
                       onKeyUp={props.onInputKeyUp}
                       onKeyDown={onInputKeyDown}
-                      data-invalid={!isValid && !readOnly ? true : null}
+                      data-invalid={
+                        !isValid && isCurrentlyEditable ? true : null
+                      }
                       data-handle-position={HandlePosition.LOWER}
-                      aria-invalid={!isValid && !readOnly ? true : undefined}
+                      aria-invalid={
+                        !isValid && isCurrentlyEditable ? true : undefined
+                      }
                       readOnly={readOnly}
                     />
-                    {!readOnly && !isValid && (
+                    {isCurrentlyEditable && !isValid && (
                       <WarningFilled
                         className={`${prefix}--slider__invalid-icon`}
                       />
@@ -1493,7 +1500,7 @@ export const Slider = (props: SliderProps) => {
                   tabIndex={-1}
                   data-invalid={
                     (twoHandles ? !isValid || !isValidUpper : !isValid) &&
-                    !readOnly
+                    isCurrentlyEditable
                       ? true
                       : null
                   }
@@ -1609,7 +1616,8 @@ export const Slider = (props: SliderProps) => {
                     onKeyDown={onInputKeyDown}
                     onKeyUp={props.onInputKeyUp}
                     data-invalid={
-                      (twoHandles ? !isValidUpper : !isValid) && !readOnly
+                      (twoHandles ? !isValidUpper : !isValid) &&
+                      isCurrentlyEditable
                         ? true
                         : null
                     }
@@ -1617,17 +1625,19 @@ export const Slider = (props: SliderProps) => {
                       twoHandles ? HandlePosition.UPPER : null
                     }
                     aria-invalid={
-                      (twoHandles ? !isValidUpper : !isValid) && !readOnly
+                      (twoHandles ? !isValidUpper : !isValid) &&
+                      isCurrentlyEditable
                         ? true
                         : undefined
                     }
                     readOnly={readOnly}
                   />
-                  {!readOnly && (twoHandles ? !isValidUpper : !isValid) && (
-                    <WarningFilled
-                      className={`${prefix}--slider__invalid-icon`}
-                    />
-                  )}
+                  {isCurrentlyEditable &&
+                    (twoHandles ? !isValidUpper : !isValid) && (
+                      <WarningFilled
+                        className={`${prefix}--slider__invalid-icon`}
+                      />
+                    )}
 
                   {showWarningUpper && (
                     <WarningAltFilled
@@ -1636,7 +1646,7 @@ export const Slider = (props: SliderProps) => {
                   )}
                 </div>
               </div>
-              {!readOnly && (!isValid || !isValidUpper) && (
+              {isCurrentlyEditable && (!isValid || !isValidUpper) && (
                 <Text
                   as="div"
                   className={classNames(
@@ -1647,7 +1657,7 @@ export const Slider = (props: SliderProps) => {
                   {invalidText}
                 </Text>
               )}
-              {!readOnly && warn && isValid && isValidUpper && (
+              {isCurrentlyEditable && warn && isValid && isValidUpper && (
                 <Text
                   as="div"
                   className={classNames(

--- a/packages/react/src/components/Slider/__test__/Slider-test.js
+++ b/packages/react/src/components/Slider/__test__/Slider-test.js
@@ -279,6 +279,54 @@ describe('Slider', () => {
       expect(onChange).toHaveBeenCalledTimes(0);
     });
 
+    it('should not display warn if disabled', () => {
+      renderSlider({
+        ariaLabelInput: inputAriaValue,
+        disabled: true,
+        warn: true,
+        warnText: 'Warning message',
+      });
+
+      const warnMessage = screen.queryByText('Warning message');
+      expect(warnMessage).not.toBeInTheDocument();
+    });
+
+    it('should not display warn if readOnly', () => {
+      renderSlider({
+        ariaLabelInput: inputAriaValue,
+        readOnly: true,
+        warn: true,
+        warnText: 'Warning message',
+      });
+
+      const warnMessage = screen.queryByText('Warning message');
+      expect(warnMessage).not.toBeInTheDocument();
+    });
+
+    it('should not display invalid message if disabled', () => {
+      renderSlider({
+        ariaLabelInput: inputAriaValue,
+        disabled: true,
+        invalid: true,
+        invalidText: 'Error message',
+      });
+
+      const invalidMessage = screen.queryByText('Error message');
+      expect(invalidMessage).not.toBeInTheDocument();
+    });
+
+    it('should not display invalid message if readOnly', () => {
+      renderSlider({
+        ariaLabelInput: inputAriaValue,
+        readOnly: true,
+        invalid: true,
+        invalidText: 'Error message',
+      });
+
+      const invalidMessage = screen.queryByText('Error message');
+      expect(invalidMessage).not.toBeInTheDocument();
+    });
+
     describe('Error handling, expected behavior from event handlers', () => {
       it('handles non-number typed into input field', async () => {
         const { type, tab } = userEvent;
@@ -1010,6 +1058,54 @@ describe('Slider', () => {
         value: 0,
         valueUpper: 435,
       });
+    });
+
+    it('should not display warn if disabled', () => {
+      renderTwoHandleSlider({
+        ariaLabelInput: inputAriaValue,
+        disabled: true,
+        warn: true,
+        warnText: 'Warning message',
+      });
+
+      const warnMessage = screen.queryByText('Warning message');
+      expect(warnMessage).not.toBeInTheDocument();
+    });
+
+    it('should not display warn if readOnly', () => {
+      renderTwoHandleSlider({
+        ariaLabelInput: inputAriaValue,
+        readOnly: true,
+        warn: true,
+        warnText: 'Warning message',
+      });
+
+      const warnMessage = screen.queryByText('Warning message');
+      expect(warnMessage).not.toBeInTheDocument();
+    });
+
+    it('should not display invalid message if disabled', () => {
+      renderTwoHandleSlider({
+        ariaLabelInput: inputAriaValue,
+        disabled: true,
+        invalid: true,
+        invalidText: 'Error message',
+      });
+
+      const invalidMessage = screen.queryByText('Error message');
+      expect(invalidMessage).not.toBeInTheDocument();
+    });
+
+    it('should not display invalid message if readOnly', () => {
+      renderTwoHandleSlider({
+        ariaLabelInput: inputAriaValue,
+        readOnly: true,
+        invalid: true,
+        invalidText: 'Error message',
+      });
+
+      const invalidMessage = screen.queryByText('Error message');
+      expect(invalidMessage).not.toBeInTheDocument();
     });
 
     describe('Error handling, expected behavior from event handlers', () => {


### PR DESCRIPTION
Closes #20731

Fix the behavior for Slider and Two Handle Slider. When component is disabled or readOnly, it should not show waning nor invalid message.

### Changelog

**Changed**

- Instead of using readOnly state to check if should display warnings or not, Slider now also checks if component is disabled. This way, warnings will not be shown if the component is disabled/readOnly.

#### Testing / Reviewing

- Access the Slider playground on storybook (/?path=/story/components-slider--default) and change the state to "Invalid = true" and "disabled = true". The invalid message should not be shown.
- Repeat above test with "readOnly = true" instead of disabled. The invalid message should not be shown.
- Repeat the two tests above using "warn = true" instead of "invalid = true". The warning message on both scenarios should not be shown.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
