### PR TITLE
fix(menu): align selectable menu layout and refine story controls

### DIFF
--- a/packages/web-components/src/components/menu/menu.scss
+++ b/packages/web-components/src/components/menu/menu.scss
@@ -28,6 +28,7 @@ $css--plex: true !default;
   --display-icon-item: flex;
 }
 .#{$prefix}--menu--with-selectable-items {
+  --grid-template: #{$spacing-05} 1fr max-content;
   --display-selection-icon: flex;
 }
 

--- a/packages/web-components/src/components/menu/menu.stories.ts
+++ b/packages/web-components/src/components/menu/menu.stories.ts
@@ -33,7 +33,7 @@ const args = {
 
 const argTypes = {
   backgroundToken: {
-    control: 'select',
+    control: { type: 'radio' },
     description: 'Specify the background token to use. Default is "layer".',
     options: [MENU_BACKGROUND_TOKEN.LAYER, MENU_BACKGROUND_TOKEN.BACKGROUND],
   },
@@ -54,8 +54,9 @@ const argTypes = {
     description: `Whether the Menu is open or not.`,
   },
   size: {
-    control: 'select',
-    description: `Specify the size of the Menu. 'xs'
+    control: { type: 'radio' },
+    description: `Specify the size of the Menu. 
+    'xs'
     'sm'
     'md'
     'lg'`,
@@ -88,19 +89,20 @@ export const Default = {
   },
   args,
   argTypes,
-  render: ({ open, size, backgroundToken, border }) => {
+  render: ({ open, size, backgroundToken, border, label }) => {
     return html`
       <cds-menu
         ?open=${open}
         size=${size}
         menuAlignment="bottom"
+        label=${label}
         background-token=${backgroundToken}
         ?border=${border}>
         <cds-menu-item label="Share with">
           ${iconLoader(FolderShared16, { slot: 'render-icon' })}
           <cds-menu-item-radio-group slot="submenu" label="Share with list">
             <cds-menu-item label="None"></cds-menu-item>
-            <cds-menu-item label="Product team"></cds-menu-item>
+            <cds-menu-item selected="true" label="Product team"></cds-menu-item>
             <cds-menu-item label="Organization"></cds-menu-item>
             <cds-menu-item label="Company"></cds-menu-item>
           </cds-menu-item-radio-group>
@@ -117,7 +119,7 @@ export const Default = {
         </cds-menu-item>
         <cds-menu-item-divider></cds-menu-item-divider>
         <cds-menu-item-group>
-          <cds-menu-item-selectable label="Bold" shortcut="⌘B">
+          <cds-menu-item-selectable selected="true" label="Bold" shortcut="⌘B">
             ${iconLoader(TextBold16, { slot: 'render-icon' })}
           </cds-menu-item-selectable>
           <cds-menu-item-selectable label="Italic" shortcut="⌘I">
@@ -126,8 +128,8 @@ export const Default = {
         </cds-menu-item-group>
         <cds-menu-item-divider></cds-menu-item-divider>
         <cds-menu-item-radio-group label="samples">
-          <cds-menu-item label="None"></cds-menu-item>
-          <cds-menu-item selected="true" label="Overline"></cds-menu-item>
+          <cds-menu-item selected="true" label="None"></cds-menu-item>
+          <cds-menu-item label="Overline"></cds-menu-item>
           <cds-menu-item label="Line-through"></cds-menu-item>
           <cds-menu-item label="Underline"></cds-menu-item>
         </cds-menu-item-radio-group>


### PR DESCRIPTION
Closes #20934

Add `Menu` WC Storybook controls and align selectable item layout.

### Changelog

**New**

- Radio controls for `backgroundToken` and `size` in the Menu WC story, just to match React.

**Changed**

- Menu story now wires the label control into `cds-menu`.
- Selectable-only menu layout now reserves the selection icon column for consistent label alignment.
- `Menu` story defaults updated to show selected states.

**Removed**

- ~None.~

#### Testing / Reviewing

- Go to `React and Web components Storybook` > `Menu` > `Default`
- Check the props are working

> [!NOTE]
> I opened issue #21226 to address the React Menu focus behavior: When Menu is open, it refocuses the first menu item on every render. This causes focus to jump away from unrelated inputs (e.g., label prop), making typing impossible.
Also, the `border` prop appears only in dark theme.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- ~[ ] Wrote passing tests that cover this change~
- ~[ ] Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
