### PR TITLE
fix(combo-box): correct focus and item highlight behavior

### DIFF
--- a/packages/web-components/src/components/combo-box/combo-box-item.ts
+++ b/packages/web-components/src/components/combo-box/combo-box-item.ts
@@ -1,14 +1,20 @@
 /**
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { PropertyValues } from 'lit';
 import { prefix } from '../../globals/settings';
 import CDSDropdownItem from '../dropdown/dropdown-item';
 import styles from './combo-box.scss?lit';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
+
+type NextSiblingAttribute =
+  | 'hovered-next-sibling'
+  | 'highlighted-next-sibling'
+  | 'selected-next-sibling';
 
 /**
  * Combo box item.
@@ -17,6 +23,80 @@ import { carbonElement as customElement } from '../../globals/decorators/carbon-
  */
 @customElement(`${prefix}-combo-box-item`)
 class CDSComboBoxItem extends CDSDropdownItem {
+  private _nextSiblingRefs: Record<NextSiblingAttribute, Element | null> = {
+    'hovered-next-sibling': null,
+    'highlighted-next-sibling': null,
+    'selected-next-sibling': null,
+  };
+
+  private _handleMouseEnter = () => {
+    if (this.hasAttribute('disabled')) {
+      return;
+    }
+    this._syncNextSibling('hovered-next-sibling', true);
+  };
+
+  private _handleMouseLeave = () => {
+    this._syncNextSibling('hovered-next-sibling', false);
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.classList.add(`${prefix}--list-box__menu-item`);
+    this.addEventListener('mouseenter', this._handleMouseEnter);
+    this.addEventListener('mouseleave', this._handleMouseLeave);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('mouseenter', this._handleMouseEnter);
+    this.removeEventListener('mouseleave', this._handleMouseLeave);
+    this._syncNextSibling('hovered-next-sibling', false);
+    this._syncNextSibling('highlighted-next-sibling', false);
+    this._syncNextSibling('selected-next-sibling', false);
+    super.disconnectedCallback();
+  }
+
+  private _getNextItem(): Element | null {
+    let next = this.nextElementSibling;
+    while (next) {
+      if (
+        next instanceof HTMLElement &&
+        next.tagName.toLowerCase() === `${prefix}-combo-box-item`
+      ) {
+        return next;
+      }
+      next = next.nextElementSibling;
+    }
+    return null;
+  }
+
+  private _syncNextSibling(
+    attribute: NextSiblingAttribute,
+    shouldSet: boolean
+  ) {
+    const currentSibling = this._nextSiblingRefs[attribute];
+    currentSibling?.removeAttribute(attribute);
+    if (shouldSet) {
+      const next = this._getNextItem();
+      if (next) {
+        next.setAttribute(attribute, '');
+        this._nextSiblingRefs[attribute] = next;
+        return;
+      }
+    }
+    this._nextSiblingRefs[attribute] = null;
+  }
+
+  protected updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+    if (changedProperties.has('highlighted')) {
+      this._syncNextSibling('highlighted-next-sibling', this.highlighted);
+    }
+    if (changedProperties.has('selected')) {
+      this._syncNextSibling('selected-next-sibling', this.selected);
+    }
+  }
+
   static styles = styles;
 }
 

--- a/packages/web-components/src/components/combo-box/combo-box.scss
+++ b/packages/web-components/src/components/combo-box/combo-box.scss
@@ -108,6 +108,8 @@ $css--plex: true !default;
 }
 
 :host(#{$prefix}-combo-box-item[disabled]) {
+  cursor: not-allowed;
+
   .#{$prefix}--list-box__menu-item__option {
     color: $text-disabled;
     cursor: not-allowed;

--- a/packages/web-components/src/components/combo-box/combo-box.scss
+++ b/packages/web-components/src/components/combo-box/combo-box.scss
@@ -11,6 +11,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities' as *;
+@use '@carbon/styles/scss/utilities/focus-outline' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/layout' as *;
 @use '@carbon/styles/scss/components/combo-box' as *;
@@ -41,6 +42,11 @@ $css--plex: true !default;
   }
 }
 
+:host(#{$prefix}-combo-box) .#{$prefix}--text-input--highlighted-outline {
+  outline: 1px solid $focus;
+  outline-offset: -1px;
+}
+
 :host(#{$prefix}-combo-box[disabled]),
 :host(#{$prefix}-combo-box[read-only]) {
   .#{$prefix}--list-box__selection {
@@ -68,18 +74,57 @@ $css--plex: true !default;
   .#{$prefix}--list-box__menu-item__option {
     block-size: auto;
   }
+}
 
