### PR TITLE
fix(link): align story controls and visited styles

### DIFF
--- a/packages/react/src/components/Link/Link.stories.js
+++ b/packages/react/src/components/Link/Link.stories.js
@@ -40,10 +40,10 @@ export const Default = (args) => {
   );
 };
 
-export const Inline = () => {
+export const Inline = ({ children, ...args }) => {
   return (
     <>
-      <Link inline href="#">
+      <Link {...args}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </Link>
       <p>
@@ -51,7 +51,7 @@ export const Inline = () => {
         fringilla eros vehicula id. Ut at enim quis libero pharetra ullamcorper.
         Maecenas feugiat sodales arcu ut porttitor. In blandit ultricies est.
         Vivamus risus massa, cursus eu tellus sed, sagittis commodo nunc.{' '}
-        <Link inline href="#">
+        <Link {...args}>
           Maecenas nunc mauris, consequat quis mauris sit amet
         </Link>
         , finibus suscipit nunc. Phasellus ex quam, placerat quis tempus sit
@@ -62,6 +62,9 @@ export const Inline = () => {
       </p>
     </>
   );
+};
+Inline.args = {
+  inline: true,
 };
 
 export const PairedWithIcon = (args) => {

--- a/packages/react/src/components/Link/Link.stories.js
+++ b/packages/react/src/components/Link/Link.stories.js
@@ -40,7 +40,7 @@ export const Default = (args) => {
   );
 };
 
-export const Inline = ({ children, ...args }) => {
+export const Inline = (args) => {
   return (
     <>
       <Link {...args}>
@@ -64,6 +64,7 @@ export const Inline = ({ children, ...args }) => {
   );
 };
 Inline.args = {
+  ...Default.args,
   inline: true,
 };
 

--- a/packages/styles/scss/components/link/_link.scss
+++ b/packages/styles/scss/components/link/_link.scss
@@ -84,10 +84,12 @@ $link-focus-text-color: custom-property.get-var(
     text-decoration: none;
   }
 
+  .#{$prefix}--link.#{$prefix}--link--visited,
   .#{$prefix}--link.#{$prefix}--link--visited:visited {
     color: $link-visited-text-color;
   }
 
+  .#{$prefix}--link.#{$prefix}--link--visited:hover,
   .#{$prefix}--link.#{$prefix}--link--visited:visited:hover {
     color: $link-hover-text-color;
   }

--- a/packages/web-components/src/components/link/link.stories.ts
+++ b/packages/web-components/src/components/link/link.stories.ts
@@ -24,6 +24,10 @@ const controls = {
     control: 'boolean',
     description: `Specify if the control should be disabled, or not`,
   },
+  inline: {
+    control: 'boolean',
+    description: `Specify whether the link should render inline`,
+  },
   href: {
     control: 'text',
     description: `Provide the href attribute for the <a> node`,
@@ -56,8 +60,19 @@ export const Default = {
 };
 
 export const Inline = {
-  render: () => html`
-    <cds-link inline href="#"
+  argTypes: controls,
+  args: {
+    ...defaultArgs,
+    inline: true,
+  },
+  render: ({ disabled, href, inline, size, visited, onClick }) => html`
+    <cds-link
+      ?disabled="${disabled}"
+      .href="${ifDefined(href)}"
+      .size="${ifDefined(size)}"
+      ?inline="${inline}"
+      ?visited="${visited}"
+      @click="${onClick}"
       >Lorem ipsum dolor sit amet, consectetur adipiscing elit.</cds-link
     >
     <p>
@@ -65,7 +80,13 @@ export const Inline = {
       fringilla eros vehicula id. Ut at enim quis libero pharetra ullamcorper.
       Maecenas feugiat sodales arcu ut porttitor. In blandit ultricies est.
       Vivamus risus massa, cursus eu tellus sed, sagittis commodo nunc.
-      <cds-link inline href="#"
+      <cds-link
+        ?disabled="${disabled}"
+        .href="${ifDefined(href)}"
+        .size="${ifDefined(size)}"
+        ?inline="${inline}"
+        ?visited="${visited}"
+        @click="${onClick}"
         >Maecenas nunc mauris, consequat quis mauris sit amet,</cds-link
       >
       finibus suscipit nunc. Phasellus ex quam, placerat quis tempus sit amet,
@@ -80,11 +101,12 @@ export const Inline = {
 export const PairedWithIcon = {
   args: defaultArgs,
   argTypes: controls,
-  render: ({ disabled, href, size, onClick }) => html`
+  render: ({ disabled, href, size, visited, onClick }) => html`
     <cds-link
       ?disabled="${disabled}"
       .href="${ifDefined(href)}"
       .size="${ifDefined(size)}"
+      ?visited="${visited}"
       @click="${onClick}">
       Carbon Docs ${iconLoader(ArrowRight16, { slot: 'icon' })}
     </cds-link>


### PR DESCRIPTION
Closes #20932

Add story controls and align visited styling in the Link component so WC + React stories behave, and hovering a visited link no longer reverts to the default color.

### Changelog

**New**

- Added `inline` control wiring for both React and WC Link stories so the Inline example is interactive.

**Changed**

- Link now applies the visited colors via the --link--visited.
- In WC Link stories (Default, Inline, PairedWithIcon) now pass visited down, fixing the icon story.

**Removed**

- ~None.~

#### Testing / Reviewing

- Go to React/ WC Deploy Preview > Link > and check all the stories controls (disabled, inline, visited, etc.).

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
