### PR TITLE
fix(list-box): text input style selector

### DIFF
--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -885,7 +885,7 @@ $list-box-menu-width: convert.to-rem(300px);
   // When handling input, we need to target nodes that specifically opt-in to
   // the type text in order to make sure the text input is styled
   // correctly.
-  .#{$prefix}--list-box input[type='text'] {
+  .#{$prefix}--list-box .#{$prefix}--text-input {
     background-color: inherit;
     min-inline-size: 0;
     text-overflow: ellipsis;


### PR DESCRIPTION
Closes #21171

Fixes a selector issue with the `_list-box.scss` styles that affected the Filterable MultiSelect component in React and Web Components. 

This originated from #21149 that applied a TODO comment to remove the legacy selector `.#{$prefix}--list-box input[role='combobox']`. FilterableMultiSelect was still relying on this selector as it had the `combobox` role but did not have the `<input>` type of `text`.

I have refactored this style block to simply rely on `.#{$prefix}--text-input` since all list-box components with a text input have this class. Please let me know if you believe the old selector `.#{$prefix}--list-box input[type='text']` should still be present on top of this new one.

### Changelog

**Changed**

- Removed `.#{$prefix}--list-box input[type='text']` selector in favour of `.#{$prefix}--list-box .#{$prefix}--text-input` since all list-box components with a text input have the `cds--text-input` class, but not all have `<input type="text">`


#### Testing / Reviewing

- Go to Filterable MultiSelect stories in React and Web Components
- Styles should be working and back to normal
- Test `readOnly` for React
- Check ComboBox stories for regressions as this is the only other component that uses a list-box with a text input

## PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~~[ ] Updated documentation and storybook examples~~
- ~~[ ] Wrote passing tests that cover this change~~
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass