### PR TITLE
fix(menu): nested menu closes unexpectedly when hovering back from submenu item to parent menu item

### DIFF
--- a/packages/react/src/components/Menu/Menu.tsx
+++ b/packages/react/src/components/Menu/Menu.tsx
@@ -272,7 +272,13 @@ const Menu = forwardRef<HTMLUListElement, MenuProps>(function Menu(
   }
 
   function handleBlur(e: React.FocusEvent<HTMLUListElement>) {
-    if (open && onClose && isRoot && !menu.current?.contains(e.relatedTarget)) {
+    if (
+      open &&
+      onClose &&
+      isRoot &&
+      e.relatedTarget &&
+      !menu.current?.contains(e.relatedTarget)
+    ) {
       handleClose();
     }
   }


### PR DESCRIPTION
Menu closes when relatedTarget is undefined during navigation. The solution is not to close when relatedTarget is undefined.

Closes #20790

when hovering over a submenu and then moving the cursor back to the parent menu, the entire menu closes unexpectedly.

### Changelog

**New**

- {{new thing}}

**Changed**

- Added a check whether related target is undefined.

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add steps or a checklist for how reviewers can verify this PR works or not }}

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
