### PR TITLE
style(tokens): update label to helper-text

### DIFF
--- a/packages/styles/scss/components/file-uploader/_file-uploader.scss
+++ b/packages/styles/scss/components/file-uploader/_file-uploader.scss
@@ -290,7 +290,7 @@
     .#{$prefix}--form-requirement__title,
   .#{$prefix}--file__selected-file--invalid
     .#{$prefix}--form-requirement__supplement {
-    @include type-style('label-01');
+    @include type-style('helper-text-01');
 
     padding: 0 $spacing-05;
   }
@@ -307,7 +307,7 @@
 
   // TODO: deprecate
   .#{$prefix}--file__selected-file--invalid + .#{$prefix}--form-requirement {
-    @include type-style('label-01');
+    @include type-style('helper-text-01');
 
     display: block;
     overflow: visible;

--- a/packages/styles/scss/components/form/_form.scss
+++ b/packages/styles/scss/components/form/_form.scss
@@ -217,7 +217,7 @@ $input-label-weight: 400 !default;
 
   .#{$prefix}--form-requirement {
     @include reset;
-    @include type-style('label-01');
+    @include type-style('helper-text-01');
 
     display: none;
     overflow: hidden;


### PR DESCRIPTION
Closes #19462

Switch validation messages (`invalidText` and `warnText`) from `label` to `helper-text` back to the `helper-text` token instead of `label`.

I checked where the validation text actually comes from, so anything using `useNormalizedInputProps`, like `TextInput`, `Dropdown`, `NumberInput`, `Slider`, `RadioButton`, `TimePicker`, etc., ends up rendering a `<className="…form-requirement">`. Once we swapped the Sass for `.form-requirement` to `helper-text-01`, every one of those components picked up the new token automatically. Even components with custom markup, like `FileUploader`, the checkbox/radio group wrappers, or the list-box family, still style their validation blocks with `.form-requirement`, so they get the same change through the shared mixin. (`ProgressBar` already matched)

### Changelog

**New**

- ~None.~

**Changed**

- `.cds--form-requirement`, which every `useNormalizedInputProps` consumer renders for validation (`TextInput`, `Dropdown`, `NumberInput`, `Slider`, `RadioButton`, `TimePicker` etc.), now uses `helper-text-01` instead of `label-01`.
- `FileUploader’s` custom validation blocks (title + supplement inside an invalid row and the deprecated summary block) also switch to` helper-text-01` so its errors match the shared `helper text`style.

**Removed**

- ~None.~

#### Testing / Reviewing

- Go to `React or WC Deploy Preview` > check any component (`TextInput`, `Dropdown`, `NumberInput`, `Slider`, `RadioButton`, `TimePicker`, etc.), set `invalid=true` or `warn=true`, inspect the validation message and confirm `.cds--form-requirement` computes to the `helper-text` token.



https://github.com/user-attachments/assets/3b94819c-208b-4b0f-be69-1ceaa60271b8


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- ~[ ] Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)