### PR TITLE
chore(ci): update yl event link in design office hours slack notification

### DIFF
--- a/.github/workflows/slack-office-hours-design.yml
+++ b/.github/workflows/slack-office-hours-design.yml
@@ -72,7 +72,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/event/10522523",
+                    "url": "https://ec.yourlearning.ibm.com/w3/event/10547769",
                     "action_id": "button-action"
                   }
                 },


### PR DESCRIPTION
Partially closes: #21231 

This PR updates the YL event link to our new 2026 one for Carbon Design Office Hours.

---

**Changed**

- Updated the YL event link with our new 2026 event.

