### PR TITLE
fix(ai-label): fix caret visibility

### DIFF
--- a/packages/web-components/src/components/ai-label/ai-label.scss
+++ b/packages/web-components/src/components/ai-label/ai-label.scss
@@ -75,6 +75,13 @@ $colorMap: (
     --cds-button-focus-color: var(--cds-focus);
   }
 
+  .#{$prefix}--slug__button.#{$prefix}--slug__button--mini:focus,
+  .#{$prefix}--slug__button.#{$prefix}--slug__button--2xs:focus {
+    box-shadow: none;
+  }
+}
+
+:host(#{$prefix}-ai-label[open]) {
   .#{$prefix}--popover-caret {
     background: transparent;
     clip-path: none;
@@ -100,11 +107,6 @@ $colorMap: (
       content: '';
       inline-size: $spacing-01;
     }
-  }
-
-  .#{$prefix}--slug__button.#{$prefix}--slug__button--mini:focus,
-  .#{$prefix}--slug__button.#{$prefix}--slug__button--2xs:focus {
-    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Closes #20813

Fixes a regression where the caret of the ai-label content was not visible

Before:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/7ed0d6bf-3b9b-4081-95ae-1ef94d44aca7" />


After:
<img width="538" height="481" alt="Screenshot 2025-10-27 at 2 05 25 PM" src="https://github.com/user-attachments/assets/2836a093-1b7d-40ec-b3aa-588809a6080f" />

### Changelog


**Changed**

- Wrapped the ai-label popover-caret styles into a more specific selector with the `open` attribute so that its styles can be applied properly since the newly updated popover styles done in #20669 used a more specific selector


#### Testing / Reviewing

- Go to `AI Label/Default` in WC deploy preview 
- Caret should be visible
- There should no regression

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~~[ ] Wrote passing tests that cover this change~~
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass