### PR TITLE
fix(popover): update specificity for border and background-token

### DIFF
--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -17,7 +17,6 @@ import { Settings } from '@carbon/icons-react';
 import { keys, match } from '../../internal/keyboard';
 import OverflowMenu from '../OverflowMenu/OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
-import { Tooltip } from '../Tooltip';
 
 const prefix = 'cds';
 

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -17,6 +17,7 @@ import { Settings } from '@carbon/icons-react';
 import { keys, match } from '../../internal/keyboard';
 import OverflowMenu from '../OverflowMenu/OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
+import { Tooltip } from '../Tooltip';
 
 const prefix = 'cds';
 
@@ -394,6 +395,25 @@ export const TabTipExperimentalAutoAlign = () => {
           </PopoverContent>
         </Popover>
       </div>
+    </div>
+  );
+};
+
+export const Test = () => {
+  return (
+    <div style={{ padding: '50px 200px' }}>
+      <Popover open border backgroundToken="background" dropShadow={false}>
+        <PopoverContent>
+          <h2 className="popover-title">Available storage</h2>
+          <p className="popover-details">
+            This server has 150 GB of block storage remaining.
+          </p>
+
+          <Tooltip label="Close" open>
+            <button type="button">Tooltip test</button>
+          </Tooltip>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 };

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -397,22 +397,3 @@ export const TabTipExperimentalAutoAlign = () => {
     </div>
   );
 };
-
-export const Test = () => {
-  return (
-    <div style={{ padding: '50px 200px' }}>
-      <Popover open border backgroundToken="background" dropShadow={false}>
-        <PopoverContent>
-          <h2 className="popover-title">Available storage</h2>
-          <p className="popover-details">
-            This server has 150 GB of block storage remaining.
-          </p>
-
-          <Tooltip label="Close" open>
-            <button type="button">Tooltip test</button>
-          </Tooltip>
-        </PopoverContent>
-      </Popover>
-    </div>
-  );
-};

--- a/packages/styles/scss/components/popover/_popover.scss
+++ b/packages/styles/scss/components/popover/_popover.scss
@@ -119,7 +119,7 @@ $popover-caret-height: custom-property.get-var(
 
   // Border modifier
   .#{$prefix}--popover--border
-    .#{$prefix}--popover
+    > .#{$prefix}--popover
     > .#{$prefix}--popover-content {
     outline: 1px solid $popover-border-color;
     outline-offset: -1px;
@@ -175,7 +175,8 @@ $popover-caret-height: custom-property.get-var(
   }
 
   .#{$prefix}--popover--background-token__background
-    .#{$prefix}--popover-content {
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-content {
     background-color: theme.$background;
   }
 
@@ -225,7 +226,8 @@ $popover-caret-height: custom-property.get-var(
   }
 
   .#{$prefix}--popover--background-token__background
-    .#{$prefix}--popover-caret::after {
+    > .#{$prefix}--popover
+    > .#{$prefix}--popover-caret::after {
     background-color: theme.$background;
   }
 


### PR DESCRIPTION
Over in Carbon Labs we have Tooltips inside of Popovers and I noticed the new border/backgroundToken prop styles were bleeding through to the nested tooltip styles. This PR updates the styles to specifically only target the child so nested Tooltips keep their correct styling based on their own props. 

Example of what is happening over in Labs
<img width="201" height="188" alt="Screenshot 2025-10-27 at 1 35 54 PM" src="https://github.com/user-attachments/assets/87c1bf29-f6ef-44c0-8385-4681e2efaf2e" />

> [!IMPORTANT]
> Test story will need to be deleted before merge 

### Changelog


**Changed**

- update border and backgroundToken styles for Popover to be more specific

#### Testing / Reviewing



## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)

