### PR TITLE
fix(combobox): sync menu highlight with controlled selection

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-test.js
+++ b/packages/react/src/components/ComboBox/ComboBox-test.js
@@ -672,6 +672,28 @@ describe('ComboBox', () => {
       expect(screen.getByTestId('selected-item').textContent).toBe('none');
       expect(findInputNode()).toHaveDisplayValue('');
     });
+    it('should sync the menu active item when `selectedItem` updates externally', async () => {
+      render(<ControlledComboBox />);
+      await openMenu();
+      let menuItems = screen.getAllByRole('option');
+      expect(menuItems[0]).toHaveClass(
+        `${prefix}--list-box__menu-item--active`
+      );
+
+      await userEvent.keyboard('{Escape}');
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Choose item 3' })
+      );
+
+      await openMenu();
+      menuItems = screen.getAllByRole('option');
+      expect(menuItems[3]).toHaveClass(
+        `${prefix}--list-box__menu-item--active`
+      );
+      expect(menuItems[0]).not.toHaveClass(
+        `${prefix}--list-box__menu-item--active`
+      );
+    });
     it('should update and call `onChange` once when selection is updated externally', async () => {
       const { rerender } = render(
         <ComboBox {...mockProps} selectedItem={mockProps.items[0]} />

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -882,6 +882,11 @@ const ComboBox = forwardRef(
       },
     });
 
+    // Keep the dropdown highlight in sync with either the controlled value or
+    // Downshift's own selection when uncontrolled.
+    const menuSelectedItem =
+      typeof selectedItemProp !== 'undefined' ? selectedItemProp : selectedItem;
+
     useEffect(() => {
       // Used to expose the downshift actions to consumers for use with downshiftProps
       // An odd pattern, here we mutate the value stored in the ref provided from the consumer.
@@ -907,6 +912,7 @@ const ComboBox = forwardRef(
       downshiftSetInputValue,
       toggleMenu,
     ]);
+
     const buttonProps = getToggleButtonProps({
       disabled: disabled || readOnly,
       onClick: handleToggleClick(isOpen),
@@ -1205,7 +1211,7 @@ const ComboBox = forwardRef(
                     return (
                       <ListBox.MenuItem
                         key={itemProps.id}
-                        isActive={isEqual(selectedItem, item)}
+                        isActive={isEqual(menuSelectedItem, item)}
                         isHighlighted={highlightedIndex === index}
                         title={title}
                         disabled={disabled}
@@ -1215,7 +1221,7 @@ const ComboBox = forwardRef(
                         ) : (
                           itemToString(item)
                         )}
-                        {isEqual(selectedItem, item) && (
+                        {isEqual(menuSelectedItem, item) && (
                           <Checkmark
                             className={`${prefix}--list-box__menu-item__selected-icon`}
                           />


### PR DESCRIPTION
Closes #21060

This fix keeps the combobox menu highlight in sync with whatever the parent selects, even after state updates, so the dropdown always shows the right active option.

### Changelog

**New**

- Added test.

**Changed**

- ComboBox now just highlights whatever you pass via `selectedItem`, so the dropdown always matches the parent state.

**Removed**

- ~None.~

#### Testing / Reviewing

- Go to `React Deploy Preview` > `ComboBox` > `Fully Controlled`:
    -  use the buttons to change selections, reopen the menu, and confirm the highlight follows each new selection.
- You can also run `yarn test ComboBox-test.js` to double-check the tests.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
