### PR TITLE
docs(tag): align story controls

### DIFF
--- a/packages/react/src/components/Tag/InteractiveTag.stories.js
+++ b/packages/react/src/components/Tag/InteractiveTag.stories.js
@@ -101,6 +101,12 @@ Selectable.argTypes = {
       type: 'select',
     },
   },
+  id: {
+    control: false,
+  },
+  renderIcon: {
+    control: false,
+  },
 };
 
 export const Operational = (args) => {
@@ -287,6 +293,9 @@ Operational.argTypes = {
       type: 'select',
     },
   },
+  renderIcon: {
+    control: false,
+  },
 };
 
 export const Dismissible = (args) => {
@@ -423,5 +432,11 @@ Dismissible.argTypes = {
     table: {
       defaultValue: { summary: 'bottom' },
     },
+  },
+  id: {
+    control: false,
+  },
+  renderIcon: {
+    control: false,
   },
 };

--- a/packages/react/src/components/Tag/Tag.stories.js
+++ b/packages/react/src/components/Tag/Tag.stories.js
@@ -112,7 +112,19 @@ ReadOnly.argTypes = {
     },
   },
   type: {
-    control: false,
+    options: [
+      'red',
+      'blue',
+      'cyan',
+      'teal',
+      'green',
+      'gray',
+      'high-contrast',
+      'outline',
+    ],
+    control: {
+      type: 'select',
+    },
   },
 };
 
@@ -141,7 +153,7 @@ Skeleton.argTypes = {
   },
 };
 
