### PR TITLE
fix(feature-flags): update semver range to prevent version mismatches

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.27.3",
-    "@carbon/feature-flags": "^0.32.0",
+    "@carbon/feature-flags": "workspace:>=0.32.0",
     "@carbon/icons-react": "^11.70.0",
     "@carbon/layout": "^11.43.0",
     "@carbon/styles": "^1.93.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@carbon/colors": "^11.42.0",
-    "@carbon/feature-flags": "^0.32.0",
+    "@carbon/feature-flags": "workspace:>=0.32.0",
     "@carbon/grid": "^11.45.0",
     "@carbon/layout": "^11.43.0",
     "@carbon/motion": "^11.37.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,7 +1703,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/feature-flags@npm:^0.32.0, @carbon/feature-flags@workspace:packages/feature-flags":
+"@carbon/feature-flags@workspace:>=0.32.0, @carbon/feature-flags@workspace:packages/feature-flags":
   version: 0.0.0-use.local
   resolution: "@carbon/feature-flags@workspace:packages/feature-flags"
   dependencies:
@@ -1896,7 +1896,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.27.1"
     "@babel/preset-typescript": "npm:^7.27.1"
     "@babel/runtime": "npm:^7.27.3"
-    "@carbon/feature-flags": "npm:^0.32.0"
+    "@carbon/feature-flags": "workspace:>=0.32.0"
     "@carbon/icons-react": "npm:^11.70.0"
     "@carbon/layout": "npm:^11.43.0"
     "@carbon/styles": "npm:^1.93.0"
@@ -1981,7 +1981,7 @@ __metadata:
   resolution: "@carbon/styles@workspace:packages/styles"
   dependencies:
     "@carbon/colors": "npm:^11.42.0"
-    "@carbon/feature-flags": "npm:^0.32.0"
+    "@carbon/feature-flags": "workspace:>=0.32.0"
     "@carbon/grid": "npm:^11.45.0"
     "@carbon/layout": "npm:^11.43.0"
     "@carbon/motion": "npm:^11.37.0"


### PR DESCRIPTION
Closes #20785

This updates the semver range so that when consumers install new versions of `@carbon/react` and `@carbon/styles` it will be less likely for there to be version mismatches. The primary reason for this is that when the version is pre-v1, like `^0.32.0`, the caret acts more like a tilde and will only accept new _patch_ versions.

### Changelog

**Changed**

- update specified semver range for `@carbon/feature-flags` usage

#### Testing / Reviewing

- We can release a patch with this to verify this resolves as expected in consumer environments

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
