### PR TITLE
fix(ComboBox): ensure aria-controls is always applied for a11y

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -1520,4 +1520,16 @@ describe('ComboBox', () => {
       value: '',
     });
   });
+
+  it('should set `aria-controls` on the combobox input when the menu opens', async () => {
+    render(<ComboBox {...mockProps} />);
+
+    await openMenu();
+
+    const combobox = screen.getByRole('combobox');
+    const listbox = screen.getByRole('listbox');
+
+    expect(listbox).toHaveAttribute('id');
+    expect(combobox).toHaveAttribute('aria-controls', listbox.id);
+  });
 });

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1003,7 +1003,7 @@ const ComboBox = forwardRef(
                 'aria-label': titleText
                   ? undefined
                   : deprecatedAriaLabel || ariaLabel,
-                'aria-controls': isOpen ? undefined : menuProps.id,
+                'aria-controls': menuProps.id,
                 placeholder,
                 value: inputValue,
                 ...inputProps,


### PR DESCRIPTION
Closes #18776

Ensures the `ComboBox` input always includes `aria-controls` for accessibility.

### Changelog

**New**

- ~None.~

**Changed**

- `ComboBox` now sets the `aria-controls` attribute to match the listbox `id` for improved a11y support.
- Add test to cover the changes.

**Removed**

- ~None.~

#### Testing / Reviewing

- Go to `React Deploy Preview` > `ComboBox` > `Default`
  - Open the canvas in new tab in the storybook toolbar.
  - Open the menu and inspect the `ComboBox`.
  - Use IBM Access Accessibility Checker to scan
  - Verify that the accessibility violation no longer appears:
    > The 'aria-controls' attribute of the expanded combobox is missing  

- There should no regression.

Before:

<img width="1701" height="439" alt="image" src="https://github.com/user-attachments/assets/16a38459-45f3-44ca-9a00-fbba135ce7d8" />

After: 

<img width="1693" height="366" alt="image" src="https://github.com/user-attachments/assets/2578bbac-7b7c-46b2-9ca7-41559cee3740" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
