### PR TITLE
fix(list-box): allow autoAlign menu positioning in RTL

### DIFF
--- a/packages/styles/scss/components/list-box/_list-box.scss
+++ b/packages/styles/scss/components/list-box/_list-box.scss
@@ -533,6 +533,11 @@ $list-box-menu-width: convert.to-rem(300px);
     }
   }
 
+  // Allow auto-alignment to control inline placement
+  .#{$prefix}--autoalign .#{$prefix}--list-box__menu {
+    inset-inline: auto;
+  }
+
   .#{$prefix}--list-box .#{$prefix}--list-box__field[aria-expanded='false'] {
     .#{$prefix}--list-box__menu {
       display: none;


### PR DESCRIPTION
Closes #21000

Fix RTL `autoAlign` dropdown menu so options stay on screen. This also fixes `ComboBox` and `MultiSelect` since they use the same list box menu styles.

### Changelog

**New**

- ~None.~

**Changed**

- When `autoAlign` is true, the list box menu no longer forces left/right with `inset-inline: 0`. This lets floating-ui place the menu correctly in RTL and LTR.

**Removed**

- ~None.~

#### Testing / Reviewing

- Go to React Deplow Preview > Default > `autoAlign=true` or 
- Go to React Deplow Preview > Experimental  Auto Align 
- Set Text direction to RTL
- Open the dropdown and confirm the menu is visible

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- ~[ ] Updated documentation and storybook examples~
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
