### PR TITLE
fix(multiselect): fix for incorrect height for multiselect component

### DIFF
--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -317,7 +317,7 @@ $list-box-menu-width: convert.to-rem(300px);
     overflow: hidden;
     align-items: center;
     // Account for the border in `.cds--list-box`
-    block-size: calc(100% + 1px);
+    block-size: calc(100%);
     cursor: pointer;
     outline: none;
     padding-block: 0;


### PR DESCRIPTION
Closes #21134

Incorrect height for 

### Changelog

**New**

- Updated the MultiSelect component as per the style.

**Changed**

- Changes the css for the MultiSelect component for Web-Component package.

**Removed**

- NA

#### Testing / Reviewing

Updated the `_list-box.scss` file where `block-size` had a variable added to it.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
~- [ ] Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
