### PR TITLE
fix(RadioTile): ensure aria attributes apply to input instead of label

### DIFF
--- a/packages/react/src/components/RadioTile/RadioTile-test.js
+++ b/packages/react/src/components/RadioTile/RadioTile-test.js
@@ -134,6 +134,77 @@ describe('RadioTile', () => {
       );
       expect(screen.getByRole('radio')).toHaveAttribute('required');
     });
+
+    it('should apply "aria-describedby" to the input element', () => {
+      render(
+        <RadioTile value="standard" aria-describedby="description-id">
+          Option 1
+        </RadioTile>
+      );
+
+      expect(screen.getByRole('radio')).toHaveAttribute(
+        'aria-describedby',
+        'description-id'
+      );
+    });
+
+    it('should apply "aria-labelledby" to the input element', () => {
+      render(
+        <RadioTile value="standard" aria-labelledby="label-id">
+          Option 1
+        </RadioTile>
+      );
+
+      expect(screen.getByRole('radio')).toHaveAttribute(
+        'aria-labelledby',
+        'label-id'
+      );
+    });
+
+    it('should apply both "aria-describedby" and "aria-labelledby" to the input element', () => {
+      render(
+        <RadioTile
+          value="standard"
+          aria-describedby="description-id"
+          aria-labelledby="label-id">
+          Option 1
+        </RadioTile>
+      );
+
+      const input = screen.getByRole('radio');
+      expect(input).toHaveAttribute('aria-describedby', 'description-id');
+      expect(input).toHaveAttribute('aria-labelledby', 'label-id');
+    });
+
+    it('should not apply "aria-describedby" to the label element', () => {
+      render(
+        <RadioTile
+          value="standard"
+          aria-describedby="description-id"
+          data-testid="test-id">
+          Option 1
+        </RadioTile>
+      );
+
+      expect(screen.getByTestId('test-id')).not.toHaveAttribute(
+        'aria-describedby'
+      );
+    });
+
+    it('should not apply "aria-labelledby" to the label element', () => {
+      render(
+        <RadioTile
+          value="standard"
+          aria-labelledby="label-id"
+          data-testid="test-id">
+          Option 1
+        </RadioTile>
+      );
+
+      expect(screen.getByTestId('test-id')).not.toHaveAttribute(
+        'aria-labelledby'
+      );
+    });
   });
 
   it('should check decorator prop and if AILabel exists on radio tile and is xs', async () => {

--- a/packages/react/src/components/RadioTile/RadioTile.tsx
+++ b/packages/react/src/components/RadioTile/RadioTile.tsx
@@ -106,6 +106,7 @@ export interface RadioTileProps {
    */
   required?: boolean;
 }
+type AriaSupportedProps = React.AriaAttributes;
 
 const RadioTile = React.forwardRef(
   (
@@ -125,7 +126,7 @@ const RadioTile = React.forwardRef(
       slug,
       required,
       ...rest
-    }: RadioTileProps,
+    }: RadioTileProps & AriaSupportedProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     const prefix = usePrefix();
@@ -145,6 +146,11 @@ const RadioTile = React.forwardRef(
         [`${prefix}--tile--decorator-rounded`]: decorator && hasRoundedCorners,
       }
     );
+    const {
+      'aria-describedby': ariaDescribedBy,
+      'aria-labelledby': ariaLabelledBy,
+      ...labelProps
+    } = rest;
     const v12TileRadioIcons = useFeatureFlag('enable-v12-tile-radio-icons');
     function icon() {
       if (v12TileRadioIcons) {
@@ -193,10 +199,12 @@ const RadioTile = React.forwardRef(
           tabIndex={!disabled ? tabIndex : undefined}
           type="radio"
           value={value}
+          {...(ariaDescribedBy && { 'aria-describedby': ariaDescribedBy })}
+          {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}
           ref={ref}
           required={required}
         />
-        <label {...rest} htmlFor={inputId} className={className}>
+        <label {...labelProps} htmlFor={inputId} className={className}>
           <span className={`${prefix}--tile__checkmark`}>{icon()}</span>
           <Text className={`${prefix}--tile-content`}>{children}</Text>
           {slug ? (


### PR DESCRIPTION
Closes #20496

Apply aria-describedby and aria-labelledby to the input element in RadioTile

### Changelog

Updated RadioTile so aria-describedby and aria-labelledby are applied to the underlying <input> instead of the <label> to improving screen reader support

**Changed**

{...(ariaDescribedBy && { 'aria-describedby': ariaDescribedBy })}
{...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}

**New**
Added test cases against the fix 

#### Testing / Reviewing

Render RadioTile with aria-describedby and/or aria-labelledby.
Confirm accessibility attributes are applied only to the <input> element and not the <label>
Check new test cases are passing 

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
