### PR TITLE
chore(ci): update yl event link in dev office hours slack notification 

### DIFF
--- a/.github/workflows/slack-office-hours-dev.yml
+++ b/.github/workflows/slack-office-hours-dev.yml
@@ -70,7 +70,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/enrollment/event/10482832",
+                    "url": "https://ec.yourlearning.ibm.com/w3/event/10547775",
                     "action_id": "button-action"
                   }
                 },
@@ -162,7 +162,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/enrollment/event/10482832",
+                    "url": "https://ec.yourlearning.ibm.com/w3/event/10547775",
                     "action_id": "button-action"
                   }
                 },
@@ -254,7 +254,7 @@ jobs:
                       "emoji": true
                     },
                     "value": "click_me_123",
-                    "url": "https://ec.yourlearning.ibm.com/w3/enrollment/event/10482832",
+                    "url": "https://ec.yourlearning.ibm.com/w3/event/10547775",
                     "action_id": "button-action"
                   }
                 },


### PR DESCRIPTION
Partially closes #21231 

This PR updates the YL event link to our new 2026 one for Carbon Developer Office Hours.

---

**Changed**

- Updated the YL event link with our new 2026 event.