### PR TITLE
feat(ModalPresence): add higher-order function

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -15815,5 +15815,7 @@ Map {
   "usePrefix" => {},
   "useTheme" => {},
   "validateNumberSeparators" => {},
+  "withComposedModalPresence" => {},
+  "withModalPresence" => {},
 }
 `;

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -375,6 +375,8 @@ describe('Carbon Components React', () => {
         "usePrefix",
         "useTheme",
         "validateNumberSeparators",
+        "withComposedModalPresence",
+        "withModalPresence",
       ]
     `);
   });

--- a/packages/react/src/components/ComposedModal/ComposedModal-test.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal-test.js
@@ -17,7 +17,10 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ComposedModal, { ModalBody } from './ComposedModal';
-import { ComposedModalPresence } from './ComposedModalPresence';
+import {
+  ComposedModalPresence,
+  withComposedModalPresence,
+} from './ComposedModalPresence';
 import { FeatureFlags, useFeatureFlag } from '../FeatureFlags';
 import { ModalHeader } from './ModalHeader';
 import { ModalFooter } from './ModalFooter';
@@ -915,5 +918,26 @@ describe('state with presence context', () => {
     expect(childModal).not.toBeInTheDocument();
     expect(siblingModal).not.toBeInTheDocument();
     expect(screen.queryByTestId('modal')).toBeInTheDocument();
+  });
+});
+
+const ComposedModalWithPresenceHof = withComposedModalPresence((props) => {
+  return <ComposedModal {...props} />;
+});
+
+describe('state with hof withModalPresence', () => {
+  it('should be present when state is open', () => {
+    render(<ComposedModalWithPresenceHof open data-testid="modal" />);
+    expect(screen.queryByTestId('modal')).toBeInTheDocument();
+  });
+
+  it('should not be present when open is false', () => {
+    render(<ComposedModalWithPresenceHof open={false} data-testid="modal" />);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  it('should not be present when open is undefined', () => {
+    render(<ComposedModalWithPresenceHof data-testid="modal" />);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/ComposedModal/ComposedModal.featureflag.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.featureflag.mdx
@@ -95,3 +95,16 @@ to a different level:
   <ComposedModal ... />
 </ComposedModalPresence>
 ```
+
+Instead of wrapping your component with `ComposedModalPresence`, you can also use the higher-order function `withComposedModalPresence`.
+This will automatically wrap your component and handle the props as well as their types for you:
+
+```jsx
+export const MyComposedModal = withComposedModalPresence(
+  ({ onSubmit, onClose }) => {
+    ...
+  },
+);
+
+<MyComposedModal open={open} onSubmit={noop} onClose={noop} />
+```

--- a/packages/react/src/components/ComposedModal/ComposedModal.featureflag.mdx
+++ b/packages/react/src/components/ComposedModal/ComposedModal.featureflag.mdx
@@ -97,7 +97,7 @@ to a different level:
 ```
 
 Instead of wrapping your component with `ComposedModalPresence`, you can also use the higher-order function `withComposedModalPresence`.
-This will automatically wrap your component and handle the props as well as their types for you:
+This will automatically wrap your component and handle the props and types for you:
 
 ```jsx
 export const MyComposedModal = withComposedModalPresence(

--- a/packages/react/src/components/ComposedModal/ComposedModalPresence.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModalPresence.tsx
@@ -9,6 +9,8 @@ import React, {
   createContext,
   useContext,
   useMemo,
+  type ComponentType,
+  type FC,
   type PropsWithChildren,
 } from 'react';
 import {
@@ -79,4 +81,29 @@ export const ComposedModalPresenceContext = createContext<
 export const useExclusiveComposedModalPresenceContext = (id: string) => {
   const ctx = useContext(ComposedModalPresenceContext);
   return ctx?.isPresenceExclusive(id) ? ctx : undefined;
+};
+
+type WithComposedModalPresenceProps = Pick<ComposedModalPresenceProps, 'open'>;
+
+/**
+ * Higher-order function that wraps a component with ComposedModalPresence
+ */
+export const withComposedModalPresence = <TProps extends object>(
+  Component: ComponentType<TProps>
+): FC<TProps & WithComposedModalPresenceProps> => {
+  const WithComposedModalPresence: FC<
+    TProps & WithComposedModalPresenceProps
+  > = (props) => {
+    const { open, ...componentProps } = props;
+
+    return (
+      <ComposedModalPresence open={open}>
+        <Component {...(componentProps as TProps)} />
+      </ComposedModalPresence>
+    );
+  };
+
+  WithComposedModalPresence.displayName = `withComposedModalPresence(${Component.displayName || Component.name || 'Component'})`;
+
+  return WithComposedModalPresence;
 };

--- a/packages/react/src/components/ComposedModal/ComposedModalPresence.tsx
+++ b/packages/react/src/components/ComposedModal/ComposedModalPresence.tsx
@@ -10,7 +10,6 @@ import React, {
   useContext,
   useMemo,
   type ComponentType,
-  type FC,
   type PropsWithChildren,
 } from 'react';
 import {
@@ -90,18 +89,15 @@ type WithComposedModalPresenceProps = Pick<ComposedModalPresenceProps, 'open'>;
  */
 export const withComposedModalPresence = <TProps extends object>(
   Component: ComponentType<TProps>
-): FC<TProps & WithComposedModalPresenceProps> => {
-  const WithComposedModalPresence: FC<
-    TProps & WithComposedModalPresenceProps
-  > = (props) => {
-    const { open, ...componentProps } = props;
-
-    return (
-      <ComposedModalPresence open={open}>
-        <Component {...(componentProps as TProps)} />
-      </ComposedModalPresence>
-    );
-  };
+) => {
+  const WithComposedModalPresence = ({
+    open,
+    ...componentProps
+  }: TProps & WithComposedModalPresenceProps) => (
+    <ComposedModalPresence open={open}>
+      <Component {...(componentProps as TProps)} />
+    </ComposedModalPresence>
+  );
 
   WithComposedModalPresence.displayName = `withComposedModalPresence(${Component.displayName || Component.name || 'Component'})`;
 

--- a/packages/react/src/components/ComposedModal/index.tsx
+++ b/packages/react/src/components/ComposedModal/index.tsx
@@ -13,6 +13,7 @@ export {
 } from './ComposedModal';
 export {
   ComposedModalPresence,
+  withComposedModalPresence,
   type ComposedModalPresenceProps,
 } from './ComposedModalPresence';
 

--- a/packages/react/src/components/Modal/Modal-test.js
+++ b/packages/react/src/components/Modal/Modal-test.js
@@ -12,7 +12,7 @@ import Modal from './Modal';
 import TextInput from '../TextInput';
 import { AILabel } from '../AILabel';
 import { FeatureFlags } from '../FeatureFlags';
-import { ModalPresence } from './ModalPresence';
+import { ModalPresence, withModalPresence } from './ModalPresence';
 import OverflowMenu from '../OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
 
@@ -759,6 +759,27 @@ describe('state with presence context', () => {
     expect(childModal).not.toBeInTheDocument();
     expect(siblingModal).not.toBeInTheDocument();
     expect(screen.queryByTestId('modal')).toBeInTheDocument();
+  });
+});
+
+const ModalWithPresenceHof = withModalPresence((props) => {
+  return <Modal {...props} />;
+});
+
+describe('state with hof withModalPresence', () => {
+  it('should be present when state is open', () => {
+    render(<ModalWithPresenceHof open data-testid="modal" />);
+    expect(screen.queryByTestId('modal')).toBeInTheDocument();
+  });
+
+  it('should not be present when open is false', () => {
+    render(<ModalWithPresenceHof open={false} data-testid="modal" />);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  it('should not be present when open is undefined', () => {
+    render(<ModalWithPresenceHof data-testid="modal" />);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/react/src/components/Modal/Modal.featureflag.mdx
+++ b/packages/react/src/components/Modal/Modal.featureflag.mdx
@@ -99,7 +99,7 @@ different level:
 ```
 
 Instead of wrapping your component with `ModalPresence`, you can also use the higher-order function `withModalPresence`.
-This will automatically wrap your component and handle the props as well as their types for you:
+This will automatically wrap your component and handle the props and types for you:
 
 ```jsx
 export const MyModal = withModalPresence(

--- a/packages/react/src/components/Modal/Modal.featureflag.mdx
+++ b/packages/react/src/components/Modal/Modal.featureflag.mdx
@@ -97,3 +97,16 @@ different level:
   <ComposedModal ... />
 </ModalPresence>
 ```
+
+Instead of wrapping your component with `ModalPresence`, you can also use the higher-order function `withModalPresence`.
+This will automatically wrap your component and handle the props as well as their types for you:
+
+```jsx
+export const MyModal = withModalPresence(
+  ({ onSubmit, onClose }) => {
+    ...
+  },
+);
+
+<MyModal open={open} onSubmit={noop} onClose={noop} />
+```

--- a/packages/react/src/components/Modal/ModalPresence.tsx
+++ b/packages/react/src/components/Modal/ModalPresence.tsx
@@ -10,7 +10,6 @@ import React, {
   useContext,
   useMemo,
   type ComponentType,
-  type FC,
   type PropsWithChildren,
 } from 'react';
 import {
@@ -83,16 +82,15 @@ type WithModalPresenceProps = Pick<ModalPresenceProps, 'open'>;
  */
 export const withModalPresence = <TProps extends object>(
   Component: ComponentType<TProps>
-): FC<TProps & WithModalPresenceProps> => {
-  const WithModalPresence: FC<TProps & WithModalPresenceProps> = (props) => {
-    const { open, ...componentProps } = props;
-
-    return (
-      <ModalPresence open={open}>
-        <Component {...(componentProps as TProps)} />
-      </ModalPresence>
-    );
-  };
+) => {
+  const WithModalPresence = ({
+    open,
+    ...componentProps
+  }: TProps & WithModalPresenceProps) => (
+    <ModalPresence open={open}>
+      <Component {...(componentProps as TProps)} />
+    </ModalPresence>
+  );
 
   WithModalPresence.displayName = `withModalPresence(${Component.displayName || Component.name || 'Component'})`;
 

--- a/packages/react/src/components/Modal/ModalPresence.tsx
+++ b/packages/react/src/components/Modal/ModalPresence.tsx
@@ -9,6 +9,8 @@ import React, {
   createContext,
   useContext,
   useMemo,
+  type ComponentType,
+  type FC,
   type PropsWithChildren,
 } from 'react';
 import {
@@ -72,4 +74,27 @@ export const ModalPresenceContext = createContext<
 export const useExclusiveModalPresenceContext = (id: string) => {
   const ctx = useContext(ModalPresenceContext);
   return ctx?.isPresenceExclusive(id) ? ctx : undefined;
+};
+
+type WithModalPresenceProps = Pick<ModalPresenceProps, 'open'>;
+
+/**
+ * Higher-order function that wraps a component with ModalPresence
+ */
+export const withModalPresence = <TProps extends object>(
+  Component: ComponentType<TProps>
+): FC<TProps & WithModalPresenceProps> => {
+  const WithModalPresence: FC<TProps & WithModalPresenceProps> = (props) => {
+    const { open, ...componentProps } = props;
+
+    return (
+      <ModalPresence open={open}>
+        <Component {...(componentProps as TProps)} />
+      </ModalPresence>
+    );
+  };
+
+  WithModalPresence.displayName = `withModalPresence(${Component.displayName || Component.name || 'Component'})`;
+
+  return WithModalPresence;
 };

--- a/packages/react/src/components/Modal/index.ts
+++ b/packages/react/src/components/Modal/index.ts
@@ -5,7 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 import Modal, { type ModalProps } from './Modal';
-import { ModalPresence, type ModalPresenceProps } from './ModalPresence';
+import {
+  ModalPresence,
+  withModalPresence,
+  type ModalPresenceProps,
+} from './ModalPresence';
 
 export default Modal;
-export { Modal, ModalPresence, type ModalProps, type ModalPresenceProps };
+export {
+  Modal,
+  ModalPresence,
+  withModalPresence,
+  type ModalProps,
+  type ModalPresenceProps,
+};


### PR DESCRIPTION
If you wanted to apply `ModalPresence` to a shared modal, you had to either individually wrap your component for every occurrence:

```jsx
// definition
export const MyModal = ({ onSubmit, onClose }) => {
    ...
}

// usage
<ModalPresence open={open}>
   <MyModal onSubmit={noop} onClose={noop} />
</ModalPresence>
```

or compose your modal differently:

```jsx
// definition
export const MyModal = () => {
    return (
      <ModalPresence>
           <MyModalContent onSubmit={noop} onClose={noop} />
      </ModalPresence>
    )
}

const MyModalContent = ({ onSubmit, onClose }) => {
    ...
}

// usage
<MyModal open={open} onSubmit={noop} onClose={noop} />
```
To improve the DX, this PR adds higher-order functions for both `ModalPresence` and `ComposedModalPresence`:
```jsx
// definition
export const MyModal = withModalPresence(
  ({ onSubmit, onClose }) => {
    ...
  },
);

// usage
<MyModal open={open} onSubmit={noop} onClose={noop} />
```
This helps maintaining re-usability while improving DX. 

### Changelog

**New**

- withModalPresence
- withComposedModalPresence

#### Testing / Reviewing

- Define your shared modal component using `withModalPresence`
- Call your modal component
- See if it unmounts/mounts

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
