### PR TITLE
fix: issue 16430 DropdownSkeleton missing helper text and caret

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.Skeleton.tsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React, { type HTMLAttributes } from 'react';
 import cx from 'classnames';
 import { ListBoxSizePropType, type ListBoxSize } from '../ListBox';
+import ListBoxMenuIcon from '../ListBox/ListBoxMenuIcon';
 import { usePrefix } from '../../internal/usePrefix';
 
 export interface DropdownSkeletonProps extends HTMLAttributes<HTMLDivElement> {
@@ -49,8 +50,12 @@ const DropdownSkeleton: React.FC<DropdownSkeletonProps> = ({
       <div
         className={cx(`${prefix}--skeleton ${prefix}--dropdown`, {
           [`${prefix}--list-box--${size}`]: size,
-        })}
-      />
+        })}>
+        <div className={`${prefix}--list-box__field`}>
+          <ListBoxMenuIcon isOpen={false} />
+        </div>
+      </div>
+      <div className={`${prefix}--skeleton ${prefix}--form__helper-text `} />
     </div>
   );
 };

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -118,7 +118,7 @@ $input-label-weight: 400 !default;
   .#{$prefix}--form__helper-text.#{$prefix}--skeleton {
     @include skeleton;
 
-    block-size: 0.5rem;
+    block-size: $spacing-03;
 
     inline-size: 7.5rem;
   }

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -115,6 +115,13 @@ $input-label-weight: 400 !default;
 
     inline-size: convert.to-rem(75px);
   }
+  .#{$prefix}--form__helper-text.#{$prefix}--skeleton {
+    @include skeleton;
+
+    block-size: 0.5rem;
+
+    inline-size: 7.5rem;
+  }
 
   input[type='number'],
   input[type='text'].#{$prefix}--number {


### PR DESCRIPTION
Closes #

Introduced skeleton for help text and caret icon in DropdownSkeleton
[Issue Link](https://github.com/carbon-design-system/carbon/issues/16430)

### Changelog

**New**

- Added skeleton size for helper text class according to [Figma mockup](https://www.figma.com/design/YAnB1jKx0yCUL29j6uSLpg/-v11--Carbon-Design-System?node-id=14591-300309) in _form.scss packages/styles 
- Introduced ListBoxMenuIcon and div for form_helper-text.

**Changed**

- 

**Removed**

- 

#### Testing / Reviewing

- Checkout the repository and build packages
- Run `yarn storybook` in packages/react.
- View skeleton component in [localhost](http://localhost:3000/?path=/story/components-dropdown--skeleton)

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [~] Updated documentation and storybook examples
- [~] Wrote passing tests that cover this change
- [~] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
