### PR TITLE
fix: fixed the Filterable multiselect's divider between the decorator and close button

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.tsx
@@ -1070,7 +1070,11 @@ export const FilterableMultiSelect = forwardRef(function FilterableMultiSelect<
           normalizedDecorator
         ) : decorator ? (
           <div className={`${prefix}--list-box__inner-wrapper--decorator`}>
-            {normalizedDecorator}
+            {candidateIsAILabel ? (
+              normalizedDecorator
+            ) : (
+              <span>{normalizedDecorator}</span>
+            )}
           </div>
         ) : (
           ''

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -10,6 +10,7 @@ import { View, FolderOpen, Folders, Information } from '@carbon/icons-react';
 import { action } from 'storybook/actions';
 import { WithLayer } from '../../../.storybook/templates/WithLayer';
 import mdx from './MultiSelect.mdx';
+import { Locked } from '@carbon/react/icons';
 
 import { FilterableMultiSelect, MultiSelect } from '.';
 import Button from '../Button';
@@ -678,6 +679,53 @@ export const SelectAllWithDynamicItems = () => {
         onChange={onChange}
       />
       <Button onClick={addItems}>Add 2 items to the list</Button>
+    </div>
+  );
+};
+
+export const Test = (args) => {
+  const items = [
+    {
+      id: 'downshift-1-item-0',
+      text: 'Option 1',
+    },
+    {
+      id: 'downshift-1-item-1',
+      text: 'Option 2',
+    },
+    {
+      id: 'downshift-1-item-2',
+      text: 'Option 3 - a disabled item',
+      disabled: true,
+    },
+    {
+      id: 'downshift-1-item-3',
+      text: 'Option 4',
+    },
+    {
+      id: 'downshift-1-item-4',
+      text: 'An example option that is really long to show what should be done to handle long text',
+    },
+    {
+      id: 'downshift-1-item-5',
+      text: 'Option 5',
+    },
+  ];
+  return (
+    <div
+      style={{
+        width: 300,
+      }}>
+      <FilterableMultiSelect
+        id="carbon-multiselect-example-3"
+        titleText="FilterableMultiSelect title"
+        helperText="This is helper text"
+        items={items}
+        decorator={<Locked />}
+        itemToString={(item) => (item ? item.text : '')}
+        selectionFeedback="top-after-reopen"
+        {...args}
+      />
     </div>
   );
 };

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -10,7 +10,6 @@ import { View, FolderOpen, Folders, Information } from '@carbon/icons-react';
 import { action } from 'storybook/actions';
 import { WithLayer } from '../../../.storybook/templates/WithLayer';
 import mdx from './MultiSelect.mdx';
-import { Locked } from '@carbon/react/icons';
 
 import { FilterableMultiSelect, MultiSelect } from '.';
 import Button from '../Button';
@@ -679,53 +678,6 @@ export const SelectAllWithDynamicItems = () => {
         onChange={onChange}
       />
       <Button onClick={addItems}>Add 2 items to the list</Button>
-    </div>
-  );
-};
-
-export const Test = (args) => {
-  const items = [
-    {
-      id: 'downshift-1-item-0',
-      text: 'Option 1',
-    },
-    {
-      id: 'downshift-1-item-1',
-      text: 'Option 2',
-    },
-    {
-      id: 'downshift-1-item-2',
-      text: 'Option 3 - a disabled item',
-      disabled: true,
-    },
-    {
-      id: 'downshift-1-item-3',
-      text: 'Option 4',
-    },
-    {
-      id: 'downshift-1-item-4',
-      text: 'An example option that is really long to show what should be done to handle long text',
-    },
-    {
-      id: 'downshift-1-item-5',
-      text: 'Option 5',
-    },
-  ];
-  return (
-    <div
-      style={{
-        width: 300,
-      }}>
-      <FilterableMultiSelect
-        id="carbon-multiselect-example-3"
-        titleText="FilterableMultiSelect title"
-        helperText="This is helper text"
-        items={items}
-        decorator={<Locked />}
-        itemToString={(item) => (item ? item.text : '')}
-        selectionFeedback="top-after-reopen"
-        {...args}
-      />
     </div>
   );
 };

--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -1156,18 +1156,7 @@ $list-box-menu-width: convert.to-rem(300px);
     .#{$prefix}--list-box__invalid-icon {
     inset-inline-end: convert.to-rem(114px);
   }
-  .#{$prefix}--list-box__wrapper--decorator
-    .#{$prefix}--list-box--invalid
-    .#{$prefix}--list-box__field:has(.#{$prefix}--list-box__selection)
-    ~ .#{$prefix}--list-box__inner-wrapper--decorator
-    > *,
-  .#{$prefix}--list-box__wrapper--decorator
-    .#{$prefix}--list-box--warning
-    .#{$prefix}--list-box__field:has(.#{$prefix}--list-box__selection)
-    ~ .#{$prefix}--list-box__inner-wrapper--decorator
-    > * {
-    inset-inline-end: convert.to-rem(116px);
-  }
+
   // Windows HCM fix
   .#{$prefix}--list-box__field,
   .#{$prefix}--list-box__menu,


### PR DESCRIPTION
Closes #20824 


When the user types in the input, the divider between decorator and the close(x) button is appearing as expected.

> [!WARNING]  
> This PR includes a temporary test. Please **do not merge** until the test has been removed.


### Changelog

**New**

- wraps the span around the `normalizedDecorator` on the condition that it's not an AILabel component



#### Testing / Reviewing

- open the test story
- type something in the input
- see that the divider is appearing between decorator and x button.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff~
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
