### PR TITLE
fix: a11y word limit announcement bug

### DIFF
--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -397,8 +397,12 @@ const TextArea = frFn((props, forwardRef) => {
     (counterMode === 'character' || counterMode === 'word') ? (
       <Text
         as="div"
-        className={counterClasses}>{`${textCount}/${maxCount}`}</Text>
+        className={counterClasses}
+        aria-hidden="true">{`${textCount}/${maxCount}`}</Text>
     ) : null;
+
+  const counterDescriptionId =
+    enableCounter && maxCount ? `${id}-counter-desc` : undefined;
 
   const helperId = !helperText
     ? undefined
@@ -451,8 +455,13 @@ const TextArea = frFn((props, forwardRef) => {
   let ariaDescribedBy;
   if (invalid) {
     ariaDescribedBy = errorId;
-  } else if (!invalid && !warn && !isFluid && helperText) {
-    ariaDescribedBy = helperId;
+  } else if (warn && !isFluid) {
+    ariaDescribedBy = warnId;
+  } else {
+    const ids: string[] = [];
+    if (!isFluid && helperText && helperId) ids.push(helperId);
+    if (counterDescriptionId) ids.push(counterDescriptionId);
+    ariaDescribedBy = ids.length > 0 ? ids.join(' ') : undefined;
   }
 
   if (enableCounter) {
@@ -527,6 +536,15 @@ const TextArea = frFn((props, forwardRef) => {
         {label}
         {counter}
       </div>
+      {enableCounter && maxCount && (
+        <span
+          id={counterDescriptionId}
+          className={`${prefix}--visually-hidden`}>
+          {counterMode === 'word'
+            ? `Word limit ${maxCount}`
+            : `Character limit ${maxCount}`}
+        </span>
+      )}
       <div
         ref={wrapperRef}
         className={textAreaWrapperClasses}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/19735

Fixes character limit not being announced by screen readers in TextArea 

### Changelog

**Changed**
Added visually hidden counter description that's announced via aria-describedby when TextArea receives focus
Updated aria-describedby logic to include both helper text and counter description
Added aria-hidden="true" to visual counter to prevent double-announcement


#### Testing / Reviewing
 
 open textarea story
 Tab to a TextArea with enableCounter={true} and maxCount set. Verify JAWS announces the character/word limit (e.g., "Character limit 100") when the textarea receives focus


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
~- [ ] Updated documentation and storybook examples~
~- [ ] Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
