### PR TITLE
fix(menu): prevent overflow

### DIFF
--- a/packages/web-components/src/components/menu/__tests__/menu-test.js
+++ b/packages/web-components/src/components/menu/__tests__/menu-test.js
@@ -90,4 +90,24 @@ describe('cds-menu', () => {
       expect(el.context.isRoot).to.be.false;
     });
   });
+
+  describe('positioning', () => {
+    it('should adjust position when the menu cannot open to the bottom right', async () => {
+      const nearMaxX = window.innerWidth - 10;
+      const nearMaxY = window.innerHeight - 10;
+
+      const el = await fixture(html`
+        <cds-menu .x=${nearMaxX} .y=${nearMaxY} open>
+          <cds-menu-item label="Item 1"></cds-menu-item>
+        </cds-menu>
+      `);
+
+      await el.updateComplete;
+
+      expect(el.position[0]).to.be.a('number');
+      expect(el.position[1]).to.be.a('number');
+      expect(el.position[0]).to.be.lessThan(nearMaxX);
+      expect(el.position[1]).to.be.lessThan(nearMaxY);
+    });
+  });
 });

--- a/packages/web-components/src/components/menu/menu.stories.ts
+++ b/packages/web-components/src/components/menu/menu.stories.ts
@@ -140,62 +140,6 @@ export const Default = {
   },
 };
 
-export const ContextMenu = {
-  render: () => {
-    const handleContextMenuOpen = (e) => {
-      e.preventDefault();
-      const menu = document.querySelector('#context-menu-demo');
-      if (menu) {
-        menu.setAttribute('x', e.clientX);
-        menu.setAttribute('y', e.clientY);
-        menu.setAttribute('open', 'true');
-      }
-    };
-
-    const handleContextMenuClose = () => {
-      const menu = document.querySelector('#context-menu-demo');
-      if (menu) {
-        menu.removeAttribute('open');
-      }
-    };
-
-    setTimeout(() => {
-      document.addEventListener('contextmenu', handleContextMenuOpen);
-      const menu = document.querySelector('#context-menu-demo');
-      if (menu) {
-        menu.addEventListener('cds-menu-closed', handleContextMenuClose);
-      }
-    }, 0);
-
-    return html`
-      <div
-        style="width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;">
-        <p>Right-click anywhere to open the context menu</p>
-      </div>
-
-      <cds-menu
-        id="context-menu-demo"
-        size="sm"
-        background-token="layer"
-        open="false">
-        <cds-menu-item label="Share with">
-          ${iconLoader(FolderShared16, { slot: 'render-icon' })}
-          <cds-menu-item-radio-group slot="submenu" label="Share with list">
-            <cds-menu-item label="None"></cds-menu-item>
-            <cds-menu-item label="Product team"></cds-menu-item>
-            <cds-menu-item label="Organization"></cds-menu-item>
-            <cds-menu-item label="Company"></cds-menu-item>
-          </cds-menu-item-radio-group>
-        </cds-menu-item>
-        <cds-menu-item-divider></cds-menu-item-divider>
-        <cds-menu-item label="Delete" shortcut="⌫" kind="danger">
-          ${iconLoader(TrashCan16, { slot: 'render-icon' })}
-        </cds-menu-item>
-      </cds-menu>
-    `;
-  },
-};
-
 const meta = {
   title: 'Components/Menu',
 };

--- a/packages/web-components/src/components/menu/menu.stories.ts
+++ b/packages/web-components/src/components/menu/menu.stories.ts
@@ -140,6 +140,62 @@ export const Default = {
   },
 };
 
+export const ContextMenu = {
+  render: () => {
+    const handleContextMenuOpen = (e) => {
+      e.preventDefault();
+      const menu = document.querySelector('#context-menu-demo');
+      if (menu) {
+        menu.setAttribute('x', e.clientX);
+        menu.setAttribute('y', e.clientY);
+        menu.setAttribute('open', 'true');
+      }
+    };
+
+    const handleContextMenuClose = () => {
+      const menu = document.querySelector('#context-menu-demo');
+      if (menu) {
+        menu.removeAttribute('open');
+      }
+    };
+
+    setTimeout(() => {
+      document.addEventListener('contextmenu', handleContextMenuOpen);
+      const menu = document.querySelector('#context-menu-demo');
+      if (menu) {
+        menu.addEventListener('cds-menu-closed', handleContextMenuClose);
+      }
+    }, 0);
+
+    return html`
+      <div
+        style="width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;">
+        <p>Right-click anywhere to open the context menu</p>
+      </div>
+
+      <cds-menu
+        id="context-menu-demo"
+        size="sm"
+        background-token="layer"
+        open="false">
+        <cds-menu-item label="Share with">
+          ${iconLoader(FolderShared16, { slot: 'render-icon' })}
+          <cds-menu-item-radio-group slot="submenu" label="Share with list">
+            <cds-menu-item label="None"></cds-menu-item>
+            <cds-menu-item label="Product team"></cds-menu-item>
+            <cds-menu-item label="Organization"></cds-menu-item>
+            <cds-menu-item label="Company"></cds-menu-item>
+          </cds-menu-item-radio-group>
+        </cds-menu-item>
+        <cds-menu-item-divider></cds-menu-item-divider>
+        <cds-menu-item label="Delete" shortcut="⌫" kind="danger">
+          ${iconLoader(TrashCan16, { slot: 'render-icon' })}
+        </cds-menu-item>
+      </cds-menu>
+    `;
+  },
+};
+
 const meta = {
   title: 'Components/Menu',
 };

--- a/packages/web-components/src/components/menu/menu.ts
+++ b/packages/web-components/src/components/menu/menu.ts
@@ -313,7 +313,8 @@ class CDSMenu extends HostListenerMixin(LitElement) {
     const { isRoot } = this.context;
 
     // const isRoot =  false
-    const { width, height } = this.getBoundingClientRect();
+    const menuElement = this.shadowRoot?.querySelector(`.${prefix}--menu`);
+    const { width, height } = (menuElement ?? this).getBoundingClientRect();
     const alignment = isRoot ? 'vertical' : 'horizontal';
     const axes = {
       x: {


### PR DESCRIPTION
This addresses that the menu would not correctly switch sides when it would run out of the screen. It was fixed by using the correct menu html element for checking the size of the menu to correctly compute the newposition to avoid overflow.

Closes #20997

### Changelog

**New**

- A new context menu example was added to the storybook for the menu.

**Changed**

- Use the cds-menu html element itself for checking the size of the menu.

#### Testing / Reviewing

- Access context menu example in the storybook (/?path=/story/components-menu--context-menu).
- Open the context menu at different positions by right-clicking. Check whether the position is correct, especially close to the right and bottom edge. The menu should no longer flow out of the screen.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
