### PR TITLE
fix(feature-flag): storybook-duplicate-feature-flags

### DIFF
--- a/packages/web-components/docs/feature-flags.mdx
+++ b/packages/web-components/docs/feature-flags.mdx
@@ -1,7 +1,7 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import FeatureFlags from '../../../docs/feature-flags.md?raw';
 
-<Meta title="Introduction/Feature Flags" name="Guidance" />
+<Meta title="Introduction/Feature Flags" name="Feature Flags" />
 
 # Feature Flags
 

--- a/packages/web-components/docs/feature-flags.mdx
+++ b/packages/web-components/docs/feature-flags.mdx
@@ -1,7 +1,7 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import FeatureFlags from '../../../docs/feature-flags.md?raw';
 
-<Meta title="Introduction/Feature Flags" />
+<Meta title="Introduction/Feature Flags" name="Guidance" />
 
 # Feature Flags
 

--- a/packages/web-components/src/components/feature-flags/overview.mdx
+++ b/packages/web-components/src/components/feature-flags/overview.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Introduction/Feature Flags" />
+<Meta title="Introduction/Feature Flags" name="Component Overview" />
 
 
 # Feature Flags

--- a/packages/web-components/src/components/feature-flags/overview.mdx
+++ b/packages/web-components/src/components/feature-flags/overview.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Introduction/Feature Flags" name="Component Overview" />
+<Meta title="Introduction/Feature Flags" />
 
 
 # Feature Flags


### PR DESCRIPTION
No issue.

This PR fixes the issue that occurred when running yarn storybook for web components

Unable to index ./docs/feature-flags.mdx,./src/components/feature-flags/overview.mdx:
WARN   Error: You have two component docs pages with the same name Introduction/Feature Flags:Overview. Use `<Meta of={} name="Other Name">` to distinguish them.

https://github.com/carbon-design-system/carbon/pull/20601
https://github.com/carbon-design-system/carbon/issues/20560

#### Testing / Reviewing

- run web components storybook localy

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
