### PR TITLE
fix(callout-notification): render icons via iconLoader

### DIFF
--- a/packages/web-components/src/components/notification/callout-notification.ts
+++ b/packages/web-components/src/components/notification/callout-notification.ts
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, svg } from 'lit';
+import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { prefix } from '../../globals/settings';
 import { carbonElement as customElement } from '../../globals/decorators/carbon-element';
-import CDSActionableNotification from './actionable-notification';
-import { iconsForKinds } from './actionable-notification';
+import { iconLoader } from '../../globals/internal/icon-loader';
+import CDSActionableNotification, {
+  iconsForKinds,
+} from './actionable-notification';
 import { NOTIFICATION_KIND } from './defs';
 import styles from './actionable-notification.scss?lit';
 
@@ -38,15 +40,13 @@ class CDSCalloutNotification extends CDSActionableNotification {
 
   protected _renderIcon() {
     const { statusIconDescription, kind } = this;
-    const { [kind]: icon } = iconsForKinds;
-    return !icon
-      ? undefined
-      : icon({
+    const IconComponent = iconsForKinds[kind];
+    return IconComponent
+      ? iconLoader(IconComponent, {
           class: `${prefix}--inline-notification__icon`,
-          children: !statusIconDescription
-            ? undefined
-            : svg`<title>${statusIconDescription}</title>`,
-        });
+          'aria-label': statusIconDescription || undefined,
+        })
+      : undefined;
   }
 
   protected _renderText() {


### PR DESCRIPTION
Closes #21201

Fixes `cds-callout-notification` so it uses the shared `iconLoader` (same approach as #20357).

### Changelog

**New**

- ~None~

**Changed**

- `cds-callout-notification` now calls `iconLoader`

**Removed**

- ~None~

#### Testing / Reviewing

- Go to `WC Deploy Preview` > `Noticiation` > `Callout`
- Should be visible like this:
<img width="871" height="129" alt="image" src="https://github.com/user-attachments/assets/3c69eb46-b806-4de9-b3c2-6b8867cb63ac" />

<img width="818" height="133" alt="image" src="https://github.com/user-attachments/assets/4cfbb6f4-093d-425c-a41e-3d1c2110e629" />

No more console error:
<img width="1389" height="389" alt="image" src="https://github.com/user-attachments/assets/856d681c-5755-4a29-8c8e-1e96ccd67557" />


## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
