### PR TITLE
feat(stories): add theme control to all component stories

### DIFF
--- a/packages/react/src/components/AILabel/AILabel.stories.js
+++ b/packages/react/src/components/AILabel/AILabel.stories.js
@@ -17,6 +17,16 @@ import './ailabel-story.scss';
 export default {
   title: 'Components/AILabel',
   component: AILabel,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,
@@ -292,6 +302,11 @@ ExplainabilityPopover.argTypes = {
       type: 'boolean',
     },
     description: 'Playground only - toggle to show the callout toolbar',
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
   align: {
     options: [

--- a/packages/react/src/components/AISkeleton/AISkeletonIcon.stories.js
+++ b/packages/react/src/components/AISkeleton/AISkeletonIcon.stories.js
@@ -20,6 +20,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const propsSkeleton = {

--- a/packages/react/src/components/Accordion/Accordion.stories.js
+++ b/packages/react/src/components/Accordion/Accordion.stories.js
@@ -27,6 +27,9 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
 };
 
 const sharedArgTypes = {
@@ -53,6 +56,11 @@ const sharedArgTypes = {
   size: {
     options: ['sm', 'md', 'lg'],
     control: { type: 'select' },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/AspectRatio/AspectRatio.stories.js
+++ b/packages/react/src/components/AspectRatio/AspectRatio.stories.js
@@ -27,6 +27,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = (args) => {
@@ -66,5 +76,10 @@ Default.argTypes = {
     table: {
       category: 'AspectRatio',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -25,12 +25,20 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
 };
 
 const sharedArgTypes = {
   size: {
     options: ['sm', 'md'],
     control: { type: 'select' },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/Button/Button.stories.js
+++ b/packages/react/src/components/Button/Button.stories.js
@@ -47,6 +47,14 @@ export default {
     as: {
       control: false,
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
   },
   parameters: {
     docs: {

--- a/packages/react/src/components/ChatButton/ChatButton.stories.js
+++ b/packages/react/src/components/ChatButton/ChatButton.stories.js
@@ -14,6 +14,16 @@ export default {
   title: 'Preview/preview__ChatButton',
   component: ChatButton,
   parameters: {},
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => (

--- a/packages/react/src/components/Checkbox/Checkbox.stories.js
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.js
@@ -46,6 +46,7 @@ const sharedArgs = {
   invalidText: 'Invalid message goes here',
   warn: false,
   warnText: 'Warning message goes here',
+  theme: 'g10',
 };
 
 const sharedArgTypes = {
@@ -98,6 +99,11 @@ const sharedArgTypes = {
     description: 'Provide how checkbox should be displayed',
     control: 'select',
     options: ['horizontal', 'vertical'],
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/ClassPrefix/ClassPrefix.stories.js
+++ b/packages/react/src/components/ClassPrefix/ClassPrefix.stories.js
@@ -13,6 +13,16 @@ import mdx from './ClassPrefix.mdx';
 export default {
   title: 'Components/ClassPrefix',
   component: ClassPrefix,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/CodeSnippet/CodeSnippet.stories.js
+++ b/packages/react/src/components/CodeSnippet/CodeSnippet.stories.js
@@ -26,6 +26,14 @@ export default {
         disable: true,
       },
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
   },
 };
 

--- a/packages/react/src/components/ComboBox/ComboBox.stories.js
+++ b/packages/react/src/components/ComboBox/ComboBox.stories.js
@@ -46,6 +46,11 @@ export default {
   title: 'Components/ComboBox',
   component: ComboBox,
   argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
     size: {
       options: ['sm', 'md', 'lg'],
       control: { type: 'select' },
@@ -56,6 +61,9 @@ export default {
       },
     },
     onChange: { action: 'onChange' },
+  },
+  args: {
+    theme: 'g10',
   },
   parameters: {
     docs: {

--- a/packages/react/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/react/src/components/ComboButton/ComboButton.stories.js
@@ -21,6 +21,16 @@ export default {
     MenuItem,
     MenuItemDivider,
   },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/ComposedModal/ComposedModal.stories.js
+++ b/packages/react/src/components/ComposedModal/ComposedModal.stories.js
@@ -36,6 +36,16 @@ export default {
     ModalBody,
     ModalFooter,
   },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/ContainedList/ContainedList.stories.js
+++ b/packages/react/src/components/ContainedList/ContainedList.stories.js
@@ -34,6 +34,16 @@ export default {
   title: 'Components/ContainedList',
   component: ContainedList,
   subcomponents: { ContainedListItem },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/ContentSwitcher/ContentSwitcher.stories.js
+++ b/packages/react/src/components/ContentSwitcher/ContentSwitcher.stories.js
@@ -31,6 +31,14 @@ export default {
         disable: true,
       },
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
   },
   parameters: {
     docs: {

--- a/packages/react/src/components/ContextMenu/useContextMenu.stories.js
+++ b/packages/react/src/components/ContextMenu/useContextMenu.stories.js
@@ -26,6 +26,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const Text = () => (

--- a/packages/react/src/components/CopyButton/CopyButton.stories.js
+++ b/packages/react/src/components/CopyButton/CopyButton.stories.js
@@ -13,6 +13,16 @@ import mdx from './CopyButton.mdx';
 export default {
   title: 'Components/CopyButton',
   component: CopyButton,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/DataTable/stories/DataTable-basic.stories.js
+++ b/packages/react/src/components/DataTable/stories/DataTable-basic.stories.js
@@ -20,26 +20,6 @@ const {
 
 import mdx from '../DataTable.mdx';
 import './datatable-story.scss';
-
-export default {
-  title: 'Components/DataTable/Basic',
-  component: DataTable,
-  subcomponents: {
-    TableContainer,
-    Table,
-    TableHead,
-    TableRow,
-    TableHeader,
-    TableBody,
-    TableCell,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
 const sharedArgTypes = {
   size: {
     control: 'select',
@@ -59,6 +39,11 @@ const sharedArgTypes = {
     control: 'boolean',
     description: 'Add zebra striping to rows',
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };
 
 const sharedArgs = {
@@ -66,8 +51,29 @@ const sharedArgs = {
   stickyHeader: false,
   useStaticWidth: false,
   useZebraStyles: false,
+  theme: 'g10',
 };
 
+export default {
+  title: 'Components/DataTable/Basic',
+  component: DataTable,
+  subcomponents: {
+    TableContainer,
+    Table,
+    TableHead,
+    TableRow,
+    TableHeader,
+    TableBody,
+    TableCell,
+  },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  args: sharedArgs,
+  argTypes: sharedArgTypes,
+};
 export const Default = (args) => {
   const rows = [
     {

--- a/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
+++ b/packages/react/src/components/DataTableSkeleton/DataTableSkeleton.stories.js
@@ -21,6 +21,16 @@ const props = () => ({
 export default {
   title: 'Components/DataTable/Skeleton',
   component: DataTableSkeleton,
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Skeleton = (args) => {

--- a/packages/react/src/components/DatePicker/DatePicker.stories.js
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.js
@@ -49,6 +49,14 @@ export default {
         disable: true,
       },
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
   },
 };
 

--- a/packages/react/src/components/Dropdown/Dropdown.stories.js
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.js
@@ -93,6 +93,7 @@ const sharedArgs = {
   warnText: 'please notice the warning',
   titleText: 'This is an example title',
   type: 'default',
+  theme: 'g10',
 };
 
 const sharedArgTypes = {
@@ -148,6 +149,11 @@ const sharedArgTypes = {
   type: {
     control: { type: 'select' },
     options: ['default', 'inline'],
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/ErrorBoundary/ErrorBoundary.stories.js
+++ b/packages/react/src/components/ErrorBoundary/ErrorBoundary.stories.js
@@ -14,6 +14,16 @@ import mdx from './ErrorBoundary.mdx';
 export default {
   title: 'Components/ErrorBoundary',
   component: ErrorBoundary,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/FileUploader/FileUploader.stories.js
+++ b/packages/react/src/components/FileUploader/FileUploader.stories.js
@@ -31,6 +31,16 @@ export default {
     FileUploaderItem,
     FileUploaderDropContainer,
   },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,
@@ -191,6 +201,10 @@ Default.argTypes = {
   size: {
     control: { type: 'select' },
     options: ['sm', 'md', 'lg'],
+  },
+  theme: {
+    control: { type: 'select' },
+    options: ['white', 'g10', 'g90', 'g100'],
   },
 };
 

--- a/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
+++ b/packages/react/src/components/FluidComboBox/FluidComboBox.stories.js
@@ -18,48 +18,6 @@ import { IconButton } from '../IconButton';
 import { Button } from '../Button';
 import { Information, View, FolderOpen, Folders } from '@carbon/icons-react';
 import mdx from './FluidComboBox.mdx';
-
-export default {
-  title: 'Components/Fluid Components/FluidComboBox',
-  component: FluidComboBox,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  subcomponents: {
-    FluidComboBoxSkeleton,
-  },
-};
-
-const items = [
-  {
-    id: 'option-0',
-    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
-  },
-  {
-    id: 'option-1',
-    text: 'Option 1',
-  },
-  {
-    id: 'option-2',
-    text: 'Option 2',
-  },
-  {
-    id: 'option-3',
-    text: 'Option 3 - a disabled item',
-    disabled: true,
-  },
-  {
-    id: 'option-4',
-    text: 'Option 4',
-  },
-  {
-    id: 'option-5',
-    text: 'Option 5',
-  },
-];
-
 const sharedArgTypes = {
   className: {
     control: {
@@ -106,8 +64,68 @@ const sharedArgTypes = {
       type: 'text',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Fluid Components/FluidComboBox',
+  component: FluidComboBox,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  subcomponents: {
+    FluidComboBoxSkeleton,
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+    slug: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
+const items = [
+  {
+    id: 'option-0',
+    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+  },
+  {
+    id: 'option-1',
+    text: 'Option 1',
+  },
+  {
+    id: 'option-2',
+    text: 'Option 2',
+  },
+  {
+    id: 'option-3',
+    text: 'Option 3 - a disabled item',
+    disabled: true,
+  },
+  {
+    id: 'option-4',
+    text: 'Option 4',
+  },
+  {
+    id: 'option-5',
+    text: 'Option 5',
+  },
+];
 export const Default = (args) => (
   <div style={{ width: args.defaultWidth }}>
     <FluidComboBox

--- a/packages/react/src/components/FluidDatePicker/FluidDatePicker.stories.js
+++ b/packages/react/src/components/FluidDatePicker/FluidDatePicker.stories.js
@@ -17,38 +17,6 @@ import {
 } from '../Toggletip';
 import { Information } from '@carbon/icons-react';
 import mdx from './FluidDatePicker.mdx';
-
-export default {
-  title: 'Components/Fluid Components/FluidDatePicker',
-  component: FluidDatePicker,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-    controls: {
-      exclude: [
-        'appendTo',
-        'disable',
-        'enable',
-        'inline',
-        'light',
-        'locale',
-        'value',
-      ],
-    },
-  },
-  subcomponents: {
-    FluidDatePickerSkeleton,
-  },
-};
-
-const sharedArgs = {
-  invalidText:
-    'Error message that is really long can wrap to more lines but should not be excessively long.',
-  warnText:
-    'Warning message that is really long can wrap to more lines but should not be excessively long.',
-};
-
 const sharedArgTypes = {
   onChange: {
     action: 'clicked',
@@ -101,6 +69,50 @@ const sharedArgTypes = {
       category: 'DatePickerInput',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Fluid Components/FluidDatePicker',
+  component: FluidDatePicker,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+    controls: {
+      exclude: [
+        'appendTo',
+        'disable',
+        'enable',
+        'inline',
+        'light',
+        'locale',
+        'value',
+      ],
+    },
+  },
+  subcomponents: {
+    FluidDatePickerSkeleton,
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    datePickerType: {
+      control: false,
+    },
+  },
+};
+
+const sharedArgs = {
+  invalidText:
+    'Error message that is really long can wrap to more lines but should not be excessively long.',
+  warnText:
+    'Warning message that is really long can wrap to more lines but should not be excessively long.',
 };
 
 const ToggleTip = (

--- a/packages/react/src/components/FluidDropdown/FluidDropdown.stories.js
+++ b/packages/react/src/components/FluidDropdown/FluidDropdown.stories.js
@@ -18,48 +18,6 @@ import { IconButton } from '../IconButton';
 import { Button } from '../Button';
 import { Information, View, FolderOpen, Folders } from '@carbon/icons-react';
 import mdx from './FluidDropdown.mdx';
-
-export default {
-  title: 'Components/Fluid Components/FluidDropdown',
-  component: FluidDropdown,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  subcomponents: {
-    FluidDropdownSkeleton,
-  },
-};
-
-const items = [
-  {
-    id: 'option-0',
-    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
-  },
-  {
-    id: 'option-1',
-    text: 'Option 1',
-  },
-  {
-    id: 'option-2',
-    text: 'Option 2',
-  },
-  {
-    id: 'option-3',
-    text: 'Option 3 - a disabled item',
-    disabled: true,
-  },
-  {
-    id: 'option-4',
-    text: 'Option 4',
-  },
-  {
-    id: 'option-5',
-    text: 'Option 5',
-  },
-];
-
 const sharedArgTypes = {
   className: {
     control: {
@@ -106,8 +64,63 @@ const sharedArgTypes = {
       type: 'text',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Fluid Components/FluidDropdown',
+  component: FluidDropdown,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  subcomponents: {
+    FluidDropdownSkeleton,
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    initialSelectedItem: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
+const items = [
+  {
+    id: 'option-0',
+    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+  },
+  {
+    id: 'option-1',
+    text: 'Option 1',
+  },
+  {
+    id: 'option-2',
+    text: 'Option 2',
+  },
+  {
+    id: 'option-3',
+    text: 'Option 3 - a disabled item',
+    disabled: true,
+  },
+  {
+    id: 'option-4',
+    text: 'Option 4',
+  },
+  {
+    id: 'option-5',
+    text: 'Option 5',
+  },
+];
 export const Default = (args) => (
   <div style={{ width: args.defaultWidth }}>
     <FluidDropdown

--- a/packages/react/src/components/FluidForm/FluidForm.stories.js
+++ b/packages/react/src/components/FluidForm/FluidForm.stories.js
@@ -54,6 +54,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => (

--- a/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.stories.js
+++ b/packages/react/src/components/FluidMultiSelect/FluidMultiSelect.stories.js
@@ -23,62 +23,6 @@ import { IconButton } from '../IconButton';
 import { Button } from '../Button';
 import { Information, View, FolderOpen, Folders } from '@carbon/icons-react';
 import mdx from './FluidMultiSelect.mdx';
-
-export default {
-  title: 'Components/Fluid Components/FluidMultiSelect',
-  component: FluidMultiSelect,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  subcomponents: {
-    FluidMultiSelectSkeleton,
-  },
-};
-
-const items = [
-  {
-    id: 'option-0',
-    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
-  },
-  {
-    id: 'option-1',
-    text: 'Option 1',
-  },
-  {
-    id: 'option-2',
-    text: 'Option 2',
-  },
-  {
-    id: 'option-3',
-    text: 'Option 3 - a disabled item',
-    disabled: true,
-  },
-  {
-    id: 'option-4',
-    text: 'Option 4',
-  },
-  {
-    id: 'option-5',
-    text: 'Option 5',
-  },
-];
-
-export const Default = (args) => (
-  <div style={{ width: args.defaultWidth }}>
-    <FluidMultiSelect
-      onChange={() => {}}
-      id="default"
-      titleText="Label"
-      label="Choose an option"
-      items={items}
-      itemToString={(item) => (item ? item.text : '')}
-      {...args}
-    />
-  </div>
-);
-
 const sharedArgTypes = {
   className: {
     control: {
@@ -130,7 +74,77 @@ const sharedArgTypes = {
       type: 'text',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };
+export default {
+  title: 'Components/Fluid Components/FluidMultiSelect',
+  component: FluidMultiSelect,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  subcomponents: {
+    FluidMultiSelectSkeleton,
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    initialSelectedItems: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
+
+const items = [
+  {
+    id: 'option-0',
+    text: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit.',
+  },
+  {
+    id: 'option-1',
+    text: 'Option 1',
+  },
+  {
+    id: 'option-2',
+    text: 'Option 2',
+  },
+  {
+    id: 'option-3',
+    text: 'Option 3 - a disabled item',
+    disabled: true,
+  },
+  {
+    id: 'option-4',
+    text: 'Option 4',
+  },
+  {
+    id: 'option-5',
+    text: 'Option 5',
+  },
+];
+
+export const Default = (args) => (
+  <div style={{ width: args.defaultWidth }}>
+    <FluidMultiSelect
+      onChange={() => {}}
+      id="default"
+      titleText="Label"
+      label="Choose an option"
+      items={items}
+      itemToString={(item) => (item ? item.text : '')}
+      {...args}
+    />
+  </div>
+);
 
 Default.args = {
   defaultWidth: 400,

--- a/packages/react/src/components/FluidNumberInput/FluidNumberInput.stories.js
+++ b/packages/react/src/components/FluidNumberInput/FluidNumberInput.stories.js
@@ -27,6 +27,16 @@ export default {
   subcomponents: {
     FluidNumberInputSkeleton,
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const ToggleTip = (
@@ -105,6 +115,11 @@ Default.argTypes = {
     control: {
       type: 'text',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/FluidSearch/FluidSearch.stories.js
+++ b/packages/react/src/components/FluidSearch/FluidSearch.stories.js
@@ -23,6 +23,16 @@ export default {
   subcomponents: {
     FluidSearchSkeleton,
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Skeleton = () => (
@@ -73,5 +83,10 @@ Default.argTypes = {
     control: {
       type: 'text',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };

--- a/packages/react/src/components/FluidSelect/FluidSelect.stories.js
+++ b/packages/react/src/components/FluidSelect/FluidSelect.stories.js
@@ -19,30 +19,6 @@ import { AILabel, AILabelContent, AILabelActions } from '../AILabel';
 import { IconButton } from '../IconButton';
 import { Information, View, FolderOpen, Folders } from '@carbon/icons-react';
 import mdx from './FluidSelect.mdx';
-
-export default {
-  title: 'Components/Fluid Components/FluidSelect',
-  component: FluidSelect,
-  subcomponents: {
-    FluidSelectSkeleton,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-    controls: {
-      exclude: ['defaultValue', 'id'],
-    },
-  },
-  argTypes: {
-    light: {
-      table: {
-        disable: true,
-      },
-    },
-  },
-};
-
 const sharedArgTypes = {
   className: {
     control: {
@@ -77,6 +53,37 @@ const sharedArgTypes = {
   warnText: {
     control: {
       type: 'text',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Fluid Components/FluidSelect',
+  component: FluidSelect,
+  subcomponents: {
+    FluidSelectSkeleton,
+  },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+    controls: {
+      exclude: ['defaultValue', 'id'],
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    light: {
+      table: {
+        disable: true,
+      },
     },
   },
 };

--- a/packages/react/src/components/FluidTextArea/FluidTextArea.stories.js
+++ b/packages/react/src/components/FluidTextArea/FluidTextArea.stories.js
@@ -19,40 +19,6 @@ import {
 } from '../Toggletip';
 import { Information } from '@carbon/icons-react';
 import mdx from './FluidTextArea.mdx';
-
-export default {
-  title: 'Components/Fluid Components/FluidTextArea',
-  component: FluidTextArea,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-    controls: {
-      exclude: ['id', 'value', 'defaultValue'],
-    },
-  },
-  subcomponents: {
-    FluidTextAreaSkeleton,
-  },
-  argTypes: {
-    hideLabel: {
-      table: {
-        disable: true,
-      },
-    },
-    helperText: {
-      table: {
-        disable: true,
-      },
-    },
-    light: {
-      table: {
-        disable: true,
-      },
-    },
-  },
-};
-
 const sharedArgTypes = {
   className: {
     control: {
@@ -102,6 +68,47 @@ const sharedArgTypes = {
   warnText: {
     control: {
       type: 'text',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Fluid Components/FluidTextArea',
+  component: FluidTextArea,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+    controls: {
+      exclude: ['id', 'value', 'defaultValue'],
+    },
+  },
+  subcomponents: {
+    FluidTextAreaSkeleton,
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    hideLabel: {
+      table: {
+        disable: true,
+      },
+    },
+    helperText: {
+      table: {
+        disable: true,
+      },
+    },
+    light: {
+      table: {
+        disable: true,
+      },
     },
   },
 };

--- a/packages/react/src/components/FluidTextInput/FluidTextInput.stories.js
+++ b/packages/react/src/components/FluidTextInput/FluidTextInput.stories.js
@@ -32,6 +32,16 @@ export default {
   subcomponents: {
     FluidTextInputSkeleton,
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const ToggleTip = (
@@ -120,6 +130,11 @@ Default.argTypes = {
     control: {
       type: 'text',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/FluidTimePicker/FluidTimePicker.stories.js
+++ b/packages/react/src/components/FluidTimePicker/FluidTimePicker.stories.js
@@ -31,6 +31,16 @@ export default {
     FluidTimePickerSelect,
     FluidTimePickerSkeleton,
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const ToggleTip = (
@@ -117,5 +127,10 @@ Default.argTypes = {
   },
   warnText: {
     control: { type: 'text' },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };

--- a/packages/react/src/components/Form/Form.stories.js
+++ b/packages/react/src/components/Form/Form.stories.js
@@ -95,6 +95,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => {
@@ -528,5 +538,10 @@ withAILabel.argTypes = {
     table: {
       category: 'AILabel',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };

--- a/packages/react/src/components/FormGroup/FormGroup.stories.js
+++ b/packages/react/src/components/FormGroup/FormGroup.stories.js
@@ -18,6 +18,16 @@ import mdx from './FormGroup.mdx';
 export default {
   title: 'Components/FormGroup',
   component: FormGroup,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/FormLabel/FormLabel.stories.js
+++ b/packages/react/src/components/FormLabel/FormLabel.stories.js
@@ -24,6 +24,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => {

--- a/packages/react/src/components/Grid/Grid.stories.js
+++ b/packages/react/src/components/Grid/Grid.stories.js
@@ -10,13 +10,55 @@ import './Grid.stories.scss';
 import React from 'react';
 import { Grid, Column, ColumnHang, GridSettings } from '../Grid';
 import mdx from './Grid.mdx';
+const defaultArgs = {
+  as: 'div',
+  fullWidth: false,
+  narrow: false,
+  condensed: false,
+  theme: 'g10',
+};
 
+const defaultArgTypes = {
+  as: {
+    control: {
+      type: 'text',
+    },
+  },
+  children: {
+    control: false,
+  },
+  className: {
+    control: false,
+  },
+  fullWidth: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  narrow: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  condensed: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Elements/Grid',
   component: Grid,
   subcomponents: {
     Column,
   },
+  argTypes: defaultArgTypes,
+  args: defaultArgs,
   parameters: {
     controls: {
       hideNoControlsWarning: true,
@@ -47,42 +89,6 @@ export const Default = (args) => {
       </Grid>
     </div>
   );
-};
-
-Default.args = {
-  as: 'div',
-  fullWidth: false,
-  narrow: false,
-  condensed: false,
-};
-
-Default.argTypes = {
-  as: {
-    control: {
-      type: 'text',
-    },
-  },
-  children: {
-    control: false,
-  },
-  className: {
-    control: false,
-  },
-  fullWidth: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  narrow: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  condensed: {
-    control: {
-      type: 'boolean',
-    },
-  },
 };
 
 export const Narrow = () => {

--- a/packages/react/src/components/Heading/Heading.stories.js
+++ b/packages/react/src/components/Heading/Heading.stories.js
@@ -20,6 +20,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => {

--- a/packages/react/src/components/HideAtBreakpoint/HideAtBreakpoint.stories.js
+++ b/packages/react/src/components/HideAtBreakpoint/HideAtBreakpoint.stories.js
@@ -17,6 +17,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const HideAtBreakpoint = () => {

--- a/packages/react/src/components/IconButton/IconButton.stories.js
+++ b/packages/react/src/components/IconButton/IconButton.stories.js
@@ -23,6 +23,16 @@ export default {
     },
     layout: 'centered',
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = (args) => {
@@ -79,6 +89,11 @@ Default.argTypes = {
     },
     options: ['primary', 'secondary', 'ghost', 'tertiary'],
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };
 
 export const withBadgeIndicator = (args) => {
@@ -102,5 +117,12 @@ withBadgeIndicator.args = {
 withBadgeIndicator.parameters = {
   controls: {
     exclude: ['size', 'kind'],
+  },
+};
+withBadgeIndicator.argTypes = {
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };

--- a/packages/react/src/components/IconIndicator/IconIndicator.stories.js
+++ b/packages/react/src/components/IconIndicator/IconIndicator.stories.js
@@ -9,17 +9,6 @@ import React from 'react';
 import IconIndicator from '.';
 import { IconIndicatorKinds } from './index';
 import mdx from './IconIndicator.mdx';
-
-export default {
-  title: 'Preview/StatusIndicators/preview__IconIndicator',
-  component: IconIndicator,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
 const sharedArgTypes = {
   label: {
     control: {
@@ -34,6 +23,26 @@ const sharedArgTypes = {
       type: 'select',
     },
     options: [16, 20],
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Preview/StatusIndicators/preview__IconIndicator',
+  component: IconIndicator,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
   },
 };
 

--- a/packages/react/src/components/Icons/Icons.stories.js
+++ b/packages/react/src/components/Icons/Icons.stories.js
@@ -19,6 +19,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
   decorators: [
     (Story, { args }) => {
       return (

--- a/packages/react/src/components/IdPrefix/IdPrefix.stories.js
+++ b/packages/react/src/components/IdPrefix/IdPrefix.stories.js
@@ -18,6 +18,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => {

--- a/packages/react/src/components/InlineLoading/InlineLoading.stories.js
+++ b/packages/react/src/components/InlineLoading/InlineLoading.stories.js
@@ -10,9 +10,33 @@ import Button from '../Button';
 import InlineLoading from '.';
 import mdx from './InlineLoading.mdx';
 
+const defaultArgs = {
+  description: 'Loading',
+  iconDescription: 'Loading data...',
+  theme: 'g10',
+};
+const defaultArgTypes = {
+  description: {
+    control: {
+      type: 'text',
+    },
+  },
+  iconDescription: {
+    control: {
+      type: 'text',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Components/InlineLoading',
   component: InlineLoading,
+  argTypes: defaultArgTypes,
+  args: defaultArgs,
   parameters: {
     docs: {
       page: mdx,
@@ -79,26 +103,8 @@ export const UxExample = () => {
 
 export const Default = (args) => <InlineLoading {...args} />;
 
-Default.args = {
-  description: 'Loading',
-  iconDescription: 'Loading data...',
-};
-
 Default.parameters = {
   controls: {
     exclude: ['successDelay'],
-  },
-};
-
-Default.argTypes = {
-  description: {
-    control: {
-      type: 'text',
-    },
-  },
-  iconDescription: {
-    control: {
-      type: 'text',
-    },
   },
 };

--- a/packages/react/src/components/Layer/Layer.stories.js
+++ b/packages/react/src/components/Layer/Layer.stories.js
@@ -23,6 +23,14 @@ export default {
   },
   args: {
     level: 0,
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
   },
 };
 
@@ -81,7 +89,13 @@ export const CustomLevel = (args) => {
 CustomLevel.args = {
   level: 2,
 };
-
+CustomLevel.argTypes = {
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export const UseLayer = () => {
   function ExampleComponent() {
     const { level } = useLayer();

--- a/packages/react/src/components/Layout/Layout.stories.js
+++ b/packages/react/src/components/Layout/Layout.stories.js
@@ -27,6 +27,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const Demo = () => (

--- a/packages/react/src/components/Link/Link.stories.js
+++ b/packages/react/src/components/Link/Link.stories.js
@@ -22,12 +22,18 @@ export default {
     disabled: false,
     inline: false,
     visited: false,
+    theme: 'g10',
   },
   argTypes: {
     renderIcon: {
       table: {
         disable: true,
       },
+    },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
     },
   },
 };

--- a/packages/react/src/components/Loading/Loading.stories.js
+++ b/packages/react/src/components/Loading/Loading.stories.js
@@ -8,33 +8,15 @@
 import React from 'react';
 import Loading from '.';
 import mdx from './Loading.mdx';
-
-export default {
-  title: 'Components/Loading',
-  component: Loading,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-    // The id prop is deprecated and should be remove in the next major release
-    controls: {
-      exclude: ['id'],
-    },
-  },
-};
-
-export const Default = (args) => {
-  return <Loading className={'some-class'} {...args} />;
-};
-
-Default.args = {
+const Defaultargs = {
   active: true,
   withOverlay: false,
   small: false,
   description: 'Loading',
+  theme: 'g10',
 };
 
-Default.argTypes = {
+const DefaultargTypes = {
   active: {
     control: {
       type: 'boolean',
@@ -55,4 +37,28 @@ Default.argTypes = {
       type: 'text',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Loading',
+  component: Loading,
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+    // The id prop is deprecated and should be remove in the next major release
+    controls: {
+      exclude: ['id'],
+    },
+  },
+};
+
+export const Default = (args) => {
+  return <Loading className={'some-class'} {...args} />;
 };

--- a/packages/react/src/components/Menu/Menu.stories.js
+++ b/packages/react/src/components/Menu/Menu.stories.js
@@ -46,7 +46,15 @@ export default {
       exclude: ['target'],
     },
   },
+  args: {
+    theme: 'g10',
+  },
   argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
     mode: {
       control: false,
     },

--- a/packages/react/src/components/MenuButton/MenuButton.stories.js
+++ b/packages/react/src/components/MenuButton/MenuButton.stories.js
@@ -30,6 +30,16 @@ export default {
       exclude: ['menuTarget'],
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = (args) => {

--- a/packages/react/src/components/Modal/Modal.stories.js
+++ b/packages/react/src/components/Modal/Modal.stories.js
@@ -36,6 +36,16 @@ import CheckboxGroup from '../CheckboxGroup';
 export default {
   title: 'Components/Modal',
   component: Modal,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/ModalWrapper/ ModalWrapper.stories.js
+++ b/packages/react/src/components/ModalWrapper/ ModalWrapper.stories.js
@@ -11,7 +11,15 @@ import ModalWrapper from './ModalWrapper';
 export default {
   title: 'Deprecated/ModalWrapper',
   component: ModalWrapper,
+  args: {
+    theme: 'g10',
+  },
   argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
     triggerButtonKind: {
       options: [
         'primary',

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.js
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.js
@@ -117,6 +117,11 @@ export default {
     readOnly: {
       control: { type: 'boolean' },
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
   },
   parameters: {
     docs: {
@@ -190,6 +195,7 @@ const sharedArgs = {
   clearSelectionText: 'To clear selection, press Delete or Backspace,',
   selectAll: false,
   selectAllItemText: 'All options',
+  theme: 'g10',
 };
 
 export const Default = (args) => {

--- a/packages/react/src/components/Notification/stories/InlineNotification.stories.js
+++ b/packages/react/src/components/Notification/stories/InlineNotification.stories.js
@@ -30,6 +30,14 @@ export default {
     statusIconDescription: 'notification',
     onClose: action('onClose'),
     onCloseButtonClick: action('onCloseButtonClick'),
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
   },
 };
 

--- a/packages/react/src/components/NumberInput/NumberInput.stories.js
+++ b/packages/react/src/components/NumberInput/NumberInput.stories.js
@@ -47,6 +47,11 @@ const sharedArgTypes = {
   },
   label: { control: { type: 'text' } },
   helperText: { control: { type: 'text' } },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };
 
 const reusableProps = {
@@ -85,6 +90,7 @@ Default.args = {
   warnText:
     'Warning message that is really long can wrap to more lines but should not be excessively long.',
   size: 'md',
+  theme: 'g10',
 };
 
 Default.argTypes = { ...sharedArgTypes };

--- a/packages/react/src/components/OrderedList/OrderedList.stories.js
+++ b/packages/react/src/components/OrderedList/OrderedList.stories.js
@@ -21,6 +21,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = (args) => (
@@ -62,6 +72,11 @@ Default.argTypes = {
     control: {
       type: 'boolean',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -10,46 +10,13 @@ import { OverflowMenu } from './OverflowMenu';
 import { default as OverflowMenuItem } from '../OverflowMenuItem';
 import { Filter } from '@carbon/icons-react';
 import mdx from './OverflowMenu.mdx';
-
-export default {
-  title: 'Components/OverflowMenu',
-  component: OverflowMenu,
-  subcomponents: {
-    OverflowMenuItem,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
-export const RenderCustomIcon = () => {
-  return (
-    <OverflowMenu flipped={document?.dir === 'rtl'} renderIcon={Filter}>
-      <OverflowMenuItem itemText="Filter A" />
-      <OverflowMenuItem itemText="Filter B" />
-    </OverflowMenu>
-  );
-};
-export const Default = (args) => (
-  <OverflowMenu aria-label="overflow-menu" {...args}>
-    <OverflowMenuItem itemText="Stop app" />
-    <OverflowMenuItem itemText="Restart app" />
-    <OverflowMenuItem itemText="Rename app" />
-    <OverflowMenuItem itemText="Clone and move app" disabled requireTitle />
-    <OverflowMenuItem itemText="Edit routes and access" requireTitle />
-    <OverflowMenuItem hasDivider isDelete itemText="Delete app" />
-  </OverflowMenu>
-);
-
-Default.args = {
+const Defaultargs = {
   flipped: document?.dir === 'rtl',
   focusTrap: false,
   open: false,
+  theme: 'g10',
 };
-
-Default.argTypes = {
+const DefaultargTypes = {
   align: {
     options: [
       'top',
@@ -91,8 +58,45 @@ Default.argTypes = {
     options: ['xs', 'sm', 'md', 'lg'],
     control: { type: 'select' },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/OverflowMenu',
+  component: OverflowMenu,
+  subcomponents: {
+    OverflowMenuItem,
+  },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
 };
 
+export const RenderCustomIcon = () => {
+  return (
+    <OverflowMenu flipped={document?.dir === 'rtl'} renderIcon={Filter}>
+      <OverflowMenuItem itemText="Filter A" />
+      <OverflowMenuItem itemText="Filter B" />
+    </OverflowMenu>
+  );
+};
+export const Default = (args) => (
+  <OverflowMenu aria-label="overflow-menu" {...args}>
+    <OverflowMenuItem itemText="Stop app" />
+    <OverflowMenuItem itemText="Restart app" />
+    <OverflowMenuItem itemText="Rename app" />
+    <OverflowMenuItem itemText="Clone and move app" disabled requireTitle />
+    <OverflowMenuItem itemText="Edit routes and access" requireTitle />
+    <OverflowMenuItem hasDivider isDelete itemText="Delete app" />
+  </OverflowMenu>
+);
 Default.parameters = {
   controls: {
     exclude: [

--- a/packages/react/src/components/OverflowMenuV2/OverflowMenuv2.stories.js
+++ b/packages/react/src/components/OverflowMenuV2/OverflowMenuv2.stories.js
@@ -31,6 +31,16 @@ export default {
     MenuItemRadioGroup,
     MenuItemDivider,
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const _OverflowMenuV2 = () => {

--- a/packages/react/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/react/src/components/PageHeader/PageHeader.stories.js
@@ -70,11 +70,18 @@ export default {
     PageHeaderHeroImage,
     PageHeaderTabBar,
     PageHeaderContentText,
-    PageHeaderContentPageActions,
+  },
+  args: {
+    theme: 'g10',
   },
   argTypes: {
     children: {
       control: false, // ReactNode props don't work in the controls pane
+    },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
     },
   },
   parameters: {
@@ -227,6 +234,11 @@ Default.argTypes = {
     control: {
       type: 'boolean',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/Pagination/Pagination.stories.js
+++ b/packages/react/src/components/Pagination/Pagination.stories.js
@@ -33,9 +33,15 @@ export default {
       options: ['sm', 'md', 'lg'],
       control: { type: 'select' },
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
   },
   args: {
     size: 'md',
+    theme: 'g10',
   },
   decorators: [
     (story) => (
@@ -67,6 +73,7 @@ Default.args = {
   pagesUnknown: false,
   pageSizeInputDisabled: false,
   totalItems: 103,
+  theme: 'g10',
 };
 
 Default.argTypes = {
@@ -147,6 +154,11 @@ Default.argTypes = {
     control: {
       type: 'number',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/PaginationNav/PaginationNav.stories.js
+++ b/packages/react/src/components/PaginationNav/PaginationNav.stories.js
@@ -9,36 +9,17 @@ import React from 'react';
 import PaginationNav from '../PaginationNav';
 import './styles.scss';
 import mdx from './PaginationNav.mdx';
-
-export default {
-  title: 'Components/PaginationNav',
-  component: PaginationNav,
-  subcomponents: {},
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
-export const Default = (args) => {
-  return (
-    <div style={{ width: '800px' }}>
-      <PaginationNav totalItems={25} {...args} />
-    </div>
-  );
-};
-
-Default.args = {
+const Defaultargs = {
   size: 'lg',
   loop: false,
   itemsShown: 10,
   page: 0,
   totalItems: 25,
   disableOverflow: false,
+  theme: 'g10',
 };
 
-Default.argTypes = {
+const DefaultargTypes = {
   size: {
     options: ['sm', 'md', 'lg'],
     control: { type: 'select' },
@@ -68,4 +49,29 @@ Default.argTypes = {
       type: 'boolean',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/PaginationNav',
+  component: PaginationNav,
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
+  subcomponents: {},
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = (args) => {
+  return (
+    <div style={{ width: '800px' }}>
+      <PaginationNav totalItems={25} {...args} />
+    </div>
+  );
 };

--- a/packages/react/src/components/Plex/Plex.stories.js
+++ b/packages/react/src/components/Plex/Plex.stories.js
@@ -24,9 +24,15 @@ export default {
       },
       options: ['Light', 'Regular', 'SemiBold'],
     },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
   },
   args: {
     fontWeight: 'Regular',
+    theme: 'g10',
   },
 };
 

--- a/packages/react/src/components/Popover/Popover.stories.js
+++ b/packages/react/src/components/Popover/Popover.stories.js
@@ -19,13 +19,76 @@ import OverflowMenu from '../OverflowMenu/OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
 
 const prefix = 'cds';
+const Defaultargs = {
+  caret: true,
+  dropShadow: true,
+  highContrast: false,
+  open: true,
+  theme: 'g10',
+};
 
+const DefaultargTypes = {
+  align: {
+    options: [
+      'top',
+      'top-start',
+      'top-end',
+
+      'bottom',
+      'bottom-start',
+      'bottom-end',
+
+      'left',
+      'left-end',
+      'left-start',
+
+      'right',
+      'right-end',
+      'right-start',
+    ],
+    control: {
+      type: 'select',
+    },
+  },
+  border: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  caret: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  dropShadow: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  highContrast: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  open: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Components/Popover',
   component: Popover,
   subcomponents: {
     PopoverContent,
   },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
   parameters: {
     controls: {
       hideNoControlsWarning: true,
@@ -169,63 +232,6 @@ TabTip.argTypes = {
 };
 
 export const Default = DefaultStory.bind({});
-
-Default.args = {
-  caret: true,
-  dropShadow: true,
-  highContrast: false,
-  open: true,
-};
-
-Default.argTypes = {
-  align: {
-    options: [
-      'top',
-      'top-start',
-      'top-end',
-
-      'bottom',
-      'bottom-start',
-      'bottom-end',
-
-      'left',
-      'left-end',
-      'left-start',
-
-      'right',
-      'right-end',
-      'right-start',
-    ],
-    control: {
-      type: 'select',
-    },
-  },
-  border: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  caret: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  dropShadow: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  highContrast: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  open: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
 
 Default.story = {
   decorators: [

--- a/packages/react/src/components/ProgressBar/ProgressBar.stories.js
+++ b/packages/react/src/components/ProgressBar/ProgressBar.stories.js
@@ -11,7 +11,23 @@ import { WithLayer } from '../../../.storybook/templates/WithLayer';
 import mdx from './ProgressBar.mdx';
 
 import ProgressBar from './';
-
+const DefaultargTypes = {
+  hideLabel: {
+    control: { type: 'boolean' },
+  },
+  status: {
+    options: ['active', 'finished', 'error'],
+    control: { type: 'select' },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+const Defaultargs = {
+  theme: 'g10',
+};
 export default {
   title: 'Components/ProgressBar',
   component: ProgressBar,
@@ -20,6 +36,8 @@ export default {
       page: mdx,
     },
   },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
 };
 
 const DefaultStory = (args) => {
@@ -33,16 +51,6 @@ const DefaultStory = (args) => {
 };
 
 export const Default = DefaultStory.bind({});
-
-Default.argTypes = {
-  hideLabel: {
-    control: { type: 'boolean' },
-  },
-  status: {
-    options: ['active', 'finished', 'error'],
-    control: { type: 'select' },
-  },
-};
 
 export const Indeterminate = () => (
   <ProgressBar label="Progress bar label" helperText="Optional helper text" />

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.stories.js
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.stories.js
@@ -8,7 +8,29 @@
 import React from 'react';
 import { ProgressIndicator, ProgressStep, ProgressIndicatorSkeleton } from './';
 import mdx from './ProgressIndicator.mdx';
+const Defaultargs = {
+  currentIndex: 0,
+  spaceEqually: false,
+  vertical: false,
+  theme: 'g10',
+};
 
+const DefaultargTypes = {
+  currentIndex: {
+    control: { type: 'number' },
+  },
+  spaceEqually: {
+    control: { type: 'boolean' },
+  },
+  vertical: {
+    control: { type: 'boolean' },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Components/ProgressIndicator',
   component: ProgressIndicator,
@@ -21,6 +43,8 @@ export default {
       page: mdx,
     },
   },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
 };
 
 export const Interactive = () => {
@@ -76,21 +100,3 @@ export const Default = (args) => (
     />
   </ProgressIndicator>
 );
-
-Default.args = {
-  currentIndex: 0,
-  spaceEqually: false,
-  vertical: false,
-};
-
-Default.argTypes = {
-  currentIndex: {
-    control: { type: 'number' },
-  },
-  spaceEqually: {
-    control: { type: 'boolean' },
-  },
-  vertical: {
-    control: { type: 'boolean' },
-  },
-};

--- a/packages/react/src/components/RadioButton/RadioButton.stories.js
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.js
@@ -14,7 +14,81 @@ import { AILabel, AILabelContent, AILabelActions } from '../AILabel';
 import { IconButton } from '../IconButton';
 import { View, FolderOpen, Folders } from '@carbon/icons-react';
 import mdx from './RadioButton.mdx';
+const Defaultargs = {
+  defaultSelected: 'radio-2',
+  helperText: 'Helper text',
+  hideLabel: false,
+  invalidText: 'Invalid selection',
+  warn: false,
+  warnText: 'Please notice the warning',
+  theme: 'g10',
+};
 
+const DefaultargTypes = {
+  defaultSelected: {
+    description: 'Specify the `<RadioButton>` to be selected by default',
+    options: ['radio-1', 'radio-2', 'radio-3'],
+    control: {
+      type: 'select',
+    },
+  },
+  readOnly: {
+    description: 'Specify whether the RadioButtonGroup is read-only',
+    control: {
+      type: 'boolean',
+    },
+  },
+  helperText: {
+    description:
+      'Provide text that is used alongside the control label for additional help',
+    control: {
+      type: 'text',
+    },
+  },
+  hideLabel: {
+    description:
+      'Specify whether the label should be visually hidden but still available to screen readers',
+    control: {
+      type: 'boolean',
+    },
+  },
+  invalid: {
+    description: 'Specify whether the RadioButtonGroup is invalid',
+    control: {
+      type: 'boolean',
+    },
+  },
+  invalidText: {
+    description:
+      'Provide the text that is displayed when the control is in an invalid state',
+    control: {
+      type: 'text',
+    },
+  },
+  orientation: {
+    description: 'Provide how radio buttons should be displayed',
+    control: 'select',
+    options: ['horizontal', 'vertical'],
+  },
+  warn: {
+    description: 'Specify whether the control is currently in warning state',
+    control: {
+      type: 'boolean',
+    },
+  },
+  warnText: {
+    description:
+      'Provide the text that is displayed when the control is in warning state',
+    control: {
+      type: 'text',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Components/RadioButton',
   component: RadioButton,
@@ -39,6 +113,8 @@ export default {
       page: mdx,
     },
   },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
 };
 
 export const Vertical = () => {
@@ -206,74 +282,4 @@ export const Default = (args) => {
       />
     </RadioButtonGroup>
   );
-};
-
-Default.args = {
-  defaultSelected: 'radio-2',
-  helperText: 'Helper text',
-  hideLabel: false,
-  invalidText: 'Invalid selection',
-  warn: false,
-  warnText: 'Please notice the warning',
-};
-
-Default.argTypes = {
-  defaultSelected: {
-    description: 'Specify the `<RadioButton>` to be selected by default',
-    options: ['radio-1', 'radio-2', 'radio-3'],
-    control: {
-      type: 'select',
-    },
-  },
-  readOnly: {
-    description: 'Specify whether the RadioButtonGroup is read-only',
-    control: {
-      type: 'boolean',
-    },
-  },
-  helperText: {
-    description:
-      'Provide text that is used alongside the control label for additional help',
-    control: {
-      type: 'text',
-    },
-  },
-  hideLabel: {
-    description:
-      'Specify whether the label should be visually hidden but still available to screen readers',
-    control: {
-      type: 'boolean',
-    },
-  },
-  invalid: {
-    description: 'Specify whether the RadioButtonGroup is invalid',
-    control: {
-      type: 'boolean',
-    },
-  },
-  invalidText: {
-    description:
-      'Provide the text that is displayed when the control is in an invalid state',
-    control: {
-      type: 'text',
-    },
-  },
-  orientation: {
-    description: 'Provide how radio buttons should be displayed',
-    control: 'select',
-    options: ['horizontal', 'vertical'],
-  },
-  warn: {
-    description: 'Specify whether the control is currently in warning state',
-    control: {
-      type: 'boolean',
-    },
-  },
-  warnText: {
-    description:
-      'Provide the text that is displayed when the control is in warning state',
-    control: {
-      type: 'text',
-    },
-  },
 };

--- a/packages/react/src/components/Search/Search.stories.js
+++ b/packages/react/src/components/Search/Search.stories.js
@@ -12,7 +12,60 @@ import { WithLayer } from '../../../.storybook/templates/WithLayer';
 import ExpandableSearch from '../ExpandableSearch';
 import Search from '.';
 import mdx from './Search.mdx';
+const Defaultargs = {
+  closeButtonLabelText: 'Clear search input',
+  disabled: false,
+  labelText: 'Label text',
+  placeholder: 'Placeholder text',
+  size: 'md',
+  type: 'search',
+  theme: 'g10',
+};
 
+const DefaultargTypes = {
+  defaultWidth: {
+    control: { type: 'range', min: 300, max: 800, step: 50 },
+  },
+  closeButtonLabelText: {
+    control: {
+      type: 'text',
+    },
+  },
+  disabled: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  defaultValue: {
+    control: {
+      type: 'text',
+    },
+  },
+  labelText: {
+    control: {
+      type: 'text',
+    },
+  },
+  placeholder: {
+    control: {
+      type: 'text',
+    },
+  },
+  renderIcon: {
+    control: false,
+  },
+  size: {
+    options: ['sm', 'md', 'lg'],
+    control: {
+      type: 'select',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Components/Search',
   component: Search,
@@ -26,6 +79,8 @@ export default {
   subcomponents: {
     ExpandableSearch,
   },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
   parameters: {
     docs: {
       page: mdx,
@@ -108,53 +163,4 @@ export const Default = (args) => {
       <Search id="search-default-1" {...args} />
     </div>
   );
-};
-
-Default.args = {
-  closeButtonLabelText: 'Clear search input',
-  disabled: false,
-  labelText: 'Label text',
-  placeholder: 'Placeholder text',
-  size: 'md',
-  type: 'search',
-};
-
-Default.argTypes = {
-  defaultWidth: {
-    control: { type: 'range', min: 300, max: 800, step: 50 },
-  },
-  closeButtonLabelText: {
-    control: {
-      type: 'text',
-    },
-  },
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  defaultValue: {
-    control: {
-      type: 'text',
-    },
-  },
-  labelText: {
-    control: {
-      type: 'text',
-    },
-  },
-  placeholder: {
-    control: {
-      type: 'text',
-    },
-  },
-  renderIcon: {
-    control: false,
-  },
-  size: {
-    options: ['sm', 'md', 'lg'],
-    control: {
-      type: 'select',
-    },
-  },
 };

--- a/packages/react/src/components/Select/Select.stories.js
+++ b/packages/react/src/components/Select/Select.stories.js
@@ -29,12 +29,18 @@ export default {
     invalid: false,
     warn: false,
     size: 'md',
+    theme: 'g10',
   },
   argTypes: {
     light: {
       table: {
         disable: true,
       },
+    },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
     },
   },
   decorators: [(story) => <div style={{ width: '400px' }}>{story()}</div>],
@@ -192,4 +198,9 @@ Default.argTypes = {
   invalidText: { control: 'text' },
   labelText: { control: 'text' },
   warnText: { control: 'text' },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };

--- a/packages/react/src/components/SkeletonIcon/SkeletonIcon.stories.js
+++ b/packages/react/src/components/SkeletonIcon/SkeletonIcon.stories.js
@@ -17,6 +17,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => {

--- a/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.stories.js
+++ b/packages/react/src/components/SkeletonPlaceholder/SkeletonPlaceholder.stories.js
@@ -15,6 +15,16 @@ import mdx from './SkeletonPlaceholder.mdx';
 export default {
   title: 'Components/Skeleton/SkeletonPlaceholder',
   component: SkeletonPlaceholder,
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
   parameters: {
     docs: {
       page: mdx,

--- a/packages/react/src/components/SkeletonText/SkeletonText.stories.js
+++ b/packages/react/src/components/SkeletonText/SkeletonText.stories.js
@@ -11,29 +11,15 @@ import React from 'react';
 
 import SkeletonText from '.';
 import mdx from './SkeletonText.mdx';
-
-export default {
-  title: 'Components/Skeleton/SkeletonText',
-  component: SkeletonText,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
-export const Default = (args) => {
-  return <SkeletonText {...args} />;
-};
-
-Default.args = {
+const Defaultargs = {
   heading: false,
   paragraph: false,
   width: '100%',
   lineCount: 3,
+  theme: 'g10',
 };
 
-Default.argTypes = {
+const DefaultargTypes = {
   className: {
     control: false,
   },
@@ -57,4 +43,24 @@ Default.argTypes = {
       type: 'number',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/Skeleton/SkeletonText',
+  component: SkeletonText,
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = (args) => {
+  return <SkeletonText {...args} />;
 };

--- a/packages/react/src/components/Slider/Slider.stories.js
+++ b/packages/react/src/components/Slider/Slider.stories.js
@@ -11,36 +11,7 @@ import { WithLayer } from '../../../.storybook/templates/WithLayer';
 
 import { Slider, SliderSkeleton } from '.';
 import mdx from './Slider.mdx';
-
-export default {
-  title: 'Components/Slider',
-  component: Slider,
-  subcomponents: {
-    SliderSkeleton,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-};
-
-export const Default = (args) => {
-  return (
-    <Slider
-      {...args}
-      labelText={`Slider (must be an increment of ${args.step})`}
-    />
-  );
-};
-
-Default.parameters = {
-  controls: {
-    exclude: ['light', 'formatLabel', 'labelText'],
-  },
-};
-
-Default.argTypes = {
+const DefaultargTypes = {
   ariaLabelInput: {
     control: { type: 'text' },
   },
@@ -113,9 +84,14 @@ Default.argTypes = {
       type: 'text',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };
 
-Default.args = {
+const Defaultargs = {
   ariaLabelInput: 'Lower bound',
   unstable_ariaLabelInputUpper: 'Upper bound',
   disabled: false,
@@ -132,6 +108,36 @@ Default.args = {
   unstable_valueUpper: undefined,
   warn: false,
   warnText: 'Warning message goes here',
+  theme: 'g10',
+};
+export default {
+  title: 'Components/Slider',
+  component: Slider,
+  subcomponents: {
+    SliderSkeleton,
+  },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = (args) => {
+  return (
+    <Slider
+      {...args}
+      labelText={`Slider (must be an increment of ${args.step})`}
+    />
+  );
+};
+
+Default.parameters = {
+  controls: {
+    exclude: ['light', 'formatLabel', 'labelText'],
+  },
 };
 
 export const SliderWithHiddenInputs = () => {

--- a/packages/react/src/components/Stack/Stack.stories.js
+++ b/packages/react/src/components/Stack/Stack.stories.js
@@ -16,6 +16,16 @@ export default {
       hideNoControlsWarning: true,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Horizontal = () => {
@@ -59,5 +69,10 @@ Default.argTypes = {
     control: {
       type: 'select',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };

--- a/packages/react/src/components/StructuredList/StructuredList.stories.js
+++ b/packages/react/src/components/StructuredList/StructuredList.stories.js
@@ -20,7 +20,28 @@ import {
 import { CheckmarkFilled } from '@carbon/icons-react';
 const prefix = 'cds';
 import StructuredListSkeleton from './StructuredList.Skeleton';
-
+const DefaultargTypes = {
+  isCondensed: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  isFlush: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+const Defaultargs = {
+  isCondensed: false,
+  isFlush: false,
+  theme: 'g10',
+};
 export default {
   title: 'Components/StructuredList',
   component: StructuredListWrapper,
@@ -31,6 +52,8 @@ export default {
     StructuredListInput,
     StructuredListCell,
   },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
   parameters: {
     docs: {
       page: mdx,
@@ -73,29 +96,12 @@ export const Default = (args) => {
     </StructuredListWrapper>
   );
 };
-
-Default.args = {
-  isCondensed: false,
-  isFlush: false,
-};
-
 Default.parameters = {
   controls: {
     exclude: ['selection'],
   },
 };
-Default.argTypes = {
-  isCondensed: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  isFlush: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
+
 const structuredListBodyRowGenerator = (numRows) => {
   return Array.apply(null, Array(numRows)).map((n, i) => (
     <StructuredListRow key={`row-${i}`} id={`row-${i}`}>

--- a/packages/react/src/components/Tabs/Tabs.stories.js
+++ b/packages/react/src/components/Tabs/Tabs.stories.js
@@ -39,58 +39,14 @@ import {
   Restart,
   Icon,
 } from '@carbon/icons-react';
-
-export default {
-  title: 'Components/Tabs',
-  component: Tabs,
-  subcomponents: {
-    TabsVertical,
-    TabList,
-    TabListVertical,
-    Tab,
-    TabPanels,
-    TabPanel,
-  },
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  argTypes: {
-    light: {
-      table: {
-        disable: true,
-      },
-    },
-  },
-};
-
-export const Default = (args) => {
-  return (
-    <Tabs onTabCloseRequest={() => {}}>
-      <TabList {...args}>
-        <Tab>Dashboard</Tab>
-        <Tab>Monitoring</Tab>
-        <Tab>Activity</Tab>
-        <Tab>Settings</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Tab Panel 1</TabPanel>
-        <TabPanel>Tab Panel 2</TabPanel>
-        <TabPanel>Tab Panel 3</TabPanel>
-        <TabPanel>Tab Panel 4</TabPanel>
-      </TabPanels>
-    </Tabs>
-  );
-};
-
-Default.args = {
+const Defaultargs = {
   contained: false,
   dismissable: false,
   scrollDebounceWait: 200,
+  theme: 'g10',
 };
 
-Default.argTypes = {
+const DefaultargTypes = {
   activation: {
     control: { type: 'select' },
     options: ['automatic', 'manual'],
@@ -127,6 +83,61 @@ Default.argTypes = {
       type: 'boolean',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+  light: {
+    table: {
+      disable: true,
+    },
+  },
+};
+export default {
+  title: 'Components/Tabs',
+  component: Tabs,
+  subcomponents: {
+    TabsVertical,
+    TabList,
+    TabListVertical,
+    Tab,
+    TabPanels,
+    TabPanel,
+  },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  argTypes: {
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  argTypes: DefaultargTypes,
+  args: Defaultargs,
+};
+
+export const Default = (args) => {
+  return (
+    <Tabs onTabCloseRequest={() => {}}>
+      <TabList {...args}>
+        <Tab>Dashboard</Tab>
+        <Tab>Monitoring</Tab>
+        <Tab>Activity</Tab>
+        <Tab>Settings</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>Tab Panel 1</TabPanel>
+        <TabPanel>Tab Panel 2</TabPanel>
+        <TabPanel>Tab Panel 3</TabPanel>
+        <TabPanel>Tab Panel 4</TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
 };
 
 export const Dismissable = () => {

--- a/packages/react/src/components/Tag/Tag.stories.js
+++ b/packages/react/src/components/Tag/Tag.stories.js
@@ -16,10 +16,62 @@ import { IconButton } from '../IconButton';
 import '../AILabel/ailabel-story.scss';
 import mdx from './Tag.mdx';
 import './story.scss';
+const ReadOnlyargs = {
+  disabled: false,
+  filter: false,
+  size: 'md',
+  title: 'Clear filter',
+  theme: 'g10',
+};
 
+const ReadOnlyargTypes = {
+  children: {
+    control: false,
+  },
+  className: {
+    control: false,
+  },
+  disabled: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  filter: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  id: {
+    control: false,
+  },
+  renderIcon: {
+    control: false,
+  },
+  size: {
+    options: ['sm', 'md', 'lg'],
+    control: {
+      type: 'select',
+    },
+  },
+  title: {
+    control: {
+      type: 'text',
+    },
+  },
+  type: {
+    control: false,
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
 export default {
   title: 'Components/Tag',
   component: Tag,
+  argTypes: ReadOnlyargTypes,
+  args: ReadOnlyargs,
   parameters: {
     docs: {
       page: mdx,
@@ -68,52 +120,6 @@ export const ReadOnly = (args) => {
       </Tag>
     </>
   );
-};
-
-ReadOnly.args = {
-  disabled: false,
-  filter: false,
-  size: 'md',
-  title: 'Clear filter',
-};
-
-ReadOnly.argTypes = {
-  children: {
-    control: false,
-  },
-  className: {
-    control: false,
-  },
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  filter: {
-    control: {
-      type: 'boolean',
-    },
-  },
-  id: {
-    control: false,
-  },
-  renderIcon: {
-    control: false,
-  },
-  size: {
-    options: ['sm', 'md', 'lg'],
-    control: {
-      type: 'select',
-    },
-  },
-  title: {
-    control: {
-      type: 'text',
-    },
-  },
-  type: {
-    control: false,
-  },
 };
 
 export const Skeleton = (args) => (

--- a/packages/react/src/components/Text/Text.stories.js
+++ b/packages/react/src/components/Text/Text.stories.js
@@ -25,6 +25,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = () => {

--- a/packages/react/src/components/TextArea/TextArea.stories.js
+++ b/packages/react/src/components/TextArea/TextArea.stories.js
@@ -15,32 +15,22 @@ import { IconButton } from '../IconButton';
 import { default as TextArea, TextAreaSkeleton } from './';
 import { Tooltip } from '../Tooltip';
 import mdx from './TextArea.mdx';
-
-export default {
-  title: 'Components/TextArea',
-  component: TextArea,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  subcomponents: {
-    TextAreaSkeleton,
-  },
-  argTypes: {
-    light: {
-      table: {
-        disable: true,
-      },
-    },
-    slug: {
-      table: {
-        disable: true,
-      },
-    },
-  },
+const Defaultargs = {
+  enableCounter: true,
+  helperText: 'TextArea helper text',
+  labelText: 'TextArea label',
+  maxCount: 500,
+  disabled: false,
+  hideLabel: false,
+  invalid: false,
+  invalidText:
+    'Error message that is really long can wrap to more lines but should not be excessively long.',
+  placeholder: '',
+  rows: 4,
+  warn: false,
+  warnText: 'This is a warning message.',
+  theme: 'g10',
 };
-
 const sharedArgTypes = {
   className: {
     control: false,
@@ -123,6 +113,47 @@ const sharedArgTypes = {
       type: 'text',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+  light: {
+    table: {
+      disable: true,
+    },
+  },
+  slug: {
+    table: {
+      disable: true,
+    },
+  },
+};
+export default {
+  title: 'Components/TextArea',
+  component: TextArea,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  subcomponents: {
+    TextAreaSkeleton,
+  },
+  argTypes: sharedArgTypes,
+  args: Defaultargs,
+  argTypes: {
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+    slug: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const Default = (args) => {
@@ -131,22 +162,6 @@ export const Default = (args) => {
 
 Default.argTypes = {
   ...sharedArgTypes,
-};
-
-Default.args = {
-  enableCounter: true,
-  helperText: 'TextArea helper text',
-  labelText: 'TextArea label',
-  maxCount: 500,
-  disabled: false,
-  hideLabel: false,
-  invalid: false,
-  invalidText:
-    'Error message that is really long can wrap to more lines but should not be excessively long.',
-  placeholder: '',
-  rows: 4,
-  warn: false,
-  warnText: 'This is a warning message.',
 };
 
 export const _WithLayer = () => (

--- a/packages/react/src/components/TextInput/TextInput.stories.js
+++ b/packages/react/src/components/TextInput/TextInput.stories.js
@@ -16,32 +16,6 @@ import mdx from './TextInput.mdx';
 
 import { default as TextInput, TextInputSkeleton } from '../TextInput';
 import { Tooltip } from '../Tooltip';
-
-export default {
-  title: 'Components/TextInput',
-  component: TextInput,
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-  subcomponents: {
-    TextInputSkeleton,
-  },
-  argTypes: {
-    light: {
-      table: {
-        disable: true,
-      },
-    },
-    slug: {
-      table: {
-        disable: true,
-      },
-    },
-  },
-};
-
 const sharedArgTypes = {
   defaultWidth: {
     control: { type: 'range', min: 300, max: 800, step: 50 },
@@ -113,6 +87,39 @@ const sharedArgTypes = {
       type: 'select',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
+};
+export default {
+  title: 'Components/TextInput',
+  component: TextInput,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+  subcomponents: {
+    TextInputSkeleton,
+  },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    ...sharedArgTypes,
+    light: {
+      table: {
+        disable: true,
+      },
+    },
+    slug: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const Default = (args) => {
@@ -136,6 +143,7 @@ Default.args = {
   warnText:
     'Warning message that is really long can wrap to more lines but should not be excessively long.',
   size: 'md',
+  theme: 'g10',
 };
 
 Default.argTypes = {

--- a/packages/react/src/components/Theme/Theme.stories.js
+++ b/packages/react/src/components/Theme/Theme.stories.js
@@ -31,6 +31,13 @@ export default {
   args: {
     theme: 'g10',
   },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 const ThemeText = ({ children, showIsDark }) => {

--- a/packages/react/src/components/Tile/Tile.stories.js
+++ b/packages/react/src/components/Tile/Tile.stories.js
@@ -50,6 +50,9 @@ export default {
     TileAboveTheFoldContent,
     TileBelowTheFoldContent,
   },
+  args: {
+    theme: 'g10',
+  },
   argTypes: {
     light: {
       table: {
@@ -60,6 +63,11 @@ export default {
       table: {
         disable: true,
       },
+    },
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
     },
   },
   parameters: {
@@ -114,6 +122,11 @@ Clickable.argTypes = {
       type: 'boolean',
     },
   },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
+  },
 };
 
 export const ClickableWithCustomIcon = (args) => {
@@ -132,13 +145,7 @@ ClickableWithCustomIcon.args = {
   disabled: false,
 };
 
-ClickableWithCustomIcon.argTypes = {
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
+ClickableWithCustomIcon.argTypes = Clickable.argTypes;
 
 export const ClickableWithLayer = () => (
   <WithLayer>
@@ -164,13 +171,7 @@ Selectable.args = {
   disabled: false,
 };
 
-Selectable.argTypes = {
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
+Selectable.argTypes = Clickable.argTypes;
 
 export const MultiSelect = (args) => {
   return (
@@ -192,13 +193,7 @@ MultiSelect.args = {
   disabled: false,
 };
 
-MultiSelect.argTypes = {
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
+MultiSelect.argTypes = Clickable.argTypes;
 
 export const Radio = (args) => {
   return (
@@ -232,13 +227,7 @@ Radio.args = {
   disabled: false,
 };
 
-Radio.argTypes = {
-  disabled: {
-    control: {
-      type: 'boolean',
-    },
-  },
-};
+Radio.argTypes = Clickable.argTypes;
 
 export const RadioWithLayer = () => (
   <WithLayer>

--- a/packages/react/src/components/Toggle/Toggle.stories.js
+++ b/packages/react/src/components/Toggle/Toggle.stories.js
@@ -19,6 +19,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = (args) => {
@@ -74,6 +84,11 @@ Default.argTypes = {
       options: ['sm', 'md'],
       control: { type: 'select' },
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/Toggletip/Toggletip.stories.js
+++ b/packages/react/src/components/Toggletip/Toggletip.stories.js
@@ -33,6 +33,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const ExperimentalAutoAlign = () => {

--- a/packages/react/src/components/Tooltip/DefinitionTooltip.stories.js
+++ b/packages/react/src/components/Tooltip/DefinitionTooltip.stories.js
@@ -14,6 +14,16 @@ import mdx from './DefinitionTooltip.mdx';
 export default {
   title: 'Components/DefinitionTooltip',
   component: DefinitionTooltip,
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
+  args: {
+    theme: 'g10',
+  },
   parameters: {
     controls: {
       hideNoControlsWarning: true,

--- a/packages/react/src/components/Tooltip/Tooltip.stories.js
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.js
@@ -25,6 +25,9 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
   argTypes: {
     align: {
       options: [
@@ -46,6 +49,11 @@ export default {
       ],
       control: {
         type: 'select',
+      },
+      theme: {
+        options: ['white', 'g10', 'g90', 'g100'],
+        control: { type: 'select' },
+        description: 'The theme to apply to the component.',
       },
     },
     highContrast: {

--- a/packages/react/src/components/TreeView/Treeview.stories.js
+++ b/packages/react/src/components/TreeView/Treeview.stories.js
@@ -50,6 +50,14 @@ export default {
   },
   args: {
     onSelect: action('onSelect'),
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
   },
 };
 
@@ -240,6 +248,11 @@ Default.argTypes = {
   size: {
     options: ['xs', 'sm'],
     control: { type: 'select' },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 

--- a/packages/react/src/components/UnorderedList/UnorderedList.stories.js
+++ b/packages/react/src/components/UnorderedList/UnorderedList.stories.js
@@ -22,6 +22,16 @@ export default {
       page: mdx,
     },
   },
+  args: {
+    theme: 'g10',
+  },
+  argTypes: {
+    theme: {
+      options: ['white', 'g10', 'g90', 'g100'],
+      control: { type: 'select' },
+      description: 'The theme to apply to the component.',
+    },
+  },
 };
 
 export const Default = (args) => {
@@ -43,6 +53,11 @@ Default.argTypes = {
     control: {
       type: 'boolean',
     },
+  },
+  theme: {
+    options: ['white', 'g10', 'g90', 'g100'],
+    control: { type: 'select' },
+    description: 'The theme to apply to the component.',
   },
 };
 


### PR DESCRIPTION
Closes #20958

Adds the theme control to all component story files for consistent visual testing across themes.

### Changelog

**New**

~{{new thing}}~

**Changed**

- Adds the 'theme' argType and default 'g10' arg to all component story files to enable theme switching in Storybook.

**Removed**

~{{removed thing}}~

#### Testing / Reviewing

For each component story file modified (e.g., ContentSwitcher, Tooltip, TreeView, etc.), verify that the 'theme' control is present and functional in the Storybook Controls tab. Switching the theme should visually update the component (where applicable).

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