-export const withAILabel = () => {
+export const withAILabel = (args) => {
   const aiLabel = (
     <AILabel className="ai-label-container">
       <AILabelContent>
@@ -179,8 +191,9 @@ export const withAILabel = () => {
         decorator={aiLabel}
         className="some-class"
         type="red"
-        title="Clear Filter">
-        {'Tag'}
+        title="Clear Filter"
+        {...args}>
+        {args.text}
       </Tag>
 
       <DismissibleTag
@@ -188,15 +201,16 @@ export const withAILabel = () => {
         className="some-class"
         type="purple"
         title="Clear Filter"
-        text="Tag"></DismissibleTag>
+        {...args}></DismissibleTag>
 
       <Tag
         renderIcon={Asleep}
         decorator={aiLabel}
         className="some-class"
         type="blue"
-        title="Clear Filter">
-        {'Tag'}
+        title="Clear Filter"
+        {...args}>
+        {args.text}
       </Tag>
 
       <DismissibleTag
@@ -205,7 +219,76 @@ export const withAILabel = () => {
         className="some-class"
         type="green"
         title="Clear Filter"
-        text="Tag"></DismissibleTag>
+        {...args}></DismissibleTag>
     </div>
   );
+};
+
+withAILabel.args = {
+  disabled: false,
+  size: 'md',
+  text: 'Tag content',
+};
+
+withAILabel.argTypes = {
+  children: {
+    control: false,
+  },
+  className: {
+    control: false,
+  },
+  decorator: {
+    control: false,
+  },
+  disabled: {
+    control: {
+      type: 'boolean',
+    },
+  },
+  filter: {
+    control: false,
+  },
+  id: {
+    control: false,
+  },
+  renderIcon: {
+    control: false,
+  },
+  size: {
+    options: ['sm', 'md', 'lg'],
+    control: {
+      type: 'select',
+    },
+  },
+  title: {
+    control: {
+      type: 'text',
+    },
+  },
+  type: {
+    options: [
+      'red',
+      'blue',
+      'cyan',
+      'teal',
+      'green',
+      'gray',
+      'high-contrast',
+      'outline',
+    ],
+    control: {
+      type: 'select',
+    },
+  },
+  text: {
+    control: {
+      type: 'text',
+    },
+  },
+};
+
+withAILabel.parameters = {
+  controls: {
+    exclude: ['filter'],
+  },
 };

--- a/packages/web-components/src/components/tag/tag.stories.ts
+++ b/packages/web-components/src/components/tag/tag.stories.ts
@@ -119,12 +119,23 @@ export const Dismissible = {
         defaultValue: { summary: 'bottom' },
       },
     },
+    dismissTooltipLabel: {
+      control: 'text',
+      description: 'Text to show on clear filters',
+    },
   },
   args: {
     ...defaultArgs,
     dismissTooltipAlignment: 'bottom',
+    dismissTooltipLabel: 'Dismiss',
   },
-  render: ({ disabled, size, text, dismissTooltipAlignment }) => {
+  render: ({
+    disabled,
+    size,
+    text,
+    dismissTooltipAlignment,
+    dismissTooltipLabel,
+  }) => {
     const tags = [
       {
         type: 'red',
@@ -194,6 +205,7 @@ export const Dismissible = {
             tag-title="${tag.tagTitle}"
             type="${tag.type}"
             size="${size}"
+            dismiss-tooltip-label="${dismissTooltipLabel}"
             dismiss-tooltip-alignment="${dismissTooltipAlignment}"
             >${iconLoader(Asleep16, { slot: 'icon' })}
           </cds-dismissible-tag>`
@@ -413,6 +425,10 @@ export const ReadOnly = {
       control: 'text',
       description: 'Text to show on clear filters',
     },
+    text: {
+      control: 'text',
+      description: 'Provide text to be rendered inside of a the tag.',
+    },
     filter: {
       control: 'boolean',
       description: 'Determine if `Tag` is a filter/chip',
@@ -422,15 +438,16 @@ export const ReadOnly = {
     ...defaultArgs,
     filter: false,
     title: 'Clear filters',
+    text: 'Tag content',
   },
-  render: ({ filter, title, size, disabled }) =>
+  render: ({ filter, title, size, disabled, text }) =>
     html` <cds-tag
         type="red"
         ?filter="${filter}"
         title="${title}"
         size="${size}"
         ?disabled="${disabled}">
-        Tag content with a long text description
+        ${text}
       </cds-tag>
       ${types
         .slice(1)
@@ -442,39 +459,64 @@ export const ReadOnly = {
               title="${title}"
               size="${size}"
               ?disabled="${disabled}"
-              >Tag content</cds-tag
+              >${text}</cds-tag
             >`
         )}`,
 };
 
 export const WithAILabel = {
-  render: () =>
-    html`<cds-tag type="red"
-        >Tag
+  argTypes: {
+    ...controls,
+    dismissTooltipLabel: {
+      control: 'text',
+      description: 'Text to show on clear filters',
+    },
+    text: {
+      control: 'text',
+      description: 'Provide text to be rendered inside of a the tag.',
+    },
+  },
+  args: {
+    ...defaultArgs,
+    text: 'Tag content',
+    dismissTooltipLabel: 'Dismiss',
+  },
+  render: ({ disabled, size, text, dismissTooltipLabel }) =>
+    html`<cds-tag type="red" ?disabled="${disabled}" size="${size}"
+        >${text}
         <cds-ai-label alignment="bottom-left">
           ${content}${actions}</cds-ai-label
         >
       </cds-tag>
 
-      <cds-tag filter type="purple">
-        Tag
+      <cds-dismissible-tag
+        type="purple"
+        ?disabled="${disabled}"
+        size="${size}"
+        dismiss-tooltip-label="${dismissTooltipLabel}"
+        text="${text}">
         <cds-ai-label alignment="bottom-left">
           ${content}${actions}</cds-ai-label
         >
-      </cds-tag>
+      </cds-dismissible-tag>
 
-      <cds-tag type="blue">
-        ${iconLoader(Asleep16, { slot: 'icon' })} Tag
+      <cds-tag type="blue" ?disabled="${disabled}" size="${size}">
+        ${iconLoader(Asleep16, { slot: 'icon' })} ${text}
         <cds-ai-label alignment="bottom-left">
           ${content}${actions}</cds-ai-label
         >
       </cds-tag>
-      <cds-tag filter type="green">
-        ${iconLoader(Asleep16, { slot: 'icon' })} Tag
+      <cds-dismissible-tag
+        type="green"
+        ?disabled="${disabled}"
+        size="${size}"
+        dismiss-tooltip-label="${dismissTooltipLabel}"
+        text="${text}">
+        ${iconLoader(Asleep16, { slot: 'icon' })}
         <cds-ai-label alignment="bottom-left">
           ${content}${actions}</cds-ai-label
         >
-      </cds-tag>`,
+      </cds-dismissible-tag>`,
 };
 
 const meta = {


### PR DESCRIPTION
Closes #20955

Added story controls to Tag component in both React & WC packages

### Changelog

**New**

- Added controls for With AI Label story in React & WC

**Changed**

- Made control 'id' un-interactive.  Because storybook throws warning upon updating 'id' 
- Same change for 'renderIcon' control

**Removed**

- None

#### Testing / Reviewing

Go to React/ WC Deploy Preview > Tag > and check all the stories controls.

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- ~[]  Wrote passing tests that cover this change~
- ~[]  Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
