### PR TITLE
fix(combobox): preselect mark on initial load

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -498,6 +498,29 @@ describe('ComboBox', () => {
       // The displayed value should still be the one from the first render.
       expect(findInputNode()).toHaveDisplayValue(mockProps.items[0].label);
     });
+
+    it('should mark the initially selectedItem on load when rendered', async () => {
+      render(
+        <ComboBox
+          {...mockProps}
+          initialSelectedItem={mockProps.items[0]}
+          selectedItem={mockProps.items[0]}
+        />
+      );
+      await openMenu();
+
+      // Find the first menu item (which should be the initially selected item)
+      const menuItems = screen.getAllByRole('option');
+      const firstMenuItem = menuItems[0];
+
+      // Check if the initially selected item has the active class
+      expect(firstMenuItem).toHaveClass(
+        `${prefix}--list-box__menu-item--active`
+      );
+
+      // Check if the initially selected item contains an SVG (checkmark icon)
+      expect(firstMenuItem.querySelector('svg')).toBeInTheDocument();
+    });
   });
 
   describe('provided `selectedItem`', () => {

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -356,14 +356,52 @@ AutocompleteWithTypeahead.argTypes = {
   onChange: { action: 'onChange' },
 };
 
-export const Test = () => {
+export const Test = (args) => {
+  const items = [
+    {
+      id: 'option-0',
+      text: 'An example option that is really long to show what should be done to handle long text',
+    },
+    {
+      id: 'option-1',
+      text: 'Option 1',
+    },
+    {
+      id: 'option-2',
+      text: 'Option 2',
+    },
+    {
+      id: 'option-3',
+      text: 'Option 3 - a disabled item',
+      disabled: true,
+    },
+    {
+      id: 'option-4',
+      text: 'Option 4',
+    },
+    {
+      id: 'option-5',
+      text: 'Option 5',
+    },
+  ];
   return (
     <div style={{ width: 300 }}>
       <ComboBox
-        id="compForIssue"
-        decorator={<Locked />}
-        items={['zero', 'one', 'two', 'three']}
-        onChange={() => {}}
+        id="carbon-combobox"
+        items={items}
+        itemToString={(item) => (item ? item.text : '')}
+        titleText="ComboBox title"
+        helperText="Combobox helper text"
+        onChange={action('onChange')}
+        initialSelectedItem={{
+          id: 'option-1',
+          text: 'Option 1',
+        }}
+        selectedItem={{
+          id: 'option-1',
+          text: 'Option 1',
+        }}
+        {...args}
       />
     </div>
   );

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1188,7 +1188,7 @@ const ComboBox = forwardRef(
                     return (
                       <ListBox.MenuItem
                         key={itemProps.id}
-                        isActive={selectedItem === item}
+                        isActive={isEqual(selectedItem, item)}
                         isHighlighted={highlightedIndex === index}
                         title={title}
                         disabled={disabled}
@@ -1198,7 +1198,7 @@ const ComboBox = forwardRef(
                         ) : (
                           itemToString(item)
                         )}
-                        {selectedItem === item && (
+                        {isEqual(selectedItem, item) && (
                           <Checkmark
                             className={`${prefix}--list-box__menu-item__selected-icon`}
                           />


### PR DESCRIPTION
Closes #20886

This updates the combobox when comparing values to make sure items marked on initial select show selected on inital load

### Changelog

**Changed**

- Changed `===` to use the `isEqual` from the already imported `react-fast-compare`

#### Testing / Reviewing

Go to the Test story in Combobox, which uses

```
initialSelectedItem={{
          id: 'option-1',
          text: 'Option 1',
        }}
        selectedItem={{
          id: 'option-1',
          text: 'Option 1',
        }}
```

inside the Combobox.

***

- [ ] REMOVE TEST STORY BEFORE MERGING


***
## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