-  &:hover {
-    background-color: $layer-hover;
+:host(#{$prefix}-combo-box-item:not([disabled]):hover) {
+  background-color: $layer-hover;
+}
+
+:host(#{$prefix}-combo-box-item:first-of-type)
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: transparent;
+}
+
+:host(#{$prefix}-combo-box-item:first-of-type[highlighted]) {
+  @include focus-outline('reset');
+
+  &::before {
+    position: absolute;
+    border: 2px solid $focus;
+    block-size: 100%;
+    border-block-start: 1px solid $focus;
+    content: '';
+    inline-size: 100%;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    pointer-events: none;
   }
+}
+
+:host(#{$prefix}-combo-box-item[highlighted-next-sibling]),
+:host(#{$prefix}-combo-box-item[hovered-next-sibling])
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: transparent;
 }
 
 :host(#{$prefix}-combo-box-item[disabled]) {
   .#{$prefix}--list-box__menu-item__option {
     color: $text-disabled;
     cursor: not-allowed;
+    pointer-events: none;
     text-decoration: none;
   }
+}
+
+:host(#{$prefix}-combo-box-item[disabled][highlighted-next-sibling]:hover),
+:host(#{$prefix}-combo-box-item[disabled][hovered-next-sibling]:hover)
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: $border-subtle;
+}
+
+:host(#{$prefix}-combo-box-item[disabled]:hover)
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: $border-subtle-01;
 }
 
 :host(#{$prefix}-combo-box-item[highlighted]) {
@@ -88,15 +133,25 @@ $css--plex: true !default;
 
 :host(#{$prefix}-combo-box-item[selected]) {
   @extend .#{$prefix}--list-box__menu-item--active;
-  @extend .#{$prefix}--list-box__menu-item--highlighted;
 
   .#{$prefix}--list-box__menu-item__option {
+    border-block-start-color: transparent;
     color: $text-primary;
   }
 
   .#{$prefix}--list-box__menu-item__selected-icon {
     display: block;
   }
+}
+
+:host(#{$prefix}-combo-box-item[selected-next-sibling])
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: transparent;
+}
+
+:host(#{$prefix}-combo-box-item[disabled][selected-next-sibling]:hover)
+  .#{$prefix}--list-box__menu-item__option {
+  border-block-start-color: $border-subtle;
 }
 
 :host(#{$prefix}-combo-box-item[size='sm']) {
@@ -112,6 +167,18 @@ $css--plex: true !default;
 
   .#{$prefix}--list-box__menu-item__option {
     padding-block: to-rem(15px);
+  }
+}
+
+:host(#{$prefix}-combo-box[size='sm']) {
+  .#{$prefix}--list-box__menu-icon {
+    inset-block: $spacing-02;
+  }
+}
+
+:host(#{$prefix}-combo-box[size='lg']) {
+  .#{$prefix}--list-box__menu-icon {
+    inset-block: $spacing-04;
   }
 }
 

--- a/packages/web-components/src/components/combo-box/combo-box.ts
+++ b/packages/web-components/src/components/combo-box/combo-box.ts
@@ -226,7 +226,7 @@ class CDSComboBox extends CDSDropdown {
       } else {
         (comboItem as HTMLElement).style.display = '';
       }
-      comboItem.highlighted = index === firstMatchIndex;
+      comboItem.highlighted = index === firstMatchIndex && !comboItem.disabled;
     });
     return firstMatchIndex;
   }

--- a/packages/web-components/src/components/combo-box/combo-box.ts
+++ b/packages/web-components/src/components/combo-box/combo-box.ts
@@ -359,6 +359,7 @@ class CDSComboBox extends CDSDropdown {
     const inputClasses = classMap({
       [`${prefix}--text-input`]: true,
       [`${prefix}--text-input--empty`]: !value,
+      [`${prefix}--text-input--highlighted-outline`]: this._hasHighlightedItem,
     });
 
     let activeDescendantFallback: string | undefined;
@@ -388,6 +389,17 @@ class CDSComboBox extends CDSDropdown {
         @input=${handleInput}
         @keydown=${handleInputKeydown} />
     `;
+  }
+
+  protected get _hasHighlightedItem() {
+    return (
+      this.open &&
+      Boolean(
+        this.querySelector(
+          (this.constructor as typeof CDSComboBox).selectorItemHighlighted
+        )
+      )
+    );
   }
 
   // eslint-disable-next-line   @typescript-eslint/no-invalid-void-type -- https://github.com/carbon-design-system/carbon/issues/20452


### PR DESCRIPTION
Closes #20787 

> **This PR fixes the focus issue. There’s still some parity work to be done. https://github.com/carbon-design-system/carbon/issues/18333**

 It improves the`combo-box` behavior so the focus outline and item highlight work correctly and match the React parity work.

### Changelog

**New**

- Added the `cds--text-input--highlighted-outline` class to show the focus outline when a menu item is `highlighted`.

**Changed**

- Simplified `cds-combo-box-item` sibling handling so hover/highlight borders stay in sync.
- Reworked the first-item pseudo-element and size-based menu-icon spacing to remove double borders and match React spacing.
- Fixed a bug in the caret

**Removed**

- Outdated outline/border rules that caused incorrect outlines on the input or the first item.

#### Testing / Reviewing

- Go to `WC Deploy Preview` > `Combo box` > `Default` (pls, test all stories)
- Move through the list with keyboard arrows 
- Hover items with the mouse
- Check filtering:
  - Typing should highlight the first matching item.
  - Outline should update while filtering

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
