### PR TITLE
feat(numberinput): export `validateNumberSeparators`

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -15752,5 +15752,6 @@ Map {
   "usePrefersDarkScheme" => {},
   "usePrefix" => {},
   "useTheme" => {},
+  "validateNumberSeparators" => {},
 }
 `;

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -374,6 +374,7 @@ describe('Carbon Components React', () => {
         "usePrefersDarkScheme",
         "usePrefix",
         "useTheme",
+        "validateNumberSeparators",
       ]
     `);
   });

--- a/packages/react/src/components/NumberInput/index.ts
+++ b/packages/react/src/components/NumberInput/index.ts
@@ -6,4 +6,8 @@
  */
 
 export { default as NumberInputSkeleton } from './NumberInput.Skeleton';
-export { NumberInput, type NumberInputProps } from './NumberInput';
+export {
+  NumberInput,
+  validateNumberSeparators,
+  type NumberInputProps,
+} from './NumberInput';


### PR DESCRIPTION
Thanks for bringing this up @abpaul1993, this will allow you to

```js
import { validateNumberSeparators } from '@carbon/react';
```

### Changelog

**New**

- update `NumberInput/index.ts` to export `validateNumberSeparators`

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
~- [ ] Addressed any impact on accessibility (a11y)~
~- [ ] Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
