### PR TITLE
fix(multiselect): apply box-sizing to multi-select container

### DIFF
--- a/packages/styles/scss/components/multiselect/_multiselect.scss
+++ b/packages/styles/scss/components/multiselect/_multiselect.scss
@@ -18,6 +18,10 @@
 /// @access public
 /// @group multi-select
 @mixin multiselect {
+  .#{$prefix}--multi-select {
+    box-sizing: border-box;
+  }
+
   .#{$prefix}--multi-select .#{$prefix}--list-box__field--wrapper {
     display: inline-flex;
     align-items: center;

--- a/packages/web-components/src/components/multi-select/multi-select.scss
+++ b/packages/web-components/src/components/multi-select/multi-select.scss
@@ -19,6 +19,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/utilities/convert';
 
 :host(#{$prefix}-multi-select) {
+  box-sizing: border-box;
   outline: none;
 
   .#{$prefix}--assistive-text {


### PR DESCRIPTION
Closes #21134 

Fix incorrect height for multi-select by scoping box-sizing: border-box to the multi-select container and item host.

### Changelog

**New**

- None

**Changed**

- Apply `box-sizing: border-box` to the multi-select container and item host:
   - _multiselect.scss
   - multi-select.scss
   
**Removed**

- None

#### Testing / Reviewing

- Run component tests:

`cd packages/web-components
  yarn install
  yarn test`

- Test Screenshot:
<img width="654" height="120" alt="coverage-test" src="https://github.com/user-attachments/assets/3e970585-b216-4643-88bc-0af810820685" />

**Before**
<img width="416" height="120" alt="before" src="https://github.com/user-attachments/assets/3f61bf8d-2f2d-4d87-ac25-c3d6f5eab010" />

**After**
<img width="416" height="120" alt="after" src="https://github.com/user-attachments/assets/c0de210f-7865-45b4-a01a-312625765e47" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
