### PR TITLE
feat: export part on copy button to allow styling

### DIFF
--- a/packages/web-components/src/components/copy-button/__tests__/__snapshots__/copy-button-test.snap.js
+++ b/packages/web-components/src/components/copy-button/__tests__/__snapshots__/copy-button-test.snap.js
@@ -5,6 +5,7 @@ snapshots['CopyButton should set tabIndex if one is passed via props'] =
   `<cds-copy
   align="bottom"
   button-class-name="cds--copy-btn"
+  exportparts="button"
   feedback="Copied!"
   feedback-timeout="2000"
   kind="primary"
@@ -24,6 +25,7 @@ snapshots['CopyButton should add extra classes via passed button-class-name'] =
   `<cds-copy
   align="bottom"
   button-class-name="cds--copy-btn extra-class"
+  exportparts="button"
   feedback="Copied!"
   feedback-timeout="2000"
   kind="primary"
@@ -44,6 +46,7 @@ snapshots['Button props should disable button if disabled prop is passed'] =
   align="bottom"
   button-class-name="cds--copy-btn"
   disabled=""
+  exportparts="button"
   feedback="Copied!"
   feedback-timeout="2000"
   kind="primary"
@@ -62,6 +65,7 @@ snapshots['Button props should disable button if disabled prop is passed'] =
 snapshots['Button props should call the click handler'] = `<cds-copy
   align="bottom"
   button-class-name="cds--copy-btn"
+  exportparts="button"
   feedback="Copied!"
   feedback-timeout="2000"
   kind="primary"
@@ -82,6 +86,7 @@ snapshots[
 ] = `<cds-copy
   align="bottom"
   button-class-name="cds--copy-btn"
+  exportparts="button"
   feedback="Copied!"
   feedback-timeout="500"
   kind="primary"
@@ -101,6 +106,7 @@ snapshots['Feedback should be able to specify the feedback message'] =
   `<cds-copy
   align="bottom"
   button-class-name="cds--copy-btn"
+  exportparts="button"
   feedback="Custom feedback message"
   feedback-timeout="200"
   kind="primary"
@@ -121,6 +127,7 @@ snapshots[
 ] = `<cds-copy
   align="bottom"
   button-class-name="cds--copy-btn"
+  exportparts="button"
   feedback="Copied!"
   feedback-timeout="100"
   kind="primary"

--- a/packages/web-components/src/components/copy-button/copy-button.stories.ts
+++ b/packages/web-components/src/components/copy-button/copy-button.stories.ts
@@ -83,4 +83,32 @@ export const Default = {
   argTypes: controls,
 };
 
+// remove after verifying
+export const TestExportedPartButton = {
+  title: 'Components/Copy button exported part button',
+  render: ({
+    feedbackText,
+    feedbackTimeout,
+    onClick,
+    iconDescription,
+    align,
+    autoAlign,
+  }) => html`
+    <style>
+      cds-copy-button::part(button) {
+        border-top-right-radius: 8px;
+      }
+    </style>
+    <cds-copy-button
+      align="${align}"
+      ?autoalign="${autoAlign}"
+      feedback="${ifDefined(feedbackText)}"
+      feedback-timeout="${ifDefined(feedbackTimeout)}"
+      @click="${onClick}">
+      ${iconDescription}
+    </cds-copy-button>
+  `,
+  args: defaultArgs,
+};
+
 export default meta;

--- a/packages/web-components/src/components/copy-button/copy-button.stories.ts
+++ b/packages/web-components/src/components/copy-button/copy-button.stories.ts
@@ -83,32 +83,4 @@ export const Default = {
   argTypes: controls,
 };
 
-// remove after verifying
-export const TestExportedPartButton = {
-  title: 'Components/Copy button exported part button',
-  render: ({
-    feedbackText,
-    feedbackTimeout,
-    onClick,
-    iconDescription,
-    align,
-    autoAlign,
-  }) => html`
-    <style>
-      cds-copy-button::part(button) {
-        border-top-right-radius: 8px;
-      }
-    </style>
-    <cds-copy-button
-      align="${align}"
-      ?autoalign="${autoAlign}"
-      feedback="${ifDefined(feedbackText)}"
-      feedback-timeout="${ifDefined(feedbackTimeout)}"
-      @click="${onClick}">
-      ${iconDescription}
-    </cds-copy-button>
-  `,
-  args: defaultArgs,
-};
-
 export default meta;

--- a/packages/web-components/src/components/copy-button/copy-button.ts
+++ b/packages/web-components/src/components/copy-button/copy-button.ts
@@ -82,6 +82,7 @@ class CDSCopyButton extends FocusMixin(LitElement) {
         feedback=${feedback}
         feedback-timeout=${feedbackTimeout}
         button-class-name=${classes}
+        exportparts="button"
         align=${align}>
         ${iconLoader(Copy16, {
           slot: 'icon',


### PR DESCRIPTION
Closes #

exports button part at the top level cds-copy-button to allow styling

### Changelog

**Changed**

- exposed part button on cds-copy-button

#### Testing / Reviewing

test story added (remove after verifying)

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
